### PR TITLE
fix(flags): fire `user_blast_radius` when adding new condition sets with empty filters

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -184,6 +184,7 @@ describe('the feature flag release conditions logic', () => {
             jest.spyOn(api, 'create')
                 .mockReturnValueOnce(Promise.resolve({ users_affected: 124, total_users: 2000 }))
                 .mockReturnValueOnce(Promise.resolve({ users_affected: 248, total_users: 2000 }))
+                .mockReturnValueOnce(Promise.resolve({ users_affected: 120, total_users: 2000 }))
                 .mockReturnValueOnce(Promise.resolve({ users_affected: 496, total_users: 2000 }))
 
             logic = featureFlagReleaseConditionsLogic({
@@ -246,11 +247,16 @@ describe('the feature flag release conditions logic', () => {
             })
                 .toDispatchActions(['setAffectedUsers'])
                 .toMatchValues({
-                    // expect the new empty condition set to initialize affected users to be same as total users
-                    affectedUsers: { A: 248, B: 2000 },
+                    // first setAffectedUsers clears to undefined (loading state)
+                    affectedUsers: { A: 248, B: undefined },
                     totalUsers: 2000,
                 })
-                .toNotHaveDispatchedActions(['setTotalUsers'])
+                .toDispatchActions(['setAffectedUsers', 'setTotalUsers'])
+                .toMatchValues({
+                    // then the API response sets the actual blast radius
+                    affectedUsers: { A: 248, B: 120 },
+                    totalUsers: 2000,
+                })
 
             // update newly added condition set
             await expectLogic(logic, () => {
@@ -303,7 +309,9 @@ describe('the feature flag release conditions logic', () => {
         })
 
         it('uses explicit sortKey when provided to addConditionSet', async () => {
-            jest.spyOn(api, 'create').mockReturnValueOnce(Promise.resolve({ users_affected: 500, total_users: 1000 }))
+            jest.spyOn(api, 'create')
+                .mockReturnValueOnce(Promise.resolve({ users_affected: 500, total_users: 1000 }))
+                .mockReturnValueOnce(Promise.resolve({ users_affected: 500, total_users: 1000 }))
 
             const testLogic = featureFlagReleaseConditionsLogic({
                 id: 'sortkey-test',

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -382,7 +382,7 @@ describe('the feature flag release conditions logic', () => {
         })
 
         describe('API calls', () => {
-            beforeEach(() => {
+            it('doesnt make extra API calls when rollout percentage or variants change', async () => {
                 logic?.unmount()
 
                 jest.spyOn(api, 'create').mockClear()
@@ -419,40 +419,25 @@ describe('the feature flag release conditions logic', () => {
                         },
                     ]),
                 })
+
+                // Mount and wait for all listeners to finish
                 logic.mount()
-            })
+                await expectLogic(logic).toFinishAllListeners()
 
-            it('doesnt make extra API calls when rollout percentage or variants change', async () => {
-                await expectLogic(logic)
-                    .toDispatchActions([
-                        'setAffectedUsers',
-                        'setAffectedUsers',
-                        'setAffectedUsers',
-                        'setAffectedUsers',
-                        'setAffectedUsers',
-                        'setAffectedUsers',
-                        'setTotalUsers',
-                    ])
-                    .toMatchValues({
-                        affectedUsers: { A: 120, B: 120, C: 120 },
-                        totalUsers: 2000,
-                    })
+                // Verify final state - all conditions have their blast radius calculated
+                expect(logic.values.affectedUsers).toEqual({ A: 120, B: 120, C: 120 })
+                expect(logic.values.totalUsers).toEqual(2000)
 
+                // 3 API calls made (one for each condition)
                 expect(api.create).toHaveBeenCalledTimes(3)
 
-                await expectLogic(logic, () => {
-                    logic.actions.updateConditionSet(0, 20, undefined, undefined)
-                }).toNotHaveDispatchedActions(['setAffectedUsers', 'setTotalUsers'])
+                // Change rollout percentage and variant - should NOT trigger additional API calls
+                logic.actions.updateConditionSet(0, 20, undefined, undefined)
+                logic.actions.updateConditionSet(1, 30, undefined, 'test-variant')
+                logic.actions.updateConditionSet(2, undefined, undefined, 'test-variant2')
+                await expectLogic(logic).toFinishAllListeners()
 
-                await expectLogic(logic, () => {
-                    logic.actions.updateConditionSet(1, 30, undefined, 'test-variant')
-                }).toNotHaveDispatchedActions(['setAffectedUsers', 'setTotalUsers'])
-
-                await expectLogic(logic, () => {
-                    logic.actions.updateConditionSet(2, undefined, undefined, 'test-variant2')
-                }).toNotHaveDispatchedActions(['setAffectedUsers', 'setTotalUsers'])
-
-                // no extra calls when changing rollout percentage
+                // No extra API calls when only changing rollout percentage or variant
                 expect(api.create).toHaveBeenCalledTimes(3)
             })
         })

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -113,6 +113,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         }),
         setTotalUsers: (count: number) => ({ count }),
         calculateBlastRadius: true,
+        calculateBlastRadiusForCondition: (sortKey: string, properties: AnyPropertyFilter[] | undefined) => ({
+            sortKey,
+            properties,
+        }),
         loadAllFlagKeys: (flagIds: string[]) => ({ flagIds }),
         setFlagKeys: (flagKeys: Record<string, string>) => ({ flagKeys }),
         setFlagKeysLoading: (isLoading: boolean) => ({ isLoading }),
@@ -344,28 +348,11 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             actions.setAffectedUsers(sortKey, response.users_affected)
             actions.setTotalUsers(response.total_users)
         },
-        addConditionSet: async () => {
+        addConditionSet: () => {
             const newGroup = values.filters.groups[values.filters.groups.length - 1]
             if (newGroup.sort_key) {
-                actions.setAffectedUsers(newGroup.sort_key, undefined)
                 actions.openCondition(newGroup.sort_key)
-
-                // Fire the API call to calculate blast radius for the new empty condition set
-                try {
-                    const response = await api.create(
-                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
-                        {
-                            condition: { properties: [] },
-                            group_type_index: values.filters?.aggregation_group_type_index ?? null,
-                        }
-                    )
-
-                    actions.setAffectedUsers(newGroup.sort_key, response.users_affected)
-                    actions.setTotalUsers(response.total_users)
-                } catch {
-                    // Fall back to the sentinel value so the UI shows the rollout percentage
-                    actions.setAffectedUsers(newGroup.sort_key, -1)
-                }
+                actions.calculateBlastRadiusForCondition(newGroup.sort_key, newGroup.properties)
             }
         },
         removeConditionSet: () => {
@@ -400,52 +387,28 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 actions.setOpenConditions(newOpenConditions)
             }
         },
-        calculateBlastRadius: async () => {
-            const usersAffectedPromises: Promise<{
-                result: UserBlastRadiusType
-                sortKey: string
-            }>[] = []
+        calculateBlastRadiusForCondition: async ({ sortKey, properties }) => {
+            actions.setAffectedUsers(sortKey, undefined)
 
+            let response: UserBlastRadiusType
+            if (!properties || properties.some(isEmptyProperty)) {
+                // don't compute for incomplete conditions
+                response = { users_affected: -1, total_users: -1 }
+            } else {
+                response = await api.create(`api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`, {
+                    condition: { properties },
+                    group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                })
+            }
+
+            actions.setAffectedUsers(sortKey, response.users_affected)
+            if (response.total_users !== -1) {
+                actions.setTotalUsers(response.total_users)
+            }
+        },
+        calculateBlastRadius: () => {
             values.filters.groups.forEach((condition: FeatureFlagGroupTypeWithSortKey) => {
-                const { sort_key: sortKey } = condition
-                actions.setAffectedUsers(sortKey, undefined)
-
-                const properties = condition.properties
-                let responsePromise: Promise<UserBlastRadiusType>
-                if (!properties || properties.some(isEmptyProperty)) {
-                    // don't compute for incomplete conditions
-                    responsePromise = Promise.resolve({
-                        users_affected: -1,
-                        total_users: -1,
-                    })
-                } else if (properties.length === 0) {
-                    // Request total users for empty condition sets
-                    responsePromise = api.create(
-                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
-                        {
-                            condition: { properties: [] },
-                            group_type_index: values.filters?.aggregation_group_type_index ?? null,
-                        }
-                    )
-                } else {
-                    responsePromise = api.create(
-                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
-                        {
-                            condition,
-                            group_type_index: values.filters?.aggregation_group_type_index ?? null,
-                        }
-                    )
-                }
-                usersAffectedPromises.push(responsePromise.then((result) => ({ result, sortKey })))
-            })
-
-            const results = await Promise.all(usersAffectedPromises)
-
-            results.forEach(({ result, sortKey }) => {
-                actions.setAffectedUsers(sortKey, result.users_affected)
-                if (result.total_users !== -1) {
-                    actions.setTotalUsers(result.total_users)
-                }
+                actions.calculateBlastRadiusForCondition(condition.sort_key, condition.properties)
             })
         },
         loadAllFlagKeys: async ({ flagIds }) => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -325,12 +325,23 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             actions.setAffectedUsers(sortKey, response.users_affected)
             actions.setTotalUsers(response.total_users)
         },
-        addConditionSet: () => {
+        addConditionSet: async () => {
             const newGroup = values.filters.groups[values.filters.groups.length - 1]
             if (newGroup.sort_key) {
-                // Use ?? instead of || to properly handle totalUsers = 0
-                actions.setAffectedUsers(newGroup.sort_key, values.totalUsers ?? -1)
+                actions.setAffectedUsers(newGroup.sort_key, undefined)
                 actions.openCondition(newGroup.sort_key)
+
+                // Fire the API call to calculate blast radius for the new empty condition set
+                const response = await api.create(
+                    `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
+                    {
+                        condition: { properties: [] },
+                        group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                    }
+                )
+
+                actions.setAffectedUsers(newGroup.sort_key, response.users_affected)
+                actions.setTotalUsers(response.total_users)
             }
         },
         removeConditionSet: () => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -387,7 +387,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 actions.setOpenConditions(newOpenConditions)
             }
         },
-        calculateBlastRadiusForCondition: async ({ sortKey, properties }, breakpoint) => {
+        calculateBlastRadiusForCondition: async ({ sortKey, properties }) => {
             actions.setAffectedUsers(sortKey, undefined)
 
             let response: UserBlastRadiusType
@@ -407,8 +407,6 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     response = { users_affected: -1, total_users: -1 }
                 }
             }
-
-            breakpoint()
 
             actions.setAffectedUsers(sortKey, response.users_affected)
             if (response.total_users !== -1) {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -351,16 +351,21 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 actions.openCondition(newGroup.sort_key)
 
                 // Fire the API call to calculate blast radius for the new empty condition set
-                const response = await api.create(
-                    `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
-                    {
-                        condition: { properties: [] },
-                        group_type_index: values.filters?.aggregation_group_type_index ?? null,
-                    }
-                )
+                try {
+                    const response = await api.create(
+                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
+                        {
+                            condition: { properties: [] },
+                            group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                        }
+                    )
 
-                actions.setAffectedUsers(newGroup.sort_key, response.users_affected)
-                actions.setTotalUsers(response.total_users)
+                    actions.setAffectedUsers(newGroup.sort_key, response.users_affected)
+                    actions.setTotalUsers(response.total_users)
+                } catch {
+                    // Fall back to the sentinel value so the UI shows the rollout percentage
+                    actions.setAffectedUsers(newGroup.sort_key, -1)
+                }
             }
         },
         removeConditionSet: () => {

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -60,7 +60,9 @@ export interface FeatureFlagReleaseConditionsLogicProps {
     evaluationRuntime?: FeatureFlagEvaluationRuntime
 }
 
-export type FeatureFlagGroupTypeWithSortKey = FeatureFlagGroupType & { sort_key: string }
+export type FeatureFlagGroupTypeWithSortKey = FeatureFlagGroupType & {
+    sort_key: string
+}
 
 function ensureSortKeys(
     filters: FeatureFlagFilters
@@ -105,7 +107,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             newVariant,
             newDescription,
         }),
-        setAffectedUsers: (sortKey: string, count?: number) => ({ sortKey, count }),
+        setAffectedUsers: (sortKey: string, count?: number) => ({
+            sortKey,
+            count,
+        }),
         setTotalUsers: (count: number) => ({ count }),
         calculateBlastRadius: true,
         loadAllFlagKeys: (flagIds: string[]) => ({ flagIds }),
@@ -164,7 +169,12 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 }
                 const groups = [
                     ...(state?.groups || []),
-                    { properties: [], rollout_percentage: 0, variant: null, sort_key: sortKey ?? uuidv4() },
+                    {
+                        properties: [],
+                        rollout_percentage: 0,
+                        variant: null,
+                        sort_key: sortKey ?? uuidv4(),
+                    },
                 ]
                 return { ...state, groups }
             },
@@ -175,7 +185,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
 
                 const groups = [...(state?.groups || [])]
                 if (newRolloutPercentage !== undefined) {
-                    groups[index] = { ...groups[index], rollout_percentage: newRolloutPercentage }
+                    groups[index] = {
+                        ...groups[index],
+                        rollout_percentage: newRolloutPercentage,
+                    }
                 }
 
                 if (newProperties !== undefined) {
@@ -216,13 +229,19 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 if (!state || index >= state.groups.length - 1) {
                     return state
                 }
-                return { ...state, groups: moveConditionSet(state.groups, index, index + 1) }
+                return {
+                    ...state,
+                    groups: moveConditionSet(state.groups, index, index + 1),
+                }
             },
             moveConditionSetUp: (state, { index }) => {
                 if (!state || index <= 0) {
                     return state
                 }
-                return { ...state, groups: moveConditionSet(state.groups, index, index - 1) }
+                return {
+                    ...state,
+                    groups: moveConditionSet(state.groups, index, index - 1),
+                }
             },
         },
         affectedUsers: [
@@ -377,7 +396,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             }
         },
         calculateBlastRadius: async () => {
-            const usersAffectedPromises: Promise<{ result: UserBlastRadiusType; sortKey: string }>[] = []
+            const usersAffectedPromises: Promise<{
+                result: UserBlastRadiusType
+                sortKey: string
+            }>[] = []
 
             values.filters.groups.forEach((condition: FeatureFlagGroupTypeWithSortKey) => {
                 const { sort_key: sortKey } = condition
@@ -387,7 +409,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 let responsePromise: Promise<UserBlastRadiusType>
                 if (!properties || properties.some(isEmptyProperty)) {
                     // don't compute for incomplete conditions
-                    responsePromise = Promise.resolve({ users_affected: -1, total_users: -1 })
+                    responsePromise = Promise.resolve({
+                        users_affected: -1,
+                        total_users: -1,
+                    })
                 } else if (properties.length === 0) {
                     // Request total users for empty condition sets
                     responsePromise = api.create(
@@ -538,7 +563,10 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
 
                 const taxonomicOptions: TaxonomicFilterProps['optionsFromProp'] = {
                     [TaxonomicFilterGroupType.Metadata]: [
-                        { name: 'distinct_id', propertyFilterType: PropertyFilterType.Person },
+                        {
+                            name: 'distinct_id',
+                            propertyFilterType: PropertyFilterType.Person,
+                        },
                     ],
                 }
                 return taxonomicOptions

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -387,7 +387,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 actions.setOpenConditions(newOpenConditions)
             }
         },
-        calculateBlastRadiusForCondition: async ({ sortKey, properties }) => {
+        calculateBlastRadiusForCondition: async ({ sortKey, properties }, breakpoint) => {
             actions.setAffectedUsers(sortKey, undefined)
 
             let response: UserBlastRadiusType
@@ -395,11 +395,20 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 // don't compute for incomplete conditions
                 response = { users_affected: -1, total_users: -1 }
             } else {
-                response = await api.create(`api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`, {
-                    condition: { properties },
-                    group_type_index: values.filters?.aggregation_group_type_index ?? null,
-                })
+                try {
+                    response = await api.create(
+                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
+                        {
+                            condition: { properties },
+                            group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                        }
+                    )
+                } catch {
+                    response = { users_affected: -1, total_users: -1 }
+                }
             }
+
+            breakpoint()
 
             actions.setAffectedUsers(sortKey, response.users_affected)
             if (response.total_users !== -1) {


### PR DESCRIPTION
## Problem

Noticed that adding new condition sets with no conditions didn't trigger the `user_blast_radius` call. Fixed it. context: https://posthog.slack.com/archives/C07Q2U4BH4L/p1773263738016269?thread_ts=1773263619.604409&cid=C07Q2U4BH4L

## How did you test this code?

Manually

## Publish to changelog?

No
