### PR TITLE
fix(ci): refactor CI Docker orchestration to new helper

### DIFF
--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -50,8 +50,10 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Start Docker services
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
               run: |
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d
+                  bin/ci-wait-for-docker launch
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -88,7 +90,9 @@ jobs:
               run: ./bin/hogli lint:skills
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker wait
 
             - name: Run migrations and create test data
               env:
@@ -130,8 +134,10 @@ jobs:
                   fetch-depth: 0
 
             - name: Start Docker services
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
               run: |
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d
+                  bin/ci-wait-for-docker launch
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -165,7 +171,9 @@ jobs:
               run: cargo install sqlx-cli --version 0.8.0 --features postgres --no-default-features --locked
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker wait
 
             - name: Run migrations and create test data
               env:

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -79,12 +79,15 @@ jobs:
               continue-on-error: true
 
             - name: Stop/Start stack with Docker Compose
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
               run: |
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d
+                  bin/ci-wait-for-docker launch --down
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker wait
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -121,6 +121,7 @@ jobs:
                         - docker-compose.profiles.yml
                         - docker-compose.base.yml
                         - bin/wait-for-docker
+                        - bin/ci-wait-for-docker
                         - frontend/public/email/*
                         - docker/clickhouse
                       legacy:
@@ -148,6 +149,7 @@ jobs:
                         - docker-compose.profiles.yml
                         - docker-compose.base.yml
                         - bin/wait-for-docker
+                        - bin/ci-wait-for-docker
                         - frontend/public/email/*
                         - docker/clickhouse
                       migrations:
@@ -294,12 +296,14 @@ jobs:
               continue-on-error: true
 
             - name: Start services
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:25.8.12.129
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=clickhouse/clickhouse-server:25.8.12.129
-                  export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile temporal --profile azure up -d &
+                  bin/ci-wait-for-docker launch --background --down
 
             - name: Setup pnpm
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -363,7 +367,12 @@ jobs:
                   ./bin/download-mmdb
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:25.8.12.129
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
+              run: bin/ci-wait-for-docker wait
 
             - name: Run product tests
               # --force: discover already decided this product needs testing, skip turbo cache
@@ -475,10 +484,12 @@ jobs:
               continue-on-error: true
 
             - name: Stop/Start stack with Docker Compose
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: |
-                  export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile temporal --profile azure up -d &
+                  bin/ci-wait-for-docker launch --background --down
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -526,7 +537,11 @@ jobs:
                   UV_PROJECT_ENVIRONMENT=.venv-master uv sync --frozen --dev
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
+              run: bin/ci-wait-for-docker wait
 
             - name: Run migrations up to master
               run: |
@@ -999,41 +1014,16 @@ jobs:
             # Copies the fully versioned UDF xml file for use in CI testing
             - name: Stop/Start stack with Docker Compose
               shell: bash
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
+                  WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
+                  WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-                  export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
-
-                  # Start docker compose in background
-                  (
-                      max_attempts=3
-                      attempt=1
-                      delay=5
-
-                      while [ $attempt -le $max_attempts ]; do
-                          echo "Attempt $attempt of $max_attempts to start stack..."
-
-                          # Docker profiles control which services start — consult #team-devex before changing
-                          if docker compose -f docker-compose.dev.yml --profile '*' down && \
-                            docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile temporal --profile azure up -d; then
-                              echo "Stack started successfully"
-                              exit 0
-                          fi
-
-                          echo "Failed to start stack on attempt $attempt"
-
-                          if [ $attempt -lt $max_attempts ]; then
-                              sleep_time=$((delay * 2 ** (attempt - 1)))
-                              echo "Waiting ${sleep_time} seconds before retry..."
-                              sleep $sleep_time
-                          fi
-
-                          attempt=$((attempt + 1))
-                      done
-
-                      echo "Failed to start stack after $max_attempts attempts"
-                      exit 1
-                  ) &
+                  bin/ci-wait-for-docker launch --background --down-all-profiles
 
             - name: Add Kafka and ClickHouse to /etc/hosts
               shell: bash
@@ -1144,7 +1134,12 @@ jobs:
               # because it blocks on ALL project containers including temporal, which
               # boots slowly (auto-setup runs DB migrations). Temporal was started in
               # background above and will be ready by the time temporal tests run.
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
+              run: bin/ci-wait-for-docker wait
 
             - name: Determine if --snapshot-update should be on
               # UPDATE mode: human commits - update snapshots
@@ -1564,11 +1559,13 @@ jobs:
               continue-on-error: true
 
             - name: Start stack with Docker Compose
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-                  export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile temporal --profile azure up -d &
+                  bin/ci-wait-for-docker launch --background --down
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -1622,7 +1619,12 @@ jobs:
 
             - name: Wait for Docker services
               shell: bash
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: temporal,azure
+                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
+                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
+              run: bin/ci-wait-for-docker wait
 
             - name: Run async migrations tests
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -525,9 +525,11 @@ jobs:
             - name: Preserve CI Docker helper during rollout
               run: |
                   # Temporary during rollout: this job checks out `master`,
-                  # which does not include `bin/ci-wait-for-docker` yet.
+                  # which does not include the latest Docker wait helpers yet.
                   cp bin/ci-wait-for-docker /tmp/ci-wait-for-docker
                   chmod +x /tmp/ci-wait-for-docker
+                  cp bin/wait-for-docker /tmp/wait-for-docker
+                  chmod +x /tmp/wait-for-docker
 
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
@@ -538,10 +540,12 @@ jobs:
 
             - name: Restore CI Docker helper during rollout
               run: |
-                  # Temporary during rollout: restore the helper after the
-                  # checkout to `master` removes it from the workspace.
+                  # Temporary during rollout: restore the helpers after the
+                  # checkout to `master` removes them from the workspace.
                   cp /tmp/ci-wait-for-docker bin/ci-wait-for-docker
                   chmod +x bin/ci-wait-for-docker
+                  cp /tmp/wait-for-docker bin/wait-for-docker
+                  chmod +x bin/wait-for-docker
 
             - name: Install python dependencies for master
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -300,7 +300,6 @@ jobs:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
                   CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:25.8.12.129
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: |
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
                   bin/ci-wait-for-docker launch --background --down
@@ -371,7 +370,6 @@ jobs:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
                   CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:25.8.12.129
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: bin/ci-wait-for-docker wait
 
             - name: Run product tests
@@ -487,7 +485,6 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: |
                   bin/ci-wait-for-docker launch --background --down
 
@@ -525,12 +522,26 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
+            - name: Preserve CI Docker helper during rollout
+              run: |
+                  # Temporary during rollout: this job checks out `master`,
+                  # which does not include `bin/ci-wait-for-docker` yet.
+                  cp bin/ci-wait-for-docker /tmp/ci-wait-for-docker
+                  chmod +x /tmp/ci-wait-for-docker
+
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
               uses: actions/checkout@v6
               with:
                   ref: master
                   clean: false
+
+            - name: Restore CI Docker helper during rollout
+              run: |
+                  # Temporary during rollout: restore the helper after the
+                  # checkout to `master` removes it from the workspace.
+                  cp /tmp/ci-wait-for-docker bin/ci-wait-for-docker
+                  chmod +x bin/ci-wait-for-docker
 
             - name: Install python dependencies for master
               run: |
@@ -540,7 +551,6 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: bin/ci-wait-for-docker wait
 
             - name: Run migrations up to master
@@ -1018,7 +1028,6 @@ jobs:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
                   CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
                   WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
                   WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5
               run: |
@@ -1138,7 +1147,6 @@ jobs:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
                   CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: bin/ci-wait-for-docker wait
 
             - name: Determine if --snapshot-update should be on
@@ -1563,7 +1571,6 @@ jobs:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
                   CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: |
                   bin/ci-wait-for-docker launch --background --down
 
@@ -1623,7 +1630,6 @@ jobs:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
                   CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image || needs.get_clickhouse_versions.outputs.oldest_supported_image }}
-                  DOCKER_REGISTRY_PREFIX: us-east1-docker.pkg.dev/posthog-301601/mirror/
               run: bin/ci-wait-for-docker wait
 
             - name: Run async migrations tests

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -112,13 +112,17 @@ jobs:
               continue-on-error: true
 
             - name: Start stack with Docker Compose
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image }}
               run: |
-                  export CLICKHOUSE_SERVER_IMAGE=${{ matrix.clickhouse-server-image }}
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d
+                  bin/ci-wait-for-docker launch --down
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  CLICKHOUSE_SERVER_IMAGE: ${{ matrix.clickhouse-server-image }}
+              run: bin/ci-wait-for-docker wait
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -216,7 +216,6 @@ jobs:
               shell: bash
               run: |
                   export CLICKHOUSE_SERVER_IMAGE=${{ needs.get_clickhouse_versions.outputs.oldest_supported }}
-                  export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
 
                   (

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -352,14 +352,16 @@ jobs:
                   bin/turbo --filter=@posthog/frontend prepare
 
             - name: Start Docker services
-              run: docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d
               env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: capture
+              run: bin/ci-wait-for-docker launch
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker capture
               env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: capture
+              run: bin/ci-wait-for-docker wait capture
 
             - name: Build frontend
               run: |
@@ -414,7 +416,7 @@ jobs:
                   # WARNING: Worker count is tuned to avoid CPU scheduling contention. Talk to #team-devex before changing.
                   python -m granian --interface asgi posthog.asgi:application --host 0.0.0.0 --port 8000 --log-level debug --workers 2 &> /tmp/server.log &
                   # Start the Node.js ingestion container now that the database exists and migrations have run.
-                  docker compose -f docker-compose.dev.yml --profile capture --profile ingestion up -d plugins
+                  COMPOSE_FILE=docker-compose.dev.yml COMPOSE_PROFILES=capture,ingestion bin/ci-wait-for-docker launch plugins
 
             # Install Playwright browsers while we wait for PostHog to be ready
             - name: Install Playwright browsers
@@ -429,9 +431,10 @@ jobs:
                   verbose: true
 
             - name: Wait for ingestion service to be ready
-              run: bin/wait-for-docker plugins
               env:
+                  COMPOSE_FILE: docker-compose.dev.yml
                   COMPOSE_PROFILES: capture,ingestion
+              run: bin/ci-wait-for-docker wait plugins
 
             - name: Run Playwright tests
               id: playwright-tests

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -156,7 +156,6 @@ jobs:
             - name: Stop/Start stack with Docker Compose
               shell: bash
               run: |
-                  export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
                   (
                       max_attempts=3

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -255,11 +255,15 @@ jobs:
 
             - name: Start Docker services
               shell: bash
-              run: docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker launch
 
             - name: Wait for Docker services
               shell: bash
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker wait
 
             - name: Run migrations
               run: |

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -173,12 +173,17 @@ jobs:
               continue-on-error: true
 
             - name: Stop/Start stack with Docker Compose
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: dev_tools,localstack
               run: |
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile dev_tools --profile localstack down
-                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile dev_tools --profile localstack up -d
+                  bin/ci-wait-for-docker launch --down
 
             - name: Wait for Docker services
-              run: bin/wait-for-docker
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+                  COMPOSE_PROFILES: dev_tools,localstack
+              run: bin/ci-wait-for-docker wait
 
             - name: Add Kafka and ClickHouse to /etc/hosts
               run: echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -197,27 +197,13 @@ jobs:
 
             - name: Setup main repo and dependencies
               env:
-                  COMPOSE_FILES: -f ../docker-compose.dev.yml -f ../docker-compose.profiles.yml --profile etcd
+                  COMPOSE_FILE: ../docker-compose.dev.yml:../docker-compose.profiles.yml
+                  COMPOSE_PROFILES: etcd
+                  WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
+                  WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 10
               run: |
-                  docker compose $COMPOSE_FILES down
-
-                  # Retry docker compose up with exponential backoff to handle transient registry errors
-                  for i in 1 2 3; do
-                    if docker compose $COMPOSE_FILES up -d; then
-                      echo "Docker compose up succeeded"
-                      break
-                    else
-                      if [ $i -lt 3 ]; then
-                        echo "Docker compose up failed (attempt $i/3), retrying in $((i * 10)) seconds..."
-                        sleep $((i * 10))
-                      else
-                        echo "Docker compose up failed after 3 attempts"
-                        exit 1
-                      fi
-                    fi
-                  done
-
-                  COMPOSE_FILE=../docker-compose.dev.yml ../bin/wait-for-docker
+                  ../bin/ci-wait-for-docker launch --down
+                  ../bin/ci-wait-for-docker wait
 
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 

--- a/bin/ci-wait-for-docker
+++ b/bin/ci-wait-for-docker
@@ -33,8 +33,20 @@ EOF
 }
 
 compose() {
+    local compose_files=()
+    local compose_args=()
+    local compose_file
+    local separator
+
     if [ -n "${COMPOSE_FILE:-}" ]; then
-        docker compose "$@"
+        separator="${COMPOSE_PATH_SEPARATOR:-:}"
+        IFS="$separator" read -r -a compose_files <<< "$COMPOSE_FILE"
+        for compose_file in "${compose_files[@]}"; do
+            if [ -n "$compose_file" ]; then
+                compose_args+=(-f "$compose_file")
+            fi
+        done
+        env -u COMPOSE_FILE docker compose "${compose_args[@]}" "$@"
     else
         docker compose -f "$DEFAULT_COMPOSE_FILE" "$@"
     fi

--- a/bin/ci-wait-for-docker
+++ b/bin/ci-wait-for-docker
@@ -5,8 +5,10 @@ set -euo pipefail
 #
 # `launch` starts services with the current Compose context and returns
 # immediately when `--background` is used so the runner can do other work.
-# `wait` delegates readiness polling to bin/wait-for-docker and retries only
-# when timed-out services never materialized into containers.
+# `wait` delegates readiness polling to bin/wait-for-docker. It waits for any
+# in-flight background `launch` for the same Compose context before starting
+# health timeouts and retries only when timed-out services never materialized
+# into containers.
 #
 # The workflow must pass the Compose context via standard Docker Compose env
 # such as COMPOSE_FILE, COMPOSE_PROFILES, and any image/tag overrides.
@@ -16,6 +18,7 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 DEFAULT_COMPOSE_FILE="${REPO_ROOT}/docker-compose.dev.yml"
 WAIT_RETRIES="${WAIT_FOR_DOCKER_RETRIES:-1}"
 WAIT_RETRY_TIMEOUT="${WAIT_FOR_DOCKER_RETRY_TIMEOUT:-120}"
+COMPOSE_WAIT_TIMEOUT="${WAIT_FOR_COMPOSE_TIMEOUT:-600}"
 LAUNCH_RETRIES="${WAIT_FOR_DOCKER_LAUNCH_RETRIES:-1}"
 LAUNCH_RETRY_DELAY="${WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY:-5}"
 
@@ -35,6 +38,71 @@ compose() {
     else
         docker compose -f "$DEFAULT_COMPOSE_FILE" "$@"
     fi
+}
+
+background_launch_pid_file() {
+    local compose_file="${COMPOSE_FILE:-$DEFAULT_COMPOSE_FILE}"
+    local state_key
+
+    state_key=$(printf '%s\n%s\n%s\n' "$REPO_ROOT" "$compose_file" "${COMPOSE_PROFILES:-}" | cksum | awk '{print $1}')
+    printf '%s/ci-wait-for-docker-%s.pid\n' "${TMPDIR:-/tmp}" "$state_key"
+}
+
+read_background_launch_pid() {
+    local pid_file
+    pid_file="$(background_launch_pid_file)"
+    if [ -f "$pid_file" ]; then
+        cat "$pid_file"
+    fi
+}
+
+clear_background_launch_pid() {
+    rm -f "$(background_launch_pid_file)"
+}
+
+background_launch_is_running() {
+    local launch_pid="${1:-}"
+
+    if [ -z "$launch_pid" ]; then
+        return 1
+    fi
+
+    kill -0 "$launch_pid" 2>/dev/null
+}
+
+wait_for_background_launch() {
+    local launch_pid
+    local wait_start
+    local last_progress_log=-10
+    local elapsed
+
+    launch_pid="$(read_background_launch_pid)"
+    if ! background_launch_is_running "$launch_pid"; then
+        if [ -n "$launch_pid" ]; then
+            clear_background_launch_pid
+        fi
+        return 1
+    fi
+
+    echo "Docker Compose launch is still running in background (pid ${launch_pid}); waiting for it to finish..."
+    wait_start=$SECONDS
+    while background_launch_is_running "$launch_pid"; do
+        elapsed=$(( SECONDS - wait_start ))
+        if [ "$elapsed" -ge "$COMPOSE_WAIT_TIMEOUT" ]; then
+            echo "Timed out after ${COMPOSE_WAIT_TIMEOUT}s waiting for background docker compose launch to finish."
+            return 2
+        fi
+
+        if [ $(( elapsed - last_progress_log )) -ge 10 ]; then
+            echo "Waiting for background docker compose launch to finish... (${elapsed}s)"
+            last_progress_log=$elapsed
+        fi
+        sleep 2
+    done
+
+    echo "Background docker compose launch finished after $(( SECONDS - wait_start ))s."
+    clear_background_launch_pid
+    return 0
 }
 
 dedupe_services() {
@@ -161,34 +229,69 @@ run_launch() {
     }
 
     if [ "$background" -eq 1 ]; then
-        launch_runner &
-        echo "Docker Compose launch started in background."
+        local pid_file
+
+        pid_file="$(background_launch_pid_file)"
+        clear_background_launch_pid
+        (
+            printf '%s\n' "$BASHPID" > "$pid_file"
+            trap 'rm -f "$pid_file"' EXIT
+            launch_runner
+        ) &
+        echo "Docker Compose launch started in background (pid $!)."
         return 0
     fi
 
+    clear_background_launch_pid
     launch_runner
 }
 
 run_wait() {
     local core_services=(db redis7 kafka clickhouse)
     local wait_services=("${core_services[@]}" "$@")
-    local current_timeout="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
+    local initial_timeout="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
+    local current_timeout="$initial_timeout"
     local attempt=0
     local missing=()
+    local launch_wait_status
 
     mapfile -t wait_services < <(dedupe_services "${wait_services[@]}")
 
     while true; do
-        if WAIT_FOR_DOCKER_TIMEOUT="$current_timeout" "${SCRIPT_DIR}/wait-for-docker" "${wait_services[@]:4}"; then
-            return 0
+        if wait_for_background_launch; then
+            launch_wait_status=0
+        else
+            launch_wait_status=$?
+        fi
+        if [ "$launch_wait_status" -eq 2 ]; then
+            echo "Proceeding with readiness checks even though the background docker compose launch is still running."
         fi
 
-        if [ "$attempt" -ge "$WAIT_RETRIES" ]; then
-            return 1
+        if WAIT_FOR_DOCKER_TIMEOUT="$current_timeout" "${SCRIPT_DIR}/wait-for-docker" "$@"; then
+            return 0
         fi
 
         mapfile -t missing < <(missing_services "${wait_services[@]}")
         if [ "${#missing[@]}" -eq 0 ] || [ -z "${missing[0]}" ]; then
+            return 1
+        fi
+
+        if wait_for_background_launch; then
+            launch_wait_status=0
+        else
+            launch_wait_status=$?
+        fi
+        if [ "$launch_wait_status" -eq 0 ]; then
+            echo "Background docker compose launch finished after the timeout. Re-running readiness checks before issuing any retry."
+            current_timeout="$initial_timeout"
+            continue
+        fi
+        if [ "$launch_wait_status" -eq 2 ]; then
+            echo "Background docker compose launch is still running. Skipping compose retry to avoid colliding with the in-flight launch."
+            return 1
+        fi
+
+        if [ "$attempt" -ge "$WAIT_RETRIES" ]; then
             return 1
         fi
 

--- a/bin/ci-wait-for-docker
+++ b/bin/ci-wait-for-docker
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI-only helper around Docker Compose startup and readiness checks.
+#
+# `launch` starts services with the current Compose context and returns
+# immediately when `--background` is used so the runner can do other work.
+# `wait` delegates readiness polling to bin/wait-for-docker and retries only
+# when timed-out services never materialized into containers.
+#
+# The workflow must pass the Compose context via standard Docker Compose env
+# such as COMPOSE_FILE, COMPOSE_PROFILES, and any image/tag overrides.
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+DEFAULT_COMPOSE_FILE="${REPO_ROOT}/docker-compose.dev.yml"
+WAIT_RETRIES="${WAIT_FOR_DOCKER_RETRIES:-1}"
+WAIT_RETRY_TIMEOUT="${WAIT_FOR_DOCKER_RETRY_TIMEOUT:-120}"
+LAUNCH_RETRIES="${WAIT_FOR_DOCKER_LAUNCH_RETRIES:-1}"
+LAUNCH_RETRY_DELAY="${WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY:-5}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  bin/ci-wait-for-docker launch [--down|--down-all-profiles] [--background] [services...]
+  bin/ci-wait-for-docker wait [services...]
+
+`wait` is the default command when omitted.
+EOF
+}
+
+compose() {
+    if [ -n "${COMPOSE_FILE:-}" ]; then
+        docker compose "$@"
+    else
+        docker compose -f "$DEFAULT_COMPOSE_FILE" "$@"
+    fi
+}
+
+dedupe_services() {
+    local deduped=()
+    local svc existing already_present
+
+    for svc in "$@"; do
+        already_present=0
+        for existing in "${deduped[@]:-}"; do
+            if [ "$existing" = "$svc" ]; then
+                already_present=1
+                break
+            fi
+        done
+        if [ "$already_present" -eq 0 ]; then
+            deduped+=("$svc")
+        fi
+    done
+
+    printf '%s\n' "${deduped[@]}"
+}
+
+compose_up() {
+    if [ "$#" -eq 0 ]; then
+        compose up -d
+    else
+        compose up -d "$@"
+    fi
+}
+
+missing_services() {
+    local services=("$@")
+    local missing=()
+    local svc
+
+    for svc in "${services[@]}"; do
+        if [ -z "$(compose ps -q "$svc" 2>/dev/null || true)" ]; then
+            missing+=("$svc")
+        fi
+    done
+
+    printf '%s\n' "${missing[@]}"
+}
+
+run_launch_once() {
+    local down_mode="$1"
+    shift
+
+    case "$down_mode" in
+        current)
+            compose down
+            ;;
+        all_profiles)
+            compose --profile '*' down
+            ;;
+        none)
+            ;;
+        *)
+            echo "Unknown down mode: $down_mode" >&2
+            return 2
+            ;;
+    esac
+
+    compose_up "$@"
+}
+
+run_launch() {
+    local down_mode="none"
+    local background=0
+    local launch_services=()
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --down)
+                down_mode="current"
+                ;;
+            --down-all-profiles)
+                down_mode="all_profiles"
+                ;;
+            --background)
+                background=1
+                ;;
+            --help|-h)
+                usage
+                return 0
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                echo "Unknown launch option: $1" >&2
+                return 2
+                ;;
+            *)
+                break
+                ;;
+        esac
+        shift
+    done
+
+    launch_services=("$@")
+
+    launch_runner() {
+        local inner_attempt=1
+        local inner_sleep_time
+
+        while [ "$inner_attempt" -le "$LAUNCH_RETRIES" ]; do
+            if run_launch_once "$down_mode" "${launch_services[@]}"; then
+                echo "Docker Compose launch succeeded"
+                return 0
+            fi
+
+            if [ "$inner_attempt" -ge "$LAUNCH_RETRIES" ]; then
+                echo "Docker Compose launch failed after ${LAUNCH_RETRIES} attempt(s)" >&2
+                return 1
+            fi
+
+            inner_sleep_time=$(( LAUNCH_RETRY_DELAY * 2 ** (inner_attempt - 1) ))
+            echo "Docker Compose launch failed (attempt ${inner_attempt}/${LAUNCH_RETRIES}), retrying in ${inner_sleep_time}s..."
+            sleep "$inner_sleep_time"
+            inner_attempt=$(( inner_attempt + 1 ))
+        done
+    }
+
+    if [ "$background" -eq 1 ]; then
+        launch_runner &
+        echo "Docker Compose launch started in background."
+        return 0
+    fi
+
+    launch_runner
+}
+
+run_wait() {
+    local core_services=(db redis7 kafka clickhouse)
+    local wait_services=("${core_services[@]}" "$@")
+    local current_timeout="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
+    local attempt=0
+    local missing=()
+
+    mapfile -t wait_services < <(dedupe_services "${wait_services[@]}")
+
+    while true; do
+        if WAIT_FOR_DOCKER_TIMEOUT="$current_timeout" "${SCRIPT_DIR}/wait-for-docker" "${wait_services[@]:4}"; then
+            return 0
+        fi
+
+        if [ "$attempt" -ge "$WAIT_RETRIES" ]; then
+            return 1
+        fi
+
+        mapfile -t missing < <(missing_services "${wait_services[@]}")
+        if [ "${#missing[@]}" -eq 0 ] || [ -z "${missing[0]}" ]; then
+            return 1
+        fi
+
+        attempt=$(( attempt + 1 ))
+        echo "Retry ${attempt}/${WAIT_RETRIES}: re-running docker compose up for missing services: ${missing[*]}"
+        if ! compose_up "${missing[@]}"; then
+            echo "Retry ${attempt}/${WAIT_RETRIES} failed while starting: ${missing[*]}"
+        fi
+        current_timeout="$WAIT_RETRY_TIMEOUT"
+    done
+}
+
+command="${1:-wait}"
+case "$command" in
+    launch|wait)
+        shift
+        ;;
+    --help|-h)
+        usage
+        exit 0
+        ;;
+    *)
+        command="wait"
+        ;;
+esac
+
+case "$command" in
+    launch)
+        run_launch "$@"
+        ;;
+    wait)
+        run_wait "$@"
+        ;;
+esac

--- a/bin/wait-for-docker
+++ b/bin/wait-for-docker
@@ -32,8 +32,20 @@ done
 SERVICES=("${unique_services[@]}")
 
 compose() {
+    local compose_files=()
+    local compose_args=()
+    local compose_file
+    local separator
+
     if [ -n "${COMPOSE_FILE:-}" ]; then
-        docker compose "$@"
+        separator="${COMPOSE_PATH_SEPARATOR:-:}"
+        IFS="$separator" read -r -a compose_files <<< "$COMPOSE_FILE"
+        for compose_file in "${compose_files[@]}"; do
+            if [ -n "$compose_file" ]; then
+                compose_args+=(-f "$compose_file")
+            fi
+        done
+        env -u COMPOSE_FILE docker compose "${compose_args[@]}" "$@"
     else
         docker compose -f "$DEFAULT_COMPOSE_FILE" "$@"
     fi

--- a/bin/wait-for-docker
+++ b/bin/wait-for-docker
@@ -8,72 +8,157 @@ set -euo pipefail
 # Always checks core services (db, redis7, kafka, clickhouse).
 # Pass extra service names as arguments, e.g.: bin/wait-for-docker temporal
 
-COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.dev.yml}"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+DEFAULT_COMPOSE_FILE="${REPO_ROOT}/docker-compose.dev.yml"
 TIMEOUT="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
 
 SERVICES=(db redis7 kafka clickhouse)
 SERVICES+=("$@")
 
-# CI workflows launch `docker compose up -d &` so image pulls run in
-# parallel with dependency installs.  If compose is still pulling when we
-# start checking health, the 300 s timeout burns on image downloads
-# instead of actual service startup.  Wait for any running compose
-# process to finish first so the timeout only measures health-check time.
-#
-# Only in CI — locally mprocs keeps a shell wrapper alive whose command
-# string matches "docker compose.*up" long after `up -d` has finished,
-# causing a permanent false positive.
-if [ -n "${CI:-}" ] && pgrep -f "docker compose.*up" >/dev/null 2>&1; then
-    COMPOSE_WAIT_TIMEOUT="${WAIT_FOR_COMPOSE_TIMEOUT:-600}"
-    echo "docker compose is still running (likely pulling images) — waiting for it to finish…"
-    compose_wait_start=$SECONDS
-    while pgrep -f "docker compose.*up" >/dev/null 2>&1; do
-        if [ $(( SECONDS - compose_wait_start )) -ge "$COMPOSE_WAIT_TIMEOUT" ]; then
-            echo "Timed out after ${COMPOSE_WAIT_TIMEOUT}s waiting for docker compose to finish. Proceeding anyway."
+unique_services=()
+for svc in "${SERVICES[@]}"; do
+    already_present=0
+    for existing_svc in "${unique_services[@]:-}"; do
+        if [ "$existing_svc" = "$svc" ]; then
+            already_present=1
             break
         fi
-        sleep 2
     done
-    echo "docker compose wait done after $(( SECONDS - compose_wait_start ))s."
-fi
+    if [ "$already_present" -eq 0 ]; then
+        unique_services+=("$svc")
+    fi
+done
+SERVICES=("${unique_services[@]}")
+
+compose() {
+    if [ -n "${COMPOSE_FILE:-}" ]; then
+        docker compose "$@"
+    else
+        docker compose -f "$DEFAULT_COMPOSE_FILE" "$@"
+    fi
+}
+
+get_container_id() {
+    compose ps -q "$1" 2>/dev/null || true
+}
+
+get_service_state() {
+    local svc="$1"
+    local container_id status
+
+    container_id=$(get_container_id "$svc")
+    if [ -z "$container_id" ]; then
+        echo "missing"
+        return
+    fi
+
+    status=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || echo "unknown")
+    echo "$status $container_id"
+}
+
+service_is_ready() {
+    [ "$1" = "healthy" ] || [ "$1" = "running" ]
+}
+
+print_service_diagnostics() {
+    local svc="$1"
+    local elapsed="$2"
+    local status="$3"
+    local container_id="$4"
+
+    echo ""
+    echo "=========================================="
+    echo "TIMEOUT: ${TIMEOUT}s waiting for $svc"
+    echo "Last observed state after ${elapsed}s: ${status}"
+    echo "=========================================="
+    if [ -z "$container_id" ]; then
+        echo "Container for '$svc' does not exist yet."
+        echo ""
+        echo "docker compose ps $svc:"
+        compose ps "$svc" 2>&1 || true
+    else
+        echo "Container exists (id=${container_id:0:12}) but readiness state is: $status"
+        echo ""
+        echo "Last 20 lines of container logs:"
+        docker logs --tail 20 "$container_id" 2>&1 || true
+        echo ""
+        echo "Health check log:"
+        docker inspect --format='{{if .State.Health}}{{range .State.Health.Log}}{{.Output}}{{end}}{{else}}no health check configured{{end}}' "$container_id" 2>&1 | tail -5 || true
+    fi
+    echo "=========================================="
+}
 
 SECONDS=0
-for svc in "${SERVICES[@]}"; do
-    while true; do
-        if [ "$SECONDS" -ge "$TIMEOUT" ]; then
-            echo ""
-            echo "=========================================="
-            echo "TIMEOUT: ${TIMEOUT}s waiting for $svc"
-            echo "=========================================="
-            container_id=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
-            if [ -z "$container_id" ]; then
-                echo "Container for '$svc' does not exist — docker compose may still be pulling the image."
-                echo ""
-                echo "docker compose ps:"
-                docker compose -f "$COMPOSE_FILE" ps 2>&1 || true
-            else
-                status=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null || echo "unknown")
-                echo "Container exists (id=${container_id:0:12}) but health status is: $status"
-                echo ""
-                echo "Last 20 lines of container logs:"
-                docker logs --tail 20 "$container_id" 2>&1 || true
-                echo ""
-                echo "Health check log:"
-                docker inspect --format='{{range .State.Health.Log}}{{.Output}}{{end}}' "$container_id" 2>&1 | tail -5 || true
-            fi
-            echo "=========================================="
-            exit 1
-        fi
-        container_id=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
-        if [ -n "$container_id" ]; then
-            status=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null || echo "starting")
-            if [ "$status" = "healthy" ]; then
-                break
-            fi
-        fi
-        echo "Waiting for $svc... (${SECONDS}s)"
-        sleep 1
-    done
+last_progress_log=-5
+timed_out_services=()
+timed_out_elapsed=()
+timed_out_statuses=()
+timed_out_container_ids=()
+service_done=()
+
+for idx in "${!SERVICES[@]}"; do
+    service_done[idx]=0
 done
 
-echo "All services healthy in ${SECONDS}s."
+while true; do
+    pending_count=0
+    pending_summary=()
+
+    for idx in "${!SERVICES[@]}"; do
+        if [ "${service_done[idx]}" -eq 1 ]; then
+            continue
+        fi
+
+        svc="${SERVICES[$idx]}"
+        elapsed=$SECONDS
+        service_state=$(get_service_state "$svc")
+        status=${service_state%% *}
+        container_id=""
+        if [ "$service_state" != "$status" ]; then
+            container_id=${service_state#* }
+        fi
+
+        if service_is_ready "$status"; then
+            echo "$svc is ready after ${elapsed}s."
+            service_done[idx]=1
+            continue
+        fi
+
+        if [ "$elapsed" -ge "$TIMEOUT" ]; then
+            timed_out_services+=("$svc")
+            timed_out_elapsed+=("$elapsed")
+            timed_out_statuses+=("$status")
+            timed_out_container_ids+=("$container_id")
+            service_done[idx]=1
+            continue
+        fi
+
+        pending_count=$(( pending_count + 1 ))
+        pending_summary+=("$svc=${status}(${elapsed}s)")
+    done
+
+    if [ "$pending_count" -eq 0 ]; then
+        break
+    fi
+
+    if [ $(( SECONDS - last_progress_log )) -ge 5 ]; then
+        echo "Waiting for: ${pending_summary[*]}"
+        last_progress_log=$SECONDS
+    fi
+
+    sleep 1
+done
+
+if [ "${#timed_out_services[@]}" -gt 0 ]; then
+    for idx in "${!timed_out_services[@]}"; do
+        print_service_diagnostics \
+            "${timed_out_services[$idx]}" \
+            "${timed_out_elapsed[$idx]}" \
+            "${timed_out_statuses[$idx]}" \
+            "${timed_out_container_ids[$idx]}"
+    done
+    exit 1
+fi
+
+echo "All services ready in ${SECONDS}s."

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -645,6 +645,10 @@ tools:
         bin_script: phrocs
         description: Run phrocs directly with a custom mprocs-format YAML config
         hidden: true
+    ci:wait:for:docker:
+        bin_script: ci-wait-for-docker
+        description: Launch Docker Compose services in CI and later wait for readiness
+        hidden: true
 utilities:
     nuke:
         steps:


### PR DESCRIPTION
Summary
- Introduce `bin/ci-wait-for-docker` to centralize Compose launch/wait logic with retries, diagnostics, and background execution so workflows no longer craft their own loops.
- Point workflows at the new helper for starting/stopping services and overhaul the env overrides so each job shares the same Compose context (profiles, registry images, etc.).
- Keep `bin/wait-for-docker` focused on health polling while reusing it from the new script, improving diagnostics when services hang.

Testing
- Not run (not requested)