### PR TITLE
chore(flags): add auth method metrics to local evaluation endpoints

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -74,7 +74,7 @@ from posthog.models.group.group import Group
 from posthog.models.property import Property
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.surveys.survey import Survey
-from posthog.permissions import ProjectSecretAPITokenPermission
+from posthog.permissions import ProjectSecretAPITokenPermission, is_authenticated_via_project_secret_api_token
 from posthog.queries.base import determine_parsed_date_for_property_matching
 from posthog.rate_limit import BurstRateThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
@@ -143,6 +143,12 @@ LOCAL_EVALUATION_ETAG_COUNTER = Counter(
 LOCAL_EVALUATION_SECRET_KEY_IN_BODY_COUNTER = Counter(
     "posthog_local_evaluation_secret_api_key_in_body_total",
     "Local evaluation requests where secret_api_key was passed in request body instead of Authorization header",
+)
+
+LOCAL_EVALUATION_AUTH_COUNTER = Counter(
+    "posthog_local_evaluation_auth_total",
+    "Local evaluation requests by authentication method",
+    labelnames=["method"],  # "secret_api_token" or "personal_api_key"
 )
 
 
@@ -2568,6 +2574,11 @@ class FeatureFlagViewSet(
 
         # Track send_cohorts parameter usage
         LOCAL_EVALUATION_REQUEST_COUNTER.labels(send_cohorts=str(include_cohorts).lower()).inc()
+
+        auth_method = (
+            "secret_api_token" if is_authenticated_via_project_secret_api_token(request) else "personal_api_key"
+        )
+        LOCAL_EVALUATION_AUTH_COUNTER.labels(method=auth_method).inc()
 
         try:
             # Check if team is quota limited for feature flags

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     handler::types::Library,
     metrics::consts::{
-        FLAG_DEFINITIONS_CACHE_HIT_COUNTER, FLAG_DEFINITIONS_CACHE_MISS_COUNTER,
-        FLAG_DEFINITIONS_ETAG_COUNTER,
+        FLAG_DEFINITIONS_AUTH_COUNTER, FLAG_DEFINITIONS_CACHE_HIT_COUNTER,
+        FLAG_DEFINITIONS_CACHE_MISS_COUNTER, FLAG_DEFINITIONS_ETAG_COUNTER,
     },
     router::State as AppState,
     team::team_models::Team,
@@ -351,12 +351,28 @@ async fn authenticate_flag_definitions(
     // Try team secret token first (from Authorization header only)
     // Secret tokens have priority over personal API keys
     if let Some(token) = auth::extract_team_secret_token(headers) {
-        return auth::validate_secret_api_token_for_team(state, &token, team.id).await;
+        let result = auth::validate_secret_api_token_for_team(state, &token, team.id).await;
+        if result.is_ok() {
+            inc(
+                FLAG_DEFINITIONS_AUTH_COUNTER,
+                &[("method".to_string(), "secret_api_token".to_string())],
+                1,
+            );
+        }
+        return result;
     }
 
     // Try personal API key (with scope validation)
     if let Some(key) = auth::extract_personal_api_key(headers)? {
-        return auth::validate_personal_api_key_with_scopes_for_team(state, &key, team).await;
+        let result = auth::validate_personal_api_key_with_scopes_for_team(state, &key, team).await;
+        if result.is_ok() {
+            inc(
+                FLAG_DEFINITIONS_AUTH_COUNTER,
+                &[("method".to_string(), "personal_api_key".to_string())],
+                1,
+            );
+        }
+        return result;
     }
 
     Err(FlagError::NoAuthenticationProvided)

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -78,6 +78,10 @@ pub const FLAG_DEFINITIONS_CACHE_MISS_COUNTER: &str = "flags_flag_definitions_ca
 // Labels: result (hit = 304, miss = 200 with stale etag, none = 200 without etag, redis_error = etag read failed)
 pub const FLAG_DEFINITIONS_ETAG_COUNTER: &str = "flags_flag_definitions_etag_total";
 
+// Flag definitions auth method
+// Labels: method (secret_api_token, personal_api_key)
+pub const FLAG_DEFINITIONS_AUTH_COUNTER: &str = "flags_flag_definitions_auth_total";
+
 // Request-level timeout (tower TimeoutLayer killed the request before completion)
 pub const FLAG_REQUEST_TIMEOUT_COUNTER: &str = "flags_request_timeout_total";
 


### PR DESCRIPTION
## Problem

We want to understand adoption patterns as we migrate authentication methods for local evaluation / flag definitions requests. Currently there is no metric tracking whether a request uses a secret API token vs a personal API key.

## Changes

- **Python (`posthog/api/feature_flag.py`)**: Add `posthog_local_evaluation_auth_total` Prometheus counter with a `method` label (`secret_api_token` or `personal_api_key`), incremented on each `local_evaluation()` request using the existing `is_authenticated_via_project_secret_api_token` helper.
- **Rust (`rust/feature-flags/src/metrics/consts.rs`)**: Add `FLAG_DEFINITIONS_AUTH_COUNTER` constant (`flags_flag_definitions_auth_total`).
- **Rust (`rust/feature-flags/src/api/flag_definitions.rs`)**: Increment the counter after each successful auth path in `authenticate_flag_definitions()`.

## How did you test this code?

- `ruff check` passes with no lint errors
- `cargo check -p feature-flags` compiles successfully
- No behavioral changes — only metric emission added, so existing tests remain valid
- For Rust: `RUST_LOG=info ENABLE_METRICS=true cargo run -p feature-flags` and then `curl http://localhost:3001/metrics`

## Publish to changelog?

Do not publish to changelog.