### PR TITLE
feat(flags): add SADD support to Redis pipeline builder

### DIFF
--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -558,6 +558,9 @@ impl Client for RedisClient {
                 PipelineCommand::Scard { key } => {
                     pipe.cmd("SCARD").arg(key);
                 }
+                PipelineCommand::SAdd { key, member } => {
+                    pipe.cmd("SADD").arg(key).arg(member);
+                }
                 PipelineCommand::ZRangeByScore { key, min, max } => {
                     pipe.cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max);
                 }
@@ -617,7 +620,8 @@ impl RedisClient {
             PipelineCommand::Set { .. }
             | PipelineCommand::SetEx { .. }
             | PipelineCommand::Del { .. }
-            | PipelineCommand::HIncrBy { .. } => Ok(PipelineResult::Ok),
+            | PipelineCommand::HIncrBy { .. }
+            | PipelineCommand::SAdd { .. } => Ok(PipelineResult::Ok),
             PipelineCommand::SetNxEx { .. } => {
                 // SET NX returns OK if set, nil if key existed
                 match raw {

--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -620,8 +620,11 @@ impl RedisClient {
             PipelineCommand::Set { .. }
             | PipelineCommand::SetEx { .. }
             | PipelineCommand::Del { .. }
-            | PipelineCommand::HIncrBy { .. }
-            | PipelineCommand::SAdd { .. } => Ok(PipelineResult::Ok),
+            | PipelineCommand::HIncrBy { .. } => Ok(PipelineResult::Ok),
+            PipelineCommand::SAdd { .. } => {
+                let count: u64 = redis::from_redis_value(&raw)?;
+                Ok(PipelineResult::Count(count))
+            }
             PipelineCommand::SetNxEx { .. } => {
                 // SET NX returns OK if set, nil if key existed
                 match raw {

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -629,7 +629,7 @@ impl MockRedisClient {
             }
             PipelineCommand::SAdd { key, member } => {
                 self.record_call("pipeline_sadd", &key, MockRedisValue::String(member));
-                Self::lookup_or_ok(&self.sadd_ret, &key).map(|_| PipelineResult::Ok)
+                Self::lookup_or_ok(&self.sadd_ret, &key).map(|_| PipelineResult::Count(1))
             }
             PipelineCommand::ZRangeByScore { key, min, max } => {
                 self.record_call(

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -18,6 +18,7 @@ pub struct MockRedisClient {
     del_ret: HashMap<String, Result<(), CustomRedisError>>,
     hget_ret: HashMap<String, Result<String, CustomRedisError>>,
     scard_ret: HashMap<String, Result<u64, CustomRedisError>>,
+    sadd_ret: HashMap<String, Result<(), CustomRedisError>>,
     mget_ret: HashMap<String, Option<Vec<u8>>>,
     mget_error: Option<CustomRedisError>,
     calls: Arc<Mutex<Vec<MockRedisCall>>>,
@@ -37,6 +38,7 @@ impl Default for MockRedisClient {
             del_ret: HashMap::new(),
             hget_ret: HashMap::new(),
             scard_ret: HashMap::new(),
+            sadd_ret: HashMap::new(),
             mget_ret: HashMap::new(),
             mget_error: None,
             calls: Arc::new(Mutex::new(Vec::new())),
@@ -122,6 +124,11 @@ impl MockRedisClient {
 
     pub fn scard_ret(&mut self, key: &str, ret: Result<u64, CustomRedisError>) -> Self {
         self.scard_ret.insert(key.to_owned(), ret);
+        self.clone()
+    }
+
+    pub fn sadd_ret(&mut self, key: &str, ret: Result<(), CustomRedisError>) -> Self {
+        self.sadd_ret.insert(key.to_owned(), ret);
         self.clone()
     }
 
@@ -619,6 +626,10 @@ impl MockRedisClient {
             PipelineCommand::Scard { key } => {
                 self.record_call("pipeline_scard", &key, MockRedisValue::None);
                 Self::lookup_or_not_found(&self.scard_ret, &key).map(PipelineResult::Count)
+            }
+            PipelineCommand::SAdd { key, member } => {
+                self.record_call("pipeline_sadd", &key, MockRedisValue::String(member));
+                Self::lookup_or_ok(&self.sadd_ret, &key).map(|_| PipelineResult::Ok)
             }
             PipelineCommand::ZRangeByScore { key, min, max } => {
                 self.record_call(

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -27,7 +27,7 @@ use crate::{Client, CustomRedisError, RedisValueFormat};
 /// Each variant corresponds to the return type of a Redis command.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PipelineResult {
-    /// Success with no return value (SET, DEL, HINCRBY, etc.)
+    /// Success — return value intentionally discarded (SET, DEL, HINCRBY, SADD, etc.)
     Ok,
     /// String value (GET)
     String(String),
@@ -82,6 +82,10 @@ pub enum PipelineCommand {
     },
     Scard {
         key: String,
+    },
+    SAdd {
+        key: String,
+        member: String,
     },
     ZRangeByScore {
         key: String,
@@ -236,6 +240,15 @@ impl<C> Pipeline<C> {
         self
     }
 
+    /// Add an SADD command to the pipeline.
+    pub fn sadd(mut self, key: impl Into<String>, member: impl Into<String>) -> Self {
+        self.commands.push(PipelineCommand::SAdd {
+            key: key.into(),
+            member: member.into(),
+        });
+        self
+    }
+
     /// Add a ZRANGEBYSCORE command to the pipeline.
     pub fn zrangebyscore(
         mut self,
@@ -345,9 +358,10 @@ mod tests {
             .hget("k11", "f11")
             .hincrby("k12", "f12", 5)
             .scard("k13")
-            .zrangebyscore("k14", "0", "100");
+            .sadd("k14", "m14")
+            .zrangebyscore("k15", "0", "100");
 
-        assert_eq!(pipeline.len(), 14);
+        assert_eq!(pipeline.len(), 15);
     }
 
     #[test]
@@ -461,19 +475,21 @@ mod integration_tests {
             .del("del_key")
             .set_nx_ex("nx_key", "value", 60)
             .scard("scard_key")
+            .sadd("sadd_key", "member1")
             .zrangebyscore("zset_key", "0", "100")
             .execute()
             .await
             .unwrap();
 
-        assert_eq!(results.len(), 6);
+        assert_eq!(results.len(), 7);
         assert!(matches!(&results[0], Ok(PipelineResult::String(s)) if s == "string_value"));
         assert!(matches!(results[1], Ok(PipelineResult::Ok)));
         assert!(matches!(results[2], Ok(PipelineResult::Ok)));
         assert!(matches!(results[3], Ok(PipelineResult::Bool(true))));
         assert!(matches!(results[4], Ok(PipelineResult::Count(42))));
+        assert!(matches!(results[5], Ok(PipelineResult::Ok))); // SADD
         assert!(
-            matches!(&results[5], Ok(PipelineResult::Strings(v)) if v == &vec!["a".to_string(), "b".to_string()])
+            matches!(&results[6], Ok(PipelineResult::Strings(v)) if v == &vec!["a".to_string(), "b".to_string()])
         );
     }
 }

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -487,7 +487,7 @@ mod integration_tests {
         assert!(matches!(results[2], Ok(PipelineResult::Ok)));
         assert!(matches!(results[3], Ok(PipelineResult::Bool(true))));
         assert!(matches!(results[4], Ok(PipelineResult::Count(42))));
-        assert!(matches!(results[5], Ok(PipelineResult::Ok))); // SADD
+        assert!(matches!(results[5], Ok(PipelineResult::Count(_)))); // SADD
         assert!(
             matches!(&results[6], Ok(PipelineResult::Strings(v)) if v == &vec!["a".to_string(), "b".to_string()])
         );


### PR DESCRIPTION
## Problem

The Redis pipeline builder supports various commands (GET, SET, DEL, SCARD, ZRANGEBYSCORE, etc.) but is missing SADD, which is needed for adding members to Redis sets via pipelines.

## Changes

- Add `SAdd` variant to `PipelineCommand` enum and `PipelineResult::Ok` mapping
- Add `sadd()` builder method on `Pipeline`
- Add SADD execution in `RedisClient` and mock client
- Update pipeline length test and mock integration test to cover SADD

## How did you test this code?

- Unit test verifying pipeline length includes the new SADD command
- Integration test (`mock_pipeline_executes_all_commands`) verifying SADD returns `PipelineResult::Ok`

## Publish to changelog?

No