### PR TITLE
fix: remove 'Marketing settings' from submenu

### DIFF
--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -278,13 +278,6 @@
         { "path": "SQL variables", "category": "Schema", "iconType": null, "type": null, "intents": [] },
         { "path": "Annotations", "category": "Metadata", "iconType": "annotation", "type": null, "intents": [] },
         { "path": "Comments", "category": "Metadata", "iconType": "comment", "type": null, "intents": [] },
-        { "path": "Revenue definitions", "category": "Schema", "iconType": null, "type": null, "intents": [] },
-        {
-            "path": "Marketing settings",
-            "category": "Unreleased",
-            "iconType": "marketing_settings",
-            "type": null,
-            "intents": []
-        }
+        { "path": "Revenue definitions", "category": "Schema", "iconType": null, "type": null, "intents": [] }
     ]
 }

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1729,15 +1729,6 @@ export const getTreeItemsMetadata = (): FileSystemImport[] => [
         sceneKeys: ['DataWarehouse', 'Models', 'SQLEditor'],
     },
     {
-        path: 'Marketing settings',
-        category: 'Unreleased',
-        iconType: 'marketing_settings',
-        href: urls.marketingAnalytics(),
-        flag: FEATURE_FLAGS.WEB_ANALYTICS_MARKETING,
-        sceneKey: 'WebAnalyticsMarketing',
-        sceneKeys: ['WebAnalyticsMarketing'],
-    },
-    {
         path: 'Models',
         category: 'Tools',
         type: 'sql',

--- a/products/web_analytics/manifest.tsx
+++ b/products/web_analytics/manifest.tsx
@@ -1,4 +1,3 @@
-import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
 import { ProductKey } from '~/queries/schema/schema-general'
@@ -28,15 +27,5 @@ export const manifest: ProductManifest = {
             sceneKeys: ['WebAnalytics'],
         },
     ],
-    treeItemsMetadata: [
-        {
-            path: 'Marketing settings',
-            category: 'Unreleased',
-            iconType: 'marketing_settings',
-            href: urls.marketingAnalytics(),
-            flag: FEATURE_FLAGS.WEB_ANALYTICS_MARKETING,
-            sceneKey: 'WebAnalyticsMarketing',
-            sceneKeys: ['WebAnalyticsMarketing'],
-        },
-    ],
+    treeItemsMetadata: [],
 }


### PR DESCRIPTION
## Problem

Marketing settings already exist in the settings page..

## Changes

Fix it

Not appearing anymore here: 
<img width="412" height="151" alt="image" src="https://github.com/user-attachments/assets/bc47dadf-d795-45f3-b6b1-8ab5bd5221e7" />


