### PR TITLE
fix: dashboard saving

### DIFF
--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -434,26 +434,12 @@ export function SceneName({
         'text-lg font-semibold my-0 pl-[var(--button-padding-x-sm)] min-h-[var(--button-height-sm)] leading-[1.4] select-auto'
 
     const debouncedOnBlurSave = useDebouncedCallback((value: string) => {
-        if (onChange) {
-            onChange(value)
-        }
+        onChange?.(value)
     }, renameDebounceMs)
 
     const debouncedOnChange = useDebouncedCallback((value: string) => {
-        if (onChange) {
-            onChange(value)
-        }
+        onChange?.(value)
     }, renameDebounceMs)
-
-    // Cancel any pending debounced saves when leaving forceEdit (e.g. Cancel in edit mode).
-    // Without this, a keystroke's debouncedOnChange could fire after Cancel and route to
-    // updateDashboard because dashboardMode is already null.
-    useEffect(() => {
-        if (!forceEdit) {
-            debouncedOnBlurSave.cancel()
-            debouncedOnChange.cancel()
-        }
-    }, [forceEdit]) // eslint-disable-line react-hooks/exhaustive-deps -- stable refs from useDebouncedCallback
 
     useEffect(() => {
         if (!isLoading && forceEdit) {
@@ -464,7 +450,6 @@ export function SceneName({
     }, [isLoading, forceEdit])
 
     const handleBlur = (e: React.FocusEvent): void => {
-        // Check if focus is moving to an element within our container (like the generate button)
         const relatedTarget = e.relatedTarget as HTMLElement | null
         if (relatedTarget && containerRef.current && containerRef.current.contains(relatedTarget)) {
             return
@@ -490,8 +475,9 @@ export function SceneName({
                             value={name || ''}
                             onChange={(e) => {
                                 setName(e.target.value)
-                                if (!saveOnBlur || forceEdit) {
-                                    // Call onChange immediately if not using saveOnBlur, or if in forceEdit mode
+                                if (forceEdit) {
+                                    onChange?.(e.target.value)
+                                } else if (!saveOnBlur) {
                                     debouncedOnChange(e.target.value)
                                 }
                             }}
@@ -623,23 +609,12 @@ function SceneDescription({
     const emptyText = canEdit ? 'Enter description (optional)' : 'No description'
 
     const debouncedOnBlurSaveDescription = useDebouncedCallback((value: string) => {
-        if (onChange) {
-            onChange(value)
-        }
+        onChange?.(value)
     }, renameDebounceMs)
 
     const debouncedOnDescriptionChange = useDebouncedCallback((value: string) => {
-        if (onChange) {
-            onChange(value)
-        }
+        onChange?.(value)
     }, renameDebounceMs)
-
-    useEffect(() => {
-        if (!forceEdit) {
-            debouncedOnBlurSaveDescription.cancel()
-            debouncedOnDescriptionChange.cancel()
-        }
-    }, [forceEdit]) // eslint-disable-line react-hooks/exhaustive-deps -- stable refs from useDebouncedCallback
 
     useEffect(() => {
         if (!isLoading && forceEdit) {
@@ -669,8 +644,9 @@ function SceneDescription({
                         maxLength={maxLength}
                         onChange={(e) => {
                             setDescription(e.target.value)
-                            if (!saveOnBlur || forceEdit) {
-                                // Call onChange immediately if not using saveOnBlur, or if in forceEdit mode
+                            if (forceEdit) {
+                                onChange?.(e.target.value)
+                            } else if (!saveOnBlur) {
                                 debouncedOnDescriptionChange(e.target.value)
                             }
                         }}

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -433,14 +433,6 @@ export function SceneName({
     const textClasses =
         'text-lg font-semibold my-0 pl-[var(--button-padding-x-sm)] min-h-[var(--button-height-sm)] leading-[1.4] select-auto'
 
-    const debouncedOnBlurSave = useDebouncedCallback((value: string) => {
-        onChange?.(value)
-    }, renameDebounceMs)
-
-    const debouncedOnChange = useDebouncedCallback((value: string) => {
-        onChange?.(value)
-    }, renameDebounceMs)
-
     useEffect(() => {
         if (!isLoading && forceEdit) {
             setIsEditing(true)
@@ -448,6 +440,14 @@ export function SceneName({
             setIsEditing(false)
         }
     }, [isLoading, forceEdit])
+
+    const debouncedOnBlurSave = useDebouncedCallback((value: string) => {
+        onChange?.(value)
+    }, renameDebounceMs)
+
+    const debouncedOnChange = useDebouncedCallback((value: string) => {
+        onChange?.(value)
+    }, renameDebounceMs)
 
     const handleBlur = (e: React.FocusEvent): void => {
         const relatedTarget = e.relatedTarget as HTMLElement | null
@@ -608,14 +608,6 @@ function SceneDescription({
 
     const emptyText = canEdit ? 'Enter description (optional)' : 'No description'
 
-    const debouncedOnBlurSaveDescription = useDebouncedCallback((value: string) => {
-        onChange?.(value)
-    }, renameDebounceMs)
-
-    const debouncedOnDescriptionChange = useDebouncedCallback((value: string) => {
-        onChange?.(value)
-    }, renameDebounceMs)
-
     useEffect(() => {
         if (!isLoading && forceEdit) {
             setIsEditing(true)
@@ -623,6 +615,14 @@ function SceneDescription({
             setIsEditing(false)
         }
     }, [isLoading, forceEdit])
+
+    const debouncedOnBlurSaveDescription = useDebouncedCallback((value: string) => {
+        onChange?.(value)
+    }, renameDebounceMs)
+
+    const debouncedOnDescriptionChange = useDebouncedCallback((value: string) => {
+        onChange?.(value)
+    }, renameDebounceMs)
 
     const handleBlur = (): void => {
         if (saveOnBlur && !forceEdit && description !== initialDescription) {

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -421,25 +421,17 @@ export function SceneName({
     suffix,
 }: SceneNameProps): JSX.Element {
     const [name, setName] = useState(initialName)
+    const [prevInitialName, setPrevInitialName] = useState(initialName)
+    if (initialName !== prevInitialName) {
+        setPrevInitialName(initialName)
+        setName(initialName)
+    }
+
     const [isEditing, setIsEditing] = useState(forceEdit)
     const containerRef = useRef<HTMLDivElement>(null)
 
     const textClasses =
         'text-lg font-semibold my-0 pl-[var(--button-padding-x-sm)] min-h-[var(--button-height-sm)] leading-[1.4] select-auto'
-
-    useEffect(() => {
-        if (!isLoading) {
-            setName(initialName)
-        }
-    }, [initialName, isLoading])
-
-    useEffect(() => {
-        if (!isLoading && forceEdit) {
-            setIsEditing(true)
-        } else {
-            setIsEditing(false)
-        }
-    }, [isLoading, forceEdit])
 
     const debouncedOnBlurSave = useDebouncedCallback((value: string) => {
         if (onChange) {
@@ -453,13 +445,31 @@ export function SceneName({
         }
     }, renameDebounceMs)
 
+    // Cancel any pending debounced saves when leaving forceEdit (e.g. Cancel in edit mode).
+    // Without this, a keystroke's debouncedOnChange could fire after Cancel and route to
+    // updateDashboard because dashboardMode is already null.
+    useEffect(() => {
+        if (!forceEdit) {
+            debouncedOnBlurSave.cancel()
+            debouncedOnChange.cancel()
+        }
+    }, [forceEdit]) // eslint-disable-line react-hooks/exhaustive-deps -- stable refs from useDebouncedCallback
+
+    useEffect(() => {
+        if (!isLoading && forceEdit) {
+            setIsEditing(true)
+        } else {
+            setIsEditing(false)
+        }
+    }, [isLoading, forceEdit])
+
     const handleBlur = (e: React.FocusEvent): void => {
         // Check if focus is moving to an element within our container (like the generate button)
         const relatedTarget = e.relatedTarget as HTMLElement | null
         if (relatedTarget && containerRef.current && containerRef.current.contains(relatedTarget)) {
             return
         }
-        if (saveOnBlur && name !== initialName) {
+        if (saveOnBlur && !forceEdit && name !== initialName) {
             debouncedOnBlurSave(name || '')
         }
         if (!forceEdit) {
@@ -600,25 +610,17 @@ function SceneDescription({
     maxLength,
 }: SceneDescriptionProps): JSX.Element | null {
     const [description, setDescription] = useState(initialDescription)
+    const [prevInitialDescription, setPrevInitialDescription] = useState(initialDescription)
+    if (initialDescription !== prevInitialDescription) {
+        setPrevInitialDescription(initialDescription)
+        setDescription(initialDescription)
+    }
+
     const [isEditing, setIsEditing] = useState(forceEdit)
 
     const textClasses = 'text-sm my-0 select-auto'
 
     const emptyText = canEdit ? 'Enter description (optional)' : 'No description'
-
-    useEffect(() => {
-        if (!isLoading) {
-            setDescription(initialDescription)
-        }
-    }, [initialDescription, isLoading])
-
-    useEffect(() => {
-        if (!isLoading && forceEdit) {
-            setIsEditing(true)
-        } else {
-            setIsEditing(false)
-        }
-    }, [isLoading, forceEdit])
 
     const debouncedOnBlurSaveDescription = useDebouncedCallback((value: string) => {
         if (onChange) {
@@ -632,8 +634,23 @@ function SceneDescription({
         }
     }, renameDebounceMs)
 
+    useEffect(() => {
+        if (!forceEdit) {
+            debouncedOnBlurSaveDescription.cancel()
+            debouncedOnDescriptionChange.cancel()
+        }
+    }, [forceEdit]) // eslint-disable-line react-hooks/exhaustive-deps -- stable refs from useDebouncedCallback
+
+    useEffect(() => {
+        if (!isLoading && forceEdit) {
+            setIsEditing(true)
+        } else {
+            setIsEditing(false)
+        }
+    }, [isLoading, forceEdit])
+
     const handleBlur = (): void => {
-        if (saveOnBlur && description !== initialDescription) {
+        if (saveOnBlur && !forceEdit && description !== initialDescription) {
             debouncedOnBlurSaveDescription(description || '')
         }
         if (!forceEdit) {

--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -138,54 +138,12 @@ describe('DashboardHeader', () => {
         logic.unmount()
     })
 
-    it('new dashboard gets forceEdit on SceneTitleSection', () => {
-        const dashboard = makeDashboard({
-            name: 'New Dashboard',
-            tiles: [
-                {
-                    id: 1,
-                    layouts: {},
-                    color: null,
-                    insight: {
-                        id: 10,
-                        short_id: 'xyz',
-                        name: 'Some insight',
-                        query: { kind: 'TrendsQuery', series: [] },
-                    },
-                },
-            ],
-        })
+    it('forceEdit is only active in edit mode, not for new dashboards', () => {
+        const dashboard = makeDashboard({ name: 'New Dashboard' })
         const { logic } = renderHeader({ dashboard })
 
+        // Without edit mode, even a "new" dashboard should not have forceEdit
         const textarea = document.querySelector('[data-attr="scene-title-textarea"]')
-        expect(textarea).toBeInTheDocument()
-
-        logic.unmount()
-    })
-
-    it('existing dashboard does not get forceEdit on SceneTitleSection', () => {
-        const dashboard = makeDashboard({
-            name: 'My Custom Dashboard',
-            created_at: '2020-01-01T00:00:00Z',
-            tiles: [
-                {
-                    id: 1,
-                    layouts: {},
-                    color: null,
-                    insight: {
-                        id: 10,
-                        short_id: 'xyz',
-                        name: 'Some insight',
-                        query: { kind: 'TrendsQuery', series: [] },
-                    },
-                },
-            ],
-        })
-        const { logic } = renderHeader({ dashboard })
-
-        const textarea = document.querySelector('[data-attr="scene-title-textarea"]')
-        // SceneTitleSection should not be in forceEdit for old dashboards —
-        // it renders but the textarea won't be auto-focused/editable
         expect(textarea).not.toBeInTheDocument()
 
         logic.unmount()

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -19,8 +19,9 @@ export const DASHBOARD_CANNOT_EDIT_MESSAGE =
     "You don't have edit permissions for this dashboard. Ask a dashboard collaborator with edit access to add you."
 
 export function DashboardHeader(): JSX.Element | null {
-    const { dashboard, dashboardLoading, dashboardMode, canEditDashboard, isNewDashboard } = useValues(dashboardLogic)
-    const { setDashboardMode, loadDashboard } = useActions(dashboardLogic)
+    const { dashboard, dashboardLoading, dashboardMode, canEditDashboard, pendingName, pendingDescription } =
+        useValues(dashboardLogic)
+    const { setDashboardMode, loadDashboard, setPendingName, setPendingDescription } = useActions(dashboardLogic)
     const { updateDashboard } = useActions(dashboardsModel)
 
     if (!dashboard && !dashboardLoading) {
@@ -38,20 +39,31 @@ export function DashboardHeader(): JSX.Element | null {
             <DashboardScenePanel />
 
             <SceneTitleSection
-                name={dashboard?.name}
-                description={dashboard?.description}
+                name={pendingName ?? dashboard?.name}
+                description={pendingDescription ?? dashboard?.description}
                 resourceType={{
                     type: sceneConfigurations[Scene.Dashboard].iconType || 'default_icon_type',
                 }}
-                onNameChange={(value) => updateDashboard({ id: dashboard?.id, name: value, allowUndo: true })}
-                onDescriptionChange={(value) =>
-                    updateDashboard({ id: dashboard?.id, description: value, allowUndo: true })
-                }
+                onNameChange={(value) => {
+                    if (dashboardMode === DashboardMode.Edit) {
+                        setPendingName(value)
+                    } else {
+                        updateDashboard({ id: dashboard?.id, name: value, allowUndo: true })
+                    }
+                }}
+                onDescriptionChange={(value) => {
+                    if (dashboardMode === DashboardMode.Edit) {
+                        setPendingDescription(value)
+                    } else {
+                        updateDashboard({ id: dashboard?.id, description: value, allowUndo: true })
+                    }
+                }}
                 markdown
                 canEdit={canEditDashboard}
                 isLoading={dashboardLoading}
-                forceEdit={dashboardMode === DashboardMode.Edit || isNewDashboard}
-                renameDebounceMs={1000}
+                forceEdit={dashboardMode === DashboardMode.Edit}
+                saveOnBlur
+                renameDebounceMs={0}
                 maxToolProps={
                     dashboard && canEditDashboard
                         ? {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -257,6 +257,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setSubscriptionMode: (enabled: boolean, id?: number | 'new') => ({ enabled, id }),
         /** Set the dashboard mode, see DashboardMode for details. */
         setDashboardMode: (mode: DashboardMode | null, source: DashboardEventSource | null) => ({ mode, source }),
+        /** Pending name/description during edit mode — only persisted on save, cleared on cancel. */
+        setPendingName: (name: string) => ({ name }),
+        setPendingDescription: (description: string) => ({ description }),
+        clearPendingMetadata: true,
         /** Optimistic pin/unpin toggle. */
         togglePinned: true,
         /** Open/close the Terraform export modal. */
@@ -397,6 +401,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         const dashboard: DashboardType<InsightModel> = await api.update(
                             `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
                             {
+                                ...(values.pendingName !== null ? { name: values.pendingName } : {}),
+                                ...(values.pendingDescription !== null
+                                    ? { description: values.pendingDescription }
+                                    : {}),
                                 filters: values.effectiveEditBarFilters,
                                 variables: values.effectiveDashboardVariableOverrides,
                                 breakdown_colors: values.temporaryBreakdownColors,
@@ -776,6 +784,24 @@ export const dashboardLogic = kea<dashboardLogicType>([
             null as DashboardMode | null,
             {
                 setDashboardMode: (_, { mode }) => mode,
+            },
+        ],
+        pendingName: [
+            null as string | null,
+            {
+                setPendingName: (_, { name }) => name,
+                clearPendingMetadata: () => null,
+                // Clear once the single save PATCH confirms — avoids flicker where
+                // display briefly shows the old dashboard.name before the response
+                saveEditModeChangesSuccess: () => null,
+            },
+        ],
+        pendingDescription: [
+            null as string | null,
+            {
+                setPendingDescription: (_, { description }) => description,
+                clearPendingMetadata: () => null,
+                saveEditModeChangesSuccess: () => null,
             },
         ],
         loadLayoutFromServerOnPreview: [
@@ -1901,12 +1927,20 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 eventUsageLogic.actions.reportDashboardPropertiesChanged(values.dashboard)
             }
         },
+        saveEditModeChangesSuccess: ({ dashboard }) => {
+            if (dashboard) {
+                // Sync the saved dashboard (including any name/description changes) to
+                // dashboardsModel so the sidebar and other global views stay up to date
+                dashboardsModel.actions.updateDashboardSuccess(dashboard)
+            }
+        },
         setDashboardMode: async ({ mode, source }) => {
             if (mode === DashboardMode.Edit && source !== DashboardEventSource.DashboardHeaderDiscardChanges) {
                 clearDOMTextSelection()
                 lemonToast.info('Now editing the dashboard – press E or click Save to persist changes')
             } else if (source === DashboardEventSource.DashboardHeaderDiscardChanges) {
-                // cancel edit mode changesdashboardLogi
+                // cancel edit mode changes — discard pending name/description without saving
+                actions.clearPendingMetadata()
 
                 // reset filters to that before previewing
                 actions.resetIntermittentFilters()
@@ -1938,6 +1972,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     source === DashboardEventSource.SceneCommonButtons)
             ) {
                 // save edit mode changes when exiting via Save button or E key/Edit layout button
+                // Pending name/description are included in the saveEditModeChanges PATCH
+                // to avoid a race between two concurrent PATCHes to the same endpoint.
                 actions.saveEditModeChanges()
             }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -876,13 +876,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
 
-        dashboardLoadedAt: [
-            null as number | null,
-            {
-                loadDashboardSuccess: () => Date.now(),
-            },
-        ],
-
         lastDashboardRefresh: [
             null as Dayjs | null,
             {
@@ -1314,23 +1307,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                           AccessControlLevel.Editor
                       )
                     : false
-            },
-        ],
-        isNewDashboard: [
-            (s) => [s.dashboard, s.dashboardLoading, s.dashboardLoadedAt],
-            (dashboard, dashboardLoading, dashboardLoadedAt): boolean => {
-                if (!dashboard || dashboardLoading) {
-                    return false
-                }
-                const isRecentlyCreated =
-                    dashboardLoadedAt != null && dashboardLoadedAt - new Date(dashboard.created_at).getTime() < 30000
-                return (
-                    Boolean(dashboard._highlight) ||
-                    dashboard.name === 'New Dashboard' ||
-                    isRecentlyCreated ||
-                    !dashboard.tiles ||
-                    dashboard.tiles.length === 0
-                )
             },
         ],
         canRestrictDashboard: [

--- a/playwright/page-models/dashboardPage.ts
+++ b/playwright/page-models/dashboardPage.ts
@@ -36,7 +36,9 @@ export class DashboardPage {
 
         if (dashboardName) {
             const textarea = this.page.locator('.scene-title-section textarea')
-            await textarea.or(this.page.locator('.scene-title-section')).first().click()
+            // Click the title button to enter edit mode (textarea is not auto-shown)
+            await this.page.locator('.scene-title-section').getByRole('button').first().click()
+            await expect(textarea).toBeVisible()
             await textarea.fill(dashboardName)
         }
 

--- a/playwright/page-models/dashboardPage.ts
+++ b/playwright/page-models/dashboardPage.ts
@@ -35,11 +35,17 @@ export class DashboardPage {
         await this.dismissQuickStartIfVisible()
 
         if (dashboardName) {
-            const textarea = this.page.locator('.scene-title-section textarea')
-            // Click the title to enter edit mode (textarea is not auto-shown)
-            await this.page.locator('[data-attr="scene-name"]').click()
-            await expect(textarea).toBeVisible()
+            const nameButton = this.page.locator('[data-attr="scene-name"] button').first()
+            const textarea = this.page.locator('[data-attr="scene-title-textarea"]')
+            // Click the title button to enter edit mode, retrying if loading resets the state
+            await expect(async () => {
+                if (!(await textarea.isVisible().catch(() => false))) {
+                    await nameButton.click()
+                }
+                await expect(textarea).toBeVisible({ timeout: 3000 })
+            }).toPass({ timeout: 30000 })
             await textarea.fill(dashboardName)
+            await textarea.blur()
         }
 
         return this

--- a/playwright/page-models/dashboardPage.ts
+++ b/playwright/page-models/dashboardPage.ts
@@ -36,8 +36,8 @@ export class DashboardPage {
 
         if (dashboardName) {
             const textarea = this.page.locator('.scene-title-section textarea')
-            // Click the title button to enter edit mode (textarea is not auto-shown)
-            await this.page.locator('.scene-title-section').getByRole('button').first().click()
+            // Click the title to enter edit mode (textarea is not auto-shown)
+            await this.page.locator('[data-attr="scene-name"]').click()
             await expect(textarea).toBeVisible()
             await textarea.fill(dashboardName)
         }


### PR DESCRIPTION
## Problem
Dashboard name and description debouncing behavior is confusing

## Changes
Fix edit mode. In edit mode, make cancel restore the old name and description. Only save them on "save"

Outside of edit mode, get rid of the auto-save. Only save on blur.

## How did you test this code?
Tested on local