### PR TITLE
Prompts compare endpoint

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -16,6 +16,9 @@ from rest_framework.serializers import BaseSerializer
 
 from posthog.api.capture import capture_internal
 from posthog.api.llm_prompt_serializers import (
+    LLMPromptCompareQuerySerializer,
+    LLMPromptCompareResponseSerializer,
+    LLMPromptCompareVersionSerializer,
     LLMPromptFetchQuerySerializer,
     LLMPromptListQuerySerializer,
     LLMPromptPublicSerializer,
@@ -32,6 +35,7 @@ from posthog.api.services.llm_prompt import (
     LLMPromptVersionConflictError,
     LLMPromptVersionLimitError,
     archive_prompt,
+    compare_prompt_versions,
     get_active_prompt_queryset,
     get_latest_prompts_queryset,
     get_prompt_by_name_from_db,
@@ -109,7 +113,7 @@ class LLMPromptViewSet(
     def get_throttles(self):
         if self.action == "update_by_name":
             return [LLMPromptPublishBurstRateThrottle(), BurstRateThrottle(), SustainedRateThrottle()]
-        if self.action in ["get_by_name", "resolve_by_name"]:
+        if self.action in ["get_by_name", "resolve_by_name", "compare"]:
             return [BurstRateThrottle(), SustainedRateThrottle()]
 
         return super().get_throttles()
@@ -330,6 +334,44 @@ class LLMPromptViewSet(
                 "prompt": self._serialize_prompt(prompt),
                 "versions": self._serialize_version_summaries(versions),
                 "has_more": has_more,
+            }
+        )
+
+    @extend_schema(
+        parameters=[LLMPromptCompareQuerySerializer],
+        responses={200: LLMPromptCompareResponseSerializer},
+    )
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"compare/name/(?P<prompt_name>[^/]+)",
+        required_scopes=["llm_prompt:read"],
+    )
+    @llma_track_latency("llma_prompts_compare")
+    @monitor(feature=None, endpoint="llma_prompts_compare", method="GET")
+    def compare(self, request: Request, prompt_name: str = "", **kwargs) -> Response:
+        query_serializer = LLMPromptCompareQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        params = query_serializer.validated_data
+
+        try:
+            result = compare_prompt_versions(
+                self.team,
+                prompt_name,
+                version_from=params["version_from"],
+                version_to=params["version_to"],
+            )
+        except LLMPromptNotFoundError:
+            return self._prompt_not_found_response(prompt_name)
+
+        return Response(
+            {
+                "prompt_name": prompt_name,
+                "version_from": LLMPromptCompareVersionSerializer(result.version_from).data,
+                "version_to": LLMPromptCompareVersionSerializer(result.version_to).data,
+                "diff": result.diff,
+                "additions": result.additions,
+                "deletions": result.deletions,
             }
         )
 

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -350,6 +350,10 @@ class LLMPromptViewSet(
     @llma_track_latency("llma_prompts_compare")
     @monitor(feature=None, endpoint="llma_prompts_compare", method="GET")
     def compare(self, request: Request, prompt_name: str = "", **kwargs) -> Response:
+        auth_error = self._ensure_web_authenticated(request)
+        if auth_error is not None:
+            return auth_error
+
         query_serializer = LLMPromptCompareQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
         params = query_serializer.validated_data

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -221,3 +221,37 @@ class LLMPromptResolveResponseSerializer(serializers.Serializer):
     prompt = LLMPromptSerializer()
     versions = LLMPromptVersionSummarySerializer(many=True)
     has_more = serializers.BooleanField()
+
+
+class LLMPromptCompareQuerySerializer(serializers.Serializer):
+    version_from = serializers.IntegerField(
+        min_value=1,
+        help_text="Version number to compare from (the baseline).",
+    )
+    version_to = serializers.IntegerField(
+        min_value=1,
+        help_text="Version number to compare to (the target).",
+    )
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs["version_from"] == attrs["version_to"]:
+            raise serializers.ValidationError("version_from and version_to must be different.")
+        return attrs
+
+
+class LLMPromptCompareVersionSerializer(serializers.Serializer):
+    id = serializers.UUIDField(help_text="Unique identifier for this prompt version.")
+    version = serializers.IntegerField(help_text="Version number.")
+    prompt = serializers.JSONField(help_text="Full prompt content for this version.")
+    created_by = UserBasicSerializer(read_only=True)
+    created_at = serializers.DateTimeField(help_text="When this version was created.")
+    is_latest = serializers.BooleanField(help_text="Whether this is the latest active version.")
+
+
+class LLMPromptCompareResponseSerializer(serializers.Serializer):
+    prompt_name = serializers.CharField(help_text="Name of the prompt being compared.")
+    version_from = LLMPromptCompareVersionSerializer(help_text="The baseline version details.")
+    version_to = LLMPromptCompareVersionSerializer(help_text="The target version details.")
+    diff = serializers.CharField(help_text="Unified diff between the two prompt versions.")
+    additions = serializers.IntegerField(help_text="Number of lines added.")
+    deletions = serializers.IntegerField(help_text="Number of lines removed.")

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -174,8 +174,8 @@ def compare_prompt_versions(
 
     diff_lines = list(
         difflib.unified_diff(
-            text_from.splitlines(keepends=True),
-            text_to.splitlines(keepends=True),
+            text_from.splitlines(),
+            text_to.splitlines(),
             fromfile=f"v{version_from}",
             tofile=f"v{version_to}",
             lineterm="",
@@ -183,8 +183,11 @@ def compare_prompt_versions(
     )
     diff_text = "\n".join(diff_lines)
 
-    additions = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
-    deletions = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+    # Skip the two header lines (--- fromfile / +++ tofile) so we don't
+    # mis-count content that happens to start with those prefixes.
+    change_lines = diff_lines[2:] if len(diff_lines) >= 2 else []
+    additions = sum(1 for line in change_lines if line.startswith("+"))
+    deletions = sum(1 for line in change_lines if line.startswith("-"))
 
     return PromptCompareResult(
         version_from=prompt_from,

--- a/posthog/api/services/llm_prompt.py
+++ b/posthog/api/services/llm_prompt.py
@@ -1,3 +1,5 @@
+import json
+import difflib
 from dataclasses import dataclass
 from typing import Any
 
@@ -132,6 +134,65 @@ def publish_prompt_version(
             .first()
         )
         return fallback_prompt if fallback_prompt is not None else published_prompt
+
+
+def _prompt_to_text(prompt_payload: Any) -> str:
+    """Normalize a prompt payload to a text representation for diffing."""
+    if isinstance(prompt_payload, str):
+        return prompt_payload
+    return json.dumps(prompt_payload, indent=2, ensure_ascii=False)
+
+
+@dataclass
+class PromptCompareResult:
+    version_from: LLMPrompt
+    version_to: LLMPrompt
+    diff: str
+    additions: int
+    deletions: int
+
+
+def compare_prompt_versions(
+    team: Team,
+    prompt_name: str,
+    *,
+    version_from: int,
+    version_to: int,
+) -> PromptCompareResult:
+    queryset = LLMPrompt.objects.filter(team=team, name=prompt_name, deleted=False).select_related("created_by")
+
+    prompt_from = queryset.filter(version=version_from).first()
+    if prompt_from is None:
+        raise LLMPromptNotFoundError()
+
+    prompt_to = queryset.filter(version=version_to).first()
+    if prompt_to is None:
+        raise LLMPromptNotFoundError()
+
+    text_from = _prompt_to_text(prompt_from.prompt)
+    text_to = _prompt_to_text(prompt_to.prompt)
+
+    diff_lines = list(
+        difflib.unified_diff(
+            text_from.splitlines(keepends=True),
+            text_to.splitlines(keepends=True),
+            fromfile=f"v{version_from}",
+            tofile=f"v{version_to}",
+            lineterm="",
+        )
+    )
+    diff_text = "\n".join(diff_lines)
+
+    additions = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+    deletions = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+
+    return PromptCompareResult(
+        version_from=prompt_from,
+        version_to=prompt_to,
+        diff=diff_text,
+        additions=additions,
+        deletions=deletions,
+    )
 
 
 def archive_prompt(team: Team, prompt_name: str) -> list[int]:

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -652,39 +652,26 @@ class TestLLMPromptAPI(APIBaseTest):
         assert data["additions"] == 0
         assert data["deletions"] == 0
 
-    def test_compare_rejects_same_version_numbers(self, mock_feature_enabled):
-        self.create_prompt_version(name="test-prompt", version=1, is_latest=True)
+    @parameterized.expand(
+        [
+            ("same_versions", "test-prompt", 1, "version_from=1&version_to=1", status.HTTP_400_BAD_REQUEST),
+            ("nonexistent_prompt", None, None, "version_from=1&version_to=2", status.HTTP_404_NOT_FOUND),
+            ("nonexistent_version", "test-prompt", 1, "version_from=1&version_to=99", status.HTTP_404_NOT_FOUND),
+            ("missing_version_to", "test-prompt", 1, "version_from=1", status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_compare_error_cases(
+        self, mock_feature_enabled, _name, seed_name, seed_version, query_string, expected_status
+    ):
+        if seed_name is not None and seed_version is not None:
+            self.create_prompt_version(name=seed_name, version=seed_version, is_latest=True)
+        prompt_name = seed_name or "nonexistent"
 
         response = self.client.get(
-            f"/api/environments/{self.team.id}/llm_prompts/compare/name/test-prompt/?version_from=1&version_to=1"
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/{prompt_name}/?{query_string}"
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_compare_returns_404_for_nonexistent_prompt(self, mock_feature_enabled):
-        response = self.client.get(
-            f"/api/environments/{self.team.id}/llm_prompts/compare/name/nonexistent/?version_from=1&version_to=2"
-        )
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_compare_returns_404_for_nonexistent_version(self, mock_feature_enabled):
-        self.create_prompt_version(name="test-prompt", version=1, is_latest=True)
-
-        response = self.client.get(
-            f"/api/environments/{self.team.id}/llm_prompts/compare/name/test-prompt/?version_from=1&version_to=99"
-        )
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_compare_requires_both_version_params(self, mock_feature_enabled):
-        self.create_prompt_version(name="test-prompt", version=1, is_latest=True)
-
-        response = self.client.get(
-            f"/api/environments/{self.team.id}/llm_prompts/compare/name/test-prompt/?version_from=1"
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == expected_status
 
     def test_compare_supports_reverse_version_order(self, mock_feature_enabled):
         self.create_prompt_version(name="diff-prompt", version=1, is_latest=False, prompt="Version one")

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -597,6 +597,127 @@ class TestLLMPromptAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    def test_compare_returns_diff_between_string_versions(self, mock_feature_enabled):
+        self.create_prompt_version(name="diff-prompt", version=1, is_latest=False, prompt="Hello world")
+        self.create_prompt_version(name="diff-prompt", version=2, is_latest=True, prompt="Hello PostHog")
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/diff-prompt/?version_from=1&version_to=2"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["prompt_name"] == "diff-prompt"
+        assert data["version_from"]["version"] == 1
+        assert data["version_to"]["version"] == 2
+        assert "-Hello world" in data["diff"]
+        assert "+Hello PostHog" in data["diff"]
+        assert data["additions"] == 1
+        assert data["deletions"] == 1
+
+    def test_compare_returns_diff_between_json_versions(self, mock_feature_enabled):
+        self.create_prompt_version(
+            name="json-prompt",
+            version=1,
+            is_latest=False,
+            prompt={"role": "system", "content": "You are helpful."},
+        )
+        self.create_prompt_version(
+            name="json-prompt",
+            version=2,
+            is_latest=True,
+            prompt={"role": "system", "content": "You are very helpful.", "temperature": 0.7},
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/json-prompt/?version_from=1&version_to=2"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["additions"] > 0 or data["deletions"] > 0
+        assert "diff" in data
+
+    def test_compare_returns_empty_diff_for_identical_content_different_versions(self, mock_feature_enabled):
+        self.create_prompt_version(name="same-prompt", version=1, is_latest=False, prompt="Same content")
+        self.create_prompt_version(name="same-prompt", version=2, is_latest=True, prompt="Same content")
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/same-prompt/?version_from=1&version_to=2"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["diff"] == ""
+        assert data["additions"] == 0
+        assert data["deletions"] == 0
+
+    def test_compare_rejects_same_version_numbers(self, mock_feature_enabled):
+        self.create_prompt_version(name="test-prompt", version=1, is_latest=True)
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/test-prompt/?version_from=1&version_to=1"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_compare_returns_404_for_nonexistent_prompt(self, mock_feature_enabled):
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/nonexistent/?version_from=1&version_to=2"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_compare_returns_404_for_nonexistent_version(self, mock_feature_enabled):
+        self.create_prompt_version(name="test-prompt", version=1, is_latest=True)
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/test-prompt/?version_from=1&version_to=99"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_compare_requires_both_version_params(self, mock_feature_enabled):
+        self.create_prompt_version(name="test-prompt", version=1, is_latest=True)
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/test-prompt/?version_from=1"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_compare_supports_reverse_version_order(self, mock_feature_enabled):
+        self.create_prompt_version(name="diff-prompt", version=1, is_latest=False, prompt="Version one")
+        self.create_prompt_version(name="diff-prompt", version=2, is_latest=True, prompt="Version two")
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/diff-prompt/?version_from=2&version_to=1"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["version_from"]["version"] == 2
+        assert data["version_to"]["version"] == 1
+
+    def test_compare_includes_version_metadata(self, mock_feature_enabled):
+        self.create_prompt_version(name="meta-prompt", version=1, is_latest=False, prompt="v1")
+        self.create_prompt_version(name="meta-prompt", version=2, is_latest=True, prompt="v2")
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/llm_prompts/compare/name/meta-prompt/?version_from=1&version_to=2"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "id" in data["version_from"]
+        assert "created_at" in data["version_from"]
+        assert "created_by" in data["version_from"]
+        assert "prompt" in data["version_from"]
+        assert "id" in data["version_to"]
+        assert "created_at" in data["version_to"]
+        assert "created_by" in data["version_to"]
+        assert "prompt" in data["version_to"]
+
     def test_get_by_name_patch_uses_write_scope(self, mock_feature_enabled):
         request = APIRequestFactory().patch("/api/environments/1/llm_prompts/name/example/")
         view = LLMPromptViewSet()

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -677,6 +677,35 @@ export interface PaginatedLLMPromptListApi {
     results: LLMPromptApi[]
 }
 
+export interface LLMPromptCompareVersionApi {
+    /** Unique identifier for this prompt version. */
+    id: string
+    /** Version number. */
+    version: number
+    /** Full prompt content for this version. */
+    prompt: unknown
+    readonly created_by: UserBasicApi
+    /** When this version was created. */
+    created_at: string
+    /** Whether this is the latest active version. */
+    is_latest: boolean
+}
+
+export interface LLMPromptCompareResponseApi {
+    /** Name of the prompt being compared. */
+    prompt_name: string
+    /** The baseline version details. */
+    version_from: LLMPromptCompareVersionApi
+    /** The target version details. */
+    version_to: LLMPromptCompareVersionApi
+    /** Unified diff between the two prompt versions. */
+    diff: string
+    /** Number of lines added. */
+    additions: number
+    /** Number of lines removed. */
+    deletions: number
+}
+
 export interface LLMPromptPublicApi {
     id: string
     name: string
@@ -916,6 +945,19 @@ export type LlmPromptsListParams = {
      * Optional substring filter applied to prompt names and prompt content.
      */
     search?: string
+}
+
+export type LlmPromptsCompareNameRetrieveParams = {
+    /**
+     * Version number to compare from (the baseline).
+     * @minimum 1
+     */
+    version_from: number
+    /**
+     * Version number to compare to (the target).
+     * @minimum 1
+     */
+    version_to: number
 }
 
 export type LlmPromptsNameRetrieveParams = {

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -22,11 +22,13 @@ import type {
     EvaluationSummaryResponseApi,
     EvaluationsListParams,
     LLMPromptApi,
+    LLMPromptCompareResponseApi,
     LLMPromptPublicApi,
     LLMPromptResolveResponseApi,
     LLMProviderKeyApi,
     LlmAnalyticsClusteringJobsListParams,
     LlmAnalyticsProviderKeysListParams,
+    LlmPromptsCompareNameRetrieveParams,
     LlmPromptsListParams,
     LlmPromptsNameRetrieveParams,
     LlmPromptsResolveNameRetrieveParams,
@@ -767,6 +769,38 @@ export const llmPromptsCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(lLMPromptApi),
+    })
+}
+
+export const getLlmPromptsCompareNameRetrieveUrl = (
+    projectId: string,
+    promptName: string,
+    params: LlmPromptsCompareNameRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/environments/${projectId}/llm_prompts/compare/name/${promptName}/?${stringifiedParams}`
+        : `/api/environments/${projectId}/llm_prompts/compare/name/${promptName}/`
+}
+
+export const llmPromptsCompareNameRetrieve = async (
+    projectId: string,
+    promptName: string,
+    params: LlmPromptsCompareNameRetrieveParams,
+    options?: RequestInit
+): Promise<LLMPromptCompareResponseApi> => {
+    return apiMutator<LLMPromptCompareResponseApi>(getLlmPromptsCompareNameRetrieveUrl(projectId, promptName, params), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/llm_analytics/mcp/prompts.yaml
+++ b/products/llm_analytics/mcp/prompts.yaml
@@ -66,3 +66,17 @@ tools:
         title: Update prompt
         description: >
             Publish a new version of an existing LLM prompt by name. Name is immutable after creation.
+    prompt-compare:
+        operation: llm_prompts_compare_name_retrieve
+        enabled: true
+        scopes:
+            - llm_prompt:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Compare prompt versions
+        description: >
+            Compare two versions of an LLM prompt by name. Returns a unified diff between the two versions
+            along with version metadata and addition/deletion counts. Useful for reviewing what changed
+            between prompt iterations.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -269,6 +269,21 @@
             "readOnlyHint": false
         }
     },
+    "prompt-compare": {
+        "description": "Compare two versions of an LLM prompt by name. Returns a unified diff between the two versions along with version metadata and addition/deletion counts. Useful for reviewing what changed between prompt iterations.",
+        "category": "Prompts",
+        "feature": "prompts",
+        "summary": "Compare prompt versions",
+        "title": "Compare prompt versions",
+        "required_scopes": ["llm_prompt:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "workflows-list": {
         "description": "List all workflows in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
         "category": "Workflows",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1182,6 +1182,21 @@
             "readOnlyHint": false
         }
     },
+    "prompt-compare": {
+        "description": "Compare two versions of an LLM prompt by name. Returns a unified diff between the two versions along with version metadata and addition/deletion counts. Useful for reviewing what changed between prompt iterations.",
+        "category": "Prompts",
+        "feature": "prompts",
+        "summary": "Compare prompt versions",
+        "title": "Compare prompt versions",
+        "required_scopes": ["llm_prompt:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "workflows-list": {
         "description": "List all workflows in the project. Returns workflows with their name, description, status (draft/active/archived), version, trigger configuration, and timestamps.",
         "category": "Workflows",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16051,6 +16051,35 @@ export namespace Schemas {
       readonly first_version_created_at: string;
     }
 
+    export interface LLMPromptCompareVersion {
+      /** Unique identifier for this prompt version. */
+      id: string;
+      /** Version number. */
+      version: number;
+      /** Full prompt content for this version. */
+      prompt: unknown;
+      readonly created_by: UserBasic;
+      /** When this version was created. */
+      created_at: string;
+      /** Whether this is the latest active version. */
+      is_latest: boolean;
+    }
+
+    export interface LLMPromptCompareResponse {
+      /** Name of the prompt being compared. */
+      prompt_name: string;
+      /** The baseline version details. */
+      version_from: LLMPromptCompareVersion;
+      /** The target version details. */
+      version_to: LLMPromptCompareVersion;
+      /** Unified diff between the two prompt versions. */
+      diff: string;
+      /** Number of lines added. */
+      additions: number;
+      /** Number of lines removed. */
+      deletions: number;
+    }
+
     export interface LLMPromptPublic {
       id: string;
       name: string;
@@ -27836,6 +27865,19 @@ export namespace Schemas {
      * Optional substring filter applied to prompt names and prompt content.
      */
     search?: string;
+    };
+
+    export type LlmPromptsCompareNameRetrieveParams = {
+    /**
+     * Version number to compare from (the baseline).
+     * @minimum 1
+     */
+    version_from: number;
+    /**
+     * Version number to compare to (the target).
+     * @minimum 1
+     */
+    version_to: number;
     };
 
     export type LlmPromptsNameRetrieveParams = {

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    LlmPromptsCompareNameRetrieveParams,
+    LlmPromptsCompareNameRetrieveQueryParams,
     LlmPromptsCreateBody,
     LlmPromptsListQueryParams,
     LlmPromptsNamePartialUpdateBody,
@@ -98,9 +100,31 @@ const promptUpdate = (): ToolBase<typeof PromptUpdateSchema, Schemas.LLMPrompt> 
     },
 })
 
+const PromptCompareSchema = LlmPromptsCompareNameRetrieveParams.omit({ project_id: true }).extend(
+    LlmPromptsCompareNameRetrieveQueryParams.shape
+)
+
+const promptCompare = (): ToolBase<typeof PromptCompareSchema, Schemas.LLMPromptCompareResponse> => ({
+    name: 'prompt-compare',
+    schema: PromptCompareSchema,
+    handler: async (context: Context, params: z.infer<typeof PromptCompareSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.LLMPromptCompareResponse>({
+            method: 'GET',
+            path: `/api/environments/${projectId}/llm_prompts/compare/name/${params.prompt_name}/`,
+            query: {
+                version_from: params.version_from,
+                version_to: params.version_to,
+            },
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'prompt-list': promptList,
     'prompt-get': promptGet,
     'prompt-create': promptCreate,
     'prompt-update': promptUpdate,
+    'prompt-compare': promptCompare,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users managing LLM prompts need a way to compare different versions of a prompt to understand changes over time. This endpoint provides a diff functionality, which can be exposed via the PostHog MCP, enabling agents to easily track and review prompt evolution.

## Changes

This PR introduces a new endpoint to compare two versions of an LLM prompt:

**`GET /api/environments/{project_id}/llm_prompts/compare/name/{prompt_name}/?version_from=1&version_to=2`**

This endpoint returns a unified diff between the specified prompt versions, along with full metadata for both versions.

Key changes include:
*   A new service function `compare_prompt_versions` in `posthog/api/services/llm_prompt.py` to handle the diff logic (including pretty-printing JSON prompts for readable diffs).
*   New serializers (`LLMPromptCompareQuerySerializer`, `LLMPromptCompareVersionSerializer`, `LLMPromptCompareResponseSerializer`) for request and response handling.
*   A `compare` action added to the `LLMPromptViewSet` in `posthog/api/llm_prompt.py`, with `@extend_schema` annotations for OpenAPI generation.
*   A new `prompt-compare` MCP tool definition in `products/llm_analytics/mcp/prompts.yaml`.

## How did you test this code?

Automated tests have been added in `posthog/api/test/test_llm_prompt.py`, covering 9 test cases for the compare endpoint. These tests validate:
*   String and JSON prompt diffs.
*   Comparison of identical content.
*   Handling of missing prompt names or versions (404s).
*   Validation of query parameters.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Yes

<div><a href="https://cursor.com/agents/bc-c3b0fc82-e93b-417e-8e52-4b5d39751090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3b0fc82-e93b-417e-8e52-4b5d39751090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->