### PR TITLE
chore: rename Twig to PostHog Code in settings UI

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -330,7 +330,8 @@ export const SETTINGS_MAP: SettingSection[] = [
     {
         level: 'environment',
         id: 'environment-twig',
-        title: 'Twig',
+        title: 'PostHog Code',
+        group: 'AI',
         flag: 'TASKS',
         settings: [
             {

--- a/frontend/src/scenes/settings/environment/TwigSlackIntegration.tsx
+++ b/frontend/src/scenes/settings/environment/TwigSlackIntegration.tsx
@@ -11,7 +11,7 @@ export function TwigSlackIntegration(): JSX.Element {
 
     return (
         <div>
-            <p>Connect Slack to Twig to kick off tasks like pull requests directly from Slack.</p>
+            <p>Connect Slack to PostHog Code to kick off tasks like pull requests directly from Slack.</p>
 
             <div className="deprecated-space-y-2">
                 {twigSlackIntegrations?.map((integration) => (
@@ -31,7 +31,7 @@ export function TwigSlackIntegration(): JSX.Element {
                         </Link>
                     ) : (
                         <p className="text-secondary">
-                            The Twig Slack integration is not configured for this instance.
+                            The PostHog Code Slack integration is not configured for this instance.
                         </p>
                     )}
                 </div>


### PR DESCRIPTION
## Problem

The "Twig" product has been rebranded to "PostHog Code". We need to update the UI labels and descriptions to reflect this new name across the settings interface.

## Changes

- Updated the Slack integration description from "Connect Slack to Twig" to "Connect Slack to PostHog Code"
- Updated the integration configuration message from "The Twig Slack integration" to "The PostHog Code Slack integration"
- Renamed the settings section title from "Twig" to "PostHog Code"
- Added "AI" group classification to the PostHog Code settings section

## How did you test this code?

This is a straightforward UI text update with no functional logic changes. The modifications are purely cosmetic label updates in the settings interface. No automated tests are required as this involves only string constants and configuration metadata.

## Publish to changelog?

no

https://claude.ai/code/session_01ArHG917gS2Sobs6Qaj2gPq