### PR TITLE
feat(analytics-platform): Wire up analytics props for async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ __pycache__/
 .posthog/
 .postgres-backups/
 .python-version
-.scratch/
 .temporal-worker-settings
 .turbo
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 .posthog/
 .postgres-backups/
 .python-version
+.scratch/
 .temporal-worker-settings
 .turbo
 .venv

--- a/ee/hogai/chat_agent/memory/nodes.py
+++ b/ee/hogai/chat_agent/memory/nodes.py
@@ -30,7 +30,7 @@ from posthog.schema import (
     QueryStatusResponse,
 )
 
-from posthog.event_usage import report_user_action
+from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.sync import database_sync_to_async
@@ -105,7 +105,10 @@ class MemoryInitializerContextMixin(AssistantContextMixin):
             runner = EventTaxonomyQueryRunner(
                 team=self._team, query=EventTaxonomyQuery(event=event, properties=[property])
             )
-            return runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
+            return runner.run(
+                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                analytics_props={"source": EventSource.POSTHOG_AI},
+            )
 
         return await database_sync_to_async(run_query, thread_sensitive=False)()
 

--- a/ee/hogai/chat_agent/query_planner/toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/toolkit.py
@@ -15,6 +15,7 @@ from posthog.schema import (
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES
 
 from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
@@ -208,7 +209,10 @@ class TaxonomyAgentToolkit:
             verbose_name = f"action with ID {event_name_or_action_id}"
         runner = EventTaxonomyQueryRunner(query, self._team)
         with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
-            response = runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
+            response = runner.run(
+                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                analytics_props={"source": EventSource.POSTHOG_AI},
+            )
         return response, verbose_name
 
     def retrieve_event_or_action_properties(self, event_name_or_action_id: str | int) -> str:
@@ -365,7 +369,8 @@ class TaxonomyAgentToolkit:
 
         with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
             response = ActorsPropertyTaxonomyQueryRunner(query, self._team).run(
-                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
+                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                analytics_props={"source": EventSource.POSTHOG_AI},
             )
 
         if not isinstance(response, CachedActorsPropertyTaxonomyQueryResponse):

--- a/ee/hogai/chat_agent/rag/nodes.py
+++ b/ee/hogai/chat_agent/rag/nodes.py
@@ -13,7 +13,7 @@ from prometheus_client import Histogram
 from posthog.schema import CachedVectorSearchQueryResponse, MaxActionContext, TeamTaxonomyQuery, VectorSearchQuery
 
 from posthog.clickhouse.query_tagging import Product, tags_context
-from posthog.event_usage import report_user_action
+from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
 from posthog.hogql_queries.ai.vector_search_query_runner import (
     LATEST_ACTIONS_EMBEDDING_VERSION,
@@ -125,7 +125,10 @@ class InsightRagContextNode(AssistantNode):
                     query=VectorSearchQuery(embedding=embedding, embeddingVersion=LATEST_ACTIONS_EMBEDDING_VERSION),
                 )
                 with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
-                    response = runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
+                    response = runner.run(
+                        ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+                        analytics_props={"source": EventSource.POSTHOG_AI},
+                    )
                 if isinstance(response, CachedVectorSearchQueryResponse) and response.results:
                     ids = list({row.id for row in response.results} | set(ids))
                     distances = [row.distance for row in response.results]
@@ -170,7 +173,8 @@ class InsightRagContextNode(AssistantNode):
         This will slightly reduce latency.
         """
         TeamTaxonomyQueryRunner(TeamTaxonomyQuery(), self._team).run(
-            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+            analytics_props={"source": EventSource.POSTHOG_AI},
         )
 
     def _report_metrics(self, config: RunnableConfig, distances: list[float]):

--- a/ee/hogai/chat_agent/rag/test/test_nodes.py
+++ b/ee/hogai/chat_agent/rag/test/test_nodes.py
@@ -1,5 +1,5 @@
 from posthog.test.base import BaseTest, ClickhouseTestMixin
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from django.utils import timezone
 
@@ -67,7 +67,9 @@ class TestInsightRagContextNode(ClickhouseTestMixin, BaseTest):
         assert args[1] == team
 
         # Check run was called with the correct execution mode
-        mock_runner_instance.run.assert_called_once_with(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
+        mock_runner_instance.run.assert_called_once_with(
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE, analytics_props=ANY
+        )
 
     def test_injects_action(self, cohere_mock, embed_mock):
         retriever = InsightRagContextNode(team=self.team, user=self.user)

--- a/ee/hogai/chat_agent/taxonomy/toolkit.py
+++ b/ee/hogai/chat_agent/taxonomy/toolkit.py
@@ -24,6 +24,7 @@ from posthog.schema import (
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES
 
 from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
@@ -234,7 +235,10 @@ class TaxonomyAgentToolkit:
         runner = EventTaxonomyQueryRunner(query, self._team)
         with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
             # Use cache-first execution mode for optimal performance
-            response = runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
+            response = runner.run(
+                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                analytics_props={"source": EventSource.POSTHOG_AI},
+            )
         return response, verbose_name
 
     def _format_properties(self, props: list[tuple[str, str | None, str | None]]) -> str:
@@ -621,7 +625,8 @@ class TaxonomyAgentToolkit:
     ) -> CachedActorsPropertyTaxonomyQueryResponse | CacheMissResponse | QueryStatusResponse:
         with tags_context(product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id):
             return ActorsPropertyTaxonomyQueryRunner(query, self._team).run(
-                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
+                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                analytics_props={"source": EventSource.POSTHOG_AI},
             )
 
     @database_sync_to_async(thread_sensitive=False)

--- a/ee/hogai/llm_traces_summaries/tools/find_similar_traces.py
+++ b/ee/hogai/llm_traces_summaries/tools/find_similar_traces.py
@@ -12,6 +12,7 @@ from posthog.schema import (
     OrderDirection,
 )
 
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.document_embeddings_query_runner import DocumentEmbeddingsQueryRunner
 from posthog.models.team.team import Team
 
@@ -66,7 +67,7 @@ class LLMTracesSummarizerFinder:
             ),
         )
         runner = DocumentEmbeddingsQueryRunner(query=similarity_query, team=self._team)
-        response = runner.run()
+        response = runner.run(analytics_props={"source": EventSource.POSTHOG_AI})
         if not isinstance(response, CachedDocumentSimilarityQueryResponse):
             raise ValueError(
                 f'Failed to get similarity results for query "{query}" ({request_id}) '

--- a/ee/hogai/llm_traces_summaries/tools/get_traces.py
+++ b/ee/hogai/llm_traces_summaries/tools/get_traces.py
@@ -1,5 +1,6 @@
 from posthog.schema import CachedTracesQueryResponse, DateRange, HogQLPropertyFilter, QueryLogTags, TracesQuery
 
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.traces_query_runner import TracesQueryRunner
 from posthog.models.team.team import Team
 
@@ -13,7 +14,7 @@ class LLMTracesSummarizerCollector:
     def get_db_traces_per_page(self, offset: int, date_range: DateRange) -> CachedTracesQueryResponse:
         query = self._get_traces_query(offset=offset, date_range=date_range, limit=self._traces_per_page)
         runner = TracesQueryRunner(query=query, team=self._team)
-        response = runner.run()
+        response = runner.run(analytics_props={"source": EventSource.POSTHOG_AI})
         if not isinstance(response, CachedTracesQueryResponse):
             raise ValueError(f"Failed to get result for the previous day when summarizing LLM traces: {response}")
         return response

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -36,6 +36,7 @@ from posthog.schema import (
     TrendsQuery,
 )
 
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team
@@ -158,7 +159,8 @@ def _process_events_data(
     """Common logic for processing events and building event data."""
     query = TeamTaxonomyQuery(limit=limit, offset=offset)
     response = TeamTaxonomyQueryRunner(query, team).run(
-        ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
+        ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+        analytics_props={"source": EventSource.POSTHOG_AI},
     )
 
     if not isinstance(response, CachedTeamTaxonomyQueryResponse):

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -2,7 +2,7 @@ import datetime
 import xml.etree.ElementTree as ET
 
 from posthog.test.base import BaseTest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from posthog.schema import CachedTeamTaxonomyQueryResponse, MaxEventContext, TeamTaxonomyItem, TeamTaxonomyQuery
 
@@ -403,5 +403,6 @@ class TestFormatEventsPrompt(BaseTest):
         # Verify TeamTaxonomyQueryRunner was called correctly
         mock_runner_class.assert_called_once_with(TeamTaxonomyQuery(), self.team)
         mock_runner_class.return_value.run.assert_called_once_with(
-            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+            analytics_props=ANY,
         )

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -12,6 +12,7 @@ from prometheus_client import Histogram
 from temporalio import activity, workflow
 from temporalio.common import MetricCounter, MetricHistogramTimedelta, MetricMeter
 
+from posthog.event_usage import EventSource
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -219,8 +220,9 @@ async def generate_assets_async(
             cancellation_events[asset.id] = cancellation_event
 
             try:
+                source = EventSource.SUBSCRIPTION if isinstance(resource, Subscription) else None
                 await database_sync_to_async(exporter.export_asset_direct, thread_sensitive=False)(
-                    asset, cancellation_event=cancellation_event
+                    asset, cancellation_event=cancellation_event, source=source
                 )
 
                 logger.info(

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -191,7 +191,10 @@ class AlertSerializer(serializers.ModelSerializer):
                 user=user, alert_configuration=instance, created_by=self.context["request"].user
             )
 
-        instance.report_created(self.context["request"].user, get_request_analytics_properties(self.context["request"]))
+        instance.report_created(
+            self.context["request"].user,
+            analytics_props=get_request_analytics_properties(self.context["request"]),
+        )
         return instance
 
     def update(self, instance, validated_data):
@@ -256,7 +259,10 @@ class AlertSerializer(serializers.ModelSerializer):
             instance.mark_for_recheck(reset_state=conditions_or_threshold_changed)
 
         instance = super().update(instance, validated_data)
-        instance.report_updated(self.context["request"].user, get_request_analytics_properties(self.context["request"]))
+        instance.report_updated(
+            self.context["request"].user,
+            analytics_props=get_request_analytics_properties(self.context["request"]),
+        )
         return instance
 
     def validate_snoozed_until(self, value):

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -41,7 +41,7 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSet
 from posthog.api.utils import action
 from posthog.clickhouse.client.async_task_chain import task_chain_context
 from posthog.constants import GENERATED_DASHBOARD_PREFIX
-from posthog.event_usage import report_user_action
+from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.helpers import create_dashboard_from_template
 from posthog.helpers.dashboard_templates import create_from_template
 from posthog.hogql_queries.query_runner import ExecutionMode
@@ -875,6 +875,7 @@ class DashboardsViewSet(
         """
         results = {}
         tiles = dashboard.tiles.filter(insight__isnull=False).select_related("insight")
+        analytics_props = get_request_analytics_properties(request)
 
         for tile in tiles:
             insight = tile.insight
@@ -893,7 +894,7 @@ class DashboardsViewSet(
                     query,
                     execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                     user=request.user if request.user.is_authenticated else None,
-                    request=request,
+                    analytics_props=analytics_props,
                 )
 
                 result_data = None

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -33,6 +33,7 @@ from posthog.api.utils import action
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.clickhouse.client import query_with_columns
 from posthog.clickhouse.client.limit import get_events_list_rate_limiter
+from posthog.event_usage import get_request_analytics_properties
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Element, Filter, Person, PropertyDefinition
 from posthog.models.event.query_event_list import query_events_list
@@ -526,7 +527,7 @@ class EventViewSet(
                 if force_refresh
                 else ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
             )
-            result = runner.run(execution_mode)
+            result = runner.run(execution_mode, analytics_props=get_request_analytics_properties(self.request))
             assert isinstance(result, (PropertyValuesQueryResponse, CachedPropertyValuesQueryResponse))
             is_refreshing = (
                 isinstance(result, CachedPropertyValuesQueryResponse)

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -520,7 +520,6 @@ class EventViewSet(
                     search_value=query_params.value,
                     event_names=query_params.event_names or None,
                 ),
-                request=self.request,
             )
             execution_mode = (
                 ExecutionMode.CALCULATE_BLOCKING_ALWAYS

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1178,7 +1178,11 @@ class FeatureFlagSerializer(
         analytics_metadata = instance.get_analytics_metadata()
         analytics_metadata["creation_context"] = creation_context
         report_user_action(
-            request.user, "feature flag created", analytics_metadata, team=instance.team, request=request
+            request.user,
+            "feature flag created",
+            analytics_metadata,
+            team=instance.team,
+            request=request,
         )
 
         return instance

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1544,7 +1544,10 @@ When set, the specified dashboard's filters and date range override will be appl
         query_runner = get_query_runner(query, team, limit_context=None)
 
         # we use the legacy caching mechanism (@cached_by_filters decorator), no need to cache in the query runner
-        result = query_runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+        result = query_runner.run(
+            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+            analytics_props=get_request_analytics_properties(request),
+        )
         assert (
             isinstance(result, schema.CachedTrendsQueryResponse)
             or isinstance(result, schema.CachedStickinessQueryResponse)
@@ -1609,7 +1612,10 @@ When set, the specified dashboard's filters and date range override will be appl
         query_runner = get_query_runner(query, team, limit_context=None)
 
         # we use the legacy caching mechanism (@cached_by_filters decorator), no need to cache in the query runner
-        result = query_runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+        result = query_runner.run(
+            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+            analytics_props=get_request_analytics_properties(request),
+        )
         assert isinstance(result, schema.CachedFunnelsQueryResponse)
 
         return {"result": result.results, "timezone": team.timezone}

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -56,7 +56,7 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.constants import INSIGHT, INSIGHT_FUNNELS, INSIGHT_STICKINESS, TRENDS_STICKINESS, FunnelVizType
 from posthog.decorators import cached_by_filters
 from posthog.errors import ExposedCHQueryError
-from posthog.event_usage import report_user_action
+from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.helpers.multi_property_breakdown import protect_old_clients_from_multi_property_default
 from posthog.hogql_queries.apply_dashboard_filters import (
     WRAPPER_NODE_KINDS,
@@ -864,6 +864,7 @@ class InsightSerializer(InsightBasicSerializer):
                     filters_override=filters_override,
                     variables_override=variables_override,
                     tile_filters_override=tile_filters_override,
+                    analytics_props=get_request_analytics_properties(self.context["request"]),
                 )
             except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
                 raise ValidationError(str(e), getattr(e, "code_name", None))
@@ -1371,7 +1372,7 @@ When set, the specified dashboard's filters and date range override will be appl
                 query,
                 execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                 user=request.user if request.user.is_authenticated else None,
-                request=request,
+                analytics_props=get_request_analytics_properties(request),
             )
             if isinstance(result_ctx, BaseModel):
                 result = result_ctx.model_dump()
@@ -1415,7 +1416,7 @@ When set, the specified dashboard's filters and date range override will be appl
                 query,
                 execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
                 user=request.user if request.user.is_authenticated else None,
-                request=request,
+                analytics_props=get_request_analytics_properties(request),
             )
             if isinstance(result_ctx, BaseModel):
                 result = result_ctx.model_dump()

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1541,7 +1541,7 @@ When set, the specified dashboard's filters and date range override will be appl
         filter = Filter(request=request, team=team)
         query = filter_to_query(filter.to_dict()).model_dump()
         query = upgrade(query)  # should not be necessary, but just in case
-        query_runner = get_query_runner(query, team, limit_context=None, request=request)
+        query_runner = get_query_runner(query, team, limit_context=None)
 
         # we use the legacy caching mechanism (@cached_by_filters decorator), no need to cache in the query runner
         result = query_runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
@@ -1606,7 +1606,7 @@ When set, the specified dashboard's filters and date range override will be appl
         filter = filter.shallow_clone(overrides={"insight": "FUNNELS"})
         query = filter_to_query(filter.to_dict()).model_dump()
         query = upgrade(query)  # should not be necessary, but just in case
-        query_runner = get_query_runner(query, team, limit_context=None, request=request)
+        query_runner = get_query_runner(query, team, limit_context=None)
 
         # we use the legacy caching mechanism (@cached_by_filters decorator), no need to cache in the query runner
         result = query_runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -37,6 +37,7 @@ from posthog.api.utils import action, format_paginated_url, get_pk_or_uuid, get_
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.constants import INSIGHT_FUNNELS, LIMIT, OFFSET, FunnelVizType
 from posthog.decorators import cached_by_filters
+from posthog.event_usage import get_request_analytics_properties
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Cohort, Filter, Person, Team, User
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
@@ -598,7 +599,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 if force_refresh
                 else ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS
             )
-            result = runner.run(execution_mode)
+            result = runner.run(execution_mode, analytics_props=get_request_analytics_properties(request))
             assert isinstance(result, (PropertyValuesQueryResponse, CachedPropertyValuesQueryResponse))
             is_refreshing = (
                 isinstance(result, CachedPropertyValuesQueryResponse)

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -592,7 +592,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     property_key=key,
                     search_value=value,
                 ),
-                request=request,
             )
             execution_mode = (
                 ExecutionMode.CALCULATE_BLOCKING_ALWAYS

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -39,7 +39,7 @@ from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
-from posthog.event_usage import report_user_or_team_action
+from posthog.event_usage import get_request_analytics_properties, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.apply_dashboard_filters import apply_dashboard_filters, apply_dashboard_variables
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -166,7 +166,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 user=request.user,  # type: ignore[arg-type]
                 is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
                 limit_context=limit_context,
-                request=request,
+                analytics_props=get_request_analytics_properties(request),
             )
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)
@@ -187,7 +187,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                     user=request.user if isinstance(request.user, User) else None,
                     team=self.team,
                     organization=self.team.organization,
-                    request=request,
+                    analytics_props=get_request_analytics_properties(request),
                 )
             except Exception:
                 pass

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -144,6 +144,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 data, self.team, data.client_query_id, request.user
             )
             self._tag_client_query_id(client_query_id)
+            analytics_props = get_request_analytics_properties(request)
             query_dict = query.model_dump()
 
             if data.limit_context == SchemaLimitContext.POSTHOG_AI:
@@ -166,7 +167,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 user=request.user,  # type: ignore[arg-type]
                 is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
                 limit_context=limit_context,
-                analytics_props=get_request_analytics_properties(request),
+                analytics_props=analytics_props,
             )
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)
@@ -187,7 +188,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                     user=request.user if isinstance(request.user, User) else None,
                     team=self.team,
                     organization=self.team.organization,
-                    analytics_props=get_request_analytics_properties(request),
+                    analytics_props=analytics_props,
                 )
             except Exception:
                 pass

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -1,14 +1,9 @@
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import structlog
 import pydantic_core
 from pydantic import BaseModel
 from rest_framework.exceptions import ValidationError
-
-from posthog.hogql.modifiers import create_default_modifiers_for_team
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
 
 from posthog.schema import (
     DashboardFilter,
@@ -29,9 +24,11 @@ from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.direct_connection import resolve_database_for_connection
 from posthog.hogql.metadata import get_hogql_metadata
+from posthog.hogql.modifiers import create_default_modifiers_for_team
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import is_cloud
+from posthog.event_usage import AnalyticsProps
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import CacheMissResponse, ExecutionMode, QueryResponse, get_query_runner
 from posthog.models import Team, User
@@ -57,8 +54,8 @@ def process_query_dict(
     insight_id: Optional[int] = None,
     dashboard_id: Optional[int] = None,
     is_query_service: bool = False,
-    request: Optional["Request"] = None,
     pagination_cursor: Optional[str] = None,
+    analytics_props: Optional[AnalyticsProps] = None,
 ) -> dict | BaseModel:
     upgraded_query_json = upgrade(query_json)
     try:
@@ -107,8 +104,8 @@ def process_query_dict(
         insight_id=insight_id,
         dashboard_id=dashboard_id,
         is_query_service=is_query_service,
-        request=request,
         pagination_cursor=pagination_cursor,
+        analytics_props=analytics_props,
     )
 
 
@@ -126,8 +123,8 @@ def process_query_model(
     dashboard_id: Optional[int] = None,
     is_query_service: bool = False,
     cache_age_seconds: Optional[int] = None,
-    request: Optional["Request"] = None,
     pagination_cursor: Optional[str] = None,
+    analytics_props: Optional[AnalyticsProps] = None,
 ) -> dict | BaseModel:
     result: dict | BaseModel
 
@@ -181,7 +178,7 @@ def process_query_model(
         )
 
     try:
-        query_runner = get_query_runner(query, team, limit_context=limit_context, request=request)
+        query_runner = get_query_runner(query, team, limit_context=limit_context)
     except ValueError:  # This query doesn't run via query runner
         if hasattr(query, "source") and isinstance(query.source, BaseModel):
             result = process_query_model(
@@ -197,7 +194,7 @@ def process_query_model(
                 dashboard_id=dashboard_id,
                 is_query_service=is_query_service,
                 cache_age_seconds=cache_age_seconds,
-                request=request,
+                analytics_props=analytics_props,
             )
         elif execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
             # Caching is handled by query runners, so in this case we can only return a cache miss
@@ -235,6 +232,7 @@ def process_query_model(
             insight_id=insight_id,
             dashboard_id=dashboard_id,
             cache_age_seconds=cache_age_seconds,
+            analytics_props=analytics_props,
         )
 
     return result

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -336,15 +336,16 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
             self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
-            with self.assertNumQueries(baseline + 11 + 12):
+            # +1 for session load triggered by analytics props extraction during insight serialization
+            with self.assertNumQueries(baseline + 11 + 13):
                 self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
             self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
-            with self.assertNumQueries(baseline + 11 + 12):
+            with self.assertNumQueries(baseline + 11 + 13):
                 self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
         self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
-        with self.assertNumQueries(baseline + 11 + 12):
+        with self.assertNumQueries(baseline + 11 + 13):
             self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
     @snapshot_postgres_queries

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -336,7 +336,6 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                 self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 
             self.dashboard_api.create_insight({"filters": filter_dict, "dashboards": [dashboard_id]})
-            # +1 for session load triggered by analytics props extraction during insight serialization
             with self.assertNumQueries(baseline + 11 + 13):
                 self.dashboard_api.get_dashboard(dashboard_id, query_params={"no_items_field": "true"})
 

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -456,7 +456,10 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             return_value=PropertyValuesQueryResponse(results=[]),
         ) as mock_run:
             self.client.get(url)
-            mock_run.assert_called_once_with(ExecutionMode[expected_mode_name])
+            mock_run.assert_called_once()
+            args, kwargs = mock_run.call_args
+            assert args[0] == ExecutionMode[expected_mode_name]
+            assert "analytics_props" in kwargs
 
     @also_test_with_materialized_columns(["test_prop"])
     @freeze_time("2020-01-20 20:00:00")

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -474,6 +474,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 filters_override={},
                 variables_override={},
                 tile_filters_override={},
+                analytics_props=ANY,
             )
 
         with patch(
@@ -489,6 +490,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 filters_override={},
                 variables_override={},
                 tile_filters_override={},
+                analytics_props=ANY,
             )
 
     def test_get_insight_by_short_id(self) -> None:

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -202,7 +202,10 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             return_value=PropertyValuesQueryResponse(results=[]),
         ) as mock_run:
             self.client.get(url)
-            mock_run.assert_called_once_with(ExecutionMode[expected_mode_name])
+            mock_run.assert_called_once()
+            args, kwargs = mock_run.call_args
+            assert args[0] == ExecutionMode[expected_mode_name]
+            assert "analytics_props" in kwargs
 
     @also_test_with_materialized_columns(event_properties=["email"], person_properties=["email"])
     @snapshot_clickhouse_queries

--- a/posthog/api/web_vitals.py
+++ b/posthog/api/web_vitals.py
@@ -33,7 +33,6 @@ class WebVitalsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             raise exceptions.ValidationError({"pathname": "This field is required."})
 
         query_runner = get_query_runner(
-            request=request,
             query={
                 "kind": "TrendsQuery",
                 "dateRange": {"date_from": "-7d", "explicitDate": False},

--- a/posthog/api/web_vitals.py
+++ b/posthog/api/web_vitals.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import get_request_analytics_properties
 from posthog.hogql_queries.query_runner import ExecutionMode, get_query_runner
 from posthog.rbac.user_access_control import UserAccessControlError
 
@@ -79,7 +80,10 @@ class WebVitalsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
 
         try:
-            result = query_runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
+            result = query_runner.run(
+                execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+                analytics_props=get_request_analytics_properties(request),
+            )
         except UserAccessControlError as e:
             raise ValidationError(str(e))
 

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -10,6 +10,7 @@ from posthog.hogql.constants import LimitContext
 
 from posthog.api.services.query import ExecutionMode, process_query_dict
 from posthog.clickhouse.query_tagging import tag_queries
+from posthog.event_usage import AnalyticsProps
 from posthog.hogql_queries.query_runner import get_query_runner_or_none
 from posthog.models import Dashboard, DashboardTile, Insight, Team, User
 from posthog.models.insight import generate_insight_filters_hash
@@ -52,6 +53,7 @@ def calculate_for_query_based_insight(
     filters_override: Optional[dict] = None,
     variables_override: Optional[dict] = None,
     tile_filters_override: Optional[dict] = None,
+    analytics_props: Optional[AnalyticsProps] = None,
 ) -> "InsightResult":
     from posthog.caching.fetch_from_cache import InsightResult, NothingInCacheResult
     from posthog.caching.insight_cache import update_cached_state
@@ -84,6 +86,7 @@ def calculate_for_query_based_insight(
         dashboard_id=dashboard.pk if dashboard else None,
         # QUERY_ASYNC provides extended max execution time for insight queries
         limit_context=LimitContext.QUERY_ASYNC,
+        analytics_props=analytics_props,
     )
 
     if isinstance(process_response, BaseModel):

--- a/posthog/caching/insight_cache.py
+++ b/posthog/caching/insight_cache.py
@@ -10,6 +10,7 @@ from prometheus_client import Counter, Gauge
 
 from posthog.api.services.query import process_query_dict
 from posthog.clickhouse.query_tagging import tag_queries
+from posthog.event_usage import EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Dashboard, Insight, InsightCachingState
@@ -75,6 +76,7 @@ def update_cache(caching_state_id: UUID):
                 insight.query,
                 dashboard_filters_json=dashboard.filters if dashboard is not None else None,
                 execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+                analytics_props={"source": EventSource.CACHE_WARMING},
             )
             # TRICKY: `result` is null, because `process_query` already set the cache. `cache_type` also irrelevant
             cache_key, cache_type, result = getattr(response, "cache_key", None), None, None

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -17,6 +17,7 @@ from posthog.api.services.query import process_query_dict
 from posthog.caching.utils import largest_teams
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
+from posthog.event_usage import EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
 from posthog.hogql_queries.query_runner import ExecutionMode
@@ -233,6 +234,7 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
                 execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                 insight_id=insight_id,
                 dashboard_id=dashboard_id,
+                analytics_props={"source": EventSource.CACHE_WARMING},
             )
 
             is_cached = getattr(results, "is_cached", False)

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -18,6 +18,7 @@ from posthog import celery, redis
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
 from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries, ExposedCHQueryError
+from posthog.event_usage import AnalyticsProps
 from posthog.exceptions_capture import capture_exception
 from posthog.renderers import SafeJSONRenderer
 from posthog.tasks.tasks import process_query_task
@@ -180,6 +181,7 @@ def execute_process_query(
     query_json: dict,
     limit_context: Optional[LimitContext],
     is_query_service: bool = False,
+    analytics_props: Optional[AnalyticsProps] = None,
 ):
     tag_queries(client_query_id=query_id, team_id=team_id, user_id=user_id)
     manager = QueryStatusManager(query_id, team_id)
@@ -225,6 +227,7 @@ def execute_process_query(
             dashboard_id=query_status.dashboard_id,
             user=user,
             is_query_service=is_query_service,
+            analytics_props=analytics_props,
         )
         if isinstance(results, BaseModel):
             results = results.model_dump(by_alias=True)
@@ -278,6 +281,7 @@ def enqueue_process_query_task(
     _test_only_bypass_celery: bool = False,
     is_query_service: bool = False,
     is_posthog_ai: bool = False,
+    analytics_props: Optional[AnalyticsProps] = None,
 ) -> QueryStatus:
     if not query_id:
         query_id = uuid.uuid4().hex
@@ -336,7 +340,7 @@ def enqueue_process_query_task(
 
     limit_context = LimitContext.POSTHOG_AI if is_posthog_ai else LimitContext.QUERY_ASYNC
     task_signature = process_query_task.si(
-        team.id, user_id, query_id, query_json, query_tags, is_query_service, limit_context
+        team.id, user_id, query_id, query_json, query_tags, is_query_service, limit_context, analytics_props
     )
 
     if _test_only_bypass_celery:

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -18,12 +18,12 @@ from posthog import celery, redis
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
 from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries, ExposedCHQueryError
-from posthog.event_usage import AnalyticsProps
 from posthog.exceptions_capture import capture_exception
 from posthog.renderers import SafeJSONRenderer
 from posthog.tasks.tasks import process_query_task
 
 if TYPE_CHECKING:
+    from posthog.event_usage import AnalyticsProps
     from posthog.models.team.team import Team
 
 logger = structlog.get_logger(__name__)
@@ -181,7 +181,7 @@ def execute_process_query(
     query_json: dict,
     limit_context: Optional[LimitContext],
     is_query_service: bool = False,
-    analytics_props: Optional[AnalyticsProps] = None,
+    analytics_props: Optional["AnalyticsProps"] = None,
 ):
     tag_queries(client_query_id=query_id, team_id=team_id, user_id=user_id)
     manager = QueryStatusManager(query_id, team_id)
@@ -281,7 +281,7 @@ def enqueue_process_query_task(
     _test_only_bypass_celery: bool = False,
     is_query_service: bool = False,
     is_posthog_ai: bool = False,
-    analytics_props: Optional[AnalyticsProps] = None,
+    analytics_props: Optional["AnalyticsProps"] = None,
 ) -> QueryStatus:
     if not query_id:
         query_id = uuid.uuid4().hex

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -340,7 +340,14 @@ def enqueue_process_query_task(
 
     limit_context = LimitContext.POSTHOG_AI if is_posthog_ai else LimitContext.QUERY_ASYNC
     task_signature = process_query_task.si(
-        team.id, user_id, query_id, query_json, query_tags, is_query_service, limit_context, analytics_props
+        team.id,
+        user_id,
+        query_id,
+        query_json,
+        query_tags,
+        is_query_service,
+        limit_context,
+        analytics_props=analytics_props,
     )
 
     if _test_only_bypass_celery:

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -7,9 +7,6 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, NotRequired, Optional, Required, TypedDict
 from urllib.parse import urlparse
 
-if TYPE_CHECKING:
-    from rest_framework.request import Request
-
 from django.contrib.auth.models import AnonymousUser
 
 import posthoganalytics
@@ -20,6 +17,9 @@ from posthog.models.activity_logging.model_activity import is_impersonated_sessi
 from posthog.models.team import Team
 from posthog.settings import SITE_URL
 from posthog.utils import get_instance_realm
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
 
 
 def report_user_signed_up(

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -4,7 +4,7 @@ Module to centralize event reporting on the server-side.
 
 import re
 from enum import StrEnum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, NotRequired, Optional, Required, TypedDict
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -274,7 +274,29 @@ class EventSource(StrEnum):
     TERRAFORM = "terraform"
     MCP = "mcp"
     WIZARD = "wizard"
+    CACHE_WARMING = "cache_warming"
+    ALERT = "alert"
+    EXPORT = "export"
+    SUBSCRIPTION = "subscription"
 
+
+AnalyticsProps = TypedDict(
+    "AnalyticsProps",
+    {
+        "source": Required[EventSource],
+        "$current_url": NotRequired[str | None],
+        "$host": NotRequired[str | None],
+        "$pathname": NotRequired[str | None],
+        "$session_id": NotRequired[str | None],
+        "was_impersonated": NotRequired[bool],
+        "mcp_user_agent": NotRequired[str | None],
+        "mcp_client_name": NotRequired[str | None],
+        "mcp_client_version": NotRequired[str | None],
+        "mcp_protocol_version": NotRequired[str | None],
+        "mcp_oauth_client_name": NotRequired[str | None],
+    },
+    total=False,
+)
 
 _POSTHOG_CODE_UA_RE = re.compile(r"posthog/(code|[\w.-]+\.hog\.dev)")
 
@@ -304,7 +326,7 @@ MAX_HEADER_VALUE_LENGTH = 1000
 
 
 def sanitize_header_value(value: str | None) -> str | None:
-    if not value:
+    if not isinstance(value, str) or not value:
         return None
     return re.sub(r"[\x00-\x1f\x7f]", "", value).strip()[:MAX_HEADER_VALUE_LENGTH] or None
 
@@ -320,21 +342,23 @@ def get_mcp_properties(request) -> dict[str, str | None]:
     }
 
 
-def get_request_analytics_properties(request) -> dict[str, str | bool | None]:
+def get_request_analytics_properties(request) -> AnalyticsProps:
     """Extract standard analytics properties from a request."""
     current_url = request.headers.get("Referer")
     host: str | None = None
     pathname: str | None = None
-    if current_url:
+    if isinstance(current_url, str) and current_url:
         parsed = urlparse(current_url)
         host = parsed.netloc or None
         pathname = parsed.path or None
+    else:
+        current_url = None
     return {
         "source": get_event_source(request),
         "$current_url": current_url,
         "$host": host,
         "$pathname": pathname,
-        "$session_id": request.headers.get("X-Posthog-Session-Id"),
+        "$session_id": sanitize_header_value(request.headers.get("X-Posthog-Session-Id")),
         "was_impersonated": is_impersonated_session(request),
         **get_mcp_properties(request),
     }
@@ -348,14 +372,19 @@ def report_user_action(
     team: Optional[Team] = None,
     organization: Optional[Organization] = None,
     request: Optional["Request"] = None,
+    analytics_props: Optional[AnalyticsProps] = None,
 ):
     # isinstance works through Django's SimpleLazyObject because it proxies __class__
     if not isinstance(user, User) or not user.distinct_id:
         return
+    if request is not None and analytics_props is not None:
+        raise ValueError("Pass either request or analytics_props, not both")
     if properties is None:
         properties = {}
     if request is not None:
         properties = {**get_request_analytics_properties(request), **properties}
+    if analytics_props is not None:
+        properties = {**analytics_props, **properties}
     if user.email:
         properties["$set_once"] = {"email": user.email}
     posthoganalytics.capture(
@@ -373,12 +402,12 @@ def report_user_or_team_action(
     user: Optional[User | AnonymousUser] = None,
     team: Optional[Team] = None,
     organization: Optional[Organization] = None,
-    request: Optional["Request"] = None,
+    analytics_props: Optional[AnalyticsProps] = None,
 ):
     if properties is None:
         properties = {}
-    if request is not None:
-        properties = {**get_request_analytics_properties(request), **properties}
+    if analytics_props is not None:
+        properties = {**analytics_props, **properties}
 
     # isinstance works through Django's SimpleLazyObject because it proxies __class__
     real_user = user if isinstance(user, User) else None

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -280,6 +280,14 @@ class EventSource(StrEnum):
     SUBSCRIPTION = "subscription"
 
 
+class McpProps(TypedDict):
+    mcp_user_agent: str | None
+    mcp_client_name: str | None
+    mcp_client_version: str | None
+    mcp_protocol_version: str | None
+    mcp_oauth_client_name: str | None
+
+
 AnalyticsProps = TypedDict(
     "AnalyticsProps",
     {
@@ -303,7 +311,9 @@ _POSTHOG_CODE_UA_RE = re.compile(r"posthog/(code|[\w.-]+\.hog\.dev)")
 
 def get_event_source(request) -> EventSource:
     """Determine the source of an API request for analytics."""
-    user_agent = request.META.get("HTTP_USER_AGENT", "")
+    user_agent = request.META.get("HTTP_USER_AGENT", "") or ""
+    if not isinstance(user_agent, str):
+        user_agent = ""
     if "posthog/terraform-provider" in user_agent:
         return EventSource.TERRAFORM
     if "posthog/wizard" in user_agent:
@@ -331,7 +341,7 @@ def sanitize_header_value(value: str | None) -> str | None:
     return re.sub(r"[\x00-\x1f\x7f]", "", value).strip()[:MAX_HEADER_VALUE_LENGTH] or None
 
 
-def get_mcp_properties(request) -> dict[str, str | None]:
+def get_mcp_properties(request) -> McpProps:
     """Extract MCP client metadata from request headers."""
     return {
         "mcp_user_agent": sanitize_header_value(request.headers.get("X-Posthog-Mcp-User-Agent")),

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -43,9 +43,7 @@ class ActorsQueryRunner(AnalyticsQueryRunner[ActorsQueryResponse]):
         self.source_query_runner: Optional[QueryRunner] = None
 
         if self.query.source:
-            self.source_query_runner = get_query_runner(
-                self.query.source, self.team, self.timings, self.limit_context, request=self.request
-            )
+            self.source_query_runner = get_query_runner(self.query.source, self.team, self.timings, self.limit_context)
             self.modifiers = self.source_query_runner.modifiers
         else:
             # For direct person queries (no source), ensure we use V2 to get latest person data only

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -1,7 +1,10 @@
 import re
 import itertools
 from collections.abc import Iterable, Iterator, Sequence
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from posthog.event_usage import AnalyticsProps
 
 from posthoganalytics import feature_enabled
 
@@ -69,9 +72,18 @@ class ActorsQueryRunner(AnalyticsQueryRunner[ActorsQueryResponse]):
         insight_id: Optional[int] = None,
         dashboard_id: Optional[int] = None,
         cache_age_seconds: Optional[int] = None,
+        analytics_props: Optional["AnalyticsProps"] = None,
     ):
         self.user = user
-        return super().run(execution_mode, user, query_id, insight_id, dashboard_id, cache_age_seconds)
+        return super().run(
+            execution_mode,
+            user,
+            query_id,
+            insight_id,
+            dashboard_id,
+            cache_age_seconds,
+            analytics_props=analytics_props,
+        )
 
     @property
     def group_type_index(self) -> int | None:

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -65,9 +65,7 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
 
         return cast(
             InsightActorsQueryRunner,
-            get_query_runner(
-                self.query.source, self.team, self.timings, self.limit_context, self.modifiers, request=self.request
-            ),
+            get_query_runner(self.query.source, self.team, self.timings, self.limit_context, self.modifiers),
         )
 
     def select_cols(self) -> tuple[list[str], list[ast.Expr]]:

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -1,8 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, cast
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Literal, Optional, TypedDict, cast
 
 from rest_framework.exceptions import ValidationError
 
@@ -104,11 +101,8 @@ class FunnelCorrelationQueryRunner(AnalyticsQueryRunner[FunnelCorrelationRespons
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
-        request: Optional["Request"] = None,
     ):
-        super().__init__(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, request=request
-        )
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
         self.actors_query = self.query.source
         self.funnels_query = self.actors_query.source
 

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -1,9 +1,6 @@
 from datetime import datetime, timedelta
 from math import ceil
-from typing import TYPE_CHECKING, Any, Optional
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Optional
 
 from posthog.schema import (
     CachedFunnelsQueryResponse,
@@ -42,12 +39,9 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
-        request: Optional["Request"] = None,
         just_summarize: bool = False,
     ):
-        super().__init__(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, request=request
-        )
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
 
         self.just_summarize = just_summarize
         self.context = FunnelQueryContext(

--- a/posthog/hogql_queries/insights/insight_actors_query_options_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_options_runner.py
@@ -20,9 +20,7 @@ class InsightActorsQueryOptionsRunner(QueryRunner):
 
     @cached_property
     def source_runner(self) -> QueryRunner:
-        return get_query_runner(
-            self.query.source.source, self.team, self.timings, self.limit_context, request=self.request
-        )
+        return get_query_runner(self.query.source.source, self.team, self.timings, self.limit_context)
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         raise ValueError(f"Cannot convert source query of type {self.query.source.kind} to query")

--- a/posthog/hogql_queries/insights/insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_runner.py
@@ -1,7 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, cast
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Optional, cast
 
 from posthog.schema import (
     FunnelAggregateByHogQL,
@@ -48,7 +45,6 @@ class InsightActorsQueryRunner(AnalyticsQueryRunner[HogQLQueryResponse]):
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
         query_id: Optional[str] = None,
-        request: Optional["Request"] = None,
     ):
         super().__init__(
             query,
@@ -58,14 +54,11 @@ class InsightActorsQueryRunner(AnalyticsQueryRunner[HogQLQueryResponse]):
             limit_context=limit_context,
             query_id=query_id,
             extract_modifiers=lambda query: query.source.modifiers if hasattr(query.source, "modifiers") else None,
-            request=request,
         )
 
     @cached_property
     def source_runner(self) -> QueryRunner:
-        return get_query_runner(
-            self.query.source, self.team, self.timings, self.limit_context, self.modifiers, request=self.request
-        )
+        return get_query_runner(self.query.source, self.team, self.timings, self.limit_context, self.modifiers)
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         if isinstance(self.source_runner, TrendsQueryRunner):

--- a/posthog/hogql_queries/insights/paths_query_runner.py
+++ b/posthog/hogql_queries/insights/paths_query_runner.py
@@ -3,10 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from math import ceil
 from re import escape
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Literal, Optional, cast
 
 from posthog.schema import (
     CachedPathsQueryResponse,
@@ -56,11 +53,8 @@ class PathsQueryRunner(AnalyticsQueryRunner[PathsQueryResponse]):
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
-        request: Optional["Request"] = None,
     ):
-        super().__init__(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, request=request
-        )
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
 
         if not self.query.pathsFilter:
             self.query.pathsFilter = PathsFilter()

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -1,9 +1,6 @@
 from datetime import datetime, timedelta
 from math import ceil
-from typing import TYPE_CHECKING, Any, Optional, cast
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Optional, cast
 
 from posthog.schema import (
     AggregationType,
@@ -70,7 +67,6 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
-        request: Optional["Request"] = None,
     ):
         super().__init__(
             query=query,
@@ -83,7 +79,6 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                 if not limit_context or limit_context in (LimitContext.QUERY_ASYNC, LimitContext.QUERY)
                 else limit_context
             ),
-            request=request,
         )
 
         self.start_event = self.query.retentionFilter.targetEntity or DEFAULT_ENTITY

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -1,9 +1,6 @@
 from datetime import timedelta
 from math import ceil
-from typing import TYPE_CHECKING, Any, Optional, cast
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Optional, cast
 
 from django.utils.timezone import now
 
@@ -65,11 +62,8 @@ class StickinessQueryRunner(AnalyticsQueryRunner[StickinessQueryResponse]):
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
-        request: Optional["Request"] = None,
     ):
-        super().__init__(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, request=request
-        )
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
         self.series = self.setup_series()
 
     def _refresh_frequency(self):

--- a/posthog/hogql_queries/insights/trends/calendar_heatmap_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/calendar_heatmap_query_runner.py
@@ -1,9 +1,6 @@
 from datetime import datetime, timedelta
 from math import ceil
-from typing import TYPE_CHECKING, Any, Optional, Union
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Optional, Union
 
 from django.db import models
 from django.db.models.functions import Coalesce
@@ -130,14 +127,11 @@ class CalendarHeatmapQueryRunner(AnalyticsQueryRunner[CalendarHeatmapResponse]):
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
-        request: Optional["Request"] = None,
     ):
         if isinstance(query, dict):
             query = CalendarHeatmapQuery.model_validate(query)
 
-        super().__init__(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, request=request
-        )
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
 
     def _refresh_frequency(self):
         date_to = self.query_date_range.date_to()

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -3,10 +3,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from math import ceil
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Optional, Union
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
+from typing import Any, Optional, Union
 
 from django.conf import settings
 from django.db import models
@@ -96,7 +93,6 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
-        request: Optional["Request"] = None,
     ):
         from posthog.hogql_queries.insights.utils.utils import convert_active_user_math_based_on_interval
 
@@ -120,9 +116,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
         # Use the new function to handle WAU/MAU conversions
         query = convert_active_user_math_based_on_interval(query)
 
-        super().__init__(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, request=request
-        )
+        super().__init__(query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context)
 
     def __post_init__(self):
         self.update_hogql_modifiers()

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -22,11 +22,6 @@ import posthoganalytics
 from prometheus_client import Counter, Histogram
 from pydantic import BaseModel, ConfigDict
 
-from posthog.errors import clickhouse_error_type
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
-
 from posthog.schema import (
     ActorsPropertyTaxonomyQuery,
     ActorsQuery,
@@ -105,7 +100,11 @@ from posthog.clickhouse.client.limit import (
     get_org_app_concurrency_limit,
 )
 from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
-from posthog.event_usage import groups, report_user_or_team_action
+from posthog.errors import clickhouse_error_type
+from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache import count_query_cache_hit
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
@@ -1096,6 +1095,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         cache_manager: QueryCacheManagerBase,
         refresh_requested: bool = False,
         user: Optional[User] = None,
+        analytics_props: Optional[AnalyticsProps] = None,
     ) -> QueryStatus:
         posthoganalytics.capture(
             distinct_id=user.distinct_id if user else str(self.team.uuid),
@@ -1122,6 +1122,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             refresh_requested=refresh_requested,
             is_query_service=self.is_query_service,
             is_posthog_ai=self.limit_context == LimitContext.POSTHOG_AI,
+            analytics_props=analytics_props,
         )
 
     def get_async_query_status(self, *, cache_key: str) -> Optional[QueryStatus]:
@@ -1135,7 +1136,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             return None
 
     def handle_cache_and_async_logic(
-        self, execution_mode: ExecutionMode, cache_manager: QueryCacheManagerBase, user: Optional[User] = None
+        self,
+        execution_mode: ExecutionMode,
+        cache_manager: QueryCacheManagerBase,
+        user: Optional[User] = None,
+        analytics_props: Optional[AnalyticsProps] = None,
     ) -> Optional[CR | CacheMissResponse]:
         CachedResponse: type[CR] = self.cached_response_type
         cached_response: CR | CacheMissResponse
@@ -1190,7 +1195,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             ):
                 # We're allowed to calculate, but we'll do it asynchronously and attach the query status
                 cached_response.query_status = self.enqueue_async_calculation(
-                    cache_manager=cache_manager, user=user, refresh_requested=True
+                    cache_manager=cache_manager, user=user, refresh_requested=True, analytics_props=analytics_props
                 )
                 return cached_response
             elif execution_mode == ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE:
@@ -1198,7 +1203,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 assert isinstance(cached_response, CachedResponse)
                 if self._is_stale(last_refresh=last_refresh_from_cached_result(cached_response), lazy=True):
                     cached_response.query_status = self.enqueue_async_calculation(
-                        cache_manager=cache_manager, user=user
+                        cache_manager=cache_manager, user=user, analytics_props=analytics_props
                     )
                 cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
                 return cached_response
@@ -1214,7 +1219,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
             ):
                 # We're allowed to calculate, but we'll do it asynchronously
-                cached_response.query_status = self.enqueue_async_calculation(cache_manager=cache_manager, user=user)
+                cached_response.query_status = self.enqueue_async_calculation(
+                    cache_manager=cache_manager, user=user, analytics_props=analytics_props
+                )
                 return cached_response
 
         # Nothing useful out of cache, nor async query status
@@ -1273,6 +1280,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         insight_id: Optional[int] = None,
         dashboard_id: Optional[int] = None,
         cache_age_seconds: Optional[int] = None,
+        analytics_props: Optional[AnalyticsProps] = None,
     ) -> CR | CacheMissResponse | QueryStatusResponse:
         # Set user for access control during query execution
         if user is not None:
@@ -1340,13 +1348,19 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 # We should always kick off async calculation and disregard the cache
                 return QueryStatusResponse(
                     query_status=self.enqueue_async_calculation(
-                        refresh_requested=True, cache_manager=cache_manager, user=user
+                        refresh_requested=True,
+                        cache_manager=cache_manager,
+                        user=user,
+                        analytics_props=analytics_props,
                     )
                 )
             elif execution_mode != ExecutionMode.CALCULATE_BLOCKING_ALWAYS:
                 # Let's look in the cache first
                 results = self.handle_cache_and_async_logic(
-                    execution_mode=execution_mode, cache_manager=cache_manager, user=user
+                    execution_mode=execution_mode,
+                    cache_manager=cache_manager,
+                    user=user,
+                    analytics_props=analytics_props,
                 )
                 if results:
                     cache_tracking_props = {}
@@ -1384,7 +1398,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                         user=user,
                         team=self.team,
                         organization=self.team.organization,
-                        request=self.request,
+                        analytics_props=analytics_props,
                     )
 
                     return results
@@ -1399,6 +1413,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     trigger=trigger,
                     user=user,
                     start_time=start_time,
+                    analytics_props=analytics_props,
                 )
 
             if execution_mode == ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE:
@@ -1430,6 +1445,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         trigger: Optional[str],
         user: Optional[User],
         start_time: float,
+        analytics_props: Optional["AnalyticsProps"] = None,
     ) -> CR:
         CachedResponse: type[CR] = self.cached_response_type
 
@@ -1513,7 +1529,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             user=user,
             team=self.team,
             organization=self.team.organization,
-            request=self.request,
+            analytics_props=analytics_props,
         )
 
         return CachedResponse(**fresh_response_dict)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -3,19 +3,7 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from time import perf_counter
 from types import UnionType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Optional,
-    Protocol,
-    TypeGuard,
-    TypeVar,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-)
+from typing import Any, Generic, Optional, Protocol, TypeGuard, TypeVar, Union, cast, get_args, get_origin
 
 import structlog
 import posthoganalytics
@@ -102,9 +90,6 @@ from posthog.clickhouse.client.limit import (
 from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.errors import clickhouse_error_type
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
-
-if TYPE_CHECKING:
-    from rest_framework.request import Request
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache import count_query_cache_hit
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
@@ -225,7 +210,6 @@ def get_query_runner(
     timings: Optional[HogQLTimings] = None,
     limit_context: Optional[LimitContext] = None,
     modifiers: Optional[HogQLQueryModifiers] = None,
-    request: Optional["Request"] = None,
 ) -> "QueryRunner":
     try:
         kind = get_from_dict_or_attr(query, "kind")
@@ -247,7 +231,6 @@ def get_query_runner(
                 timings=timings,
                 limit_context=limit_context,
                 modifiers=modifiers,
-                request=request,
             )
 
         if display_type == ChartDisplayType.BOX_PLOT:
@@ -269,7 +252,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "FunnelsQuery":
         from .insights.funnels.funnels_query_runner import FunnelsQueryRunner
@@ -280,7 +262,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "RetentionQuery":
         from .insights.retention_query_runner import RetentionQueryRunner
@@ -291,7 +272,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "PathsQuery":
         from .insights.paths_query_runner import PathsQueryRunner
@@ -302,7 +282,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
 
     if kind == "CalendarHeatmapQuery":
@@ -314,7 +293,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "StickinessQuery":
         from .insights.stickiness_query_runner import StickinessQueryRunner
@@ -325,7 +303,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "LifecycleQuery":
         from .insights.lifecycle_query_runner import LifecycleQueryRunner
@@ -336,7 +313,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "EventsQuery":
         from .events_query_runner import EventsQueryRunner
@@ -347,7 +323,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "SessionsQuery":
         from .sessions_query_runner import SessionsQueryRunner
@@ -358,7 +333,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "SessionBatchEventsQuery":
         from .ai.session_batch_events_query_runner import SessionBatchEventsQueryRunner
@@ -369,7 +343,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "ActorsQuery":
         from .actors_query_runner import ActorsQueryRunner
@@ -380,7 +353,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
 
     if kind == "GroupsQuery":
@@ -392,7 +364,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind in ("InsightActorsQuery", "FunnelsActorsQuery", "FunnelCorrelationActorsQuery", "StickinessActorsQuery"):
@@ -404,7 +375,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "InsightActorsQueryOptions":
         from .insights.insight_actors_query_options_runner import InsightActorsQueryOptionsRunner
@@ -415,7 +385,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "FunnelCorrelationQuery":
         from .insights.funnels.funnel_correlation_query_runner import FunnelCorrelationQueryRunner
@@ -426,7 +395,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "HogQLQuery":
         from .hogql_query_runner import HogQLQueryRunner
@@ -437,7 +405,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "SessionsTimelineQuery":
         from .sessions_timeline_query_runner import SessionsTimelineQueryRunner
@@ -448,7 +415,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
     if kind == "WebOverviewQuery":
         from .web_analytics.web_overview import WebOverviewQueryRunner
@@ -459,7 +425,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "WebStatsTableQuery":
@@ -471,7 +436,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "WebGoalsQuery":
@@ -483,7 +447,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "WebTrendsQuery":
@@ -495,7 +458,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "WebExternalClicksTableQuery":
@@ -507,7 +469,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "WebVitalsPathBreakdownQuery":
@@ -516,7 +477,6 @@ def get_query_runner(
         return WebVitalsPathBreakdownQueryRunner(
             query=query,
             team=team,
-            request=request,
         )
 
     if kind == "WebPageURLSearchQuery":
@@ -528,7 +488,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "SessionAttributionExplorerQuery":
@@ -540,7 +499,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "RevenueAnalyticsGrossRevenueQuery":
@@ -554,7 +512,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "RevenueAnalyticsMetricsQuery":
@@ -568,7 +525,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "RevenueAnalyticsMRRQuery":
@@ -582,7 +538,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "RevenueAnalyticsOverviewQuery":
@@ -596,7 +551,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "RevenueAnalyticsTopCustomersQuery":
@@ -610,7 +564,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "RevenueExampleEventsQuery":
@@ -624,7 +577,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "RevenueExampleDataWarehouseTablesQuery":
@@ -638,7 +590,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ErrorTrackingQuery":
@@ -650,8 +601,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
-            user=request.user if request is not None else None,
         )
 
     if kind == "DocumentSimilarityQuery":
@@ -663,7 +612,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ErrorTrackingIssueCorrelationQuery":
@@ -677,7 +625,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ErrorTrackingSimilarIssuesQuery":
@@ -691,7 +638,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ErrorTrackingBreakdownsQuery":
@@ -705,7 +651,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ExperimentFunnelsQuery":
@@ -717,7 +662,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ExperimentTrendsQuery":
@@ -729,7 +673,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ExperimentQuery":
@@ -741,7 +684,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "ExperimentExposureQuery":
@@ -753,7 +695,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
 
     if kind == "SuggestedQuestionsQuery":
@@ -765,7 +706,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "TeamTaxonomyQuery":
         from .ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
@@ -776,7 +716,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "EventTaxonomyQuery":
         from .ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
@@ -787,7 +726,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "ActorsPropertyTaxonomyQuery":
         from .ai.actors_property_taxonomy_query_runner import ActorsPropertyTaxonomyQueryRunner
@@ -798,7 +736,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "TracesQuery":
         from .ai.traces_query_runner import TracesQueryRunner
@@ -809,7 +746,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "TraceQuery":
         from .ai.trace_query_runner import TraceQueryRunner
@@ -820,7 +756,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "TraceNeighborsQuery":
         from .ai.trace_neighbors_query_runner import TraceNeighborsQueryRunner
@@ -831,7 +766,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
     if kind == "VectorSearchQuery":
         from .ai.vector_search_query_runner import VectorSearchQueryRunner
@@ -842,7 +776,6 @@ def get_query_runner(
             timings=timings,
             limit_context=limit_context,
             modifiers=modifiers,
-            request=request,
         )
 
     if kind == NodeKind.MARKETING_ANALYTICS_TABLE_QUERY:
@@ -856,7 +789,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == NodeKind.MARKETING_ANALYTICS_AGGREGATED_QUERY:
@@ -870,7 +802,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == NodeKind.NON_INTEGRATED_CONVERSIONS_TABLE_QUERY:
@@ -884,7 +815,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "UsageMetricsQuery":
@@ -896,7 +826,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "EndpointsUsageOverviewQuery":
@@ -908,7 +837,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "EndpointsUsageTableQuery":
@@ -920,7 +848,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "EndpointsUsageTrendsQuery":
@@ -932,7 +859,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     # Registered here for server-side CSV export only (ExportedAsset + Celery).
@@ -946,7 +872,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     if kind == "PropertyValuesQuery":
@@ -958,7 +883,6 @@ def get_query_runner(
             timings=timings,
             modifiers=modifiers,
             limit_context=limit_context,
-            request=request,
         )
 
     raise ValueError(f"Can't get a runner for an unknown query kind: {kind}")
@@ -970,11 +894,10 @@ def get_query_runner_or_none(
     timings: Optional[HogQLTimings] = None,
     limit_context: Optional[LimitContext] = None,
     modifiers: Optional[HogQLQueryModifiers] = None,
-    request: Optional["Request"] = None,
 ) -> Optional["QueryRunner"]:
     try:
         return get_query_runner(
-            query=query, team=team, timings=timings, limit_context=limit_context, modifiers=modifiers, request=request
+            query=query, team=team, timings=timings, limit_context=limit_context, modifiers=modifiers
         )
     except ValueError as e:
         if "Can't get a runner for an unknown" in str(e):
@@ -1017,11 +940,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         workload: Workload = Workload.DEFAULT,
         extract_modifiers=lambda query: query.modifiers if hasattr(query, "modifiers") else None,
         user: Optional[User] = None,
-        request: Optional["Request"] = None,
     ):
         self.team = team
         self.user = user
-        self.request = request
         self.timings = timings or HogQLTimings()
         self.limit_context = limit_context or LimitContext.QUERY
         self.query_id = query_id

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 
 if TYPE_CHECKING:
+    from posthog.event_usage import AnalyticsProps
     from posthog.models.organization import Organization
     from posthog.models.user import User
 
@@ -140,26 +141,23 @@ class AlertConfiguration(ModelActivityMixin, CreatedMetaFields, UUIDTModel):
 
         super().save(*args, **kwargs)
 
-    def _get_event_properties(self, additional_properties: dict | None = None) -> dict:
-        properties = {
+    def _get_event_properties(self) -> dict:
+        return {
             "alert_id": self.id,
             "alert_name": self.name,
             "condition_type": self.condition.get("type") if self.condition else None,
             "calculation_interval": self.calculation_interval,
         }
-        if additional_properties:
-            properties.update(additional_properties)
-        return properties
 
-    def report_created(self, user: User, additional_properties: dict | None = None) -> None:
+    def report_created(self, user: User, analytics_props: AnalyticsProps | None = None) -> None:
         from posthog.event_usage import report_user_action
 
-        report_user_action(user, "alert created", self._get_event_properties(additional_properties))
+        report_user_action(user, "alert created", self._get_event_properties(), analytics_props=analytics_props)
 
-    def report_updated(self, user: User, additional_properties: dict | None = None) -> None:
+    def report_updated(self, user: User, analytics_props: AnalyticsProps | None = None) -> None:
         from posthog.event_usage import report_user_action
 
-        report_user_action(user, "alert updated", self._get_event_properties(additional_properties))
+        report_user_action(user, "alert updated", self._get_event_properties(), analytics_props=analytics_props)
 
     @classmethod
     def check_alert_limit(cls, team_id: int, organization: Organization) -> str | None:

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -14,6 +14,7 @@ from posthog.schema import (
 from posthog.api.services.query import ExecutionMode
 from posthog.caching.calculate_results import calculate_for_query_based_insight
 from posthog.caching.fetch_from_cache import InsightResult
+from posthog.event_usage import EventSource
 from posthog.models import AlertConfiguration, Insight
 from posthog.tasks.alerts.utils import AlertEvaluationResult, is_non_time_series_trend
 
@@ -108,6 +109,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 execution_mode=execution_mode,
                 user=None,
                 filters_override=filters_override,
+                analytics_props={"source": EventSource.ALERT},
             )
 
             interval = query.interval if not is_non_time_series else None
@@ -192,6 +194,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 execution_mode=execution_mode,
                 user=None,
                 filters_override=filters_overrides,
+                analytics_props={"source": EventSource.ALERT},
             )
 
             if no_result_evaluation := _is_empty_query_result(
@@ -291,6 +294,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 execution_mode=execution_mode,
                 user=None,
                 filters_override=filters_overrides,
+                analytics_props={"source": EventSource.ALERT},
             )
 
             if no_result_evaluation := _is_empty_query_result(

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -9,7 +9,7 @@ from celery import current_task, shared_task
 from prometheus_client import Counter, Histogram
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
-from posthog.event_usage import groups
+from posthog.event_usage import EventSource, groups
 from posthog.models import ExportedAsset
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.tasks.exports.failure_handler import (
@@ -103,6 +103,7 @@ def export_asset_direct(
     limit: Optional[int] = None,  # For CSV/XLSX: max row count
     max_height_pixels: Optional[int] = None,  # For images: max screenshot height in pixels
     cancellation_event: Optional[threading.Event] = None,  # For async callers to signal cancellation
+    source: Optional[str] = None,  # EventSource value to tag queries with (e.g. "subscription")
 ) -> None:
     from posthog.tasks.exports import csv_exporter, image_exporter
 
@@ -142,6 +143,8 @@ def export_asset_direct(
             )
             raise ExportCancelled("Export was cancelled due to timeout")
 
+    export_source = source or EventSource.EXPORT
+
     @retry(
         retry=retry_if_exception_type(EXCEPTIONS_TO_RETRY),
         stop=stop_after_attempt(4),
@@ -152,9 +155,9 @@ def export_asset_direct(
     def _do_export() -> None:
         _check_cancelled()
         if exported_asset.export_format in (ExportedAsset.ExportFormat.CSV, ExportedAsset.ExportFormat.XLSX):
-            csv_exporter.export_tabular(exported_asset, limit=limit)
+            csv_exporter.export_tabular(exported_asset, limit=limit, source=export_source)
         else:
-            image_exporter.export_image(exported_asset, max_height_pixels=max_height_pixels)
+            image_exporter.export_image(exported_asset, max_height_pixels=max_height_pixels, source=export_source)
 
     try:
         _do_export()

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -103,7 +103,7 @@ def export_asset_direct(
     limit: Optional[int] = None,  # For CSV/XLSX: max row count
     max_height_pixels: Optional[int] = None,  # For images: max screenshot height in pixels
     cancellation_event: Optional[threading.Event] = None,  # For async callers to signal cancellation
-    source: Optional[str] = None,  # EventSource value to tag queries with (e.g. "subscription")
+    source: Optional[EventSource] = None,  # EventSource value to tag queries with (e.g. "subscription")
 ) -> None:
     from posthog.tasks.exports import csv_exporter, image_exporter
 

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -23,7 +23,7 @@ from rest_framework_csv.renderers import CSVRenderer
 from posthog.schema import QuerySchemaRoot
 
 from posthog.api.services.query import process_query_dict
-from posthog.event_usage import EventSource
+from posthog.event_usage import AnalyticsProps, EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.jwt import PosthogJwtAudience, encode_jwt
@@ -131,7 +131,7 @@ class RowBuffer:
 
 @contextmanager
 def _buffer_rows(
-    exported_asset: ExportedAsset, limit: int, source: Optional[EventSource] = None
+    exported_asset: ExportedAsset, limit: int, analytics_props: Optional[AnalyticsProps] = None
 ) -> Iterator[RowBuffer]:
     """Buffer rows to a temp file, discovering columns along the way.
 
@@ -142,7 +142,9 @@ def _buffer_rows(
     - __iter__: yields rows as dicts
     """
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".jsonl", delete=True) as jsonl_file:
-        row_count, columns, seen_keys = _write_rows_to_jsonl(jsonl_file, exported_asset, limit, source=source)
+        row_count, columns, seen_keys = _write_rows_to_jsonl(
+            jsonl_file, exported_asset, limit, analytics_props=analytics_props
+        )
         jsonl_file.seek(0)
 
         yield RowBuffer(
@@ -455,7 +457,7 @@ def _query_supports_limit(query: dict) -> bool:
 
 
 def get_from_query(
-    exported_asset: ExportedAsset, limit: int, resource: dict, source: Optional[EventSource] = None
+    exported_asset: ExportedAsset, limit: int, resource: dict, analytics_props: Optional[AnalyticsProps] = None
 ) -> Generator[Any, None, None]:
     query = resource.get("source")
     assert query is not None
@@ -482,7 +484,7 @@ def get_from_query(
                 limit_context=LimitContext.EXPORT,
                 execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
                 pagination_cursor=cursor,
-                analytics_props={"source": source or EventSource.EXPORT},
+                analytics_props=analytics_props,
             )
         except ClickHouseQuerySizeExceeded:
             if "breakdownFilter" not in query or limit <= CSV_EXPORT_BREAKDOWN_LIMIT_LOW:
@@ -524,12 +526,12 @@ def get_from_query(
 
 
 def _iter_rows(
-    exported_asset: ExportedAsset, limit: int, source: Optional[EventSource] = None
+    exported_asset: ExportedAsset, limit: int, analytics_props: Optional[AnalyticsProps] = None
 ) -> Generator[Any, None, None]:
     resource = exported_asset.export_context or {}
 
     if resource.get("source"):
-        yield from get_from_query(exported_asset, limit, resource, source=source)
+        yield from get_from_query(exported_asset, limit, resource, analytics_props=analytics_props)
     else:
         # Legacy path for PersonsNode exports (uses API path instead of HogQL source).
         # PersonsNode was migrated to ActorsQuery in migration 0459, so this path
@@ -538,7 +540,7 @@ def _iter_rows(
 
 
 def _write_rows_to_jsonl(
-    jsonl_file: Any, exported_asset: ExportedAsset, limit: int, source: Optional[EventSource] = None
+    jsonl_file: Any, exported_asset: ExportedAsset, limit: int, analytics_props: Optional[AnalyticsProps] = None
 ) -> tuple[int, list[str], set[str]]:
     """Write flattened rows to a JSON lines file, discovering columns as we go.
 
@@ -550,7 +552,7 @@ def _write_rows_to_jsonl(
     seen_keys: set[str] = set()
     row_count = 0
 
-    for row in _iter_rows(exported_asset, limit, source=source):
+    for row in _iter_rows(exported_asset, limit, analytics_props=analytics_props):
         flat_row = dict(renderer.flatten_item(row))
 
         for key in flat_row.keys():
@@ -591,12 +593,12 @@ def _determine_columns(user_columns: list[str], all_keys: list[str], seen_keys: 
 
 
 def _export_tabular(
-    exported_asset: ExportedAsset, limit: int, writer: TabularWriter, source: Optional[EventSource] = None
+    exported_asset: ExportedAsset, limit: int, writer: TabularWriter, analytics_props: Optional[AnalyticsProps] = None
 ) -> None:
     """Export data using the provided writer."""
     user_columns = (exported_asset.export_context or {}).get("columns", [])
 
-    with _buffer_rows(exported_asset, limit, source=source) as buffer:
+    with _buffer_rows(exported_asset, limit, analytics_props=analytics_props) as buffer:
         if buffer.row_count == 0:
             columns = user_columns if user_columns else ["error"]
             writer.write_header(columns)
@@ -653,12 +655,14 @@ def export_tabular(
     if not limit:
         limit = CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL
 
+    analytics_props: AnalyticsProps = {"source": source or EventSource.EXPORT}
+
     try:
         with EXPORT_TIMER.labels(type=exported_asset.export_format).time():
             if exported_asset.export_format == ExportedAsset.ExportFormat.CSV:
-                _export_tabular(exported_asset, limit, CsvWriter(), source=source)
+                _export_tabular(exported_asset, limit, CsvWriter(), analytics_props=analytics_props)
             elif exported_asset.export_format == ExportedAsset.ExportFormat.XLSX:
-                _export_tabular(exported_asset, limit, ExcelWriter(), source=source)
+                _export_tabular(exported_asset, limit, ExcelWriter(), analytics_props=analytics_props)
             else:
                 raise NotImplementedError(f"Export to format {exported_asset.export_format} is not supported")
     except Exception as e:

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -23,6 +23,7 @@ from rest_framework_csv.renderers import CSVRenderer
 from posthog.schema import QuerySchemaRoot
 
 from posthog.api.services.query import process_query_dict
+from posthog.event_usage import EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.jwt import PosthogJwtAudience, encode_jwt
@@ -129,7 +130,7 @@ class RowBuffer:
 
 
 @contextmanager
-def _buffer_rows(exported_asset: ExportedAsset, limit: int) -> Iterator[RowBuffer]:
+def _buffer_rows(exported_asset: ExportedAsset, limit: int, source: Optional[str] = None) -> Iterator[RowBuffer]:
     """Buffer rows to a temp file, discovering columns along the way.
 
     Yields a RowBuffer that exposes:
@@ -139,7 +140,7 @@ def _buffer_rows(exported_asset: ExportedAsset, limit: int) -> Iterator[RowBuffe
     - __iter__: yields rows as dicts
     """
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".jsonl", delete=True) as jsonl_file:
-        row_count, columns, seen_keys = _write_rows_to_jsonl(jsonl_file, exported_asset, limit)
+        row_count, columns, seen_keys = _write_rows_to_jsonl(jsonl_file, exported_asset, limit, source=source)
         jsonl_file.seek(0)
 
         yield RowBuffer(
@@ -451,7 +452,9 @@ def _query_supports_limit(query: dict) -> bool:
         return False
 
 
-def get_from_query(exported_asset: ExportedAsset, limit: int, resource: dict) -> Generator[Any, None, None]:
+def get_from_query(
+    exported_asset: ExportedAsset, limit: int, resource: dict, source: Optional[str] = None
+) -> Generator[Any, None, None]:
     query = resource.get("source")
     assert query is not None
 
@@ -477,6 +480,7 @@ def get_from_query(exported_asset: ExportedAsset, limit: int, resource: dict) ->
                 limit_context=LimitContext.EXPORT,
                 execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
                 pagination_cursor=cursor,
+                analytics_props={"source": source or EventSource.EXPORT},
             )
         except ClickHouseQuerySizeExceeded:
             if "breakdownFilter" not in query or limit <= CSV_EXPORT_BREAKDOWN_LIMIT_LOW:
@@ -517,11 +521,11 @@ def get_from_query(exported_asset: ExportedAsset, limit: int, resource: dict) ->
             break
 
 
-def _iter_rows(exported_asset: ExportedAsset, limit: int) -> Generator[Any, None, None]:
+def _iter_rows(exported_asset: ExportedAsset, limit: int, source: Optional[str] = None) -> Generator[Any, None, None]:
     resource = exported_asset.export_context or {}
 
     if resource.get("source"):
-        yield from get_from_query(exported_asset, limit, resource)
+        yield from get_from_query(exported_asset, limit, resource, source=source)
     else:
         # Legacy path for PersonsNode exports (uses API path instead of HogQL source).
         # PersonsNode was migrated to ActorsQuery in migration 0459, so this path
@@ -529,7 +533,9 @@ def _iter_rows(exported_asset: ExportedAsset, limit: int) -> Generator[Any, None
         yield from get_from_insights_api(exported_asset, CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL, resource)
 
 
-def _write_rows_to_jsonl(jsonl_file: Any, exported_asset: ExportedAsset, limit: int) -> tuple[int, list[str], set[str]]:
+def _write_rows_to_jsonl(
+    jsonl_file: Any, exported_asset: ExportedAsset, limit: int, source: Optional[str] = None
+) -> tuple[int, list[str], set[str]]:
     """Write flattened rows to a JSON lines file, discovering columns as we go.
 
     Returns:
@@ -540,7 +546,7 @@ def _write_rows_to_jsonl(jsonl_file: Any, exported_asset: ExportedAsset, limit: 
     seen_keys: set[str] = set()
     row_count = 0
 
-    for row in _iter_rows(exported_asset, limit):
+    for row in _iter_rows(exported_asset, limit, source=source):
         flat_row = dict(renderer.flatten_item(row))
 
         for key in flat_row.keys():
@@ -580,11 +586,13 @@ def _determine_columns(user_columns: list[str], all_keys: list[str], seen_keys: 
     return columns
 
 
-def _export_tabular(exported_asset: ExportedAsset, limit: int, writer: TabularWriter) -> None:
+def _export_tabular(
+    exported_asset: ExportedAsset, limit: int, writer: TabularWriter, source: Optional[str] = None
+) -> None:
     """Export data using the provided writer."""
     user_columns = (exported_asset.export_context or {}).get("columns", [])
 
-    with _buffer_rows(exported_asset, limit) as buffer:
+    with _buffer_rows(exported_asset, limit, source=source) as buffer:
         if buffer.row_count == 0:
             columns = user_columns if user_columns else ["error"]
             writer.write_header(columns)
@@ -635,16 +643,16 @@ def make_api_call(
     return response
 
 
-def export_tabular(exported_asset: ExportedAsset, limit: Optional[int] = None) -> None:
+def export_tabular(exported_asset: ExportedAsset, limit: Optional[int] = None, source: Optional[str] = None) -> None:
     if not limit:
         limit = CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL
 
     try:
         with EXPORT_TIMER.labels(type=exported_asset.export_format).time():
             if exported_asset.export_format == ExportedAsset.ExportFormat.CSV:
-                _export_tabular(exported_asset, limit, CsvWriter())
+                _export_tabular(exported_asset, limit, CsvWriter(), source=source)
             elif exported_asset.export_format == ExportedAsset.ExportFormat.XLSX:
-                _export_tabular(exported_asset, limit, ExcelWriter())
+                _export_tabular(exported_asset, limit, ExcelWriter(), source=source)
             else:
                 raise NotImplementedError(f"Export to format {exported_asset.export_format} is not supported")
     except Exception as e:

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -130,7 +130,9 @@ class RowBuffer:
 
 
 @contextmanager
-def _buffer_rows(exported_asset: ExportedAsset, limit: int, source: Optional[str] = None) -> Iterator[RowBuffer]:
+def _buffer_rows(
+    exported_asset: ExportedAsset, limit: int, source: Optional[EventSource] = None
+) -> Iterator[RowBuffer]:
     """Buffer rows to a temp file, discovering columns along the way.
 
     Yields a RowBuffer that exposes:
@@ -453,7 +455,7 @@ def _query_supports_limit(query: dict) -> bool:
 
 
 def get_from_query(
-    exported_asset: ExportedAsset, limit: int, resource: dict, source: Optional[str] = None
+    exported_asset: ExportedAsset, limit: int, resource: dict, source: Optional[EventSource] = None
 ) -> Generator[Any, None, None]:
     query = resource.get("source")
     assert query is not None
@@ -521,7 +523,9 @@ def get_from_query(
             break
 
 
-def _iter_rows(exported_asset: ExportedAsset, limit: int, source: Optional[str] = None) -> Generator[Any, None, None]:
+def _iter_rows(
+    exported_asset: ExportedAsset, limit: int, source: Optional[EventSource] = None
+) -> Generator[Any, None, None]:
     resource = exported_asset.export_context or {}
 
     if resource.get("source"):
@@ -534,7 +538,7 @@ def _iter_rows(exported_asset: ExportedAsset, limit: int, source: Optional[str] 
 
 
 def _write_rows_to_jsonl(
-    jsonl_file: Any, exported_asset: ExportedAsset, limit: int, source: Optional[str] = None
+    jsonl_file: Any, exported_asset: ExportedAsset, limit: int, source: Optional[EventSource] = None
 ) -> tuple[int, list[str], set[str]]:
     """Write flattened rows to a JSON lines file, discovering columns as we go.
 
@@ -587,7 +591,7 @@ def _determine_columns(user_columns: list[str], all_keys: list[str], seen_keys: 
 
 
 def _export_tabular(
-    exported_asset: ExportedAsset, limit: int, writer: TabularWriter, source: Optional[str] = None
+    exported_asset: ExportedAsset, limit: int, writer: TabularWriter, source: Optional[EventSource] = None
 ) -> None:
     """Export data using the provided writer."""
     user_columns = (exported_asset.export_context or {}).get("columns", [])
@@ -643,7 +647,9 @@ def make_api_call(
     return response
 
 
-def export_tabular(exported_asset: ExportedAsset, limit: Optional[int] = None, source: Optional[str] = None) -> None:
+def export_tabular(
+    exported_asset: ExportedAsset, limit: Optional[int] = None, source: Optional[EventSource] = None
+) -> None:
     if not limit:
         limit = CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -24,7 +24,7 @@ from posthog.schema import FunnelLayout, NodeKind
 
 from posthog.api.insight_variable import map_stale_to_latest
 from posthog.caching.calculate_results import calculate_for_query_based_insight
-from posthog.event_usage import EventSource
+from posthog.event_usage import AnalyticsProps, EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import InsightVariable
@@ -399,6 +399,7 @@ def export_image(
         try:
             # Track cache keys for insights so we can pass them to Chrome for guaranteed cache hits
             insight_cache_keys: dict[int, str] = {}
+            export_analytics_props: AnalyticsProps = {"source": source or EventSource.EXPORT}
 
             if exported_asset.insight:
                 logger.info(
@@ -430,7 +431,7 @@ def export_image(
                         user=None,
                         variables_override=dashboard_variables,
                         tile_filters_override=tile_filters_override,
-                        analytics_props={"source": source or EventSource.EXPORT},
+                        analytics_props=export_analytics_props,
                     )
                     if result.cache_key:
                         insight_cache_keys[exported_asset.insight.id] = result.cache_key
@@ -463,7 +464,7 @@ def export_image(
                             user=None,
                             variables_override=dashboard_variables,
                             tile_filters_override=tile.filters_overrides,
-                            analytics_props={"source": source or EventSource.EXPORT},
+                            analytics_props=export_analytics_props,
                         )
                         if result.cache_key:
                             insight_cache_keys[insight.id] = result.cache_key

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -24,6 +24,7 @@ from posthog.schema import FunnelLayout, NodeKind
 
 from posthog.api.insight_variable import map_stale_to_latest
 from posthog.caching.calculate_results import calculate_for_query_based_insight
+from posthog.event_usage import EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import InsightVariable
@@ -388,7 +389,9 @@ def _screenshot_asset(
             driver.quit()
 
 
-def export_image(exported_asset: ExportedAsset, max_height_pixels: Optional[int] = None) -> None:
+def export_image(
+    exported_asset: ExportedAsset, max_height_pixels: Optional[int] = None, source: Optional[str] = None
+) -> None:
     with posthoganalytics.new_context():
         posthoganalytics.tag("team_id", exported_asset.team_id if exported_asset else "unknown")
         posthoganalytics.tag("asset_id", exported_asset.id if exported_asset else "unknown")
@@ -427,6 +430,7 @@ def export_image(exported_asset: ExportedAsset, max_height_pixels: Optional[int]
                         user=None,
                         variables_override=dashboard_variables,
                         tile_filters_override=tile_filters_override,
+                        analytics_props={"source": source or EventSource.EXPORT},
                     )
                     if result.cache_key:
                         insight_cache_keys[exported_asset.insight.id] = result.cache_key
@@ -459,6 +463,7 @@ def export_image(exported_asset: ExportedAsset, max_height_pixels: Optional[int]
                             user=None,
                             variables_override=dashboard_variables,
                             tile_filters_override=tile.filters_overrides,
+                            analytics_props={"source": source or EventSource.EXPORT},
                         )
                         if result.cache_key:
                             insight_cache_keys[insight.id] = result.cache_key

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -390,7 +390,7 @@ def _screenshot_asset(
 
 
 def export_image(
-    exported_asset: ExportedAsset, max_height_pixels: Optional[int] = None, source: Optional[str] = None
+    exported_asset: ExportedAsset, max_height_pixels: Optional[int] = None, source: Optional[EventSource] = None
 ) -> None:
     with posthoganalytics.new_context():
         posthoganalytics.tag("team_id", exported_asset.team_id if exported_asset else "unknown")

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1,6 +1,9 @@
 import time
 import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from posthog.event_usage import AnalyticsProps
 from uuid import UUID
 
 from django.conf import settings
@@ -107,6 +110,7 @@ def process_query_task(
     query_tags: dict,
     is_query_service: bool,
     limit_context: Optional[LimitContext] = None,
+    analytics_props: Optional["AnalyticsProps"] = None,
 ) -> None:
     """
     Kick off query
@@ -128,6 +132,7 @@ def process_query_task(
         query_json=query_json,
         limit_context=limit_context,
         is_query_service=is_query_service,
+        analytics_props=analytics_props,
     )
 
 

--- a/posthog/temporal/ai/session_summary/summarize_session_group.py
+++ b/posthog/temporal/ai/session_summary/summarize_session_group.py
@@ -18,6 +18,7 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.schema import CachedSessionBatchEventsQueryResponse
 
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.session_batch_events_query_runner import (
     SessionBatchEventsQueryRunner,
     create_session_batch_events_query,
@@ -90,7 +91,7 @@ def _get_db_events_per_page(
         offset=offset,
     )
     runner = SessionBatchEventsQueryRunner(query=query, team=team)
-    response = runner.run()
+    response = runner.run(analytics_props={"source": EventSource.POSTHOG_AI})
     if not isinstance(response, CachedSessionBatchEventsQueryResponse):
         msg = (
             f"Failed to fetch events for sessions {logging_session_ids(session_ids)} in team {team.id} "

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -236,6 +236,7 @@ class TestSanitizeHeaderValue(BaseTest):
     @parameterized.expand(
         [
             ("passthrough", "posthog/wizard 1.0", "posthog/wizard 1.0"),
+            ("uuidv7_session_id", "019644d0-a67c-7fa5-a44c-e864c81b5087", "019644d0-a67c-7fa5-a44c-e864c81b5087"),
             ("strips_control_chars", "agent\x00with\x1fnulls", "agentwithnulls"),
             ("truncates_to_max_length", "a" * 1500, "a" * 1000),
             ("strips_whitespace", "  spaces  ", "spaces"),

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
@@ -163,6 +164,45 @@ class TestReportUserAction(BaseTest):
 
         mock_capture.assert_called_once()
         assert mock_capture.call_args[1]["properties"] == {"key": "val", "$set_once": {"email": self.user.email}}
+
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_analytics_props_merged_into_capture(self, mock_capture):
+        report_user_action(
+            self.user,
+            "test event",
+            properties={"key": "val"},
+            analytics_props={"source": EventSource.CACHE_WARMING},
+        )
+
+        mock_capture.assert_called_once()
+        captured_props = mock_capture.call_args[1]["properties"]
+        assert captured_props["source"] == EventSource.CACHE_WARMING
+        assert captured_props["key"] == "val"
+        assert captured_props["$set_once"] == {"email": self.user.email}
+
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_explicit_properties_take_precedence_over_analytics_props(self, mock_capture):
+        report_user_action(
+            self.user,
+            "test event",
+            properties={"source": "override"},
+            analytics_props={"source": EventSource.CACHE_WARMING},
+        )
+
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args[1]["properties"]["source"] == "override"
+
+    def test_raises_when_both_request_and_analytics_props_provided(self):
+        factory = APIRequestFactory()
+        request = factory.get("/fake")
+
+        with pytest.raises(ValueError, match="Pass either request or analytics_props, not both"):
+            report_user_action(
+                self.user,
+                "test event",
+                request=request,
+                analytics_props={"source": EventSource.API},
+            )
 
 
 class TestGetEventSource(BaseTest):

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -146,7 +146,12 @@ class TestReportUserAction(BaseTest):
         factory = APIRequestFactory()
         request = factory.get("/fake", headers=headers)
 
-        report_user_action(self.user, "test event", properties=explicit_properties, request=request)
+        report_user_action(
+            self.user,
+            "test event",
+            properties=explicit_properties,
+            request=request,
+        )
 
         mock_capture.assert_called_once()
         captured_props = mock_capture.call_args[1]["properties"]

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -52,7 +52,7 @@ from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import Product, get_query_tag_value, tag_queries
 from posthog.errors import ExposedCHQueryError
-from posthog.event_usage import report_user_action
+from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 from posthog.hogql_queries.query_runner import BLOCKING_EXECUTION_MODES
@@ -1225,7 +1225,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             user=cast(User, request.user),
             is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
             cache_age_seconds=cache_age_seconds,
-            request=request,
+            analytics_props=get_request_analytics_properties(request),
         )
 
         if isinstance(result, BaseModel):

--- a/products/experiments/backend/experiment_summary_data_service.py
+++ b/products/experiments/backend/experiment_summary_data_service.py
@@ -28,6 +28,7 @@ from posthog.schema import (
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.event_usage import EventSource
 from posthog.hogql_queries.experiments.experiment_exposures_query_runner import ExperimentExposuresQueryRunner
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
@@ -216,7 +217,10 @@ class ExperimentSummaryDataService:
                         team=experiment.team,
                         workload=Workload.ONLINE,
                     )
-                    result = query_runner.run(execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE)
+                    result = query_runner.run(
+                        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+                        analytics_props={"source": EventSource.POSTHOG_AI},
+                    )
                 refresh_time = getattr(result, "last_refresh", None)
 
                 if is_incomplete_response(result):
@@ -265,7 +269,8 @@ class ExperimentSummaryDataService:
                             team=experiment.team,
                         )
                         exposure_result = exposure_runner.run(
-                            execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE
+                            execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+                            analytics_props={"source": EventSource.POSTHOG_AI},
                         )
 
                     if is_incomplete_response(exposure_result):

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -102,7 +102,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
 
             Of logs at a time, stopping if we hit the limit first (most queries hit it in the first 3 minutes)
             """
-            runner = LogsQueryRunner(query, self.team, request=request)
+            runner = LogsQueryRunner(query, self.team)
 
             qdr = runner.query_date_range
             date_range_length = qdr.date_to() - qdr.date_from()
@@ -156,9 +156,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
                         }
                     )
 
-                return LogsQueryRunner(slice_query, self.team, request=request), LogsQueryRunner(
-                    remainder_query, self.team, request=request
-                )
+                return LogsQueryRunner(slice_query, self.team), LogsQueryRunner(remainder_query, self.team)
 
             # Skip time-slicing for live tailing - we're always only looking at the most recent 1-2 minutes
             # Note: cursor pagination no longer skips time-slicing because we narrow the date range
@@ -240,7 +238,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             sparklineBreakdownBy=query_data.get("sparklineBreakdownBy"),
         )
 
-        runner = SparklineQueryRunner(team=self.team, query=query, request=request)
+        runner = SparklineQueryRunner(team=self.team, query=query)
         response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
         assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
         return Response(response.results, status=status.HTTP_200_OK)

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -17,6 +17,7 @@ from posthog.schema import DateRange, LogAttributesQuery, LogsQuery, LogValuesQu
 
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import AnalyticsProps, get_request_analytics_properties
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import User
 from posthog.models.exported_asset import ExportedAsset
@@ -90,8 +91,9 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         if after_cursor:
             logs_query_params["after"] = after_cursor
         query = LogsQuery(**logs_query_params)
+        analytics_props = get_request_analytics_properties(request)
 
-        def results_generator(query: LogsQuery, logs_query_params: dict):
+        def results_generator(query: LogsQuery, logs_query_params: dict, analytics_props: AnalyticsProps):
             """
             A generator that yields results by splitting the query into time slices
 
@@ -162,14 +164,14 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             # Note: cursor pagination no longer skips time-slicing because we narrow the date range
             # to end at the cursor timestamp, allowing time-slicing to work on the remaining range.
             if live_logs_checkpoint:
-                response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+                response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
                 yield from response.results
                 return
 
             # if we're searching more than 20 minutes, first fetch the first 3 minutes of logs and see if that hits the limit
             if date_range_length > dt.timedelta(minutes=20):
                 recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=3), query.orderBy)
-                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
                 limit -= len(response.results)
                 yield from response.results
                 if limit <= 0:
@@ -179,7 +181,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             # otherwise if we're searching more than 4 hours search the next hour
             if date_range_length > dt.timedelta(hours=4):
                 recent_runner, runner = runner_slice(runner, dt.timedelta(minutes=60), query.orderBy)
-                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
                 limit -= len(response.results)
                 yield from response.results
                 if limit <= 0:
@@ -189,17 +191,17 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             # otherwise if we're searching more than 24 hours search the next 6 hours
             if date_range_length > dt.timedelta(hours=24):
                 recent_runner, runner = runner_slice(runner, dt.timedelta(hours=6), query.orderBy)
-                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+                response = recent_runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
                 limit -= len(response.results)
                 yield from response.results
                 if limit <= 0:
                     return
                 runner.query.limit = limit
 
-            response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+            response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
             yield from response.results
 
-        results = list(results_generator(query, logs_query_params))
+        results = list(results_generator(query, logs_query_params, analytics_props))
         has_more = len(results) > requested_limit
         results = results[:requested_limit]  # Rm the +1 we used to check for another page
 
@@ -239,7 +241,10 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         )
 
         runner = SparklineQueryRunner(team=self.team, query=query)
-        response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+        response = runner.run(
+            ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+            analytics_props=get_request_analytics_properties(request),
+        )
         assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
         return Response(response.results, status=status.HTTP_200_OK)
 

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -17,7 +17,7 @@ from posthog.schema import DateRange, LogAttributesQuery, LogsQuery, LogValuesQu
 
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.event_usage import AnalyticsProps, get_request_analytics_properties
+from posthog.event_usage import get_request_analytics_properties
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import User
 from posthog.models.exported_asset import ExportedAsset
@@ -93,7 +93,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         query = LogsQuery(**logs_query_params)
         analytics_props = get_request_analytics_properties(request)
 
-        def results_generator(query: LogsQuery, logs_query_params: dict, analytics_props: AnalyticsProps):
+        def results_generator(query: LogsQuery, logs_query_params: dict):
             """
             A generator that yields results by splitting the query into time slices
 
@@ -201,7 +201,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             response = runner.run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS, analytics_props=analytics_props)
             yield from response.results
 
-        results = list(results_generator(query, logs_query_params, analytics_props))
+        results = list(results_generator(query, logs_query_params))
         has_more = len(results) > requested_limit
         results = results[:requested_limit]  # Rm the +1 we used to check for another page
 

--- a/products/product_tours/backend/api/product_tour.py
+++ b/products/product_tours/backend/api/product_tour.py
@@ -393,30 +393,12 @@ class ProductTourSerializerCreateUpdateOnly(serializers.ModelSerializer):
             "creation_context": creation_context,
         }
 
-        report_user_action(
-            user,
-            ProductTourEventName.UPDATED,
-            analytics_metadata,
-            team=team,
-            request=request,
-        )
+        report_user_action(user, ProductTourEventName.UPDATED, analytics_metadata, team=team, request=request)
 
         if before_start_date is None and instance.start_date is not None:
-            report_user_action(
-                user,
-                ProductTourEventName.LAUNCHED,
-                analytics_metadata,
-                team=team,
-                request=request,
-            )
+            report_user_action(user, ProductTourEventName.LAUNCHED, analytics_metadata, team=team, request=request)
         elif before_end_date is None and instance.end_date is not None:
-            report_user_action(
-                user,
-                ProductTourEventName.STOPPED,
-                analytics_metadata,
-                team=team,
-                request=request,
-            )
+            report_user_action(user, ProductTourEventName.STOPPED, analytics_metadata, team=team, request=request)
 
         if instance.draft_content is not None:
             instance.draft_content = None

--- a/products/product_tours/backend/api/product_tour.py
+++ b/products/product_tours/backend/api/product_tour.py
@@ -393,12 +393,30 @@ class ProductTourSerializerCreateUpdateOnly(serializers.ModelSerializer):
             "creation_context": creation_context,
         }
 
-        report_user_action(user, ProductTourEventName.UPDATED, analytics_metadata, team=team, request=request)
+        report_user_action(
+            user,
+            ProductTourEventName.UPDATED,
+            analytics_metadata,
+            team=team,
+            request=request,
+        )
 
         if before_start_date is None and instance.start_date is not None:
-            report_user_action(user, ProductTourEventName.LAUNCHED, analytics_metadata, team=team, request=request)
+            report_user_action(
+                user,
+                ProductTourEventName.LAUNCHED,
+                analytics_metadata,
+                team=team,
+                request=request,
+            )
         elif before_end_date is None and instance.end_date is not None:
-            report_user_action(user, ProductTourEventName.STOPPED, analytics_metadata, team=team, request=request)
+            report_user_action(
+                user,
+                ProductTourEventName.STOPPED,
+                analytics_metadata,
+                team=team,
+                request=request,
+            )
 
         if instance.draft_content is not None:
             instance.draft_content = None

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -12,6 +12,7 @@ from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.dags.common import JobOwners
 from posthog.dags.common.resources import PostHogAnalyticsResource
+from posthog.event_usage import EventSource
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_cache import DjangoCacheQueryCacheManager
 from posthog.hogql_queries.query_runner import get_query_runner
@@ -183,7 +184,7 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: dict) -> None:
                 tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
 
                 # TODO: We shouldn't try to run a query if it failed last run
-                runner.run()
+                runner.run(analytics_props={"source": EventSource.CACHE_WARMING})
                 increment_counter(team_id, normalized_query_hash, is_cached=False)
                 queries_warmed += 1
 


### PR DESCRIPTION
## Problem

We thread the request through many code paths, to add analytics props based on the request (e.g. related to the user agent).

The problem is that we don't do this for all paths, and some, e.g. async celery queries, don't get these.

Additionally, there are some queries that are not triggered either directly or indirectly through requests, like subscriptions, and we want to add a source for these

## Changes

Instead of threading through the request, let's thread through the analytics props, and evaluate them earlier when we still have the request available.

Also, pass the source in for background queries.

## How did you test this code?

Updated the tests, and ofc existing tests did not break

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
