### PR TITLE
fix(ds): reduce Klaviyo batcher chunk size to prevent heartbeat timeouts

### DIFF
--- a/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -127,7 +127,7 @@ def get_rows(
 ) -> Iterator[Any]:
     config = KLAVIYO_ENDPOINTS[endpoint]
     headers = _get_headers(api_key)
-    batcher = Batcher(logger=logger)
+    batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
     params = _build_initial_params(
         config, should_use_incremental_field, db_incremental_field_last_value, incremental_field


### PR DESCRIPTION
## Problem

Customers running Klaviyo full syncs (especially on the `events` endpoint) are hitting repeated heartbeat timeouts that exhaust all retry attempts

## Changes

  * Reduced Klaviyo batcher chunk size from 5,000 to 2,000 items
  * Reduced Klaviyo batcher memory threshold from 200 MiB to 100 MiB

## How did you test this code?

tests

## Publish to changelog?

NO
