### PR TITLE
fix(ci): use GITHUB_TOKEN for pr-approval-agent approvals

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
     contents: read
-    pull-requests: read
+    pull-requests: write
 
 concurrency:
     group: pr-approval-${{ github.event.pull_request.number }}
@@ -63,17 +63,21 @@ jobs:
             - name: Post review
               if: success()
               env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  # Use GITHUB_TOKEN for approvals so github-actions[bot] is the
+                  # reviewer — its approvals count toward branch protection rules,
+                  # unlike GitHub App bot approvals which show author_association NONE.
+                  GH_TOKEN_APPROVE: ${{ github.token }}
+                  GH_TOKEN_COMMENT: ${{ steps.app-token.outputs.token }}
               run: |
                   VERDICT=$(jq -r '.final_verdict' /tmp/review.json)
                   REASONING=$(jq -r '.reviewer.reasoning // "No reasoning provided"' /tmp/review.json)
                   PR=${{ github.event.pull_request.number }}
 
                   if [ "$VERDICT" = "APPROVED" ]; then
-                    gh pr review "$PR" --approve --body "$REASONING" \
+                    GH_TOKEN="$GH_TOKEN_APPROVE" gh pr review "$PR" --approve --body "$REASONING" \
                       --repo ${{ github.repository }}
                   else
-                    gh pr review "$PR" --comment --body "$REASONING" \
+                    GH_TOKEN="$GH_TOKEN_COMMENT" gh pr review "$PR" --comment --body "$REASONING" \
                       --repo ${{ github.repository }}
                   fi
 


### PR DESCRIPTION
**Problem**
stamphog[bot] approvals show `author_association: NONE` and don't satisfy branch protection's "require approving review" rule.

**Fix**
Use `GITHUB_TOKEN` (github-actions[bot]) for the approval step — it has write access and its approvals count. Non-approval actions (comments, label removal) still use the app token.

Requires "Allow GitHub Actions to create and approve pull requests" in repo Settings > Actions > General.