### PR TITLE
feat(mcp): support for nested exclude_params

### DIFF
--- a/services/mcp/scripts/generate-orval-schemas.mjs
+++ b/services/mcp/scripts/generate-orval-schemas.mjs
@@ -16,10 +16,12 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
 
 import { filterSchemaByOperationIds } from '@posthog/openapi-codegen'
 
 import { discoverDefinitions, resolveSchemaPath } from './lib/definitions.mjs'
+import { applyNestedExclusions } from './lib/schema-exclusions.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const mcpRoot = path.resolve(__dirname, '..')
@@ -35,13 +37,29 @@ if (!fs.existsSync(schemaPath)) {
     process.exit(1)
 }
 
-function collectOperationIdsFromFile(filePath) {
-    const operationIds = new Set()
+/**
+ * Parse a YAML tool definition and return operationIds plus all exclude_params
+ * grouped by operationId for schema-level exclusion before Orval runs.
+ */
+function parseToolDefinition(filePath) {
     const content = fs.readFileSync(filePath, 'utf-8')
-    for (const match of content.matchAll(/^\s+operation:\s+(\S+)/gm)) {
-        operationIds.add(match[1])
+    const parsed = parseYaml(content)
+    const operationIds = new Set()
+    /** @type {Map<string, string[]>} */
+    const schemaExclusions = new Map()
+
+    if (parsed?.tools) {
+        for (const tool of Object.values(parsed.tools)) {
+            if (tool?.operation) {
+                operationIds.add(tool.operation)
+                const excludeParams = tool.exclude_params ?? []
+                if (excludeParams.length > 0) {
+                    schemaExclusions.set(tool.operation, excludeParams)
+                }
+            }
+        }
     }
-    return operationIds
+    return { operationIds, schemaExclusions }
 }
 
 // ------------------------------------------------------------------
@@ -154,7 +172,7 @@ const outputDirs = []
 let totalOps = 0
 
 for (const def of definitions) {
-    const operationIds = collectOperationIdsFromFile(def.filePath)
+    const { operationIds, schemaExclusions } = parseToolDefinition(def.filePath)
     if (operationIds.size === 0) {
         continue
     }
@@ -167,6 +185,7 @@ for (const def of definitions) {
 
     filtered = stripNullDefaults(filtered)
     stripUuidFormat(filtered)
+    applyNestedExclusions(filtered, schemaExclusions)
     const pathCount = Object.keys(filtered.paths).length
     const schemaCount = Object.keys(filtered.components.schemas).length
 

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -312,13 +312,16 @@ function composeToolSchema(config: ToolConfig, resolved: ResolvedOperation, spec
                         continue
                     }
 
-                    // Auto-exclude underscore-prefixed fields
-                    if (name.startsWith('_')) {
-                        bodyOmitFields.add(name)
+                    // exclude_params are removed at the Orval schema level by
+                    // applyNestedExclusions in generate-orval-schemas.mjs, so
+                    // they won't exist in the Zod schema. Skip them here to
+                    // avoid generating .omit() calls for nonexistent fields.
+                    if (excludeSet.has(name)) {
                         continue
                     }
-                    // Apply exclude_params / include_params
-                    if (excludeSet.has(name)) {
+
+                    // Auto-exclude underscore-prefixed fields
+                    if (name.startsWith('_')) {
                         bodyOmitFields.add(name)
                         continue
                     }

--- a/services/mcp/scripts/lib/schema-exclusions.mjs
+++ b/services/mcp/scripts/lib/schema-exclusions.mjs
@@ -1,0 +1,111 @@
+/**
+ * Applies nested field exclusions to an OpenAPI spec before Orval runs.
+ *
+ * Supports dot-notation paths for nested field removal:
+ *   - `steps.*.selector_regex` — for each item in the `steps` array, remove `selector_regex`
+ *   - `steps.*.properties.*.value` — nested arrays
+ *   - `*` navigates into array `items`; regular segments navigate into `properties[segment]`
+ *   - `$ref` is resolved transparently at each step
+ *
+ * Mutates the spec in place.
+ */
+
+/**
+ * Resolve a $ref string to the corresponding schema object.
+ * Only handles local component references (#/components/schemas/...).
+ */
+function resolveRef(spec, schema) {
+    if (schema?.$ref) {
+        const name = schema.$ref.replace('#/components/schemas/', '')
+        return spec.components?.schemas?.[name]
+    }
+    return schema
+}
+
+/**
+ * Walk a dotted path through an OpenAPI schema, resolving $ref at each step,
+ * and delete the final segment from `properties` (updating `required` too).
+ */
+function excludePath(spec, schema, segments) {
+    if (!schema || typeof schema !== 'object' || segments.length === 0) {
+        return
+    }
+
+    schema = resolveRef(spec, schema)
+    if (!schema) {
+        return
+    }
+
+    const [head, ...tail] = segments
+
+    if (tail.length === 0) {
+        // Last segment — delete the property
+        if (schema.properties?.[head]) {
+            delete schema.properties[head]
+            if (Array.isArray(schema.required)) {
+                schema.required = schema.required.filter((r) => r !== head)
+                if (schema.required.length === 0) {
+                    delete schema.required
+                }
+            }
+        }
+        return
+    }
+
+    if (head === '*') {
+        // Navigate into array items
+        const items = resolveRef(spec, schema.items)
+        if (items) {
+            excludePath(spec, items, tail)
+        }
+        return
+    }
+
+    // Navigate into a named property
+    const child = schema.properties?.[head]
+    if (child) {
+        excludePath(spec, resolveRef(spec, child), tail)
+    }
+}
+
+/**
+ * Find the request body schema for a given operationId.
+ */
+function findRequestBodySchema(spec, operationId) {
+    for (const methods of Object.values(spec.paths ?? {})) {
+        for (const operation of Object.values(methods)) {
+            if (operation?.operationId !== operationId) {
+                continue
+            }
+            const jsonContent = operation.requestBody?.content?.['application/json']
+            if (jsonContent?.schema) {
+                return resolveRef(spec, jsonContent.schema)
+            }
+        }
+    }
+    return undefined
+}
+
+/**
+ * Apply field exclusions to the OpenAPI spec before Orval runs.
+ *
+ * Handles both top-level field names (`deleted`) and dotted paths
+ * (`steps.*.selector_regex`). Walks each path through the operation's
+ * request body schema, resolving $ref transparently — so changes to
+ * shared component schemas affect all references.
+ *
+ * @param {object} spec — full OpenAPI spec (mutated in place)
+ * @param {Map<string, string[]>} operationExclusions — operationId → paths to exclude
+ */
+export function applyNestedExclusions(spec, operationExclusions) {
+    for (const [operationId, paths] of operationExclusions) {
+        const bodySchema = findRequestBodySchema(spec, operationId)
+        if (!bodySchema) {
+            continue
+        }
+        for (const dottedPath of paths) {
+            const segments = dottedPath.split('.')
+            excludePath(spec, bodySchema, segments)
+        }
+    }
+}

--- a/services/mcp/src/generated/actions/api.ts
+++ b/services/mcp/src/generated/actions/api.ts
@@ -470,12 +470,8 @@ export const ActionsListResponse = zod.object({
                         ])
                         .nullish(),
                 }),
-                deleted: zod.boolean().optional(),
-                is_calculating: zod.boolean(),
-                last_calculated_at: zod.string().datetime({}).optional(),
                 team_id: zod.number(),
                 is_action: zod.boolean(),
-                bytecode_error: zod.string().nullable(),
                 pinned_at: zod
                     .string()
                     .datetime({})
@@ -483,7 +479,6 @@ export const ActionsListResponse = zod.object({
                     .describe(
                         'ISO 8601 timestamp when the action was pinned, or null if not pinned. Set any value to pin, null to unpin.'
                     ),
-                creation_context: zod.string(),
                 _create_in_folder: zod.string().optional(),
                 user_access_level: zod
                     .string()
@@ -880,8 +875,6 @@ export const ActionsCreateBody = zod
             .describe(
                 'Action steps defining trigger conditions. Each step matches events by name, properties, URL, or element attributes. Multiple steps are OR-ed together.'
             ),
-        deleted: zod.boolean().optional(),
-        last_calculated_at: zod.string().datetime({}).optional(),
         pinned_at: zod
             .string()
             .datetime({})
@@ -1321,12 +1314,8 @@ export const ActionsRetrieveResponse = zod
                 ])
                 .nullish(),
         }),
-        deleted: zod.boolean().optional(),
-        is_calculating: zod.boolean(),
-        last_calculated_at: zod.string().datetime({}).optional(),
         team_id: zod.number(),
         is_action: zod.boolean(),
-        bytecode_error: zod.string().nullable(),
         pinned_at: zod
             .string()
             .datetime({})
@@ -1334,7 +1323,6 @@ export const ActionsRetrieveResponse = zod
             .describe(
                 'ISO 8601 timestamp when the action was pinned, or null if not pinned. Set any value to pin, null to unpin.'
             ),
-        creation_context: zod.string(),
         _create_in_folder: zod.string().optional(),
         user_access_level: zod.string().nullable().describe('The effective access level the user has for this object'),
     })
@@ -1727,8 +1715,6 @@ export const ActionsUpdateBody = zod
             .describe(
                 'Action steps defining trigger conditions. Each step matches events by name, properties, URL, or element attributes. Multiple steps are OR-ed together.'
             ),
-        deleted: zod.boolean().optional(),
-        last_calculated_at: zod.string().datetime({}).optional(),
         pinned_at: zod
             .string()
             .datetime({})
@@ -2155,12 +2141,8 @@ export const ActionsUpdateResponse = zod
                 ])
                 .nullish(),
         }),
-        deleted: zod.boolean().optional(),
-        is_calculating: zod.boolean(),
-        last_calculated_at: zod.string().datetime({}).optional(),
         team_id: zod.number(),
         is_action: zod.boolean(),
-        bytecode_error: zod.string().nullable(),
         pinned_at: zod
             .string()
             .datetime({})
@@ -2168,7 +2150,6 @@ export const ActionsUpdateResponse = zod
             .describe(
                 'ISO 8601 timestamp when the action was pinned, or null if not pinned. Set any value to pin, null to unpin.'
             ),
-        creation_context: zod.string(),
         _create_in_folder: zod.string().optional(),
         user_access_level: zod.string().nullable().describe('The effective access level the user has for this object'),
     })
@@ -2563,8 +2544,6 @@ export const ActionsPartialUpdateBody = zod
             .describe(
                 'Action steps defining trigger conditions. Each step matches events by name, properties, URL, or element attributes. Multiple steps are OR-ed together.'
             ),
-        deleted: zod.boolean().optional(),
-        last_calculated_at: zod.string().datetime({}).optional(),
         pinned_at: zod
             .string()
             .datetime({})
@@ -3001,12 +2980,8 @@ export const ActionsPartialUpdateResponse = zod
                 ])
                 .nullish(),
         }),
-        deleted: zod.boolean().optional(),
-        is_calculating: zod.boolean(),
-        last_calculated_at: zod.string().datetime({}).optional(),
         team_id: zod.number(),
         is_action: zod.boolean(),
-        bytecode_error: zod.string().nullable(),
         pinned_at: zod
             .string()
             .datetime({})
@@ -3014,7 +2989,6 @@ export const ActionsPartialUpdateResponse = zod
             .describe(
                 'ISO 8601 timestamp when the action was pinned, or null if not pinned. Set any value to pin, null to unpin.'
             ),
-        creation_context: zod.string(),
         _create_in_folder: zod.string().optional(),
         user_access_level: zod.string().nullable().describe('The effective access level the user has for this object'),
     })

--- a/services/mcp/src/generated/cohorts/api.ts
+++ b/services/mcp/src/generated/cohorts/api.ts
@@ -28,14 +28,6 @@ export const cohortsListResponseResultsItemDescriptionMax = 1000
 export const cohortsListResponseResultsItemFiltersOnePropertiesValuesItemOneNegationDefault = false
 export const cohortsListResponseResultsItemFiltersOnePropertiesValuesItemTwoNegationDefault = false
 export const cohortsListResponseResultsItemFiltersOnePropertiesValuesItemThreeNegationDefault = false
-export const cohortsListResponseResultsItemCreatedByOneDistinctIdMax = 200
-
-export const cohortsListResponseResultsItemCreatedByOneFirstNameMax = 150
-
-export const cohortsListResponseResultsItemCreatedByOneLastNameMax = 150
-
-export const cohortsListResponseResultsItemCreatedByOneEmailMax = 254
-
 export const cohortsListResponseResultsItemCreateStaticPersonIdsDefault = []
 
 export const CohortsListResponse = zod.object({
@@ -47,8 +39,6 @@ export const CohortsListResponse = zod.object({
             id: zod.number(),
             name: zod.string().max(cohortsListResponseResultsItemNameMax).nullish(),
             description: zod.string().max(cohortsListResponseResultsItemDescriptionMax).optional(),
-            groups: zod.unknown().optional(),
-            deleted: zod.boolean().optional(),
             filters: zod
                 .object({
                     properties: zod
@@ -135,44 +125,6 @@ export const CohortsListResponse = zod.object({
                 })
                 .nullish(),
             query: zod.unknown().nullish(),
-            version: zod.number().nullable(),
-            pending_version: zod.number().nullable(),
-            is_calculating: zod.boolean(),
-            created_by: zod.object({
-                id: zod.number(),
-                uuid: zod.string(),
-                distinct_id: zod.string().max(cohortsListResponseResultsItemCreatedByOneDistinctIdMax).nullish(),
-                first_name: zod.string().max(cohortsListResponseResultsItemCreatedByOneFirstNameMax).optional(),
-                last_name: zod.string().max(cohortsListResponseResultsItemCreatedByOneLastNameMax).optional(),
-                email: zod.string().email().max(cohortsListResponseResultsItemCreatedByOneEmailMax),
-                is_email_verified: zod.boolean().nullish(),
-                hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-                role_at_organization: zod
-                    .union([
-                        zod
-                            .enum([
-                                'engineering',
-                                'data',
-                                'product',
-                                'founder',
-                                'leadership',
-                                'marketing',
-                                'sales',
-                                'other',
-                            ])
-                            .describe(
-                                '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                            ),
-                        zod.enum(['']),
-                        zod.literal(null),
-                    ])
-                    .nullish(),
-            }),
-            created_at: zod.string().datetime({}).nullable(),
-            last_calculation: zod.string().datetime({}).nullable(),
-            errors_calculating: zod.number(),
-            last_error_message: zod.string().nullable(),
-            count: zod.number().nullable(),
             is_static: zod.boolean().optional(),
             cohort_type: zod
                 .union([
@@ -188,7 +140,6 @@ export const CohortsListResponse = zod.object({
                 .describe(
                     'Type of cohort based on filter complexity\n\n* `static` - static\n* `person_property` - person_property\n* `behavioral` - behavioral\n* `realtime` - realtime\n* `analytical` - analytical'
                 ),
-            experiment_set: zod.array(zod.number()),
             _create_in_folder: zod.string().optional(),
             _create_static_person_ids: zod
                 .array(zod.string())
@@ -217,8 +168,6 @@ export const cohortsCreateBodyCreateStaticPersonIdsDefault = []
 export const CohortsCreateBody = zod.object({
     name: zod.string().max(cohortsCreateBodyNameMax).nullish(),
     description: zod.string().max(cohortsCreateBodyDescriptionMax).optional(),
-    groups: zod.unknown().optional(),
-    deleted: zod.boolean().optional(),
     filters: zod
         .object({
             properties: zod
@@ -334,22 +283,12 @@ export const cohortsRetrieveResponseDescriptionMax = 1000
 export const cohortsRetrieveResponseFiltersOnePropertiesValuesItemOneNegationDefault = false
 export const cohortsRetrieveResponseFiltersOnePropertiesValuesItemTwoNegationDefault = false
 export const cohortsRetrieveResponseFiltersOnePropertiesValuesItemThreeNegationDefault = false
-export const cohortsRetrieveResponseCreatedByOneDistinctIdMax = 200
-
-export const cohortsRetrieveResponseCreatedByOneFirstNameMax = 150
-
-export const cohortsRetrieveResponseCreatedByOneLastNameMax = 150
-
-export const cohortsRetrieveResponseCreatedByOneEmailMax = 254
-
 export const cohortsRetrieveResponseCreateStaticPersonIdsDefault = []
 
 export const CohortsRetrieveResponse = zod.object({
     id: zod.number(),
     name: zod.string().max(cohortsRetrieveResponseNameMax).nullish(),
     description: zod.string().max(cohortsRetrieveResponseDescriptionMax).optional(),
-    groups: zod.unknown().optional(),
-    deleted: zod.boolean().optional(),
     filters: zod
         .object({
             properties: zod
@@ -430,35 +369,6 @@ export const CohortsRetrieveResponse = zod.object({
         })
         .nullish(),
     query: zod.unknown().nullish(),
-    version: zod.number().nullable(),
-    pending_version: zod.number().nullable(),
-    is_calculating: zod.boolean(),
-    created_by: zod.object({
-        id: zod.number(),
-        uuid: zod.string(),
-        distinct_id: zod.string().max(cohortsRetrieveResponseCreatedByOneDistinctIdMax).nullish(),
-        first_name: zod.string().max(cohortsRetrieveResponseCreatedByOneFirstNameMax).optional(),
-        last_name: zod.string().max(cohortsRetrieveResponseCreatedByOneLastNameMax).optional(),
-        email: zod.string().email().max(cohortsRetrieveResponseCreatedByOneEmailMax),
-        is_email_verified: zod.boolean().nullish(),
-        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-        role_at_organization: zod
-            .union([
-                zod
-                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
-                    .describe(
-                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                    ),
-                zod.enum(['']),
-                zod.literal(null),
-            ])
-            .nullish(),
-    }),
-    created_at: zod.string().datetime({}).nullable(),
-    last_calculation: zod.string().datetime({}).nullable(),
-    errors_calculating: zod.number(),
-    last_error_message: zod.string().nullable(),
-    count: zod.number().nullable(),
     is_static: zod.boolean().optional(),
     cohort_type: zod
         .union([
@@ -474,7 +384,6 @@ export const CohortsRetrieveResponse = zod.object({
         .describe(
             'Type of cohort based on filter complexity\n\n* `static` - static\n* `person_property` - person_property\n* `behavioral` - behavioral\n* `realtime` - realtime\n* `analytical` - analytical'
         ),
-    experiment_set: zod.array(zod.number()),
     _create_in_folder: zod.string().optional(),
     _create_static_person_ids: zod.array(zod.string()).default(cohortsRetrieveResponseCreateStaticPersonIdsDefault),
 })
@@ -500,8 +409,6 @@ export const cohortsUpdateBodyCreateStaticPersonIdsDefault = []
 export const CohortsUpdateBody = zod.object({
     name: zod.string().max(cohortsUpdateBodyNameMax).nullish(),
     description: zod.string().max(cohortsUpdateBodyDescriptionMax).optional(),
-    groups: zod.unknown().optional(),
-    deleted: zod.boolean().optional(),
     filters: zod
         .object({
             properties: zod
@@ -608,22 +515,12 @@ export const cohortsUpdateResponseDescriptionMax = 1000
 export const cohortsUpdateResponseFiltersOnePropertiesValuesItemOneNegationDefault = false
 export const cohortsUpdateResponseFiltersOnePropertiesValuesItemTwoNegationDefault = false
 export const cohortsUpdateResponseFiltersOnePropertiesValuesItemThreeNegationDefault = false
-export const cohortsUpdateResponseCreatedByOneDistinctIdMax = 200
-
-export const cohortsUpdateResponseCreatedByOneFirstNameMax = 150
-
-export const cohortsUpdateResponseCreatedByOneLastNameMax = 150
-
-export const cohortsUpdateResponseCreatedByOneEmailMax = 254
-
 export const cohortsUpdateResponseCreateStaticPersonIdsDefault = []
 
 export const CohortsUpdateResponse = zod.object({
     id: zod.number(),
     name: zod.string().max(cohortsUpdateResponseNameMax).nullish(),
     description: zod.string().max(cohortsUpdateResponseDescriptionMax).optional(),
-    groups: zod.unknown().optional(),
-    deleted: zod.boolean().optional(),
     filters: zod
         .object({
             properties: zod
@@ -704,35 +601,6 @@ export const CohortsUpdateResponse = zod.object({
         })
         .nullish(),
     query: zod.unknown().nullish(),
-    version: zod.number().nullable(),
-    pending_version: zod.number().nullable(),
-    is_calculating: zod.boolean(),
-    created_by: zod.object({
-        id: zod.number(),
-        uuid: zod.string(),
-        distinct_id: zod.string().max(cohortsUpdateResponseCreatedByOneDistinctIdMax).nullish(),
-        first_name: zod.string().max(cohortsUpdateResponseCreatedByOneFirstNameMax).optional(),
-        last_name: zod.string().max(cohortsUpdateResponseCreatedByOneLastNameMax).optional(),
-        email: zod.string().email().max(cohortsUpdateResponseCreatedByOneEmailMax),
-        is_email_verified: zod.boolean().nullish(),
-        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-        role_at_organization: zod
-            .union([
-                zod
-                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
-                    .describe(
-                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                    ),
-                zod.enum(['']),
-                zod.literal(null),
-            ])
-            .nullish(),
-    }),
-    created_at: zod.string().datetime({}).nullable(),
-    last_calculation: zod.string().datetime({}).nullable(),
-    errors_calculating: zod.number(),
-    last_error_message: zod.string().nullable(),
-    count: zod.number().nullable(),
     is_static: zod.boolean().optional(),
     cohort_type: zod
         .union([
@@ -748,7 +616,6 @@ export const CohortsUpdateResponse = zod.object({
         .describe(
             'Type of cohort based on filter complexity\n\n* `static` - static\n* `person_property` - person_property\n* `behavioral` - behavioral\n* `realtime` - realtime\n* `analytical` - analytical'
         ),
-    experiment_set: zod.array(zod.number()),
     _create_in_folder: zod.string().optional(),
     _create_static_person_ids: zod.array(zod.string()).default(cohortsUpdateResponseCreateStaticPersonIdsDefault),
 })
@@ -774,7 +641,6 @@ export const cohortsPartialUpdateBodyCreateStaticPersonIdsDefault = []
 export const CohortsPartialUpdateBody = zod.object({
     name: zod.string().max(cohortsPartialUpdateBodyNameMax).nullish(),
     description: zod.string().max(cohortsPartialUpdateBodyDescriptionMax).optional(),
-    groups: zod.unknown().optional(),
     deleted: zod.boolean().optional(),
     filters: zod
         .object({
@@ -884,22 +750,12 @@ export const cohortsPartialUpdateResponseDescriptionMax = 1000
 export const cohortsPartialUpdateResponseFiltersOnePropertiesValuesItemOneNegationDefault = false
 export const cohortsPartialUpdateResponseFiltersOnePropertiesValuesItemTwoNegationDefault = false
 export const cohortsPartialUpdateResponseFiltersOnePropertiesValuesItemThreeNegationDefault = false
-export const cohortsPartialUpdateResponseCreatedByOneDistinctIdMax = 200
-
-export const cohortsPartialUpdateResponseCreatedByOneFirstNameMax = 150
-
-export const cohortsPartialUpdateResponseCreatedByOneLastNameMax = 150
-
-export const cohortsPartialUpdateResponseCreatedByOneEmailMax = 254
-
 export const cohortsPartialUpdateResponseCreateStaticPersonIdsDefault = []
 
 export const CohortsPartialUpdateResponse = zod.object({
     id: zod.number(),
     name: zod.string().max(cohortsPartialUpdateResponseNameMax).nullish(),
     description: zod.string().max(cohortsPartialUpdateResponseDescriptionMax).optional(),
-    groups: zod.unknown().optional(),
-    deleted: zod.boolean().optional(),
     filters: zod
         .object({
             properties: zod
@@ -986,35 +842,6 @@ export const CohortsPartialUpdateResponse = zod.object({
         })
         .nullish(),
     query: zod.unknown().nullish(),
-    version: zod.number().nullable(),
-    pending_version: zod.number().nullable(),
-    is_calculating: zod.boolean(),
-    created_by: zod.object({
-        id: zod.number(),
-        uuid: zod.string(),
-        distinct_id: zod.string().max(cohortsPartialUpdateResponseCreatedByOneDistinctIdMax).nullish(),
-        first_name: zod.string().max(cohortsPartialUpdateResponseCreatedByOneFirstNameMax).optional(),
-        last_name: zod.string().max(cohortsPartialUpdateResponseCreatedByOneLastNameMax).optional(),
-        email: zod.string().email().max(cohortsPartialUpdateResponseCreatedByOneEmailMax),
-        is_email_verified: zod.boolean().nullish(),
-        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-        role_at_organization: zod
-            .union([
-                zod
-                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
-                    .describe(
-                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                    ),
-                zod.enum(['']),
-                zod.literal(null),
-            ])
-            .nullish(),
-    }),
-    created_at: zod.string().datetime({}).nullable(),
-    last_calculation: zod.string().datetime({}).nullable(),
-    errors_calculating: zod.number(),
-    last_error_message: zod.string().nullable(),
-    count: zod.number().nullable(),
     is_static: zod.boolean().optional(),
     cohort_type: zod
         .union([
@@ -1030,7 +857,6 @@ export const CohortsPartialUpdateResponse = zod.object({
         .describe(
             'Type of cohort based on filter complexity\n\n* `static` - static\n* `person_property` - person_property\n* `behavioral` - behavioral\n* `realtime` - realtime\n* `analytical` - analytical'
         ),
-    experiment_set: zod.array(zod.number()),
     _create_in_folder: zod.string().optional(),
     _create_static_person_ids: zod
         .array(zod.string())

--- a/services/mcp/src/tools/generated/actions.ts
+++ b/services/mcp/src/tools/generated/actions.ts
@@ -44,7 +44,7 @@ const actionsGetAll = (): ToolBase<typeof ActionsGetAllSchema, unknown> => ({
     },
 })
 
-const ActionCreateSchema = ActionsCreateBody.omit({ deleted: true, last_calculated_at: true, _create_in_folder: true })
+const ActionCreateSchema = ActionsCreateBody.omit({ _create_in_folder: true })
 
 const actionCreate = (): ToolBase<typeof ActionCreateSchema, Schemas.Action & { _posthogUrl: string }> => ({
     name: 'action-create',
@@ -114,7 +114,7 @@ const actionGet = (): ToolBase<typeof ActionGetSchema, Schemas.Action & { _posth
 })
 
 const ActionUpdateSchema = ActionsPartialUpdateParams.omit({ project_id: true }).extend(
-    ActionsPartialUpdateBody.omit({ deleted: true, last_calculated_at: true, _create_in_folder: true }).shape
+    ActionsPartialUpdateBody.omit({ _create_in_folder: true }).shape
 )
 
 const actionUpdate = (): ToolBase<typeof ActionUpdateSchema, Schemas.Action & { _posthogUrl: string }> => ({

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -47,12 +47,7 @@ const cohortsList = (): ToolBase<typeof CohortsListSchema, unknown> => ({
     },
 })
 
-const CohortsCreateSchema = CohortsCreateBody.omit({
-    groups: true,
-    deleted: true,
-    _create_in_folder: true,
-    _create_static_person_ids: true,
-})
+const CohortsCreateSchema = CohortsCreateBody.omit({ _create_in_folder: true, _create_static_person_ids: true })
 
 const cohortsCreate = (): ToolBase<typeof CohortsCreateSchema, Schemas.Cohort & { _posthogUrl: string }> => ({
     name: 'cohorts-create',
@@ -119,7 +114,7 @@ const cohortsRetrieve = (): ToolBase<typeof CohortsRetrieveSchema, Schemas.Cohor
 })
 
 const CohortsPartialUpdateSchema = CohortsPartialUpdateParams.omit({ project_id: true }).extend(
-    CohortsPartialUpdateBody.omit({ groups: true, _create_in_folder: true, _create_static_person_ids: true }).shape
+    CohortsPartialUpdateBody.omit({ _create_in_folder: true, _create_static_person_ids: true }).shape
 )
 
 const cohortsPartialUpdate = (): ToolBase<

--- a/services/mcp/tests/unit/schema-exclusions.test.ts
+++ b/services/mcp/tests/unit/schema-exclusions.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyNestedExclusions } from '../../scripts/lib/schema-exclusions.mjs'
+
+describe('applyNestedExclusions', () => {
+    it('removes a nested property via wildcard path (array items)', () => {
+        const spec = {
+            paths: {
+                '/api/projects/{project_id}/actions/': {
+                    post: {
+                        operationId: 'actions_create',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: { $ref: '#/components/schemas/Action' },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            components: {
+                schemas: {
+                    Action: {
+                        type: 'object',
+                        properties: {
+                            name: { type: 'string' },
+                            steps: {
+                                type: 'array',
+                                items: {
+                                    $ref: '#/components/schemas/ActionStep',
+                                },
+                            },
+                        },
+                    },
+                    ActionStep: {
+                        type: 'object',
+                        required: ['event', 'selector_regex'],
+                        properties: {
+                            event: { type: 'string' },
+                            selector_regex: { type: 'string' },
+                            tag_name: { type: 'string' },
+                        },
+                    },
+                },
+            },
+        }
+
+        applyNestedExclusions(spec, new Map([['actions_create', ['steps.*.selector_regex']]]))
+
+        expect(spec.components.schemas.ActionStep.properties).not.toHaveProperty('selector_regex')
+        expect(spec.components.schemas.ActionStep.properties).toHaveProperty('event')
+        expect(spec.components.schemas.ActionStep.properties).toHaveProperty('tag_name')
+        expect(spec.components.schemas.ActionStep.required).toEqual(['event'])
+    })
+
+    it('removes a deep nested property via double wildcard', () => {
+        const spec = {
+            paths: {
+                '/api/things/': {
+                    post: {
+                        operationId: 'things_create',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: {
+                                        type: 'object',
+                                        properties: {
+                                            steps: {
+                                                type: 'array',
+                                                items: {
+                                                    type: 'object',
+                                                    properties: {
+                                                        properties: {
+                                                            type: 'array',
+                                                            items: {
+                                                                type: 'object',
+                                                                required: ['key', 'value'],
+                                                                properties: {
+                                                                    key: { type: 'string' },
+                                                                    value: { type: 'string' },
+                                                                },
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            components: { schemas: {} },
+        }
+
+        applyNestedExclusions(spec, new Map([['things_create', ['steps.*.properties.*.value']]]))
+
+        const innerProps =
+            spec.paths['/api/things/'].post.requestBody.content['application/json'].schema.properties.steps.items
+                .properties.properties.items.properties
+        expect(innerProps).not.toHaveProperty('value')
+        expect(innerProps).toHaveProperty('key')
+    })
+
+    it('removes a property via object path (no wildcard)', () => {
+        const spec = {
+            paths: {
+                '/api/things/': {
+                    post: {
+                        operationId: 'things_create',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: {
+                                        type: 'object',
+                                        properties: {
+                                            config: {
+                                                type: 'object',
+                                                properties: {
+                                                    keep: { type: 'string' },
+                                                    remove: { type: 'string' },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            components: { schemas: {} },
+        }
+
+        applyNestedExclusions(spec, new Map([['things_create', ['config.remove']]]))
+
+        const configProps =
+            spec.paths['/api/things/'].post.requestBody.content['application/json'].schema.properties.config.properties
+        expect(configProps).not.toHaveProperty('remove')
+        expect(configProps).toHaveProperty('keep')
+    })
+
+    it('resolves $ref at the request body level', () => {
+        const spec = {
+            paths: {
+                '/api/things/': {
+                    post: {
+                        operationId: 'things_create',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: { $ref: '#/components/schemas/Thing' },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            components: {
+                schemas: {
+                    Thing: {
+                        type: 'object',
+                        required: ['name', 'secret'],
+                        properties: {
+                            name: { type: 'string' },
+                            secret: { type: 'string' },
+                        },
+                    },
+                },
+            },
+        }
+
+        // Even a non-dotted single-segment path works for direct property removal
+        applyNestedExclusions(spec, new Map([['things_create', ['secret']]]))
+
+        expect(spec.components.schemas.Thing.properties).not.toHaveProperty('secret')
+        expect(spec.components.schemas.Thing.required).toEqual(['name'])
+    })
+
+    it('deletes required array when all required fields are excluded', () => {
+        const spec = {
+            paths: {
+                '/api/things/': {
+                    post: {
+                        operationId: 'things_create',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: {
+                                        type: 'object',
+                                        required: ['only_field'],
+                                        properties: {
+                                            only_field: { type: 'string' },
+                                            optional: { type: 'string' },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            components: { schemas: {} },
+        }
+
+        applyNestedExclusions(spec, new Map([['things_create', ['only_field']]]))
+
+        const bodySchema = spec.paths['/api/things/'].post.requestBody.content['application/json'].schema
+        expect(bodySchema.properties).not.toHaveProperty('only_field')
+        expect(bodySchema).not.toHaveProperty('required')
+    })
+
+    it('is a no-op for nonexistent paths', () => {
+        const spec = {
+            paths: {
+                '/api/things/': {
+                    post: {
+                        operationId: 'things_create',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: {
+                                        type: 'object',
+                                        properties: {
+                                            name: { type: 'string' },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            components: { schemas: {} },
+        }
+
+        expect(() => applyNestedExclusions(spec, new Map([['things_create', ['nonexistent.*.field']]]))).not.toThrow()
+
+        expect(
+            spec.paths['/api/things/'].post.requestBody.content['application/json'].schema.properties
+        ).toHaveProperty('name')
+    })
+
+    it('is a no-op for nonexistent operationId', () => {
+        const spec = {
+            paths: {},
+            components: { schemas: {} },
+        }
+
+        expect(() => applyNestedExclusions(spec, new Map([['nonexistent_op', ['foo.bar']]]))).not.toThrow()
+    })
+
+    it('handles empty spec gracefully', () => {
+        expect(() => applyNestedExclusions({}, new Map())).not.toThrow()
+    })
+
+    it('handles empty exclusions map', () => {
+        const spec = {
+            paths: {
+                '/api/things/': {
+                    post: {
+                        operationId: 'things_create',
+                        requestBody: {
+                            content: {
+                                'application/json': {
+                                    schema: {
+                                        type: 'object',
+                                        properties: { name: { type: 'string' } },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            components: { schemas: {} },
+        }
+
+        applyNestedExclusions(spec, new Map())
+        expect(
+            spec.paths['/api/things/'].post.requestBody.content['application/json'].schema.properties
+        ).toHaveProperty('name')
+    })
+})


### PR DESCRIPTION
## Problem

We do not have a way how to exclude nested params


## Summary

  - Extend `exclude_params` to support dot-notation paths for nested field exclusion (e.g., `steps.*.selector_regex`)
  - All `exclude_params` — both top-level and nested — are now applied to the OpenAPI spec **before Orval runs**, so the generated Zod schemas never contain
  excluded fields. This means `generate-tools.ts` simply skips excluded fields instead of generating `.omit()` calls against them, preventing runtime errors
  from trying to omit nonexistent keys.

  ## What changed

  - **`schema-exclusions.mjs`** (new) — `applyNestedExclusions()` walks dot-notation paths through OpenAPI schemas, resolving `$ref` transparently, and
  deletes targeted properties + updates `required` arrays
  - **`generate-orval-schemas.mjs`** — replaced regex-based `collectOperationIdsFromFile` with YAML-parsing `parseToolDefinition` that extracts
  `exclude_params` per operation; calls `applyNestedExclusions` instead of the deleted `applyMcpExtensions`
  - **`generate-tools.ts`** — removed `applyMcpExtensions` import/call and `x-mcp-*` interface fields; skips excluded fields in body schema iteration
  (they're already gone from the Zod schema)
  - **Generated files** — `actions/api.ts` lost 26 lines (excluded fields removed from schemas), `cohorts/api.ts` lost 174 lines (same cleanup from
  regeneration)
  - **`schema-exclusions.test.ts`** (new) — 9 tests covering wildcard paths, deep nesting, `$ref` resolution, required array cleanup, edge cases

  ## Test plan

  - `hogli build:openapi` — full pipeline succeeds
  - Generated `actions/api.ts` — zero occurrences of excluded fields
