### PR TITLE
chore(ph-ai): handle httpx transport errors as transient LLM exceptions

### DIFF
--- a/ee/hogai/core/test/test_runner.py
+++ b/ee/hogai/core/test/test_runner.py
@@ -188,6 +188,16 @@ class TestRunnerLLMProviderErrorHandling(BaseTest):
                 ),
                 "openai",
             ),
+            (
+                "httpx_read_error",
+                httpx.ReadError("Connection reset by peer"),
+                "httpx",
+            ),
+            (
+                "httpx_connect_error",
+                httpx.ConnectError("Connection refused"),
+                "httpx",
+            ),
         ]
     )
     async def test_llm_transient_errors_handled_with_retry_message(self, _name, exception, expected_provider):

--- a/ee/hogai/utils/exceptions.py
+++ b/ee/hogai/utils/exceptions.py
@@ -1,3 +1,4 @@
+import httpx
 import openai
 import anthropic
 from prometheus_client import Counter
@@ -17,6 +18,9 @@ LLM_TRANSIENT_EXCEPTIONS = (
     openai.RateLimitError,
     openai.APITimeoutError,
     openai.APIConnectionError,
+    # httpx transport errors that can escape SDK wrapping during streaming
+    httpx.ReadError,
+    httpx.ConnectError,
 )
 
 # Client/validation errors that won't resolve on retry (400, 422, etc.)


### PR DESCRIPTION
## Problem

Not a huge deal but annoying, `httpx.ReadError` exceptions during Anthropic API streaming escaped the SDK's error wrapping and fall through to the generic catch all, resulting in poor error categorization.

[error link](https://us.posthog.com/project/2/error_tracking/019bb8e7-ef5d-7da0-9974-6403b1d8bb62?timestamp=2026-03-11%2009:19:16.222000-07:00&filterGroup=%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22type%22:%22AND%22,%22values%22:%5B%7B%22key%22:%22tag%22,%22value%22:%5B%22max_ai%22%5D,%22operator%22:%22exact%22,%22type%22:%22event%22%7D%5D%7D%5D%7D)

<img width="1061" height="290" alt="image" src="https://github.com/user-attachments/assets/4d153ca3-c29c-479b-908a-ee5586017588" />

## Changes

- Add `httpx.ReadError` and `httpx.ConnectError` to `LLM_TRANSIENT_EXCEPTIONS` so they are handled like other transient errors