### PR TITLE
feat: sort taxonomic filter by a lite relevancy measure so exact matches are surfaced more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,7 +285,7 @@ RUN --mount=type=cache,id=playwright-browsers,target=/tmp/playwright-cache \
     PLAYWRIGHT_BROWSERS_PATH=/tmp/playwright-cache \
     /python-runtime/bin/python -m playwright install --with-deps chromium && \
     mkdir -p /ms-playwright && \
-    cp -r /tmp/playwright-cache/. /ms-playwright/ && \
+    cp -r /tmp/playwright-cache/* /ms-playwright/ && \
     chown -R posthog:posthog /ms-playwright
 USER posthog
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -285,7 +285,7 @@ RUN --mount=type=cache,id=playwright-browsers,target=/tmp/playwright-cache \
     PLAYWRIGHT_BROWSERS_PATH=/tmp/playwright-cache \
     /python-runtime/bin/python -m playwright install --with-deps chromium && \
     mkdir -p /ms-playwright && \
-    cp -r /tmp/playwright-cache/* /ms-playwright/ && \
+    cp -r /tmp/playwright-cache/. /ms-playwright/ && \
     chown -R posthog:posthog /ms-playwright
 USER posthog
 

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -385,9 +385,9 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         EnterpriseEventDefinition.objects.create(team=self.demo_team, name="installed_app")
 
         response = self.client.get("/api/projects/@current/event_definitions/?search=app&event_type=event")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 2)
-        self.assertEqual([row["name"] for row in response.json()["results"]], ["rated_app", "installed_app"])
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["count"] == 2
+        assert [row["name"] for row in response.json()["results"]] == ["rated_app", "installed_app"]
 
     def test_create_event_definition_with_description(self):
         """Test creating an event definition with enterprise fields"""

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -387,7 +387,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         response = self.client.get("/api/projects/@current/event_definitions/?search=app&event_type=event")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 2)
-        self.assertEqual(response.json()["results"][0]["name"], "installed_app")
+        self.assertEqual([row["name"] for row in response.json()["results"]], ["rated_app", "installed_app"])
 
     def test_create_event_definition_with_description(self):
         """Test creating an event definition with enterprise fields"""

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -149,10 +149,11 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             ["entered_free_trial", "enterprise event"],
         )
 
-        self.assertEqual(response_data["results"][1]["name"], "enterprise event")
-        self.assertEqual(response_data["results"][1]["description"], "")
-        self.assertEqual(response_data["results"][1]["tags"], ["deprecated"])
-        self.assertEqual(response_data["results"][1]["owner"]["id"], self.user.id)
+        enterprise_event = next((r for r in response_data["results"] if r["name"] == "enterprise event"), None)
+        assert enterprise_event is not None
+        assert enterprise_event["description"] == ""
+        assert enterprise_event["tags"] == ["deprecated"]
+        assert enterprise_event["owner"]["id"] == self.user.id
 
         response = self.client.get(f"/api/projects/@current/event_definitions/?search=enterprise")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -200,6 +200,9 @@ class EventDefinitionViewSet(
         params = {"project_id": self.project_id, "is_posthog_event": "$%", **search_kwargs}
         order_expressions = self._ordering_params_from_request()
 
+        if search:
+            order_expressions = [("length(name)", "ASC"), *order_expressions]
+
         event_definition_object_manager: Manager
         if EE_AVAILABLE:
             from ee.models.event_definition import EnterpriseEventDefinition

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -199,8 +199,10 @@ class EventDefinitionViewSet(
 
         params = {"project_id": self.project_id, "is_posthog_event": "$%", **search_kwargs}
         order_expressions = self._ordering_params_from_request()
+        has_explicit_ordering = "ordering" in self.request.GET
+        has_search_terms = bool(search and search.strip())
 
-        if search:
+        if has_search_terms and not has_explicit_ordering:
             order_expressions = [("length(name)", "ASC"), *order_expressions]
 
         event_definition_object_manager: Manager

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -242,6 +242,9 @@ class TestEventDefinitionAPI(APIBaseTest):
     @parameterized.expand(
         [
             ("shorter match first for 'app'", "app", ["rated_app", "installed_app"]),
+            ("shorter match first for uppercase 'APP'", "APP", ["rated_app", "installed_app"]),
+            ("shorter match first for encoded ' app '", "%20app%20", ["rated_app", "installed_app"]),
+            ("multiple matches sorted by length for 'ed'", "ed", ["rated_app", "watched_movie", "entered_free_trial"]),
         ]
     )
     def test_search_results_ordered_by_name_length(

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -244,7 +244,11 @@ class TestEventDefinitionAPI(APIBaseTest):
             ("shorter match first for 'app'", "app", ["rated_app", "installed_app"]),
             ("shorter match first for uppercase 'APP'", "APP", ["rated_app", "installed_app"]),
             ("shorter match first for encoded ' app '", "%20app%20", ["rated_app", "installed_app"]),
-            ("multiple matches sorted by length for 'ed'", "ed", ["rated_app", "watched_movie", "entered_free_trial"]),
+            (
+                "multiple matches sorted by length for 'ed'",
+                "ed",
+                ["rated_app", "installed_app", "watched_movie", "entered_free_trial"],
+            ),
         ]
     )
     def test_search_results_ordered_by_name_length(

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -242,7 +242,6 @@ class TestEventDefinitionAPI(APIBaseTest):
     @parameterized.expand(
         [
             ("shorter match first for 'app'", "app", ["rated_app", "installed_app"]),
-            ("shorter match first for 'purchase'", "purchase", ["purchase"]),
         ]
     )
     def test_search_results_ordered_by_name_length(
@@ -252,6 +251,23 @@ class TestEventDefinitionAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         result_names = [r["name"] for r in response.json()["results"]]
         assert result_names == expected_names
+
+    def test_search_keeps_explicit_ordering(self) -> None:
+        response = self.client.get("/api/projects/@current/event_definitions/?search=app&ordering=name")
+        assert response.status_code == status.HTTP_200_OK
+        result_names = [r["name"] for r in response.json()["results"]]
+        assert result_names == ["installed_app", "rated_app"]
+
+    def test_whitespace_search_does_not_change_default_ordering(self) -> None:
+        default_response = self.client.get("/api/projects/@current/event_definitions/")
+        assert default_response.status_code == status.HTTP_200_OK
+        default_names = [r["name"] for r in default_response.json()["results"]]
+
+        whitespace_search_response = self.client.get("/api/projects/@current/event_definitions/?search=%20%20")
+        assert whitespace_search_response.status_code == status.HTTP_200_OK
+        whitespace_search_names = [r["name"] for r in whitespace_search_response.json()["results"]]
+
+        assert whitespace_search_names == default_names
 
     def test_event_type_event(self):
         action = Action.objects.create(team=self.demo_team, name="action1_app")

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -239,6 +239,20 @@ class TestEventDefinitionAPI(APIBaseTest):
         for item in response.json()["results"]:
             assert item["name"] in ["watched_movie"]
 
+    @parameterized.expand(
+        [
+            ("shorter match first for 'app'", "app", ["rated_app", "installed_app"]),
+            ("shorter match first for 'purchase'", "purchase", ["purchase"]),
+        ]
+    )
+    def test_search_results_ordered_by_name_length(
+        self, _name: str, search_term: str, expected_names: list[str]
+    ) -> None:
+        response = self.client.get(f"/api/projects/@current/event_definitions/?search={search_term}")
+        assert response.status_code == status.HTTP_200_OK
+        result_names = [r["name"] for r in response.json()["results"]]
+        assert result_names == expected_names
+
     def test_event_type_event(self):
         action = Action.objects.create(team=self.demo_team, name="action1_app")
 

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -166,11 +166,15 @@ class TestPropertyDefinitionAPI(APIBaseTest):
             ("URL-encoded search for properties starting with '$cur'", "$cur", ["$current_url"]),
             ("Fuzzy search: 'hase ' matches properties containing 'chase'", "hase ", ["purchase", "purchase_value"]),
             ("Search matching multiple properties", "brow", ["$browser", "$browser_version"]),
+            ("Shorter name preferred: 'visit' before 'first_visit'", "visit", ["visit", "first_visit"]),
         ]
     )
     def test_property_search_returns_expected_results(
         self, _name: str, search_term: str, expected_property_names: list[str]
     ) -> None:
+        if search_term == "visit":
+            PropertyDefinition.objects.create(team=self.team, name="visit")
+
         response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?search={search_term}")
         assert response.status_code == status.HTTP_200_OK
 
@@ -179,12 +183,18 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         if search_term == "p ting":
             assert response.json()["results"][0]["is_seen_on_filtered_events"] is None
 
-    def test_search_results_prefer_shorter_names_over_alphabetical(self) -> None:
-        PropertyDefinition.objects.create(team=self.team, name="visit")
-        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?search=visit")
-        assert response.status_code == status.HTTP_200_OK
-        result_names = [r["name"] for r in response.json()["results"]]
-        assert result_names == ["visit", "first_visit"]
+    def test_whitespace_search_does_not_change_default_ordering(self) -> None:
+        default_response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/")
+        assert default_response.status_code == status.HTTP_200_OK
+        default_names = [r["name"] for r in default_response.json()["results"]]
+
+        whitespace_search_response = self.client.get(
+            f"/api/projects/{self.team.pk}/property_definitions/?search=%20%20"
+        )
+        assert whitespace_search_response.status_code == status.HTTP_200_OK
+        whitespace_search_names = [r["name"] for r in whitespace_search_response.json()["results"]]
+
+        assert whitespace_search_names == default_names
 
     def test_property_search_with_event_filter_shows_event_association(self):
         # URL params: search=$ and event_names=["$pageview"]

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -179,6 +179,13 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         if search_term == "p ting":
             assert response.json()["results"][0]["is_seen_on_filtered_events"] is None
 
+    def test_search_results_prefer_shorter_names_over_alphabetical(self) -> None:
+        PropertyDefinition.objects.create(team=self.team, name="visit")
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?search=visit")
+        assert response.status_code == status.HTTP_200_OK
+        result_names = [r["name"] for r in response.json()["results"]]
+        assert result_names == ["visit", "first_visit"]
+
     def test_property_search_with_event_filter_shows_event_association(self):
         # URL params: search=$ and event_names=["$pageview"]
         response = self.client.get(
@@ -190,9 +197,9 @@ class TestPropertyDefinitionAPI(APIBaseTest):
 
         assert actual_results == [
             ("$browser", True),
-            ("$browser_version", False),
-            ("$current_url", False),
             ("$lib", False),
+            ("$current_url", False),
+            ("$browser_version", False),
         ]
 
     def test_is_event_property_filter(self):

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -656,7 +656,7 @@ class PropertyDefinitionViewSet(
                 .with_search(
                     search_query,
                     search_kwargs,
-                    order_by_search_relevance=bool(search),
+                    order_by_search_relevance=bool(search and search.strip()),
                 )
                 .with_excluded_properties(query.validated_data.get("excluded_properties"))
                 .with_excluded_core_properties(

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -144,6 +144,8 @@ class QueryContext:
     is_feature_flag_filter: str = ""
     excluded_properties_filter: str = ""
 
+    order_by_search_relevance: bool = False
+
     event_property_join_type: str = ""
     event_property_field: str = "NULL"
 
@@ -258,10 +260,11 @@ class QueryContext:
             params={**self.params, "event_names": list(map(str, event_names or []))},
         )
 
-    def with_search(self, search_query: str, search_kwargs: dict) -> Self:
+    def with_search(self, search_query: str, search_kwargs: dict, order_by_search_relevance: bool = False) -> Self:
         return dataclasses.replace(
             self,
             search_query=search_query,
+            order_by_search_relevance=order_by_search_relevance,
             params={**self.params, "project_id": self.project_id, **search_kwargs},
         )
 
@@ -324,6 +327,9 @@ class QueryContext:
 
     def as_sql(self, order_by_verified: bool):
         verified_ordering = "verified DESC NULLS LAST," if order_by_verified else ""
+        length_ordering = (
+            f"length({self.property_definition_table}.name) ASC," if self.order_by_search_relevance else ""
+        )
         query = f"""
             SELECT {self.property_definition_fields}, {self.event_property_field} AS is_seen_on_filtered_events
             FROM {self.table}
@@ -334,7 +340,7 @@ class QueryContext:
               {self.excluded_properties_filter}
              {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
              {self.event_name_filter}
-            ORDER BY is_seen_on_filtered_events DESC, {verified_ordering} {self.property_definition_table}.name ASC
+            ORDER BY is_seen_on_filtered_events DESC, {length_ordering} {verified_ordering} {self.property_definition_table}.name ASC
             LIMIT %(limit)s OFFSET %(offset)s
             """
 
@@ -647,7 +653,11 @@ class PropertyDefinitionViewSet(
                     event_names=event_names,
                     filter_by_event_names=filter_by_event_names,
                 )
-                .with_search(search_query, search_kwargs)
+                .with_search(
+                    search_query,
+                    search_kwargs,
+                    order_by_search_relevance=bool(search),
+                )
                 .with_excluded_properties(query.validated_data.get("excluded_properties"))
                 .with_excluded_core_properties(
                     query.validated_data.get("exclude_core_properties", False),


### PR DESCRIPTION
if you have many properties or events with `source` in the name (for example)

and search for "source"

we sort by recently seen and then by name
we should prefer length of match since the shortest match will more like by exact or close

you can do this more fancily but length should be a good proxy