### PR TITLE
fix: session property type boolean fields handling

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -37,6 +37,8 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 from posthog.hogql.base import AST
+from posthog.hogql.database.models import BooleanDatabaseField
+from posthog.hogql.database.schema.sessions_v3 import LAZY_SESSIONS_FIELDS
 from posthog.hogql.errors import NotImplementedError, QueryError
 from posthog.hogql.functions import find_hogql_aggregation
 from posthog.hogql.parser import parse_expr
@@ -278,6 +280,15 @@ def _handle_bool_values(value: ValueT, expr: ast.Expr, property: Property, team:
             if value == "false":
                 value = False
 
+        return value
+
+    elif property.type == "session":
+        field_definition = LAZY_SESSIONS_FIELDS.get(property.key)
+        if isinstance(field_definition, BooleanDatabaseField):
+            if value == "true":
+                return True
+            if value == "false":
+                return False
         return value
 
     else:

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -890,6 +890,22 @@ class TestProperty(BaseTest):
             self._parse_expr("session.$session_duration = 10"),
         )
 
+    def test_session_boolean_property(self):
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "session", "key": "$is_bounce", "value": "true", "operator": "exact"},
+                scope="event",
+            ),
+            self._parse_expr("session.$is_bounce = true"),
+        )
+        self.assertEqual(
+            self._property_to_expr(
+                {"type": "session", "key": "$is_bounce", "value": "false", "operator": "exact"},
+                scope="event",
+            ),
+            self._parse_expr("session.$is_bounce = false"),
+        )
+
     def test_data_warehouse_person_property(self):
         credential = DataWarehouseCredential.objects.create(
             team=self.team, access_key="_accesskey", access_secret="_secret"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
`Cannot convert string 'true' to type UInt8`

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- handle boolean fields coming from a session property
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- unit test
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
