### PR TITLE
feat(llma): use tabs for evaluation detail settings and runs

### DIFF
--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -185,6 +185,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                     type="button"
                     className="flex items-center gap-2 cursor-pointer select-none py-2 bg-transparent border-0 p-0"
                     aria-expanded={settingsExpanded}
+                    data-attr="llma-evaluation-settings-toggle"
                     onClick={() => setSettingsExpanded(!settingsExpanded)}
                 >
                     {settingsExpanded ? (

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -94,10 +94,10 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         // If percentage is unset but other fields are valid, expand settings and scroll to triggers
         if (basicFieldsValid && percentageUnset) {
             setSettingsExpanded(true)
-            // Use setTimeout to allow the DOM to update before scrolling
-            setTimeout(() => {
+            // Use rAF to scroll after the expanded form has been painted
+            requestAnimationFrame(() => {
                 triggersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-            }, 100)
+            })
             return
         }
 
@@ -181,8 +181,10 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
 
             {/* Configuration Form */}
             <div className="max-w-4xl">
-                <div
-                    className="flex items-center gap-2 cursor-pointer select-none py-2"
+                <button
+                    type="button"
+                    className="flex items-center gap-2 cursor-pointer select-none py-2 bg-transparent border-0 p-0"
+                    aria-expanded={settingsExpanded}
                     onClick={() => setSettingsExpanded(!settingsExpanded)}
                 >
                     {settingsExpanded ? (
@@ -191,7 +193,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                         <IconExpand className="text-muted text-lg" />
                     )}
                     <h3 className="text-lg font-semibold m-0">Settings</h3>
-                </div>
+                </button>
                 {settingsExpanded && (
                     <Form logic={llmEvaluationLogic} formKey="evaluation" className="space-y-6 mt-4">
                         {/* Basic Information */}

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -3,7 +3,7 @@ import { Field, Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconArrowLeft, IconInfo, IconPlay } from '@posthog/icons'
+import { IconArrowLeft, IconCollapse, IconExpand, IconInfo, IconPlay } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -50,6 +50,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         runsSummary,
         evaluationProviderKeyIssue,
         signalEmissionEnabled,
+        settingsExpanded,
     } = useValues(llmEvaluationLogic)
     const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -63,6 +64,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         resetEvaluation,
         setEvaluationType,
         setSignalEmission,
+        setSettingsExpanded,
     } = useActions(llmEvaluationLogic)
     const { push } = useActions(router)
     const triggersRef = useRef<HTMLDivElement>(null)
@@ -89,9 +91,13 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
     const saveButtonDisabled = !basicFieldsValid
 
     const handleSave = (): void => {
-        // If percentage is unset but other fields are valid, scroll to triggers
+        // If percentage is unset but other fields are valid, expand settings and scroll to triggers
         if (basicFieldsValid && percentageUnset) {
-            triggersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            setSettingsExpanded(true)
+            // Use setTimeout to allow the DOM to update before scrolling
+            setTimeout(() => {
+                triggersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            }, 100)
             return
         }
 
@@ -175,144 +181,157 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
 
             {/* Configuration Form */}
             <div className="max-w-4xl">
-                <Form logic={llmEvaluationLogic} formKey="evaluation" className="space-y-6">
-                    {/* Basic Information */}
-                    <div className="bg-bg-light border rounded p-6">
-                        <h3 className="text-lg font-semibold mb-4">Basic information</h3>
+                <div
+                    className="flex items-center gap-2 cursor-pointer select-none py-2"
+                    onClick={() => setSettingsExpanded(!settingsExpanded)}
+                >
+                    {settingsExpanded ? (
+                        <IconCollapse className="text-muted text-lg" />
+                    ) : (
+                        <IconExpand className="text-muted text-lg" />
+                    )}
+                    <h3 className="text-lg font-semibold m-0">Settings</h3>
+                </div>
+                {settingsExpanded && (
+                    <Form logic={llmEvaluationLogic} formKey="evaluation" className="space-y-6 mt-4">
+                        {/* Basic Information */}
+                        <div className="bg-bg-light border rounded p-6">
+                            <h3 className="text-lg font-semibold mb-4">Basic information</h3>
 
-                        <div className="space-y-4">
-                            <Field name="name" label="Name">
-                                <LemonInput
-                                    value={evaluation.name}
-                                    onChange={setEvaluationName}
-                                    placeholder="e.g., Helpfulness Check"
-                                    maxLength={100}
-                                />
-                            </Field>
-
-                            {featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_HOG_CODE] && (
-                                <Field name="evaluation_type" label="Method">
-                                    <LemonSelect
-                                        value={evaluation.evaluation_type}
-                                        onChange={(value) => setEvaluationType(value as EvaluationType)}
-                                        options={[
-                                            {
-                                                value: 'llm_judge',
-                                                label: 'LLM as a judge',
-                                            },
-                                            {
-                                                value: 'hog',
-                                                label: 'Hog code',
-                                            },
-                                        ]}
-                                        fullWidth
+                            <div className="space-y-4">
+                                <Field name="name" label="Name">
+                                    <LemonInput
+                                        value={evaluation.name}
+                                        onChange={setEvaluationName}
+                                        placeholder="e.g., Helpfulness Check"
+                                        maxLength={100}
                                     />
                                 </Field>
-                            )}
-                            <p className="text-muted text-sm -mt-2">
-                                {isHog ? (
-                                    <>
-                                        Run deterministic{' '}
-                                        <Link to="https://posthog.com/docs/hog" target="_blank">
-                                            Hog code
-                                        </Link>{' '}
-                                        against each generation. No LLM cost, instant results.
-                                    </>
-                                ) : (
-                                    'Use an LLM to evaluate each generation against a natural-language prompt.'
+
+                                {featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_HOG_CODE] && (
+                                    <Field name="evaluation_type" label="Method">
+                                        <LemonSelect
+                                            value={evaluation.evaluation_type}
+                                            onChange={(value) => setEvaluationType(value as EvaluationType)}
+                                            options={[
+                                                {
+                                                    value: 'llm_judge',
+                                                    label: 'LLM as a judge',
+                                                },
+                                                {
+                                                    value: 'hog',
+                                                    label: 'Hog code',
+                                                },
+                                            ]}
+                                            fullWidth
+                                        />
+                                    </Field>
                                 )}
-                            </p>
+                                <p className="text-muted text-sm -mt-2">
+                                    {isHog ? (
+                                        <>
+                                            Run deterministic{' '}
+                                            <Link to="https://posthog.com/docs/hog" target="_blank">
+                                                Hog code
+                                            </Link>{' '}
+                                            against each generation. No LLM cost, instant results.
+                                        </>
+                                    ) : (
+                                        'Use an LLM to evaluate each generation against a natural-language prompt.'
+                                    )}
+                                </p>
 
-                            <Field name="description" label="Description (optional)">
-                                <LemonTextArea
-                                    value={evaluation.description || ''}
-                                    onChange={setEvaluationDescription}
-                                    placeholder="Describe what this evaluation checks for..."
-                                    rows={2}
-                                    maxLength={500}
-                                />
-                            </Field>
+                                <Field name="description" label="Description (optional)">
+                                    <LemonTextArea
+                                        value={evaluation.description || ''}
+                                        onChange={setEvaluationDescription}
+                                        placeholder="Describe what this evaluation checks for..."
+                                        rows={2}
+                                        maxLength={500}
+                                    />
+                                </Field>
 
-                            <div className="flex items-center gap-2">
-                                <LemonSwitch
-                                    checked={evaluation.enabled}
-                                    onChange={setEvaluationEnabled}
-                                    label="Enable evaluation"
-                                />
-                                <span className="text-muted text-sm">
-                                    {evaluation.enabled
-                                        ? 'This evaluation will run automatically based on triggers'
-                                        : 'This evaluation is paused and will not run'}
-                                </span>
-                            </div>
+                                <div className="flex items-center gap-2">
+                                    <LemonSwitch
+                                        checked={evaluation.enabled}
+                                        onChange={setEvaluationEnabled}
+                                        label="Enable evaluation"
+                                    />
+                                    <span className="text-muted text-sm">
+                                        {evaluation.enabled
+                                            ? 'This evaluation will run automatically based on triggers'
+                                            : 'This evaluation is paused and will not run'}
+                                    </span>
+                                </div>
 
-                            <Field
-                                name="allows_na"
-                                label={
-                                    <div className="flex items-center gap-1">
-                                        <span>Allow N/A responses</span>
-                                        <Tooltip
-                                            title={
-                                                isHog
-                                                    ? 'When enabled, returning null from your Hog code means "not applicable" instead of being treated as an error.'
-                                                    : 'Sometimes forcing a True or False is not enough and you want the LLM to decide if the evaluation is applicable or not. Enable this when the evaluation criteria may not apply to all generations.'
-                                            }
-                                        >
+                                <Field
+                                    name="allows_na"
+                                    label={
+                                        <div className="flex items-center gap-1">
+                                            <span>Allow N/A responses</span>
+                                            <Tooltip
+                                                title={
+                                                    isHog
+                                                        ? 'When enabled, returning null from your Hog code means "not applicable" instead of being treated as an error.'
+                                                        : 'Sometimes forcing a True or False is not enough and you want the LLM to decide if the evaluation is applicable or not. Enable this when the evaluation criteria may not apply to all generations.'
+                                                }
+                                            >
+                                                <IconInfo className="text-muted text-base" />
+                                            </Tooltip>
+                                        </div>
+                                    }
+                                >
+                                    <div className="flex items-center gap-2">
+                                        <LemonSwitch
+                                            checked={evaluation.output_config.allows_na ?? false}
+                                            onChange={setAllowsNA}
+                                        />
+                                        <span className="text-muted text-sm">
+                                            {evaluation.output_config.allows_na
+                                                ? isHog
+                                                    ? 'Returning null means "Not Applicable"'
+                                                    : 'Evaluation can return "Not Applicable" when criteria doesn\'t apply'
+                                                : isHog
+                                                  ? 'Evaluation must return true or false'
+                                                  : 'Evaluation returns true or false'}
+                                        </span>
+                                    </div>
+                                </Field>
+                                {!isNewEvaluation && user?.is_staff && (
+                                    <div className="flex items-center gap-2">
+                                        <LemonSwitch checked={signalEmissionEnabled} onChange={setSignalEmission} />
+                                        <span>Emit signals</span>
+                                        <Tooltip title="When enabled, true verdicts from this evaluation will be emitted as signals for clustering and investigation.">
                                             <IconInfo className="text-muted text-base" />
                                         </Tooltip>
                                     </div>
-                                }
-                            >
-                                <div className="flex items-center gap-2">
-                                    <LemonSwitch
-                                        checked={evaluation.output_config.allows_na ?? false}
-                                        onChange={setAllowsNA}
-                                    />
-                                    <span className="text-muted text-sm">
-                                        {evaluation.output_config.allows_na
-                                            ? isHog
-                                                ? 'Returning null means "Not Applicable"'
-                                                : 'Evaluation can return "Not Applicable" when criteria doesn\'t apply'
-                                            : isHog
-                                              ? 'Evaluation must return true or false'
-                                              : 'Evaluation returns true or false'}
-                                    </span>
-                                </div>
-                            </Field>
-                            {!isNewEvaluation && user?.is_staff && (
-                                <div className="flex items-center gap-2">
-                                    <LemonSwitch checked={signalEmissionEnabled} onChange={setSignalEmission} />
-                                    <span>Emit signals</span>
-                                    <Tooltip title="When enabled, true verdicts from this evaluation will be emitted as signals for clustering and investigation.">
-                                        <IconInfo className="text-muted text-base" />
-                                    </Tooltip>
-                                </div>
-                            )}
+                                )}
+                            </div>
                         </div>
-                    </div>
 
-                    {/* Prompt / Code Configuration */}
-                    <div className="bg-bg-light border rounded p-6">
-                        <h3 className="text-lg font-semibold mb-4">
-                            {isHog ? 'Evaluation code' : 'Evaluation prompt'}
-                        </h3>
-                        {isHog ? <EvaluationCodeEditor /> : <EvaluationPromptEditor />}
-                    </div>
+                        {/* Prompt / Code Configuration */}
+                        <div className="bg-bg-light border rounded p-6">
+                            <h3 className="text-lg font-semibold mb-4">
+                                {isHog ? 'Evaluation code' : 'Evaluation prompt'}
+                            </h3>
+                            {isHog ? <EvaluationCodeEditor /> : <EvaluationPromptEditor />}
+                        </div>
 
-                    {/* Judge Model Configuration (LLM judge only) */}
-                    {!isHog && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_CUSTOM_MODELS] && (
-                        <EvaluationModelPicker />
-                    )}
+                        {/* Judge Model Configuration (LLM judge only) */}
+                        {!isHog && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_CUSTOM_MODELS] && (
+                            <EvaluationModelPicker />
+                        )}
 
-                    {/* Trigger Configuration */}
-                    <div ref={triggersRef} className="bg-bg-light border rounded p-6">
-                        <h3 className="text-lg font-semibold mb-4">Triggers</h3>
-                        <p className="text-muted text-sm mb-4">
-                            Configure when this evaluation should run on your LLM generations.
-                        </p>
-                        <EvaluationTriggers />
-                    </div>
-                </Form>
+                        {/* Trigger Configuration */}
+                        <div ref={triggersRef} className="bg-bg-light border rounded p-6">
+                            <h3 className="text-lg font-semibold mb-4">Triggers</h3>
+                            <p className="text-muted text-sm mb-4">
+                                Configure when this evaluation should run on your LLM generations.
+                            </p>
+                            <EvaluationTriggers />
+                        </div>
+                    </Form>
+                )}
             </div>
 
             {/* Evaluation Runs (only for existing evaluations) */}

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -3,15 +3,15 @@ import { Field, Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconArrowLeft, IconCollapse, IconExpand, IconInfo, IconPlay } from '@posthog/icons'
+import { IconArrowLeft, IconInfo, IconPlay } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
-    LemonDivider,
     LemonInput,
     LemonSelect,
     LemonSkeleton,
     LemonSwitch,
+    LemonTabs,
     LemonTag,
     LemonTextArea,
     Link,
@@ -50,7 +50,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         runsSummary,
         evaluationProviderKeyIssue,
         signalEmissionEnabled,
-        settingsExpanded,
+        activeTab,
     } = useValues(llmEvaluationLogic)
     const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -64,7 +64,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         resetEvaluation,
         setEvaluationType,
         setSignalEmission,
-        setSettingsExpanded,
+        setActiveTab,
     } = useActions(llmEvaluationLogic)
     const { push } = useActions(router)
     const triggersRef = useRef<HTMLDivElement>(null)
@@ -91,10 +91,9 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
     const saveButtonDisabled = !basicFieldsValid
 
     const handleSave = (): void => {
-        // If percentage is unset but other fields are valid, expand settings and scroll to triggers
+        // If percentage is unset but other fields are valid, switch to settings and scroll to triggers
         if (basicFieldsValid && percentageUnset) {
-            setSettingsExpanded(true)
-            // Use rAF to scroll after the expanded form has been painted
+            setActiveTab('settings')
             requestAnimationFrame(() => {
                 triggersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
             })
@@ -179,205 +178,206 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                 </LemonBanner>
             )}
 
-            {/* Configuration Form */}
-            <div className="max-w-4xl">
-                <button
-                    type="button"
-                    className="flex items-center gap-2 cursor-pointer select-none py-2 bg-transparent border-0 p-0"
-                    aria-expanded={settingsExpanded}
-                    data-attr="llma-evaluation-settings-toggle"
-                    onClick={() => setSettingsExpanded(!settingsExpanded)}
-                >
-                    {settingsExpanded ? (
-                        <IconCollapse className="text-muted text-lg" />
-                    ) : (
-                        <IconExpand className="text-muted text-lg" />
-                    )}
-                    <h3 className="text-lg font-semibold m-0">Settings</h3>
-                </button>
-                {settingsExpanded && (
-                    <Form logic={llmEvaluationLogic} formKey="evaluation" className="space-y-6 mt-4">
-                        {/* Basic Information */}
-                        <div className="bg-bg-light border rounded p-6">
-                            <h3 className="text-lg font-semibold mb-4">Basic information</h3>
+            <LemonTabs
+                activeKey={activeTab}
+                onChange={(key) => setActiveTab(key)}
+                data-attr="llma-evaluation-tabs"
+                tabs={[
+                    {
+                        key: 'settings',
+                        label: 'Settings',
+                        'data-attr': 'llma-evaluation-settings-tab',
+                        content: (
+                            <div className="max-w-4xl">
+                                <Form logic={llmEvaluationLogic} formKey="evaluation" className="space-y-6">
+                                    {/* Basic Information */}
+                                    <div className="bg-bg-light border rounded p-6">
+                                        <h3 className="text-lg font-semibold mb-4">Basic information</h3>
 
-                            <div className="space-y-4">
-                                <Field name="name" label="Name">
-                                    <LemonInput
-                                        value={evaluation.name}
-                                        onChange={setEvaluationName}
-                                        placeholder="e.g., Helpfulness Check"
-                                        maxLength={100}
-                                    />
-                                </Field>
+                                        <div className="space-y-4">
+                                            <Field name="name" label="Name">
+                                                <LemonInput
+                                                    value={evaluation.name}
+                                                    onChange={setEvaluationName}
+                                                    placeholder="e.g., Helpfulness Check"
+                                                    maxLength={100}
+                                                />
+                                            </Field>
 
-                                {featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_HOG_CODE] && (
-                                    <Field name="evaluation_type" label="Method">
-                                        <LemonSelect
-                                            value={evaluation.evaluation_type}
-                                            onChange={(value) => setEvaluationType(value as EvaluationType)}
-                                            options={[
-                                                {
-                                                    value: 'llm_judge',
-                                                    label: 'LLM as a judge',
-                                                },
-                                                {
-                                                    value: 'hog',
-                                                    label: 'Hog code',
-                                                },
-                                            ]}
-                                            fullWidth
-                                        />
-                                    </Field>
-                                )}
-                                <p className="text-muted text-sm -mt-2">
-                                    {isHog ? (
-                                        <>
-                                            Run deterministic{' '}
-                                            <Link to="https://posthog.com/docs/hog" target="_blank">
-                                                Hog code
-                                            </Link>{' '}
-                                            against each generation. No LLM cost, instant results.
-                                        </>
-                                    ) : (
-                                        'Use an LLM to evaluate each generation against a natural-language prompt.'
-                                    )}
-                                </p>
+                                            {featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_HOG_CODE] && (
+                                                <Field name="evaluation_type" label="Method">
+                                                    <LemonSelect
+                                                        value={evaluation.evaluation_type}
+                                                        onChange={(value) => setEvaluationType(value as EvaluationType)}
+                                                        options={[
+                                                            {
+                                                                value: 'llm_judge',
+                                                                label: 'LLM as a judge',
+                                                            },
+                                                            {
+                                                                value: 'hog',
+                                                                label: 'Hog code',
+                                                            },
+                                                        ]}
+                                                        fullWidth
+                                                    />
+                                                </Field>
+                                            )}
+                                            <p className="text-muted text-sm -mt-2">
+                                                {isHog ? (
+                                                    <>
+                                                        Run deterministic{' '}
+                                                        <Link to="https://posthog.com/docs/hog" target="_blank">
+                                                            Hog code
+                                                        </Link>{' '}
+                                                        against each generation. No LLM cost, instant results.
+                                                    </>
+                                                ) : (
+                                                    'Use an LLM to evaluate each generation against a natural-language prompt.'
+                                                )}
+                                            </p>
 
-                                <Field name="description" label="Description (optional)">
-                                    <LemonTextArea
-                                        value={evaluation.description || ''}
-                                        onChange={setEvaluationDescription}
-                                        placeholder="Describe what this evaluation checks for..."
-                                        rows={2}
-                                        maxLength={500}
-                                    />
-                                </Field>
+                                            <Field name="description" label="Description (optional)">
+                                                <LemonTextArea
+                                                    value={evaluation.description || ''}
+                                                    onChange={setEvaluationDescription}
+                                                    placeholder="Describe what this evaluation checks for..."
+                                                    rows={2}
+                                                    maxLength={500}
+                                                />
+                                            </Field>
 
-                                <div className="flex items-center gap-2">
-                                    <LemonSwitch
-                                        checked={evaluation.enabled}
-                                        onChange={setEvaluationEnabled}
-                                        label="Enable evaluation"
-                                    />
-                                    <span className="text-muted text-sm">
-                                        {evaluation.enabled
-                                            ? 'This evaluation will run automatically based on triggers'
-                                            : 'This evaluation is paused and will not run'}
-                                    </span>
-                                </div>
+                                            <div className="flex items-center gap-2">
+                                                <LemonSwitch
+                                                    checked={evaluation.enabled}
+                                                    onChange={setEvaluationEnabled}
+                                                    label="Enable evaluation"
+                                                />
+                                                <span className="text-muted text-sm">
+                                                    {evaluation.enabled
+                                                        ? 'This evaluation will run automatically based on triggers'
+                                                        : 'This evaluation is paused and will not run'}
+                                                </span>
+                                            </div>
 
-                                <Field
-                                    name="allows_na"
-                                    label={
-                                        <div className="flex items-center gap-1">
-                                            <span>Allow N/A responses</span>
-                                            <Tooltip
-                                                title={
-                                                    isHog
-                                                        ? 'When enabled, returning null from your Hog code means "not applicable" instead of being treated as an error.'
-                                                        : 'Sometimes forcing a True or False is not enough and you want the LLM to decide if the evaluation is applicable or not. Enable this when the evaluation criteria may not apply to all generations.'
+                                            <Field
+                                                name="allows_na"
+                                                label={
+                                                    <div className="flex items-center gap-1">
+                                                        <span>Allow N/A responses</span>
+                                                        <Tooltip
+                                                            title={
+                                                                isHog
+                                                                    ? 'When enabled, returning null from your Hog code means "not applicable" instead of being treated as an error.'
+                                                                    : 'Sometimes forcing a True or False is not enough and you want the LLM to decide if the evaluation is applicable or not. Enable this when the evaluation criteria may not apply to all generations.'
+                                                            }
+                                                        >
+                                                            <IconInfo className="text-muted text-base" />
+                                                        </Tooltip>
+                                                    </div>
                                                 }
                                             >
-                                                <IconInfo className="text-muted text-base" />
-                                            </Tooltip>
+                                                <div className="flex items-center gap-2">
+                                                    <LemonSwitch
+                                                        checked={evaluation.output_config.allows_na ?? false}
+                                                        onChange={setAllowsNA}
+                                                    />
+                                                    <span className="text-muted text-sm">
+                                                        {evaluation.output_config.allows_na
+                                                            ? isHog
+                                                                ? 'Returning null means "Not Applicable"'
+                                                                : 'Evaluation can return "Not Applicable" when criteria doesn\'t apply'
+                                                            : isHog
+                                                              ? 'Evaluation must return true or false'
+                                                              : 'Evaluation returns true or false'}
+                                                    </span>
+                                                </div>
+                                            </Field>
+                                            {!isNewEvaluation && user?.is_staff && (
+                                                <div className="flex items-center gap-2">
+                                                    <LemonSwitch
+                                                        checked={signalEmissionEnabled}
+                                                        onChange={setSignalEmission}
+                                                    />
+                                                    <span>Emit signals</span>
+                                                    <Tooltip title="When enabled, true verdicts from this evaluation will be emitted as signals for clustering and investigation.">
+                                                        <IconInfo className="text-muted text-base" />
+                                                    </Tooltip>
+                                                </div>
+                                            )}
                                         </div>
-                                    }
-                                >
-                                    <div className="flex items-center gap-2">
-                                        <LemonSwitch
-                                            checked={evaluation.output_config.allows_na ?? false}
-                                            onChange={setAllowsNA}
-                                        />
-                                        <span className="text-muted text-sm">
-                                            {evaluation.output_config.allows_na
-                                                ? isHog
-                                                    ? 'Returning null means "Not Applicable"'
-                                                    : 'Evaluation can return "Not Applicable" when criteria doesn\'t apply'
-                                                : isHog
-                                                  ? 'Evaluation must return true or false'
-                                                  : 'Evaluation returns true or false'}
-                                        </span>
                                     </div>
-                                </Field>
-                                {!isNewEvaluation && user?.is_staff && (
-                                    <div className="flex items-center gap-2">
-                                        <LemonSwitch checked={signalEmissionEnabled} onChange={setSignalEmission} />
-                                        <span>Emit signals</span>
-                                        <Tooltip title="When enabled, true verdicts from this evaluation will be emitted as signals for clustering and investigation.">
-                                            <IconInfo className="text-muted text-base" />
-                                        </Tooltip>
+
+                                    {/* Prompt / Code Configuration */}
+                                    <div className="bg-bg-light border rounded p-6">
+                                        <h3 className="text-lg font-semibold mb-4">
+                                            {isHog ? 'Evaluation code' : 'Evaluation prompt'}
+                                        </h3>
+                                        {isHog ? <EvaluationCodeEditor /> : <EvaluationPromptEditor />}
                                     </div>
-                                )}
+
+                                    {/* Judge Model Configuration (LLM judge only) */}
+                                    {!isHog && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_CUSTOM_MODELS] && (
+                                        <EvaluationModelPicker />
+                                    )}
+
+                                    {/* Trigger Configuration */}
+                                    <div ref={triggersRef} className="bg-bg-light border rounded p-6">
+                                        <h3 className="text-lg font-semibold mb-4">Triggers</h3>
+                                        <p className="text-muted text-sm mb-4">
+                                            Configure when this evaluation should run on your LLM generations.
+                                        </p>
+                                        <EvaluationTriggers />
+                                    </div>
+                                </Form>
                             </div>
-                        </div>
-
-                        {/* Prompt / Code Configuration */}
-                        <div className="bg-bg-light border rounded p-6">
-                            <h3 className="text-lg font-semibold mb-4">
-                                {isHog ? 'Evaluation code' : 'Evaluation prompt'}
-                            </h3>
-                            {isHog ? <EvaluationCodeEditor /> : <EvaluationPromptEditor />}
-                        </div>
-
-                        {/* Judge Model Configuration (LLM judge only) */}
-                        {!isHog && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_CUSTOM_MODELS] && (
-                            <EvaluationModelPicker />
-                        )}
-
-                        {/* Trigger Configuration */}
-                        <div ref={triggersRef} className="bg-bg-light border rounded p-6">
-                            <h3 className="text-lg font-semibold mb-4">Triggers</h3>
-                            <p className="text-muted text-sm mb-4">
-                                Configure when this evaluation should run on your LLM generations.
-                            </p>
-                            <EvaluationTriggers />
-                        </div>
-                    </Form>
-                )}
-            </div>
-
-            {/* Evaluation Runs (only for existing evaluations) */}
-            {!isNewEvaluation && (
-                <>
-                    <LemonDivider />
-                    <div className="max-w-6xl">
-                        <div className="flex justify-between items-center mb-4">
-                            <div>
-                                <h3 className="text-lg font-semibold">Evaluation runs</h3>
-                                <p className="text-muted text-sm">History of when this evaluation has been executed.</p>
-                            </div>
-                            {runsSummary && (
-                                <div className="flex gap-4 text-sm">
-                                    <div className="text-center">
-                                        <div className="font-semibold text-lg">{runsSummary.total}</div>
-                                        <div className="text-muted">Total Runs</div>
-                                    </div>
-                                    <div className="text-center">
-                                        <div className="font-semibold text-lg text-success">
-                                            {runsSummary.successRate}%
-                                        </div>
-                                        <div className="text-muted">Success Rate</div>
-                                    </div>
-                                    {evaluation.output_config.allows_na && (
-                                        <div className="text-center">
-                                            <div className="font-semibold text-lg">
-                                                {runsSummary.applicabilityRate}%
+                        ),
+                    },
+                    !isNewEvaluation && {
+                        key: 'runs',
+                        label: 'Runs',
+                        'data-attr': 'llma-evaluation-runs-tab',
+                        content: (
+                            <div className="max-w-6xl">
+                                <div className="flex justify-between items-center mb-4">
+                                    <p className="text-muted text-sm m-0">
+                                        History of when this evaluation has been executed.
+                                    </p>
+                                    {runsSummary && (
+                                        <div className="flex gap-4 text-sm">
+                                            <div className="text-center">
+                                                <div className="font-semibold text-lg">{runsSummary.total}</div>
+                                                <div className="text-muted">Total runs</div>
                                             </div>
-                                            <div className="text-muted">Applicable</div>
+                                            <div className="text-center">
+                                                <div className="font-semibold text-lg text-success">
+                                                    {runsSummary.successRate}%
+                                                </div>
+                                                <div className="text-muted">Success rate</div>
+                                            </div>
+                                            {evaluation.output_config.allows_na && (
+                                                <div className="text-center">
+                                                    <div className="font-semibold text-lg">
+                                                        {runsSummary.applicabilityRate}%
+                                                    </div>
+                                                    <div className="text-muted">Applicable</div>
+                                                </div>
+                                            )}
+                                            <div className="text-center">
+                                                <div className="font-semibold text-lg text-danger">
+                                                    {runsSummary.errors}
+                                                </div>
+                                                <div className="text-muted">Errors</div>
+                                            </div>
                                         </div>
                                     )}
-                                    <div className="text-center">
-                                        <div className="font-semibold text-lg text-danger">{runsSummary.errors}</div>
-                                        <div className="text-muted">Errors</div>
-                                    </div>
                                 </div>
-                            )}
-                        </div>
-                        <EvaluationRunsTable />
-                    </div>
-                </>
-            )}
+                                <EvaluationRunsTable />
+                            </div>
+                        ),
+                    },
+                ]}
+            />
         </div>
     )
 }

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -147,19 +147,21 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                     <LemonButton type="secondary" icon={<IconArrowLeft />} onClick={handleCancel}>
                         {hasUnsavedChanges ? 'Cancel' : 'Back'}
                     </LemonButton>
-                    <AccessControlAction
-                        resourceType={AccessControlResourceType.LlmAnalytics}
-                        minAccessLevel={AccessControlLevel.Editor}
-                    >
-                        <LemonButton
-                            type="primary"
-                            onClick={handleSave}
-                            disabled={saveButtonDisabled}
-                            loading={evaluationFormSubmitting}
+                    {activeTab !== 'runs' && (
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.LlmAnalytics}
+                            minAccessLevel={AccessControlLevel.Editor}
                         >
-                            {isNewEvaluation ? 'Create evaluation' : 'Save changes'}
-                        </LemonButton>
-                    </AccessControlAction>
+                            <LemonButton
+                                type="primary"
+                                onClick={handleSave}
+                                disabled={saveButtonDisabled}
+                                loading={evaluationFormSubmitting}
+                            >
+                                {isNewEvaluation ? 'Create evaluation' : 'Save changes'}
+                            </LemonButton>
+                        </AccessControlAction>
+                    )}
                 </div>
             </div>
 

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -93,7 +93,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
     const handleSave = (): void => {
         // If percentage is unset but other fields are valid, switch to settings and scroll to triggers
         if (basicFieldsValid && percentageUnset) {
-            setActiveTab('settings')
+            setActiveTab('configuration')
             requestAnimationFrame(() => {
                 triggersRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
             })
@@ -183,10 +183,53 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                 onChange={(key) => setActiveTab(key)}
                 data-attr="llma-evaluation-tabs"
                 tabs={[
+                    !isNewEvaluation && {
+                        key: 'runs',
+                        label: 'Runs',
+                        'data-attr': 'llma-evaluation-runs-tab',
+                        content: (
+                            <div className="max-w-6xl">
+                                <div className="flex justify-between items-center mb-4">
+                                    <p className="text-muted text-sm m-0">
+                                        History of when this evaluation has been executed.
+                                    </p>
+                                    {runsSummary && (
+                                        <div className="flex gap-4 text-sm">
+                                            <div className="text-center">
+                                                <div className="font-semibold text-lg">{runsSummary.total}</div>
+                                                <div className="text-muted">Total runs</div>
+                                            </div>
+                                            <div className="text-center">
+                                                <div className="font-semibold text-lg text-success">
+                                                    {runsSummary.successRate}%
+                                                </div>
+                                                <div className="text-muted">Success rate</div>
+                                            </div>
+                                            {evaluation.output_config.allows_na && (
+                                                <div className="text-center">
+                                                    <div className="font-semibold text-lg">
+                                                        {runsSummary.applicabilityRate}%
+                                                    </div>
+                                                    <div className="text-muted">Applicable</div>
+                                                </div>
+                                            )}
+                                            <div className="text-center">
+                                                <div className="font-semibold text-lg text-danger">
+                                                    {runsSummary.errors}
+                                                </div>
+                                                <div className="text-muted">Errors</div>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                                <EvaluationRunsTable />
+                            </div>
+                        ),
+                    },
                     {
-                        key: 'settings',
-                        label: 'Settings',
-                        'data-attr': 'llma-evaluation-settings-tab',
+                        key: 'configuration',
+                        label: 'Configuration',
+                        'data-attr': 'llma-evaluation-configuration-tab',
                         content: (
                             <div className="max-w-4xl">
                                 <Form logic={llmEvaluationLogic} formKey="evaluation" className="space-y-6">
@@ -330,49 +373,6 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                                         <EvaluationTriggers />
                                     </div>
                                 </Form>
-                            </div>
-                        ),
-                    },
-                    !isNewEvaluation && {
-                        key: 'runs',
-                        label: 'Runs',
-                        'data-attr': 'llma-evaluation-runs-tab',
-                        content: (
-                            <div className="max-w-6xl">
-                                <div className="flex justify-between items-center mb-4">
-                                    <p className="text-muted text-sm m-0">
-                                        History of when this evaluation has been executed.
-                                    </p>
-                                    {runsSummary && (
-                                        <div className="flex gap-4 text-sm">
-                                            <div className="text-center">
-                                                <div className="font-semibold text-lg">{runsSummary.total}</div>
-                                                <div className="text-muted">Total runs</div>
-                                            </div>
-                                            <div className="text-center">
-                                                <div className="font-semibold text-lg text-success">
-                                                    {runsSummary.successRate}%
-                                                </div>
-                                                <div className="text-muted">Success rate</div>
-                                            </div>
-                                            {evaluation.output_config.allows_na && (
-                                                <div className="text-center">
-                                                    <div className="font-semibold text-lg">
-                                                        {runsSummary.applicabilityRate}%
-                                                    </div>
-                                                    <div className="text-muted">Applicable</div>
-                                                </div>
-                                            )}
-                                            <div className="text-center">
-                                                <div className="font-semibold text-lg text-danger">
-                                                    {runsSummary.errors}
-                                                </div>
-                                                <div className="text-muted">Errors</div>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                                <EvaluationRunsTable />
                             </div>
                         ),
                     },

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -88,6 +88,9 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         // Signal emission
         setSignalEmission: (enabled: boolean) => ({ enabled }),
 
+        // Settings panel
+        setSettingsExpanded: (expanded: boolean) => ({ expanded }),
+
         // Evaluation management actions
         saveEvaluation: true,
         saveEvaluationSuccess: (evaluation: EvaluationConfig) => ({ evaluation }),
@@ -340,6 +343,14 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             {
                 toggleSummaryExpanded: (state) => !state,
                 generateEvaluationSummarySuccess: () => true,
+            },
+        ],
+        settingsExpanded: [
+            true,
+            {
+                setSettingsExpanded: (_, { expanded }) => expanded,
+                // Collapse settings once an existing evaluation loads, expand for new
+                loadEvaluationSuccess: (_, { evaluation }) => !evaluation?.id,
             },
         ],
     }),

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -346,11 +346,11 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             },
         ],
         activeTab: [
-            'settings' as string,
+            'configuration' as string,
             {
                 setActiveTab: (_, { tab }) => tab,
-                // Show runs tab for existing evaluations, settings for new
-                loadEvaluationSuccess: (_, { evaluation }) => (evaluation?.id ? 'runs' : 'settings'),
+                // Show runs tab for existing evaluations, configuration for new
+                loadEvaluationSuccess: (_, { evaluation }) => (evaluation?.id ? 'runs' : 'configuration'),
             },
         ],
     }),

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -88,8 +88,8 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         // Signal emission
         setSignalEmission: (enabled: boolean) => ({ enabled }),
 
-        // Settings panel
-        setSettingsExpanded: (expanded: boolean) => ({ expanded }),
+        // Tab navigation
+        setActiveTab: (tab: string) => ({ tab }),
 
         // Evaluation management actions
         saveEvaluation: true,
@@ -345,12 +345,12 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 generateEvaluationSummarySuccess: () => true,
             },
         ],
-        settingsExpanded: [
-            true,
+        activeTab: [
+            'settings' as string,
             {
-                setSettingsExpanded: (_, { expanded }) => expanded,
-                // Collapse settings once an existing evaluation loads, expand for new
-                loadEvaluationSuccess: (_, { evaluation }) => !evaluation?.id,
+                setActiveTab: (_, { tab }) => tab,
+                // Show runs tab for existing evaluations, settings for new
+                loadEvaluationSuccess: (_, { evaluation }) => (evaluation?.id ? 'runs' : 'settings'),
             },
         ],
     }),


### PR DESCRIPTION
## Summary
- Replaces the collapsible "Settings" toggle with **LemonTabs** ("Settings" / "Runs") on the evaluation detail page
- Existing evaluations default to the **Runs** tab so users see results immediately
- New evaluations default to the **Settings** tab
- Follows established PostHog tab patterns (URL-driven, state in Kea logic)
- Addresses review feedback: accessible button semantics, `requestAnimationFrame` instead of `setTimeout`

<img width="1396" height="604" alt="image" src="https://github.com/user-attachments/assets/7c3c8130-e9c1-4562-9806-c24689bd83b5" />

## Test plan
- [ ] Navigate to an existing evaluation — should land on the "Runs" tab
- [ ] Switch to "Settings" tab — form should display correctly
- [ ] Create a new evaluation — should land on the "Settings" tab (no "Runs" tab shown)
- [ ] Try saving with 0% rollout — should switch to Settings tab and scroll to triggers
- [ ] Verify tabs are keyboard-accessible