### PR TITLE
feat: first last seen info icons

### DIFF
--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -274,13 +274,23 @@ export function DefinitionView(props: DefinitionLogicProps): JSX.Element {
             <div className="flex flex-wrap">
                 {isEvent && (
                     <div className="flex flex-col flex-1">
-                        <h5>First seen</h5>
+                        <h5>
+                            First seen{' '}
+                            <Tooltip title="This is the first time this event was ingested. Event timestamps can be historical, so it may not match the timestamp of the earliest event.">
+                                <IconInfo className="text-sm" />
+                            </Tooltip>
+                        </h5>
                         <b>{definition.created_at ? <TZLabel time={definition.created_at} /> : '-'}</b>
                     </div>
                 )}
                 {isEvent && (
                     <div className="flex flex-col flex-1">
-                        <h5>Last seen</h5>
+                        <h5>
+                            Last seen{' '}
+                            <Tooltip title="This is the last time this event was ingested. Event timestamps can be historical, so it may not match the timestamp of the latest event.">
+                                <IconInfo className="text-sm" />
+                            </Tooltip>
+                        </h5>
                         <b>{definition.last_seen_at ? <TZLabel time={definition.last_seen_at} /> : '-'}</b>
                     </div>
                 )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users might misunderstand the "First seen" and "Last seen" timestamps on the event definition page, potentially confusing them with event property timestamps rather than ingestion timestamps. This PR adds clarity to these headings.

## Changes

Adds `IconInfo` tooltips to the "First seen" and "Last seen" headings on the event definition page (`DefinitionView.tsx`).

The tooltips clarify that these timestamps refer to when the event was *ingested* into PostHog, not the event's timestamp property:
- **First seen**: "This is the first time this event was ingested. Event timestamps can be historical, so it may not match the timestamp of the earliest event."
- **Last seen**: "This is the last time this event was ingested. Event timestamps can be historical, so it may not match the timestamp of the latest event."

This follows the existing pattern for `IconInfo` tooltips already present on the page (e.g., for "30 day queries").

## How did you test this code?

Automated tests:
- `npm run lint -- --fix`
- `npm run prettier -- --write`
- `npm run typecheck`
- `npm run test`

As an agent, I have not performed manual testing.

## Publish to changelog?

no

[Slack Thread](https://posthog.slack.com/archives/D0ACMC57HDE/p1773314438136079?thread_ts=1773314438.136079&cid=D0ACMC57HDE)

<div><a href="https://cursor.com/agents/bc-ddece50d-74d0-5315-a4b6-bbfc23828078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddece50d-74d0-5315-a4b6-bbfc23828078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->