### PR TITLE
chore(ds): increase retry attempts for resumable warehouse sources

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -304,21 +304,27 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
                 source = SourceRegistry.get_source(ExternalDataSourceType(source_type))
                 is_resumable_source = isinstance(source, ResumableSource)
 
-            timeout_params = (
-                {
+            if is_resumable_source:
+                timeout_params = {
+                    "start_to_close_timeout": dt.timedelta(weeks=1),
+                    "retry_policy": RetryPolicy(
+                        maximum_attempts=15, non_retryable_error_types=["NonRetryableException"]
+                    ),
+                }
+            elif incremental_or_append:
+                timeout_params = {
                     "start_to_close_timeout": dt.timedelta(weeks=1),
                     "retry_policy": RetryPolicy(
                         maximum_attempts=9, non_retryable_error_types=["NonRetryableException"]
                     ),
                 }
-                if incremental_or_append or is_resumable_source
-                else {
+            else:
+                timeout_params = {
                     "start_to_close_timeout": dt.timedelta(hours=24),
                     "retry_policy": RetryPolicy(
                         maximum_attempts=3, non_retryable_error_types=["NonRetryableException"]
                     ),
                 }
-            )
 
             pipeline_result = await workflow.execute_activity(
                 import_data_activity_sync,

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -3191,8 +3191,8 @@ async def test_non_retryable_error_short_circuiting(team, stripe_customer, mock_
                 ignore_assertions=True,
             )
 
-    # Incremental and resumable source syncs retry up to 9 times
-    assert mock_get_rows.call_count == 9
+    # Resumable source syncs retry up to 15 times
+    assert mock_get_rows.call_count == 15
 
     source_cls = SourceRegistry.get_source(ExternalDataSourceType.STRIPE)
     non_retryable_errors = source_cls.get_non_retryable_errors()


### PR DESCRIPTION
## Problem

We want to give resumable sources more chances to finish their runs

## Changes

  * Increased Temporal `maximum_attempts` from 9 to 15 for resumable warehouse sources

## How did you test this code?

test pass

## Publish to changelog?

NO
