### PR TITLE
fix(proxy): clear stale warning message when proxy becomes valid

### DIFF
--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -565,13 +565,15 @@ class CreateManagedProxyWorkflow(PostHogWorkflow):
                     ),
                 )
 
-            # Everything's created and ready to go, update to VALID
+            # Everything's created and ready to go, update to VALID and clear
+            # any messages from earlier retries (e.g. Cloudflare proxying warning)
             await temporalio.workflow.execute_activity(
                 activity_update_proxy_record,
                 UpdateProxyRecordInputs(
                     organization_id=inputs.organization_id,
                     proxy_record_id=inputs.proxy_record_id,
                     status=ProxyRecord.Status.VALID.value,
+                    message="",
                 ),
                 start_to_close_timeout=dt.timedelta(seconds=10),
                 retry_policy=temporalio.common.RetryPolicy(


### PR DESCRIPTION
## Problem

When a managed proxy setup encounters a transient issue (e.g. Cloudflare proxying detection during DNS validation), a warning message is written to the ProxyRecord. If the customer fixes the issue and the setup completes successfully, the status updates to VALID/Live but the old warning message persists in the UI — confusing customers into thinking there's still a problem.

## Changes

Pass `message=""` when updating the ProxyRecord status to VALID in the create workflow, clearing any stale messages from earlier retries. This matches what the monitor workflow already does (line 445 of `monitor.py`).

## How did you test this code?

Verified the monitor workflow already uses `message=""` when setting VALID status. The create workflow was the only place missing it. The `update_record` function correctly handles empty strings (the check is `if message is not None`).

## Publish to changelog?

No