### PR TITLE
fix(hogai): preserve layouts in upsert_dashboard updates

### DIFF
--- a/ee/hogai/tools/upsert_dashboard/prompts.py
+++ b/ee/hogai/tools/upsert_dashboard/prompts.py
@@ -19,11 +19,18 @@ Call this tool when you have enough information to create or update the dashboar
 # Understanding dashboard update with insight_ids
 
 When `insight_ids` is provided, it replaces all dashboard insights with the provided insights.
-Layouts are preserved positionally: the first insight takes the first tile's position, etc.
 You can use insight_ids to add, replace, or remove insights.
+By default, keep existing insight tile layouts unchanged (`layout_mode="preserve_existing"`).
+Use `layout_mode="reflow_all"` whenever the user explicitly asks to change placement/order, including phrases like:
+- reorder/rearrange/reflow the dashboard
+- move an insight before/after another insight
+- insert an insight between two insights
+- place an insight first/last/at the top
+Keep `layout_mode="preserve_existing"` for plain add/remove/replace requests where layout should stay unchanged.
+When using `layout_mode="reflow_all"`, tile coordinates are recomputed in the order of `insight_ids`.
 
-Example: Dashboard has [A, B, C] (in layout order). Use `insight_ids=[A', C']`.
-Result: A' takes A's layout, C' takes B's layout, B is removed.
+Example: Dashboard has [A, B, C] (in layout order). Use `insight_ids=[A, C]` (same insight IDs, omitting B).
+Result: A and C keep their existing tile layouts, B's tile is soft-deleted, and no new tiles are created.
 
 # When to use this tool
 - The user asks to create or update a dashboard.

--- a/ee/hogai/tools/upsert_dashboard/test/test_tool.py
+++ b/ee/hogai/tools/upsert_dashboard/test/test_tool.py
@@ -354,6 +354,7 @@ class TestUpsertDashboardTool(BaseTest):
         action = UpdateDashboardToolArgs(
             dashboard_id=str(dashboard.id),
             insight_ids=[insight_a_new.short_id, insight_b_new.short_id],
+            layout_mode="reflow_all",
         )
 
         await tool._arun_impl(action)
@@ -368,6 +369,48 @@ class TestUpsertDashboardTool(BaseTest):
         sorted_tiles = DashboardTile.sort_tiles_by_layout(active_tiles)
         self.assertEqual(sorted_tiles[0].insight_id, insight_a_new.id)
         self.assertEqual(sorted_tiles[1].insight_id, insight_b_new.id)
+
+    async def test_add_insight_preserves_existing_layouts_by_default(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard with custom layout",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("Insight A")
+        insight_b = await self._create_insight("Insight B")
+        insight_c = await self._create_insight("Insight C")
+
+        tile_a = await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            insight=insight_a,
+            layouts={"sm": {"x": 0, "y": 0, "w": 8, "h": 7}, "xs": {"x": 0, "y": 0, "w": 1, "h": 5}},
+        )
+        tile_b = await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            insight=insight_b,
+            layouts={"sm": {"x": 8, "y": 0, "w": 4, "h": 6}, "xs": {"x": 0, "y": 5, "w": 1, "h": 5}},
+        )
+
+        original_layout_a = tile_a.layouts.copy()
+        original_layout_b = tile_b.layouts.copy()
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_b.short_id, insight_c.short_id],
+        )
+
+        await tool._arun_impl(action)
+
+        await tile_a.arefresh_from_db()
+        await tile_b.arefresh_from_db()
+
+        self.assertEqual(tile_a.layouts, original_layout_a)
+        self.assertEqual(tile_b.layouts, original_layout_b)
+
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+        self.assertEqual(tile_c.layouts, {})
 
     @parameterized.expand(
         [
@@ -545,6 +588,7 @@ class TestUpsertDashboardTool(BaseTest):
         action = UpdateDashboardToolArgs(
             dashboard_id=str(dashboard.id),
             insight_ids=[insight_b.short_id, insight_d.short_id, insight_a.short_id, insight_e.short_id],
+            layout_mode="reflow_all",
         )
 
         result, _ = await tool._arun_impl(action)
@@ -609,6 +653,7 @@ class TestUpsertDashboardTool(BaseTest):
         action = UpdateDashboardToolArgs(
             dashboard_id=str(dashboard.id),
             insight_ids=[insight_b.short_id, insight_d.short_id, insight_a.short_id, insight_e.short_id],
+            layout_mode="reflow_all",
         )
 
         result, _ = await tool._arun_impl(action)
@@ -636,14 +681,15 @@ class TestUpsertDashboardTool(BaseTest):
             self.assertIn("sm", tile.layouts)
             self.assertIn("y", tile.layouts["sm"])
 
-    async def test_update_preserves_existing_insight_tiles(self):
+    async def test_reflow_all_updates_existing_insight_tiles(self):
         """
-        Test that existing insights keep their original tiles with updated coordinates.
+        Test that reflow_all keeps tile IDs while rewriting layout.
 
         When updating a dashboard:
         - Existing insights that remain keep their tile IDs
         - Their layouts are updated based on position in insight_ids
-        - Sizes (w, h) are preserved, coordinates (x, y) are updated
+        - Heights are preserved
+        - Widths are equalized per row when there is horizontal gap
         """
         dashboard = await Dashboard.objects.acreate(
             team=self.team,
@@ -671,6 +717,7 @@ class TestUpsertDashboardTool(BaseTest):
         action = UpdateDashboardToolArgs(
             dashboard_id=str(dashboard.id),
             insight_ids=[insight_b.short_id, insight_a.short_id],
+            layout_mode="reflow_all",
         )
 
         await tool._arun_impl(action)
@@ -683,29 +730,66 @@ class TestUpsertDashboardTool(BaseTest):
         self.assertEqual(tile_a.id, original_tile_a_id)
         self.assertEqual(tile_b.id, original_tile_b_id)
 
-        # Sizes are preserved
-        self.assertEqual(tile_a.layouts["sm"]["w"], 8)
+        # Heights are preserved and single-tile rows are widened to fill.
+        self.assertEqual(tile_a.layouts["sm"]["w"], 12)
         self.assertEqual(tile_a.layouts["sm"]["h"], 7)
-        self.assertEqual(tile_b.layouts["sm"]["w"], 10)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 12)
         self.assertEqual(tile_b.layouts["sm"]["h"], 6)
 
         # Coordinates are updated based on order
-        # B (w=10, wide) at position 0: x=0, y=0
-        # A (w=8, wide) at position 1: x=0, y=6 (below B which has h=6)
+        # B at position 0: x=0, y=0
+        # A at position 1: x=0, y=6 (below B which has h=6)
         self.assertEqual(tile_b.layouts["sm"]["x"], 0)
         self.assertEqual(tile_b.layouts["sm"]["y"], 0)
         self.assertEqual(tile_a.layouts["sm"]["x"], 0)
         self.assertEqual(tile_a.layouts["sm"]["y"], 6)
 
-    async def test_two_column_flow_layout_algorithm(self):
+    async def test_reflow_all_preserves_existing_xs_heights(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard preserve xs heights",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            insight=insight_a,
+            layouts={"sm": {"x": 0, "y": 0, "w": 8, "h": 5}, "xs": {"x": 0, "y": 0, "w": 1, "h": 9}},
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            insight=insight_b,
+            layouts={"sm": {"x": 8, "y": 0, "w": 4, "h": 4}, "xs": {"x": 0, "y": 9, "w": 1, "h": 3}},
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_b.short_id],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+
+        self.assertEqual(tile_a.layouts["xs"]["h"], 9)
+        self.assertEqual(tile_b.layouts["xs"]["h"], 3)
+        self.assertEqual(tile_a.layouts["xs"]["y"], 0)
+        self.assertEqual(tile_b.layouts["xs"]["y"], 9)
+
+    async def test_reflow_all_compacts_layout_and_preserves_sizes(self):
         """
-        Test the 2-column flow layout algorithm.
+        Test row compaction for reflow_all.
 
         Rules:
-        - Half-width tiles (w<=6) flow left-to-right into 2 columns
-        - Full-width tiles (w>6) span both columns
-        - Tiles are placed in the column with lower Y (prefers left when equal)
-        - Original widths and heights are preserved
+        - Tile order is preserved
+        - Row heights are normalized to the tallest tile in the row
+        - Full-width single-tile rows stay unchanged
+        - Rows are stacked without overlap
         """
         dashboard = await Dashboard.objects.acreate(
             team=self.team,
@@ -749,6 +833,7 @@ class TestUpsertDashboardTool(BaseTest):
                 insight_d.short_id,
                 insight_e.short_id,
             ],
+            layout_mode="reflow_all",
         )
 
         await tool._arun_impl(action)
@@ -766,25 +851,30 @@ class TestUpsertDashboardTool(BaseTest):
 
         # Expected layout:
         # A (w=6, h=5): x=0, y=0 (left column, first)
-        # B (w=6, h=4): x=6, y=0 (right column, left_y=5 > right_y=0, so goes right)
+        # B (w=6, h=4): x=6, y=0 (fills top row gap on the right)
         # C (w=12, h=3): x=0, y=5 (full width, below max(5, 4)=5)
         # D (w=6, h=5): x=0, y=8 (left column, both at y=8 after C)
         # E (w=6, h=6): x=6, y=8 (right column)
 
-        # Verify widths and heights preserved
+        # Verify widths and heights
         self.assertEqual(tile_a.layouts["sm"]["w"], 6)
         self.assertEqual(tile_a.layouts["sm"]["h"], 5)
         self.assertEqual(tile_b.layouts["sm"]["w"], 6)
-        self.assertEqual(tile_b.layouts["sm"]["h"], 4)
+        # First row height is normalized to tallest tile (A has h=5).
+        self.assertEqual(tile_b.layouts["sm"]["h"], 5)
         self.assertEqual(tile_c.layouts["sm"]["w"], 12)
+        # Full-width single row remains unchanged.
         self.assertEqual(tile_c.layouts["sm"]["h"], 3)
+        # Third row height is normalized to tallest tile (E has h=6).
+        self.assertEqual(tile_d.layouts["sm"]["h"], 6)
+        self.assertEqual(tile_e.layouts["sm"]["h"], 6)
 
         # Verify coordinates
         # A: first tile, goes to left column
         self.assertEqual(tile_a.layouts["sm"]["x"], 0)
         self.assertEqual(tile_a.layouts["sm"]["y"], 0)
 
-        # B: second tile, left_y=5, right_y=0, goes to right column (lower Y)
+        # B: second tile fills the top-right gap
         self.assertEqual(tile_b.layouts["sm"]["x"], 6)
         self.assertEqual(tile_b.layouts["sm"]["y"], 0)
 
@@ -796,9 +886,619 @@ class TestUpsertDashboardTool(BaseTest):
         self.assertEqual(tile_d.layouts["sm"]["x"], 0)
         self.assertEqual(tile_d.layouts["sm"]["y"], 8)
 
-        # E: left_y=13, right_y=8, goes to right column
+        # E: follows D in the same row
         self.assertEqual(tile_e.layouts["sm"]["x"], 6)
         self.assertEqual(tile_e.layouts["sm"]["y"], 8)
+
+    async def test_reflow_all_fills_top_row_gap_for_mixed_widths(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard mixed widths",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 8, "h": 4}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 0, "y": 4, "w": 4, "h": 3}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 4, "y": 4, "w": 4, "h": 2}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_b.short_id, insight_c.short_id],
+            layout_mode="reflow_all",
+        )
+
+        await tool._arun_impl(action)
+
+        tiles = {
+            t.insight_id: t async for t in DashboardTile.objects.filter(dashboard=dashboard).select_related("insight")
+        }
+
+        tile_a = tiles[insight_a.id]
+        tile_b = tiles[insight_b.id]
+        tile_c = tiles[insight_c.id]
+
+        # First row stays [A, B] because it already fills 12 columns.
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 8)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 12)
+        # C is alone in row 2, so it expands to fill the row.
+        self.assertEqual(tile_c.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 4)
+
+    async def test_reflow_all_equalizes_partial_row_widths(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard equal width scaling",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 8, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 8, "y": 0, "w": 2, "h": 5}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_b.short_id],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+
+        # Row width 10 is expanded to 12 with equal split for two tiles.
+        self.assertEqual(tile_a.layouts["sm"]["w"], 6)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 6)
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 6)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 0)
+
+    async def test_reflow_all_equalizes_three_tile_row_with_gap(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard three tile equalization",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 4, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 4, "y": 0, "w": 2, "h": 3}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 6, "y": 0, "w": 2, "h": 4}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_b.short_id, insight_c.short_id],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+
+        # Row total width 8 is expanded to 12 as equal thirds.
+        self.assertEqual(tile_a.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 4)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 8)
+        # Row heights normalized to tallest tile (A has h=5).
+        self.assertEqual(tile_a.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_b.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_c.layouts["sm"]["h"], 5)
+
+    async def test_reflow_all_adapts_inserted_large_middle_tile_to_row(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard middle insertion",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+
+        # Existing row with A and B, each taking a third, with a gap in between.
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 4, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 8, "y": 0, "w": 4, "h": 4}}
+        )
+        # New/moved large tile that would normally overflow after A (4 + 10 > 12).
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 0, "y": 8, "w": 10, "h": 6}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_c.short_id, insight_b.short_id],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+
+        # All three should stay in one row and adapt to equal thirds.
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 8)
+        self.assertEqual(tile_a.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 4)
+        # Height normalized to tallest in row (tile C h=6).
+        self.assertEqual(tile_a.layouts["sm"]["h"], 6)
+        self.assertEqual(tile_c.layouts["sm"]["h"], 6)
+        self.assertEqual(tile_b.layouts["sm"]["h"], 6)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 0)
+
+    async def test_reflow_all_adapts_third_tile_into_two_half_width_tiles_row(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard half width insertion",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 6, "y": 0, "w": 6, "h": 4}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 0, "y": 8, "w": 4, "h": 3}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_c.short_id, insight_b.short_id],
+            layout_mode="reflow_all",
+        )
+
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+
+        # Two half-width tiles plus inserted third tile should compact to one equal row.
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 8)
+        self.assertEqual(tile_a.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 0)
+        # Row height normalized to tallest tile in that row (A has h=5).
+        self.assertEqual(tile_a.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_c.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_b.layouts["sm"]["h"], 5)
+
+    async def test_reflow_all_does_not_pull_fourth_tile_into_already_full_three_tile_row(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard four tile adaptation",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+        insight_d = await self._create_insight("D")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 6, "y": 0, "w": 6, "h": 4}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 0, "y": 8, "w": 3, "h": 3}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_d, layouts={"sm": {"x": 3, "y": 8, "w": 3, "h": 2}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_c.short_id, insight_d.short_id, insight_b.short_id],
+            layout_mode="reflow_all",
+        )
+
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+        tile_d = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_d)
+
+        # Row [A, C, D] already fills 12 columns, so B stays in the next row.
+        self.assertEqual(tile_a.layouts["sm"]["w"], 6)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_d.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 12)
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 6)
+        self.assertEqual(tile_d.layouts["sm"]["x"], 9)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_d.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 5)
+        self.assertEqual(tile_a.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_c.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_d.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_b.layouts["sm"]["h"], 4)
+
+    async def test_reflow_all_keeps_insert_between_two_tiles_as_three_tile_row(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard insert between keeps row at three",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+        insight_d = await self._create_insight("D")
+
+        # Initial shape: [A, B] in first row, [C, D] in next rows.
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 6, "y": 0, "w": 4, "h": 6}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 0, "y": 6, "w": 4, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_d, layouts={"sm": {"x": 6, "y": 6, "w": 6, "h": 4}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_d.short_id, insight_b.short_id, insight_c.short_id],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+        tile_d = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_d)
+
+        # A, D, B share first row. C must stay on the next row.
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_d.layouts["sm"]["x"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 8)
+        self.assertEqual(tile_a.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_d.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_d.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 6)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 12)
+
+    async def test_reflow_all_can_adapt_four_tiles_when_row_has_slack_before_overflow(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard four tile slack adaptation",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+        insight_d = await self._create_insight("D")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 5, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 5, "y": 0, "w": 2, "h": 4}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 7, "y": 0, "w": 2, "h": 3}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_d, layouts={"sm": {"x": 0, "y": 8, "w": 4, "h": 2}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_b.short_id, insight_c.short_id, insight_d.short_id],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+        tile_d = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_d)
+
+        # Row had slack (width 9) before D caused overflow, so all four are adapted to one row.
+        self.assertEqual(tile_a.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_d.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 3)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 6)
+        self.assertEqual(tile_d.layouts["sm"]["x"], 9)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_d.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_a.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_b.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_c.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_d.layouts["sm"]["h"], 5)
+
+    async def test_reflow_all_splits_five_tiles_when_equalization_would_overcompress(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard five tile adaptation",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+        insight_d = await self._create_insight("D")
+        insight_e = await self._create_insight("E")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 6, "y": 0, "w": 6, "h": 4}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 0, "y": 8, "w": 3, "h": 3}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_d, layouts={"sm": {"x": 3, "y": 8, "w": 3, "h": 2}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_e, layouts={"sm": {"x": 6, "y": 8, "w": 3, "h": 4}}
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[
+                insight_a.short_id,
+                insight_c.short_id,
+                insight_d.short_id,
+                insight_e.short_id,
+                insight_b.short_id,
+            ],
+            layout_mode="reflow_all",
+        )
+
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+        tile_d = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_d)
+        tile_e = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_e)
+
+        # Row [A, C, D] stays full. E and B are reflowed in the next row.
+        self.assertEqual(tile_a.layouts["sm"]["w"], 6)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_d.layouts["sm"]["w"], 3)
+        self.assertEqual(tile_e.layouts["sm"]["w"], 6)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 6)
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 6)
+        self.assertEqual(tile_d.layouts["sm"]["x"], 9)
+        self.assertEqual(tile_e.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 6)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_d.layouts["sm"]["y"], 0)
+        self.assertEqual(tile_e.layouts["sm"]["y"], 5)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 5)
+        self.assertEqual(tile_a.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_c.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_d.layouts["sm"]["h"], 5)
+        self.assertEqual(tile_e.layouts["sm"]["h"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["h"], 4)
+
+    async def test_reflow_all_does_not_overcompress_six_medium_tiles_into_one_row(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard six tile over-compression guard",
+            created_by=self.user,
+        )
+
+        insights = [await self._create_insight(name) for name in ["A", "B", "C", "D", "E", "F"]]
+        for index, insight in enumerate(insights):
+            await DashboardTile.objects.acreate(
+                dashboard=dashboard,
+                insight=insight,
+                layouts={"sm": {"x": (index % 3) * 4, "y": (index // 3) * 5, "w": 4, "h": 5}},
+            )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight.short_id for insight in insights],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        tiles_by_insight_id = {
+            tile.insight_id: tile async for tile in DashboardTile.objects.filter(dashboard=dashboard)
+        }
+        row1 = [tiles_by_insight_id[insights[i].id] for i in range(3)]
+        row2 = [tiles_by_insight_id[insights[i].id] for i in range(3, 6)]
+
+        for expected_x, tile in zip([0, 4, 8], row1):
+            self.assertEqual(tile.layouts["sm"]["x"], expected_x)
+            self.assertEqual(tile.layouts["sm"]["y"], 0)
+            self.assertEqual(tile.layouts["sm"]["w"], 4)
+            self.assertEqual(tile.layouts["sm"]["h"], 5)
+
+        for expected_x, tile in zip([0, 4, 8], row2):
+            self.assertEqual(tile.layouts["sm"]["x"], expected_x)
+            self.assertEqual(tile.layouts["sm"]["y"], 5)
+            self.assertEqual(tile.layouts["sm"]["w"], 4)
+            self.assertEqual(tile.layouts["sm"]["h"], 5)
+
+    async def test_reflow_all_respects_full_width_text_tile_band(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard with full width text separator",
+            created_by=self.user,
+        )
+
+        insight_a = await self._create_insight("A")
+        insight_b = await self._create_insight("B")
+        insight_c = await self._create_insight("C")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_a, layouts={"sm": {"x": 0, "y": 4, "w": 4, "h": 5}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_b, layouts={"sm": {"x": 8, "y": 4, "w": 4, "h": 4}}
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard, insight=insight_c, layouts={"sm": {"x": 0, "y": 10, "w": 8, "h": 5}}
+        )
+
+        text = await Text.objects.acreate(team=self.team, body="Separator")
+        text_tile = await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            text=text,
+            layouts={"sm": {"x": 0, "y": 0, "w": 12, "h": 3}},
+        )
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_c.short_id, insight_b.short_id],
+            layout_mode="reflow_all",
+        )
+
+        await tool._arun_impl(action)
+
+        tile_a = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_a)
+        tile_b = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_b)
+        tile_c = await DashboardTile.objects.aget(dashboard=dashboard, insight=insight_c)
+        await text_tile.arefresh_from_db()
+
+        # Row should compact to equal thirds while staying below the fixed full-width text tile.
+        self.assertEqual(tile_a.layouts["sm"]["x"], 0)
+        self.assertEqual(tile_c.layouts["sm"]["x"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["x"], 8)
+        self.assertEqual(tile_a.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_c.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_b.layouts["sm"]["w"], 4)
+        self.assertEqual(tile_a.layouts["sm"]["y"], 3)
+        self.assertEqual(tile_c.layouts["sm"]["y"], 3)
+        self.assertEqual(tile_b.layouts["sm"]["y"], 3)
+
+        # Text tile stays fixed and undeleted.
+        self.assertFalse(text_tile.deleted)
+        self.assertEqual(text_tile.layouts["sm"]["x"], 0)
+        self.assertEqual(text_tile.layouts["sm"]["y"], 0)
+        self.assertEqual(text_tile.layouts["sm"]["w"], 12)
+        self.assertEqual(text_tile.layouts["sm"]["h"], 3)
+
+    async def test_reflow_all_produces_non_overlapping_layouts(self):
+        dashboard = await Dashboard.objects.acreate(
+            team=self.team,
+            name="Dashboard no overlap",
+            created_by=self.user,
+        )
+
+        insights = [await self._create_insight(name) for name in ["A", "B", "C", "D", "E", "F"]]
+        layouts = [
+            {"w": 8, "h": 4},
+            {"w": 4, "h": 5},
+            {"w": 6, "h": 3},
+            {"w": 6, "h": 4},
+            {"w": 12, "h": 2},
+            {"w": 4, "h": 6},
+        ]
+
+        for insight, layout in zip(insights, layouts):
+            await DashboardTile.objects.acreate(dashboard=dashboard, insight=insight, layouts={"sm": layout})
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight.short_id for insight in insights],
+            layout_mode="reflow_all",
+        )
+        await tool._arun_impl(action)
+
+        active_tiles = [t async for t in DashboardTile.objects.filter(dashboard=dashboard)]
+        sm_layouts = [tile.layouts["sm"] for tile in active_tiles]
+
+        def overlaps(a: dict, b: dict) -> bool:
+            return (
+                a["x"] < b["x"] + b["w"]
+                and a["x"] + a["w"] > b["x"]
+                and a["y"] < b["y"] + b["h"]
+                and a["y"] + a["h"] > b["y"]
+            )
+
+        for i, layout_a in enumerate(sm_layouts):
+            for layout_b in sm_layouts[i + 1 :]:
+                self.assertFalse(overlaps(layout_a, layout_b))
 
     @parameterized.expand(
         [
@@ -829,6 +1529,7 @@ class TestUpsertDashboardTool(BaseTest):
         action = UpdateDashboardToolArgs(
             dashboard_id=str(dashboard.id),
             insight_ids=[insights[key].short_id for key in new_order],
+            layout_mode="reflow_all",
         )
         result, _ = await tool._arun_impl(action)
 
@@ -847,6 +1548,47 @@ class TestUpsertDashboardTool(BaseTest):
         active_tiles = [t async for t in DashboardTile.objects.filter(dashboard=dashboard)]
         self.assertEqual(len(active_tiles), 3)
         self.assertEqual({t.insight_id for t in active_tiles}, {insights[k].id for k in ["A", "B", "C"]})
+
+    async def test_preserve_existing_restores_soft_deleted_tile_and_keeps_layout(self):
+        dashboard = await Dashboard.objects.acreate(team=self.team, name="Dashboard", created_by=self.user)
+        insight_a = await self._create_insight("Insight_A")
+        insight_b = await self._create_insight("Insight_B")
+        insight_c = await self._create_insight("Insight_C")
+
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            insight=insight_a,
+            layouts={"sm": {"x": 0, "y": 0, "w": 4, "h": 5}, "xs": {"x": 0, "y": 0, "w": 1, "h": 5}},
+        )
+        tile_b = await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            insight=insight_b,
+            layouts={"sm": {"x": 4, "y": 0, "w": 8, "h": 6}, "xs": {"x": 0, "y": 5, "w": 1, "h": 5}},
+        )
+        await DashboardTile.objects.acreate(
+            dashboard=dashboard,
+            insight=insight_c,
+            layouts={"sm": {"x": 0, "y": 6, "w": 12, "h": 4}, "xs": {"x": 0, "y": 10, "w": 1, "h": 5}},
+        )
+
+        original_layout_b = tile_b.layouts.copy()
+        tile_b.deleted = True
+        await tile_b.asave(update_fields=["deleted"])
+
+        tool = self._create_tool()
+        action = UpdateDashboardToolArgs(
+            dashboard_id=str(dashboard.id),
+            insight_ids=[insight_a.short_id, insight_b.short_id, insight_c.short_id],
+        )
+        await tool._arun_impl(action)
+
+        await tile_b.arefresh_from_db()
+        self.assertFalse(tile_b.deleted)
+        self.assertEqual(tile_b.layouts, original_layout_b)
+
+        active_tiles = [t async for t in DashboardTile.objects.filter(dashboard=dashboard)]
+        self.assertEqual(len(active_tiles), 3)
+        self.assertEqual({t.insight_id for t in active_tiles}, {insight_a.id, insight_b.id, insight_c.id})
 
     @parameterized.expand(
         [

--- a/ee/hogai/tools/upsert_dashboard/tool.py
+++ b/ee/hogai/tools/upsert_dashboard/tool.py
@@ -50,8 +50,12 @@ class UpdateDashboardToolArgs(BaseModel):
     action: Literal["update"] = "update"
     dashboard_id: str = Field(description="Provide the ID of the dashboard to be update it.")
     insight_ids: list[str] | None = Field(
-        description="The IDs of the insights for the dashboard. Replaces all existing insights. Order determines positional mapping for layout preservation.",
+        description="The IDs of the insights for the dashboard. Replaces all existing insights.",
         default=None,
+    )
+    layout_mode: Literal["preserve_existing", "reflow_all"] = Field(
+        description="How to handle existing tile layouts when insight_ids are provided. Use preserve_existing by default. Use reflow_all only when the user explicitly asks to rearrange or reorder tiles.",
+        default="preserve_existing",
     )
     name: str | None = Field(
         description="A short and concise (3-7 words) name of the dashboard. If not provided, the dashboard name will not be updated.",
@@ -76,6 +80,17 @@ class UpsertDashboardToolArgs(BaseModel):
 class UpdateDiff(TypedDict):
     created: list[VisualizationWithSourceResult]
     deleted: list[DashboardTile]
+
+
+class ReflowRowItem(TypedDict):
+    tile: DashboardTile
+    h: int
+    w: int
+
+
+class ReflowTileLayoutUpdate(TypedDict):
+    tile: DashboardTile
+    layouts: dict[str, dict[str, int]]
 
 
 class UpsertDashboardTool(MaxTool):
@@ -174,6 +189,7 @@ class UpsertDashboardTool(MaxTool):
             action.description,
             insight_ids,
             artifacts,
+            action.layout_mode,
         )
         await self._report_dashboard_action(dashboard, "dashboard updated")
 
@@ -283,6 +299,7 @@ class UpsertDashboardTool(MaxTool):
         description: str | None,
         insight_ids: list[str],
         artifacts: list[VisualizationWithSourceResult],
+        layout_mode: Literal["preserve_existing", "reflow_all"],
     ) -> tuple[Dashboard, list[Insight]]:
         """Update dashboard tiles based on provided insight IDs.
 
@@ -292,6 +309,7 @@ class UpsertDashboardTool(MaxTool):
             description: New dashboard description (if provided)
             insight_ids: Ordered list of insight IDs for the dashboard
             artifacts: Resolved visualization artifacts matching insight_ids order
+            layout_mode: Layout strategy for existing tiles
 
         Returns:
             Tuple of (dashboard, resolved_insights) where resolved_insights
@@ -324,6 +342,7 @@ class UpsertDashboardTool(MaxTool):
         # Track tiles that will be active after update
         active_tile_ids: set[int] = set()
         tiles_to_update: list[DashboardTile] = []
+        restored_tile_ids: list[int] = []
 
         # 2. Create new tiles or restore soft deleted
         for insight_id, insight in zip(insight_ids, resolved_insights):
@@ -333,6 +352,7 @@ class UpsertDashboardTool(MaxTool):
                 # Restore if soft deleted
                 if existing_tile.deleted:
                     existing_tile.deleted = False
+                    restored_tile_ids.append(existing_tile.id)
                 active_tile_ids.add(existing_tile.id)
                 tiles_to_update.append(existing_tile)
             else:
@@ -353,44 +373,149 @@ class UpsertDashboardTool(MaxTool):
             # nosemgrep: idor-lookup-without-team
             DashboardTile.objects.filter(id__in=tiles_to_delete).update(deleted=True)
 
-        # 4. Update coordinates based on insight_ids order, keeping original sizes
-        # 2-column flow layout: tiles flow left-to-right, respecting their widths
-        # Track current Y position for each column
-        left_y = 0  # Column at x=0
-        right_y = 0  # Column at x=6
+        if layout_mode == "preserve_existing":
+            if restored_tile_ids:
+                DashboardTile.objects_including_soft_deleted.filter(id__in=restored_tile_ids).update(deleted=False)
+            return dashboard, resolved_insights
+
+        fixed_non_insight_vertical_spans: list[tuple[int, int]] = []
+        for tile in all_tiles:
+            if tile.deleted or tile.insight_id is not None:
+                continue
+            sm_layout = (tile.layouts or {}).get("sm", {})
+            raw_y = sm_layout.get("y")
+            raw_h = sm_layout.get("h")
+            if not isinstance(raw_y, int | float) or not isinstance(raw_h, int | float):
+                continue
+            y_start = int(raw_y)
+            height = int(raw_h)
+            if y_start < 0 or height <= 0:
+                continue
+            fixed_non_insight_vertical_spans.append((y_start, y_start + height))
+
+        # 4. Reflow insight tile layouts when requested.
+        layout_updates = self._compute_reflow_layout_updates(tiles_to_update, fixed_non_insight_vertical_spans)
+        for layout_update in layout_updates:
+            row_tile = layout_update["tile"]
+            row_tile.layouts = layout_update["layouts"]
+            row_tile.save(update_fields=["layouts", "deleted"])
+
+        return dashboard, resolved_insights
+
+    @staticmethod
+    def _compute_reflow_layout_updates(
+        tiles_to_update: list[DashboardTile], fixed_non_insight_vertical_spans: list[tuple[int, int]]
+    ) -> list[ReflowTileLayoutUpdate]:
+        # Reflow is intentionally row-based and simple:
+        # - preserve tile order
+        # - normalize row heights
+        # - fill row gaps using equal widths
+        # - allow local adaptation for inserted middle tiles
+        # - avoid vertical overlap with fixed non-insight tiles (e.g. text)
+        column_count = 12
         xs_y = 0  # For xs breakpoint (single column)
+        rows: list[list[ReflowRowItem]] = []
+        current_row: list[ReflowRowItem] = []
+        current_row_width = 0
 
         for tile in tiles_to_update:
             sm_layout = (tile.layouts or {}).get("sm", {})
 
-            # Keep original sizes, use defaults if not set
-            h = sm_layout.get("h", 5)
-            w = sm_layout.get("w", 6)
+            # Use original sizes as the baseline, falling back to defaults.
+            raw_h = sm_layout.get("h")
+            raw_w = sm_layout.get("w")
 
-            if w > 6:
-                # Wide tile: spans full width, place below both columns
-                y = max(left_y, right_y)
-                x = 0
-                left_y = right_y = y + h
+            h = int(raw_h) if isinstance(raw_h, int | float) and raw_h > 0 else 5
+            w = int(raw_w) if isinstance(raw_w, int | float) and raw_w > 0 else 6
+            w = min(w, column_count)
+
+            if current_row and current_row_width + w > column_count:
+                # Generic local adaptation for insert/reorder:
+                # If the row starts with a small tile, we can keep an overflowing
+                # tile in this row only when equal-splitting still respects the
+                # smallest baseline tile width in the proposed row.
+                proposed_row_widths = [int(item["w"]) for item in current_row] + [w]
+                proposed_tile_count = len(proposed_row_widths)
+                proposed_equalized_base_width = column_count // proposed_tile_count
+                smallest_baseline_width = min(proposed_row_widths)
+                row_is_already_full = current_row_width >= column_count
+                can_adapt_overflow_in_row = (
+                    current_row[0]["w"] <= column_count // 2
+                    and w < column_count
+                    and proposed_equalized_base_width >= smallest_baseline_width
+                    and not (row_is_already_full and len(current_row) >= 3)
+                )
+                has_single_full_width_tile = len(current_row) == 1 and current_row[0]["w"] == column_count
+
+                if not has_single_full_width_tile and can_adapt_overflow_in_row:
+                    # Keep this tile in the same row; widths will be equalized later.
+                    current_row.append({"tile": tile, "h": h, "w": w})
+                    current_row_width += w
+                    continue
+
+                rows.append(current_row)
+                current_row = []
+                current_row_width = 0
+
+            current_row.append({"tile": tile, "h": h, "w": w})
+            current_row_width += w
+
+        if current_row:
+            rows.append(current_row)
+
+        def _find_next_row_y(candidate_y: int, row_height: int) -> int:
+            """Push a row down until it no longer overlaps fixed non-insight tiles."""
+            y_position = candidate_y
+            while True:
+                conflicting_bottom: int | None = None
+                row_bottom = y_position + row_height
+                for span_start, span_end in fixed_non_insight_vertical_spans:
+                    if y_position < span_end and row_bottom > span_start:
+                        conflicting_bottom = (
+                            span_end if conflicting_bottom is None else max(conflicting_bottom, span_end)
+                        )
+                if conflicting_bottom is None:
+                    return y_position
+                y_position = conflicting_bottom
+
+        y = 0
+        layout_updates: list[ReflowTileLayoutUpdate] = []
+        for row in rows:
+            row_height = max(item["h"] for item in row)
+            row_width = sum(item["w"] for item in row)
+            has_single_full_width_tile = len(row) == 1 and row[0]["w"] == column_count
+            y = _find_next_row_y(y, row_height)
+
+            target_widths: list[int]
+            if has_single_full_width_tile:
+                target_widths = [row[0]["w"]]
+            elif row_width != column_count:
+                tile_count = len(row)
+                base_width = column_count // tile_count
+                remainder = column_count % tile_count
+                target_widths = [base_width + (1 if index < remainder else 0) for index in range(tile_count)]
             else:
-                # Half-width tile: place in the column with lower Y (left-to-right flow)
-                if left_y <= right_y:
-                    x = 0
-                    y = left_y
-                    left_y += h
-                else:
-                    x = 6
-                    y = right_y
-                    right_y += h
+                target_widths = [item["w"] for item in row]
 
-            tile.layouts = {
-                "sm": {"h": h, "w": w, "x": x, "y": y, "minH": 1, "minW": 1},
-                "xs": {"h": 5, "w": 1, "x": 0, "y": xs_y, "minH": 1, "minW": 1},
-            }
-            tile.save(update_fields=["layouts", "deleted"])
-            xs_y += 5
+            x = 0
 
-        return dashboard, resolved_insights
+            for item, target_width in zip(row, target_widths):
+                row_tile = item["tile"]
+                h = item["h"] if has_single_full_width_tile else row_height
+                w = target_width
+                raw_xs_h = ((row_tile.layouts or {}).get("xs") or {}).get("h")
+                # Keep existing mobile height for existing tiles; default only for new/invalid layouts.
+                xs_h = int(raw_xs_h) if isinstance(raw_xs_h, int | float) and raw_xs_h > 0 else 5
+                layouts = {
+                    "sm": {"h": h, "w": w, "x": x, "y": y, "minH": 1, "minW": 1},
+                    "xs": {"h": xs_h, "w": 1, "x": 0, "y": xs_y, "minH": 1, "minW": 1},
+                }
+                layout_updates.append({"tile": row_tile, "layouts": layouts})
+                x += w
+                xs_y += xs_h
+            y += row_height
+
+        return layout_updates
 
     async def _format_dashboard_output(
         self,


### PR DESCRIPTION
## Problem

Users updating dashboards via `upsert_dashboard` were getting unintended layout mutations.
When they only added or removed insights, existing tiles were resized/repositioned, which broke carefully arranged dashboard templates and forced manual re-layout.
Reorder flows also had edge cases where rows were over-compacted and could pull in extra tiles unexpectedly.

## Changes

Added explicit layout strategy to `upsert_dashboard` updates:

- `layout_mode="preserve_existing"` (default): update active insight without mutating existing layout.
- `layout_mode="reflow_all"`: explicitly opt in to recompute layouts when the user asks to reorder/rearrange.

Updated preserve behavior:

- Existing insight tiles keep their `layouts` unchanged.
- Newly created insight tiles are created with empty `layouts` so client placement can occur without mutating existing tile geometry.

Updated reflow behavior (row-based):

- Preserve insight order from `insight_ids`.
- Use existing `sm` `w/h` as baseline (with defaults when missing).
- Normalize each row height to tallest tile.
- Equalize widths when a row is not exactly 12 columns.
- Add overflow adaptation for insert/reorder cases (including “insert between two”).
- Prevent over-compaction by not pulling a 4th tile into an already full 3-tile row.
- Keep full-width single-tile rows stable.
- Respect fixed non-insight tile vertical bands (for example, text tiles) to avoid overlap during reflow.

## How did you test this code?

- Unit tests
- Manually validated with before/after dashboard scenarios and recording shared in thread.

### Before

https://github.com/user-attachments/assets/d947a08e-9e47-4df4-a72e-d495873a0013

### After

https://github.com/user-attachments/assets/1dda28ad-6d6d-4f1d-b4d9-bc90536157b5

## Publish to changelog?

no

## Docs update

No docs update needed.