### PR TITLE
feat(phai): Add sandboxed agents handbook documentation

### DIFF
--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -9,24 +9,24 @@ GitHub repositories, and code execution.
 Use them when your feature needs an autonomous agent that reads PostHog data, writes code, and produces artifacts like PRs or reports.
 
 For simpler LLM calls (summarization, translation, classification),
-skip this page and use the [LLM gateway](/handbook/engineering/llm-gateway) directly —
+skip this page and use the LLM gateway (`get_llm_client()`) directly —
 it's simpler and doesn't need a sandbox.
 
 ## When to use what
 
-| Need                                                                            | Solution                                                                | Example                                                                                         |
-| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| Autonomous agent that reads PostHog data and writes code                        | Sandboxed agent (this page)                                             | Signals team building an enrichment pipeline that generates reports from PostHog analytics data |
-| Autonomous agent that interacts with customers or performs multi-step reasoning | Sandboxed agent (this page)                                             | Conversations team building a customer support agent that queries PostHog and creates PRs       |
-| Single-shot LLM call (summarize, classify, translate)                           | [LLM gateway](/handbook/engineering/llm-gateway) via `get_llm_client()` | LLM analytics summarizing a funnel, generating a natural-language insight title                 |
-| Not sure                                                                        | Ask in `#team-posthog-ai`                                               | —                                                                                               |
+| Example                                                                                         | Solution                           |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Signals team building an enrichment pipeline that generates reports from PostHog analytics data | Sandboxed agent (this page)        |
+| Conversations team building a support agent that queries PostHog and customer documentation     | Sandboxed agent (this page)        |
+| LLM analytics summarizing a funnel, generating a natural-language insight title                 | LLM gateway via `get_llm_client()` |
+| Not sure                                                                                        | Ask in `#team-posthog-ai`          |
 
 **Rule of thumb**: if the LLM needs to _do things_ (query data, read files, create branches, open PRs), use a sandboxed agent.
 If it just needs to _answer a question_ given some context you already have, use the LLM gateway.
 
 ## How it works
 
-A sandboxed agent runs inside an isolated cloud container (gVisor in production, Docker locally).
+A sandboxed agent runs inside an isolated cloud container (Modal in production, Docker locally).
 The system provisions the sandbox, clones a GitHub repo, starts an agent server, and waits for the agent to finish.
 
 ```text
@@ -64,7 +64,6 @@ task = Task.create_and_run(
     description="Analyze error trends and generate a summary report with recommendations.",
     origin_product=Task.OriginProduct.ERROR_TRACKING,  # or your product's origin
     user_id=user.id,
-    repository="posthog/posthog",
     posthog_mcp_scopes="read_only",  # or "full" if the agent needs write access
 )
 ```
@@ -184,57 +183,6 @@ Network access is configured per-team via `SandboxEnvironment`:
 - **Trusted** — only allows access to a default set of trusted domains (GitHub, npm, PyPI, etc.)
 - **Full** — unrestricted network access
 - **Custom** — explicit allowlist of domains, optionally including the trusted defaults
-
-## Examples
-
-### Signals: enrichment pipeline for generating reports
-
-The Signals team uses sandboxed agents to analyze error trends and generate enrichment reports.
-The agent reads PostHog error tracking data via MCP, analyzes patterns, and produces a structured report.
-
-```python
-from products.tasks.backend.models import Task
-
-task = Task.create_and_run(
-    team=team,
-    title=f"Analyze error cluster {cluster_id}",
-    description=(
-        f"Analyze the error cluster {cluster_id} and generate a report "
-        "with root cause analysis, affected users, and recommended fixes. "
-        "Query error events using HogQL to identify patterns."
-    ),
-    origin_product=Task.OriginProduct.ERROR_TRACKING,
-    user_id=user.id,
-    repository="posthog/posthog",
-    posthog_mcp_scopes="read_only",  # only needs to read data
-    create_pr=False,  # produces a report, not a code change
-)
-```
-
-### Conversations: customer support agent
-
-The Conversations team uses sandboxed agents triggered from Slack
-to investigate customer issues, query relevant PostHog data, and create fixes.
-
-```python
-from products.tasks.backend.models import Task
-
-task = Task.create_and_run(
-    team=team,
-    title="Fix signup flow error for customer",
-    description=(
-        "A customer reported that the signup flow crashes on mobile. "
-        "Investigate session recordings and error events for the last 24 hours, "
-        "identify the root cause, and create a PR with a fix."
-    ),
-    origin_product=Task.OriginProduct.SLACK,
-    user_id=user.id,
-    repository="posthog/posthog",
-    posthog_mcp_scopes="full",
-    slack_thread_context=slack_thread_context,
-    slack_thread_url=slack_thread_url,
-)
-```
 
 ## Local development
 

--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -1,0 +1,254 @@
+---
+title: Using sandboxed agents
+sidebar: Docs
+showTitle: true
+---
+
+Sandboxed agents are background AI agents that run in isolated cloud containers with access to PostHog data,
+GitHub repositories, and code execution.
+Use them when your feature needs an autonomous agent that reads PostHog data, writes code, and produces artifacts like PRs or reports.
+
+For simpler LLM calls (summarization, translation, classification),
+skip this page and use the [LLM gateway](/handbook/engineering/llm-gateway) directly —
+it's simpler and doesn't need a sandbox.
+
+## When to use what
+
+| Need                                                                            | Solution                                                                | Example                                                                                         |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Autonomous agent that reads PostHog data and writes code                        | Sandboxed agent (this page)                                             | Signals team building an enrichment pipeline that generates reports from PostHog analytics data |
+| Autonomous agent that interacts with customers or performs multi-step reasoning | Sandboxed agent (this page)                                             | Conversations team building a customer support agent that queries PostHog and creates PRs       |
+| Single-shot LLM call (summarize, classify, translate)                           | [LLM gateway](/handbook/engineering/llm-gateway) via `get_llm_client()` | LLM analytics summarizing a funnel, generating a natural-language insight title                 |
+| Not sure                                                                        | Ask in `#team-posthog-ai`                                               | —                                                                                               |
+
+**Rule of thumb**: if the LLM needs to _do things_ (query data, read files, create branches, open PRs), use a sandboxed agent.
+If it just needs to _answer a question_ given some context you already have, use the LLM gateway.
+
+## How it works
+
+A sandboxed agent runs inside an isolated cloud container (gVisor in production, Docker locally).
+The system provisions the sandbox, clones a GitHub repo, starts an agent server, and waits for the agent to finish.
+
+```text
+Your product code
+    │
+    │  Task.create_and_run(...)
+    ▼
+Temporal workflow (process-task)
+    │
+    ├── 1. Create scoped OAuth token
+    ├── 2. Provision sandbox (Modal / Docker)
+    ├── 3. Clone repository
+    ├── 4. Start agent server
+    ├── 5. Wait for completion (heartbeat-extended timeout)
+    └── 6. Cleanup sandbox
+```
+
+The agent inside the sandbox gets:
+
+- A **scoped OAuth access token** for the PostHog API (6-hour TTL)
+- A **GitHub installation token** for repo operations
+- Access to the **PostHog MCP server** for querying data
+- **Code execution** capabilities within the sandbox
+
+## Creating a sandboxed agent
+
+Use `Task.create_and_run()` to launch a sandboxed agent from your product code:
+
+```python
+from products.tasks.backend.models import Task
+
+task = Task.create_and_run(
+    team=team,
+    title="Generate weekly signal report",
+    description="Analyze error trends and generate a summary report with recommendations.",
+    origin_product=Task.OriginProduct.ERROR_TRACKING,  # or your product's origin
+    user_id=user.id,
+    repository="posthog/posthog",
+    posthog_mcp_scopes="read_only",  # or "full" if the agent needs write access
+)
+```
+
+### Parameters
+
+| Parameter              | Required | Description                                                                |
+| ---------------------- | -------- | -------------------------------------------------------------------------- |
+| `team`                 | Yes      | The team this task belongs to                                              |
+| `title`                | Yes      | Human-readable task title                                                  |
+| `description`          | Yes      | Detailed description of what the agent should do                           |
+| `origin_product`       | Yes      | Which product created this task (see `Task.OriginProduct` choices)         |
+| `user_id`              | Yes      | User ID — used for feature flag validation and creating the scoped API key |
+| `repository`           | Yes      | GitHub repo in `org/repo` format (e.g., `posthog/posthog-js`)              |
+| `posthog_mcp_scopes`   | No       | Scope preset or explicit scope list (default: `"read_only"`)               |
+| `create_pr`            | No       | Whether the agent should create a PR (default: `True`)                     |
+| `mode`                 | No       | Execution mode (default: `"background"`)                                   |
+| `slack_thread_context` | No       | Slack thread context for agents triggered from Slack                       |
+| `start_workflow`       | No       | Whether to start the Temporal workflow immediately (default: `True`)       |
+
+### Adding a new origin product
+
+If your product doesn't have an `OriginProduct` entry yet,
+add one to `Task.OriginProduct` in `products/tasks/backend/models.py`:
+
+```python
+class OriginProduct(models.TextChoices):
+    ERROR_TRACKING = "error_tracking", "Error Tracking"
+    # ...
+    YOUR_PRODUCT = "your_product", "Your Product"
+```
+
+Then create and run a Django migration.
+
+## Fine-grained access tokens
+
+Every sandboxed agent gets a scoped OAuth access token that controls what PostHog resources it can access.
+Tokens expire after 6 hours and are scoped to a single team.
+
+### Scope presets
+
+Use the `posthog_mcp_scopes` parameter to control access:
+
+| Preset                  | What it grants                                                                                            | When to use                                                                                        |
+| ----------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `"read_only"` (default) | Read access to actions, cohorts, dashboards, experiments, feature flags, insights, queries, surveys, etc. | Agent only needs to read data for analysis or reporting                                            |
+| `"full"`                | Read + write access to all MCP-exposed resources                                                          | Agent needs to create or modify PostHog resources (e.g., create feature flags, update experiments) |
+
+### Custom scopes
+
+For more granular control, pass an explicit list of scopes instead of a preset:
+
+```python
+Task.create_and_run(
+    # ...
+    posthog_mcp_scopes=["query:read", "feature_flag:read", "experiment:read"],
+)
+```
+
+Available read scopes: `action:read`, `cohort:read`, `dashboard:read`, `error_tracking:read`,
+`event_definition:read`, `experiment:read`, `feature_flag:read`, `insight:read`,
+`project:read`, `query:read`, `survey:read`, and others.
+
+Available write scopes: `action:write`, `cohort:write`, `dashboard:write`,
+`experiment:write`, `feature_flag:write`, `insight:write`, `survey:write`, and others.
+
+Internal scopes (`task:write`, `llm_gateway:read`) are always added automatically.
+
+See `posthog/temporal/oauth.py` for the full list.
+
+> **Principle of least privilege**: default to `"read_only"` unless your agent genuinely needs to create or modify resources.
+> This limits blast radius if the agent misbehaves.
+
+## PostHog MCP server
+
+The sandbox comes with access to the PostHog MCP server,
+which exposes PostHog resources as tools the agent can call —
+listing feature flags, running HogQL queries, searching session recordings, etc.
+
+The MCP server is ready to use today.
+For details on available tools, see [Implementing MCP tools](/handbook/engineering/ai/implementing-mcp-tools).
+
+### Skills (coming soon)
+
+Skills are job-to-be-done templates that teach agents _how_ to compose MCP tools into workflows.
+They provide domain knowledge, query patterns, and step-by-step guidance.
+
+Skills are currently used by PostHog Code and Max.
+Support for sandboxed agents is coming soon.
+
+For details on writing skills, see [Writing skills](/handbook/engineering/ai/writing-skills).
+
+## Code execution
+
+Agents run inside an isolated sandbox with full code execution capabilities.
+They can:
+
+- Read, write, and execute files in the cloned repository
+- Install dependencies (npm, pip, etc.)
+- Run tests, linters, and build tools
+- Create git branches, commits, and pull requests
+- Execute arbitrary shell commands within the container
+
+### Sandbox isolation
+
+|           | Production (Modal)                     | Local dev (Docker)                      |
+| --------- | -------------------------------------- | --------------------------------------- |
+| Isolation | gVisor kernel-level sandboxing         | Standard Docker container               |
+| Network   | Configurable via `SandboxEnvironment`  | Host network via `host.docker.internal` |
+| Image     | `ghcr.io/posthog/posthog-sandbox-base` | Local Dockerfile build                  |
+| Auth      | Modal connect token                    | No token needed                         |
+
+### Network access
+
+Network access is configured per-team via `SandboxEnvironment`:
+
+- **Trusted** — only allows access to a default set of trusted domains (GitHub, npm, PyPI, etc.)
+- **Full** — unrestricted network access
+- **Custom** — explicit allowlist of domains, optionally including the trusted defaults
+
+## Examples
+
+### Signals: enrichment pipeline for generating reports
+
+The Signals team uses sandboxed agents to analyze error trends and generate enrichment reports.
+The agent reads PostHog error tracking data via MCP, analyzes patterns, and produces a structured report.
+
+```python
+from products.tasks.backend.models import Task
+
+task = Task.create_and_run(
+    team=team,
+    title=f"Analyze error cluster {cluster_id}",
+    description=(
+        f"Analyze the error cluster {cluster_id} and generate a report "
+        "with root cause analysis, affected users, and recommended fixes. "
+        "Query error events using HogQL to identify patterns."
+    ),
+    origin_product=Task.OriginProduct.ERROR_TRACKING,
+    user_id=user.id,
+    repository="posthog/posthog",
+    posthog_mcp_scopes="read_only",  # only needs to read data
+    create_pr=False,  # produces a report, not a code change
+)
+```
+
+### Conversations: customer support agent
+
+The Conversations team uses sandboxed agents triggered from Slack
+to investigate customer issues, query relevant PostHog data, and create fixes.
+
+```python
+from products.tasks.backend.models import Task
+
+task = Task.create_and_run(
+    team=team,
+    title="Fix signup flow error for customer",
+    description=(
+        "A customer reported that the signup flow crashes on mobile. "
+        "Investigate session recordings and error events for the last 24 hours, "
+        "identify the root cause, and create a PR with a fix."
+    ),
+    origin_product=Task.OriginProduct.SLACK,
+    user_id=user.id,
+    repository="posthog/posthog",
+    posthog_mcp_scopes="full",
+    slack_thread_context=slack_thread_context,
+    slack_thread_url=slack_thread_url,
+)
+```
+
+## Local development
+
+See the [Cloud runs setup guide](https://github.com/PostHog/posthog/blob/master/products/tasks/backend/temporal/process_task/SETUP_GUIDE.md)
+for step-by-step instructions on running sandboxed agents locally with Docker.
+
+Key requirements:
+
+- `DEBUG=1` and `SANDBOX_PROVIDER=docker` in your `.env`
+- A GitHub App with Contents and Pull Requests permissions
+- The `tasks` feature flag enabled at 100%
+- Temporal running (starts automatically via mprocs with `./bin/start`)
+
+## Questions?
+
+If you're unsure whether a sandboxed agent is the right fit for your use case,
+ask in **#team-posthog-ai** on Slack.

--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -78,7 +78,7 @@ task = Task.create_and_run(
 | `origin_product`       | Yes      | Which product created this task (see `Task.OriginProduct` choices)         |
 | `user_id`              | Yes      | User ID — used for feature flag validation and creating the scoped API key |
 | `repository`           | Yes      | GitHub repo in `org/repo` format (e.g., `posthog/posthog-js`)              |
-| `posthog_mcp_scopes`   | No       | Scope preset or explicit scope list (default: `"read_only"`)               |
+| `posthog_mcp_scopes`   | No       | Scope preset or explicit scope list (default: `"full"`)                    |
 | `create_pr`            | No       | Whether the agent should create a PR (default: `True`)                     |
 | `mode`                 | No       | Execution mode (default: `"background"`)                                   |
 | `slack_thread_context` | No       | Slack thread context for agents triggered from Slack                       |
@@ -107,10 +107,10 @@ Tokens expire after 6 hours and are scoped to a single team.
 
 Use the `posthog_mcp_scopes` parameter to control access:
 
-| Preset                  | What it grants                                                                                            | When to use                                                                                        |
-| ----------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `"read_only"` (default) | Read access to actions, cohorts, dashboards, experiments, feature flags, insights, queries, surveys, etc. | Agent only needs to read data for analysis or reporting                                            |
-| `"full"`                | Read + write access to all MCP-exposed resources                                                          | Agent needs to create or modify PostHog resources (e.g., create feature flags, update experiments) |
+| Preset             | What it grants                                                                                            | When to use                                                                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `"read_only"`      | Read access to actions, cohorts, dashboards, experiments, feature flags, insights, queries, surveys, etc. | Agent only needs to read data for analysis or reporting                                            |
+| `"full"` (default) | Read + write access to all MCP-exposed resources                                                          | Agent needs to create or modify PostHog resources (e.g., create feature flags, update experiments) |
 
 ### Custom scopes
 


### PR DESCRIPTION
## Problem

The AI team needs comprehensive documentation for engineers building features with sandboxed agents. Currently, there's no single source of truth explaining when to use sandboxed agents, how they work, how to create them, and what capabilities they provide.

This documentation will help product teams (Signals, Conversations, etc.) understand the sandboxed agent system and implement autonomous agents that read PostHog data, execute code, and produce artifacts like PRs or reports.

## Changes

Added `docs/published/handbook/engineering/ai/sandboxed-agents.md` with:

- **Overview**: What sandboxed agents are and when to use them vs. the LLM gateway
- **Decision table**: Clear guidance on choosing between sandboxed agents, LLM gateway, and other solutions
- **Architecture**: How sandboxed agents work (Temporal workflow, sandbox provisioning, OAuth tokens, MCP server)
- **API reference**: Complete `Task.create_and_run()` parameter documentation
- **Access control**: Fine-grained OAuth token scopes (read_only, full, custom)
- **MCP server**: Available tools and skills (coming soon)
- **Code execution**: Sandbox isolation details for production (Modal/gVisor) and local dev (Docker)
- **Network access**: Configuration options per team
- **Examples**: Real-world use cases from Signals (enrichment reports) and Conversations (customer support agent)
- **Local development**: Link to setup guide with key requirements

## How did you test this code?

N/A — This is documentation only. No code changes or automated tests required.

## Publish to changelog?

No — This is internal handbook documentation, not a user-facing feature.

https://claude.ai/code/session_0184siKwbQAJTqapxnyDq1ok