### PR TITLE
feat(experiments): enrich results refresh event with experiment duration

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -635,6 +635,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 triggered_by: 'page_load' | 'manual' | 'auto_refresh' | 'config_change'
                 force_refresh: boolean
                 refresh_id: string
+                experiment_duration_hours: number | null
+                experiment_status: string | null
+                total_metrics_count: number
             }
         ) => ({
             experimentId,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1474,6 +1474,13 @@ export const experimentLogic = kea<experimentLogicType>([
                         triggered_by: triggeredBy ?? 'manual',
                         force_refresh: !!forceRefresh,
                         refresh_id: refreshId,
+                        experiment_duration_hours: values.experiment?.start_date
+                            ? Math.round(
+                                  (Date.now() - new Date(values.experiment.start_date).getTime()) / (1000 * 60 * 60)
+                              )
+                            : null,
+                        experiment_status: values.experiment?.status ?? null,
+                        total_metrics_count: primaryCount + secondaryCount,
                     }
                 )
 


### PR DESCRIPTION
## Problem

The "experiment results refresh completed" event lacks context about experiment maturity, making aggregate analysis noisy — many events fire for newly created experiments with little data.

## Changes

Add three properties to the event in `experimentLogic.tsx`:
- `experiment_duration_hours`: hours since `start_date` (null if not launched)
- `experiment_status`: draft/running/complete
- `total_metrics_count`: primary + secondary metric count

## Testing

1. Navigate to an experiment page
2. Check that incoming events contain the new data