### PR TITLE
fix(trends): property lookup for metadata in actors queries

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -278,7 +278,7 @@ class Breakdown:
 
         is_numeric_breakdown = isinstance(histogram_bin_count, int)
 
-        if breakdown_type == "hogql":
+        if breakdown_type == "hogql" or breakdown_type == "event_metadata":
             left = parse_expr(breakdown_value)
         else:
             left = ast.Field(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -6,6 +6,8 @@ from posthog.test.base import BaseTest
 
 from posthog.schema import (
     BaseMathType,
+    Breakdown,
+    BreakdownFilter,
     ChartDisplayType,
     Compare,
     CompareFilter,
@@ -27,6 +29,7 @@ from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.timings import HogQLTimings
+from posthog.hogql.transforms.lazy_tables import find_field_chains
 
 from posthog.constants import UNIQUE_GROUPS
 from posthog.hogql_queries.insights.trends.trends_actors_query_builder import TrendsActorsQueryBuilder
@@ -46,6 +49,7 @@ class TestTrendsActorsQueryBuilder(BaseTest):
         series_index: int = 0,
         trends_query: TrendsQuery = default_query,
         compare_value: Optional[Compare] = None,
+        breakdown_value: Optional[str | int | list[str]] = None,
     ) -> TrendsActorsQueryBuilder:
         timings = HogQLTimings()
         modifiers = create_default_modifiers_for_team(self.team)
@@ -58,6 +62,7 @@ class TestTrendsActorsQueryBuilder(BaseTest):
             series_index=series_index,
             time_frame=time_frame,
             compare_value=compare_value,
+            breakdown_value=breakdown_value,
         )
 
     def _print_hogql_expr(self, conditions: list[ast.Expr]):
@@ -504,3 +509,18 @@ class TestTrendsActorsQueryBuilder(BaseTest):
         assert result.exprs[0].right == ast.Constant(value="event_a")
         assert isinstance(result.exprs[1], ast.CompareOperation)
         assert result.exprs[1].right == ast.Constant(value="event_b")
+
+    def test_event_metadata_breakdown_uses_event_field_for_actors_query_filter(self):
+        trends_query = default_query.model_copy(
+            update={
+                "breakdownFilter": BreakdownFilter(breakdowns=[Breakdown(type="event_metadata", property="event")])
+            },
+            deep=True,
+        )
+
+        builder = self._get_builder(trends_query=trends_query, breakdown_value=["$pageview"])
+        breakdown_filter = ast.And(exprs=builder._breakdown_where_expr())
+        field_chains = find_field_chains(breakdown_filter)
+
+        assert ["event"] in field_chains
+        assert ["properties", "event"] not in field_chains


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1773311619019629

## Changes

Fixes actors query for metadata breakdowns.

## How did you test this code?

Added a test case + manual example