### PR TITLE
chore(endpoints): use the right Icon!!

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/ScopeIcon.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/ScopeIcon.tsx
@@ -1,7 +1,7 @@
 import {
     IconApps,
     IconBug,
-    IconCode2,
+    IconEndpoints,
     IconCursor,
     IconDashboard,
     IconDatabase,
@@ -37,7 +37,7 @@ export function ScopeIcon(props: { scope: APIScopeObject }): JSX.Element | null 
         case 'early_access_feature':
             return <IconRocket />
         case 'endpoint':
-            return <IconCode2 />
+            return <IconEndpoints />
         case 'error_tracking':
             return <IconWarning />
         case 'event_definition':

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -8,7 +8,7 @@ import {
     IconCircleDashed,
     IconClock,
     IconCode,
-    IconCode2,
+    IconEndpoints,
     IconDashboard,
     IconDatabase,
     IconDecisionTree,
@@ -109,7 +109,7 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
         iconColor: ['var(--color-product-web-analytics-light)', 'var(--color-product-web-analytics-dark)'],
     },
     endpoints: {
-        icon: <IconCode2 />,
+        icon: <IconEndpoints />,
         iconColor: ['var(--color-product-endpoints-light)', 'var(--color-product-endpoints-dark)'],
     },
     sql_editor: {

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconCode2 } from '@posthog/icons'
+import { IconEndpoints } from '@posthog/icons'
 import {
     LemonButton,
     LemonInput,
@@ -162,7 +162,7 @@ export function Endpoint({ tabId }: EndpointProps): JSX.Element {
                     />
                 </LemonField.Pure>
 
-                <LemonButton type="primary" onClick={handleSubmit} icon={<IconCode2 />} size="medium">
+                <LemonButton type="primary" onClick={handleSubmit} icon={<IconEndpoints />} size="medium">
                     {isUpdateMode ? 'Update endpoint' : 'Create endpoint'}
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -3,7 +3,7 @@ import { actions, connect, events, kea, listeners, path, reducers, selectors } f
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
-import { IconBolt, IconCode2, IconDatabase, IconDocument, IconPlug, IconPlus } from '@posthog/icons'
+import { IconBolt, IconDatabase, IconDocument, IconEndpoints, IconPlug, IconPlus } from '@posthog/icons'
 import { LemonMenuItem } from '@posthog/lemon-ui'
 import { Spinner } from '@posthog/lemon-ui'
 
@@ -885,7 +885,7 @@ const createEndpointNode = (
         id: `${isSearch ? 'search-' : ''}endpoint-${endpointTable.id}`,
         name: displayName,
         type: 'node',
-        icon: <IconCode2 />,
+        icon: <IconEndpoints />,
         record: {
             type: 'endpoint',
             table: endpointTable,

--- a/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCode2, IconPencil, IconPeople } from '@posthog/icons'
+import { IconCode2, IconEndpoints, IconPencil, IconPeople } from '@posthog/icons'
 
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { SceneAddToDashboardButton } from 'lib/components/Scenes/InsightOrDashboard/SceneAddToDashboardButton'
@@ -158,7 +158,7 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
                             : undefined
                     }
                 >
-                    <IconCode2 />
+                    <IconEndpoints />
                     Create endpoint
                 </ButtonPrimitive>
             ) : null}

--- a/products/endpoints/frontend/InsightPickerEndpointModal.tsx
+++ b/products/endpoints/frontend/InsightPickerEndpointModal.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { BindLogic } from 'kea'
 
-import { IconCode2, IconFunnels, IconPlus, IconRetention, IconTrends } from '@posthog/icons'
+import { IconEndpoints, IconFunnels, IconPlus, IconRetention, IconTrends } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
@@ -65,7 +65,7 @@ export function InsightPickerEndpointModal({ tabId }: InsightPickerEndpointModal
                                 <div className="text-sm text-secondary">
                                     <>
                                         Once the insight is saved, open the right side panel and click
-                                        <br /> <IconCode2 /> <code>Create endpoint</code>.
+                                        <br /> <IconEndpoints /> <code>Create endpoint</code>.
                                     </>
                                 </div>
                             </div>


### PR DESCRIPTION
## Problem

The codebase was using `IconCode2` from `@posthog/icons` for endpoint-related UI elements, but there is now a more semantically appropriate `IconEndpoints` icon available that better represents the endpoints feature.

## Changes

Replaced all instances of `IconCode2` with `IconEndpoints` across the following files:
- `frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/ScopeIcon.tsx` - Updated scope icon for 'endpoint' case
- `frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx` - Updated endpoints icon in file system tree
- `frontend/src/scenes/data-warehouse/editor/output-pane-tabs/Endpoint.tsx` - Updated endpoint creation button icon
- `frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx` - Updated endpoint node icon in query sidebar
- `frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx` - Updated "Create endpoint" button icon
- `products/endpoints/frontend/InsightPickerEndpointModal.tsx` - Updated icon in endpoint creation instructions

This change improves visual consistency by using the dedicated endpoints icon throughout the application.

## How did you test this code?

This is a straightforward icon replacement with no functional logic changes. The changes are purely UI-related, replacing one icon component with another. Existing tests should continue to pass as the component behavior remains unchanged.

## Publish to changelog?

no

https://claude.ai/code/session_011yMC37vnRWF5TRBDwRaEsa