### PR TITLE
fix(trends): cache key collision for unstacked bar and pie chart

### DIFF
--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -128,15 +128,17 @@ export const validateQuery = (q: DataNode): boolean => {
     return true
 }
 
+// keep in sync with posthog/schema_helpers.py `grouped_chart_display_types` method
 const groupedChartDisplayTypes: Record<ChartDisplayType, ChartDisplayType> = {
-    [ChartDisplayType.Auto]: ChartDisplayType.ActionsLineGraph,
+    [ChartDisplayType.Auto]: ChartDisplayType.Auto,
 
     // time series
     [ChartDisplayType.ActionsLineGraph]: ChartDisplayType.ActionsLineGraph,
+    [ChartDisplayType.ActionsAreaGraph]: ChartDisplayType.ActionsLineGraph,
     [ChartDisplayType.ActionsBar]: ChartDisplayType.ActionsLineGraph,
     [ChartDisplayType.ActionsUnstackedBar]: ChartDisplayType.ActionsLineGraph,
-    [ChartDisplayType.ActionsAreaGraph]: ChartDisplayType.ActionsLineGraph,
     [ChartDisplayType.ActionsStackedBar]: ChartDisplayType.ActionsLineGraph,
+    [ChartDisplayType.TwoDimensionalHeatmap]: ChartDisplayType.ActionsLineGraph,
 
     // cumulative time series
     [ChartDisplayType.ActionsLineGraphCumulative]: ChartDisplayType.ActionsLineGraphCumulative,
@@ -146,10 +148,14 @@ const groupedChartDisplayTypes: Record<ChartDisplayType, ChartDisplayType> = {
     [ChartDisplayType.ActionsBarValue]: ChartDisplayType.ActionsBarValue,
     [ChartDisplayType.ActionsPie]: ChartDisplayType.ActionsBarValue,
     [ChartDisplayType.ActionsTable]: ChartDisplayType.ActionsBarValue,
+
+    // separate: different breakdown limit (250)
     [ChartDisplayType.WorldMap]: ChartDisplayType.WorldMap,
+
+    // separate runner
     [ChartDisplayType.CalendarHeatmap]: ChartDisplayType.CalendarHeatmap,
 
-    [ChartDisplayType.TwoDimensionalHeatmap]: ChartDisplayType.ActionsLineGraph,
+    // separate runner
     [ChartDisplayType.BoxPlot]: ChartDisplayType.BoxPlot,
 }
 

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -146,10 +146,10 @@ const groupedChartDisplayTypes: Record<ChartDisplayType, ChartDisplayType> = {
     [ChartDisplayType.ActionsBarValue]: ChartDisplayType.ActionsBarValue,
     [ChartDisplayType.ActionsPie]: ChartDisplayType.ActionsBarValue,
     [ChartDisplayType.ActionsTable]: ChartDisplayType.ActionsBarValue,
-    [ChartDisplayType.WorldMap]: ChartDisplayType.ActionsBarValue,
-    [ChartDisplayType.CalendarHeatmap]: ChartDisplayType.ActionsBarValue,
+    [ChartDisplayType.WorldMap]: ChartDisplayType.WorldMap,
+    [ChartDisplayType.CalendarHeatmap]: ChartDisplayType.CalendarHeatmap,
 
-    [ChartDisplayType.TwoDimensionalHeatmap]: ChartDisplayType.TwoDimensionalHeatmap,
+    [ChartDisplayType.TwoDimensionalHeatmap]: ChartDisplayType.ActionsLineGraph,
     [ChartDisplayType.BoxPlot]: ChartDisplayType.BoxPlot,
 }
 

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -154,12 +154,13 @@ def filter_key_for_query(node: InsightQueryNode) -> str:
         raise ValidationError(f"Expected an insight node, got {node.__name__}")
 
 
+# keep in sync with frontend/src/scenes/insights/utils/queryUtils.ts `groupedChartDisplayTypes` object
 def grouped_chart_display_types(display: ChartDisplayType) -> ChartDisplayType:
     match display:
         case (
             ChartDisplayType.ACTIONS_LINE_GRAPH
-            | ChartDisplayType.ACTIONS_BAR
             | ChartDisplayType.ACTIONS_AREA_GRAPH
+            | ChartDisplayType.ACTIONS_BAR
             | ChartDisplayType.ACTIONS_UNSTACKED_BAR
             | ChartDisplayType.ACTIONS_STACKED_BAR
             | ChartDisplayType.TWO_DIMENSIONAL_HEATMAP

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -1,4 +1,4 @@
-from typing import Literal, get_origin
+from typing import Literal, assert_never, get_origin
 
 from pydantic import BaseModel, ValidationError
 
@@ -154,17 +154,44 @@ def filter_key_for_query(node: InsightQueryNode) -> str:
         raise ValidationError(f"Expected an insight node, got {node.__name__}")
 
 
-def grouped_chart_display_types(display: ChartDisplayType) -> ChartDisplayType | None:
-    if display in [
-        ChartDisplayType.ACTIONS_LINE_GRAPH,
-        ChartDisplayType.ACTIONS_BAR,
-        ChartDisplayType.ACTIONS_AREA_GRAPH,
-    ]:
-        # time series
-        return ChartDisplayType.ACTIONS_LINE_GRAPH
-    elif display in [ChartDisplayType.ACTIONS_LINE_GRAPH_CUMULATIVE]:
-        # cumulative time series
-        return ChartDisplayType.ACTIONS_LINE_GRAPH_CUMULATIVE
-    else:
-        # total value
-        return ChartDisplayType.ACTIONS_BAR_VALUE
+def grouped_chart_display_types(display: ChartDisplayType) -> ChartDisplayType:
+    match display:
+        case (
+            ChartDisplayType.AUTO
+            | ChartDisplayType.ACTIONS_LINE_GRAPH
+            | ChartDisplayType.ACTIONS_BAR
+            | ChartDisplayType.ACTIONS_AREA_GRAPH
+            | ChartDisplayType.ACTIONS_UNSTACKED_BAR
+            | ChartDisplayType.ACTIONS_STACKED_BAR
+            | ChartDisplayType.TWO_DIMENSIONAL_HEATMAP
+        ):
+            # standard time series
+            return ChartDisplayType.ACTIONS_LINE_GRAPH
+
+        case ChartDisplayType.ACTIONS_LINE_GRAPH_CUMULATIVE:
+            # cumulative time series
+            return ChartDisplayType.ACTIONS_LINE_GRAPH_CUMULATIVE
+
+        case (
+            ChartDisplayType.ACTIONS_BAR_VALUE
+            | ChartDisplayType.BOLD_NUMBER
+            | ChartDisplayType.ACTIONS_PIE
+            | ChartDisplayType.ACTIONS_TABLE
+        ):
+            # total value
+            return ChartDisplayType.ACTIONS_BAR_VALUE
+
+        case ChartDisplayType.WORLD_MAP:
+            # separate: different breakdown limit (250)
+            return ChartDisplayType.WORLD_MAP
+
+        case ChartDisplayType.CALENDAR_HEATMAP:
+            # separate runner
+            return ChartDisplayType.CALENDAR_HEATMAP
+
+        case ChartDisplayType.BOX_PLOT:
+            # separate runner
+            return ChartDisplayType.BOX_PLOT
+
+        case _:
+            assert_never(display)

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -157,8 +157,7 @@ def filter_key_for_query(node: InsightQueryNode) -> str:
 def grouped_chart_display_types(display: ChartDisplayType) -> ChartDisplayType:
     match display:
         case (
-            ChartDisplayType.AUTO
-            | ChartDisplayType.ACTIONS_LINE_GRAPH
+            ChartDisplayType.ACTIONS_LINE_GRAPH
             | ChartDisplayType.ACTIONS_BAR
             | ChartDisplayType.ACTIONS_AREA_GRAPH
             | ChartDisplayType.ACTIONS_UNSTACKED_BAR
@@ -192,6 +191,9 @@ def grouped_chart_display_types(display: ChartDisplayType) -> ChartDisplayType:
         case ChartDisplayType.BOX_PLOT:
             # separate runner
             return ChartDisplayType.BOX_PLOT
+
+        case ChartDisplayType.AUTO:
+            return ChartDisplayType.AUTO
 
         case _:
             assert_never(display)


### PR DESCRIPTION
## Problem

Cache keys for the pie chart and the newish unstacked bar chart collide, as the `else` path in `grouped_chart_display_types` would treat any new chart types as "total value".

## Changes

- Fixes the issue for existing chart type (see LLM analysis below)
- Makes the default path throw an error and uses exhaustiveness checks to flag them early
---
From the actual trends execution paths, the safe cache buckets are:

- Standard time series: `Auto`, `ActionsLineGraph`, `ActionsBar`, `ActionsUnstackedBar`, `ActionsStackedBar`, `ActionsAreaGraph`, `TwoDimensionalHeatmap`
  Reason: these are grouped under the standard time-series cache key in [`posthog/schema_helpers.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/schema_helpers.py#L157-L175). The generic trends runner only has special execution branches for cumulative, total-value, calendar heatmap, and box plot displays. The frontend semantic-equality map is aligned in [`frontend/src/scenes/insights/utils/queryUtils.ts`](https://github.com/PostHog/posthog/blob/HEAD/frontend/src/scenes/insights/utils/queryUtils.ts#L131-L154).

- Cumulative time series: `ActionsLineGraphCumulative`
  Reason: this changes query construction and result handling. It wraps the inner query in [`posthog/hogql_queries/insights/trends/display.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/display.py#L27-L35), changes array generation in [`posthog/hogql_queries/insights/trends/trends_query_builder.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/trends_query_builder.py#L252-L259), and changes grouping for some math types in [`posthog/hogql_queries/insights/trends/trends_query_builder.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/trends_query_builder.py#L440-L450).

- Total-value displays: `BoldNumber`, `ActionsPie`, `ActionsBarValue`, `ActionsTable`
  Reason: these all share the `is_total_value()` path in [`posthog/hogql_queries/insights/trends/display.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/display.py#L16-L25) and the total-value query build in [`posthog/hogql_queries/insights/trends/trends_query_builder.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/trends_query_builder.py#L65-L74).

- `WorldMap`
  Reason: it is close to the total-value family, but it changes backend behavior by forcing a breakdown limit of `250` in [`posthog/hogql_queries/insights/trends/trends_query_builder.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/trends_query_builder.py#L603-L609). There is a dedicated test asserting that behavior in [`posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py#L2443-L2467).

- `CalendarHeatmap`
  Reason: this uses a separate runner dispatched in [`posthog/hogql_queries/query_runner.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/query_runner.py#L236-L262) and implemented by [`posthog/hogql_queries/insights/trends/calendar_heatmap_trends_query_runner.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/calendar_heatmap_trends_query_runner.py#L6-L63).

- `BoxPlot`
  Reason: this also uses a separate runner dispatched in [`posthog/hogql_queries/query_runner.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/query_runner.py#L236-L262) and implemented by [`posthog/hogql_queries/insights/trends/boxplot_trends_query_runner.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/hogql_queries/insights/trends/boxplot_trends_query_runner.py#L20-L120).

The backend cache canonicalization is now explicit and exhaustive in [`posthog/schema_helpers.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/schema_helpers.py#L157-L175), and the regression coverage is in [`posthog/test/test_schema_helpers.py`](https://github.com/PostHog/posthog/blob/HEAD/posthog/test/test_schema_helpers.py#L148-L182).

## How did you test this code?

Manually