### PR TITLE
fix: always run cyclotron migrations

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -204,7 +204,7 @@ procs:
 
     migrate-cyclotron:
         shell: 'bin/wait-for-docker && bin/migrate --scope=cyclotron'
-        capability: cyclotron
+        # no capability - always_required via intent-map.yaml
 
     migrate-persons-db:
         shell: 'bin/wait-for-docker && bin/migrate --scope=persons'

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -278,6 +278,7 @@ always_required:
     # Migrations (DBs created by postgres init scripts, run for everyone)
     - migrate-postgres
     - migrate-clickhouse
+    - migrate-cyclotron
     - migrate-persons-db
     - migrate-behavioral-cohorts
     # Core services


### PR DESCRIPTION
nodejs service won't start in a fresh install without cyclotron migrations