### PR TITLE
feat(mcp): add annotations MCP tools

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -736,103 +736,6 @@ export interface PatchedRoleApi {
     readonly is_default?: string
 }
 
-/**
- * * `USR` - user
- * `GIT` - GitHub
- */
-export type CreationTypeEnumApi = (typeof CreationTypeEnumApi)[keyof typeof CreationTypeEnumApi]
-
-export const CreationTypeEnumApi = {
-    Usr: 'USR',
-    Git: 'GIT',
-} as const
-
-/**
- * * `dashboard_item` - insight
- * `dashboard` - dashboard
- * `project` - project
- * `organization` - organization
- * `recording` - recording
- */
-export type AnnotationScopeEnumApi = (typeof AnnotationScopeEnumApi)[keyof typeof AnnotationScopeEnumApi]
-
-export const AnnotationScopeEnumApi = {
-    DashboardItem: 'dashboard_item',
-    Dashboard: 'dashboard',
-    Project: 'project',
-    Organization: 'organization',
-    Recording: 'recording',
-} as const
-
-export interface AnnotationApi {
-    readonly id: number
-    /**
-     * @maxLength 8192
-     * @nullable
-     */
-    content?: string | null
-    /** @nullable */
-    date_marker?: string | null
-    creation_type?: CreationTypeEnumApi
-    /** @nullable */
-    dashboard_item?: number | null
-    /** @nullable */
-    dashboard_id?: number | null
-    /** @nullable */
-    readonly dashboard_name: string | null
-    /** @nullable */
-    readonly insight_short_id: string | null
-    /** @nullable */
-    readonly insight_name: string | null
-    /** @nullable */
-    readonly insight_derived_name: string | null
-    readonly created_by: UserBasicApi
-    /** @nullable */
-    readonly created_at: string | null
-    readonly updated_at: string
-    deleted?: boolean
-    scope?: AnnotationScopeEnumApi
-}
-
-export interface PaginatedAnnotationListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: AnnotationApi[]
-}
-
-export interface PatchedAnnotationApi {
-    readonly id?: number
-    /**
-     * @maxLength 8192
-     * @nullable
-     */
-    content?: string | null
-    /** @nullable */
-    date_marker?: string | null
-    creation_type?: CreationTypeEnumApi
-    /** @nullable */
-    dashboard_item?: number | null
-    /** @nullable */
-    dashboard_id?: number | null
-    /** @nullable */
-    readonly dashboard_name?: string | null
-    /** @nullable */
-    readonly insight_short_id?: string | null
-    /** @nullable */
-    readonly insight_name?: string | null
-    /** @nullable */
-    readonly insight_derived_name?: string | null
-    readonly created_by?: UserBasicApi
-    /** @nullable */
-    readonly created_at?: string | null
-    readonly updated_at?: string
-    deleted?: boolean
-    scope?: AnnotationScopeEnumApi
-}
-
 export interface CommentApi {
     readonly id: string
     readonly created_by: UserBasicApi
@@ -1927,21 +1830,6 @@ export type RolesListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
-}
-
-export type AnnotationsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number
-    /**
-     * A search term.
-     */
-    search?: string
 }
 
 export type CommentsListParams = {

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -9,8 +9,6 @@ import { apiMutator } from '../../lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
-    AnnotationApi,
-    AnnotationsListParams,
     CommentApi,
     CommentsListParams,
     DashboardTemplateApi,
@@ -35,7 +33,6 @@ import type {
     OrganizationDomainApi,
     OrganizationInviteApi,
     OrganizationMemberApi,
-    PaginatedAnnotationListApi,
     PaginatedCommentListApi,
     PaginatedDashboardTemplateListApi,
     PaginatedEnterprisePropertyDefinitionListApi,
@@ -51,7 +48,6 @@ import type {
     PaginatedScheduledChangeListApi,
     PaginatedSubscriptionListApi,
     PaginatedUserListApi,
-    PatchedAnnotationApi,
     PatchedCommentApi,
     PatchedDashboardTemplateApi,
     PatchedEnterprisePropertyDefinitionApi,
@@ -841,130 +837,6 @@ export const getRolesDestroyUrl = (organizationId: string, id: string) => {
 
 export const rolesDestroy = async (organizationId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getRolesDestroyUrl(organizationId, id), {
-        ...options,
-        method: 'DELETE',
-    })
-}
-
-/**
- * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
- */
-export const getAnnotationsListUrl = (projectId: string, params?: AnnotationsListParams) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/annotations/?${stringifiedParams}`
-        : `/api/projects/${projectId}/annotations/`
-}
-
-export const annotationsList = async (
-    projectId: string,
-    params?: AnnotationsListParams,
-    options?: RequestInit
-): Promise<PaginatedAnnotationListApi> => {
-    return apiMutator<PaginatedAnnotationListApi>(getAnnotationsListUrl(projectId, params), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-/**
- * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
- */
-export const getAnnotationsCreateUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/annotations/`
-}
-
-export const annotationsCreate = async (
-    projectId: string,
-    annotationApi: NonReadonly<AnnotationApi>,
-    options?: RequestInit
-): Promise<AnnotationApi> => {
-    return apiMutator<AnnotationApi>(getAnnotationsCreateUrl(projectId), {
-        ...options,
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(annotationApi),
-    })
-}
-
-/**
- * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
- */
-export const getAnnotationsRetrieveUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/annotations/${id}/`
-}
-
-export const annotationsRetrieve = async (
-    projectId: string,
-    id: number,
-    options?: RequestInit
-): Promise<AnnotationApi> => {
-    return apiMutator<AnnotationApi>(getAnnotationsRetrieveUrl(projectId, id), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-/**
- * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
- */
-export const getAnnotationsUpdateUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/annotations/${id}/`
-}
-
-export const annotationsUpdate = async (
-    projectId: string,
-    id: number,
-    annotationApi: NonReadonly<AnnotationApi>,
-    options?: RequestInit
-): Promise<AnnotationApi> => {
-    return apiMutator<AnnotationApi>(getAnnotationsUpdateUrl(projectId, id), {
-        ...options,
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(annotationApi),
-    })
-}
-
-/**
- * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
- */
-export const getAnnotationsPartialUpdateUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/annotations/${id}/`
-}
-
-export const annotationsPartialUpdate = async (
-    projectId: string,
-    id: number,
-    patchedAnnotationApi: NonReadonly<PatchedAnnotationApi>,
-    options?: RequestInit
-): Promise<AnnotationApi> => {
-    return apiMutator<AnnotationApi>(getAnnotationsPartialUpdateUrl(projectId, id), {
-        ...options,
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedAnnotationApi),
-    })
-}
-
-/**
- * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
- */
-export const getAnnotationsDestroyUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/annotations/${id}/`
-}
-
-export const annotationsDestroy = async (projectId: string, id: number, options?: RequestInit): Promise<unknown> => {
-    return apiMutator<unknown>(getAnnotationsDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
     })

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -64,6 +64,32 @@ class AnnotationSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         ]
+        extra_kwargs = {
+            "content": {
+                "help_text": "Annotation text shown on charts to describe the change, release, or incident.",
+            },
+            "date_marker": {
+                "help_text": "When this annotation happened (ISO 8601 timestamp). Used to position it on charts.",
+            },
+            "creation_type": {
+                "help_text": "Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.",
+            },
+            "dashboard_id": {
+                "help_text": "Optional dashboard ID to attach this annotation to. Must belong to the current project.",
+            },
+            "dashboard_item": {
+                "help_text": "Optional insight ID to attach this annotation to. Must belong to the current project.",
+            },
+            "deleted": {
+                "help_text": "Soft-delete flag. Set to true to hide the annotation, or false to restore it.",
+            },
+            "scope": {
+                "help_text": (
+                    "Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. "
+                    "`recording` is deprecated and rejected."
+                ),
+            },
+        }
 
     def update(self, instance: Annotation, validated_data: dict[str, Any]) -> Annotation:
         instance.team_id = self.context["team_id"]

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -287,7 +287,6 @@ annotations: PostgresTable = PostgresTable(
     fields={
         "id": IntegerDatabaseField(name="id"),
         "team_id": IntegerDatabaseField(name="team_id"),
-        "organization_id": StringDatabaseField(name="organization_id", nullable=True),
         "content": StringDatabaseField(name="content", nullable=True),
         "scope": StringDatabaseField(name="scope"),
         "creation_type": StringDatabaseField(name="creation_type"),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -280,6 +280,28 @@ actions: PostgresTable = PostgresTable(
     },
 )
 
+annotations: PostgresTable = PostgresTable(
+    name="annotations",
+    postgres_table_name="posthog_annotation",
+    access_scope="annotation",
+    fields={
+        "id": IntegerDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "organization_id": StringDatabaseField(name="organization_id", nullable=True),
+        "content": StringDatabaseField(name="content", nullable=True),
+        "scope": StringDatabaseField(name="scope"),
+        "creation_type": StringDatabaseField(name="creation_type"),
+        "date_marker": DateTimeDatabaseField(name="date_marker", nullable=True),
+        "_deleted": BooleanDatabaseField(name="deleted", hidden=True),
+        "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
+        "dashboard_item_id": IntegerDatabaseField(name="dashboard_item_id", nullable=True),
+        "dashboard_id": IntegerDatabaseField(name="dashboard_id", nullable=True),
+        "created_by_id": IntegerDatabaseField(name="created_by_id", nullable=True),
+        "created_at": DateTimeDatabaseField(name="created_at", nullable=True),
+        "updated_at": DateTimeDatabaseField(name="updated_at"),
+    },
+)
+
 hog_flows: PostgresTable = PostgresTable(
     name="hog_flows",
     postgres_table_name="posthog_hogflow",
@@ -389,6 +411,7 @@ class SystemTables(TableNode):
     name: str = "system"
     children: dict[str, TableNode] = {
         "actions": TableNode(name="actions", table=actions),
+        "annotations": TableNode(name="annotations", table=annotations),
         "cohort_calculation_history": TableNode(name="cohort_calculation_history", table=cohort_calculation_history),
         "cohorts": TableNode(name="cohorts", table=cohorts),
         "dashboards": TableNode(name="dashboards", table=dashboards),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -11,6 +11,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.models import (
     Action,
+    Annotation,
     Cohort,
     Dashboard,
     Experiment,
@@ -84,6 +85,10 @@ def _create_action(team: Team, label: str) -> Action:
 
 def _create_cohort(team: Team, label: str) -> Cohort:
     return Cohort.objects.create(team=team, name=f"cohort_{label}")
+
+
+def _create_annotation(team: Team, label: str) -> Annotation:
+    return Annotation.objects.create(team=team, content=f"annotation_{label}")
 
 
 def _create_cohort_calculation_history(team: Team, label: str) -> CohortCalculationHistory:
@@ -188,6 +193,7 @@ def _create_team(team: Team, label: str) -> Team:
 
 SYSTEM_TABLE_FACTORIES = [
     ("actions", _create_action),
+    ("annotations", _create_annotation),
     ("cohorts", _create_cohort),
     ("cohort_calculation_history", _create_cohort_calculation_history),
     ("dashboards", _create_dashboard),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -2700,6 +2700,124 @@
           "row_count": null,
           "type": "system"
       },
+      "system.annotations": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "content": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "content",
+                  "id": null,
+                  "name": "content",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "scope": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "scope",
+                  "id": null,
+                  "name": "scope",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "creation_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "creation_type",
+                  "id": null,
+                  "name": "creation_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "date_marker": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "date_marker",
+                  "id": null,
+                  "name": "date_marker",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "deleted": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "deleted",
+                  "id": null,
+                  "name": "deleted",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "dashboard_item_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "dashboard_item_id",
+                  "id": null,
+                  "name": "dashboard_item_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "dashboard_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "dashboard_id",
+                  "id": null,
+                  "name": "dashboard_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.annotations",
+          "name": "system.annotations",
+          "row_count": null,
+          "type": "system"
+      },
       "system.cohort_calculation_history": {
           "fields": {
               "id": {
@@ -6163,6 +6281,124 @@
           },
           "id": "system.actions",
           "name": "system.actions",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.annotations": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "content": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "content",
+                  "id": null,
+                  "name": "content",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "scope": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "scope",
+                  "id": null,
+                  "name": "scope",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "creation_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "creation_type",
+                  "id": null,
+                  "name": "creation_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "date_marker": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "date_marker",
+                  "id": null,
+                  "name": "date_marker",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "deleted": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "deleted",
+                  "id": null,
+                  "name": "deleted",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "expression"
+              },
+              "dashboard_item_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "dashboard_item_id",
+                  "id": null,
+                  "name": "dashboard_item_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "dashboard_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "dashboard_id",
+                  "id": null,
+                  "name": "dashboard_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_by_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by_id",
+                  "id": null,
+                  "name": "created_by_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "updated_at",
+                  "id": null,
+                  "name": "updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.annotations",
+          "name": "system.annotations",
           "row_count": null,
           "type": "system"
       },

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -54,6 +54,7 @@ class TestAccessControlSystemTables(BaseTest):
         assert "experiments" not in system_node.children
         assert "feature_flags" not in system_node.children
         assert "surveys" not in system_node.children
+        assert "annotations" not in system_node.children
         assert "data_warehouse_sources" not in system_node.children
         assert "actions" not in system_node.children
         assert "hog_flows" not in system_node.children
@@ -65,6 +66,7 @@ class TestAccessControlSystemTables(BaseTest):
         assert "system.experiments" in database._denied_tables
         assert "system.feature_flags" in database._denied_tables
         assert "system.surveys" in database._denied_tables
+        assert "system.annotations" in database._denied_tables
         assert "system.data_warehouse_sources" in database._denied_tables
         assert "system.actions" in database._denied_tables
         assert "system.hog_flows" in database._denied_tables

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -100,6 +100,7 @@
     'filters',
     'name',
     'pinned',
+    'quick_filter_ids',
     'restriction_level',
     'variables',
   ])

--- a/products/annotations/frontend/generated/api.schemas.ts
+++ b/products/annotations/frontend/generated/api.schemas.ts
@@ -1,0 +1,211 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+/**
+ * * `USR` - user
+ * `GIT` - GitHub
+ */
+export type CreationTypeEnumApi = (typeof CreationTypeEnumApi)[keyof typeof CreationTypeEnumApi]
+
+export const CreationTypeEnumApi = {
+    Usr: 'USR',
+    Git: 'GIT',
+} as const
+
+/**
+ * * `engineering` - Engineering
+ * `data` - Data
+ * `product` - Product Management
+ * `founder` - Founder
+ * `leadership` - Leadership
+ * `marketing` - Marketing
+ * `sales` - Sales / Success
+ * `other` - Other
+ */
+export type RoleAtOrganizationEnumApi = (typeof RoleAtOrganizationEnumApi)[keyof typeof RoleAtOrganizationEnumApi]
+
+export const RoleAtOrganizationEnumApi = {
+    Engineering: 'engineering',
+    Data: 'data',
+    Product: 'product',
+    Founder: 'founder',
+    Leadership: 'leadership',
+    Marketing: 'marketing',
+    Sales: 'sales',
+    Other: 'other',
+} as const
+
+export type BlankEnumApi = (typeof BlankEnumApi)[keyof typeof BlankEnumApi]
+
+export const BlankEnumApi = {
+    '': '',
+} as const
+
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
+
+export const NullEnumApi = {} as const
+
+/**
+ * @nullable
+ */
+export type UserBasicApiHedgehogConfig = { [key: string]: unknown } | null | null
+
+export interface UserBasicApi {
+    readonly id: number
+    readonly uuid: string
+    /**
+     * @maxLength 200
+     * @nullable
+     */
+    distinct_id?: string | null
+    /** @maxLength 150 */
+    first_name?: string
+    /** @maxLength 150 */
+    last_name?: string
+    /** @maxLength 254 */
+    email: string
+    /** @nullable */
+    is_email_verified?: boolean | null
+    /** @nullable */
+    readonly hedgehog_config: UserBasicApiHedgehogConfig
+    role_at_organization?: RoleAtOrganizationEnumApi | BlankEnumApi | NullEnumApi | null
+}
+
+/**
+ * * `dashboard_item` - insight
+ * `dashboard` - dashboard
+ * `project` - project
+ * `organization` - organization
+ * `recording` - recording
+ */
+export type AnnotationScopeEnumApi = (typeof AnnotationScopeEnumApi)[keyof typeof AnnotationScopeEnumApi]
+
+export const AnnotationScopeEnumApi = {
+    DashboardItem: 'dashboard_item',
+    Dashboard: 'dashboard',
+    Project: 'project',
+    Organization: 'organization',
+    Recording: 'recording',
+} as const
+
+export interface AnnotationApi {
+    readonly id: number
+    /**
+     * Annotation text shown on charts to describe the change, release, or incident.
+     * @maxLength 8192
+     * @nullable
+     */
+    content?: string | null
+    /**
+     * When this annotation happened (ISO 8601 timestamp). Used to position it on charts.
+     * @nullable
+     */
+    date_marker?: string | null
+    /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
+
+* `USR` - user
+* `GIT` - GitHub */
+    creation_type?: CreationTypeEnumApi
+    /** @nullable */
+    dashboard_item?: number | null
+    /** @nullable */
+    dashboard_id?: number | null
+    /** @nullable */
+    readonly dashboard_name: string | null
+    /** @nullable */
+    readonly insight_short_id: string | null
+    /** @nullable */
+    readonly insight_name: string | null
+    /** @nullable */
+    readonly insight_derived_name: string | null
+    readonly created_by: UserBasicApi
+    /** @nullable */
+    readonly created_at: string | null
+    readonly updated_at: string
+    /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
+    deleted?: boolean
+    /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
+
+* `dashboard_item` - insight
+* `dashboard` - dashboard
+* `project` - project
+* `organization` - organization
+* `recording` - recording */
+    scope?: AnnotationScopeEnumApi
+}
+
+export interface PaginatedAnnotationListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: AnnotationApi[]
+}
+
+export interface PatchedAnnotationApi {
+    readonly id?: number
+    /**
+     * Annotation text shown on charts to describe the change, release, or incident.
+     * @maxLength 8192
+     * @nullable
+     */
+    content?: string | null
+    /**
+     * When this annotation happened (ISO 8601 timestamp). Used to position it on charts.
+     * @nullable
+     */
+    date_marker?: string | null
+    /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
+
+* `USR` - user
+* `GIT` - GitHub */
+    creation_type?: CreationTypeEnumApi
+    /** @nullable */
+    dashboard_item?: number | null
+    /** @nullable */
+    dashboard_id?: number | null
+    /** @nullable */
+    readonly dashboard_name?: string | null
+    /** @nullable */
+    readonly insight_short_id?: string | null
+    /** @nullable */
+    readonly insight_name?: string | null
+    /** @nullable */
+    readonly insight_derived_name?: string | null
+    readonly created_by?: UserBasicApi
+    /** @nullable */
+    readonly created_at?: string | null
+    readonly updated_at?: string
+    /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
+    deleted?: boolean
+    /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
+
+* `dashboard_item` - insight
+* `dashboard` - dashboard
+* `project` - project
+* `organization` - organization
+* `recording` - recording */
+    scope?: AnnotationScopeEnumApi
+}
+
+export type AnnotationsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+    /**
+     * A search term.
+     */
+    search?: string
+}

--- a/products/annotations/frontend/generated/api.ts
+++ b/products/annotations/frontend/generated/api.ts
@@ -1,0 +1,157 @@
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import type {
+    AnnotationApi,
+    AnnotationsListParams,
+    PaginatedAnnotationListApi,
+    PatchedAnnotationApi,
+} from './api.schemas'
+
+// https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
+type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? A : B
+
+type WritableKeys<T> = {
+    [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P>
+}[keyof T]
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never
+
+type Writable<T> = Pick<T, WritableKeys<T>>
+type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
+    ? {
+          [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
+      }
+    : DistributeReadOnlyOverUnions<T>
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const getAnnotationsListUrl = (projectId: string, params?: AnnotationsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/annotations/?${stringifiedParams}`
+        : `/api/projects/${projectId}/annotations/`
+}
+
+export const annotationsList = async (
+    projectId: string,
+    params?: AnnotationsListParams,
+    options?: RequestInit
+): Promise<PaginatedAnnotationListApi> => {
+    return apiMutator<PaginatedAnnotationListApi>(getAnnotationsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const getAnnotationsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/annotations/`
+}
+
+export const annotationsCreate = async (
+    projectId: string,
+    annotationApi: NonReadonly<AnnotationApi>,
+    options?: RequestInit
+): Promise<AnnotationApi> => {
+    return apiMutator<AnnotationApi>(getAnnotationsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(annotationApi),
+    })
+}
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const getAnnotationsRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/annotations/${id}/`
+}
+
+export const annotationsRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<AnnotationApi> => {
+    return apiMutator<AnnotationApi>(getAnnotationsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const getAnnotationsUpdateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/annotations/${id}/`
+}
+
+export const annotationsUpdate = async (
+    projectId: string,
+    id: number,
+    annotationApi: NonReadonly<AnnotationApi>,
+    options?: RequestInit
+): Promise<AnnotationApi> => {
+    return apiMutator<AnnotationApi>(getAnnotationsUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(annotationApi),
+    })
+}
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const getAnnotationsPartialUpdateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/annotations/${id}/`
+}
+
+export const annotationsPartialUpdate = async (
+    projectId: string,
+    id: number,
+    patchedAnnotationApi: NonReadonly<PatchedAnnotationApi>,
+    options?: RequestInit
+): Promise<AnnotationApi> => {
+    return apiMutator<AnnotationApi>(getAnnotationsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedAnnotationApi),
+    })
+}
+
+/**
+ * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
+ */
+export const getAnnotationsDestroyUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/annotations/${id}/`
+}
+
+export const annotationsDestroy = async (projectId: string, id: number, options?: RequestInit): Promise<unknown> => {
+    return apiMutator<unknown>(getAnnotationsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}

--- a/products/annotations/mcp/tools.yaml
+++ b/products/annotations/mcp/tools.yaml
@@ -1,0 +1,91 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: Annotations
+feature: annotations
+url_prefix: /annotations
+tools:
+    annotations-list:
+        operation: annotations_list
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - annotation:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List annotations
+        description: >
+            List annotations in the current project, newest first. Use this to review existing deployment markers and
+            analysis notes before adding new annotations.
+    annotation-create:
+        operation: annotations_create
+        enabled: true
+        scopes:
+            - annotation:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        include_params:
+            - content
+            - date_marker
+            - scope
+        title: Create annotation
+        description: >
+            Create an annotation to mark an important change (for example, a deployment) on charts and trends. Provide
+            a note in `content`, when it happened in `date_marker` (ISO 8601), and whether it is scoped to the current
+            `project` or the whole `organization`.
+    annotation-retrieve:
+        operation: annotations_retrieve
+        enabled: true
+        mcp_version: 1
+        scopes:
+            - annotation:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Retrieve annotation
+        description: >
+            Retrieve a single annotation by ID from the current project. Use this when you already know the annotation
+            ID and want complete details.
+    annotations-update:
+        operation: annotations_update
+        enabled: false
+    annotations-partial-update:
+        operation: annotations_partial_update
+        enabled: true
+        scopes:
+            - annotation:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        include_params:
+            - content
+            - date_marker
+            - scope
+        title: Update annotation
+        description: >
+            Update an existing annotation by ID. You can change its text (`content`), when it happened (`date_marker`,
+            ISO 8601), or its visibility scope (`project` or `organization`). Only the fields you provide are updated.
+    annotation-delete:
+        operation: annotations_destroy
+        enabled: true
+        scopes:
+            - annotation:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        soft_delete: true
+        title: Delete annotation
+        description: >
+            Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical
+            records.

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -97,7 +97,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.actions', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issue_assignments', 'system.error_tracking_issue_fingerprints', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.hog_flows', 'system.hog_functions', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.actions', 'system.annotations', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issue_assignments', 'system.error_tracking_issue_fingerprints', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.hog_flows', 'system.hog_functions', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.

--- a/products/posthog_ai/skills/query-examples/SKILL.md
+++ b/products/posthog_ai/skills/query-examples/SKILL.md
@@ -12,6 +12,7 @@ If the MCP server haven't provided instructions on querying data in PostHog, rea
 Schema reference for PostHog's core system models, organized by domain:
 
 - [Actions](./references/models-actions.md)
+- [Annotations](./references/models-annotations.md)
 - [Cohorts & Persons](./references/models-cohorts.md)
 - [Dashboards, Tiles & Insights](./references/models-dashboards-insights.md)
 - [Data Warehouse](./references/models-data-warehouse.md)

--- a/products/posthog_ai/skills/query-examples/references/models-annotations.md
+++ b/products/posthog_ai/skills/query-examples/references/models-annotations.md
@@ -1,0 +1,66 @@
+# Annotations
+
+## Annotation (`system.annotations`)
+
+Annotations are timestamped notes used to mark product changes, incidents, or releases directly on charts.
+
+### Columns
+
+Column | Type | Nullable | Description
+`id` | integer | NOT NULL | Primary key (auto-generated)
+`team_id` | integer | NOT NULL | Project/team ID for isolation
+`content` | varchar(8192) | NULL | Annotation text content
+`scope` | varchar(24) | NOT NULL | Annotation scope: `project`, `organization`, `dashboard`, `dashboard_item`, `recording`
+`creation_type` | varchar(3) | NOT NULL | Creation source: `USR` (user) or `GIT` (GitHub/bot)
+`date_marker` | timestamp with tz | NULL | Timestamp shown on charts
+`deleted` | boolean | NOT NULL | Soft delete flag
+`dashboard_item_id` | integer | NULL | Linked insight ID (if scoped to insight)
+`dashboard_id` | integer | NULL | Linked dashboard ID (if scoped to dashboard)
+`created_by_id` | integer | NULL | Creator user ID
+`created_at` | timestamp with tz | NULL | Creation timestamp
+`updated_at` | timestamp with tz | NOT NULL | Last update timestamp
+
+### Key Relationships
+
+- **Insights**: `dashboard_item_id` -> `system.insights.id`
+- **Dashboards**: `dashboard_id` -> `system.dashboards.id`
+
+### Important Notes
+
+- The API usually hides `deleted=true` rows; SQL queries should filter them explicitly when needed.
+- `scope='organization'` annotations can appear across multiple projects in the same organization.
+
+---
+
+## Common Query Patterns
+
+**List recent non-deleted annotations:**
+
+```sql
+SELECT id, scope, content, date_marker, created_at
+FROM system.annotations
+WHERE NOT deleted
+ORDER BY date_marker DESC NULLS LAST
+LIMIT 100
+```
+
+**Find annotations around a release window:**
+
+```sql
+SELECT id, content, scope, date_marker
+FROM system.annotations
+WHERE NOT deleted
+  AND date_marker >= toDateTime('2026-03-01 00:00:00')
+  AND date_marker < toDateTime('2026-03-08 00:00:00')
+ORDER BY date_marker ASC
+```
+
+**Get organization-scoped annotations only:**
+
+```sql
+SELECT id, content, date_marker, created_by_id
+FROM system.annotations
+WHERE NOT deleted
+  AND scope = 'organization'
+ORDER BY date_marker DESC NULLS LAST
+```

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -1,0 +1,9 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */

--- a/products/tracing/frontend/generated/api.ts
+++ b/products/tracing/frontend/generated/api.ts
@@ -1,0 +1,47 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+
+export const getTracingSpansRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/tracing/spans/`
+}
+
+export const tracingSpansRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getTracingSpansRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTracingSpansSparklineRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/tracing/spans/sparkline/`
+}
+
+export const tracingSpansSparklineRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getTracingSpansSparklineRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTracingSpansTraceRetrieveUrl = (projectId: string, traceId: string) => {
+    return `/api/projects/${projectId}/tracing/spans/trace/${traceId}/`
+}
+
+export const tracingSpansTraceRetrieve = async (
+    projectId: string,
+    traceId: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTracingSpansTraceRetrieveUrl(projectId, traceId), {
+        ...options,
+        method: 'GET',
+    })
+}

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -74,6 +74,66 @@
             "readOnlyHint": false
         }
     },
+    "annotations-list": {
+        "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "List annotations",
+        "title": "List annotations",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-create": {
+        "description": "Create an annotation to mark an important change (for example, a deployment) on charts and trends. Provide a note in `content`, when it happened in `date_marker` (ISO 8601), and whether it is scoped to the current `project` or the whole `organization`.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Create annotation",
+        "title": "Create annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "annotation-retrieve": {
+        "description": "Retrieve a single annotation by ID from the current project. Use this when you already know the annotation ID and want complete details.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Retrieve annotation",
+        "title": "Retrieve annotation",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-delete": {
+        "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Delete annotation",
+        "title": "Delete annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "cdp-function-templates-list": {
         "description": "List available function templates. Templates are pre-built function configurations for common integrations (Slack, webhooks, email, etc.) and transformations (GeoIP, etc.). Filter by type (destination, site_destination, site_app, transformation, etc.) via the 'type' query parameter. Results are sorted by popularity (number of active functions using each template).",
         "category": "Function templates",
@@ -204,66 +264,6 @@
         "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "annotations-list": {
-        "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "List annotations",
-        "title": "List annotations",
-        "required_scopes": ["annotation:read"],
-        "new_mcp": false,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        }
-    },
-    "annotation-create": {
-        "description": "Create an annotation to mark an important change (for example, a deployment) on charts and trends. Provide a note in `content`, when it happened in `date_marker` (ISO 8601), and whether it is scoped to the current `project` or the whole `organization`.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Create annotation",
-        "title": "Create annotation",
-        "required_scopes": ["annotation:write"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "annotation-retrieve": {
-        "description": "Retrieve a single annotation by ID from the current project. Use this when you already know the annotation ID and want complete details.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Retrieve annotation",
-        "title": "Retrieve annotation",
-        "required_scopes": ["annotation:read"],
-        "new_mcp": false,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        }
-    },
-    "annotation-delete": {
-        "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Delete annotation",
-        "title": "Delete annotation",
-        "required_scopes": ["annotation:write"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": true,
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -119,6 +119,21 @@
             "readOnlyHint": true
         }
     },
+    "annotations-partial-update": {
+        "description": "Update an existing annotation by ID. You can change its text (`content`), when it happened (`date_marker`, ISO 8601), or its visibility scope (`project` or `organization`). Only the fields you provide are updated.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Update annotation",
+        "title": "Update annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "annotation-delete": {
         "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
         "category": "Annotations",
@@ -642,21 +657,6 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
-    },
-    "annotations-partial-update": {
-        "description": "Update an existing annotation by ID. You can change its text (`content`), when it happened (`date_marker`, ISO 8601), or its visibility scope (`project` or `organization`). Only the fields you provide are updated.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Update annotation",
-        "title": "Update annotation",
-        "required_scopes": ["annotation:write"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
         }
     },
     "workflows-get": {

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -209,6 +209,66 @@
             "readOnlyHint": false
         }
     },
+    "annotations-list": {
+        "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "List annotations",
+        "title": "List annotations",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-create": {
+        "description": "Create an annotation to mark an important change (for example, a deployment) on charts and trends. Provide a note in `content`, when it happened in `date_marker` (ISO 8601), and whether it is scoped to the current `project` or the whole `organization`.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Create annotation",
+        "title": "Create annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "annotation-retrieve": {
+        "description": "Retrieve a single annotation by ID from the current project. Use this when you already know the annotation ID and want complete details.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Retrieve annotation",
+        "title": "Retrieve annotation",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-delete": {
+        "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Delete annotation",
+        "title": "Delete annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "cohorts-list": {
         "description": "List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic cohorts (automatically updated based on property filters).",
         "category": "Cohorts",
@@ -582,6 +642,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "annotations-partial-update": {
+        "description": "Update an existing annotation by ID. You can change its text (`content`), when it happened (`date_marker`, ISO 8601), or its visibility scope (`project` or `organization`). Only the fields you provide are updated.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Update annotation",
+        "title": "Update annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "workflows-get": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -852,6 +852,21 @@
             "readOnlyHint": true
         }
     },
+    "annotations-partial-update": {
+        "description": "Update an existing annotation by ID. You can change its text (`content`), when it happened (`date_marker`, ISO 8601), or its visibility scope (`project` or `organization`). Only the fields you provide are updated.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Update annotation",
+        "title": "Update annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "annotation-delete": {
         "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
         "category": "Annotations",
@@ -1375,21 +1390,6 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
-        }
-    },
-    "annotations-partial-update": {
-        "description": "Update an existing annotation by ID. You can change its text (`content`), when it happened (`date_marker`, ISO 8601), or its visibility scope (`project` or `organization`). Only the fields you provide are updated.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Update annotation",
-        "title": "Update annotation",
-        "required_scopes": ["annotation:write"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
         }
     },
     "workflows-get": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -807,6 +807,66 @@
             "readOnlyHint": false
         }
     },
+    "annotations-list": {
+        "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "List annotations",
+        "title": "List annotations",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-create": {
+        "description": "Create an annotation to mark an important change (for example, a deployment) on charts and trends. Provide a note in `content`, when it happened in `date_marker` (ISO 8601), and whether it is scoped to the current `project` or the whole `organization`.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Create annotation",
+        "title": "Create annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "annotation-retrieve": {
+        "description": "Retrieve a single annotation by ID from the current project. Use this when you already know the annotation ID and want complete details.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Retrieve annotation",
+        "title": "Retrieve annotation",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-delete": {
+        "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Delete annotation",
+        "title": "Delete annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "cdp-function-templates-list": {
         "description": "List available function templates. Templates are pre-built function configurations for common integrations (Slack, webhooks, email, etc.) and transformations (GeoIP, etc.). Filter by type (destination, site_destination, site_app, transformation, etc.) via the 'type' query parameter. Results are sorted by popularity (number of active functions using each template).",
         "category": "Function templates",
@@ -937,66 +997,6 @@
         "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "annotations-list": {
-        "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "List annotations",
-        "title": "List annotations",
-        "required_scopes": ["annotation:read"],
-        "new_mcp": false,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        }
-    },
-    "annotation-create": {
-        "description": "Create an annotation to mark an important change (for example, a deployment) on charts and trends. Provide a note in `content`, when it happened in `date_marker` (ISO 8601), and whether it is scoped to the current `project` or the whole `organization`.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Create annotation",
-        "title": "Create annotation",
-        "required_scopes": ["annotation:write"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true,
-            "readOnlyHint": false
-        }
-    },
-    "annotation-retrieve": {
-        "description": "Retrieve a single annotation by ID from the current project. Use this when you already know the annotation ID and want complete details.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Retrieve annotation",
-        "title": "Retrieve annotation",
-        "required_scopes": ["annotation:read"],
-        "new_mcp": false,
-        "annotations": {
-            "destructiveHint": false,
-            "idempotentHint": true,
-            "openWorldHint": true,
-            "readOnlyHint": true
-        }
-    },
-    "annotation-delete": {
-        "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
-        "category": "Annotations",
-        "feature": "annotations",
-        "summary": "Delete annotation",
-        "title": "Delete annotation",
-        "required_scopes": ["annotation:write"],
-        "new_mcp": true,
-        "annotations": {
-            "destructiveHint": true,
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -942,6 +942,66 @@
             "readOnlyHint": false
         }
     },
+    "annotations-list": {
+        "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "List annotations",
+        "title": "List annotations",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-create": {
+        "description": "Create an annotation to mark an important change (for example, a deployment) on charts and trends. Provide a note in `content`, when it happened in `date_marker` (ISO 8601), and whether it is scoped to the current `project` or the whole `organization`.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Create annotation",
+        "title": "Create annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "annotation-retrieve": {
+        "description": "Retrieve a single annotation by ID from the current project. Use this when you already know the annotation ID and want complete details.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Retrieve annotation",
+        "title": "Retrieve annotation",
+        "required_scopes": ["annotation:read"],
+        "new_mcp": false,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "annotation-delete": {
+        "description": "Soft-delete an annotation by ID. This hides the annotation from normal lists while preserving historical records.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Delete annotation",
+        "title": "Delete annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "cohorts-list": {
         "description": "List all cohorts in the project. Returns both static cohorts (manually defined user lists) and dynamic cohorts (automatically updated based on property filters).",
         "category": "Cohorts",
@@ -1315,6 +1375,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        }
+    },
+    "annotations-partial-update": {
+        "description": "Update an existing annotation by ID. You can change its text (`content`), when it happened (`date_marker`, ISO 8601), or its visibility scope (`project` or `organization`). Only the fields you provide are updated.",
+        "category": "Annotations",
+        "feature": "annotations",
+        "summary": "Update annotation",
+        "title": "Update annotation",
+        "required_scopes": ["annotation:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
         }
     },
     "workflows-get": {

--- a/services/mcp/scripts/lib/definitions.mjs
+++ b/services/mcp/scripts/lib/definitions.mjs
@@ -68,5 +68,5 @@ export function discoverDefinitions({ definitionsDir, productsDir }) {
         }
     }
 
-    return sources
+    return sources.sort((a, b) => a.moduleName.localeCompare(b.moduleName))
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4257,12 +4257,20 @@ export namespace Schemas {
     export interface Annotation {
       readonly id: number;
       /**
+       * Annotation text shown on charts to describe the change, release, or incident.
        * @maxLength 8192
        * @nullable
        */
       content?: string | null;
-      /** @nullable */
+      /**
+       * When this annotation happened (ISO 8601 timestamp). Used to position it on charts.
+       * @nullable
+       */
       date_marker?: string | null;
+      /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
+
+    * `USR` - user
+    * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -4280,7 +4288,15 @@ export namespace Schemas {
       /** @nullable */
       readonly created_at: string | null;
       readonly updated_at: string;
+      /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
+      /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
+
+    * `dashboard_item` - insight
+    * `dashboard` - dashboard
+    * `project` - project
+    * `organization` - organization
+    * `recording` - recording */
       scope?: AnnotationScopeEnum;
     }
 
@@ -19819,12 +19835,20 @@ export namespace Schemas {
     export interface PatchedAnnotation {
       readonly id?: number;
       /**
+       * Annotation text shown on charts to describe the change, release, or incident.
        * @maxLength 8192
        * @nullable
        */
       content?: string | null;
-      /** @nullable */
+      /**
+       * When this annotation happened (ISO 8601 timestamp). Used to position it on charts.
+       * @nullable
+       */
       date_marker?: string | null;
+      /** Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.
+
+    * `USR` - user
+    * `GIT` - GitHub */
       creation_type?: CreationTypeEnum;
       /** @nullable */
       dashboard_item?: number | null;
@@ -19842,7 +19866,15 @@ export namespace Schemas {
       /** @nullable */
       readonly created_at?: string | null;
       readonly updated_at?: string;
+      /** Soft-delete flag. Set to true to hide the annotation, or false to restore it. */
       deleted?: boolean;
+      /** Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.
+
+    * `dashboard_item` - insight
+    * `dashboard` - dashboard
+    * `project` - project
+    * `organization` - organization
+    * `recording` - recording */
       scope?: AnnotationScopeEnum;
     }
 

--- a/services/mcp/src/generated/annotations/api.ts
+++ b/services/mcp/src/generated/annotations/api.ts
@@ -42,9 +42,23 @@ export const AnnotationsListResponse = zod.object({
     results: zod.array(
         zod.object({
             id: zod.number(),
-            content: zod.string().max(annotationsListResponseResultsItemContentMax).nullish(),
-            date_marker: zod.string().datetime({}).nullish(),
-            creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+            content: zod
+                .string()
+                .max(annotationsListResponseResultsItemContentMax)
+                .nullish()
+                .describe('Annotation text shown on charts to describe the change, release, or incident.'),
+            date_marker: zod
+                .string()
+                .datetime({})
+                .nullish()
+                .describe('When this annotation happened (ISO 8601 timestamp). Used to position it on charts.'),
+            creation_type: zod
+                .enum(['USR', 'GIT'])
+                .describe('* `USR` - user\n* `GIT` - GitHub')
+                .optional()
+                .describe(
+                    'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.\n\n* `USR` - user\n* `GIT` - GitHub'
+                ),
             dashboard_item: zod.number().nullish(),
             dashboard_id: zod.number().nullish(),
             dashboard_name: zod.string().nullable(),
@@ -83,12 +97,18 @@ export const AnnotationsListResponse = zod.object({
             }),
             created_at: zod.string().datetime({}).nullable(),
             updated_at: zod.string().datetime({}),
-            deleted: zod.boolean().optional(),
+            deleted: zod
+                .boolean()
+                .optional()
+                .describe('Soft-delete flag. Set to true to hide the annotation, or false to restore it.'),
             scope: zod
                 .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
-                .optional()
                 .describe(
                     '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+                )
+                .optional()
+                .describe(
+                    'Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.\n\n* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
                 ),
         })
     ),
@@ -108,17 +128,37 @@ export const AnnotationsCreateParams = zod.object({
 export const annotationsCreateBodyContentMax = 8192
 
 export const AnnotationsCreateBody = zod.object({
-    content: zod.string().max(annotationsCreateBodyContentMax).nullish(),
-    date_marker: zod.string().datetime({}).nullish(),
-    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
-    deleted: zod.boolean().optional(),
-    scope: zod
-        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+    content: zod
+        .string()
+        .max(annotationsCreateBodyContentMax)
+        .nullish()
+        .describe('Annotation text shown on charts to describe the change, release, or incident.'),
+    date_marker: zod
+        .string()
+        .datetime({})
+        .nullish()
+        .describe('When this annotation happened (ISO 8601 timestamp). Used to position it on charts.'),
+    creation_type: zod
+        .enum(['USR', 'GIT'])
+        .describe('* `USR` - user\n* `GIT` - GitHub')
         .optional()
         .describe(
+            'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.\n\n* `USR` - user\n* `GIT` - GitHub'
+        ),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    deleted: zod
+        .boolean()
+        .optional()
+        .describe('Soft-delete flag. Set to true to hide the annotation, or false to restore it.'),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .describe(
             '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        )
+        .optional()
+        .describe(
+            'Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.\n\n* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
         ),
 })
 
@@ -146,9 +186,23 @@ export const annotationsRetrieveResponseCreatedByOneEmailMax = 254
 
 export const AnnotationsRetrieveResponse = zod.object({
     id: zod.number(),
-    content: zod.string().max(annotationsRetrieveResponseContentMax).nullish(),
-    date_marker: zod.string().datetime({}).nullish(),
-    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    content: zod
+        .string()
+        .max(annotationsRetrieveResponseContentMax)
+        .nullish()
+        .describe('Annotation text shown on charts to describe the change, release, or incident.'),
+    date_marker: zod
+        .string()
+        .datetime({})
+        .nullish()
+        .describe('When this annotation happened (ISO 8601 timestamp). Used to position it on charts.'),
+    creation_type: zod
+        .enum(['USR', 'GIT'])
+        .describe('* `USR` - user\n* `GIT` - GitHub')
+        .optional()
+        .describe(
+            'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.\n\n* `USR` - user\n* `GIT` - GitHub'
+        ),
     dashboard_item: zod.number().nullish(),
     dashboard_id: zod.number().nullish(),
     dashboard_name: zod.string().nullable(),
@@ -178,12 +232,18 @@ export const AnnotationsRetrieveResponse = zod.object({
     }),
     created_at: zod.string().datetime({}).nullable(),
     updated_at: zod.string().datetime({}),
-    deleted: zod.boolean().optional(),
+    deleted: zod
+        .boolean()
+        .optional()
+        .describe('Soft-delete flag. Set to true to hide the annotation, or false to restore it.'),
     scope: zod
         .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
-        .optional()
         .describe(
             '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        )
+        .optional()
+        .describe(
+            'Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.\n\n* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
         ),
 })
 
@@ -202,17 +262,37 @@ export const AnnotationsUpdateParams = zod.object({
 export const annotationsUpdateBodyContentMax = 8192
 
 export const AnnotationsUpdateBody = zod.object({
-    content: zod.string().max(annotationsUpdateBodyContentMax).nullish(),
-    date_marker: zod.string().datetime({}).nullish(),
-    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
-    deleted: zod.boolean().optional(),
-    scope: zod
-        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+    content: zod
+        .string()
+        .max(annotationsUpdateBodyContentMax)
+        .nullish()
+        .describe('Annotation text shown on charts to describe the change, release, or incident.'),
+    date_marker: zod
+        .string()
+        .datetime({})
+        .nullish()
+        .describe('When this annotation happened (ISO 8601 timestamp). Used to position it on charts.'),
+    creation_type: zod
+        .enum(['USR', 'GIT'])
+        .describe('* `USR` - user\n* `GIT` - GitHub')
         .optional()
         .describe(
+            'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.\n\n* `USR` - user\n* `GIT` - GitHub'
+        ),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    deleted: zod
+        .boolean()
+        .optional()
+        .describe('Soft-delete flag. Set to true to hide the annotation, or false to restore it.'),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .describe(
             '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        )
+        .optional()
+        .describe(
+            'Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.\n\n* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
         ),
 })
 
@@ -228,9 +308,23 @@ export const annotationsUpdateResponseCreatedByOneEmailMax = 254
 
 export const AnnotationsUpdateResponse = zod.object({
     id: zod.number(),
-    content: zod.string().max(annotationsUpdateResponseContentMax).nullish(),
-    date_marker: zod.string().datetime({}).nullish(),
-    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    content: zod
+        .string()
+        .max(annotationsUpdateResponseContentMax)
+        .nullish()
+        .describe('Annotation text shown on charts to describe the change, release, or incident.'),
+    date_marker: zod
+        .string()
+        .datetime({})
+        .nullish()
+        .describe('When this annotation happened (ISO 8601 timestamp). Used to position it on charts.'),
+    creation_type: zod
+        .enum(['USR', 'GIT'])
+        .describe('* `USR` - user\n* `GIT` - GitHub')
+        .optional()
+        .describe(
+            'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.\n\n* `USR` - user\n* `GIT` - GitHub'
+        ),
     dashboard_item: zod.number().nullish(),
     dashboard_id: zod.number().nullish(),
     dashboard_name: zod.string().nullable(),
@@ -260,12 +354,18 @@ export const AnnotationsUpdateResponse = zod.object({
     }),
     created_at: zod.string().datetime({}).nullable(),
     updated_at: zod.string().datetime({}),
-    deleted: zod.boolean().optional(),
+    deleted: zod
+        .boolean()
+        .optional()
+        .describe('Soft-delete flag. Set to true to hide the annotation, or false to restore it.'),
     scope: zod
         .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
-        .optional()
         .describe(
             '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        )
+        .optional()
+        .describe(
+            'Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.\n\n* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
         ),
 })
 
@@ -284,17 +384,37 @@ export const AnnotationsPartialUpdateParams = zod.object({
 export const annotationsPartialUpdateBodyContentMax = 8192
 
 export const AnnotationsPartialUpdateBody = zod.object({
-    content: zod.string().max(annotationsPartialUpdateBodyContentMax).nullish(),
-    date_marker: zod.string().datetime({}).nullish(),
-    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
-    dashboard_item: zod.number().nullish(),
-    dashboard_id: zod.number().nullish(),
-    deleted: zod.boolean().optional(),
-    scope: zod
-        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+    content: zod
+        .string()
+        .max(annotationsPartialUpdateBodyContentMax)
+        .nullish()
+        .describe('Annotation text shown on charts to describe the change, release, or incident.'),
+    date_marker: zod
+        .string()
+        .datetime({})
+        .nullish()
+        .describe('When this annotation happened (ISO 8601 timestamp). Used to position it on charts.'),
+    creation_type: zod
+        .enum(['USR', 'GIT'])
+        .describe('* `USR` - user\n* `GIT` - GitHub')
         .optional()
         .describe(
+            'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.\n\n* `USR` - user\n* `GIT` - GitHub'
+        ),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    deleted: zod
+        .boolean()
+        .optional()
+        .describe('Soft-delete flag. Set to true to hide the annotation, or false to restore it.'),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .describe(
             '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        )
+        .optional()
+        .describe(
+            'Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.\n\n* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
         ),
 })
 
@@ -310,9 +430,23 @@ export const annotationsPartialUpdateResponseCreatedByOneEmailMax = 254
 
 export const AnnotationsPartialUpdateResponse = zod.object({
     id: zod.number(),
-    content: zod.string().max(annotationsPartialUpdateResponseContentMax).nullish(),
-    date_marker: zod.string().datetime({}).nullish(),
-    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    content: zod
+        .string()
+        .max(annotationsPartialUpdateResponseContentMax)
+        .nullish()
+        .describe('Annotation text shown on charts to describe the change, release, or incident.'),
+    date_marker: zod
+        .string()
+        .datetime({})
+        .nullish()
+        .describe('When this annotation happened (ISO 8601 timestamp). Used to position it on charts.'),
+    creation_type: zod
+        .enum(['USR', 'GIT'])
+        .describe('* `USR` - user\n* `GIT` - GitHub')
+        .optional()
+        .describe(
+            'Who created this annotation. Use `USR` for user-created notes and `GIT` for bot/deployment notes.\n\n* `USR` - user\n* `GIT` - GitHub'
+        ),
     dashboard_item: zod.number().nullish(),
     dashboard_id: zod.number().nullish(),
     dashboard_name: zod.string().nullable(),
@@ -342,12 +476,18 @@ export const AnnotationsPartialUpdateResponse = zod.object({
     }),
     created_at: zod.string().datetime({}).nullable(),
     updated_at: zod.string().datetime({}),
-    deleted: zod.boolean().optional(),
+    deleted: zod
+        .boolean()
+        .optional()
+        .describe('Soft-delete flag. Set to true to hide the annotation, or false to restore it.'),
     scope: zod
         .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
-        .optional()
         .describe(
             '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        )
+        .optional()
+        .describe(
+            'Annotation visibility scope: `project`, `organization`, `dashboard`, or `dashboard_item`. `recording` is deprecated and rejected.\n\n* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
         ),
 })
 

--- a/services/mcp/src/generated/annotations/api.ts
+++ b/services/mcp/src/generated/annotations/api.ts
@@ -41,7 +41,7 @@ export const AnnotationsListResponse = zod.object({
     previous: zod.string().url().nullish(),
     results: zod.array(
         zod.object({
-            id: zod.number(),
+            id: zod.number().optional(),
             content: zod
                 .string()
                 .max(annotationsListResponseResultsItemContentMax)
@@ -61,42 +61,47 @@ export const AnnotationsListResponse = zod.object({
                 ),
             dashboard_item: zod.number().nullish(),
             dashboard_id: zod.number().nullish(),
-            dashboard_name: zod.string().nullable(),
-            insight_short_id: zod.string().nullable(),
-            insight_name: zod.string().nullable(),
-            insight_derived_name: zod.string().nullable(),
-            created_by: zod.object({
-                id: zod.number(),
-                uuid: zod.string(),
-                distinct_id: zod.string().max(annotationsListResponseResultsItemCreatedByOneDistinctIdMax).nullish(),
-                first_name: zod.string().max(annotationsListResponseResultsItemCreatedByOneFirstNameMax).optional(),
-                last_name: zod.string().max(annotationsListResponseResultsItemCreatedByOneLastNameMax).optional(),
-                email: zod.string().email().max(annotationsListResponseResultsItemCreatedByOneEmailMax),
-                is_email_verified: zod.boolean().nullish(),
-                hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-                role_at_organization: zod
-                    .union([
-                        zod
-                            .enum([
-                                'engineering',
-                                'data',
-                                'product',
-                                'founder',
-                                'leadership',
-                                'marketing',
-                                'sales',
-                                'other',
-                            ])
-                            .describe(
-                                '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                            ),
-                        zod.enum(['']),
-                        zod.literal(null),
-                    ])
-                    .nullish(),
-            }),
-            created_at: zod.string().datetime({}).nullable(),
-            updated_at: zod.string().datetime({}),
+            dashboard_name: zod.string().nullish(),
+            insight_short_id: zod.string().nullish(),
+            insight_name: zod.string().nullish(),
+            insight_derived_name: zod.string().nullish(),
+            created_by: zod
+                .object({
+                    id: zod.number().optional(),
+                    uuid: zod.string().optional(),
+                    distinct_id: zod
+                        .string()
+                        .max(annotationsListResponseResultsItemCreatedByOneDistinctIdMax)
+                        .nullish(),
+                    first_name: zod.string().max(annotationsListResponseResultsItemCreatedByOneFirstNameMax).optional(),
+                    last_name: zod.string().max(annotationsListResponseResultsItemCreatedByOneLastNameMax).optional(),
+                    email: zod.string().email().max(annotationsListResponseResultsItemCreatedByOneEmailMax),
+                    is_email_verified: zod.boolean().nullish(),
+                    hedgehog_config: zod.record(zod.string(), zod.unknown()).nullish(),
+                    role_at_organization: zod
+                        .union([
+                            zod
+                                .enum([
+                                    'engineering',
+                                    'data',
+                                    'product',
+                                    'founder',
+                                    'leadership',
+                                    'marketing',
+                                    'sales',
+                                    'other',
+                                ])
+                                .describe(
+                                    '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                                ),
+                            zod.enum(['']),
+                            zod.literal(null),
+                        ])
+                        .nullish(),
+                })
+                .optional(),
+            created_at: zod.string().datetime({}).nullish(),
+            updated_at: zod.string().datetime({}).optional(),
             deleted: zod
                 .boolean()
                 .optional()
@@ -185,7 +190,7 @@ export const annotationsRetrieveResponseCreatedByOneLastNameMax = 150
 export const annotationsRetrieveResponseCreatedByOneEmailMax = 254
 
 export const AnnotationsRetrieveResponse = zod.object({
-    id: zod.number(),
+    id: zod.number().optional(),
     content: zod
         .string()
         .max(annotationsRetrieveResponseContentMax)
@@ -205,33 +210,44 @@ export const AnnotationsRetrieveResponse = zod.object({
         ),
     dashboard_item: zod.number().nullish(),
     dashboard_id: zod.number().nullish(),
-    dashboard_name: zod.string().nullable(),
-    insight_short_id: zod.string().nullable(),
-    insight_name: zod.string().nullable(),
-    insight_derived_name: zod.string().nullable(),
-    created_by: zod.object({
-        id: zod.number(),
-        uuid: zod.string(),
-        distinct_id: zod.string().max(annotationsRetrieveResponseCreatedByOneDistinctIdMax).nullish(),
-        first_name: zod.string().max(annotationsRetrieveResponseCreatedByOneFirstNameMax).optional(),
-        last_name: zod.string().max(annotationsRetrieveResponseCreatedByOneLastNameMax).optional(),
-        email: zod.string().email().max(annotationsRetrieveResponseCreatedByOneEmailMax),
-        is_email_verified: zod.boolean().nullish(),
-        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-        role_at_organization: zod
-            .union([
-                zod
-                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
-                    .describe(
-                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                    ),
-                zod.enum(['']),
-                zod.literal(null),
-            ])
-            .nullish(),
-    }),
-    created_at: zod.string().datetime({}).nullable(),
-    updated_at: zod.string().datetime({}),
+    dashboard_name: zod.string().nullish(),
+    insight_short_id: zod.string().nullish(),
+    insight_name: zod.string().nullish(),
+    insight_derived_name: zod.string().nullish(),
+    created_by: zod
+        .object({
+            id: zod.number().optional(),
+            uuid: zod.string().optional(),
+            distinct_id: zod.string().max(annotationsRetrieveResponseCreatedByOneDistinctIdMax).nullish(),
+            first_name: zod.string().max(annotationsRetrieveResponseCreatedByOneFirstNameMax).optional(),
+            last_name: zod.string().max(annotationsRetrieveResponseCreatedByOneLastNameMax).optional(),
+            email: zod.string().email().max(annotationsRetrieveResponseCreatedByOneEmailMax),
+            is_email_verified: zod.boolean().nullish(),
+            hedgehog_config: zod.record(zod.string(), zod.unknown()).nullish(),
+            role_at_organization: zod
+                .union([
+                    zod
+                        .enum([
+                            'engineering',
+                            'data',
+                            'product',
+                            'founder',
+                            'leadership',
+                            'marketing',
+                            'sales',
+                            'other',
+                        ])
+                        .describe(
+                            '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                        ),
+                    zod.enum(['']),
+                    zod.literal(null),
+                ])
+                .nullish(),
+        })
+        .optional(),
+    created_at: zod.string().datetime({}).nullish(),
+    updated_at: zod.string().datetime({}).optional(),
     deleted: zod
         .boolean()
         .optional()
@@ -307,7 +323,7 @@ export const annotationsUpdateResponseCreatedByOneLastNameMax = 150
 export const annotationsUpdateResponseCreatedByOneEmailMax = 254
 
 export const AnnotationsUpdateResponse = zod.object({
-    id: zod.number(),
+    id: zod.number().optional(),
     content: zod
         .string()
         .max(annotationsUpdateResponseContentMax)
@@ -327,33 +343,44 @@ export const AnnotationsUpdateResponse = zod.object({
         ),
     dashboard_item: zod.number().nullish(),
     dashboard_id: zod.number().nullish(),
-    dashboard_name: zod.string().nullable(),
-    insight_short_id: zod.string().nullable(),
-    insight_name: zod.string().nullable(),
-    insight_derived_name: zod.string().nullable(),
-    created_by: zod.object({
-        id: zod.number(),
-        uuid: zod.string(),
-        distinct_id: zod.string().max(annotationsUpdateResponseCreatedByOneDistinctIdMax).nullish(),
-        first_name: zod.string().max(annotationsUpdateResponseCreatedByOneFirstNameMax).optional(),
-        last_name: zod.string().max(annotationsUpdateResponseCreatedByOneLastNameMax).optional(),
-        email: zod.string().email().max(annotationsUpdateResponseCreatedByOneEmailMax),
-        is_email_verified: zod.boolean().nullish(),
-        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-        role_at_organization: zod
-            .union([
-                zod
-                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
-                    .describe(
-                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                    ),
-                zod.enum(['']),
-                zod.literal(null),
-            ])
-            .nullish(),
-    }),
-    created_at: zod.string().datetime({}).nullable(),
-    updated_at: zod.string().datetime({}),
+    dashboard_name: zod.string().nullish(),
+    insight_short_id: zod.string().nullish(),
+    insight_name: zod.string().nullish(),
+    insight_derived_name: zod.string().nullish(),
+    created_by: zod
+        .object({
+            id: zod.number().optional(),
+            uuid: zod.string().optional(),
+            distinct_id: zod.string().max(annotationsUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+            first_name: zod.string().max(annotationsUpdateResponseCreatedByOneFirstNameMax).optional(),
+            last_name: zod.string().max(annotationsUpdateResponseCreatedByOneLastNameMax).optional(),
+            email: zod.string().email().max(annotationsUpdateResponseCreatedByOneEmailMax),
+            is_email_verified: zod.boolean().nullish(),
+            hedgehog_config: zod.record(zod.string(), zod.unknown()).nullish(),
+            role_at_organization: zod
+                .union([
+                    zod
+                        .enum([
+                            'engineering',
+                            'data',
+                            'product',
+                            'founder',
+                            'leadership',
+                            'marketing',
+                            'sales',
+                            'other',
+                        ])
+                        .describe(
+                            '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                        ),
+                    zod.enum(['']),
+                    zod.literal(null),
+                ])
+                .nullish(),
+        })
+        .optional(),
+    created_at: zod.string().datetime({}).nullish(),
+    updated_at: zod.string().datetime({}).optional(),
     deleted: zod
         .boolean()
         .optional()
@@ -429,7 +456,7 @@ export const annotationsPartialUpdateResponseCreatedByOneLastNameMax = 150
 export const annotationsPartialUpdateResponseCreatedByOneEmailMax = 254
 
 export const AnnotationsPartialUpdateResponse = zod.object({
-    id: zod.number(),
+    id: zod.number().optional(),
     content: zod
         .string()
         .max(annotationsPartialUpdateResponseContentMax)
@@ -449,33 +476,44 @@ export const AnnotationsPartialUpdateResponse = zod.object({
         ),
     dashboard_item: zod.number().nullish(),
     dashboard_id: zod.number().nullish(),
-    dashboard_name: zod.string().nullable(),
-    insight_short_id: zod.string().nullable(),
-    insight_name: zod.string().nullable(),
-    insight_derived_name: zod.string().nullable(),
-    created_by: zod.object({
-        id: zod.number(),
-        uuid: zod.string(),
-        distinct_id: zod.string().max(annotationsPartialUpdateResponseCreatedByOneDistinctIdMax).nullish(),
-        first_name: zod.string().max(annotationsPartialUpdateResponseCreatedByOneFirstNameMax).optional(),
-        last_name: zod.string().max(annotationsPartialUpdateResponseCreatedByOneLastNameMax).optional(),
-        email: zod.string().email().max(annotationsPartialUpdateResponseCreatedByOneEmailMax),
-        is_email_verified: zod.boolean().nullish(),
-        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
-        role_at_organization: zod
-            .union([
-                zod
-                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
-                    .describe(
-                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
-                    ),
-                zod.enum(['']),
-                zod.literal(null),
-            ])
-            .nullish(),
-    }),
-    created_at: zod.string().datetime({}).nullable(),
-    updated_at: zod.string().datetime({}),
+    dashboard_name: zod.string().nullish(),
+    insight_short_id: zod.string().nullish(),
+    insight_name: zod.string().nullish(),
+    insight_derived_name: zod.string().nullish(),
+    created_by: zod
+        .object({
+            id: zod.number().optional(),
+            uuid: zod.string().optional(),
+            distinct_id: zod.string().max(annotationsPartialUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+            first_name: zod.string().max(annotationsPartialUpdateResponseCreatedByOneFirstNameMax).optional(),
+            last_name: zod.string().max(annotationsPartialUpdateResponseCreatedByOneLastNameMax).optional(),
+            email: zod.string().email().max(annotationsPartialUpdateResponseCreatedByOneEmailMax),
+            is_email_verified: zod.boolean().nullish(),
+            hedgehog_config: zod.record(zod.string(), zod.unknown()).nullish(),
+            role_at_organization: zod
+                .union([
+                    zod
+                        .enum([
+                            'engineering',
+                            'data',
+                            'product',
+                            'founder',
+                            'leadership',
+                            'marketing',
+                            'sales',
+                            'other',
+                        ])
+                        .describe(
+                            '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                        ),
+                    zod.enum(['']),
+                    zod.literal(null),
+                ])
+                .nullish(),
+        })
+        .optional(),
+    created_at: zod.string().datetime({}).nullish(),
+    updated_at: zod.string().datetime({}).optional(),
     deleted: zod
         .boolean()
         .optional()

--- a/services/mcp/src/generated/annotations/api.ts
+++ b/services/mcp/src/generated/annotations/api.ts
@@ -1,0 +1,364 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * MCP service uses these Zod schemas for generated tool handlers.
+ * To regenerate: hogli build:openapi
+ *
+ * PostHog API - MCP 6 ops
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const AnnotationsListParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AnnotationsListQueryParams = zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    search: zod.string().optional().describe('A search term.'),
+})
+
+export const annotationsListResponseResultsItemContentMax = 8192
+
+export const annotationsListResponseResultsItemCreatedByOneDistinctIdMax = 200
+
+export const annotationsListResponseResultsItemCreatedByOneFirstNameMax = 150
+
+export const annotationsListResponseResultsItemCreatedByOneLastNameMax = 150
+
+export const annotationsListResponseResultsItemCreatedByOneEmailMax = 254
+
+export const AnnotationsListResponse = zod.object({
+    count: zod.number(),
+    next: zod.string().url().nullish(),
+    previous: zod.string().url().nullish(),
+    results: zod.array(
+        zod.object({
+            id: zod.number(),
+            content: zod.string().max(annotationsListResponseResultsItemContentMax).nullish(),
+            date_marker: zod.string().datetime({}).nullish(),
+            creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+            dashboard_item: zod.number().nullish(),
+            dashboard_id: zod.number().nullish(),
+            dashboard_name: zod.string().nullable(),
+            insight_short_id: zod.string().nullable(),
+            insight_name: zod.string().nullable(),
+            insight_derived_name: zod.string().nullable(),
+            created_by: zod.object({
+                id: zod.number(),
+                uuid: zod.string(),
+                distinct_id: zod.string().max(annotationsListResponseResultsItemCreatedByOneDistinctIdMax).nullish(),
+                first_name: zod.string().max(annotationsListResponseResultsItemCreatedByOneFirstNameMax).optional(),
+                last_name: zod.string().max(annotationsListResponseResultsItemCreatedByOneLastNameMax).optional(),
+                email: zod.string().email().max(annotationsListResponseResultsItemCreatedByOneEmailMax),
+                is_email_verified: zod.boolean().nullish(),
+                hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+                role_at_organization: zod
+                    .union([
+                        zod
+                            .enum([
+                                'engineering',
+                                'data',
+                                'product',
+                                'founder',
+                                'leadership',
+                                'marketing',
+                                'sales',
+                                'other',
+                            ])
+                            .describe(
+                                '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                            ),
+                        zod.enum(['']),
+                        zod.literal(null),
+                    ])
+                    .nullish(),
+            }),
+            created_at: zod.string().datetime({}).nullable(),
+            updated_at: zod.string().datetime({}),
+            deleted: zod.boolean().optional(),
+            scope: zod
+                .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+                .optional()
+                .describe(
+                    '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+                ),
+        })
+    ),
+})
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const AnnotationsCreateParams = zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const annotationsCreateBodyContentMax = 8192
+
+export const AnnotationsCreateBody = zod.object({
+    content: zod.string().max(annotationsCreateBodyContentMax).nullish(),
+    date_marker: zod.string().datetime({}).nullish(),
+    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    deleted: zod.boolean().optional(),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .optional()
+        .describe(
+            '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        ),
+})
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const AnnotationsRetrieveParams = zod.object({
+    id: zod.number().describe('A unique integer value identifying this annotation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const annotationsRetrieveResponseContentMax = 8192
+
+export const annotationsRetrieveResponseCreatedByOneDistinctIdMax = 200
+
+export const annotationsRetrieveResponseCreatedByOneFirstNameMax = 150
+
+export const annotationsRetrieveResponseCreatedByOneLastNameMax = 150
+
+export const annotationsRetrieveResponseCreatedByOneEmailMax = 254
+
+export const AnnotationsRetrieveResponse = zod.object({
+    id: zod.number(),
+    content: zod.string().max(annotationsRetrieveResponseContentMax).nullish(),
+    date_marker: zod.string().datetime({}).nullish(),
+    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    dashboard_name: zod.string().nullable(),
+    insight_short_id: zod.string().nullable(),
+    insight_name: zod.string().nullable(),
+    insight_derived_name: zod.string().nullable(),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(annotationsRetrieveResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(annotationsRetrieveResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(annotationsRetrieveResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(annotationsRetrieveResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    created_at: zod.string().datetime({}).nullable(),
+    updated_at: zod.string().datetime({}),
+    deleted: zod.boolean().optional(),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .optional()
+        .describe(
+            '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        ),
+})
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const AnnotationsUpdateParams = zod.object({
+    id: zod.number().describe('A unique integer value identifying this annotation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const annotationsUpdateBodyContentMax = 8192
+
+export const AnnotationsUpdateBody = zod.object({
+    content: zod.string().max(annotationsUpdateBodyContentMax).nullish(),
+    date_marker: zod.string().datetime({}).nullish(),
+    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    deleted: zod.boolean().optional(),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .optional()
+        .describe(
+            '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        ),
+})
+
+export const annotationsUpdateResponseContentMax = 8192
+
+export const annotationsUpdateResponseCreatedByOneDistinctIdMax = 200
+
+export const annotationsUpdateResponseCreatedByOneFirstNameMax = 150
+
+export const annotationsUpdateResponseCreatedByOneLastNameMax = 150
+
+export const annotationsUpdateResponseCreatedByOneEmailMax = 254
+
+export const AnnotationsUpdateResponse = zod.object({
+    id: zod.number(),
+    content: zod.string().max(annotationsUpdateResponseContentMax).nullish(),
+    date_marker: zod.string().datetime({}).nullish(),
+    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    dashboard_name: zod.string().nullable(),
+    insight_short_id: zod.string().nullable(),
+    insight_name: zod.string().nullable(),
+    insight_derived_name: zod.string().nullable(),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(annotationsUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(annotationsUpdateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(annotationsUpdateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(annotationsUpdateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    created_at: zod.string().datetime({}).nullable(),
+    updated_at: zod.string().datetime({}),
+    deleted: zod.boolean().optional(),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .optional()
+        .describe(
+            '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        ),
+})
+
+/**
+ * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
+ */
+export const AnnotationsPartialUpdateParams = zod.object({
+    id: zod.number().describe('A unique integer value identifying this annotation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const annotationsPartialUpdateBodyContentMax = 8192
+
+export const AnnotationsPartialUpdateBody = zod.object({
+    content: zod.string().max(annotationsPartialUpdateBodyContentMax).nullish(),
+    date_marker: zod.string().datetime({}).nullish(),
+    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    deleted: zod.boolean().optional(),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .optional()
+        .describe(
+            '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        ),
+})
+
+export const annotationsPartialUpdateResponseContentMax = 8192
+
+export const annotationsPartialUpdateResponseCreatedByOneDistinctIdMax = 200
+
+export const annotationsPartialUpdateResponseCreatedByOneFirstNameMax = 150
+
+export const annotationsPartialUpdateResponseCreatedByOneLastNameMax = 150
+
+export const annotationsPartialUpdateResponseCreatedByOneEmailMax = 254
+
+export const AnnotationsPartialUpdateResponse = zod.object({
+    id: zod.number(),
+    content: zod.string().max(annotationsPartialUpdateResponseContentMax).nullish(),
+    date_marker: zod.string().datetime({}).nullish(),
+    creation_type: zod.enum(['USR', 'GIT']).optional().describe('* `USR` - user\n* `GIT` - GitHub'),
+    dashboard_item: zod.number().nullish(),
+    dashboard_id: zod.number().nullish(),
+    dashboard_name: zod.string().nullable(),
+    insight_short_id: zod.string().nullable(),
+    insight_name: zod.string().nullable(),
+    insight_derived_name: zod.string().nullable(),
+    created_by: zod.object({
+        id: zod.number(),
+        uuid: zod.string(),
+        distinct_id: zod.string().max(annotationsPartialUpdateResponseCreatedByOneDistinctIdMax).nullish(),
+        first_name: zod.string().max(annotationsPartialUpdateResponseCreatedByOneFirstNameMax).optional(),
+        last_name: zod.string().max(annotationsPartialUpdateResponseCreatedByOneLastNameMax).optional(),
+        email: zod.string().email().max(annotationsPartialUpdateResponseCreatedByOneEmailMax),
+        is_email_verified: zod.boolean().nullish(),
+        hedgehog_config: zod.record(zod.string(), zod.unknown()).nullable(),
+        role_at_organization: zod
+            .union([
+                zod
+                    .enum(['engineering', 'data', 'product', 'founder', 'leadership', 'marketing', 'sales', 'other'])
+                    .describe(
+                        '* `engineering` - Engineering\n* `data` - Data\n* `product` - Product Management\n* `founder` - Founder\n* `leadership` - Leadership\n* `marketing` - Marketing\n* `sales` - Sales / Success\n* `other` - Other'
+                    ),
+                zod.enum(['']),
+                zod.literal(null),
+            ])
+            .nullish(),
+    }),
+    created_at: zod.string().datetime({}).nullable(),
+    updated_at: zod.string().datetime({}),
+    deleted: zod.boolean().optional(),
+    scope: zod
+        .enum(['dashboard_item', 'dashboard', 'project', 'organization', 'recording'])
+        .optional()
+        .describe(
+            '* `dashboard_item` - insight\n* `dashboard` - dashboard\n* `project` - project\n* `organization` - organization\n* `recording` - recording'
+        ),
+})
+
+/**
+ * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
+ */
+export const AnnotationsDestroyParams = zod.object({
+    id: zod.number().describe('A unique integer value identifying this annotation.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -69,6 +69,8 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'profile',
     'email',
     'introspection',
+    'annotation:read',
+    'annotation:write',
     'action:read',
     'action:write',
     'cohort:read',

--- a/services/mcp/src/tools/generated/annotations.ts
+++ b/services/mcp/src/tools/generated/annotations.ts
@@ -1,0 +1,138 @@
+// AUTO-GENERATED from products/annotations/mcp/tools.yaml + OpenAPI — do not edit
+import { z } from 'zod'
+
+import type { Schemas } from '@/api/generated'
+import {
+    AnnotationsCreateBody,
+    AnnotationsDestroyParams,
+    AnnotationsListQueryParams,
+    AnnotationsPartialUpdateBody,
+    AnnotationsPartialUpdateParams,
+    AnnotationsRetrieveParams,
+} from '@/generated/annotations/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const AnnotationsListSchema = AnnotationsListQueryParams
+
+const annotationsList = (): ToolBase<
+    typeof AnnotationsListSchema,
+    Schemas.PaginatedAnnotationList & { _posthogUrl: string }
+> => ({
+    name: 'annotations-list',
+    schema: AnnotationsListSchema,
+    handler: async (context: Context, params: z.infer<typeof AnnotationsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedAnnotationList>({
+            method: 'GET',
+            path: `/api/projects/${projectId}/annotations/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                search: params.search,
+            },
+        })
+        return {
+            ...(result as any),
+            _posthogUrl: `${context.api.getProjectBaseUrl(projectId)}/annotations`,
+        }
+    },
+})
+
+const AnnotationCreateSchema = AnnotationsCreateBody.omit({
+    creation_type: true,
+    dashboard_item: true,
+    dashboard_id: true,
+    deleted: true,
+})
+
+const annotationCreate = (): ToolBase<typeof AnnotationCreateSchema, Schemas.Annotation> => ({
+    name: 'annotation-create',
+    schema: AnnotationCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AnnotationCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.content !== undefined) {
+            body['content'] = params.content
+        }
+        if (params.date_marker !== undefined) {
+            body['date_marker'] = params.date_marker
+        }
+        if (params.scope !== undefined) {
+            body['scope'] = params.scope
+        }
+        const result = await context.api.request<Schemas.Annotation>({
+            method: 'POST',
+            path: `/api/projects/${projectId}/annotations/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AnnotationRetrieveSchema = AnnotationsRetrieveParams.omit({ project_id: true })
+
+const annotationRetrieve = (): ToolBase<typeof AnnotationRetrieveSchema, Schemas.Annotation> => ({
+    name: 'annotation-retrieve',
+    schema: AnnotationRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof AnnotationRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.Annotation>({
+            method: 'GET',
+            path: `/api/projects/${projectId}/annotations/${params.id}/`,
+        })
+        return result
+    },
+})
+
+const AnnotationsPartialUpdateSchema = AnnotationsPartialUpdateParams.omit({ project_id: true }).extend(
+    AnnotationsPartialUpdateBody.omit({ creation_type: true, dashboard_item: true, dashboard_id: true, deleted: true })
+        .shape
+)
+
+const annotationsPartialUpdate = (): ToolBase<typeof AnnotationsPartialUpdateSchema, Schemas.Annotation> => ({
+    name: 'annotations-partial-update',
+    schema: AnnotationsPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof AnnotationsPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.content !== undefined) {
+            body['content'] = params.content
+        }
+        if (params.date_marker !== undefined) {
+            body['date_marker'] = params.date_marker
+        }
+        if (params.scope !== undefined) {
+            body['scope'] = params.scope
+        }
+        const result = await context.api.request<Schemas.Annotation>({
+            method: 'PATCH',
+            path: `/api/projects/${projectId}/annotations/${params.id}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AnnotationDeleteSchema = AnnotationsDestroyParams.omit({ project_id: true })
+
+const annotationDelete = (): ToolBase<typeof AnnotationDeleteSchema, unknown> => ({
+    name: 'annotation-delete',
+    schema: AnnotationDeleteSchema,
+    handler: async (context: Context, params: z.infer<typeof AnnotationDeleteSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'PATCH',
+            path: `/api/projects/${projectId}/annotations/${params.id}/`,
+            body: { deleted: true },
+        })
+        return result
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'annotations-list': annotationsList,
+    'annotation-create': annotationCreate,
+    'annotation-retrieve': annotationRetrieve,
+    'annotations-partial-update': annotationsPartialUpdate,
+    'annotation-delete': annotationDelete,
+}

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -2,9 +2,9 @@ import type { ToolBase, ZodObjectAny } from '@/tools/types'
 
 // AUTO-GENERATED — do not edit
 import { GENERATED_TOOLS as actions } from './actions'
+import { GENERATED_TOOLS as annotations } from './annotations'
 import { GENERATED_TOOLS as cdp_function_templates } from './cdp_function_templates'
 import { GENERATED_TOOLS as cdp_functions } from './cdp_functions'
-import { GENERATED_TOOLS as annotations } from './annotations'
 import { GENERATED_TOOLS as cohorts } from './cohorts'
 import { GENERATED_TOOLS as dashboards } from './dashboards'
 import { GENERATED_TOOLS as error_tracking } from './error_tracking'
@@ -14,9 +14,9 @@ import { GENERATED_TOOLS as workflows } from './workflows'
 
 export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     ...actions,
+    ...annotations,
     ...cdp_function_templates,
     ...cdp_functions,
-    ...annotations,
     ...cohorts,
     ...dashboards,
     ...error_tracking,

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -4,6 +4,7 @@ import type { ToolBase, ZodObjectAny } from '@/tools/types'
 import { GENERATED_TOOLS as actions } from './actions'
 import { GENERATED_TOOLS as cdp_function_templates } from './cdp_function_templates'
 import { GENERATED_TOOLS as cdp_functions } from './cdp_functions'
+import { GENERATED_TOOLS as annotations } from './annotations'
 import { GENERATED_TOOLS as cohorts } from './cohorts'
 import { GENERATED_TOOLS as dashboards } from './dashboards'
 import { GENERATED_TOOLS as error_tracking } from './error_tracking'
@@ -15,6 +16,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...actions,
     ...cdp_function_templates,
     ...cdp_functions,
+    ...annotations,
     ...cohorts,
     ...dashboards,
     ...error_tracking,

--- a/services/mcp/tests/tools/annotations.integration.test.ts
+++ b/services/mcp/tests/tools/annotations.integration.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+    TEST_ORG_ID,
+    TEST_PROJECT_ID,
+    createTestClient,
+    createTestContext,
+    generateUniqueKey,
+    parseToolResponse,
+    setActiveProjectAndOrg,
+    validateEnvironmentVariables,
+} from '@/shared/test-utils'
+import { GENERATED_TOOLS } from '@/tools/generated/annotations'
+import type { Context } from '@/tools/types'
+
+describe('Annotations', { concurrent: false }, () => {
+    let context: Context
+    const createdAnnotationIds: number[] = []
+
+    const createTool = GENERATED_TOOLS['annotation-create']!()
+    const listTool = GENERATED_TOOLS['annotations-list']!()
+    const retrieveTool = GENERATED_TOOLS['annotation-retrieve']!()
+    const updateTool = GENERATED_TOOLS['annotations-partial-update']!()
+    const deleteTool = GENERATED_TOOLS['annotation-delete']!()
+
+    beforeAll(async () => {
+        validateEnvironmentVariables()
+        const client = createTestClient()
+        context = createTestContext(client)
+        await setActiveProjectAndOrg(context, TEST_PROJECT_ID!, TEST_ORG_ID!)
+    })
+
+    afterEach(async () => {
+        for (const id of createdAnnotationIds) {
+            try {
+                await deleteTool.handler(context, { id })
+            } catch {
+                // best effort — annotation may already be deleted
+            }
+        }
+        createdAnnotationIds.length = 0
+    })
+
+    describe('annotation-create tool', () => {
+        it('should create an annotation with all fields', async () => {
+            const params = {
+                content: `Test annotation ${generateUniqueKey('ann')}`,
+                date_marker: '2024-01-15T12:00:00Z',
+                scope: 'project' as const,
+            }
+
+            const result = await createTool.handler(context, params)
+            const annotation = parseToolResponse(result)
+
+            expect(annotation.id).toBeTruthy()
+            expect(annotation.content).toBe(params.content)
+            expect(annotation.date_marker).toContain('2024-01-15')
+            expect(annotation.scope).toBe('project')
+
+            createdAnnotationIds.push(annotation.id)
+        })
+
+        it('should create an annotation with minimal fields', async () => {
+            const params = {
+                content: `Minimal annotation ${generateUniqueKey('min')}`,
+            }
+
+            const result = await createTool.handler(context, params)
+            const annotation = parseToolResponse(result)
+
+            expect(annotation.id).toBeTruthy()
+            expect(annotation.content).toBe(params.content)
+
+            createdAnnotationIds.push(annotation.id)
+        })
+    })
+
+    describe('annotations-list tool', () => {
+        it('should list annotations including a newly created one', async () => {
+            const createResult = await createTool.handler(context, {
+                content: `List test annotation ${generateUniqueKey('list')}`,
+                date_marker: '2024-02-01T00:00:00Z',
+                scope: 'project' as const,
+            })
+            const created = parseToolResponse(createResult)
+            createdAnnotationIds.push(created.id)
+
+            const result = await listTool.handler(context, {})
+            const response = parseToolResponse(result)
+
+            expect(Array.isArray(response.results)).toBe(true)
+            expect(response.results.some((a: { id: number }) => a.id === created.id)).toBe(true)
+        })
+
+        it('should support pagination', async () => {
+            const result = await listTool.handler(context, { limit: 5, offset: 0 })
+            const response = parseToolResponse(result)
+
+            expect(Array.isArray(response.results)).toBe(true)
+            expect(response.results.length).toBeLessThanOrEqual(5)
+        })
+    })
+
+    describe('annotation-retrieve tool', () => {
+        it('should retrieve an annotation by ID', async () => {
+            const content = `Retrieve test ${generateUniqueKey('retrieve')}`
+            const createResult = await createTool.handler(context, {
+                content,
+                date_marker: '2024-03-10T08:30:00Z',
+                scope: 'project' as const,
+            })
+            const created = parseToolResponse(createResult)
+            createdAnnotationIds.push(created.id)
+
+            const result = await retrieveTool.handler(context, { id: created.id })
+            const annotation = parseToolResponse(result)
+
+            expect(annotation.id).toBe(created.id)
+            expect(annotation.content).toBe(content)
+            expect(annotation.date_marker).toContain('2024-03-10')
+            expect(annotation.scope).toBe('project')
+        })
+    })
+
+    describe('annotations-partial-update tool', () => {
+        it('should update annotation content', async () => {
+            const createResult = await createTool.handler(context, {
+                content: `Original ${generateUniqueKey('orig')}`,
+                date_marker: '2024-04-01T00:00:00Z',
+                scope: 'project' as const,
+            })
+            const created = parseToolResponse(createResult)
+            createdAnnotationIds.push(created.id)
+
+            const updatedContent = `Updated ${generateUniqueKey('upd')}`
+            const result = await updateTool.handler(context, {
+                id: created.id,
+                content: updatedContent,
+            })
+            const updated = parseToolResponse(result)
+
+            expect(updated.id).toBe(created.id)
+            expect(updated.content).toBe(updatedContent)
+        })
+
+        it('should update annotation date_marker', async () => {
+            const createResult = await createTool.handler(context, {
+                content: `Date update ${generateUniqueKey('date')}`,
+                date_marker: '2024-05-01T00:00:00Z',
+                scope: 'project' as const,
+            })
+            const created = parseToolResponse(createResult)
+            createdAnnotationIds.push(created.id)
+
+            const result = await updateTool.handler(context, {
+                id: created.id,
+                date_marker: '2024-06-15T12:00:00Z',
+            })
+            const updated = parseToolResponse(result)
+
+            expect(updated.id).toBe(created.id)
+            expect(updated.date_marker).toContain('2024-06-15')
+        })
+
+        it('should update annotation scope', async () => {
+            const createResult = await createTool.handler(context, {
+                content: `Scope update ${generateUniqueKey('scope')}`,
+                date_marker: '2024-07-01T00:00:00Z',
+                scope: 'project' as const,
+            })
+            const created = parseToolResponse(createResult)
+            createdAnnotationIds.push(created.id)
+
+            const result = await updateTool.handler(context, {
+                id: created.id,
+                scope: 'organization' as const,
+            })
+            const updated = parseToolResponse(result)
+
+            expect(updated.id).toBe(created.id)
+            expect(updated.scope).toBe('organization')
+        })
+    })
+
+    describe('annotation-delete tool', () => {
+        it('should delete an annotation', async () => {
+            const createResult = await createTool.handler(context, {
+                content: `Delete test ${generateUniqueKey('del')}`,
+                date_marker: '2024-08-01T00:00:00Z',
+                scope: 'project' as const,
+            })
+            const created = parseToolResponse(createResult)
+            // Don't track for cleanup since we're deleting it here
+
+            await deleteTool.handler(context, { id: created.id })
+
+            const listResult = await listTool.handler(context, {})
+            const response = parseToolResponse(listResult)
+            expect(response.results.some((a: { id: number }) => a.id === created.id)).toBe(false)
+        })
+    })
+
+    describe('full CRUD workflow', () => {
+        it('should support create → retrieve → update → verify → delete', async () => {
+            // Create
+            const content = `CRUD workflow ${generateUniqueKey('crud')}`
+            const createResult = await createTool.handler(context, {
+                content,
+                date_marker: '2024-09-01T00:00:00Z',
+                scope: 'project' as const,
+            })
+            const created = parseToolResponse(createResult)
+            expect(created.id).toBeTruthy()
+            expect(created.content).toBe(content)
+
+            // Retrieve
+            const retrieveResult = await retrieveTool.handler(context, { id: created.id })
+            const retrieved = parseToolResponse(retrieveResult)
+            expect(retrieved.id).toBe(created.id)
+            expect(retrieved.content).toBe(content)
+
+            // Update
+            const updatedContent = `Updated CRUD ${generateUniqueKey('crud-upd')}`
+            const updateResult = await updateTool.handler(context, {
+                id: created.id,
+                content: updatedContent,
+                date_marker: '2024-10-15T18:00:00Z',
+                scope: 'organization' as const,
+            })
+            const updated = parseToolResponse(updateResult)
+            expect(updated.content).toBe(updatedContent)
+            expect(updated.date_marker).toContain('2024-10-15')
+            expect(updated.scope).toBe('organization')
+
+            // Verify update via retrieve
+            const verifyResult = await retrieveTool.handler(context, { id: created.id })
+            const verified = parseToolResponse(verifyResult)
+            expect(verified.content).toBe(updatedContent)
+            expect(verified.scope).toBe('organization')
+
+            // Delete
+            await deleteTool.handler(context, { id: created.id })
+
+            // Verify deletion
+            const listResult = await listTool.handler(context, {})
+            const response = parseToolResponse(listResult)
+            expect(response.results.some((a: { id: number }) => a.id === created.id)).toBe(false)
+        })
+    })
+})

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -85,6 +85,15 @@ describe('Tool Filtering - Features', () => {
                 expect(tools).toContain(tool)
             }
         })
+
+        it('should not expose annotation list/get tools in v2', () => {
+            const tools = getToolsForFeatures({ features: ['annotations'], version: 2 })
+
+            expect(tools).toContain('annotation-create')
+            expect(tools).toContain('annotation-delete')
+            expect(tools).not.toContain('annotations-list')
+            expect(tools).not.toContain('annotation-retrieve')
+        })
     })
 })
 


### PR DESCRIPTION
## Problem

We do not currently have annotations MCP tool support, and users have explicitly asked for it so they can create/review deployment annotations directly from their coding workflow.

## Changes

- Exposed annotations in HogQL as `system.annotations` (with `team_id` for project isolation).
- Added/updated HogQL coverage:
  - system table registration tests
  - access control coverage
  - query-examples schema reference for annotations
- Created annotations MCP CRUD surface via codegen and YAML config:
  - Added `products/annotations/mcp/tools.yaml`
  - Generated annotation tool handlers and schema outputs
  - Added annotation OAuth scopes (`annotation:read`, `annotation:write`)
- Applied MCP versioning as requested:
  - `annotations-list` and `annotation-retrieve` are v1-only (not exposed to v2)
  - create/delete are available where intended
  - update/partial-update remain disabled
- Enhanced annotation API request schema descriptions by adding `help_text` to create/partial-update relevant serializer fields in `posthog/api/annotation.py`.

## How did you test this code?

- `bin/hogli build:openapi`
- run manual tests with CC via scenarios below

```md
Annotations MCP Tools — Prompt Testing Scenarios

  1. Basic CRUD Operations

  Create a simple annotation:
  "Add an annotation saying 'Marketing campaign launched' on March 1st, 2026"

  Validates: annotation-create with content + date_marker, ISO 8601 formatting

  Create a project-scoped annotation:
  "Create a project-wide annotation for today that says 'Database migration completed'"

  Validates: scope: "project" is set correctly, date_marker defaults to today

  List annotations:
  "Show me all annotations"

  Validates: annotations-list basic call, pagination handling

  Retrieve by ID:
  "Show me the details of annotation 42"

  Validates: annotation-retrieve with specific ID

  Delete an annotation:
  "Delete annotation 15"

  Validates: annotation-delete soft-delete behavior (PATCH deleted: true)

  ---
  2. Scoping & Filtering

  Organization-scoped annotation:
  "Add an organization-wide annotation for January 15th saying 'Company rebrand'"

  Validates: scope: "organization"

  Search annotations:
  "Find annotations mentioning 'deploy'"

  Validates: annotations-list with search parameter

  Date-based reasoning:
  "What annotations do we have from last week?"

  Validates: Agent uses list + filters or HogQL to narrow by date window

  ---
  3. Analytical / Multi-Step Scenarios

  Annotate a spike:
  "I see a spike in pageviews on February 20th. Add an annotation there saying 'Homepage redesign went live'"

  Validates: Correct date_marker parsing from conversational date, scope: "project"

  Audit trail review:
  "List all annotations and tell me which ones are organization-scoped vs project-scoped"

  Validates: annotations-list + agent summarizing the scope field across results

  Bulk context gathering:
  "What happened around March 5th? Check if there are any annotations near that date"

  Validates: Agent uses list/search + date reasoning to find nearby annotations

  ---
  4. Edge Cases & Error Handling

  Missing required fields:
  "Create an annotation"
  (no content or date specified)

  Validates: Agent asks for clarification or handles nullable content/date_marker

  Very long content:
  "Create an annotation with this text: [paste 9000+ chars]"

  Validates: 8192 char max length enforcement

  Deprecated scope:
  "Create a recording annotation"

  Validates: recording scope is rejected — agent should explain it's not supported

  Delete then retrieve:
  "Delete annotation 10, then show me its details"

  Validates: Soft-delete behavior — retrieve may still return it with deleted: true

  ---
  5. HogQL Integration (if agent has query tool)

  Query annotations via SQL:
  "Write a HogQL query to find all annotations from last month that aren't deleted"

  Validates: Uses annotations system table, filters deleted = 0, correct date filtering

  Cross-reference with events:
  "Show me annotations alongside daily event counts for the past 30 days"

  Validates: Agent joins/correlates annotations table with event data

  ---
  6. Conversational & Ambiguous Prompts

  Vague request:
  "Mark that something important happened yesterday"

  Validates: Agent creates annotation with yesterday's date, asks for content or uses generic text

  Correction flow:
  "Add an annotation for March 3rd saying 'Release v2.1'" → "Actually, make that March 4th"

  Validates: Agent recognizes update isn't available via MCP (update tool is disabled), may delete + recreate
  or explain limitation

  Multi-annotation request:
  "Add annotations for our quarterly releases: Q1 on Jan 1st, Q2 on Apr 1st, Q3 on Jul 1st, Q4 on Oct 1st"

  Validates: Agent calls annotation-create four times with correct dates

  ---
  7. Permission & Scope Awareness

  Read-only intent:
  "Just show me what annotations exist, don't change anything"

  Validates: Agent uses only annotations-list (readOnly tool), no write calls

  Destructive action confirmation:
  "Remove all annotations from this project"

  Validates: Agent should exercise caution before bulk-deleting, confirm with user
```

## Publish to changelog?

no