### PR TITLE
feat: add '(Copy)' suffix to copied resources

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -473,6 +473,7 @@ posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Mod
 posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
+posthog/models/resource_transfer/inter_project_transferer.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 posthog/models/subscription.py:0: error: Argument 2 to "SubscriptionResourceInfo" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/models/team/team.py:0: error: Argument 1 to "union" of "QuerySet" has incompatible type "QuerySet[OrganizationMembership, int]"; expected "QuerySet[Model, Model]"  [arg-type]
 posthog/models/team/team.py:0: error: Argument 1 to "union" of "QuerySet" has incompatible type "QuerySet[RoleMembership, int]"; expected "QuerySet[Model, Model]"  [arg-type]

--- a/posthog/models/resource_transfer/inter_project_transferer.py
+++ b/posthog/models/resource_transfer/inter_project_transferer.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
+from django.db.models import Q
 
 import structlog
 
@@ -463,6 +464,40 @@ def _find_resource_with_same_name(
     return matching_resource
 
 
+def _model_has_name_field(model: type[models.Model]) -> bool:
+    return any(f.name == "name" for f in model._meta.get_fields())
+
+
+def _deduplicate_name(model: type[models.Model], name: str, team: Team) -> str:
+    """
+    Return a unique name for a resource being copied into *team*.
+
+    If no resource with *name* exists yet, return it unchanged.
+    Otherwise try ``"<name> (Copy)"``, then ``"<name> (Copy 2)"``,
+    ``"<name> (Copy 3)"`` … until a free slot is found.
+    """
+    taken_names: set[str] = set(
+        model.objects.filter(
+            Q(name=name) | Q(name__endswith="(Copy)") | Q(name__regex=r"\(Copy \d+\)$"),
+            team=team,
+            name__startswith=name,
+        ).values_list("name", flat=True)
+    )
+
+    if name not in taken_names:
+        return name
+
+    candidate = f"{name} (Copy)"
+    if candidate not in taken_names:
+        return candidate
+
+    counter = 2
+    while f"{name} (Copy {counter})" in taken_names:
+        counter += 1
+
+    return f"{name} (Copy {counter})"
+
+
 def _get_mapped_substitutions(
     substitutions: list[tuple[ResourceTransferKey, ResourceTransferKey]],
     target_team: Team | None = None,
@@ -606,6 +641,9 @@ def _duplicate_vertex(
                 target_model=edge.target_model.__name__,
                 target_pk=str(edge.target_primary_key),
             )
+
+    if "name" in payload and payload["name"] and _model_has_name_field(visitor.get_model()):
+        payload["name"] = _deduplicate_name(visitor.get_model(), payload["name"], new_team)
 
     new_resource = visitor.get_model().objects.create(**payload)
     logger.info(

--- a/posthog/models/resource_transfer/inter_project_transferer.py
+++ b/posthog/models/resource_transfer/inter_project_transferer.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Generator, Iterable
 from graphlib import TopologicalSorter
 from typing import Any, cast
@@ -478,9 +479,8 @@ def _deduplicate_name(model: type[models.Model], name: str, team: Team) -> str:
     """
     taken_names: set[str] = set(
         model.objects.filter(
-            Q(name=name) | Q(name__endswith="(Copy)") | Q(name__regex=r"\(Copy \d+\)$"),
+            Q(name=name) | Q(name=f"{name} (Copy)") | Q(name__regex=rf"^{re.escape(name)} \(Copy \d+\)$"),
             team=team,
-            name__startswith=name,
         ).values_list("name", flat=True)
     )
 

--- a/posthog/models/resource_transfer/test/test_inter_project_transferer.py
+++ b/posthog/models/resource_transfer/test/test_inter_project_transferer.py
@@ -263,6 +263,65 @@ class TestResourceTransferRecordCreation(BaseTest):
         assert transfer.duplicated_resource_id == str(new_resource.pk)
 
 
+class TestNameDeduplication(BaseTest):
+    def _create_destination_team(self) -> Team:
+        project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=self.organization)
+        return Team.objects.create(id=project.id, project=project, organization=self.organization)
+
+    def test_no_conflict_keeps_original_name(self) -> None:
+        dest_team = self._create_destination_team()
+        insight = Insight.objects.create(team=self.team, name="Unique insight")
+
+        results = duplicate_resource_to_new_team(insight, dest_team, created_by=self.user)
+        new_insight = next(r for r in results if isinstance(r, Insight))
+
+        assert new_insight.name == "Unique insight"
+
+    def test_conflict_adds_copy_suffix(self) -> None:
+        dest_team = self._create_destination_team()
+        Insight.objects.create(team=dest_team, name="My insight")
+        insight = Insight.objects.create(team=self.team, name="My insight")
+
+        results = duplicate_resource_to_new_team(insight, dest_team, created_by=self.user)
+        new_insight = next(r for r in results if isinstance(r, Insight) and r.team == dest_team)
+
+        assert new_insight.name == "My insight (Copy)"
+
+    def test_multiple_conflicts_increment_copy_number(self) -> None:
+        dest_team = self._create_destination_team()
+        Insight.objects.create(team=dest_team, name="My insight")
+        Insight.objects.create(team=dest_team, name="My insight (Copy)")
+        insight = Insight.objects.create(team=self.team, name="My insight")
+
+        results = duplicate_resource_to_new_team(insight, dest_team, created_by=self.user)
+        new_insight = next(r for r in results if isinstance(r, Insight) and r.team == dest_team)
+
+        assert new_insight.name == "My insight (Copy 2)"
+
+    def test_conflict_with_dashboard(self) -> None:
+        dest_team = self._create_destination_team()
+        Dashboard.objects.create(team=dest_team, name="Sales")
+        dashboard = Dashboard.objects.create(team=self.team, name="Sales")
+
+        results = duplicate_resource_to_new_team(dashboard, dest_team, created_by=self.user)
+        new_dashboard = next(r for r in results if isinstance(r, Dashboard) and r.team == dest_team)
+
+        assert new_dashboard.name == "Sales (Copy)"
+
+    def test_conflict_skips_taken_copy_numbers(self) -> None:
+        dest_team = self._create_destination_team()
+        Insight.objects.create(team=dest_team, name="X")
+        Insight.objects.create(team=dest_team, name="X (Copy)")
+        Insight.objects.create(team=dest_team, name="X (Copy 2)")
+        Insight.objects.create(team=dest_team, name="X (Copy 3)")
+        insight = Insight.objects.create(team=self.team, name="X")
+
+        results = duplicate_resource_to_new_team(insight, dest_team, created_by=self.user)
+        new_insight = next(r for r in results if isinstance(r, Insight) and r.team == dest_team)
+
+        assert new_insight.name == "X (Copy 4)"
+
+
 class TestSubstitutionTeamValidation(BaseTest):
     def _create_destination_team(self) -> Team:
         project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=self.organization)


### PR DESCRIPTION
## Problem

If you copy a resource to another project multiple times it is not clear which is the one that has been copied most recently if they both still have the same name in the target project. To avoid confusion and to act more like a typical copy operation, any resource that is duplicated with the same name now has the `(Copy)` suffix applied to it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add logic to add the `(Copy)` suffix to resources copied between projects
	- If a resource exists with the same name, add `(Copy)`
	- If a resource exists with the same name and one exists with `(Copy)`, then add `(Copy <copy number>)`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Tests + manually
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
