### PR TITLE
feat(hogql): Add activity_logs to system schema and query documentation

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -355,6 +355,7 @@ exports: PostgresTable = PostgresTable(
 activity_logs: PostgresTable = PostgresTable(
     name="activity_logs",
     postgres_table_name="posthog_activitylog",
+    access_scope="activity_log",
     fields={
         "id": StringDatabaseField(name="id"),
         "team_id": IntegerDatabaseField(name="team_id"),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -352,6 +352,20 @@ exports: PostgresTable = PostgresTable(
     },
 )
 
+activity_logs: PostgresTable = PostgresTable(
+    name="activity_logs",
+    postgres_table_name="posthog_activitylog",
+    fields={
+        "id": StringDatabaseField(name="id"),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "activity": StringDatabaseField(name="activity"),
+        "item_id": StringDatabaseField(name="item_id"),
+        "scope": StringDatabaseField(name="scope"),
+        "detail": StringJSONDatabaseField(name="detail"),
+        "created_at": DateTimeDatabaseField(name="created_at"),
+    },
+)
+
 actions: PostgresTable = PostgresTable(
     name="actions",
     postgres_table_name="posthog_action",
@@ -532,6 +546,7 @@ early_access_features: PostgresTable = PostgresTable(
 class SystemTables(TableNode):
     name: str = "system"
     children: dict[str, TableNode] = {
+        "activity_logs": TableNode(name="activity_logs", table=activity_logs),
         "actions": TableNode(name="actions", table=actions),
         "alerts": TableNode(name="alerts", table=alerts),
         "annotations": TableNode(name="annotations", table=annotations),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -24,6 +24,7 @@ from posthog.models import (
     Survey,
     Team,
 )
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.alert import AlertConfiguration
 from posthog.models.cohort.calculation_history import CohortCalculationHistory
 from posthog.models.hog_flow.hog_flow import HogFlow
@@ -88,6 +89,10 @@ class TestSystemTablesTeamScoping(BaseTest):
 def _create_alert(team: Team, label: str) -> AlertConfiguration:
     insight = Insight.objects.create(team=team, name=f"insight_for_alert_{label}")
     return AlertConfiguration.objects.create(team=team, insight=insight, name=f"alert_{label}")
+
+
+def _create_activity_log(team: Team, label: str) -> ActivityLog:
+    return ActivityLog.objects.create(team=team, activity="updated", scope="FeatureFlag", item_id=label)
 
 
 def _create_action(team: Team, label: str) -> Action:
@@ -254,6 +259,7 @@ def _create_team(team: Team, label: str) -> Team:
 
 
 SYSTEM_TABLE_FACTORIES = [
+    ("activity_logs", _create_activity_log),
     ("actions", _create_action),
     ("alerts", _create_alert),
     ("annotations", _create_annotation),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -92,7 +92,7 @@ def _create_alert(team: Team, label: str) -> AlertConfiguration:
 
 
 def _create_activity_log(team: Team, label: str) -> ActivityLog:
-    return ActivityLog.objects.create(team=team, activity="updated", scope="FeatureFlag", item_id=label)
+    return ActivityLog.objects.create(team_id=team.pk, activity="updated", scope="FeatureFlag", item_id=label)
 
 
 def _create_action(team: Team, label: str) -> Action:

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -2590,6 +2590,74 @@
           "row_count": null,
           "type": "system"
       },
+      "system.activity_logs": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "activity": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "activity",
+                  "id": null,
+                  "name": "activity",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "item_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "item_id",
+                  "id": null,
+                  "name": "item_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "scope": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "scope",
+                  "id": null,
+                  "name": "scope",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "detail": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "detail",
+                  "id": null,
+                  "name": "detail",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.activity_logs",
+          "name": "system.activity_logs",
+          "row_count": null,
+          "type": "system"
+      },
       "system.actions": {
           "fields": {
               "id": {
@@ -6869,6 +6937,74 @@
           },
           "id": "query_log",
           "name": "query_log",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.activity_logs": {
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "activity": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "activity",
+                  "id": null,
+                  "name": "activity",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "item_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "item_id",
+                  "id": null,
+                  "name": "item_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "scope": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "scope",
+                  "id": null,
+                  "name": "scope",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "detail": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "detail",
+                  "id": null,
+                  "name": "detail",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.activity_logs",
+          "name": "system.activity_logs",
           "row_count": null,
           "type": "system"
       },

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -49,6 +49,7 @@ class TestAccessControlSystemTables(BaseTest):
         system_node = database.tables.children.get("system")
         assert system_node is not None
         # Scoped tables removed from schema
+        assert "activity_logs" not in system_node.children
         assert "dashboards" not in system_node.children
         assert "insights" not in system_node.children
         assert "experiments" not in system_node.children
@@ -61,6 +62,7 @@ class TestAccessControlSystemTables(BaseTest):
         assert "notebooks" not in system_node.children
         assert "error_tracking_issues" not in system_node.children
         # But tracked in denied list for clear error messages
+        assert "system.activity_logs" in database._denied_tables
         assert "system.dashboards" in database._denied_tables
         assert "system.insights" in database._denied_tables
         assert "system.experiments" in database._denied_tables

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -97,7 +97,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.activity_logs', 'system.actions', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.hog_flows', 'system.hog_functions', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.activity_logs', 'system.actions', 'system.alerts', 'system.annotations', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_modeling_jobs', 'system.data_modeling_views', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issue_assignments', 'system.error_tracking_issue_fingerprints', 'system.error_tracking_issues', 'system.early_access_features', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.hog_flows', 'system.hog_functions', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.source_schemas', 'system.source_sync_jobs', 'system.surveys', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.

--- a/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
+++ b/products/data_warehouse/backend/test/__snapshots__/test_hogql_fixer_ai.ambr
@@ -97,7 +97,7 @@
   
   This is a list of all the available tables in the database:
   ```
-  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.actions', 'system.alerts', 'system.annotations', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_modeling_jobs', 'system.data_modeling_views', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issue_assignments', 'system.error_tracking_issue_fingerprints', 'system.error_tracking_issues', 'system.early_access_features', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.hog_flows', 'system.hog_functions', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.source_schemas', 'system.source_sync_jobs', 'system.surveys', 'system.teams']
+  ['events', 'groups', 'persons', 'sessions', 'logs', 'query_log', 'system.activity_logs', 'system.actions', 'system.cohort_calculation_history', 'system.cohorts', 'system.dashboards', 'system.data_warehouse_sources', 'system.data_warehouse_tables', 'system.error_tracking_issues', 'system.experiments', 'system.exports', 'system.feature_flags', 'system.groups', 'system.group_type_mappings', 'system.hog_flows', 'system.hog_functions', 'system.ingestion_warnings', 'system.insight_variables', 'system.insights', 'system.notebooks', 'system.surveys', 'system.teams']
   ```
   
   `person` or `event` metadata unspecified above (emails, names, etc.) is stored in `properties` fields, accessed like: `properties.foo.bar`.

--- a/products/posthog_ai/skills/query-examples/SKILL.md
+++ b/products/posthog_ai/skills/query-examples/SKILL.md
@@ -11,6 +11,7 @@ If the MCP server haven't provided instructions on querying data in PostHog, rea
 
 Schema reference for PostHog's core system models, organized by domain:
 
+- [Activity logs](./references/models-activity-logs.md)
 - [Actions](./references/models-actions.md)
 - [Alerts](./references/models-alerts.md)
 - [Annotations](./references/models-annotations.md)

--- a/products/posthog_ai/skills/query-examples/references/models-activity-logs.md
+++ b/products/posthog_ai/skills/query-examples/references/models-activity-logs.md
@@ -4,6 +4,8 @@
 
 Activity logs track user and system actions across PostHog entities, providing an audit trail of changes to feature flags, insights, dashboards, experiments, and more.
 
+> **Note:** Only team-scoped activity logs are visible. Organisation-level logs (e.g. membership changes) are not included because they are not associated with a specific team.
+
 ### Columns
 
 Column | Type | Nullable | Description

--- a/products/posthog_ai/skills/query-examples/references/models-activity-logs.md
+++ b/products/posthog_ai/skills/query-examples/references/models-activity-logs.md
@@ -1,0 +1,90 @@
+# Activity logs
+
+## Activity log (`system.activity_logs`)
+
+Activity logs track user and system actions across PostHog entities, providing an audit trail of changes to feature flags, insights, dashboards, experiments, and more.
+
+### Columns
+
+Column | Type | Nullable | Description
+`id` | uuid | NOT NULL | Primary key (auto-generated UUID)
+`activity` | varchar(79) | NOT NULL | Action performed (e.g., `created`, `updated`, `deleted`)
+`item_id` | varchar(72) | NULL | ID of the entity being logged (may be numeric ID, short ID, or UUID)
+`scope` | varchar(79) | NOT NULL | Entity type being logged (e.g., `FeatureFlag`, `Insight`)
+`detail` | jsonb | NULL | Structured details about the change
+`created_at` | timestamp with tz | NOT NULL | When the activity occurred
+
+### Detail JSON Structure
+
+```json
+{
+  "name": "My Feature Flag",
+  "short_id": "abc123",
+  "type": "FeatureFlag",
+  "changes": [
+    {
+      "type": "FeatureFlag",
+      "action": "changed",
+      "field": "active",
+      "before": false,
+      "after": true
+    }
+  ]
+}
+```
+
+### Detail Fields
+
+Field | Description
+`name` | Display name of the entity
+`short_id` | Short identifier (if applicable)
+`type` | Entity type
+`changes` | Array of individual field changes
+`changes[].type` | Entity type for this change
+`changes[].action` | `changed`, `created`, `deleted`, `merged`, `split`, `exported`, `revoked`, `copied`
+`changes[].field` | Name of the field that changed
+`changes[].before` | Previous value
+`changes[].after` | New value
+
+### Common Scopes
+
+`FeatureFlag`, `Insight`, `Dashboard`, `Experiment`, `Cohort`, `Survey`, `Notebook`, `Action`,
+`HogFunction`, `Person`, `Replay`, `Comment`, `BatchExport`, `Team`, `Project`,
+`ErrorTrackingIssue`, `EarlyAccessFeature`, `Annotation`, `AlertConfiguration`
+
+### Common Activities
+
+`created`, `updated`, `deleted`, `exported`, `logged_in`, `logged_out`
+
+---
+
+## Common Query Patterns
+
+**Find recent activity for a scope:**
+
+```sql
+SELECT id, activity, item_id, detail, created_at
+FROM system.activity_logs
+WHERE scope = 'FeatureFlag'
+ORDER BY created_at DESC
+LIMIT 50
+```
+
+**Find all changes to a specific entity:**
+
+```sql
+SELECT activity, detail, created_at
+FROM system.activity_logs
+WHERE scope = 'Insight' AND item_id = '42'
+ORDER BY created_at DESC
+```
+
+**Search for a specific change in detail JSON:**
+
+```sql
+SELECT id, scope, activity, detail, created_at
+FROM system.activity_logs
+WHERE JSONExtractString(detail, 'name') ILIKE '%signup%'
+ORDER BY created_at DESC
+LIMIT 20
+```

--- a/products/posthog_ai/skills/query-examples/references/models-activity-logs.md
+++ b/products/posthog_ai/skills/query-examples/references/models-activity-logs.md
@@ -8,6 +8,7 @@ Activity logs track user and system actions across PostHog entities, providing a
 
 Column | Type | Nullable | Description
 `id` | uuid | NOT NULL | Primary key (auto-generated UUID)
+`team_id` | integer | NULL | Team the activity belongs to
 `activity` | varchar(79) | NOT NULL | Action performed (e.g., `created`, `updated`, `deleted`)
 `item_id` | varchar(72) | NULL | ID of the entity being logged (may be numeric ID, short ID, or UUID)
 `scope` | varchar(79) | NOT NULL | Entity type being logged (e.g., `FeatureFlag`, `Insight`)


### PR DESCRIPTION
## Problem

Got a customer request to include Activity Logs in the MCP server.

## Changes

- Added the system table for Activity Logs (scoped by team_id).
- Updated the skill to include activity logs.
- **Tests**: Added factory function and test coverage in `test_system_tables.py` to ensure isolation tests run for the new table

## How did you test this code?

Added unit test coverage via `_create_activity_log` factory function and `SYSTEM_TABLE_FACTORIES` registration, which ensures the activity_logs table is included in the system tables isolation test suite. The test infrastructure validates that the table schema is properly defined and accessible.

## Publish to changelog?

Yes - this exposes a new queryable system table to users.