### PR TITLE
fix(dashboard): fixes a bug with dashboard tables not being scrollable inside cards

### DIFF
--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -20,6 +20,13 @@ export type ScrollableShadowsProps = {
     style?: CSSProperties
     /** Whether to disable scrolling. */
     disableScroll?: boolean
+    /**
+     * Whether scrolling should be constrained to the given direction.
+     * When false, both axes are allowed to scroll.
+     * Defaults to true for backwards compatibility.
+     * Should be used in conjunction with direction
+     */
+    constrainToDirection?: boolean
     /** Whether to hide the scrollable shadows. */
     hideShadows?: boolean
     /** Whether to hide the scrollbars. */
@@ -35,6 +42,7 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
         scrollRef,
         styledScrollbars = false,
         disableScroll = false,
+        constrainToDirection = true,
         hideShadows = false,
         hideScrollbars = false,
         style,
@@ -70,10 +78,12 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
                 style={
                     disableScroll
                         ? { overflow: 'hidden' }
-                        : {
-                              overflowX: direction === 'horizontal' ? undefined : 'hidden',
-                              overflowY: direction === 'vertical' ? undefined : 'hidden',
-                          }
+                        : constrainToDirection
+                          ? {
+                                overflowX: direction === 'horizontal' ? undefined : 'hidden',
+                                overflowY: direction === 'vertical' ? undefined : 'hidden',
+                            }
+                          : undefined
                 }
             >
                 {children}

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -88,6 +88,10 @@ export interface LemonTableProps<T extends Record<string, any>> {
     maxHeaderWidth?: string
     /** Whether to hide the scrollbar. */
     hideScrollbar?: boolean
+    /**
+     * Whether the table content is allowed to scroll inside its container.
+     */
+    allowContentScroll?: boolean
     /** Row actions to display in a "More" menu at the end of each row. Return null to hide actions for specific rows. */
     rowActions?: (record: T, recordIndex: number) => React.ReactNode | null
     /** Whether to hide the sorting indicator when no sort is active. Defaults to false. */
@@ -129,6 +133,7 @@ export function LemonTable<T extends Record<string, any>>({
     pinnedColumns,
     maxHeaderWidth,
     hideScrollbar,
+    allowContentScroll = false,
     rowActions,
     hideSortingIndicatorWhenInactive = false,
 }: LemonTableProps<T>): JSX.Element {
@@ -267,6 +272,7 @@ export function LemonTable<T extends Record<string, any>>({
             <ScrollableShadows
                 innerClassName={hideScrollbar ? 'hide-scrollbar' : undefined}
                 direction="horizontal"
+                constrainToDirection={!allowContentScroll}
                 scrollRef={scrollRef}
             >
                 <div className="LemonTable__content">

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -468,6 +468,9 @@ export function InsightsTable({
             firstColumnSticky
             pinnedColumns={pinnedColumns}
             maxHeaderWidth="20rem"
+            // Allow vertical scrolling within the card so long tables
+            // inside dashboards remain scrollable without resizing tiles.
+            allowContentScroll
         />
     )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -470,7 +470,7 @@ export function InsightsTable({
             maxHeaderWidth="20rem"
             // Allow vertical scrolling within the card so long tables
             // inside dashboards remain scrollable without resizing tiles.
-            allowContentScroll
+            allowContentScroll={isInDashboardContext}
         />
     )
 }


### PR DESCRIPTION
## Problem

When in the dashboard, and a table is inside a card, it is not scrollable due to the ScrollableShadows a table is in not allowing scrolling. noticed this when looking at a replay.

## Changes

Adds a new property to scrollableShadows and tables that allow bypassing this, which is defaulted to existing behaviour.


Before:
<img width="1162" height="483" alt="image" src="https://github.com/user-attachments/assets/7dcea2ee-ff84-4cee-aeb0-884987189d4f" />


After:
<img width="1123" height="470" alt="image" src="https://github.com/user-attachments/assets/1156a8f5-9516-4ae5-814e-9f429a715758" />


## How did you test this code?

Locally.
## Publish to changelog?
No.