### PR TITLE
feat(web-analytics): gate referrer URL drilldown behind feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -222,6 +222,7 @@ export const FEATURE_FLAGS = {
     TRACK_REACT_FRAMERATE: 'track-react-framerate', // owner: @pauldambra #team-replay
     WEB_ANALYTICS_API: 'web-analytics-api', // owner: #team-web-analytics
     WEB_ANALYTICS_FOR_MOBILE: 'web-analytics-for-mobile', // owner: #team-web-analytics
+    WEB_ANALYTICS_REFERRER_URL_DRILLDOWN: 'web-analytics-referrer-url-drilldown', // owner: @jabahamondes #team-web-analytics
     WEB_EXPERIMENTS: 'web-experiments', // owner: #team-experiments
 
     // Temporary feature flags, still WIP, should be removed eventually

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -204,6 +204,7 @@ const TabsTileItem = ({ tile }: { tile: TabsTile }): JSX.Element => {
                 insightProps: tab.insightProps,
             }))}
             tileId={tile.tileId}
+            splitIndices={tile.splitIndices}
             getNewInsightUrl={getNewInsightUrl}
         />
     )
@@ -237,6 +238,7 @@ export const WebTabs = ({
     setActiveTabId,
     getNewInsightUrl,
     tileId,
+    splitIndices,
 }: {
     className?: string
     activeTabId: string
@@ -254,6 +256,7 @@ export const WebTabs = ({
     setActiveTabId: (id: string) => void
     getNewInsightUrl: (tileId: TileId, tabId: string) => string | undefined
     tileId: TileId
+    splitIndices?: number[]
 }): JSX.Element => {
     const activeTab = tabs.find((t) => t.id === activeTabId)
     const newInsightUrl = getNewInsightUrl(tileId, activeTabId)
@@ -340,7 +343,7 @@ export const WebTabs = ({
                 )}
 
                 <LemonSegmentedDropdown
-                    splitIndices={tabSplitIndicesMap[tileId]}
+                    splitIndices={splitIndices ?? tabSplitIndicesMap[tileId]}
                     size="small"
                     value={activeTabId}
                     onChange={setActiveTabId}

--- a/frontend/src/scenes/web-analytics/common.ts
+++ b/frontend/src/scenes/web-analytics/common.ts
@@ -263,6 +263,7 @@ export interface TabsTile extends BaseTile {
     activeTabId: string
     setTabId: (id: string) => void
     tabs: TabsTileTab[]
+    splitIndices?: number[]
 }
 
 export interface ReplayTile extends BaseTile {

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -35,6 +35,7 @@ import {
     GeographyTab,
     ProductTab,
     SOURCE_DRILL_DOWN_MAP,
+    SourceTab,
     TileId,
     faviconUrl,
     webStatsBreakdownToPropertyName,
@@ -831,12 +832,20 @@ export const WebStatsTableTile = ({
     const utmCampaign = webStatsBreakdownToPropertyName(WebStatsBreakdown.InitialUTMCampaign)!
     const referringDomain = webStatsBreakdownToPropertyName(WebStatsBreakdown.InitialReferringDomain)!
 
+    const { featureFlags } = useValues(featureFlagLogic)
+
     const getDrillDownTabChange = useCallback(
         (
             filterKey: string,
             filterValue: string | number | null
         ): { sourceTab?: string; geographyTab?: string; deviceTab?: string } | undefined => {
-            const sourceTab = SOURCE_DRILL_DOWN_MAP[breakdownBy]
+            const sourceDrillDown = SOURCE_DRILL_DOWN_MAP[breakdownBy]
+            // When the referrer URL drilldown flag is off, navigate to UTM source instead of referrer URL
+            const sourceTab =
+                !featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REFERRER_URL_DRILLDOWN] &&
+                sourceDrillDown === SourceTab.REFERRING_URL
+                    ? SourceTab.UTM_SOURCE
+                    : sourceDrillDown
             const geographyTab = GEOGRAPHY_DRILL_DOWN_MAP[breakdownBy]
             const deviceTab = DEVICE_DRILL_DOWN_MAP[breakdownBy]
             const drillDownTab = sourceTab || geographyTab || deviceTab
@@ -858,7 +867,7 @@ export const WebStatsTableTile = ({
                 ...(deviceTab ? { deviceTab } : {}),
             }
         },
-        [breakdownBy, rawWebAnalyticsFilters]
+        [breakdownBy, rawWebAnalyticsFilters, featureFlags]
     )
 
     const onClick = useCallback(

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -840,11 +840,11 @@ export const WebStatsTableTile = ({
             filterValue: string | number | null
         ): { sourceTab?: string; geographyTab?: string; deviceTab?: string } | undefined => {
             const sourceDrillDown = SOURCE_DRILL_DOWN_MAP[breakdownBy]
-            // When the referrer URL drilldown flag is off, navigate to UTM source instead of referrer URL
+            // When the referrer URL drilldown flag is off, don't navigate away from referrer domain
             const sourceTab =
                 !featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REFERRER_URL_DRILLDOWN] &&
                 sourceDrillDown === SourceTab.REFERRING_URL
-                    ? SourceTab.UTM_SOURCE
+                    ? undefined
                     : sourceDrillDown
             const geographyTab = GEOGRAPHY_DRILL_DOWN_MAP[breakdownBy]
             const deviceTab = DEVICE_DRILL_DOWN_MAP[breakdownBy]

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1512,22 +1512,26 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                     },
                                 }
                             ),
-                            createTableTab(
-                                TileId.SOURCES,
-                                SourceTab.REFERRING_URL,
-                                'Referrer URLs',
-                                'Referring URL',
-                                WebStatsBreakdown.InitialReferringURL,
-                                {},
-                                {
-                                    docs: {
-                                        url: 'https://posthog.com/docs/web-analytics/dashboard#channels-referrers-utms',
-                                        title: 'Referrer URLs',
-                                        description:
-                                            'Full referring URLs (without query parameters) showing where your users came from',
-                                    },
-                                }
-                            ),
+                            ...(featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REFERRER_URL_DRILLDOWN]
+                                ? [
+                                      createTableTab(
+                                          TileId.SOURCES,
+                                          SourceTab.REFERRING_URL,
+                                          'Referrer URLs',
+                                          'Referring URL',
+                                          WebStatsBreakdown.InitialReferringURL,
+                                          {},
+                                          {
+                                              docs: {
+                                                  url: 'https://posthog.com/docs/web-analytics/dashboard#channels-referrers-utms',
+                                                  title: 'Referrer URLs',
+                                                  description:
+                                                      'Full referring URLs (without query parameters) showing where your users came from',
+                                              },
+                                          }
+                                      ),
+                                  ]
+                                : []),
                             createTableTab(
                                 TileId.SOURCES,
                                 SourceTab.UTM_SOURCE,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1445,6 +1445,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         },
                         activeTabId: sourceTab,
                         setTabId: actions.setSourceTab,
+                        splitIndices: featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REFERRER_URL_DRILLDOWN]
+                            ? [1, 3] // [Channel] [Referring Domain ▼ Referring URL] [UTM Source ▼ ...]
+                            : [2], // [Channel] [Referring Domain] [UTM Source ▼ ...]
                         tabs: [
                             createTableTab(
                                 TileId.SOURCES,


### PR DESCRIPTION
## Problem

The referrer URL drilldown feature (navigating from referrer domain to referrer URL) was shipped without a feature flag, making it hard to control the rollout and revert if needed.

## Changes

- Add `WEB_ANALYTICS_REFERRER_URL_DRILLDOWN` feature flag
- Gate the "Referrer URLs" tab in the Sources tile behind the flag
- Gate the drill-down navigation from referrer domain → referrer URL behind the flag (when off, clicking a referrer domain only filters without changing tabs)
- Adjust `splitIndices` dynamically: with the flag on, Referring Domain and Referring URL are grouped in a dropdown; with the flag off, Referring Domain is a standalone button alongside Channel
- Add `splitIndices` prop to `TabsTile` interface so tiles can define their own tab grouping

## How did you test this code?

Verified the feature flag controls both the tab visibility and the drill-down navigation behavior.

## Publish to changelog?

no
