### PR TITLE
feat(error-tracking): add bulk unassign button to issue listing

### DIFF
--- a/products/error_tracking/frontend/components/IssueActions/IssueActions.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/IssueActions.tsx
@@ -137,6 +137,11 @@ export function IssueActions({ issues, selectedIds }: IssueActionsProps): JSX.El
                         </LemonButton>
                     )}
                 </AssigneeSelect>
+                {issues.some((issue) => selectedIds.includes(issue.id) && issue.assignee != null) && (
+                    <LemonButton type="secondary" size="small" onClick={() => assignIssues(selectedIds, null)}>
+                        Unassign
+                    </LemonButton>
+                )}
             </div>
             <LemonButton type="secondary" size="small" onClick={excludeSelectedIssues}>
                 Hide from search


### PR DESCRIPTION
## Problem

Users who bulk-assigned issues have no way to bulk-unassign them from the issue listing page. They must open each issue individually to remove the assignee.

## Changes

- Add an "Unassign" button to the bulk action bar in `IssueActions.tsx`
- The button only appears when at least one selected issue has an assignee
- Calls the existing bulk assign endpoint with a `null` assignee, which the backend already handles by deleting the assignment record

## How did you test this code?

No new tests — this reuses the existing `assignIssues` action and `bulkAssign` API call with `null`, which the backend already supports (the `assign_issue` helper deletes the assignment when assignee is falsy).

## Publish to changelog?

no

<img width="744" height="305" alt="image" src="https://github.com/user-attachments/assets/fedf7c16-5980-497d-b625-4168d8ddcdba" />
