### PR TITLE
fix(insights): restore optional null chaining HogQLBoldNumber

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -266,8 +266,8 @@ export function HogQLBoldNumber(): JSX.Element {
 
     const formattedValue = tabularData[0]?.[0]?.formattedValue ?? null
     const directValue = Array.isArray(response) ? response[0]?.[0] : undefined
-    const resultsValue = 'results' in response ? response.results[0]?.[0] : undefined
-    const resultValue = 'result' in response ? response.result[0]?.[0] : undefined
+    const resultsValue = 'results' in response ? response.results?.[0]?.[0] : undefined
+    const resultValue = 'result' in response ? response.result?.[0]?.[0] : undefined
 
     // If any of the values is null, show empty state
     if (formattedValue === null || directValue === null || resultsValue === null || resultValue === null) {


### PR DESCRIPTION
## Problem

The TypeScript 5.5 upgrade (#49824, merged March 6) removed optional chaining from `response.result` and `response.results` accesses in `HogQLBoldNumber`, causing `TypeError: Cannot read properties of null (reading '0')`.

This happens when an `InsightModel` with `result: null` is passed as `cachedResults` to `dataNodeLogic` — e.g. on dashboards before query results are loaded. The `'result' in response` check passes because the key exists on the object, but the value is `null`, and `null[0]` throws.

183 occurrences across 21 users since March 7. Error tracking issue: https://us.posthog.com/error_tracking/019cc6e6-ef93-7392-bc8a-3faef56e8665

## Changes

Restored optional chaining (`?.`) on `response.results` and `response.result` accesses in `HogQLBoldNumber` (lines 269-270 of `BoldNumber.tsx`).

## How did you test this code?

This restores the pre-existing safe access pattern that was accidentally removed during the TS upgrade. I didn't test this manually.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

## 🤖 LLM context

Fix authored with Claude Code. 