### PR TITLE
fix(llma): clarify evals billing banner with doc links

### DIFF
--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -277,7 +277,15 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
             )}
 
             <LemonBanner type="info" dismissKey="evals-billing-notice">
-                Each evaluation run counts as an LLM analytics event.
+                Each{' '}
+                <Link to="https://posthog.com/docs/llm-analytics/evaluations#llm-as-a-judge-evaluations" target="_blank">
+                    LLM Judge
+                </Link>{' '}
+                evaluation run counts as an LLM analytics event.{' '}
+                <Link to="https://posthog.com/docs/llm-analytics/evaluations#code-based-evaluations-hog" target="_blank">
+                    Hog code evals
+                </Link>{' '}
+                are free.
             </LemonBanner>
 
             <div className="flex justify-between items-center">


### PR DESCRIPTION
## Summary

- Updates the evals billing notice banner to distinguish between LLM Judge evals (billable) and Hog code evals (free)
- Adds links to the relevant PostHog docs sections for each eval type

## Test plan

- [ ] Verify banner renders correctly with both links
- [ ] Verify links open correct doc sections in new tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)