### PR TITLE
fix(ds): pass schema name filter to validate_credentials

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -225,7 +225,7 @@ class PostgresSource(SimpleSource[PostgresSourceConfig], SSHTunnelMixin, Validat
             return valid_host, host_errors
 
         try:
-            self.get_schemas(config, team_id)
+            self.get_schemas(config, team_id, names=[schema_name] if schema_name else None)
         except SSLRequiredError as e:
             return False, str(e)
         except OperationalError as e:


### PR DESCRIPTION
## Problem

When a user has an already-imported Postgres source and wants to set up (enable) a new schema, the `incremental_fields` endpoint in`ExternalDataSchemaViewSet` calls `validate_credentials(config, team_id, instance.name)` with the specific schema name. However,`PostgresSource.validate_credentials` was ignoring that parameter and calling `self.get_schemas(config, team_id)` without filtering, fetching all tables instead of just the one being set up.

## Changes

  * Fixed `PostgresSource.validate_credentials` to pass `names=[schema_name]` to `get_schemas` when `schema_name` is provided

## How did you test this code?

I can't manage to test this locally, so I've just triplechecked everything
All test pass

## Publish to changelog?

NO
