### PR TITLE
fix(toolbar): replaceState bugs

### DIFF
--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -371,6 +371,29 @@ describe('toolbar toolbarConfigLogic', () => {
             warnSpy.mockRestore()
         })
 
+        it('resets authStatus to idle after failed code exchange with fallback', async () => {
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+            localStorage.setItem(
+                OAUTH_LOCALSTORAGE_KEY,
+                JSON.stringify({
+                    accessToken: 'stored-access',
+                    refreshToken: 'stored-refresh',
+                    clientId: 'stored-client',
+                })
+            )
+            localStorage.removeItem(PKCE_STORAGE_KEY)
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:stale,client_id:some-client')
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            await expectLogic(logic).delay(0).toMatchValues({
+                authStatus: 'idle',
+                isAuthenticated: true,
+            })
+            warnSpy.mockRestore()
+        })
+
         it('remains unauthenticated when code exchange fails and no stored tokens exist', async () => {
             const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
             localStorage.removeItem(OAUTH_LOCALSTORAGE_KEY)

--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -2,7 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
-import { cleanToolbarAuthHash, OAUTH_LOCALSTORAGE_KEY, PKCE_STORAGE_KEY } from '~/toolbar/utils'
+import { cleanToolbarAuthHash, OAUTH_LOCALSTORAGE_KEY, PKCE_STORAGE_KEY, readToolbarAuthHash } from '~/toolbar/utils'
 
 global.fetch = jest.fn(() =>
     Promise.resolve({
@@ -243,6 +243,233 @@ describe('toolbar toolbarConfigLogic', () => {
         })
     })
 
+    describe('toolbar re-launch and token persistence', () => {
+        afterEach(() => {
+            window.history.pushState({}, '', '/')
+        })
+
+        it('restores tokens from OAuth localStorage when posthog-js re-launches without tokens', () => {
+            // posthog-js overwrites _postHogToolbarParams on re-launch, losing tokens.
+            // OAuth tokens are persisted separately in _postHogToolbarOAuth.
+            localStorage.setItem(
+                OAUTH_LOCALSTORAGE_KEY,
+                JSON.stringify({
+                    accessToken: 'stored-access',
+                    refreshToken: 'stored-refresh',
+                    clientId: 'stored-client',
+                })
+            )
+            const logic = toolbarConfigLogic.build({
+                apiURL: 'http://localhost',
+                token: 'phc_test',
+                // No accessToken — simulates posthog-js overwrite
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                accessToken: 'stored-access',
+                refreshToken: 'stored-refresh',
+                clientId: 'stored-client',
+                isAuthenticated: true,
+            })
+        })
+
+        it('does not restore stored tokens when props already include tokens', () => {
+            localStorage.setItem(
+                OAUTH_LOCALSTORAGE_KEY,
+                JSON.stringify({
+                    accessToken: 'old-stored',
+                    refreshToken: 'old-stored-refresh',
+                    clientId: 'old-stored-client',
+                })
+            )
+            const logic = toolbarConfigLogic.build({
+                apiURL: 'http://localhost',
+                accessToken: 'props-access',
+                refreshToken: 'props-refresh',
+                clientId: 'props-client',
+            })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({ accessToken: 'props-access' })
+        })
+
+        it('code exchange takes priority over stored tokens', async () => {
+            // If a fresh code is in the hash, exchange it instead of restoring old tokens
+            localStorage.setItem(
+                OAUTH_LOCALSTORAGE_KEY,
+                JSON.stringify({
+                    accessToken: 'old-stored',
+                    refreshToken: 'old-refresh',
+                    clientId: 'old-client',
+                })
+            )
+            localStorage.setItem(PKCE_STORAGE_KEY, JSON.stringify({ verifier: 'test-verifier', ts: Date.now() }))
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:fresh,client_id:new-client')
+            mockTokenExchangeSuccess()
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            await expectLogic(logic).delay(0).toMatchValues({
+                accessToken: 'new-access',
+                refreshToken: 'new-refresh',
+                isAuthenticated: true,
+            })
+        })
+
+        it('falls back to stored tokens when code exchange fails due to expired PKCE', async () => {
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+            localStorage.setItem(
+                OAUTH_LOCALSTORAGE_KEY,
+                JSON.stringify({
+                    accessToken: 'stored-access',
+                    refreshToken: 'stored-refresh',
+                    clientId: 'stored-client',
+                })
+            )
+            // PKCE verifier expired
+            localStorage.setItem(
+                PKCE_STORAGE_KEY,
+                JSON.stringify({ verifier: 'expired-verifier', ts: Date.now() - 11 * 60 * 1000 })
+            )
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:stale,client_id:some-client')
+            mockTokenExchangeSuccess()
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            await expectLogic(logic).delay(0).toMatchValues({
+                accessToken: 'stored-access',
+                refreshToken: 'stored-refresh',
+                clientId: 'stored-client',
+                isAuthenticated: true,
+            })
+            warnSpy.mockRestore()
+        })
+
+        it('falls back to stored tokens when no PKCE verifier exists', async () => {
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+            localStorage.setItem(
+                OAUTH_LOCALSTORAGE_KEY,
+                JSON.stringify({
+                    accessToken: 'stored-access',
+                    refreshToken: 'stored-refresh',
+                    clientId: 'stored-client',
+                })
+            )
+            localStorage.removeItem(PKCE_STORAGE_KEY)
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:stale,client_id:some-client')
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            await expectLogic(logic).delay(0).toMatchValues({
+                accessToken: 'stored-access',
+                isAuthenticated: true,
+            })
+            warnSpy.mockRestore()
+        })
+
+        it('remains unauthenticated when code exchange fails and no stored tokens exist', async () => {
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+            localStorage.removeItem(OAUTH_LOCALSTORAGE_KEY)
+            localStorage.setItem(
+                PKCE_STORAGE_KEY,
+                JSON.stringify({ verifier: 'expired-verifier', ts: Date.now() - 11 * 60 * 1000 })
+            )
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:stale,client_id:some-client')
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            await expectLogic(logic).delay(0).toMatchValues({
+                isAuthenticated: false,
+                accessToken: null,
+            })
+            warnSpy.mockRestore()
+        })
+
+        it('setOAuthTokens persists to separate OAuth localStorage key', () => {
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            logic.actions.setOAuthTokens('new-access', 'new-refresh', 'new-client')
+
+            const stored = JSON.parse(localStorage.getItem(OAUTH_LOCALSTORAGE_KEY) || '{}')
+            expect(stored).toEqual({
+                accessToken: 'new-access',
+                refreshToken: 'new-refresh',
+                clientId: 'new-client',
+            })
+        })
+
+        it('logout clears both localStorage keys', () => {
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            // Authenticate first so tokens are persisted
+            logic.actions.setOAuthTokens('access', 'refresh', 'client')
+            expect(localStorage.getItem(OAUTH_LOCALSTORAGE_KEY)).not.toBeNull()
+
+            logic.actions.logout()
+
+            expect(localStorage.getItem(OAUTH_LOCALSTORAGE_KEY)).toBeNull()
+            expect(localStorage.getItem('_postHogToolbarParams')).toBeNull()
+            expect(localStorage.getItem(PKCE_STORAGE_KEY)).toBeNull()
+        })
+
+        it('tokenExpired clears OAuth localStorage key', () => {
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            logic.actions.setOAuthTokens('access', 'refresh', 'client')
+            expect(localStorage.getItem(OAUTH_LOCALSTORAGE_KEY)).not.toBeNull()
+
+            logic.actions.tokenExpired()
+
+            expect(localStorage.getItem(OAUTH_LOCALSTORAGE_KEY)).toBeNull()
+        })
+
+        it('survives mount/unmount/remount cycle with tokens intact', () => {
+            // First mount: set tokens
+            const logic1 = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic1.mount()
+            logic1.actions.setOAuthTokens('persisted-access', 'persisted-refresh', 'persisted-client')
+            logic1.unmount()
+
+            // Second mount: tokens should be restored from OAuth localStorage
+            const logic2 = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic2.mount()
+
+            expectLogic(logic2).toMatchValues({
+                accessToken: 'persisted-access',
+                refreshToken: 'persisted-refresh',
+                clientId: 'persisted-client',
+                isAuthenticated: true,
+            })
+        })
+
+        it('handles corrupted OAuth localStorage gracefully', () => {
+            localStorage.setItem(OAUTH_LOCALSTORAGE_KEY, 'not-valid-json{{{')
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({ isAuthenticated: false, accessToken: null })
+        })
+
+        it('handles partial OAuth localStorage data gracefully', () => {
+            localStorage.setItem(OAUTH_LOCALSTORAGE_KEY, JSON.stringify({ accessToken: 'only-access' }))
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            // Missing refreshToken and clientId — should not restore
+            expectLogic(logic).toMatchValues({ isAuthenticated: false, accessToken: null })
+        })
+    })
+
     describe('token refresh on 401', () => {
         it('retries request with new token after successful refresh', async () => {
             const logic = toolbarConfigLogic.build({
@@ -360,12 +587,17 @@ describe('toolbar toolbarConfigLogic', () => {
             ],
             ['handles percent-encoded delimiters', '#__posthog_toolbar=code%3Aabc%2Cclient_id%3Axyz', '/'],
         ])('%s', (_label, hash, expectedUrl) => {
+            jest.useFakeTimers()
             window.history.pushState({}, '', `/${hash}`)
 
             const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
             logic.mount()
 
+            // Hash cleanup is deferred to avoid triggering SPA router re-renders
+            expect(replaceStateSpy).not.toHaveBeenCalled()
+            jest.advanceTimersByTime(500)
             expect(replaceStateSpy).toHaveBeenCalledWith(null, '', expectedUrl)
+            jest.useRealTimers()
         })
 
         it('uses uiHost-derived URLs for token exchange', async () => {
@@ -475,6 +707,70 @@ describe('toolbar toolbarConfigLogic', () => {
         })
     })
 
+    describe('readToolbarAuthHash', () => {
+        afterEach(() => {
+            window.history.pushState({}, '', '/')
+        })
+
+        it('returns code and clientId from hash without modifying the URL', () => {
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:abc,client_id:xyz')
+            const replaceStateSpy = jest.spyOn(window.history, 'replaceState')
+            const result = readToolbarAuthHash()
+            expect(result).toEqual({ code: 'abc', clientId: 'xyz' })
+            expect(replaceStateSpy).not.toHaveBeenCalled()
+            replaceStateSpy.mockRestore()
+        })
+
+        it.each([
+            ['empty hash', '/#', null],
+            ['no hash at all', '/', null],
+            ['unrelated hash', '/#some-other-hash', null],
+            ['__posthog= without _toolbar', '/#__posthog=%7B%22action%22%3A%22ph_authorize%22%7D', null],
+            ['missing code field', '/#__posthog_toolbar=client_id:xyz', null],
+            ['missing client_id field', '/#__posthog_toolbar=code:abc', null],
+            ['empty code value', '/#__posthog_toolbar=code:,client_id:xyz', null],
+            ['similar-looking param that is not toolbar', '/#__posthog_toolbar_v2=code:abc,client_id:xyz', null],
+        ])('returns null for: %s', (_label, url, expected) => {
+            window.history.pushState({}, '', url)
+            expect(readToolbarAuthHash()).toEqual(expected)
+        })
+
+        it.each([
+            ['standard params', '/#__posthog_toolbar=code:abc,client_id:xyz', { code: 'abc', clientId: 'xyz' }],
+            [
+                'base64url-safe code with dashes and underscores',
+                '/#__posthog_toolbar=code:a2gGQw68uN8fzaKelhTZZY-cuSDnP7H_x,client_id:QUKsGDyHrQqrbBwdMYaL2rmp2rPDfHJICOM5EZzY',
+                {
+                    code: 'a2gGQw68uN8fzaKelhTZZY-cuSDnP7H_x',
+                    clientId: 'QUKsGDyHrQqrbBwdMYaL2rmp2rPDfHJICOM5EZzY',
+                },
+            ],
+            [
+                'preceded by hash-based SPA route',
+                '/#/login&__posthog_toolbar=code:abc,client_id:xyz',
+                { code: 'abc', clientId: 'xyz' },
+            ],
+            [
+                'preceded by multiple hash params',
+                '/#section1&tab=2&__posthog_toolbar=code:abc,client_id:xyz',
+                { code: 'abc', clientId: 'xyz' },
+            ],
+            [
+                'coexists with __posthog= param',
+                '/#__posthog=%7B%7D&__posthog_toolbar=code:abc,client_id:xyz',
+                { code: 'abc', clientId: 'xyz' },
+            ],
+            [
+                'percent-encoded delimiters',
+                '/#__posthog_toolbar=code%3Aabc%2Cclient_id%3Axyz',
+                { code: 'abc', clientId: 'xyz' },
+            ],
+        ])('extracts params for: %s', (_label, url, expected) => {
+            window.history.pushState({}, '', url)
+            expect(readToolbarAuthHash()).toEqual(expected)
+        })
+    })
+
     describe('cleanToolbarAuthHash', () => {
         let replaceStateSpy: jest.SpyInstance
 
@@ -487,18 +783,108 @@ describe('toolbar toolbarConfigLogic', () => {
             window.history.pushState({}, '', '/')
         })
 
-        it('returns code and clientId from hash', () => {
-            window.history.pushState({}, '', '/#__posthog_toolbar=code:abc,client_id:xyz')
-            const result = cleanToolbarAuthHash()
-            expect(result).toEqual({ code: 'abc', clientId: 'xyz' })
-            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/')
+        it.each([
+            ['toolbar-only hash', '/#__posthog_toolbar=code:abc,client_id:xyz', '/'],
+            [
+                'preserves fragment before toolbar param',
+                '/#section1&__posthog_toolbar=code:abc,client_id:xyz',
+                '/#section1',
+            ],
+            ['hash-based SPA route (Angular-style)', '/#/login&__posthog_toolbar=code:abc,client_id:xyz', '/#/login'],
+            [
+                'hash-based SPA route with nested path',
+                '/#/dashboard/settings&__posthog_toolbar=code:abc,client_id:xyz',
+                '/#/dashboard/settings',
+            ],
+            [
+                'multi-part fragment with toolbar at end',
+                '/#/dashboard&tab=1&__posthog_toolbar=code:abc,client_id:xyz',
+                '/#/dashboard&tab=1',
+            ],
+            [
+                'toolbar param in the middle of other params',
+                '/#section1&__posthog_toolbar=code:abc,client_id:xyz&other=value',
+                '/#section1&other=value',
+            ],
+            [
+                'duplicate toolbar params from re-authentication',
+                '/#__posthog_toolbar=code:old,client_id:old&__posthog_toolbar=code:new,client_id:new',
+                '/',
+            ],
+            [
+                'duplicate toolbar with SPA route preserved',
+                '/#/app&__posthog_toolbar=code:old,client_id:old&__posthog_toolbar=code:new,client_id:new',
+                '/#/app',
+            ],
+            [
+                'preserves __posthog= param (owned by posthog-js)',
+                '/#__posthog=%7B%7D&__posthog_toolbar=code:abc,client_id:xyz',
+                '/#__posthog={}',
+            ],
+            ['percent-encoded toolbar param', '/#__posthog_toolbar=code%3Aabc%2Cclient_id%3Axyz', '/'],
+            ['page has query string and hash', '/#__posthog_toolbar=code:abc,client_id:xyz', '/'],
+        ])('cleanup: %s', (_label, hash, expectedUrl) => {
+            window.history.pushState({}, '', hash)
+            cleanToolbarAuthHash()
+            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', expectedUrl)
         })
 
-        it('returns null when hash does not match', () => {
-            window.history.pushState({}, '', '/#some-other-hash')
-            const result = cleanToolbarAuthHash()
-            expect(result).toBeNull()
+        it.each([
+            ['no hash at all', '/'],
+            ['unrelated hash', '/#some-other-hash'],
+            ['__posthog= without toolbar', '/#__posthog=%7B%7D'],
+            ['empty hash', '/#'],
+        ])('does nothing for: %s', (_label, url) => {
+            window.history.pushState({}, '', url)
+            cleanToolbarAuthHash()
             expect(replaceStateSpy).not.toHaveBeenCalled()
+        })
+
+        it('cleans hash on unmount even if deferred timeout has not fired', () => {
+            jest.useFakeTimers()
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:abc,client_id:xyz')
+
+            const pkcePayload = JSON.stringify({ verifier: 'test-verifier', ts: Date.now() })
+            localStorage.setItem(PKCE_STORAGE_KEY, pkcePayload)
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            expect(replaceStateSpy).not.toHaveBeenCalled()
+            logic.unmount()
+            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/')
+            jest.useRealTimers()
+        })
+
+        it('double unmount is safe (idempotent cleanup)', () => {
+            jest.useFakeTimers()
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:abc,client_id:xyz')
+
+            const pkcePayload = JSON.stringify({ verifier: 'test-verifier', ts: Date.now() })
+            localStorage.setItem(PKCE_STORAGE_KEY, pkcePayload)
+
+            // Use a real replaceState so the URL actually changes after unmount
+            replaceStateSpy.mockRestore()
+            replaceStateSpy = jest.spyOn(window.history, 'replaceState')
+
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+            logic.unmount()
+
+            expect(replaceStateSpy).toHaveBeenCalledTimes(1)
+
+            // After first unmount the hash is gone. Second call is a no-op.
+            replaceStateSpy.mockClear()
+            cleanToolbarAuthHash()
+            expect(replaceStateSpy).not.toHaveBeenCalled()
+            jest.useRealTimers()
+        })
+
+        it('preserves page query string when cleaning hash', () => {
+            // Simulate: https://example.com/page?q=search#__posthog_toolbar=code:abc,client_id:xyz
+            window.history.pushState({}, '', '/page?q=search#__posthog_toolbar=code:abc,client_id:xyz')
+            cleanToolbarAuthHash()
+            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/page?q=search')
         })
     })
 })

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -8,7 +8,14 @@ import { ToolbarProps } from '~/types'
 
 import { withTokenRefresh } from './toolbarAuth'
 import type { toolbarConfigLogicType } from './toolbarConfigLogicType'
-import { cleanToolbarAuthHash, generatePKCE, LOCALSTORAGE_KEY, OAUTH_LOCALSTORAGE_KEY, PKCE_STORAGE_KEY } from './utils'
+import {
+    cleanToolbarAuthHash,
+    generatePKCE,
+    LOCALSTORAGE_KEY,
+    OAUTH_LOCALSTORAGE_KEY,
+    PKCE_STORAGE_KEY,
+    readToolbarAuthHash,
+} from './utils'
 
 export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
     path(['toolbar', 'toolbarConfigLogic']),
@@ -167,6 +174,7 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
             // Including them would cause a re-initialization loop after OAuth callback.
             const hash = window.location.hash
                 .replace(/[#&]__posthog=[^&]*/g, '')
+                .replace(/[#&]__posthog_toolbar=[^&]*/g, '')
                 .replace(/^&/, '#')
                 .replace(/^#$/, '')
             const redirect = encodeURIComponent(
@@ -228,10 +236,13 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
     })),
 
     afterMount(({ props, values, actions, cache }) => {
-        const authParams = cleanToolbarAuthHash()
+        // Read hash params WITHOUT modifying the URL. The URL cleanup is deferred
+        // to avoid triggering SPA routers that watch for history.replaceState changes
+        // and could destroy/re-mount the page (and the toolbar) mid-initialization.
+        const authParams = readToolbarAuthHash()
         if (authParams) {
-            // Defensive retry: some SPAs re-apply the original URL on initial render,
-            // undoing the replaceState above. Re-clean after a short delay.
+            // Defer hash cleanup: some SPAs re-apply the original URL on initial render,
+            // so we retry after a short delay as well.
             cache.hashRetryTimeout = setTimeout(cleanToolbarAuthHash, 500)
         }
 
@@ -411,13 +422,20 @@ function startCodeExchange(
     authParams: { code: string; clientId: string },
     actions: TokenActions
 ): void {
-    exchangeCodeForTokens(
+    void exchangeCodeForTokens(
         `${uiHost}/oauth/token/`,
         `${uiHost}/toolbar_oauth/callback`,
         authParams.code,
         authParams.clientId,
         actions
-    )
+    ).then((succeeded) => {
+        if (!succeeded) {
+            // Code exchange failed (stale code, expired PKCE, network error).
+            // Fall back to stored OAuth tokens so users don't have to
+            // re-authenticate when the hash wasn't cleaned properly.
+            restoreOAuthTokens(false, { accessToken: null }, actions)
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -432,7 +450,7 @@ async function exchangeCodeForTokens(
     code: string,
     clientId: string,
     actions: TokenActions
-): Promise<void> {
+): Promise<boolean> {
     actions.setAuthStatus('authenticating')
 
     let pkceData: { verifier?: string; ts?: number } = {}
@@ -446,13 +464,11 @@ async function exchangeCodeForTokens(
 
     if (!pkceData.verifier) {
         console.warn('PostHog Toolbar: no PKCE verifier found, cannot exchange code')
-        lemonToast.error('Authentication failed: session data missing. Please try again.')
-        return
+        return false
     }
     if (pkceData.ts && Date.now() - pkceData.ts > PKCE_TTL_MS) {
         console.warn('PostHog Toolbar: PKCE verifier expired')
-        lemonToast.error('Authentication timed out. Please try again.')
-        return
+        return false
     }
 
     const body = new URLSearchParams({
@@ -472,13 +488,15 @@ async function exchangeCodeForTokens(
         const data = await res.json()
         if (data.access_token && data.refresh_token) {
             actions.setOAuthTokens(data.access_token, data.refresh_token, clientId)
-        } else {
-            console.error('PostHog Toolbar: token exchange failed', data.error || data)
-            lemonToast.error('Authentication failed. Please try again.')
+            return true
         }
+        console.error('PostHog Toolbar: token exchange failed', data.error || data)
+        lemonToast.error('Authentication failed. Please try again.')
+        return false
     } catch (err) {
         console.error('PostHog Toolbar: token exchange network error', err)
         lemonToast.error('Authentication failed due to a network error. Please try again.')
+        return false
     } finally {
         actions.setAuthStatus('idle')
     }

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -464,10 +464,12 @@ async function exchangeCodeForTokens(
 
     if (!pkceData.verifier) {
         console.warn('PostHog Toolbar: no PKCE verifier found, cannot exchange code')
+        actions.setAuthStatus('idle')
         return false
     }
     if (pkceData.ts && Date.now() - pkceData.ts > PKCE_TTL_MS) {
         console.warn('PostHog Toolbar: PKCE verifier expired')
+        actions.setAuthStatus('idle')
         return false
     }
 

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -25,31 +25,52 @@ export interface ToolbarAuthParams {
 }
 
 /**
- * Clean `__posthog_toolbar=code:…,client_id:…` from the URL hash.
+ * Read `__posthog_toolbar=code:…,client_id:…` from the URL hash without modifying the URL.
  * Returns the matched params if found, or null.
  */
-export function cleanToolbarAuthHash(): ToolbarAuthParams | null {
+export function readToolbarAuthHash(): ToolbarAuthParams | null {
     let hash: string
     try {
         hash = decodeURIComponent(window.location.hash)
     } catch {
         hash = window.location.hash
     }
-    const codeMatch = hash.match(/__posthog_toolbar=code:([^,]+),client_id:([^,&#]+)/)
+    const codeMatch = hash.match(/__posthog_toolbar=code:([^,]+),client_id:([^,&]+)/)
     if (!codeMatch) {
         return null
     }
-
-    const cleanHash = hash
-        .replace(/__posthog_toolbar=[^&#]*/, '')
-        .replace(/&$/, '')
-        .replace(/^#&/, '#')
-        .replace(/^#$/, '')
-    history.replaceState(null, '', location.pathname + location.search + (cleanHash || ''))
     return {
         code: codeMatch[1],
         clientId: codeMatch[2],
     }
+}
+
+/**
+ * Remove `__posthog_toolbar=code:…,client_id:…` from the URL hash.
+ *
+ * Separated from reading so that the URL modification (history.replaceState)
+ * can be deferred — some SPAs watch for URL changes and re-render the page,
+ * which can destroy the toolbar mid-initialization if the hash is cleaned
+ * synchronously during mount.
+ */
+export function cleanToolbarAuthHash(): void {
+    let hash: string
+    try {
+        hash = decodeURIComponent(window.location.hash)
+    } catch {
+        hash = window.location.hash
+    }
+    if (!hash.includes('__posthog_toolbar=')) {
+        return
+    }
+
+    const cleanHash = hash
+        .replace(/__posthog_toolbar=[^&]*/g, '')
+        .replace(/&&+/g, '&')
+        .replace(/&$/, '')
+        .replace(/^#&/, '#')
+        .replace(/^#$/, '')
+    history.replaceState(null, '', location.pathname + location.search + (cleanHash || ''))
 }
 
 export async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {

--- a/posthog/api/oauth/toolbar_service.py
+++ b/posthog/api/oauth/toolbar_service.py
@@ -125,10 +125,13 @@ def normalize_and_validate_app_url(team: Team, app_url: str) -> str:
             403,
         )
 
-    # Strip __posthog hash params — posthog-js toolbar launch params must not
-    # survive the OAuth round-trip or they cause a re-initialization loop.
+    # Strip __posthog and __posthog_toolbar hash params — posthog-js toolbar
+    # launch params must not survive the OAuth round-trip or they cause a
+    # re-initialization loop, and leftover __posthog_toolbar params cause
+    # duplicate params on re-authentication.
     if parsed.fragment and "__posthog" in parsed.fragment:
-        clean_fragment = re.sub(r"&?__posthog=[^&]*", "", parsed.fragment).strip("&")
+        clean_fragment = re.sub(r"&?__posthog_toolbar=[^&]*", "", parsed.fragment)
+        clean_fragment = re.sub(r"&?__posthog=[^&]*", "", clean_fragment).strip("&")
         return urlunparse(parsed._replace(fragment=clean_fragment))
 
     return app_url

--- a/posthog/api/test/test_toolbar_oauth_primitives.py
+++ b/posthog/api/test/test_toolbar_oauth_primitives.py
@@ -20,6 +20,7 @@ from posthog.api.oauth.toolbar_service import (
     build_toolbar_oauth_state,
     get_or_create_toolbar_oauth_application,
     new_state_nonce,
+    normalize_and_validate_app_url,
     toolbar_oauth_state_cache,
 )
 from posthog.models import Organization, Team, User
@@ -339,7 +340,6 @@ class TestToolbarOAuthCallbackExchange(APIBaseTest):
         assert "#section1&__posthog_toolbar=code:auth_code_123" in redirect_url
 
     def test_callback_strips_posthog_hash_from_redirect(self):
-        """__posthog hash params must not survive the OAuth round-trip or they cause a re-init loop."""
         posthog_hash = "%7B%22action%22%3A%22ph_authorize%22%2C%22token%22%3A%22phc_test%22%7D"
         state = self._authorize_and_get_state(redirect_url=f"https://example.com/page#__posthog={posthog_hash}")
         response = self.client.get(f"/toolbar_oauth/callback?code=auth_code_123&state={state}")
@@ -347,6 +347,17 @@ class TestToolbarOAuthCallbackExchange(APIBaseTest):
         assert response.status_code == 302
         redirect_url = response["Location"]
         assert "__posthog=" not in redirect_url.split("__posthog_toolbar")[0]
+        assert "__posthog_toolbar=code:auth_code_123" in redirect_url
+
+    def test_callback_strips_posthog_toolbar_hash_from_redirect(self):
+        state = self._authorize_and_get_state(
+            redirect_url="https://example.com/page#__posthog_toolbar=code:old,client_id:old"
+        )
+        response = self.client.get(f"/toolbar_oauth/callback?code=auth_code_123&state={state}")
+
+        assert response.status_code == 302
+        redirect_url = response["Location"]
+        assert "code:old" not in redirect_url
         assert "__posthog_toolbar=code:auth_code_123" in redirect_url
 
     def test_callback_with_invalid_state_returns_error(self):
@@ -482,3 +493,112 @@ class TestToolbarOAuthCallbackExchange(APIBaseTest):
         response = self.client.get(f"/toolbar_oauth/callback?code=abc&state={state}")
         assert response.status_code == 302
         assert response["Location"].startswith("https://example.com#__posthog_toolbar=")
+
+    def test_callback_strips_both_posthog_and_toolbar_hash(self):
+        posthog_hash = "%7B%22action%22%3A%22ph_authorize%22%7D"
+        redirect_url = f"https://example.com/page#__posthog={posthog_hash}&__posthog_toolbar=code:old,client_id:old"
+        state = self._authorize_and_get_state(redirect_url=redirect_url)
+        response = self.client.get(f"/toolbar_oauth/callback?code=auth_code_123&state={state}")
+
+        assert response.status_code == 302
+        location = response["Location"]
+        assert "__posthog=" not in location.split("__posthog_toolbar")[0]
+        assert "code:old" not in location
+        assert "__posthog_toolbar=code:auth_code_123" in location
+
+    def test_callback_preserves_spa_hash_route(self):
+        state = self._authorize_and_get_state(redirect_url="https://example.com/#/dashboard/settings")
+        response = self.client.get(f"/toolbar_oauth/callback?code=abc&state={state}")
+
+        assert response.status_code == 302
+        location = response["Location"]
+        assert "/dashboard/settings&__posthog_toolbar=code:abc" in location
+
+    def test_callback_preserves_fragment_params_after_stripping_toolbar(self):
+        state = self._authorize_and_get_state(
+            redirect_url="https://example.com/page#section1&__posthog_toolbar=code:old,client_id:old&other=value"
+        )
+        response = self.client.get(f"/toolbar_oauth/callback?code=new_code&state={state}")
+
+        assert response.status_code == 302
+        location = response["Location"]
+        assert "code:old" not in location
+        assert "section1" in location
+        assert "other=value" in location
+        assert "__posthog_toolbar=code:new_code" in location
+
+
+class TestNormalizeAndValidateAppUrl(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.app_urls = ["https://example.com"]
+        self.team.save()
+
+    @parameterized.expand(
+        [
+            (
+                "strips __posthog param",
+                "https://example.com/page#__posthog=%7B%7D",
+                "https://example.com/page",
+            ),
+            (
+                "strips __posthog_toolbar param",
+                "https://example.com/page#__posthog_toolbar=code:old,client_id:old",
+                "https://example.com/page",
+            ),
+            (
+                "strips both params",
+                "https://example.com/page#__posthog=%7B%7D&__posthog_toolbar=code:old,client_id:old",
+                "https://example.com/page",
+            ),
+            (
+                "strips both params reversed order",
+                "https://example.com/page#__posthog_toolbar=code:old,client_id:old&__posthog=%7B%7D",
+                "https://example.com/page",
+            ),
+            (
+                "preserves SPA hash route",
+                "https://example.com/#/login&__posthog_toolbar=code:old,client_id:old",
+                "https://example.com/#/login",
+            ),
+            (
+                "preserves other fragment params",
+                "https://example.com/page#section1&__posthog_toolbar=code:old,client_id:old&other=value",
+                "https://example.com/page#section1&other=value",
+            ),
+            (
+                "preserves fragment with only non-posthog params",
+                "https://example.com/page#section1&__posthog=%7B%7D&tab=2",
+                "https://example.com/page#section1&tab=2",
+            ),
+        ]
+    )
+    def test_stripping(self, _name, app_url, expected):
+        assert normalize_and_validate_app_url(self.team, app_url) == expected
+
+    @parameterized.expand(
+        [
+            ("no fragment", "https://example.com/page"),
+            ("plain fragment", "https://example.com/page#section1"),
+            ("spa route fragment", "https://example.com/#/dashboard"),
+            ("fragment with unrelated params", "https://example.com/page#tab=2&view=grid"),
+            ("url with query string and fragment", "https://example.com/page?q=search#section1"),
+        ]
+    )
+    def test_passthrough(self, _name, app_url):
+        assert normalize_and_validate_app_url(self.team, app_url) == app_url
+
+    def test_rejects_disallowed_domain(self):
+        with self.assertRaises(ToolbarOAuthError) as cm:
+            normalize_and_validate_app_url(self.team, "https://evil.com/page")
+        assert cm.exception.code == "forbidden_app_url"
+
+    def test_rejects_non_https_for_non_loopback(self):
+        with self.assertRaises(ToolbarOAuthError) as cm:
+            normalize_and_validate_app_url(self.team, "http://example.com/page")
+        assert cm.exception.code == "invalid_app_url"
+
+    def test_rejects_missing_scheme(self):
+        with self.assertRaises(ToolbarOAuthError) as cm:
+            normalize_and_validate_app_url(self.team, "example.com/page")
+        assert cm.exception.code == "invalid_app_url"


### PR DESCRIPTION
## Problem

Toolbar OAuth authentication is broken for users on sites with SPA routers. Three related bugs:

1. **SPA router destroys toolbar during mount**: `cleanToolbarAuthHash()` calls `history.replaceState()` synchronously in `afterMount`, which triggers SPA routers (React Router, Angular, etc.) to re-render the page. The toolbar is killed mid-initialization before the OAuth code exchange can run. The PKCE verifier is never consumed and the auth params remain in the URL.

2. **Duplicate params on re-authentication**: The `authenticate` handler strips `__posthog=` from the hash before building the redirect URL, but not `__posthog_toolbar=`. Re-authenticating appends new params without removing old ones, and the backend's `normalize_and_validate_app_url` also didn't strip `__posthog_toolbar=`.

3. **No fallback when code exchange fails with stored tokens available**: If stale `__posthog_toolbar=` params survive in the URL (browser crash, navigation before cleanup), the toolbar attempts a doomed code exchange (expired PKCE/stale code) and leaves the user unauthenticated — even though valid OAuth tokens exist in `_postHogToolbarOAuth` localStorage.

## Changes

**Frontend (`utils.ts`):**
- Split `cleanToolbarAuthHash()` into `readToolbarAuthHash()` (read-only, returns params) and `cleanToolbarAuthHash()` (void, modifies URL). Reading is synchronous in `afterMount`; URL cleanup is deferred via `setTimeout(500)` to avoid triggering SPA routers.
- `cleanToolbarAuthHash` regex now uses `g` flag to handle multiple occurrences, with `&&+` cleanup for consecutive ampersands.
