### PR TITLE
fix(variables): allow clearing list variable selection

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -183,9 +183,13 @@ export const VariableInput = ({
                 {variable.type === 'List' && (
                     <LemonSelect
                         className="grow"
-                        value={localInputValue}
-                        onChange={(value) => setLocalInputValue(String(value))}
+                        value={localInputValue || null}
+                        onChange={(value) => {
+                            setLocalInputValue(value ? String(value) : '')
+                            setIsNull(!value)
+                        }}
                         options={(variable.values ?? []).map((n) => ({ label: n, value: n }))}
+                        allowClear
                     />
                 )}
                 {variable.type === 'Date' && (
@@ -344,10 +348,11 @@ export const VariableComponent = ({
             <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>
                 <LemonSelect
                     disabledReason={variableOverridesAreSet && 'Discard dashboard variables to change'}
-                    value={variable.value ?? variable.default_value}
-                    onChange={(value) => onChange(variable.id, value, variable.isNull ?? false)}
+                    value={variable.value ?? variable.default_value ?? null}
+                    onChange={(value) => onChange(variable.id, value, !value)}
                     options={(variable.values ?? []).map((n) => ({ label: n, value: n }))}
                     size={size}
+                    allowClear
                 />
             </LemonField.Pure>
         )

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -187,6 +187,10 @@ export const VariableInput = ({
                         onChange={(value) => {
                             setLocalInputValue(value ? String(value) : '')
                             setIsNull(!value)
+                            if (!value) {
+                                onChange(variable.id, null, true)
+                                closePopover()
+                            }
                         }}
                         options={(variable.values ?? []).map((n) => ({ label: n, value: n }))}
                         allowClear


### PR DESCRIPTION
Add `allowClear` to LemonSelect for list-type HogQL variables in both view/dashboard mode and edit popover mode. This lets users clear a selected list variable back to null, which is needed for optional variables (e.g. filtering by channel type).

The settings modal already had `allowClear` — this brings the runtime selectors in line.

## Problem

When using a list-type HogQL variable in a SQL insight, there's no way to clear a selected value once one has been chosen. This is fine for required variables (e.g. granularity in a time series), but for optional variables (e.g. channel type to segment conversion rates) users have no way to return to an unfiltered/non-segmented view. The current workaround is to use a string variable instead.

## Changes

- Added `allowClear` prop to `LemonSelect` for list variables in **view/dashboard mode** (`VariableComponent`)
- Added `allowClear` prop to `LemonSelect` for list variables in **edit popover mode** (`VariableInput`)
- When the user clears the selection, `isNull` is set to `true` so the variable correctly resolves to null in the query

Both changes are in `frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx`. The `ListDefaultField` in `VariableFields.tsx` (settings modal) already had `allowClear` — this brings the runtime UI in line.

## How did you test this code?

Manual testing steps:
1. Create a SQL insight with a list-type variable
2. Select a value from the list
3. Verify the X button now appears to clear the selection
4. Clear the selection and confirm the query re-runs with a null variable value

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code (Opus 4.6).
