### PR TITLE
chore: add inkeep bot trigger override

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,10 @@
 
 <!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
 
+## Docs update
+
+<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
+
 <!-- ## 🤖 LLM context -->
 
 <!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->

--- a/.github/workflows/inkeep-agent.yml
+++ b/.github/workflows/inkeep-agent.yml
@@ -1,35 +1,32 @@
 name: Inkeep Agent
-
 on:
     pull_request:
         types: [closed]
-
     issue_comment:
         types: [created]
-
     pull_request_review_comment:
         types: [created]
-
     pull_request_review:
         types: [submitted]
-
 permissions:
     contents: read
     pull-requests: read
     id-token: write
-
 jobs:
     trigger-agent:
         if: |
-            (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.user.login != 'inkeep[bot]') ||
-            (github.event_name == 'issue_comment' &&  github.event.issue.pull_request && contains(github.event.comment.body, '@inkeep')) ||
-            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@inkeep')) ||
-            (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@inkeep'))
+            !contains(github.event.pull_request.labels.*.name, 'skip-inkeep-docs') &&
+            !contains(github.event.issue.labels.*.name, 'skip-inkeep-docs') &&
+            (
+              (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.user.login != 'inkeep[bot]') ||
+              (github.event_name == 'issue_comment' &&  github.event.issue.pull_request && contains(github.event.comment.body, '@inkeep')) ||
+              (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@inkeep')) ||
+              (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@inkeep'))
+            )
         runs-on: ubuntu-latest
         steps:
             - name: Trigger Inkeep Agent
               uses: inkeep/inkeep-agents-action@39c725a2bf4d24acb89ae70139e13bf50f637c20 # v0.6.0
               with:
                   trigger-url: ${{ secrets.INKEEP_TRIGGER_URL }}
-                  # Filters out PRs that dont match the given regex. Update regex as desired or remove entirely
                   pr-title-regex: '^(feat|fix|docs|chore)(\(.+\))?:'


### PR DESCRIPTION
## Problem

right now, it's not easy to override the Inkeep bot docs PR triggers. sometimes it opens docs PRs that aren't needed. this adds a label that will override the trigger and reduce token burn. we went with a label here so it's easier to control

## Changes

- updated inkeep-agent workflow to include `skip-inkeep-docs` label that overrides triggers
- updated PR template to include note about using the label

## Publish to changelog?

no
