### PR TITLE
fix: retry kafka broker errors with error code -1

### DIFF
--- a/nodejs/src/utils/retries.ts
+++ b/nodejs/src/utils/retries.ts
@@ -56,7 +56,12 @@ export async function retryIfRetriable<T>(fn: () => Promise<T>, tries = 3, sleep
         try {
             return await fn()
         } catch (error) {
-            if (error?.isRetriable === false || i === tries - 1) {
+            // rdkafka marks ERR_UNKNOWN (code -1) as non-retriable, but these are
+            // transient errors that occur.
+            // We have hit RejectedExecutionException when reading from tiered storage
+            // and not handling this led to pods being constantly restarted.
+            const isKafkaUnknownError = (error as any)?.code === -1
+            if ((error?.isRetriable === false && !isKafkaUnknownError) || i === tries - 1) {
                 // Throw if the error is not retryable or if we're out of tries.
                 throw error
             }

--- a/nodejs/src/utils/retries.ts
+++ b/nodejs/src/utils/retries.ts
@@ -49,6 +49,11 @@ export function getNextRetryMs(baseMs: number, multiplier: number, attempt: numb
 
 /**
  * Retry a function, respecting `error.isRetriable`.
+ *
+ * Kafka ERR_UNKNOWN (code -1) gets special treatment: rdkafka marks these as
+ * non-retriable, but they are transient errors (e.g. RejectedExecutionException
+ * when reading from tiered storage). We retry them more aggressively with a
+ * higher base sleep and more attempts.
  */
 export async function retryIfRetriable<T>(fn: () => Promise<T>, tries = 3, sleepMs = 100): Promise<T> {
     let currentSleepMs = sleepMs
@@ -56,17 +61,18 @@ export async function retryIfRetriable<T>(fn: () => Promise<T>, tries = 3, sleep
         try {
             return await fn()
         } catch (error) {
-            // rdkafka marks ERR_UNKNOWN (code -1) as non-retriable, but these are
-            // transient errors that occur.
-            // We have hit RejectedExecutionException when reading from tiered storage
-            // and not handling this led to pods being constantly restarted.
             const isKafkaUnknownError = (error as any)?.code === -1
-            if ((error?.isRetriable === false && !isKafkaUnknownError) || i === tries - 1) {
-                // Throw if the error is not retryable or if we're out of tries.
+
+            if (isKafkaUnknownError) {
+                // Switch to the kafka unknown error retry path with more
+                // aggressive retries (5 tries, 500ms base sleep).
+                return retryKafkaUnknownError(fn, error, 5, 500, i)
+            }
+
+            if (error?.isRetriable === false || i === tries - 1) {
                 throw error
             }
 
-            // Fall through, `fn` will retry after sleep.
             await sleep(currentSleepMs)
             currentSleepMs = Math.min(
                 currentSleepMs * defaultRetryConfig.BACKOFF_FACTOR,
@@ -77,4 +83,32 @@ export async function retryIfRetriable<T>(fn: () => Promise<T>, tries = 3, sleep
 
     // This should never happen, but TypeScript doesn't know that.
     throw new Error('Unreachable error in retry')
+}
+
+async function retryKafkaUnknownError<T>(
+    fn: () => Promise<T>,
+    lastError: any,
+    maxTries: number,
+    sleepMs: number,
+    alreadyAttempted: number
+): Promise<T> {
+    let currentSleepMs = sleepMs
+    // Start from alreadyAttempted since those tries already happened in the caller.
+    for (let i = alreadyAttempted; i < maxTries; i++) {
+        logger.warn('🔁', `Kafka ERR_UNKNOWN (code -1) retry ${i + 1}/${maxTries}`, {
+            error: lastError.message,
+            sleepMs: currentSleepMs,
+        })
+
+        await sleep(currentSleepMs)
+        currentSleepMs = Math.min(currentSleepMs * defaultRetryConfig.BACKOFF_FACTOR, defaultRetryConfig.MAX_INTERVAL)
+
+        try {
+            return await fn()
+        } catch (error) {
+            lastError = error
+        }
+    }
+
+    throw lastError
 }

--- a/nodejs/tests/utils/retries.test.ts
+++ b/nodejs/tests/utils/retries.test.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../src/utils/logger'
 import { getNextRetryMs, retryIfRetriable } from '../../src/utils/retries'
 
 jest.mock('../../src/utils/utils', () => ({
@@ -30,8 +31,9 @@ describe('retryIfRetriable', () => {
         error.code = -1
         const fn = jest.fn().mockRejectedValueOnce(error).mockResolvedValue('ok')
 
-        const result = await retryIfRetriable(fn, 3, 0)
+        const result = await retryIfRetriable(fn)
         expect(result).toBe('ok')
+        // 1 initial attempt + 1 retry in kafka unknown path
         expect(fn).toHaveBeenCalledTimes(2)
     })
 
@@ -40,19 +42,36 @@ describe('retryIfRetriable', () => {
         error.code = -1
         const fn = jest.fn().mockRejectedValueOnce(error).mockResolvedValue('ok')
 
-        const result = await retryIfRetriable(fn, 3, 0)
+        const result = await retryIfRetriable(fn)
         expect(result).toBe('ok')
         expect(fn).toHaveBeenCalledTimes(2)
     })
 
-    it('throws kafka ERR_UNKNOWN (code -1) after exhausting retries', async () => {
+    it('throws kafka ERR_UNKNOWN (code -1) after exhausting 5 retries', async () => {
         const error = new Error('Unknown broker error') as any
         error.isRetriable = false
         error.code = -1
         const fn = jest.fn().mockRejectedValue(error)
 
-        await expect(retryIfRetriable(fn, 3, 0)).rejects.toThrow('Unknown broker error')
-        expect(fn).toHaveBeenCalledTimes(3)
+        await expect(retryIfRetriable(fn)).rejects.toThrow('Unknown broker error')
+        // 1 initial attempt in retryIfRetriable + 5 retries in kafka unknown error path
+        expect(fn).toHaveBeenCalledTimes(6)
+    })
+
+    it('logs on each kafka ERR_UNKNOWN (code -1) retry', async () => {
+        const warnSpy = jest.spyOn(logger, 'warn')
+        const error = new Error('Unknown broker error') as any
+        error.isRetriable = false
+        error.code = -1
+        const fn = jest.fn().mockRejectedValue(error)
+
+        await expect(retryIfRetriable(fn)).rejects.toThrow('Unknown broker error')
+        const kafkaRetryCalls = warnSpy.mock.calls.filter(
+            (call) => typeof call[1] === 'string' && call[1].includes('Kafka ERR_UNKNOWN')
+        )
+        // 5 retries logged (attempts 1/5 through 5/5)
+        expect(kafkaRetryCalls).toHaveLength(5)
+        warnSpy.mockRestore()
     })
 })
 

--- a/nodejs/tests/utils/retries.test.ts
+++ b/nodejs/tests/utils/retries.test.ts
@@ -1,7 +1,63 @@
-import { getNextRetryMs } from '../../src/utils/retries'
+import { getNextRetryMs, retryIfRetriable } from '../../src/utils/retries'
 
 jest.useFakeTimers()
 jest.spyOn(global, 'setTimeout')
+
+describe('retryIfRetriable', () => {
+    beforeEach(() => {
+        jest.clearAllTimers()
+    })
+
+    it('does not retry when error.isRetriable is false', async () => {
+        const error = new Error('non-retriable') as any
+        error.isRetriable = false
+        const fn = jest.fn().mockRejectedValue(error)
+
+        await expect(retryIfRetriable(fn, 3, 0)).rejects.toThrow('non-retriable')
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries when error.isRetriable is true', async () => {
+        const error = new Error('retriable') as any
+        error.isRetriable = true
+        const fn = jest.fn().mockRejectedValueOnce(error).mockResolvedValue('ok')
+
+        const result = await retryIfRetriable(fn, 3, 0)
+        expect(result).toBe('ok')
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries kafka ERR_UNKNOWN (code -1) even when isRetriable is false', async () => {
+        const error = new Error('Unknown broker error') as any
+        error.isRetriable = false
+        error.code = -1
+        const fn = jest.fn().mockRejectedValueOnce(error).mockResolvedValue('ok')
+
+        const result = await retryIfRetriable(fn, 3, 0)
+        expect(result).toBe('ok')
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries kafka ERR_UNKNOWN (code -1) when isRetriable is not set', async () => {
+        const error = new Error('Unknown broker error') as any
+        error.code = -1
+        const fn = jest.fn().mockRejectedValueOnce(error).mockResolvedValue('ok')
+
+        const result = await retryIfRetriable(fn, 3, 0)
+        expect(result).toBe('ok')
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws kafka ERR_UNKNOWN (code -1) after exhausting retries', async () => {
+        const error = new Error('Unknown broker error') as any
+        error.isRetriable = false
+        error.code = -1
+        const fn = jest.fn().mockRejectedValue(error)
+
+        await expect(retryIfRetriable(fn, 3, 0)).rejects.toThrow('Unknown broker error')
+        expect(fn).toHaveBeenCalledTimes(3)
+    })
+})
 
 describe('getNextRetryMs', () => {
     it('returns the correct number of milliseconds with a multiplier of 1', () => {

--- a/nodejs/tests/utils/retries.test.ts
+++ b/nodejs/tests/utils/retries.test.ts
@@ -1,13 +1,10 @@
 import { getNextRetryMs, retryIfRetriable } from '../../src/utils/retries'
 
-jest.useFakeTimers()
-jest.spyOn(global, 'setTimeout')
+jest.mock('../../src/utils/utils', () => ({
+    sleep: jest.fn().mockResolvedValue(undefined),
+}))
 
 describe('retryIfRetriable', () => {
-    beforeEach(() => {
-        jest.clearAllTimers()
-    })
-
     it('does not retry when error.isRetriable is false', async () => {
         const error = new Error('non-retriable') as any
         error.isRetriable = false


### PR DESCRIPTION
## Problem

When reading MSK topics from the start (hitting tiered storage), consumers are hitting an exception caused by the reader being saturated:

```
[2026-03-12 11:29:34,092] WARN [ReplicaManager broker=7] Unable to fetch data from remote storage (kafka.server.ReplicaManager)
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@43c0e2ac[Not completed, task = kafka.log.remote.RemoteLogReader@7690af6] rejected from org.apache.kafka.storage.internals.log.RemoteStorageThreadPool@1c4edfab[Running, pool size = 21, active threads = 21, queued tasks = 100, completed tasks = 1502851]
at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2065)
at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:833)
at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1365)
at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:145)
at kafka.log.remote.RemoteLogManager.asyncRead(RemoteLogManager.java:1898)
at kafka.server.ReplicaManager.processRemoteFetch(ReplicaManager.scala:1717)
at kafka.server.ReplicaManager.fetchMessages(ReplicaManager.scala:1818)
at kafka.server.KafkaApis.handleFetchRequest(KafkaApis.scala:1059)
at kafka.server.KafkaApis.handle(KafkaApis.scala:185)
at kafka.server.KafkaRequestHandler.run(KafkaRequestHandler.scala:160)
at java.base/java.lang.Thread.run(Thread.java:840)
```

This exception is being encoded as "unknown" by Kafka and hence, without any sign that this is a retry-able exception (I mean, eventually the reading queue would be drained). Unknown exceptions have errorCode=1 

## Changes

Consider errorCode = 1 as a retry-able exception

## How did you test this code?

Unit tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
