### PR TITLE
feat(evals): output metrics and traces to agents

### DIFF
--- a/ee/hogai/eval/base.py
+++ b/ee/hogai/eval/base.py
@@ -6,7 +6,7 @@ from functools import partial
 import pytest
 
 from braintrust import EvalAsync, EvalCase, Metadata, init_logger
-from braintrust.framework import EvalData, EvalScorer, EvalTask, Input, Output
+from braintrust.framework import EvalData, EvalResultWithSummary, EvalScorer, EvalTask, Input, Output
 
 from posthog.models.utils import uuid7
 
@@ -90,7 +90,63 @@ async def BaseMaxEval(
         with open("eval_results.jsonl", "a") as f:
             f.write(result.summary.as_json() + "\n")
 
+    _print_eval_stats(experiment_name, result)
+
     return result
+
+
+def _print_eval_stats(experiment_name: str, result: EvalResultWithSummary) -> None:
+    """Print eval stats to the console so agents can parse them."""
+    summary = result.summary
+    results = result.results
+
+    lines: list[str] = []
+    lines.append("")
+    lines.append(f"{'=' * 60}")
+    lines.append(f"EVAL STATS: {experiment_name} ({len(results)} cases)")
+    lines.append(f"{'=' * 60}")
+
+    # Score summary
+    if summary.scores:
+        lines.append("")
+        lines.append("Score Summary:")
+        for score_summary in summary.scores.values():
+            pct = f"{score_summary.score * 100:.1f}%"
+            diff_str = ""
+            if score_summary.diff is not None:
+                sign = "+" if score_summary.diff > 0 else ""
+                diff_str = f" ({sign}{score_summary.diff * 100:.1f}%)"
+            imp_reg = ""
+            if score_summary.improvements is not None or score_summary.regressions is not None:
+                imp_reg = (
+                    f" [{score_summary.improvements or 0} improvements, {score_summary.regressions or 0} regressions]"
+                )
+            lines.append(f"  {score_summary.name}: {pct}{diff_str}{imp_reg}")
+
+    # Per-case results
+    if results:
+        lines.append("")
+        lines.append("Per-case Results:")
+        for eval_result in results:
+            input_str = str(eval_result.input)
+            # Truncate long inputs
+            if len(input_str) > 80:
+                input_str = input_str[:77] + "..."
+            score_parts = []
+            for score_name, score_val in eval_result.scores.items():
+                if score_val is not None:
+                    score_parts.append(f"{score_name}={score_val:.2f}")
+                else:
+                    score_parts.append(f"{score_name}=N/A")
+            scores_str = ", ".join(score_parts)
+            error_str = " [ERROR]" if eval_result.error else ""
+            lines.append(f"  - {input_str}")
+            lines.append(f"    Scores: {scores_str}{error_str}")
+
+    lines.append(f"{'=' * 60}")
+    lines.append("")
+
+    print("\n".join(lines))  # noqa: T201
 
 
 MaxPublicEval = partial(BaseMaxEval, is_public=True, no_send_logs=False)

--- a/ee/hogai/eval/base.py
+++ b/ee/hogai/eval/base.py
@@ -123,15 +123,24 @@ def _print_eval_stats(experiment_name: str, result: EvalResultWithSummary) -> No
                 )
             lines.append(f"  {score_summary.name}: {pct}{diff_str}{imp_reg}")
 
-    # Per-case results
-    if results:
+    # Separate failed and passed cases
+    failed = []
+    passed = []
+    for eval_result in results:
+        has_failure = eval_result.error is not None or any(
+            v is not None and v < 1.0 for v in eval_result.scores.values()
+        )
+        if has_failure:
+            failed.append(eval_result)
+        else:
+            passed.append(eval_result)
+
+    # Failed cases with full input for debugging
+    if failed:
         lines.append("")
-        lines.append("Per-case Results:")
-        for eval_result in results:
+        lines.append(f"Failed Cases ({len(failed)}/{len(results)}):")
+        for eval_result in failed:
             input_str = str(eval_result.input)
-            # Truncate long inputs
-            if len(input_str) > 80:
-                input_str = input_str[:77] + "..."
             score_parts = []
             for score_name, score_val in eval_result.scores.items():
                 if score_val is not None:
@@ -139,9 +148,20 @@ def _print_eval_stats(experiment_name: str, result: EvalResultWithSummary) -> No
                 else:
                     score_parts.append(f"{score_name}=N/A")
             scores_str = ", ".join(score_parts)
-            error_str = " [ERROR]" if eval_result.error else ""
+            lines.append(f"  - Input: {input_str}")
+            lines.append(f"    Scores: {scores_str}")
+            if eval_result.error:
+                lines.append(f"    Error: {eval_result.error}")
+
+    # Passed cases (condensed)
+    if passed:
+        lines.append("")
+        lines.append(f"Passed Cases ({len(passed)}/{len(results)}):")
+        for eval_result in passed:
+            input_str = str(eval_result.input)
+            if len(input_str) > 80:
+                input_str = input_str[:77] + "..."
             lines.append(f"  - {input_str}")
-            lines.append(f"    Scores: {scores_str}{error_str}")
 
     lines.append(f"{'=' * 60}")
     lines.append("")

--- a/ee/hogai/eval/base.py
+++ b/ee/hogai/eval/base.py
@@ -1,5 +1,7 @@
 import os
+import json
 import asyncio
+import tempfile
 from collections.abc import Sequence
 from functools import partial
 
@@ -95,15 +97,65 @@ async def BaseMaxEval(
     return result
 
 
+def _serialize_eval_result(eval_result) -> dict:
+    """Serialize an EvalResult to a JSON-safe dict, handling non-serializable fields."""
+    result: dict = {
+        "input": str(eval_result.input),
+        "output": str(eval_result.output),
+        "scores": eval_result.scores,
+    }
+    if eval_result.expected is not None:
+        result["expected"] = str(eval_result.expected)
+    if eval_result.metadata is not None:
+        result["metadata"] = eval_result.metadata
+    if eval_result.error is not None:
+        result["error"] = str(eval_result.error)
+    if eval_result.exc_info is not None:
+        result["exc_info"] = eval_result.exc_info
+    return result
+
+
+def _dump_eval_results(experiment_name: str, result: EvalResultWithSummary) -> str:
+    """Dump full untruncated eval results to a temporary JSON file. Returns the file path."""
+    dump = {
+        "experiment_name": experiment_name,
+        "project_name": result.summary.project_name,
+        "scores_summary": {
+            name: {
+                "score": s.score,
+                "diff": s.diff,
+                "improvements": s.improvements,
+                "regressions": s.regressions,
+            }
+            for name, s in result.summary.scores.items()
+        },
+        "results": [_serialize_eval_result(r) for r in result.results],
+    }
+
+    dump_file = tempfile.NamedTemporaryFile(
+        prefix=f"eval_{experiment_name}_",
+        suffix=".json",
+        delete=False,
+        mode="w",
+    )
+    json.dump(dump, dump_file, indent=2, default=str)
+    dump_file.close()
+    return dump_file.name
+
+
 def _print_eval_stats(experiment_name: str, result: EvalResultWithSummary) -> None:
     """Print eval stats to the console so agents can parse them."""
     summary = result.summary
     results = result.results
 
+    # Dump full results to a temp file for detailed inspection
+    dump_path = _dump_eval_results(experiment_name, result)
+
     lines: list[str] = []
     lines.append("")
     lines.append(f"{'=' * 60}")
     lines.append(f"EVAL STATS: {experiment_name} ({len(results)} cases)")
+    lines.append(f"Full results: {dump_path}")
     lines.append(f"{'=' * 60}")
 
     # Score summary
@@ -135,12 +187,11 @@ def _print_eval_stats(experiment_name: str, result: EvalResultWithSummary) -> No
         else:
             passed.append(eval_result)
 
-    # Failed cases with full input for debugging
+    # Failed cases with full details for debugging
     if failed:
         lines.append("")
         lines.append(f"Failed Cases ({len(failed)}/{len(results)}):")
         for eval_result in failed:
-            input_str = str(eval_result.input)
             score_parts = []
             for score_name, score_val in eval_result.scores.items():
                 if score_val is not None:
@@ -148,7 +199,10 @@ def _print_eval_stats(experiment_name: str, result: EvalResultWithSummary) -> No
                 else:
                     score_parts.append(f"{score_name}=N/A")
             scores_str = ", ".join(score_parts)
-            lines.append(f"  - Input: {input_str}")
+            lines.append(f"  - Input: {eval_result.input}")
+            lines.append(f"    Output: {eval_result.output}")
+            if eval_result.expected is not None:
+                lines.append(f"    Expected: {eval_result.expected}")
             lines.append(f"    Scores: {scores_str}")
             if eval_result.error:
                 lines.append(f"    Error: {eval_result.error}")


### PR DESCRIPTION
## Problem

It's hard to iterate on evals with agents because we don't output metrics and traces locally.

## Changes

Added comprehensive evaluation results reporting functionality:

1. **New `_serialize_eval_result()` function**: Converts individual eval results to JSON-safe dictionaries, handling non-serializable fields by converting them to strings.

2. **New `_dump_eval_results()` function**: Serializes complete evaluation results (including all cases and detailed score summaries) to a temporary JSON file for detailed inspection. Returns the file path for reference.

3. **New `_print_eval_stats()` function**: Prints formatted evaluation statistics to console including:
   - Score summary with percentages, diffs, and improvement/regression counts
   - Failed cases with full details (input, output, expected, scores, errors)
   - Passed cases in condensed format
   - Reference to the full results dump file

4. **Integration**: Modified `BaseMaxEval()` to call `_print_eval_stats()` before returning results, ensuring stats are always printed.

5. **New imports**: Added `json` and `tempfile` modules, and imported `EvalResultWithSummary` from braintrust.

## How did you test this code?

This change adds new utility functions for reporting and printing evaluation results. The code follows existing patterns in the codebase and integrates with the braintrust framework's result types. Existing tests for `BaseMaxEval` will exercise the new `_print_eval_stats()` call path.

## Publish to changelog?

No

https://claude.ai/code/session_017p4VYApJypbnHQu9ZzgWes