### PR TITLE
fix(sig): no more toString(timestamp), pre-validate embedding requests

### DIFF
--- a/posthog/api/embedding_worker.py
+++ b/posthog/api/embedding_worker.py
@@ -117,7 +117,15 @@ def emit_embedding_request(
             f"Valid models are: {', '.join(sorted(valid_models))}"
         )
 
-    if timestamp is None:
+    if timestamp is not None:
+        if not isinstance(timestamp, datetime):
+            raise ValueError(f"timestamp must be a datetime instance, got {type(timestamp).__name__}")
+        if timestamp.tzinfo is None or timestamp.tzinfo.utcoffset(timestamp) is None:
+            raise ValueError(
+                "timestamp must be timezone-aware (e.g. '2026-03-10T12:17:44.394000Z'). "
+                "Got a naive datetime without timezone info."
+            )
+    else:
         timestamp = now()
 
     payload = {

--- a/products/signals/backend/api.py
+++ b/products/signals/backend/api.py
@@ -38,7 +38,7 @@ def soft_delete_report_signals(report_id: str, team_id: int, team: Team) -> None
             document_id,
             content,
             metadata,
-            toString(timestamp) as timestamp
+            timestamp
         FROM (
             SELECT
                 document_id,

--- a/products/signals/backend/api.py
+++ b/products/signals/backend/api.py
@@ -1,5 +1,6 @@
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from typing import Union
 
 from django.conf import settings
 
@@ -67,7 +68,7 @@ def soft_delete_report_signals(report_id: str, team_id: int, team: Team) -> None
     )
 
     for row in result.results or []:
-        document_id, content, metadata_str, timestamp_str = row
+        document_id, content, metadata_str, timestamp_raw = row
         metadata = json.loads(metadata_str)
         metadata["deleted"] = True
 
@@ -79,9 +80,18 @@ def soft_delete_report_signals(report_id: str, team_id: int, team: Team) -> None
             rendering="plain",
             document_id=document_id,
             models=[m.value for m in EmbeddingModelName],
-            timestamp=datetime.fromisoformat(timestamp_str),
+            timestamp=_ensure_tz_aware(timestamp_raw),
             metadata=metadata,
         )
+
+
+def _ensure_tz_aware(value: Union[datetime, str]) -> datetime:
+    """Coerce a ClickHouse timestamp (usually a datetime, occasionally a string) to a tz-aware datetime."""
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value
 
 
 async def emit_signal(

--- a/products/signals/backend/management/commands/list_signal_reports.py
+++ b/products/signals/backend/management/commands/list_signal_reports.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
                     document_id,
                     content,
                     metadata,
-                    toString(timestamp) as timestamp
+                    timestamp
                 FROM (
                     SELECT
                         document_id,

--- a/products/signals/backend/temporal/deletion.py
+++ b/products/signals/backend/temporal/deletion.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import temporalio
 from temporalio import workflow
@@ -81,7 +81,7 @@ class SignalReportDeletionWorkflow:
                 signals=[
                     WaitForClickHouseSignal(
                         signal_id=s.signal_id,
-                        timestamp=datetime.fromisoformat(s.timestamp),
+                        timestamp=s.timestamp,
                     )
                     for s in fetch_result.signals
                 ],

--- a/products/signals/backend/temporal/reingestion.py
+++ b/products/signals/backend/temporal/reingestion.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import structlog
 import temporalio
@@ -171,7 +171,7 @@ class SignalReportReingestionWorkflow:
                 signals=[
                     WaitForClickHouseSignal(
                         signal_id=s.signal_id,
-                        timestamp=datetime.fromisoformat(s.timestamp),
+                        timestamp=s.timestamp,
                     )
                     for s in fetch_result.signals
                 ],

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -1,7 +1,7 @@
 import json
 import asyncio
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 from django.db import transaction
 
@@ -246,7 +246,12 @@ async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -
 
         signals = []
         for row in result.results or []:
-            document_id, content, metadata_str, timestamp = row
+            document_id, content, metadata_str, timestamp_raw = row
+            # HogQL returns datetime objects, but defend against strings too
+            if isinstance(timestamp_raw, str):
+                timestamp_raw = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
+            if timestamp_raw.tzinfo is None:
+                timestamp_raw = timestamp_raw.replace(tzinfo=UTC)
             # Purposefully throw here if we fail - we rely on metadata being correct, and it's not llm generated, so
             # no defensive parsing, we want to fail loudly.
             metadata = json.loads(metadata_str)
@@ -258,7 +263,7 @@ async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -
                     source_type=metadata.get("source_type", ""),
                     source_id=metadata.get("source_id", ""),
                     weight=metadata.get("weight", 0.0),
-                    timestamp=timestamp,
+                    timestamp=timestamp_raw,
                     extra=metadata.get("extra", {}),
                 )
             )

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -216,7 +216,7 @@ async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -
                 document_id,
                 content,
                 metadata,
-                toString(timestamp) as timestamp
+                timestamp
             FROM (
                 SELECT
                     document_id,

--- a/products/signals/backend/temporal/types.py
+++ b/products/signals/backend/temporal/types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Optional
 
 
@@ -165,7 +166,7 @@ class SignalData:
     source_type: str
     source_id: str
     weight: float
-    timestamp: str
+    timestamp: datetime
     extra: dict = field(default_factory=dict)
 
 
@@ -177,7 +178,7 @@ def render_signal_to_text(
     lines = [f"Signal {index}:" if index is not None else "Signal:"]
     lines.append(f"- Source: {signal.source_product} / {signal.source_type}")
     lines.append(f"- Weight: {signal.weight}")
-    lines.append(f"- Timestamp: {signal.timestamp}")
+    lines.append(f"- Timestamp: {signal.timestamp.isoformat()}")
     lines.append(f"- Description: {signal.content}")
     return "\n".join(lines)
 

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -293,7 +293,7 @@ class SignalReportViewSet(
                 document_id,
                 content,
                 metadata,
-                toString(timestamp) as timestamp
+                timestamp
             FROM (
                 SELECT
                     document_id,


### PR DESCRIPTION
We were dropping embedding requests due to invalid timestamps fetched from CH (no timezone)