### PR TITLE
fix: use initial_current_url for initial channel type URL rules

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -100,7 +100,11 @@ def create_initial_channel_type(
                 url=ast.Call(
                     name="coalesce",
                     args=[
-                        ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_current_url"])]),
+                        wrap_with_null_if_empty(
+                            ast.Call(
+                                name="toString", args=[ast.Field(chain=[*properties_path, "$initial_current_url"])]
+                            )
+                        ),
                         ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_url"])]),
                     ],
                 ),

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -96,7 +96,14 @@ def create_initial_channel_type(
                 referring_domain=ast.Call(
                     name="toString", args=[ast.Field(chain=[*properties_path, "$initial_referring_domain"])]
                 ),
-                url=ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_url"])]),
+                # SDK sets $initial_current_url; fall back to $initial_url for backwards compatibility
+                url=ast.Call(
+                    name="coalesce",
+                    args=[
+                        ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_current_url"])]),
+                        ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_url"])]),
+                    ],
+                ),
                 hostname=ast.Call(
                     name="domain",
                     args=[ast.Call(name="toString", args=[ast.Field(chain=[*properties_path, "$initial_hostname"])])],

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -105,6 +105,26 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
         )
         return (person_response.results or [])[0][0]
 
+    def _get_person_initial_channel_type_with_rules(self, properties=None, custom_channel_rules=None):
+        person_id = str(uuid.uuid4())
+
+        _create_person(
+            uuid=person_id,
+            team_id=self.team.pk,
+            distinct_ids=[person_id],
+            properties=properties,
+        )
+
+        person_response = execute_hogql_query(
+            parse_select(
+                "select $virt_initial_channel_type as channel_type from persons where id = {person_id}",
+                placeholders={"person_id": ast.Constant(value=person_id)},
+            ),
+            self.team,
+            modifiers=HogQLQueryModifiers(customChannelTypeRules=custom_channel_rules),
+        )
+        return (person_response.results or [])[0][0]
+
     def _get_session_channel_type(self, properties=None, custom_channel_rules=None):
         person_id = str(uuid.uuid4())
         properties = {
@@ -862,4 +882,55 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
                 }
             )
             == "Email"
+        )
+
+    def test_initial_channel_type_custom_url_rule_matches_initial_current_url(self):
+        assert (
+            self._get_person_initial_channel_type_with_rules(
+                {"$initial_current_url": "https://example.com/login"},
+                custom_channel_rules=[
+                    CustomChannelRule(
+                        items=[CustomChannelCondition(key="url", op="icontains", value="/login", id="1")],
+                        channel_type="Login",
+                        combiner=FilterLogicalOperator.AND_,
+                        id="a",
+                    )
+                ],
+            )
+            == "Login"
+        )
+
+    def test_initial_channel_type_url_falls_back_to_initial_url(self):
+        assert (
+            self._get_person_initial_channel_type_with_rules(
+                {"$initial_url": "https://example.com/signup"},
+                custom_channel_rules=[
+                    CustomChannelRule(
+                        items=[CustomChannelCondition(key="url", op="icontains", value="/signup", id="1")],
+                        channel_type="Signup",
+                        combiner=FilterLogicalOperator.AND_,
+                        id="a",
+                    )
+                ],
+            )
+            == "Signup"
+        )
+
+    def test_initial_channel_type_url_prefers_initial_current_url_over_initial_url(self):
+        assert (
+            self._get_person_initial_channel_type_with_rules(
+                {
+                    "$initial_current_url": "https://example.com/correct",
+                    "$initial_url": "https://example.com/wrong",
+                },
+                custom_channel_rules=[
+                    CustomChannelRule(
+                        items=[CustomChannelCondition(key="url", op="icontains", value="/correct", id="1")],
+                        channel_type="Correct",
+                        combiner=FilterLogicalOperator.AND_,
+                        id="a",
+                    )
+                ],
+            )
+            == "Correct"
         )


### PR DESCRIPTION
Custom rules on URL (e.g. 'URL contains login') were evaluated against $initial_url which the SDK does not set; first-touch URL is stored in $initial_current_url. Use coalesce($initial_current_url, $initial_url) so initial channel type rules match correctly.

## Problem

Users who define custom channel type rules on "URL" (e.g. "URL contains login") for **Initial channel type** saw "Direct" instead of their custom channel, even when the first-touch URL matched the rule. Session-based channel type worked because it uses session entry URL; initial channel type was using a different property.

## Changes

- **`posthog/hogql/database/schema/channel_type.py`**: For initial channel type, the URL used in custom rules now comes from `coalesce($initial_current_url, $initial_url)` instead of only `$initial_url`. The SDK and app set the first page URL on `$initial_current_url`; `$initial_url` is kept as fallback for older data.

## How did you test this code?

- Confirmed locally that an insight with breakdown by "Initial channel type" and a custom rule "URL contains login" shows the custom channel for rows 
- No new automated tests added; existing channel-type logic and person-property handling are unchanged aside from the URL source.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No — bug fix only.

## Docs update

No doc changes. Channel type docs already describe custom rules; the fix aligns behavior with the property the SDK sets.

## 🤖 LLM context

