### PR TITLE
feat: add Supabase OAuth integration for marketplace

### DIFF
--- a/ee/api/supabase_integration/__init__.py
+++ b/ee/api/supabase_integration/__init__.py
@@ -1,0 +1,5 @@
+STATE_CACHE_PREFIX = "supabase_oauth_state:"
+STATE_CACHE_TTL = 600
+
+TOKEN_CACHE_PREFIX = "supabase_oauth_token:"
+TOKEN_CACHE_TTL = 60 * 60 * 24 * 30  # 30 days

--- a/ee/api/supabase_integration/test/test_views.py
+++ b/ee/api/supabase_integration/test/test_views.py
@@ -1,0 +1,179 @@
+from urllib.parse import parse_qs, urlparse
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import override_settings
+
+from ee.api.supabase_integration import STATE_CACHE_PREFIX, TOKEN_CACHE_PREFIX
+
+TEST_CLIENT_ID = "test-supabase-client-id"
+TEST_CLIENT_SECRET = "test-supabase-client-secret"
+TEST_API_BASE_URL = "https://api.supabase.com/v1"
+
+
+@override_settings(
+    SUPABASE_OAUTH_CLIENT_ID=TEST_CLIENT_ID,
+    SUPABASE_OAUTH_CLIENT_SECRET=TEST_CLIENT_SECRET,
+    SUPABASE_API_BASE_URL=TEST_API_BASE_URL,
+)
+class TestSupabaseInstall(APIBaseTest):
+    def test_redirects_to_supabase_authorize(self):
+        res = self.client.get("/integrations/supabase/install")
+        assert res.status_code == 302
+        parsed = urlparse(res["Location"])
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "api.supabase.com"
+        assert parsed.path == "/v1/oauth/authorize"
+        params = parse_qs(parsed.query)
+        assert params["client_id"] == [TEST_CLIENT_ID]
+        assert params["response_type"] == ["code"]
+        assert "state" in params
+
+    def test_caches_state_with_user_id(self):
+        res = self.client.get("/integrations/supabase/install")
+        parsed = urlparse(res["Location"])
+        params = parse_qs(parsed.query)
+        state = params["state"][0]
+        cached_user_id = cache.get(f"{STATE_CACHE_PREFIX}{state}")
+        assert cached_user_id == self.user.id
+
+    def test_redirect_uri_points_to_callback(self):
+        res = self.client.get("/integrations/supabase/install")
+        parsed = urlparse(res["Location"])
+        params = parse_qs(parsed.query)
+        redirect_uri = params["redirect_uri"][0]
+        assert redirect_uri.endswith("/integrations/supabase/callback")
+
+    def test_requires_login(self):
+        self.client.logout()
+        res = self.client.get("/integrations/supabase/install")
+        assert res.status_code == 302
+        assert "/login" in res["Location"]
+
+
+@override_settings(
+    SUPABASE_OAUTH_CLIENT_ID=TEST_CLIENT_ID,
+    SUPABASE_OAUTH_CLIENT_SECRET=TEST_CLIENT_SECRET,
+    SUPABASE_API_BASE_URL=TEST_API_BASE_URL,
+)
+class TestSupabaseCallback(APIBaseTest):
+    def test_rejects_missing_code(self):
+        res = self.client.get("/integrations/supabase/callback?state=abc")
+        assert res.status_code == 400
+
+    def test_rejects_missing_state(self):
+        res = self.client.get("/integrations/supabase/callback?code=abc")
+        assert res.status_code == 400
+
+    def test_rejects_invalid_state(self):
+        res = self.client.get("/integrations/supabase/callback?code=abc&state=invalid")
+        assert res.status_code == 400
+
+    @patch("ee.api.supabase_integration.views.external_requests")
+    def test_exchanges_code_for_tokens(self, mock_requests: MagicMock):
+        state = "valid_state"
+        cache.set(f"{STATE_CACHE_PREFIX}{state}", self.user.id, timeout=600)
+
+        token_response = MagicMock()
+        token_response.json.return_value = {
+            "access_token": "sb_access_token",
+            "refresh_token": "sb_refresh_token",
+        }
+        token_response.raise_for_status = MagicMock()
+
+        orgs_response = MagicMock()
+        orgs_response.json.return_value = [{"id": "org_1", "name": "Test Org"}]
+        orgs_response.raise_for_status = MagicMock()
+
+        mock_requests.post.return_value = token_response
+        mock_requests.get.return_value = orgs_response
+
+        res = self.client.get(f"/integrations/supabase/callback?code=test_code&state={state}")
+
+        assert res.status_code == 302
+        assert res["Location"] == "/project/settings?supabase=connected"
+
+        mock_requests.post.assert_called_once()
+        call_kwargs = mock_requests.post.call_args
+        assert call_kwargs[0][0] == f"{TEST_API_BASE_URL}/oauth/token"
+        assert call_kwargs[1]["data"]["grant_type"] == "authorization_code"
+        assert call_kwargs[1]["data"]["code"] == "test_code"
+
+    @patch("ee.api.supabase_integration.views.external_requests")
+    def test_stores_tokens_in_cache(self, mock_requests: MagicMock):
+        state = "token_state"
+        cache.set(f"{STATE_CACHE_PREFIX}{state}", self.user.id, timeout=600)
+
+        token_response = MagicMock()
+        token_response.json.return_value = {
+            "access_token": "sb_access",
+            "refresh_token": "sb_refresh",
+        }
+        token_response.raise_for_status = MagicMock()
+
+        orgs_response = MagicMock()
+        orgs_response.json.return_value = [{"id": "org_1"}]
+        orgs_response.raise_for_status = MagicMock()
+
+        mock_requests.post.return_value = token_response
+        mock_requests.get.return_value = orgs_response
+
+        self.client.get(f"/integrations/supabase/callback?code=test_code&state={state}")
+
+        cached = cache.get(f"{TOKEN_CACHE_PREFIX}{self.user.id}")
+        assert cached is not None
+        assert cached["access_token"] == "sb_access"
+        assert cached["refresh_token"] == "sb_refresh"
+        assert cached["supabase_orgs"] == [{"id": "org_1"}]
+
+    @patch("ee.api.supabase_integration.views.external_requests")
+    def test_deletes_state_after_use(self, mock_requests: MagicMock):
+        state = "one_time_state"
+        cache.set(f"{STATE_CACHE_PREFIX}{state}", self.user.id, timeout=600)
+
+        token_response = MagicMock()
+        token_response.json.return_value = {"access_token": "t", "refresh_token": "r"}
+        token_response.raise_for_status = MagicMock()
+
+        orgs_response = MagicMock()
+        orgs_response.json.return_value = []
+        orgs_response.raise_for_status = MagicMock()
+
+        mock_requests.post.return_value = token_response
+        mock_requests.get.return_value = orgs_response
+
+        self.client.get(f"/integrations/supabase/callback?code=test_code&state={state}")
+
+        assert cache.get(f"{STATE_CACHE_PREFIX}{state}") is None
+
+    @patch("ee.api.supabase_integration.views.external_requests")
+    def test_handles_token_exchange_failure(self, mock_requests: MagicMock):
+        state = "fail_state"
+        cache.set(f"{STATE_CACHE_PREFIX}{state}", self.user.id, timeout=600)
+
+        mock_requests.post.side_effect = Exception("Connection error")
+
+        res = self.client.get(f"/integrations/supabase/callback?code=test_code&state={state}")
+
+        assert res.status_code == 502
+
+    @patch("ee.api.supabase_integration.views.external_requests")
+    def test_handles_orgs_fetch_failure_gracefully(self, mock_requests: MagicMock):
+        state = "orgs_fail_state"
+        cache.set(f"{STATE_CACHE_PREFIX}{state}", self.user.id, timeout=600)
+
+        token_response = MagicMock()
+        token_response.json.return_value = {"access_token": "t", "refresh_token": "r"}
+        token_response.raise_for_status = MagicMock()
+
+        mock_requests.post.return_value = token_response
+        mock_requests.get.side_effect = Exception("Orgs fetch failed")
+
+        res = self.client.get(f"/integrations/supabase/callback?code=test_code&state={state}")
+
+        assert res.status_code == 302
+        cached = cache.get(f"{TOKEN_CACHE_PREFIX}{self.user.id}")
+        assert cached is not None
+        assert cached["supabase_orgs"] == []

--- a/ee/api/supabase_integration/views.py
+++ b/ee/api/supabase_integration/views.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import base64
+import secrets
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.core.cache import cache
+from django.http import HttpResponse, HttpResponseRedirect
+from django.http.response import HttpResponseBase
+from django.views.decorators.csrf import csrf_exempt
+
+import structlog
+
+from posthog.exceptions_capture import capture_exception
+from posthog.security.outbound_proxy import external_requests
+
+from . import STATE_CACHE_PREFIX, STATE_CACHE_TTL, TOKEN_CACHE_PREFIX, TOKEN_CACHE_TTL
+
+logger = structlog.get_logger(__name__)
+
+
+@login_required
+def supabase_install(request) -> HttpResponseBase:
+    state = secrets.token_urlsafe(32)
+    cache.set(f"{STATE_CACHE_PREFIX}{state}", request.user.id, timeout=STATE_CACHE_TTL)
+
+    redirect_uri = request.build_absolute_uri("/integrations/supabase/callback")
+    params = {
+        "client_id": settings.SUPABASE_OAUTH_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "state": state,
+    }
+    authorize_url = f"{settings.SUPABASE_API_BASE_URL}/oauth/authorize?{urlencode(params)}"
+    return HttpResponseRedirect(authorize_url)
+
+
+@csrf_exempt
+def supabase_callback(request) -> HttpResponseBase:
+    code = request.GET.get("code")
+    state = request.GET.get("state")
+
+    if not code or not state:
+        return HttpResponse("Missing code or state parameter", status=400)
+
+    user_id = cache.get(f"{STATE_CACHE_PREFIX}{state}")
+    if user_id is None:
+        return HttpResponse("Invalid or expired state", status=400)
+
+    cache.delete(f"{STATE_CACHE_PREFIX}{state}")
+
+    redirect_uri = request.build_absolute_uri("/integrations/supabase/callback")
+    credentials = base64.b64encode(
+        f"{settings.SUPABASE_OAUTH_CLIENT_ID}:{settings.SUPABASE_OAUTH_CLIENT_SECRET}".encode()
+    ).decode()
+
+    try:
+        token_response = external_requests.post(
+            f"{settings.SUPABASE_API_BASE_URL}/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+            headers={
+                "Authorization": f"Basic {credentials}",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+        )
+        token_response.raise_for_status()
+    except Exception as e:
+        logger.exception("supabase_oauth.token_exchange_failed")
+        capture_exception(e)
+        return HttpResponse("Failed to exchange authorization code", status=502)
+
+    token_data = token_response.json()
+    access_token = token_data.get("access_token")
+    refresh_token = token_data.get("refresh_token")
+
+    try:
+        orgs_response = external_requests.get(
+            f"{settings.SUPABASE_API_BASE_URL}/organizations",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        orgs_response.raise_for_status()
+        supabase_orgs = orgs_response.json()
+    except Exception as e:
+        logger.exception("supabase_oauth.orgs_fetch_failed")
+        capture_exception(e)
+        supabase_orgs = []
+
+    cache.set(
+        f"{TOKEN_CACHE_PREFIX}{user_id}",
+        {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "supabase_orgs": supabase_orgs,
+        },
+        timeout=TOKEN_CACHE_TTL,
+    )
+
+    return HttpResponseRedirect("/project/settings?supabase=connected")

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -16,6 +16,7 @@ from ee.admin.loginas_views import loginas_user, upgrade_impersonation
 from ee.admin.oauth_views import admin_auth_check, admin_oauth_success
 from ee.api import integration
 from ee.api.agentic_provisioning import views as agentic_provisioning_views
+from ee.api.supabase_integration import views as supabase_views
 from ee.api.vercel import vercel_connect, vercel_sso, vercel_webhooks
 from ee.middleware import admin_oauth2_callback
 from ee.support_sidebar_max.views import MaxChatViewSet
@@ -298,6 +299,17 @@ urlpatterns: list[Any] = [
         "api/agentic/provisioning/deep_links",
         csrf_exempt(agentic_provisioning_views.deep_links),
         name="agentic_provisioning_deep_links",
+    ),
+    # Supabase OAuth integration
+    path(
+        "integrations/supabase/install",
+        supabase_views.supabase_install,
+        name="supabase_install",
+    ),
+    path(
+        "integrations/supabase/callback",
+        supabase_views.supabase_callback,
+        name="supabase_callback",
     ),
     *admin_urlpatterns,
 ]

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -58,6 +58,10 @@ CLICKUP_APP_CLIENT_SECRET = get_from_env("CLICKUP_APP_CLIENT_SECRET", "")
 ATLASSIAN_APP_CLIENT_ID = get_from_env("ATLASSIAN_APP_CLIENT_ID", "")
 ATLASSIAN_APP_CLIENT_SECRET = get_from_env("ATLASSIAN_APP_CLIENT_SECRET", "")
 
+SUPABASE_OAUTH_CLIENT_ID = get_from_env("SUPABASE_OAUTH_CLIENT_ID", "")
+SUPABASE_OAUTH_CLIENT_SECRET = get_from_env("SUPABASE_OAUTH_CLIENT_SECRET", "")
+SUPABASE_API_BASE_URL = get_from_env("SUPABASE_API_BASE_URL", "https://api.supabase.com/v1")
+
 # Stripe requires a more complex OAuth setup: we authenticate with Stripe, then exchange tokens
 # with our internal OAuth system to allow the Stripe app to make API calls to users' PostHog instances.
 # We also support their agentic provisioning protocol which requires us to check even more stuff


### PR DESCRIPTION
## Problem

Supabase wants PostHog as an observability partner in their marketplace. To be included, we need a one-click OAuth setup -- not just a link to our signup page. This PR implements the OAuth flow so Supabase users can connect PostHog directly from the Supabase dashboard.

**Update (Mar 12):** Supabase pushed Partners Launch Week back to late April / early May. The OAuth flow is validated end-to-end and works, but there's no urgent need to merge this yet. The real user value comes from log drains auto-configuration (blocked on Supabase's Management API) and account provisioning (not built yet). Parking this until we have more clarity on their timeline.

## Changes

- `GET /integrations/supabase/install` -- initiates OAuth flow by redirecting to Supabase authorize URL with CSRF state
- `GET /integrations/supabase/callback` -- handles OAuth callback, exchanges auth code for tokens via Basic Auth, fetches Supabase orgs, caches tokens for later Management API use (log drains, once Supabase exposes them)
- Django settings for `SUPABASE_OAUTH_CLIENT_ID`, `SUPABASE_OAUTH_CLIENT_SECRET`, `SUPABASE_API_BASE_URL`
- URL registration in `ee/urls.py`

### What's missing before this is useful

- **Account provisioning**: bootstrap new PostHog accounts from the callback (same pattern as Stripe APP `User.objects.bootstrap()`)
- **Log drains**: use stored tokens to auto-configure log drains via Supabase Management API (blocked -- API doesn't support log drains yet)

## How did you test this code?

- 12 unit tests covering login requirement, redirect URL construction, state caching/validation, token exchange, token storage, error handling
- Full end-to-end manual test via ngrok tunnel: PostHog login -> Supabase authorize -> consent -> callback -> tokens cached with `sbp_oauth_*` prefix and Supabase org data stored

## Publish to changelog?

No

## Docs update

Not yet -- will add docs when the marketplace listing goes live.

## 🤖 LLM context

Co-authored with Claude Code. OAuth flow validated end-to-end against live Supabase OAuth app.