### PR TITLE
fix: delete org membership before performing deletion

### DIFF
--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -172,13 +172,20 @@ export const organizationLogic = kea<organizationLogicType>([
             }
         },
         deleteOrganizationSuccess: ({ redirectPath }) => {
+            lemonToast.success('Organization has been deleted', {
+                toastId: 'deleteOrganization',
+            })
+
+            // When deleting an org as part of the delete-account flow, skip the
+            // page reload so the user stays in the modal. The org deletion is
+            // async, so a reload would still show the org in the list.
+            if (redirectPath === urls.settings('user-danger-zone')) {
+                return
+            }
+
             router.actions.replace(redirectPath ?? router.values.currentLocation.pathname, {
                 ...router.values.searchParams,
                 organizationDeleted: true,
-            })
-
-            lemonToast.success('Organization has been deleted', {
-                toastId: 'deleteOrganization',
             })
             location.reload()
         },

--- a/frontend/src/scenes/settings/user/UserDangerZone.tsx
+++ b/frontend/src/scenes/settings/user/UserDangerZone.tsx
@@ -28,9 +28,11 @@ export function DeleteUserModal({
     const { push } = useActions(router)
     const { updateCurrentOrganization, deleteUser } = useActions(userLogic)
     const { userLoading } = useValues(userLogic)
-    const { organizationToDelete, isUserDeletionConfirmed } = useValues(userDangerZoneLogic)
+    const { organizationToDelete, isUserDeletionConfirmed, deletedOrganizationIds } = useValues(userDangerZoneLogic)
     const { leaveOrganization, setOrganizationToDelete, setIsUserDeletionConfirmed } = useActions(userDangerZoneLogic)
-    const organizations = (user?.organizations ?? []).filter(isNotNil)
+    const organizations = (user?.organizations ?? [])
+        .filter(isNotNil)
+        .filter((org) => !deletedOrganizationIds.includes(org.id))
     const { keys } = useValues(personalAPIKeysLogic)
     const { loadKeys } = useActions(personalAPIKeysLogic)
 
@@ -223,6 +225,7 @@ export function DeleteUserModal({
                 isOpen={organizationToDelete !== null}
                 setIsOpen={() => setOrganizationToDelete(null)}
                 organization={organizationToDelete}
+                redirectPath={urls.settings('user-danger-zone')}
             />
         </>
     )

--- a/frontend/src/scenes/settings/user/userDangerZoneLogic.ts
+++ b/frontend/src/scenes/settings/user/userDangerZoneLogic.ts
@@ -3,6 +3,7 @@ import { router } from 'kea-router'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { organizationLogic } from 'scenes/organizationLogic'
 import { urls } from 'scenes/urls'
 
 import type { OrganizationBasicType } from '~/types'
@@ -15,6 +16,10 @@ export const userDangerZoneLogic = kea<userDangerZoneLogicType>({
         setDeleteUserModalOpen: (open: boolean) => ({ open }),
         setOrganizationToDelete: (organization: OrganizationBasicType | null) => ({ organization }),
         setIsUserDeletionConfirmed: (confirmed: boolean) => ({ confirmed }),
+        addDeletedOrganizationId: (id: string) => ({ id }),
+    },
+    connect: {
+        actions: [organizationLogic, ['deleteOrganizationSuccess']],
     },
     loaders: {
         _leaveOrganization: [
@@ -47,13 +52,26 @@ export const userDangerZoneLogic = kea<userDangerZoneLogicType>({
                 setIsUserDeletionConfirmed: (_, { confirmed }) => confirmed,
             },
         ],
+        deletedOrganizationIds: [
+            [] as string[],
+            {
+                addDeletedOrganizationId: (state, { id }) => [...state, id],
+                setDeleteUserModalOpen: (state, { open }) => (open ? state : []),
+            },
+        ],
     },
-    listeners: () => ({
+    listeners: ({ actions, values }) => ({
         setDeleteUserModalOpen: ({ open }) => {
             if (open) {
                 router.actions.replace(urls.settings('user-danger-zone'), { deletingUser: true })
             } else {
                 router.actions.replace(urls.settings('user-danger-zone'))
+            }
+        },
+        deleteOrganizationSuccess: () => {
+            if (values.deleteUserModalOpen && values.organizationToDelete) {
+                actions.addDeletedOrganizationId(values.organizationToDelete.id)
+                actions.setOrganizationToDelete(null)
             }
         },
         leaveOrganizationSuccess: () => {

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -338,6 +338,9 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         organization_id = organization.pk
         organization_name = organization.name
 
+        # the memberships need to be deleted synchronously so that the requesting user can delete their account if they want to
+        organization.memberships.all().delete()
+
         # Queue background task to handle all deletion
         # bulky postgres, batch exports, org/team records, ClickHouse, email
         delete_organization_data_and_notify_task.delay(

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1093,6 +1093,42 @@ class TestUserAPI(APIBaseTest):
             properties=mock.ANY,
         )
 
+    @patch("posthoganalytics.capture")
+    def test_can_delete_account_after_deleting_only_organization(self, mock_capture):
+        org = Organization.objects.create(name="Solo Org")
+        user = User.objects.create(email="solo@posthog.com", password="testpassword")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=org,
+            level=OrganizationMembership.Level.OWNER,
+        )
+        self.client.force_login(user)
+
+        # User belongs to exactly one organization
+        response = self.client.get("/api/users/@me/")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["organizations"]) == 1
+
+        # Cannot delete account while still a member of an organization
+        response = self.client.delete("/api/users/@me/")
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+        # Delete the organization
+        response = self.client.delete(f"/api/organizations/{org.id}")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # Membership is removed synchronously so the user immediately
+        # sees zero organizations, even before the async Celery task runs
+        assert not OrganizationMembership.objects.filter(user=user).exists()
+        response = self.client.get("/api/users/@me/")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["organizations"]) == 0
+
+        # Now the user can delete their account
+        response = self.client.delete("/api/users/@me/")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not User.objects.filter(pk=user.pk).exists()
+
     def test_cannot_delete_another_user_with_no_org_memberships(self):
         user = self._create_user("deleteanotheruser@posthog.com", password="test")
 


### PR DESCRIPTION
## Problem

When a user requests to delete their account they must first delete or transfer ownership of all organizations they are a member of. However, now that org deletion is async, they can get stuck in a UI loop where the organization is never properly displayed as deleted. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When requesting organization deletion, immediately delete the organization memberships so that the organization is no longer accessible and the user can delete their account.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
