### PR TITLE
feat(analytics-platform): Add limited support for cohorts in real-time filters

### DIFF
--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -51,8 +51,8 @@ def _check_only_person_properties(properties: Any) -> set[str]:
                     _walk(v)
             return
 
-        if node_type and node_type != "person":
-            non_person_types.add(node_type)
+        if node_type != "person":
+            non_person_types.add(node_type or "<unknown>")
 
     _walk(properties)
     return non_person_types

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -73,6 +73,12 @@ def _try_inline_cohort_filter(prop: dict, team: Team) -> tuple[list[ast.Expr], N
     except Cohort.DoesNotExist:
         return None, f"cohort id={cohort_id} not found"
 
+    if cohort.is_static:
+        return (
+            None,
+            f"cohort '{cohort.name}' (id={cohort_id}) is a static cohort — static cohort membership can't be evaluated in real-time filters",
+        )
+
     cohort_properties = (cohort.filters or {}).get("properties")
     if not cohort_properties:
         return None, f"cohort '{cohort.name}' (id={cohort_id}) has no properties defined"
@@ -305,8 +311,8 @@ def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optio
             site_url = settings.SITE_URL.rstrip("/")
             settings_url = f"{site_url}/project/{team.id}/settings/project#internal-user-filtering"
             error_msg = (
-                f"Can't use cohorts in real-time filters. "
-                f"Only cohorts with person property filters are supported. "
+                f"Cohort membership can't be evaluated in real-time filters. "
+                f"Replace cohorts with equivalent inline person property filters. "
                 f"Update your filters at: {settings_url}"
             )
 

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -9,14 +9,129 @@ from posthog.hogql.property import action_to_expr, ast, property_to_expr
 from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.models.action.action import Action
+from posthog.models.cohort.cohort import Cohort
 from posthog.models.team.team import Team
+
+COHORT_FILTER_TYPES = frozenset({"cohort", "static-cohort", "precalculated-cohort", "dynamic-cohort"})
+
+
+class CohortInlineError(Exception):
+    """Raised when cohort test account filters can't be inlined for real-time use."""
+
+    def __init__(self, reasons: list[str]):
+        self.reasons = reasons
+        super().__init__("Can't use cohorts in real-time filters")
+
+
+def _is_cohort_filter(prop: dict) -> bool:
+    return isinstance(prop, dict) and prop.get("type") in COHORT_FILTER_TYPES
+
+
+def _check_only_person_properties(properties: Any) -> set[str]:
+    """Walk a cohort's filter property tree and return any non-person leaf types found.
+
+    Returns an empty set if all leaves are person property filters.
+    """
+    non_person_types: set[str] = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, list):
+            for item in node:
+                _walk(item)
+            return
+        if not isinstance(node, dict):
+            return
+
+        node_type = node.get("type")
+
+        if node_type in ("AND", "OR"):
+            values = node.get("values")
+            if isinstance(values, list):
+                for v in values:
+                    _walk(v)
+            return
+
+        if node_type and node_type != "person":
+            non_person_types.add(node_type)
+
+    _walk(properties)
+    return non_person_types
+
+
+def _try_inline_cohort_filter(prop: dict, team: Team) -> tuple[list[ast.Expr], None] | tuple[None, str]:
+    """Try to inline a cohort test account filter as person property expressions.
+
+    Returns (exprs, None) on success, or (None, reason) on failure.
+    """
+    cohort_id = prop.get("value")
+    if cohort_id is None:
+        return None, "cohort filter has no value"
+
+    try:
+        # nosemgrep: idor-lookup-without-team (scoped by team__project_id)
+        cohort = Cohort.objects.get(id=cohort_id, team__project_id=team.project_id)
+    except Cohort.DoesNotExist:
+        return None, f"cohort id={cohort_id} not found"
+
+    cohort_properties = (cohort.filters or {}).get("properties")
+    if not cohort_properties:
+        return None, f"cohort '{cohort.name}' (id={cohort_id}) has no properties defined"
+
+    non_person_types = _check_only_person_properties(cohort_properties)
+
+    if non_person_types:
+        types_str = ", ".join(sorted(non_person_types))
+        return None, (
+            f"cohort '{cohort.name}' (id={cohort_id}) contains {types_str} filters — "
+            f"only cohorts with exclusively person property filters can be used in real-time filters"
+        )
+
+    # Reuse cohort_filters_to_expr which walks the same AND/OR tree structure.
+    # Since _check_only_person_properties already validated only person leaves exist,
+    # the behavioral/fallback branches in cohort_filters_to_expr are unreachable here.
+    expr = cohort_filters_to_expr({"properties": cohort_properties}, team)
+    # If the tree was empty/trivial, treat as if no properties
+    if isinstance(expr, ast.Constant) and expr.value is True:
+        return None, f"cohort '{cohort.name}' (id={cohort_id}) has no person property filters"
+
+    is_negated = prop.get("negation") or prop.get("operator") == "not_in"
+    if is_negated:
+        result_expr: ast.Expr = ast.Not(expr=expr)
+        return [result_expr], None
+
+    return [expr], None
 
 
 def _build_test_account_filters(filters: dict, team: Team) -> list[ast.Expr]:
-    """Build filters to exclude test account events."""
+    """Build filters to exclude test account events.
+
+    For cohort filters that only contain person properties, inline the properties
+    directly so they work in real-time bytecode filters (which can't do cohort lookups).
+    """
     if not filters.get("filter_test_accounts", False):
         return []
-    return [property_to_expr(property, team) for property in team.test_account_filters]
+
+    result: list[ast.Expr] = []
+    inline_failures: list[str] = []
+    for prop in team.test_account_filters:
+        if _is_cohort_filter(prop):
+            exprs, reason = _try_inline_cohort_filter(prop, team)
+            if exprs is not None:
+                result.extend(exprs)
+                continue
+            # Cohort couldn't be inlined — record the reason and skip the standard
+            # path (property_to_expr would generate a CohortMembership node that
+            # the bytecode compiler will reject anyway).
+            if reason:
+                inline_failures.append(reason)
+            continue
+        # Non-cohort filter — use standard path
+        result.append(property_to_expr(prop, team))
+
+    if inline_failures:
+        raise CohortInlineError(inline_failures)
+
+    return result
 
 
 def _build_global_property_filters(filters: dict, team: Team) -> list[ast.Expr]:
@@ -168,34 +283,32 @@ def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optio
             raise Exception(f"Filter compilation errors: {error_messages}")
         if "bytecode_error" in filters:
             del filters["bytecode_error"]
+    except CohortInlineError as e:
+        site_url = settings.SITE_URL.rstrip("/")
+        settings_url = f"{site_url}/project/{team.id}/settings/project#internal-user-filtering"
+        details = "; ".join(e.reasons)
+        filters["bytecode"] = None
+        filters["bytecode_error"] = (
+            f"Your internal/test user filters include cohorts that can't be used in real-time filters: "
+            f"{details}. "
+            f"Either switch to a cohort that only uses person properties, "
+            f"or replace the cohort with inline person property filters. "
+            f"Update your filters at: {settings_url}"
+        )
     except Exception as e:
         error_msg = str(e)
 
-        # Check if the error is about cohorts and if test account filters are involved
-        if "Can't use cohorts in real-time filters" in error_msg and filters.get("filter_test_accounts", False):
-            # Check if team has cohort filters in test account filters
-            if team.test_account_filters:
-                cohort_filters = [
-                    f
-                    for f in team.test_account_filters
-                    if isinstance(f, dict)
-                    and f.get("type") in ["cohort", "static-cohort", "precalculated-cohort", "dynamic-cohort"]
-                ]
-                if cohort_filters:
-                    # Extract cohort information for the error message
-                    cohort_info = []
-                    for cohort_filter in cohort_filters:
-                        value = cohort_filter.get("value")
-                        if value:
-                            cohort_info.append(f"cohort id={value}")
-
-                    cohort_names = " (" + ", ".join(cohort_info) + ")" if cohort_info else ""
-                    site_url = settings.SITE_URL.rstrip("/")
-                    error_msg = (
-                        f"Can't use cohorts in real-time filters. "
-                        f"Update your filters at: {site_url}/project/{team.id}/settings/project#internal-user-filtering. "
-                        f"Please inline the relevant expressions{cohort_names}."
-                    )
+        # Cohort errors from sources other than test account filters (e.g. global
+        # property filters referencing a cohort) still hit the bytecode compiler's
+        # generic "Can't use cohorts in real-time filters" error.
+        if "Can't use cohorts in real-time filters" in error_msg:
+            site_url = settings.SITE_URL.rstrip("/")
+            settings_url = f"{site_url}/project/{team.id}/settings/project#internal-user-filtering"
+            error_msg = (
+                f"Can't use cohorts in real-time filters. "
+                f"Only cohorts with person property filters are supported. "
+                f"Update your filters at: {settings_url}"
+            )
 
         filters["bytecode"] = None
         filters["bytecode_error"] = error_msg

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -271,6 +271,11 @@ class SelectFinder(TraversingVisitor):
         return visitor.found
 
 
+def _internal_user_settings_url(team_id: int) -> str:
+    site_url = settings.SITE_URL.rstrip("/")
+    return f"{site_url}/project/{team_id}/settings/project#internal-user-filtering"
+
+
 def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optional[dict[int, Action]] = None) -> dict:
     filters = filters or {}
     try:
@@ -290,8 +295,7 @@ def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optio
         if "bytecode_error" in filters:
             del filters["bytecode_error"]
     except CohortInlineError as e:
-        site_url = settings.SITE_URL.rstrip("/")
-        settings_url = f"{site_url}/project/{team.id}/settings/project#internal-user-filtering"
+        settings_url = _internal_user_settings_url(team.id)
         details = "; ".join(e.reasons)
         filters["bytecode"] = None
         filters["bytecode_error"] = (
@@ -308,8 +312,7 @@ def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optio
         # property filters referencing a cohort) still hit the bytecode compiler's
         # generic "Can't use cohorts in real-time filters" error.
         if "Can't use cohorts in real-time filters" in error_msg:
-            site_url = settings.SITE_URL.rstrip("/")
-            settings_url = f"{site_url}/project/{team.id}/settings/project#internal-user-filtering"
+            settings_url = _internal_user_settings_url(team.id)
             error_msg = (
                 f"Cohort membership can't be evaluated in real-time filters. "
                 f"Replace cohorts with equivalent inline person property filters. "

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -21,7 +21,7 @@ from common.hogvm.python.operation import HOGQL_BYTECODE_VERSION
 def _normalize_error(error: str) -> str:
     """Replace dynamic IDs and URLs in error messages with stable placeholders."""
     error = re.sub(r"id=\d+", "id=N", error)
-    error = re.sub(r"http://[^/]+/project/\d+/settings/project", "SETTINGS_URL", error)
+    error = re.sub(r"https?://[^/]+/project/\d+/settings/project", "SETTINGS_URL", error)
     return error
 
 

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -718,7 +718,7 @@ class TestCohortInlining(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.team.save()
 
         result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
-        # Falls through to property_to_expr which creates a CohortMembership node
+        # Empty properties caught by _try_inline_cohort_filter, raises CohortInlineError
         assert result["bytecode"] is None
         assert _normalize_error(result["bytecode_error"]) == (
             "Your internal/test user filters include cohorts that can't be used in real-time filters: "

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -1,14 +1,28 @@
+import re
 import json
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 
 from posthog.hogql.compiler.bytecode import create_bytecode
 
-from posthog.cdp.filters import compile_filters_bytecode, hog_function_filters_to_expr
+from posthog.cdp.filters import (
+    build_behavioral_event_expr,
+    cohort_filters_to_expr,
+    compile_filters_bytecode,
+    hog_function_filters_to_expr,
+)
 from posthog.models.action.action import Action
+from posthog.models.cohort.cohort import Cohort
 
 from common.hogvm.python.execute import execute_bytecode
 from common.hogvm.python.operation import HOGQL_BYTECODE_VERSION
+
+
+def _normalize_error(error: str) -> str:
+    """Replace dynamic IDs and URLs in error messages with stable placeholders."""
+    error = re.sub(r"id=\d+", "id=N", error)
+    error = re.sub(r"http://[^/]+/project/\d+/settings/project", "SETTINGS_URL", error)
+    return error
 
 
 class TestHogFunctionFilters(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
@@ -285,8 +299,6 @@ class TestHogFunctionFilters(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest
 
 class TestCohortExprHelpers(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
     def test_build_behavioral_event_expr_supported_with_event_filters(self):
-        from posthog.cdp.filters import build_behavioral_event_expr
-
         behavioral = {
             "type": "behavioral",
             "key": "$pageview",
@@ -320,8 +332,6 @@ class TestCohortExprHelpers(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest)
         ]
 
     def test_build_behavioral_event_expr_unsupported_returns_none(self):
-        from posthog.cdp.filters import build_behavioral_event_expr
-
         behavioral = {
             "type": "behavioral",
             "key": "$pageview",
@@ -333,8 +343,6 @@ class TestCohortExprHelpers(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest)
         assert expr is None
 
     def test_cohort_filters_to_expr_and_bytecode(self):
-        from posthog.cdp.filters import cohort_filters_to_expr
-
         filters = {
             "properties": {
                 "type": "AND",
@@ -388,3 +396,334 @@ class TestCohortExprHelpers(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest)
             3,
             2,
         ]
+
+
+class TestCohortInlining(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
+    def _make_person_property_cohort(self, properties: list[dict] | dict) -> Cohort:
+        return Cohort.objects.create(
+            team=self.team,
+            name="Person property cohort",
+            filters={"properties": properties},
+            is_static=False,
+        )
+
+    def test_person_property_cohort_inlined_in_test_account_filters(self):
+        cohort = self._make_person_property_cohort(
+            {
+                "type": "AND",
+                "values": [
+                    {"type": "person", "key": "email", "operator": "not_icontains", "value": "@test.com"},
+                    {"type": "person", "key": "is_internal", "operator": "is_not", "value": "true"},
+                ],
+            }
+        )
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.pk}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result.get("bytecode") is not None, f"Expected bytecode but got error: {result.get('bytecode_error')}"
+        assert "bytecode_error" not in result
+
+    def test_person_property_cohort_with_negation(self):
+        cohort = self._make_person_property_cohort(
+            {
+                "type": "AND",
+                "values": [
+                    {"type": "person", "key": "email", "operator": "icontains", "value": "@posthog.com"},
+                ],
+            }
+        )
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.pk, "negation": True}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result.get("bytecode") is not None, f"Expected bytecode but got error: {result.get('bytecode_error')}"
+
+        # The negated cohort should produce a NOT(...) expression that compiles to bytecode
+        hog_globals = {"person": {"properties": {"email": "test@other.com"}}}
+        res = execute_bytecode(result["bytecode"], hog_globals)
+        assert res.result is True
+
+        # A person matching the cohort should be filtered out (NOT matches)
+        hog_globals = {"person": {"properties": {"email": "ben@posthog.com"}}}
+        res = execute_bytecode(result["bytecode"], hog_globals)
+        assert res.result is False
+
+    def test_person_property_cohort_mixed_with_regular_filters(self):
+        cohort = self._make_person_property_cohort(
+            {"type": "AND", "values": [{"type": "person", "key": "plan", "operator": "exact", "value": "enterprise"}]}
+        )
+        self.team.test_account_filters = [
+            {"type": "cohort", "key": "id", "value": cohort.pk},
+            {"type": "person", "key": "email", "operator": "not_icontains", "value": "@test.com"},
+        ]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result.get("bytecode") is not None, f"Expected bytecode but got error: {result.get('bytecode_error')}"
+
+        # Both filters should be applied: plan=enterprise AND email not containing @test.com
+        hog_globals = {"person": {"properties": {"plan": "enterprise", "email": "user@real.com"}}}
+        res = execute_bytecode(result["bytecode"], hog_globals)
+        assert res.result is True
+
+        hog_globals = {"person": {"properties": {"plan": "free", "email": "user@real.com"}}}
+        res = execute_bytecode(result["bytecode"], hog_globals)
+        assert res.result is False
+
+    def test_behavioral_cohort_still_errors(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Behavioral cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "behavioral",
+                            "key": "$pageview",
+                            "value": "performed_event",
+                            "event_type": "events",
+                        }
+                    ],
+                }
+            },
+            is_static=False,
+        )
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.pk}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result["bytecode"] is None
+        assert _normalize_error(result["bytecode_error"]) == (
+            "Your internal/test user filters include cohorts that can't be used in real-time filters: "
+            "cohort 'Behavioral cohort' (id=N) contains behavioral filters — "
+            "only cohorts with exclusively person property filters can be used in real-time filters. "
+            "Either switch to a cohort that only uses person properties, "
+            "or replace the cohort with inline person property filters. "
+            "Update your filters at: SETTINGS_URL#internal-user-filtering"
+        )
+
+    def test_nested_cohort_reference_still_errors(self):
+        inner_cohort = Cohort.objects.create(
+            team=self.team,
+            name="Inner cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "exact", "value": "x@y.com"}],
+                }
+            },
+            is_static=False,
+        )
+        outer_cohort = Cohort.objects.create(
+            team=self.team,
+            name="Outer cohort with nested ref",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "cohort", "key": "id", "value": inner_cohort.pk}],
+                }
+            },
+            is_static=False,
+        )
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": outer_cohort.pk}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result["bytecode"] is None
+        assert _normalize_error(result["bytecode_error"]) == (
+            "Your internal/test user filters include cohorts that can't be used in real-time filters: "
+            "cohort 'Outer cohort with nested ref' (id=N) contains cohort filters — "
+            "only cohorts with exclusively person property filters can be used in real-time filters. "
+            "Either switch to a cohort that only uses person properties, "
+            "or replace the cohort with inline person property filters. "
+            "Update your filters at: SETTINGS_URL#internal-user-filtering"
+        )
+
+    def test_nonexistent_cohort_falls_through_to_error(self):
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": 999999}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result["bytecode"] is None
+        assert _normalize_error(result["bytecode_error"]) == (
+            "Your internal/test user filters include cohorts that can't be used in real-time filters: "
+            "cohort id=N not found. "
+            "Either switch to a cohort that only uses person properties, "
+            "or replace the cohort with inline person property filters. "
+            "Update your filters at: SETTINGS_URL#internal-user-filtering"
+        )
+
+    def test_multiple_person_property_cohorts_all_inlined(self):
+        cohort1 = self._make_person_property_cohort(
+            {"type": "AND", "values": [{"type": "person", "key": "role", "operator": "exact", "value": "admin"}]}
+        )
+        cohort2 = self._make_person_property_cohort(
+            {"type": "AND", "values": [{"type": "person", "key": "org", "operator": "exact", "value": "internal"}]}
+        )
+        self.team.test_account_filters = [
+            {"type": "cohort", "key": "id", "value": cohort1.pk},
+            {"type": "cohort", "key": "id", "value": cohort2.pk},
+        ]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result.get("bytecode") is not None, f"Expected bytecode but got error: {result.get('bytecode_error')}"
+
+        hog_globals = {"person": {"properties": {"role": "admin", "org": "internal"}}}
+        res = execute_bytecode(result["bytecode"], hog_globals)
+        assert res.result is True
+
+        hog_globals = {"person": {"properties": {"role": "user", "org": "internal"}}}
+        res = execute_bytecode(result["bytecode"], hog_globals)
+        assert res.result is False
+
+    def test_exclude_test_and_internal_user_cohorts(self):
+        test_users_cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test users",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "$test_user", "operator": "exact", "value": "true"}],
+                }
+            },
+            is_static=False,
+        )
+        internal_users_cohort = Cohort.objects.create(
+            team=self.team,
+            name="Internal users",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@example.com"}],
+                }
+            },
+            is_static=False,
+        )
+        self.team.test_account_filters = [
+            {"type": "cohort", "key": "id", "value": test_users_cohort.pk, "negation": True},
+            {"type": "cohort", "key": "id", "value": internal_users_cohort.pk, "negation": True},
+        ]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result.get("bytecode") is not None, f"Expected bytecode but got error: {result.get('bytecode_error')}"
+        assert "bytecode_error" not in result
+
+        # Real external user — passes both filters
+        hog_globals = {"person": {"properties": {"$test_user": "false", "email": "customer@gmail.com"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is True
+
+        # Test user — filtered out by the test users cohort negation
+        hog_globals = {"person": {"properties": {"$test_user": "true", "email": "customer@gmail.com"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is False
+
+        # Internal user — filtered out by the internal users cohort negation
+        hog_globals = {"person": {"properties": {"$test_user": "false", "email": "alice@example.com"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is False
+
+        # Both test and internal — also filtered out
+        hog_globals = {"person": {"properties": {"$test_user": "true", "email": "dev@example.com"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is False
+
+    def test_cohort_with_or_structure_preserves_boolean_logic(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Internal domains",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {"type": "person", "key": "email", "operator": "icontains", "value": "@example.com"},
+                        {"type": "person", "key": "email", "operator": "icontains", "value": "@test.io"},
+                    ],
+                }
+            },
+            is_static=False,
+        )
+        # "not in cohort" = exclude anyone whose email matches either domain
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.pk, "negation": True}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result.get("bytecode") is not None, f"Expected bytecode but got error: {result.get('bytecode_error')}"
+
+        # External user — matches neither domain, passes filter
+        hog_globals = {"person": {"properties": {"email": "customer@gmail.com"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is True
+
+        # Matches first domain — filtered out
+        hog_globals = {"person": {"properties": {"email": "alice@example.com"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is False
+
+        # Matches second domain — also filtered out
+        # (would incorrectly pass if OR was flattened to AND, since NOT(a AND b) != NOT(a OR b))
+        hog_globals = {"person": {"properties": {"email": "bot@test.io"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is False
+
+    def test_cohort_with_nested_and_or_structure(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Complex filter cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"type": "person", "key": "email", "operator": "icontains", "value": "@example.com"},
+                                {"type": "person", "key": "email", "operator": "icontains", "value": "@test.io"},
+                            ],
+                        },
+                        {"type": "person", "key": "role", "operator": "exact", "value": "engineer"},
+                    ],
+                }
+            },
+            is_static=False,
+        )
+        # Non-negated: include only people matching the cohort (internal engineers)
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.pk}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        assert result.get("bytecode") is not None, f"Expected bytecode but got error: {result.get('bytecode_error')}"
+
+        # Matches both: internal domain AND engineer role
+        hog_globals = {"person": {"properties": {"email": "alice@example.com", "role": "engineer"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is True
+
+        # Matches domain but wrong role — fails the AND
+        hog_globals = {"person": {"properties": {"email": "alice@example.com", "role": "designer"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is False
+
+        # Right role but external domain — fails the OR
+        hog_globals = {"person": {"properties": {"email": "alice@gmail.com", "role": "engineer"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is False
+
+        # Second OR branch works: test.io domain + engineer
+        hog_globals = {"person": {"properties": {"email": "bot@test.io", "role": "engineer"}}}
+        assert execute_bytecode(result["bytecode"], hog_globals).result is True
+
+    def test_empty_cohort_properties_falls_through(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Empty cohort",
+            filters={"properties": {}},
+            is_static=False,
+        )
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.pk}]
+        self.team.save()
+
+        result = compile_filters_bytecode({"filter_test_accounts": True}, self.team)
+        # Falls through to property_to_expr which creates a CohortMembership node
+        assert result["bytecode"] is None
+        assert _normalize_error(result["bytecode_error"]) == (
+            "Your internal/test user filters include cohorts that can't be used in real-time filters: "
+            "cohort 'Empty cohort' (id=N) has no properties defined. "
+            "Either switch to a cohort that only uses person properties, "
+            "or replace the cohort with inline person property filters. "
+            "Update your filters at: SETTINGS_URL#internal-user-filtering"
+        )

--- a/posthog/cdp/test/test_site_functions.py
+++ b/posthog/cdp/test/test_site_functions.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from parameterized import parameterized
+
 from posthog.cdp.site_functions import get_transpiled_function
 from posthog.cdp.templates.helpers import mock_transpile
 from posthog.models.action.action import Action
@@ -231,7 +233,7 @@ class TestSiteFunctions(TestCase):
         assert "https://example.com" in result
 
     @patch("posthog.cdp.site_functions.transpile", side_effect=mock_transpile)
-    def test_get_transpiled_function_with_cohort_filter_raises_error(self, mock_transpile_fn):
+    def test_get_transpiled_function_with_person_property_cohort_filter_inlined(self, mock_transpile_fn):
         cohort = Cohort.objects.create(
             team=self.team,
             name="Internal users",
@@ -261,7 +263,75 @@ class TestSiteFunctions(TestCase):
             "filter_test_accounts": True,
         }
 
-        # Cohorts can't be used in real-time site functions
+        # Person-property-only cohorts are inlined into bytecode filters
+        result = get_transpiled_function(self.hog_function)
+        assert result is not None
+
+    @parameterized.expand(
+        [
+            (
+                "behavioral",
+                False,
+                {
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {"type": "behavioral", "value": "performed_event", "key": "$pageview"},
+                        ],
+                    }
+                },
+            ),
+            (
+                "static",
+                True,
+                None,
+            ),
+            (
+                "event_type_filters",
+                False,
+                {
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "key": "$current_url",
+                                "type": "event",
+                                "value": "https://example.com",
+                                "operator": "icontains",
+                            },
+                        ],
+                    }
+                },
+            ),
+            (
+                "empty_properties",
+                False,
+                {"properties": {}},
+            ),
+        ]
+    )
+    @patch("posthog.cdp.site_functions.transpile", side_effect=mock_transpile)
+    def test_get_transpiled_function_with_unsupported_cohort_raises_error(
+        self, _name, is_static, filters, mock_transpile_fn
+    ):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Unsupported cohort",
+            filters=filters,
+            is_static=is_static,
+        )
+
+        self.team.test_account_filters = [
+            {"key": "id", "type": "cohort", "value": cohort.id, "negation": True},
+        ]
+        self.team.save()
+
+        self.hog_function.hog = "export function onEvent(globals) { console.log(globals); }"
+        self.hog_function.filters = {
+            "events": [{"id": "$pageview", "name": "$pageview", "type": "events"}],
+            "filter_test_accounts": True,
+        }
+
         with pytest.raises(Exception, match="cohort"):
             get_transpiled_function(self.hog_function)
 


### PR DESCRIPTION
## Problem



See 
* https://posthog.slack.com/archives/C09B0SSQEDA/p1769702335556119?thread_ts=1769591314.825779&cid=C09B0SSQEDA
* https://posthog.slack.com/archives/C076E99B152/p1773337517732949?thread_ts=1773334304.885789&cid=C076E99B152

Some queries are over 2x slower than they need to be due to internal/test filters. This is because, for every event, they must read the host and email properties (or whichever properties are configured). This can account for most of the data read from disk for the query!

The solution to this is to use a small cohort, containing the internal/test users, and set the filters to NOT IN that cohort.

The problem with this solution is that it would break real-time CDP functions that use internal/test filters, as these cannot access the DB, so cannot use cohorts.

## Changes

This PR adds limited support for cohorts in real-time CDP functions. Specifically, if the cohort is a `dynamic` cohort that only uses `person` properties, we convert the cohort filter to equivalent person property filters.

## How did you test this code?

Added many tests, including a test for the intended common use case where the customer has 2 cohorts: internal users and test users

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
