### PR TITLE
fix(replay): use asyncio.run() for recording deletion to fix 502 errors

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1351,7 +1351,7 @@ class SessionRecordingViewSet(
                 return await storage.delete_recordings(session_ids, self.team.id, deleted_by=deleted_by)
 
         try:
-            return async_to_sync(_delete_all)()
+            return asyncio.run(_delete_all())
         except Exception as e:
             logger.exception(
                 "recording_api_delete_error",


### PR DESCRIPTION
## Summary

- Recording deletion consistently returns 502 (`upstream_reset_before_response_started{protocol_error}`) on production
- Root cause: `async_to_sync()` from asgiref doesn't work correctly with aiohttp's `ClientSession` under Nginx Unit ASGI mode
- The recording-api successfully processes the delete (key is shredded), but the Django worker connection resets before sending the response back to the browser
- Switches to `asyncio.run()` which matches the working pattern used by the snapshot block-fetch endpoint (`_stream_blob_v2_to_client`)

## Investigation findings

- Recording-api logs: all deletes complete successfully (0 failures)
- Django logs: no delete-related messages at all (no success, no failure, no exception handler reached)
- Nginx Unit stderr: `RuntimeError: failed to send body` errors
- Production config: `NGINX_UNIT_PYTHON_PROTOCOL=asgi`

## Test plan

- [ ] Deploy to production and verify single recording deletion returns 204 (not 502)
- [ ] Verify bulk delete also works
- [ ] Confirm deleted recordings disappear from the listing after refresh