### PR TITLE
fix(lemon-table): fix frequent re-renders

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -162,16 +162,18 @@ export function LemonTable<T extends Record<string, any>>({
         [location, searchParams, hashParams, push, useURLForSorting, onSort, currentSortingParam]
     )
 
-    const columnGroups = (
-        rawColumns.length > 0 && 'children' in rawColumns[0]
-            ? rawColumns
-            : [
-                  {
-                      children: rawColumns,
-                  },
-              ]
-    ) as LemonTableColumnGroup<T>[]
-    const columns = columnGroups.flatMap((group) => group.children)
+    const columnGroups = useMemo(
+        () =>
+            (rawColumns.length > 0 && 'children' in rawColumns[0]
+                ? rawColumns
+                : [
+                      {
+                          children: rawColumns,
+                      },
+                  ]) as LemonTableColumnGroup<T>[],
+        [rawColumns]
+    )
+    const columns = useMemo(() => columnGroups.flatMap((group) => group.children), [columnGroups])
 
     const scrollRef = useRef<HTMLDivElement>(null)
 


### PR DESCRIPTION
## Problem

Something is re-rendering the LemonTable on the insight pages frequently
https://posthog.slack.com/archives/C045L1VEG87/p1773320348505099

## Changes

Memoizes the wrongdoers

## How did you test this code?

Used react-scan and a custom hook Codex cooked up