### PR TITLE
fix(bing-ads): validate account_id is numeric before sync

### DIFF
--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -64,6 +64,14 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
             return False, "Account ID and Bing Ads integration are required"
 
         try:
+            int(config.account_id)
+        except ValueError:
+            return (
+                False,
+                f"Invalid Account ID '{config.account_id}'. Bing Ads Account IDs are numeric. You can find your Account ID in the Bing Ads dashboard under Settings > Account.",
+            )
+
+        try:
             self.get_oauth_integration(config.bing_ads_integration_id, team_id)
             return True, None
         except Exception as e:

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -63,9 +63,7 @@ class BingAdsSource(SimpleSource[BingAdsSourceConfig], OAuthMixin):
         if not config.account_id or not config.bing_ads_integration_id:
             return False, "Account ID and Bing Ads integration are required"
 
-        try:
-            int(config.account_id)
-        except ValueError:
+        if not config.account_id.isdigit():
             return (
                 False,
                 f"Invalid Account ID '{config.account_id}'. Bing Ads Account IDs are numeric. You can find your Account ID in the Bing Ads dashboard under Settings > Account.",

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -64,6 +64,16 @@ class TestBingAdsSource:
         assert is_valid is False
         assert error == "Account ID and Bing Ads integration are required"
 
+    def test_validate_credentials_invalid_account_id(self):
+        config = BingAdsSourceConfig(account_id="ABC123XYZ", bing_ads_integration_id=1)
+
+        is_valid, error = self.source.validate_credentials(config, self.team_id)
+
+        assert is_valid is False
+        assert error is not None
+        assert "Invalid Account ID" in error
+        assert "ABC123XYZ" in error
+
     @mock.patch.object(BingAdsSource, "get_oauth_integration")
     def test_validate_credentials_success(self, mock_get_oauth):
         """Test successful credential validation."""


### PR DESCRIPTION
## Problem

The Bing Ads integration fails with `ValueError: invalid literal for int() with base 10` when users enter a non-numeric Account ID. The error occurs deep in the sync process, making it hard to diagnose.

## Changes

Add early validation in `validate_credentials` to check that the account_id is numeric, returning a clear error message that guides users to find their correct Account ID in the Bing Ads dashboard.

## How did you test this code?

Added unit test for invalid account_id validation.

---

Reported in https://posthoghelp.zendesk.com/agent/tickets/52572 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55073)