### PR TITLE
feat(deduplicator): more granular checkpoint export cancellation

### DIFF
--- a/rust/kafka-deduplicator/README.md
+++ b/rust/kafka-deduplicator/README.md
@@ -1,140 +1,204 @@
-# Kafka Deduplicator
+# Kafka deduplicator
 
-A high-performance Rust service for real-time event deduplication in Kafka streams.
+Rust service for partition-aware Kafka event deduplication backed by RocksDB.
 
 ## Overview
 
-The Kafka Deduplicator consumes events from a Kafka topic, removes duplicates using RocksDB for persistent storage, and publishes unique events to an output topic.
+The service consumes a Kafka topic, maintains per-partition deduplication state in local RocksDB stores, and optionally publishes results to downstream Kafka topics.
 
-## How the Kafka Consumer Works
+Today it supports two pipeline types:
 
-### Stateful Consumer Architecture
+- `ingestion_events`
+- `clickhouse_events`
 
-The Kafka consumer is built as a stateful, partition-aware consumer that maintains processing state across rebalances. Key characteristics:
+The default pipeline is `ingestion_events`.
 
-- **Per-partition state management**: Each Kafka partition gets its own isolated deduplication store, allowing horizontal scaling
-- **Message tracking**: Tracks in-flight messages to ensure exactly-once processing semantics
-- **Graceful rebalancing**: During partition reassignment, the consumer:
-  - Waits for all in-flight messages from revoked partitions to complete
-  - Cleanly shuts down partition-specific stores
-  - Initializes new stores for newly assigned partitions
-- **Offset management**: Commits offsets only after messages are successfully processed, preventing data loss
+## Consumer modes
 
-### Partition Handling
+The service supports two assignment models:
 
-When partitions are assigned or revoked (during rebalancing):
+1. Group-based consumer mode
 
-1. **Partition Assignment**: Creates a new RocksDB store for each assigned partition at path: `{base_path}/{topic}_{partition}/`
-2. **Partition Revocation**:
-   - Marks the partition as "fenced" to reject new messages
-   - Waits for in-flight messages to complete
-   - Cleanly closes the RocksDB store
-3. **Isolation**: Each partition's deduplication state is completely isolated, preventing cross-partition interference
+- Uses Kafka's consumer group protocol
+- Handles partition assignment and revocation through the rebalance handler
+- Imports checkpoints on assignment when enabled
 
-### Message Flow
+2. Assigner-driven mode
 
-1. Consumer polls messages from Kafka
-2. Each message is wrapped in an `AckableMessage` for explicit acknowledgment
-3. Messages are processed with configurable concurrency limits
-4. After processing, messages are explicitly acknowledged (ack/nack)
-5. Offsets are committed only for successfully processed messages
+- Enabled with `KAFKA_ASSIGNER_ENDPOINT`
+- Uses the `kafka-assigner` service for partition assignment
+- Supports warm handoff by importing checkpoints before taking ownership
 
-## Deduplication Strategy
+## State model
 
-Events are deduplicated based on a **composite key**:
+- Deduplication state is isolated per Kafka partition
+- Each partition store lives under `STORE_PATH`
+- Checkpoint imports restore directly into timestamped store directories beneath the store path
+- Local checkpoint staging lives under `LOCAL_CHECKPOINT_DIR`
 
-- Format: `timestamp:distinct_id:token:event_name`
-- Two events with the same composite key are considered duplicates
-- UUID is used only for Kafka partitioning, not deduplication
+The service also runs store cleanup logic to enforce `MAX_STORE_CAPACITY` and remove stale directories when safe.
 
-## Checkpoint System
+## Output behavior
 
-The service includes a comprehensive checkpoint system for backup, recovery, and horizontal scaling:
+For the `ingestion_events` pipeline:
 
-### Checkpoint Strategy
+- `OUTPUT_TOPIC` is optional
+- if `OUTPUT_TOPIC` is unset, events are still consumed and deduplicated, but nothing is forwarded
+- `DUPLICATE_EVENTS_TOPIC` is optional and only applies to the ingestion-events pipeline
 
-- **Periodic snapshots**: Creates RocksDB checkpoints at configurable intervals (default: 5 minutes)
-- **Point-in-time consistency**: Checkpoints capture the complete deduplication state at a specific moment
-- **Multi-tier storage**: Local checkpoints for fast recovery, S3 uploads for durability and scaling
-- **Incremental vs Full uploads**:
-  - **Incremental**: Upload only changed SST files since last checkpoint
-  - **Full**: Upload complete checkpoint (every N incremental uploads, default: 10)
+For the `clickhouse_events` pipeline:
 
-### Checkpoint Components
+- there is no duplicate-events topic configuration
+- fail-open still bypasses deduplication logic for the pipeline
 
-- **CheckpointExporter**: Orchestrates checkpoint creation and upload process
-- **CheckpointLoader**: Handles downloading and restoring checkpoints from remote storage  
-- **S3Client**: Manages S3 operations for checkpoint storage and retrieval
-- **Metadata tracking**: Records checkpoint info (timestamp, files, offsets, sizes)
+## Checkpoint system
 
-### Checkpoint Flow
+Checkpointing is used for recovery and reassignment.
 
-1. **Creation** (synchronous): RocksDB creates atomic snapshot with SST file tracking
-2. **Upload** (asynchronous): Background upload to S3 with configurable timeouts and retries
-3. **Cleanup** (asynchronous): Automatic removal of old local checkpoints (keeps N most recent)
-4. **Recovery** (asynchronous): On startup, can restore from latest checkpoint to resume processing
+### Export
 
-### Async Operations
+When checkpoint export is enabled, the checkpoint manager periodically:
 
-- **Checkpoint loop**: Runs continuously in background with configurable intervals
-- **S3 uploads**: Non-blocking uploads prevent checkpoint creation from blocking message processing
-- **Directory cleanup**: Old checkpoint removal happens asynchronously
-- **Recovery downloads**: Checkpoint restoration from S3 is async and resumable
+1. creates a local RocksDB checkpoint for an owned partition
+2. builds a checkpoint plan from the local checkpoint directory
+3. uploads the required files plus metadata to remote object storage
+4. removes the temporary local checkpoint directory
 
-### Configuration
+Incremental exports reuse previously uploaded `.sst` files when possible.
+`CURRENT` is always re-uploaded.
+Other mutable files such as `MANIFEST-*`, `OPTIONS-*`, and `.log` files are re-uploaded when their contents change.
+
+### Import
+
+When checkpoint import is enabled, assignment-time recovery:
+
+1. lists recent checkpoint metadata files for the partition
+2. downloads metadata lazily, newest first
+3. downloads the referenced checkpoint files into a fresh local store directory
+4. restores the imported directory as the active RocksDB store
+
+If import fails, the service falls back to creating an empty store for the partition.
+
+### Rebalance behavior
+
+Rebalances suppress export work so imports get priority.
+
+Workers now check the rebalance/export-suppression token:
+
+- before local checkpoint creation
+- around checkpoint planning
+- during upload via the uploader's existing cancellation points
+
+This means export may be skipped before upload even after a local checkpoint has already been created.
+
+## Checkpoint configuration
+
+Checkpoint import and export are gated by both feature flags and remote storage configuration.
+Setting `CHECKPOINT_EXPORT_ENABLED=true` or `CHECKPOINT_IMPORT_ENABLED=true` is not enough by itself; the service also requires:
+
+- `S3_BUCKET`
+- either `AWS_REGION` or `S3_ENDPOINT`
+
+Important checkpoint-related env vars:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CHECKPOINT_INTERVAL` | Time between checkpoints | `300s` |
-| `LOCAL_CHECKPOINT_DIR` | Local checkpoint storage path | `./checkpoints` |
-| `S3_BUCKET` | S3 bucket for checkpoint uploads | (required) |
-| `S3_KEY_PREFIX` | S3 key prefix for organization | `deduplication-checkpoints` |
-| `FULL_UPLOAD_INTERVAL` | Incremental uploads before full | `10` |
-| `MAX_LOCAL_CHECKPOINTS` | Local checkpoints to retain | `5` |
+| `CHECKPOINT_INTERVAL_SECS` | Time between checkpoint submission cycles | `1800` |
+| `MAX_CONCURRENT_CHECKPOINTS` | Max in-flight checkpoint attempts per pod | `8` |
+| `LOCAL_CHECKPOINT_DIR` | Local checkpoint staging directory | `/tmp/local_checkpoints` |
+| `CHECKPOINT_FULL_UPLOAD_INTERVAL` | Full-upload cadence; `0` means always full | `0` |
+| `CHECKPOINT_IMPORT_ENABLED` | Enable checkpoint import | `false` |
+| `CHECKPOINT_EXPORT_ENABLED` | Enable checkpoint export | `false` |
+| `CHECKPOINT_IMPORT_ATTEMPT_DEPTH` | Number of recent checkpoints to try on import | `10` |
+| `CHECKPOINT_IMPORT_WINDOW_HOURS` | Recovery search window | `24` |
+| `MAX_CONCURRENT_CHECKPOINT_FILE_DOWNLOADS` | Max concurrent S3 file downloads during import | `200` |
+| `MAX_CONCURRENT_CHECKPOINT_FILE_UPLOADS` | Max concurrent S3 file uploads during export | `200` |
+| `CHECKPOINT_PARTITION_IMPORT_TIMEOUT_SECS` | End-to-end import timeout per partition | `240` |
+| `S3_OPERATION_TIMEOUT_SECS` | Total S3 op timeout including retries | `120` |
+| `S3_ATTEMPT_TIMEOUT_SECS` | Per-attempt S3 timeout | `20` |
+| `S3_MAX_RETRIES` | S3 retry count | `3` |
+| `S3_KEY_PREFIX` | Remote checkpoint prefix | `deduplication-checkpoints` |
 
-## Fail-Open Mode
+## Fail-open mode
 
-The service includes a fail-open mechanism as an emergency kill switch when the deduplication store is causing issues:
+`FAIL_OPEN=true` is the emergency bypass.
 
-- **Bypass deduplication**: When enabled, events are forwarded directly from input to output topic without any deduplication
-- **Skip store operations**: All RocksDB reads/writes are bypassed
-- **Disable checkpoints**: Checkpoint import/export and cleanup tasks are skipped
-- **Metric tracking**: Events passed through are tracked via `fail_open_events_passed_through_total` counter
+When enabled, the service:
 
-Enable fail-open mode by setting `FAIL_OPEN=true`. This should only be used as a last resort when the deduplication system needs to be temporarily disabled.
+- bypasses deduplication logic
+- skips RocksDB store usage
+- skips checkpoint import/export and cleanup infrastructure
+- treats all events as unique
 
-## Architecture Components
+This is intended as an operational kill switch when the deduplication subsystem is causing problems.
 
-- **StatefulKafkaConsumer**: Main consumer orchestrating message processing
-- **MessageTracker**: Tracks in-flight messages and manages offset completion
-- **RebalanceHandler**: Handles partition assignment/revocation during rebalancing
-- **Per-partition RocksDB stores**: Isolated storage for each partition's deduplication state
-- **CheckpointExporter**: Creates and manages periodic snapshots for backup/recovery
+## Selected runtime configuration
 
-## Configuration
-
-### Kafka Settings
+### Kafka
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `KAFKA_HOSTS` | Kafka bootstrap servers | `localhost:9092` |
 | `KAFKA_CONSUMER_GROUP` | Consumer group ID | `kafka-deduplicator` |
 | `KAFKA_CONSUMER_TOPIC` | Source topic | `events` |
-| `OUTPUT_TOPIC` | Destination topic for unique events | Optional |
-| `MAX_IN_FLIGHT_MESSAGES` | Max concurrent messages | `1000` |
+| `KAFKA_TLS` | Enable TLS for Kafka | `false` |
+| `KAFKA_MAX_POLL_INTERVAL_MS` | Max time between poll calls | `300000` |
 
-### Storage Settings
+### Pipeline / outputs
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PIPELINE_TYPE` | `ingestion_events` or `clickhouse_events` | `ingestion_events` |
+| `OUTPUT_TOPIC` | Topic for forwarded unique events | unset |
+| `DUPLICATE_EVENTS_TOPIC` | Topic for duplicate-event publishing in ingestion-events pipeline | unset |
+
+### Storage
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `STORE_PATH` | Base path for RocksDB stores | `/tmp/deduplication-store` |
-| `MAX_STORE_CAPACITY` | Max storage per partition (bytes) | `0` (unlimited) |
+| `MAX_STORE_CAPACITY` | Capacity limit per store manager config; accepts raw bytes or units like `Gi` | `1073741824` |
+| `CLEANUP_INTERVAL_SECS` | Capacity cleanup interval | `120` |
+| `ORPHAN_CLEANUP_MIN_STALENESS_SECS` | Minimum staleness before orphan cleanup | `900` |
+| `REBALANCE_CLEANUP_PARALLELISM` | Max parallel directory deletions during rebalance cleanup | `16` |
 
-### Service Mode
+### RocksDB tuning
 
-| Variable | Description | Default |
-|----------|-------------|--------|
-| `FAIL_OPEN` | Bypass all deduplication and forward events directly to output topic. Use as emergency kill switch. | `false` |
+The service exposes env overrides for RocksDB tuning and otherwise falls back to compiled defaults from `RocksDbConfig`.
+
+Common overrides include:
+
+- `ROCKSDB_SHARED_CACHE_SIZE_BYTES`
+- `ROCKSDB_TOTAL_WRITE_BUFFER_SIZE_BYTES`
+- `ROCKSDB_MAX_BACKGROUND_JOBS`
+- `ROCKSDB_WRITE_BUFFER_SIZE_BYTES`
+- `ROCKSDB_TARGET_FILE_SIZE_BASE_BYTES`
+- `ROCKSDB_MAX_OPEN_FILES`
+- `ROCKSDB_L0_COMPACTION_TRIGGER`
+- `ROCKSDB_L0_SLOWDOWN_WRITES_TRIGGER`
+- `ROCKSDB_L0_STOP_WRITES_TRIGGER`
+- `ROCKSDB_WRITE_BUFFER_MANAGER_ALLOW_STALL`
+
+## Health and metrics
+
+The binary serves:
+
+- `/_readiness`
+- `/_liveness`
+- `/metrics` when `EXPORT_PROMETHEUS=true`
+
+Prometheus export is enabled by default.
+
+## Main components
+
+- `KafkaDeduplicatorService`
+- `BatchConsumer`
+- `AssignerConsumer`
+- `ProcessorRebalanceHandler`
+- `StoreManager`
+- `CheckpointManager`
+- `CheckpointImporter`
+- `CheckpointExporter`
 
 ## Testing
 
@@ -142,6 +206,9 @@ Enable fail-open mode by setting `FAIL_OPEN=true`. This should only be used as a
 # Run all tests
 cargo test
 
-# Run Kafka integration tests (requires Kafka running)
-cargo test --test kafka_integration_tests
+# Run a specific integration suite
+cargo test --test checkpoint_integration_tests
+cargo test --test checkpoint_tests
+cargo test --test batch_consumer_integration_tests
+cargo test --test rebalance_e2e_integration_tests
 ```

--- a/rust/kafka-deduplicator/src/checkpoint/error.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/error.rs
@@ -30,6 +30,21 @@ impl fmt::Display for DownloadCancelledError {
 
 impl std::error::Error for DownloadCancelledError {}
 
+/// Error indicating checkpoint planning was cancelled before upload started.
+/// Use anyhow's downcast_ref::<PlanningCancelledError>() to detect this error type.
+#[derive(Debug)]
+pub struct PlanningCancelledError {
+    pub reason: String,
+}
+
+impl fmt::Display for PlanningCancelledError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Checkpoint planning cancelled: {}", self.reason)
+    }
+}
+
+impl std::error::Error for PlanningCancelledError {}
+
 /// Error indicating a checkpoint import operation timed out.
 /// This prevents exceeding Kafka's max poll interval during long imports.
 /// Use anyhow's downcast_ref::<ImportTimeoutError>() to detect this error type.

--- a/rust/kafka-deduplicator/src/checkpoint/mod.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/mod.rs
@@ -27,4 +27,6 @@ pub use s3_uploader::S3Uploader;
 pub use uploader::CheckpointUploader;
 pub use worker::CheckpointWorker;
 
-pub use error::{DownloadCancelledError, ImportTimeoutError, UploadCancelledError};
+pub use error::{
+    DownloadCancelledError, ImportTimeoutError, PlanningCancelledError, UploadCancelledError,
+};

--- a/rust/kafka-deduplicator/src/checkpoint/planner.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/planner.rs
@@ -1,13 +1,17 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::{hash_prefix_for_partition, CheckpointFile, CheckpointInfo, CheckpointMetadata};
+use super::{
+    hash_prefix_for_partition, CheckpointFile, CheckpointInfo, CheckpointMetadata,
+    PlanningCancelledError,
+};
 use crate::kafka::types::Partition;
 use crate::metrics_const::CHECKPOINT_PLAN_FILE_TRACKED_COUNTER;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 /// Result of checkpoint planning
@@ -30,7 +34,9 @@ pub fn plan_checkpoint(
     consumer_offset: i64,
     producer_offset: i64,
     previous_metadata: Option<&CheckpointMetadata>,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<CheckpointPlan> {
+    ensure_not_cancelled(cancel_token, "before planning start")?;
     let metadata = CheckpointMetadata::new(
         partition.topic().to_string(),
         partition.partition_number(),
@@ -44,7 +50,7 @@ pub fn plan_checkpoint(
     let mut files_to_upload: Vec<LocalCheckpointFile> = Vec::new();
 
     // Collect all files in local checkpoint directory
-    let local_files = collect_local_files(local_checkpoint_attempt_dir)?;
+    let local_files = collect_local_files(local_checkpoint_attempt_dir, cancel_token)?;
     info!(
         "Found {} files in local checkpoint directory",
         local_files.len()
@@ -158,15 +164,20 @@ fn retain_or_replace_duplicate(
 
 /// Collect all files in local checkpoint attempt directory of form:
 /// <local_base_path>/<topic_name>/<partition_number>/<checkpoint_id>
-fn collect_local_files(base_attempt_path: &Path) -> Result<Vec<LocalCheckpointFile>> {
+fn collect_local_files(
+    base_attempt_path: &Path,
+    cancel_token: Option<&CancellationToken>,
+) -> Result<Vec<LocalCheckpointFile>> {
     let mut files = Vec::new();
     let mut stack = vec![base_attempt_path.to_path_buf()];
 
     while let Some(current_path) = stack.pop() {
+        ensure_not_cancelled(cancel_token, "during directory walk")?;
         let entries = std::fs::read_dir(&current_path)
             .with_context(|| format!("Failed to read directory: {current_path:?}"))?;
 
         for entry in entries {
+            ensure_not_cancelled(cancel_token, "during directory walk")?;
             let entry = entry.context(format!(
                 "Failed to read directory entry from {base_attempt_path:?}"
             ))?;
@@ -175,7 +186,8 @@ fn collect_local_files(base_attempt_path: &Path) -> Result<Vec<LocalCheckpointFi
             if path.is_dir() {
                 stack.push(path);
             } else {
-                let candidate = build_candidate_file(&path).context("In build_candidate_file")?;
+                let candidate =
+                    build_candidate_file(&path, cancel_token).context("In build_candidate_file")?;
                 files.push(candidate);
             }
         }
@@ -184,7 +196,10 @@ fn collect_local_files(base_attempt_path: &Path) -> Result<Vec<LocalCheckpointFi
     Ok(files)
 }
 
-fn build_candidate_file(file_path: &Path) -> Result<LocalCheckpointFile> {
+fn build_candidate_file(
+    file_path: &Path,
+    cancel_token: Option<&CancellationToken>,
+) -> Result<LocalCheckpointFile> {
     let local_file_path = file_path.to_path_buf();
     let filename = file_path
         .file_name()
@@ -195,7 +210,8 @@ fn build_candidate_file(file_path: &Path) -> Result<LocalCheckpointFile> {
     let checksum = if filename.ends_with(".sst") {
         String::default()
     } else {
-        load_and_hash_file(file_path).context("In load_and_hash_file")?
+        ensure_not_cancelled(cancel_token, "before hashing non-SST file")?;
+        load_and_hash_file(file_path, cancel_token).context("In load_and_hash_file")?
     };
 
     Ok(LocalCheckpointFile::new(
@@ -205,7 +221,11 @@ fn build_candidate_file(file_path: &Path) -> Result<LocalCheckpointFile> {
     ))
 }
 
-fn load_and_hash_file(file_path: &Path) -> Result<String> {
+fn load_and_hash_file(
+    file_path: &Path,
+    cancel_token: Option<&CancellationToken>,
+) -> Result<String> {
+    ensure_not_cancelled(cancel_token, "before hashing non-SST file")?;
     let mut file = std::fs::File::open(file_path)
         .with_context(|| format!("Failed to open file for hashing: {file_path:?}"))?;
 
@@ -216,6 +236,20 @@ fn load_and_hash_file(file_path: &Path) -> Result<String> {
     let checksum = format!("{hash:x}");
 
     Ok(checksum.to_string())
+}
+
+fn ensure_not_cancelled(
+    cancel_token: Option<&CancellationToken>,
+    reason: &'static str,
+) -> Result<()> {
+    if cancel_token.is_some_and(CancellationToken::is_cancelled) {
+        return Err(PlanningCancelledError {
+            reason: reason.to_string(),
+        }
+        .into());
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -240,6 +274,7 @@ mod tests {
     use super::*;
     use chrono::Duration;
     use tempfile::TempDir;
+    use tokio_util::sync::CancellationToken;
 
     #[test]
     fn test_plan_checkpoint_no_previous() {
@@ -274,13 +309,14 @@ mod tests {
             consumer_offset,
             producer_offset,
             previous_metadata,
+            None,
         )
         .unwrap();
 
         let expected_sst1 =
-            build_candidate_file(&local_checkpoint_attempt_dir.join("file1.sst")).unwrap();
+            build_candidate_file(&local_checkpoint_attempt_dir.join("file1.sst"), None).unwrap();
         let expected_sst2 =
-            build_candidate_file(&local_checkpoint_attempt_dir.join("file2.sst")).unwrap();
+            build_candidate_file(&local_checkpoint_attempt_dir.join("file2.sst"), None).unwrap();
 
         // With no previous metadata, all files should be uploaded
         assert_eq!(plan.files_to_upload.len(), 2);
@@ -363,9 +399,9 @@ mod tests {
         std::fs::write(prev_local_attempt_dir.join("00002.sst"), b"data2").unwrap();
 
         let expected_prev_sst1 =
-            build_candidate_file(&prev_local_attempt_dir.join("00001.sst")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00001.sst"), None).unwrap();
         let expected_prev_sst2 =
-            build_candidate_file(&prev_local_attempt_dir.join("00002.sst")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00002.sst"), None).unwrap();
 
         let prev_remote_path =
             format!("{remote_bucket_namespace}/{topic}/{partition_number}/{prev_checkpoint_id}");
@@ -399,7 +435,7 @@ mod tests {
         std::fs::write(local_checkpoint_attempt_dir.join("00002.sst"), b"data2").unwrap();
         std::fs::write(local_checkpoint_attempt_dir.join("00003.sst"), b"data3").unwrap();
         let expected_sst3 =
-            build_candidate_file(&local_checkpoint_attempt_dir.join("00003.sst")).unwrap();
+            build_candidate_file(&local_checkpoint_attempt_dir.join("00003.sst"), None).unwrap();
 
         let plan = plan_checkpoint(
             &local_checkpoint_attempt_dir,
@@ -410,6 +446,7 @@ mod tests {
             consumer_offset,
             producer_offset,
             Some(&prev_metadata),
+            None,
         )
         .unwrap();
 
@@ -517,11 +554,11 @@ mod tests {
         std::fs::write(prev_local_attempt_dir.join("00003.sst"), b"data3").unwrap();
 
         let expected_prev_sst1 =
-            build_candidate_file(&prev_local_attempt_dir.join("00001.sst")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00001.sst"), None).unwrap();
         let expected_prev_sst2 =
-            build_candidate_file(&prev_local_attempt_dir.join("00002.sst")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00002.sst"), None).unwrap();
         let expected_prev_sst3 =
-            build_candidate_file(&prev_local_attempt_dir.join("00003.sst")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00003.sst"), None).unwrap();
 
         let prev_remote_path =
             format!("{remote_bucket_namespace}/{topic}/{partition_number}/{prev_checkpoint_id}",);
@@ -569,6 +606,7 @@ mod tests {
             consumer_offset,
             producer_offset,
             Some(&prev_metadata),
+            None,
         )
         .unwrap();
 
@@ -646,17 +684,17 @@ mod tests {
         std::fs::write(prev_local_attempt_dir.join("00001.log"), b"data6").unwrap();
 
         let expected_prev_sst1 =
-            build_candidate_file(&prev_local_attempt_dir.join("00001.sst")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00001.sst"), None).unwrap();
         let expected_prev_sst2 =
-            build_candidate_file(&prev_local_attempt_dir.join("00002.sst")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00002.sst"), None).unwrap();
         let expected_prev_manifest =
-            build_candidate_file(&prev_local_attempt_dir.join("MANIFEST-000000")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("MANIFEST-000000"), None).unwrap();
         let expected_prev_options =
-            build_candidate_file(&prev_local_attempt_dir.join("OPTIONS-000000")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("OPTIONS-000000"), None).unwrap();
         let expected_prev_current =
-            build_candidate_file(&prev_local_attempt_dir.join("CURRENT")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("CURRENT"), None).unwrap();
         let expected_prev_log =
-            build_candidate_file(&prev_local_attempt_dir.join("00001.log")).unwrap();
+            build_candidate_file(&prev_local_attempt_dir.join("00001.log"), None).unwrap();
 
         let prev_remote_path =
             format!("{remote_bucket_namespace}/{topic}/{partition_number}/{prev_checkpoint_id}",);
@@ -734,6 +772,7 @@ mod tests {
             consumer_offset,
             producer_offset,
             Some(&prev_metadata),
+            None,
         )
         .unwrap();
 
@@ -807,5 +846,75 @@ mod tests {
             .files
             .iter()
             .any(|f| f.remote_filepath == log_remote_path));
+    }
+
+    #[test]
+    fn test_plan_checkpoint_cancelled_before_start() {
+        let temp_dir = TempDir::new().unwrap();
+        let partition = Partition::new("test-topic".to_string(), 0);
+        let attempt_timestamp = Utc::now();
+        let checkpoint_id = CheckpointMetadata::generate_id(attempt_timestamp);
+        let local_checkpoint_attempt_dir = temp_dir
+            .path()
+            .join(partition.topic())
+            .join(partition.partition_number().to_string())
+            .join(&checkpoint_id);
+
+        std::fs::create_dir_all(&local_checkpoint_attempt_dir).unwrap();
+        std::fs::write(local_checkpoint_attempt_dir.join("00001.sst"), b"data1").unwrap();
+
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let err = plan_checkpoint(
+            &local_checkpoint_attempt_dir,
+            "checkpoints".to_string(),
+            partition,
+            attempt_timestamp,
+            1000,
+            0,
+            100,
+            None,
+            Some(&cancel_token),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.downcast_ref::<PlanningCancelledError>().is_some(),
+            "error should be PlanningCancelledError: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collect_local_files_cancelled_during_directory_walk() {
+        let temp_dir = TempDir::new().unwrap();
+        let nested_dir = temp_dir.path().join("nested");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        std::fs::write(nested_dir.join("00001.sst"), b"data1").unwrap();
+
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let err = collect_local_files(temp_dir.path(), Some(&cancel_token)).unwrap_err();
+        assert!(
+            err.downcast_ref::<PlanningCancelledError>().is_some(),
+            "error should be PlanningCancelledError: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_candidate_file_cancelled_before_hashing_non_sst() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("MANIFEST-000000");
+        std::fs::write(&file_path, b"manifest-data").unwrap();
+
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let err = build_candidate_file(&file_path, Some(&cancel_token)).unwrap_err();
+        assert!(
+            err.downcast_ref::<PlanningCancelledError>().is_some(),
+            "error should be PlanningCancelledError: {err}"
+        );
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/planner.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/planner.rs
@@ -213,7 +213,7 @@ fn build_candidate_file(
         String::default()
     } else {
         ensure_not_cancelled(cancel_token, "before hashing non-SST file")?;
-        load_and_hash_file(file_path, cancel_token).context("In load_and_hash_file")?
+        load_and_hash_file(file_path).context("In load_and_hash_file")?
     };
 
     Ok(LocalCheckpointFile::new(
@@ -223,11 +223,7 @@ fn build_candidate_file(
     ))
 }
 
-fn load_and_hash_file(
-    file_path: &Path,
-    cancel_token: Option<&CancellationToken>,
-) -> Result<String> {
-    ensure_not_cancelled(cancel_token, "before hashing non-SST file")?;
+fn load_and_hash_file(file_path: &Path) -> Result<String> {
     let mut file = std::fs::File::open(file_path)
         .with_context(|| format!("Failed to open file for hashing: {file_path:?}"))?;
 

--- a/rust/kafka-deduplicator/src/checkpoint/planner.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/planner.rs
@@ -23,7 +23,9 @@ pub struct CheckpointPlan {
     pub files_to_upload: Vec<LocalCheckpointFile>,
 }
 
-/// Create a checkpoint plan with new metadata and list of files to upload
+/// Create a checkpoint plan with new metadata and list of files to upload.
+/// If a cancellation token is provided, planning checks it during directory walk
+/// and before hashing non-SST files so rebalance can stop export before upload starts.
 #[allow(clippy::too_many_arguments)]
 pub fn plan_checkpoint(
     local_checkpoint_attempt_dir: &Path,

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -81,6 +81,14 @@ impl CheckpointWorker {
         }
     }
 
+    fn during_upload_skip_cause(cancel_cause: Option<&str>) -> &'static str {
+        match cancel_cause {
+            Some("rebalance") => "rebalance_during_upload",
+            Some("shutdown") => "shutdown_during_upload",
+            _ => "cancelled_during_upload",
+        }
+    }
+
     pub fn new(
         worker_id: u32,
         local_base_dir: &Path,
@@ -480,21 +488,29 @@ impl CheckpointWorker {
                     }
 
                     Err(e) => {
-                        // Cancellation is NOT an error - metrics only (s3_uploader already logged the detail)
                         if e.downcast_ref::<UploadCancelledError>().is_some() {
-                            let tags = [("result", "skipped"), ("cause", "cancelled")];
+                            let tags = [
+                                ("result", "skipped"),
+                                ("cause", Self::during_upload_skip_cause(cancel_cause)),
+                            ];
                             metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
-                        } else {
-                            let tags = [("result", "error"), ("cause", "export")];
-                            metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
-                            error!(
+                            info!(
                                 self.worker_id,
                                 local_attempt_path = local_attempt_path_tag,
                                 attempt_type,
-                                "Checkpoint worker: export failed: {e:#}"
+                                "Checkpoint worker: upload cancelled, skipping export"
                             );
+                            return Ok(None);
                         }
 
+                        let tags = [("result", "error"), ("cause", "export")];
+                        metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+                        error!(
+                            self.worker_id,
+                            local_attempt_path = local_attempt_path_tag,
+                            attempt_type,
+                            "Checkpoint worker: export failed: {e:#}"
+                        );
                         Err(e)
                     }
                 }

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use super::{
-    plan_checkpoint, CheckpointExporter, CheckpointInfo, CheckpointMetadata, UploadCancelledError,
+    plan_checkpoint, CheckpointExporter, CheckpointInfo, CheckpointMetadata,
+    PlanningCancelledError, UploadCancelledError,
 };
 use crate::kafka::offset_tracker::OffsetTracker;
 use crate::kafka::types::Partition;
@@ -48,6 +49,38 @@ pub struct CheckpointWorker {
 }
 
 impl CheckpointWorker {
+    fn pre_local_checkpoint_skip_cause(cancel_cause: Option<&str>) -> &'static str {
+        match cancel_cause {
+            Some("rebalance") => "rebalance_before_local_checkpoint",
+            Some("shutdown") => "shutdown_before_local_checkpoint",
+            _ => "cancelled_before_local_checkpoint",
+        }
+    }
+
+    fn pre_plan_skip_cause(cancel_cause: Option<&str>) -> &'static str {
+        match cancel_cause {
+            Some("rebalance") => "rebalance_before_planning",
+            Some("shutdown") => "shutdown_before_planning",
+            _ => "cancelled_before_planning",
+        }
+    }
+
+    fn during_plan_skip_cause(cancel_cause: Option<&str>) -> &'static str {
+        match cancel_cause {
+            Some("rebalance") => "rebalance_during_planning",
+            Some("shutdown") => "shutdown_during_planning",
+            _ => "cancelled_during_planning",
+        }
+    }
+
+    fn post_plan_skip_cause(cancel_cause: Option<&str>) -> &'static str {
+        match cancel_cause {
+            Some("rebalance") => "rebalance_after_planning",
+            Some("shutdown") => "shutdown_after_planning",
+            _ => "cancelled_after_planning",
+        }
+    }
+
     pub fn new(
         worker_id: u32,
         local_base_dir: &Path,
@@ -112,7 +145,12 @@ impl CheckpointWorker {
         cancel_cause: Option<&str>,
     ) -> Result<Option<CheckpointInfo>> {
         // Create the local checkpoint
-        let rocks_metadata = self.create_checkpoint(store).await?;
+        let Some(rocks_metadata) = self
+            .create_checkpoint_cancellable(store, cancel_token, cancel_cause)
+            .await?
+        else {
+            return Ok(None);
+        };
 
         // Export checkpoint with cancellation support
         let result = self
@@ -138,6 +176,22 @@ impl CheckpointWorker {
         &self,
         store: &DeduplicationStore,
     ) -> Result<LocalCheckpointInfo> {
+        let Some(rocks_metadata) = self
+            .create_checkpoint_cancellable(store, None, None)
+            .await?
+        else {
+            unreachable!("checkpoint creation without a cancellation token cannot be skipped");
+        };
+
+        Ok(rocks_metadata)
+    }
+
+    async fn create_checkpoint_cancellable(
+        &self,
+        store: &DeduplicationStore,
+        cancel_token: Option<&CancellationToken>,
+        cancel_cause: Option<&str>,
+    ) -> Result<Option<LocalCheckpointInfo>> {
         info!(
             self.worker_id,
             partition = self.partition.to_string(),
@@ -147,6 +201,21 @@ impl CheckpointWorker {
 
         // Ensure local checkpoint directory exists - results observed internally, safe to bubble up
         self.create_partition_checkpoint_directory().await?;
+
+        if cancel_token.is_some_and(CancellationToken::is_cancelled) {
+            let tags = [
+                ("result", "skipped"),
+                ("cause", Self::pre_local_checkpoint_skip_cause(cancel_cause)),
+            ];
+            metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+            info!(
+                self.worker_id,
+                partition = self.partition.to_string(),
+                attempt_timestamp = self.attempt_timestamp.to_string(),
+                "Checkpoint worker: cancellation observed before local checkpoint creation, skipping"
+            );
+            return Ok(None);
+        }
 
         // this creates the local RocksDB checkpoint - results observed internally, safe to bubble up
         let rocks_metadata = self.create_local_partition_checkpoint(store).await?;
@@ -161,7 +230,7 @@ impl CheckpointWorker {
             );
         }
 
-        Ok(rocks_metadata)
+        Ok(Some(rocks_metadata))
     }
 
     /// Clean up the temporary checkpoint directory (step 3 of checkpoint process)
@@ -299,6 +368,21 @@ impl CheckpointWorker {
 
         match self.exporter.as_ref() {
             Some(exporter) => {
+                if cancel_token.is_some_and(CancellationToken::is_cancelled) {
+                    let tags = [
+                        ("result", "skipped"),
+                        ("cause", Self::pre_plan_skip_cause(cancel_cause)),
+                    ];
+                    metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+                    info!(
+                        self.worker_id,
+                        local_attempt_path = local_attempt_path_tag,
+                        attempt_type,
+                        "Checkpoint worker: cancellation observed before checkpoint planning, skipping export"
+                    );
+                    return Ok(None);
+                }
+
                 // Create checkpoint plan (sync fs I/O + hashing; run on blocking pool)
                 let local_attempt_path = self.get_local_attempt_path();
                 let remote_namespace = self.remote_namespace.clone();
@@ -306,7 +390,8 @@ impl CheckpointWorker {
                 let attempt_timestamp = self.attempt_timestamp;
                 let sequence = rocks_metadata.sequence;
                 let prev_metadata_owned = previous_metadata.cloned();
-                let plan = unwrap_blocking_task(
+                let cancel_token_owned = cancel_token.cloned();
+                let plan = match unwrap_blocking_task(
                     tokio::task::spawn_blocking(move || {
                         plan_checkpoint(
                             &local_attempt_path,
@@ -317,17 +402,52 @@ impl CheckpointWorker {
                             consumer_offset,
                             producer_offset,
                             prev_metadata_owned.as_ref(),
+                            cancel_token_owned.as_ref(),
                         )
                     }),
                     "plan_checkpoint task panicked",
                 )
                 .await
-                .with_context(|| {
-                    format!(
-                        "checkpoint planning failed for {} at {}",
-                        attempt_type, local_attempt_path_tag
-                    )
-                })?;
+                {
+                    Ok(plan) => plan,
+                    Err(e) => {
+                        if e.downcast_ref::<PlanningCancelledError>().is_some() {
+                            let tags = [
+                                ("result", "skipped"),
+                                ("cause", Self::during_plan_skip_cause(cancel_cause)),
+                            ];
+                            metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+                            info!(
+                                self.worker_id,
+                                local_attempt_path = local_attempt_path_tag,
+                                attempt_type,
+                                "Checkpoint worker: cancellation observed during checkpoint planning, skipping export"
+                            );
+                            return Ok(None);
+                        }
+                        return Err(e).with_context(|| {
+                            format!(
+                                "checkpoint planning failed for {} at {}",
+                                attempt_type, local_attempt_path_tag
+                            )
+                        });
+                    }
+                };
+
+                if cancel_token.is_some_and(CancellationToken::is_cancelled) {
+                    let tags = [
+                        ("result", "skipped"),
+                        ("cause", Self::post_plan_skip_cause(cancel_cause)),
+                    ];
+                    metrics::counter!(CHECKPOINT_WORKER_STATUS_COUNTER, &tags).increment(1);
+                    info!(
+                        self.worker_id,
+                        local_attempt_path = local_attempt_path_tag,
+                        attempt_type,
+                        "Checkpoint worker: cancellation observed after checkpoint planning, skipping export"
+                    );
+                    return Ok(None);
+                }
 
                 info!(
                     self.worker_id,
@@ -535,6 +655,46 @@ mod tests {
                 .iter()
                 .any(|p| p.to_string_lossy().ends_with(".log")),
             "Missing .log file"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_worker_skips_local_checkpoint_when_token_cancelled_before_start() {
+        let tmp_store_dir = TempDir::new().unwrap();
+        let store = create_test_dedup_store(tmp_store_dir.path(), "test_topic", 0);
+
+        let event = create_test_raw_event();
+        let key = TimestampKey::from(&event);
+        let metadata = TimestampMetadata::new(&event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
+
+        let tmp_checkpoint_dir = TempDir::new().unwrap();
+        let partition = Partition::new("test_topic".to_string(), 0);
+        let attempt_timestamp = Utc::now();
+        let worker = CheckpointWorker::new_for_testing(
+            1,
+            tmp_checkpoint_dir.path(),
+            "test",
+            partition,
+            attempt_timestamp,
+            None,
+        );
+
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let result = worker
+            .checkpoint_partition_cancellable(&store, None, Some(&cancel_token), Some("rebalance"))
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "checkpoint should be skipped before local creation"
+        );
+        assert!(
+            !worker.get_local_attempt_path().exists(),
+            "local checkpoint directory should not be created when checkpoint is skipped"
         );
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/worker.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/worker.rs
@@ -134,7 +134,8 @@ impl CheckpointWorker {
     }
 
     /// Perform a complete checkpoint operation with cancellation support.
-    /// If cancel_token is provided and cancelled during export, returns an error early.
+    /// If cancel_token is provided and cancelled, the worker may skip before local
+    /// checkpoint creation, during checkpoint planning, or during export/upload.
     ///
     /// The optional `cancel_cause` is used for metrics when cancelled (e.g., "rebalance" or "shutdown").
     pub async fn checkpoint_partition_cancellable(

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -7,7 +7,8 @@
 //!
 //! Rebalance triggers checkpoint imports (S3 downloads); exports are suppressed so imports get bandwidth.
 //! Workers take a token from `RebalanceTracker::get_export_token()` — cancelled on any rebalance start (0→1),
-//! recreated when all rebalances finish (1→0). Workers check before I/O and pass to exporter for upload cancellation.
+//! recreated when all rebalances finish (1→0). Workers check that token before local checkpoint
+//! creation, around checkpoint planning, and pass it to the exporter for upload cancellation.
 
 use std::collections::HashSet;
 use std::path::Path;

--- a/rust/kafka-deduplicator/src/checkpoint_manager.rs
+++ b/rust/kafka-deduplicator/src/checkpoint_manager.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 
 use crate::checkpoint::{
     CheckpointConfig, CheckpointExporter, CheckpointMetadata, CheckpointWorker,
-    UploadCancelledError,
 };
 use crate::kafka::offset_tracker::OffsetTracker;
 use crate::kafka::types::Partition;
@@ -364,19 +363,13 @@ impl CheckpointManager {
                                 // handle releasing locks and reporting outcome
                                 let status = match &result {
                                     Ok(Some(new_checkpoint_info)) => {
-                                        // Update counter and metadata atomically on success
                                         worker_checkpoint_state.insert(partition.clone(), (counter + 1, new_checkpoint_info.metadata.clone()));
                                         "success"
                                     },
                                     Ok(None) => "skipped",
                                     Err(e) => {
-                                        // Cancellation is NOT an error - s3_uploader already logged the detail
-                                        if e.downcast_ref::<UploadCancelledError>().is_some() {
-                                            "cancelled"
-                                        } else {
-                                            error!(partition = partition_tag, "Checkpoint worker thread: attempt failed: {e:#}");
-                                            "error"
-                                        }
+                                        error!(partition = partition_tag, "Checkpoint worker thread: attempt failed: {e:#}");
+                                        "error"
                                     },
                                 };
                                 info!(worker_task_id, partition = partition_tag, result = status,

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -714,9 +714,9 @@ async fn test_parent_cancellation_stops_all_attempts() -> Result<()> {
 ///
 /// Tests:
 /// 1. Pre-cancelled token prevents upload from starting
-/// 2. Cancellation returns appropriate error with "cancelled" message
+/// 2. Pre-cancelled export is cooperatively skipped rather than treated as an error
 /// 3. No files are uploaded when pre-cancelled
-/// 4. Verifies the cancellation flows through exporter → uploader correctly
+/// 4. Verifies the cancellation flows through worker → planner/uploader correctly
 #[tokio::test]
 async fn test_export_cancellation_via_minio() -> Result<()> {
     let test_topic = "test_export_cancellation";
@@ -753,9 +753,9 @@ async fn test_export_cancellation_via_minio() -> Result<()> {
     let partition = Partition::new(test_topic.to_string(), test_partition);
 
     // ============================================================
-    // Test 1: Pre-cancelled token should fail immediately
+    // Test 1: Pre-cancelled token should skip immediately
     // ============================================================
-    info!("Test 1: Pre-cancelled token should fail immediately");
+    info!("Test 1: Pre-cancelled token should skip immediately");
 
     // Each test case gets its own TempDir to avoid directory collision
     let tmp_checkpoint_dir_1 = TempDir::new()?;
@@ -781,18 +781,14 @@ async fn test_export_cancellation_via_minio() -> Result<()> {
         .await;
     let elapsed = start.elapsed();
 
-    assert!(result.is_err(), "Checkpoint should fail when pre-cancelled");
-    let err_msg = result.unwrap_err().to_string();
     assert!(
-        err_msg.to_lowercase().contains("cancelled"),
-        "Error should mention cancellation: {}",
-        err_msg
+        matches!(result, Ok(None)),
+        "Checkpoint should be skipped when pre-cancelled, got: {result:?}"
     );
 
     info!(
         elapsed_ms = elapsed.as_millis(),
-        error = err_msg,
-        "Pre-cancelled export failed as expected"
+        "Pre-cancelled export skipped as expected"
     );
 
     // Verify: No objects should have been uploaded to MinIO
@@ -1070,7 +1066,7 @@ async fn test_export_mid_upload_cancellation() -> Result<()> {
         Ok(None) => {
             info!(
                 elapsed_ms = elapsed.as_millis(),
-                "Export was skipped (no exporter configured - unexpected)"
+                "Export was skipped before upload after cancellation"
             );
         }
         Err(e) => {

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -1053,8 +1053,11 @@ async fn test_export_mid_upload_cancellation() -> Result<()> {
         .await;
     let elapsed = start.elapsed();
 
-    // The result depends on timing - it may succeed if upload completed before cancellation,
-    // or fail with cancellation error if caught mid-upload
+    // The result depends on timing:
+    // - Ok(Some(info)): upload completed before cancellation
+    // - Ok(None): cancellation caught at any gate (pre-plan, during-plan,
+    //   post-plan, or during-upload — all return Ok(None) now)
+    // - Err: genuine non-cancellation failure (unexpected here)
     match &result {
         Ok(Some(info)) => {
             info!(
@@ -1066,40 +1069,11 @@ async fn test_export_mid_upload_cancellation() -> Result<()> {
         Ok(None) => {
             info!(
                 elapsed_ms = elapsed.as_millis(),
-                "Export was skipped before upload after cancellation"
+                "Export skipped due to cancellation"
             );
         }
         Err(e) => {
-            let err_msg = e.to_string();
-            info!(
-                elapsed_ms = elapsed.as_millis(),
-                error = err_msg,
-                "Upload cancelled mid-stream as expected"
-            );
-
-            // If cancelled, verify no metadata.json was uploaded (all-or-nothing)
-            let list_result = minio_client
-                .list_objects_v2()
-                .bucket(TEST_BUCKET)
-                .prefix(&test_prefix)
-                .send()
-                .await?;
-
-            let uploaded_keys: Vec<String> = list_result
-                .contents()
-                .iter()
-                .filter_map(|obj| obj.key().map(String::from))
-                .collect();
-
-            // metadata.json should NOT exist if cancelled mid-upload
-            // (it's uploaded last, after all files succeed)
-            let has_metadata = uploaded_keys.iter().any(|k| k.ends_with("metadata.json"));
-            if !has_metadata && !uploaded_keys.is_empty() {
-                info!(
-                    partial_files = uploaded_keys.len(),
-                    "Verified: No metadata.json uploaded (all-or-nothing semantics preserved)"
-                );
-            }
+            panic!("Unexpected error during mid-upload cancellation test: {e:#}");
         }
     }
 

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -635,7 +635,7 @@ async fn test_checkpoint_from_plan_with_previous_metadata() {
 // ============================================================
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_checkpoint_with_pre_cancelled_token_fails() {
+async fn test_checkpoint_with_pre_cancelled_token_skips() {
     let test_topic = "test_pre_cancelled";
     let test_partition = 0;
     let tmp_store_dir = TempDir::new().unwrap();
@@ -682,17 +682,14 @@ async fn test_checkpoint_with_pre_cancelled_token_fails() {
     let cancel_token = CancellationToken::new();
     cancel_token.cancel();
 
-    // Checkpoint should fail with cancellation error
+    // Pre-cancelled checkpoint should be cooperatively skipped
     let result = worker
         .checkpoint_partition_cancellable(&store, None, Some(&cancel_token), Some("test"))
         .await;
 
-    assert!(result.is_err(), "Checkpoint should fail when pre-cancelled");
-    let err_msg = result.unwrap_err().to_string();
     assert!(
-        err_msg.to_lowercase().contains("cancelled"),
-        "Error should mention cancellation: {}",
-        err_msg
+        matches!(result, Ok(None)),
+        "Checkpoint should be skipped when pre-cancelled, got: {result:?}"
     );
 
     // Verify no files were uploaded

--- a/rust/kafka-deduplicator/tests/checkpoint_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_tests.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 use kafka_deduplicator::checkpoint::{
     hash_prefix_for_partition, CheckpointConfig, CheckpointExporter, CheckpointMetadata,
-    CheckpointPlan, CheckpointUploader, CheckpointWorker,
+    CheckpointPlan, CheckpointUploader, CheckpointWorker, UploadCancelledError,
 };
 use kafka_deduplicator::kafka::types::Partition;
 use kafka_deduplicator::store::TimestampMetadata;
@@ -116,11 +116,13 @@ impl CheckpointUploader for MockUploader {
         plan: &CheckpointPlan,
         cancel_token: Option<&CancellationToken>,
     ) -> Result<Vec<String>> {
-        // Check cancellation before starting (matching real S3Uploader behavior)
         if let Some(token) = cancel_token {
             if token.is_cancelled() {
                 info!("Mock uploader: cancelled before starting");
-                return Err(anyhow::anyhow!("Upload cancelled before starting"));
+                return Err(UploadCancelledError {
+                    reason: "before starting".to_string(),
+                }
+                .into());
             }
         }
 
@@ -141,13 +143,15 @@ impl CheckpointUploader for MockUploader {
             ));
         }
 
-        // Check cancellation before each file upload (simulating real behavior)
         let mut uploaded_keys = Vec::new();
         for (local_file_path, remote_file_path_str) in files_to_upload {
             if let Some(token) = cancel_token {
                 if token.is_cancelled() {
                     info!("Mock uploader: cancelled during file upload");
-                    return Err(anyhow::anyhow!("Upload cancelled during file upload"));
+                    return Err(UploadCancelledError {
+                        reason: "during file upload".to_string(),
+                    }
+                    .into());
                 }
             }
             let remote_file_path = self.upload_dir.join(&remote_file_path_str);
@@ -158,11 +162,13 @@ impl CheckpointUploader for MockUploader {
             uploaded_keys.push(remote_file_path_str);
         }
 
-        // Check cancellation before metadata upload (final gate, matching S3Uploader)
         if let Some(token) = cancel_token {
             if token.is_cancelled() {
                 info!("Mock uploader: cancelled before metadata upload");
-                return Err(anyhow::anyhow!("Upload cancelled before metadata upload"));
+                return Err(UploadCancelledError {
+                    reason: "before metadata upload".to_string(),
+                }
+                .into());
             }
         }
 


### PR DESCRIPTION
## Problem
First of a series of small(er) config changes to cap RocksDB resource util during checkpointing (mostly the next PRs) and ensure max isolation between export and import work (this PR.)
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Thread cancellation-on-rebalance (import starting) deeper into checkpoint export flow
* Related test updates
* Bonus: updated misc. stale comments and very stale `README.md` entries (cfg vars etc.)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, CI. Smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
