### PR TITLE
feat(insights): prevent display settings leaking across insight tabs

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -11,6 +11,7 @@ import { nodeKindToDefaultQuery } from '~/queries/nodes/InsightQuery/defaults'
 import { FunnelsQuery, InsightVizNode, Node, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
+    ChartDisplayType,
     FunnelVizType,
     InsightLogicProps,
     InsightShortId,
@@ -419,6 +420,136 @@ describe('insightNavLogic', () => {
                         },
                     } as Node),
                 ])
+            })
+
+            it('does not carry trends-only display settings into funnels', async () => {
+                const trendsQueryWithDisplay: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        interval: 'hour',
+                        version: 2,
+                        trendsFilter: {
+                            display: ChartDisplayType.ActionsBar,
+                            showPercentStackView: true,
+                            showValuesOnSeries: true,
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsQueryWithDisplay)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toDispatchActions([
+                    builtInsightDataLogic.actionCreators.setQuery({
+                        kind: 'InsightVizNode',
+                        source: {
+                            kind: 'FunnelsQuery',
+                            series: [{ kind: 'EventsNode', name: '$pageview', event: '$pageview' }],
+                            funnelsFilter: { funnelVizType: 'steps', showValuesOnSeries: true },
+                            filterTestAccounts: true,
+                            interval: 'hour',
+                        },
+                    } as Node),
+                ])
+            })
+
+            it('does not carry showValuesOnSeries into retention', async () => {
+                const funnelsQueryWithValuesOnSeries: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageleave',
+                                event: '$pageleave',
+                            },
+                        ],
+                        funnelsFilter: {
+                            funnelOrderType: StepOrderValue.STRICT,
+                            funnelVizType: FunnelVizType.Steps,
+                            showValuesOnSeries: true,
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(funnelsQueryWithValuesOnSeries)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.RETENTION)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: 'InsightVizNode',
+                    source: {
+                        kind: 'RetentionQuery',
+                        filterTestAccounts: true,
+                    },
+                })
+                expect((builtInsightDataLogic.values.query as InsightVizNode).source).not.toMatchObject({
+                    retentionFilter: expect.objectContaining({ showValuesOnSeries: true }),
+                })
+            })
+
+            it('keeps display when switching from trends to stickiness', async () => {
+                const trendsQueryForStickiness: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        interval: 'hour',
+                        version: 2,
+                        trendsFilter: {
+                            display: ChartDisplayType.ActionsBar,
+                            showValuesOnSeries: true,
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsQueryForStickiness)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.STICKINESS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: 'InsightVizNode',
+                    source: {
+                        kind: 'StickinessQuery',
+                        filterTestAccounts: true,
+                        interval: 'hour',
+                        stickinessFilter: expect.objectContaining({
+                            display: ChartDisplayType.ActionsBar,
+                            showValuesOnSeries: true,
+                        }),
+                    },
+                })
             })
         })
     })

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -124,6 +124,22 @@ const cleanSeriesMath = (
     return series.map((entity) => cleanSeriesEntityMath(entity, mathAvailability))
 }
 
+const getCommonVisualizationProperties = (
+    query: InsightQueryNode,
+    commonFilter: CommonInsightFilter
+): Partial<CommonInsightFilter> => ({
+    ...((isLifecycleQuery(query) || isStickinessQuery(query) || isTrendsQuery(query) || isFunnelsQuery(query)) &&
+    commonFilter.showValuesOnSeries
+        ? { showValuesOnSeries: commonFilter.showValuesOnSeries }
+        : {}),
+    ...(isTrendsQuery(query) && commonFilter.showPercentStackView
+        ? { showPercentStackView: commonFilter.showPercentStackView }
+        : {}),
+    ...((isTrendsQuery(query) || isStickinessQuery(query)) && commonFilter.display
+        ? { display: commonFilter.display }
+        : {}),
+})
+
 export const insightNavLogic = kea<insightNavLogicType>([
     props({} as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
@@ -296,6 +312,24 @@ export const insightNavLogic = kea<insightNavLogicType>([
 const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyCache | null): QueryPropertyCache => {
     const newCache = JSON.parse(JSON.stringify(query)) as QueryPropertyCache
 
+    // // set series (first two entries) from retention target and returning entity
+    // if (isRetentionQuery(query)) {
+    //     const { targetEntity, returningEntity } = query.retentionFilter || {}
+    //     const series = actionsAndEventsToSeries({
+    //         events: [
+    //             ...(targetEntity?.type === 'events' ? [targetEntity as ActionFilter] : []),
+    //             ...(returningEntity?.type === 'events' ? [returningEntity as ActionFilter] : []),
+    //         ],
+    //         actions: [
+    //             ...(targetEntity?.type === 'actions' ? [targetEntity as ActionFilter] : []),
+    //             ...(returningEntity?.type === 'actions' ? [returningEntity as ActionFilter] : []),
+    //         ],
+    //     })
+    //     if (series.length > 0) {
+    //         newCache.series = [...series, ...(cache?.series ? cache.series.slice(series.length) : [])]
+    //     }
+    // }
+
     if (isLifecycleQuery(query)) {
         newCache.series = cache?.series
     }
@@ -448,24 +482,11 @@ const mergeCachedProperties = (
 
     // insight specific filter
     if (cache.commonFilter) {
-        const commonVisualizationProperties = {
-            // TODO: fix an issue where switching between trends and funnels with the option enabled would
-            // result in an error before uncommenting
-            // ...(cache.commonFilter?.compare ? { compare: cache.commonFilter.compare } : {}),
-            ...(cache.commonFilter?.showValuesOnSeries
-                ? { showValuesOnSeries: cache.commonFilter.showValuesOnSeries }
-                : {}),
-            ...(cache.commonFilter?.showPercentStackView
-                ? { showPercentStackView: cache.commonFilter.showPercentStackView }
-                : {}),
-            ...(cache.commonFilter?.display ? { display: cache.commonFilter.display } : {}),
-        }
-
         if (isTrendsQuery(query) && isTrendsQuery(mergedQuery)) {
             mergedQuery.trendsFilter = {
                 ...query.trendsFilter,
                 ...cache.trendsFilter,
-                ...commonVisualizationProperties,
+                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
                 ...(cache.commonFilterTrendsStickiness?.resultCustomizations
                     ? { resultCustomizations: cache.commonFilterTrendsStickiness.resultCustomizations }
                     : {}),
@@ -474,7 +495,7 @@ const mergeCachedProperties = (
             mergedQuery.stickinessFilter = {
                 ...query.stickinessFilter,
                 ...cache.stickinessFilter,
-                ...commonVisualizationProperties,
+                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
                 ...(cache.commonFilterTrendsStickiness?.resultCustomizations
                     ? { resultCustomizations: cache.commonFilterTrendsStickiness.resultCustomizations }
                     : {}),
@@ -483,25 +504,25 @@ const mergeCachedProperties = (
             mergedQuery.funnelsFilter = {
                 ...query.funnelsFilter,
                 ...cache.funnelsFilter,
-                ...commonVisualizationProperties,
+                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
             }
         } else if (isRetentionQuery(query) && isRetentionQuery(mergedQuery)) {
             mergedQuery.retentionFilter = {
                 ...query.retentionFilter,
                 ...cache.retentionFilter,
-                ...commonVisualizationProperties,
+                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
             }
         } else if (isPathsQuery(query) && isPathsQuery(mergedQuery)) {
             mergedQuery.pathsFilter = {
                 ...query.pathsFilter,
                 ...cache.pathsFilter,
-                ...commonVisualizationProperties,
+                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
             }
         } else if (isLifecycleQuery(query) && isLifecycleQuery(mergedQuery)) {
             mergedQuery.lifecycleFilter = {
                 ...query.lifecycleFilter,
                 ...cache.lifecycleFilter,
-                ...commonVisualizationProperties,
+                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
             }
         }
     }

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -124,21 +124,72 @@ const cleanSeriesMath = (
     return series.map((entity) => cleanSeriesEntityMath(entity, mathAvailability))
 }
 
-const getCommonVisualizationProperties = (
+type TrendsCommonVisualizationProperties = Pick<TrendsFilter, 'showValuesOnSeries' | 'showPercentStackView' | 'display'>
+type StickinessCommonVisualizationProperties = Pick<StickinessFilter, 'showValuesOnSeries' | 'display'>
+type FunnelsCommonVisualizationProperties = Pick<FunnelsFilter, 'showValuesOnSeries'>
+type LifecycleCommonVisualizationProperties = Pick<LifecycleFilter, 'showValuesOnSeries'>
+type EmptyCommonVisualizationProperties = Record<never, never>
+
+function getCommonVisualizationProperties(
+    query: TrendsQuery,
+    commonFilter: CommonInsightFilter
+): Partial<TrendsCommonVisualizationProperties>
+function getCommonVisualizationProperties(
+    query: StickinessQuery,
+    commonFilter: CommonInsightFilter
+): Partial<StickinessCommonVisualizationProperties>
+function getCommonVisualizationProperties(
+    query: FunnelsQuery,
+    commonFilter: CommonInsightFilter
+): Partial<FunnelsCommonVisualizationProperties>
+function getCommonVisualizationProperties(
+    query: LifecycleQuery,
+    commonFilter: CommonInsightFilter
+): Partial<LifecycleCommonVisualizationProperties>
+function getCommonVisualizationProperties(
+    query: RetentionQuery,
+    commonFilter: CommonInsightFilter
+): Partial<EmptyCommonVisualizationProperties>
+function getCommonVisualizationProperties(
+    query: PathsQuery,
+    commonFilter: CommonInsightFilter
+): Partial<EmptyCommonVisualizationProperties>
+function getCommonVisualizationProperties(
     query: InsightQueryNode,
     commonFilter: CommonInsightFilter
-): Partial<CommonInsightFilter> => ({
-    ...((isLifecycleQuery(query) || isStickinessQuery(query) || isTrendsQuery(query) || isFunnelsQuery(query)) &&
-    commonFilter.showValuesOnSeries
-        ? { showValuesOnSeries: commonFilter.showValuesOnSeries }
-        : {}),
-    ...(isTrendsQuery(query) && commonFilter.showPercentStackView
-        ? { showPercentStackView: commonFilter.showPercentStackView }
-        : {}),
-    ...((isTrendsQuery(query) || isStickinessQuery(query)) && commonFilter.display
-        ? { display: commonFilter.display }
-        : {}),
-})
+):
+    | Partial<TrendsCommonVisualizationProperties>
+    | Partial<StickinessCommonVisualizationProperties>
+    | Partial<FunnelsCommonVisualizationProperties>
+    | Partial<LifecycleCommonVisualizationProperties>
+    | Partial<EmptyCommonVisualizationProperties> {
+    const sharedProperties = {
+        ...((isLifecycleQuery(query) || isStickinessQuery(query) || isTrendsQuery(query) || isFunnelsQuery(query)) &&
+        commonFilter.showValuesOnSeries
+            ? { showValuesOnSeries: commonFilter.showValuesOnSeries }
+            : {}),
+        ...(isTrendsQuery(query) && commonFilter.showPercentStackView
+            ? { showPercentStackView: commonFilter.showPercentStackView }
+            : {}),
+        ...((isTrendsQuery(query) || isStickinessQuery(query)) && commonFilter.display
+            ? { display: commonFilter.display }
+            : {}),
+    }
+
+    if (isTrendsQuery(query)) {
+        return sharedProperties as Partial<TrendsCommonVisualizationProperties>
+    }
+    if (isStickinessQuery(query)) {
+        return sharedProperties as Partial<StickinessCommonVisualizationProperties>
+    }
+    if (isFunnelsQuery(query)) {
+        return sharedProperties as Partial<FunnelsCommonVisualizationProperties>
+    }
+    if (isLifecycleQuery(query)) {
+        return sharedProperties as Partial<LifecycleCommonVisualizationProperties>
+    }
+    return {} as Partial<EmptyCommonVisualizationProperties>
+}
 
 export const insightNavLogic = kea<insightNavLogicType>([
     props({} as InsightLogicProps),


### PR DESCRIPTION
## Summary

Fix insight tab switching so trends-only display settings no longer leak into other insight types.

## Changes

When switching from a trends insight with a custom display to funnels, the shared query-property cache was incorrectly reapplying `display` onto `funnelsFilter`. That regression came from the recent `insightNavLogic` refactor that replaced helper-based merging with direct property spreading - https://github.com/PostHog/posthog/pull/49824.

This change scopes cached visualization properties by target insight type:
- `display` now only carries across trends and stickiness
- `showPercentStackView` now only carries across trends
- `showValuesOnSeries` only carries to insight types that support it

I also restored the explanatory retention comment in `insightNavLogic.tsx`.