### PR TITLE
fix: better differentiate between legacy personal api keys

### DIFF
--- a/posthog/api/personal_api_key.py
+++ b/posthog/api/personal_api_key.py
@@ -32,7 +32,7 @@ MAX_API_KEYS_PER_USER = 10  # Same as in scopes.tsx
 class PersonalAPIKeySerializer(serializers.ModelSerializer):
     # Specifying method name because the serializer class already has a get_value method
     value = serializers.SerializerMethodField(method_name="get_key_value", read_only=True)
-    scopes = serializers.ListField(child=serializers.CharField(required=True))
+    scopes = serializers.ListField(child=serializers.CharField(required=True), allow_empty=False)
     scoped_teams = serializers.ListField(child=serializers.IntegerField(required=False))
     scoped_organizations = serializers.ListField(child=serializers.CharField(required=False))
 
@@ -129,7 +129,9 @@ class PersonalAPIKeySerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        ret["scopes"] = ret["scopes"] or ["*"]
+        # TRICKY: Legacy Personal API keys have scopes=None and are shown as ["*"].
+        # An empty list [] is NOT legacy and must be preserved as-is.
+        ret["scopes"] = ["*"] if ret["scopes"] is None else ret["scopes"]
         return ret
 
     def create(self, validated_data: dict, **kwargs) -> PersonalAPIKey:

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -267,6 +267,25 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
         assert data["mask_value"] != original_key.mask_value
 
 
+class TestPersonalAPIKeysAPIValidation(APIBaseTest):
+    def test_cannot_create_key_with_empty_scopes(self):
+        response = self.client.post(
+            "/api/personal_api_keys/",
+            {"label": "empty", "scopes": [], "scoped_organizations": [], "scoped_teams": []},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_cannot_update_key_to_empty_scopes(self):
+        key = PersonalAPIKey.objects.create(
+            label="Test",
+            user=self.user,
+            secure_value=hash_key_value(generate_random_token_personal()),
+            scopes=["insight:read"],
+        )
+        response = self.client.patch(f"/api/personal_api_keys/{key.id}", {"scopes": []})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
 class PersonalAPIKeysBaseTest(APIBaseTest):
     CONFIG_AUTO_LOGIN = False
 
@@ -286,7 +305,7 @@ class PersonalAPIKeysBaseTest(APIBaseTest):
             label="Test",
             user=self.user,
             secure_value=hash_key_value(self.value),
-            scopes=[],
+            scopes=["*"],
             scoped_teams=[],
             scoped_organizations=[],
         )
@@ -463,7 +482,7 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
             label="Test last_updated_at",
             user=self.user,
             secure_value=hash_key_value(value),
-            scopes=[],
+            scopes=["*"],
         )
         assert key.last_used_at is None
 
@@ -491,6 +510,12 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
         self.key.save()
         response = self._do_request("/api/users/@me/")
         assert response.status_code == status.HTTP_200_OK
+
+    def test_rejects_empty_scopes_list_as_not_legacy(self):
+        self.key.scopes = []
+        self.key.save()
+        response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_forbids_scoped_access_for_unsupported_endpoint(self):
         # Even * scope isn't allowed for unsupported endpoints

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -471,8 +471,9 @@ class APIScopePermission(ScopeBasePermission):
 
         if isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication):
             key_scopes = request.successful_authenticator.personal_api_key.scopes
-            # TRICKY: Legacy Personal API keys have no scopes and are allowed to do anything
-            if not key_scopes:
+            # TRICKY: Legacy Personal API keys have scopes=None and are allowed to do anything.
+            # Must use `is None` — an empty list [] is NOT legacy and must be denied.
+            if key_scopes is None:
                 return True
         elif isinstance(request.successful_authenticator, OAuthAccessTokenAuthentication):
             # OAuth tokens store scopes as space-separated string


### PR DESCRIPTION
We need to distinguish between a key with no scopes (`None`) and a key with an empty list of scopes (`[]`).
