### PR TITLE
fix(llm-gateway): restore client user param for analytics distinct_id

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -81,6 +81,24 @@ class PostHogCallback(InstrumentedCallback):
         self._api_key = api_key
         self._host = host
 
+    def _resolve_distinct_id(self, kwargs: dict[str, Any], end_user_id: str | None) -> str:
+        """Resolve the distinct_id for analytics event capture.
+
+        Rate limiting uses auth_user.user_id (via _extract_end_user_id in base)
+        to prevent poisoning. For analytics, we prefer the client-provided
+        OpenAI 'user' param so server-side callers (e.g. temporal workflows)
+        can attribute events to the correct entity (team, workflow, etc.).
+        """
+        auth_user = get_auth_user()
+        if auth_user and auth_user.auth_method == "oauth_access_token":
+            return auth_user.distinct_id
+
+        # Prefer client-provided 'user' param for analytics attribution
+        if client_user := kwargs.get("user"):
+            return str(client_user)
+
+        return end_user_id or (auth_user.distinct_id if auth_user else str(uuid4()))
+
     async def _on_success(
         self, kwargs: dict[str, Any], response_obj: Any, start_time: float, end_time: float, end_user_id: str | None
     ) -> None:
@@ -92,10 +110,7 @@ class PostHogCallback(InstrumentedCallback):
         trace_id = (
             metadata.get("user_id") or str(uuid4())
         )  # anthropic stores user_id in metadata, but it actually refers to the trace_id rather than the user for claude code.
-        if auth_user and auth_user.auth_method == "oauth_access_token":
-            distinct_id = auth_user.distinct_id
-        else:
-            distinct_id = end_user_id or (auth_user.distinct_id if auth_user else str(uuid4()))
+        distinct_id = self._resolve_distinct_id(kwargs, end_user_id)
         team_id = auth_user.team_id if auth_user and auth_user.team_id else None
 
         logger.debug(
@@ -178,10 +193,7 @@ class PostHogCallback(InstrumentedCallback):
         trace_id = (
             metadata.get("user_id") or str(uuid4())
         )  # anthropic stores user_id in metadata, but it actually refers to the trace_id rather than the user for claude code.
-        if auth_user and auth_user.auth_method == "oauth_access_token":
-            distinct_id = auth_user.distinct_id
-        else:
-            distinct_id = end_user_id or (auth_user.distinct_id if auth_user else str(uuid4()))
+        distinct_id = self._resolve_distinct_id(kwargs, end_user_id)
         team_id = auth_user.team_id if auth_user and auth_user.team_id else None
 
         logger.debug(

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -338,6 +338,77 @@ class TestPostHogCallback:
             assert call_kwargs["distinct_id"] == "openai-end-user-789"
             assert call_kwargs["properties"]["$ai_trace_id"] == "trace-id-from-metadata"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method_name", ["_on_success", "_on_failure"])
+    async def test_client_user_param_used_as_distinct_id(
+        self, callback: PostHogCallback, auth_user: AuthenticatedUser, method_name: str, mock_posthog_client: tuple
+    ) -> None:
+        """The OpenAI 'user' param should be used for analytics distinct_id
+        so server-side callers (e.g. temporal workflows) can attribute events
+        to the correct entity."""
+        _, mock_client = mock_posthog_client
+        kwargs = {
+            "user": "temporal-workflow-team-42",
+            "standard_logging_object": {
+                "model": "gpt-4.1-nano",
+                "custom_llm_provider": "openai",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "response_time": 1.0,
+                "response_cost": 0.01,
+                "response": "Hi",
+            },
+            "litellm_params": {},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="llma_summarization"),
+        ):
+            method = getattr(callback, method_name)
+            await method(kwargs, None, 0.0, 1.0, end_user_id="123")
+
+            call_kwargs = mock_client.capture.call_args.kwargs
+            assert call_kwargs["distinct_id"] == "temporal-workflow-team-42"
+
+    @pytest.mark.asyncio
+    async def test_client_user_param_ignored_for_oauth(
+        self, callback: PostHogCallback, mock_posthog_client: tuple
+    ) -> None:
+        """OAuth users should always use auth_user.distinct_id, even if
+        a client 'user' param is provided."""
+        _, mock_client = mock_posthog_client
+        oauth_user = AuthenticatedUser(
+            user_id=123,
+            team_id=456,
+            auth_method="oauth_access_token",
+            distinct_id="real-posthog-distinct-id",
+        )
+        kwargs = {
+            "user": "temporal-workflow-team-42",
+            "standard_logging_object": {
+                "model": "gpt-4",
+                "custom_llm_provider": "openai",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "response_time": 1.0,
+                "response_cost": 0.01,
+                "response": "Hi",
+            },
+            "litellm_params": {},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=oauth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="wizard"),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id="123")
+
+            call_kwargs = mock_client.capture.call_args.kwargs
+            assert call_kwargs["distinct_id"] == "real-posthog-distinct-id"
+
 
 class TestReplaceBinaryContent:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

PR #50542 hardened `_extract_end_user_id()` in the LLM gateway base callback to always return the authenticated user's numeric ID, preventing rate-limit poisoning attacks. This was correct for rate limiting but had an unintended side effect on **analytics event attribution**.

Server-side callers like temporal workflows pass `user="temporal-workflow-team-{id}"` via the OpenAI client to attribute `$ai_generation` events per-team. After #50542, this `user` param was ignored and all events got attributed to the gateway service account's numeric user ID instead.

**Impact on the "Cost per user" insight ([link](https://us.posthog.com/project/2/insights/4jIyohgF?dashboard=637874)):**

| Metric | Before Mar 11 | After Mar 11 |
|---|---|---|
| Daily unique users (llma_summarization) | ~2,300 | 2 |
| Cost per user | ~$0.12 | $148 |
| Total daily cost | ~$280 (normal) | ~$296 (normal) |

The total cost was unchanged — the spike was purely a denominator collapse from `~2,300 → 2` unique distinct_ids.

**Root cause trace:**
1. `summarize_with_openai()` passes `user=f"temporal-workflow-team-{team_id}"` to the LLM gateway
2. `InstrumentedCallback._extract_end_user_id()` (changed in #50542) now ignores this and returns `str(auth_user.user_id)` (e.g. `164122`)
3. `PostHogCallback._on_success()` uses this as `distinct_id` for the captured event
4. All ~360k daily events now map to just 2 distinct_ids instead of ~2,300

## Changes

Separates rate-limiting identity from analytics identity:

- **Rate limiting** (`base.py` `_extract_end_user_id`): unchanged — still uses `auth_user.user_id` to prevent poisoning
- **Analytics capture** (`posthog.py`): new `_resolve_distinct_id()` method that prefers the client-provided OpenAI `user` param for `distinct_id`, falling back to `end_user_id` and then `auth_user.distinct_id`. OAuth users still always use `auth_user.distinct_id`.

## How did you test this code?

- All 64 existing + new tests pass (`test_posthog.py`: 41, `test_base.py`: 23)
- Added 3 new test cases:
  - `test_client_user_param_used_as_distinct_id` (parameterized for success/failure)
  - `test_client_user_param_ignored_for_oauth`
- All existing poisoning prevention tests in `test_base.py` still pass (rate limiting is unaffected)

cc @kappa90 — this preserves your rate-limit poisoning fix while restoring analytics attribution