### PR TITLE
chore(modeling): add 10/minute rate limit on running saved queries for mcp

### DIFF
--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -785,7 +785,7 @@ class RunSavedQueryRateThrottle(PersonalApiKeyRateThrottle):
     # Rate limit running a saved query per saved query per team.
     # Prevents agents from running the same query repeatedly without reason.
     scope = "saved_query"
-    rate = "1/minute"
+    rate = "10/minute"
 
     def get_cache_key(self, request, view):
         team_id = self.safely_get_team_id_from_view(view)

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -781,6 +781,20 @@ class CodeInviteThrottle(UserRateThrottle):
     rate = "20000/hour"
 
 
+class RunSavedQueryRateThrottle(PersonalApiKeyRateThrottle):
+    # Rate limit running a saved query per saved query per team.
+    # Prevents agents from running the same query repeatedly without reason.
+    scope = "saved_query"
+    rate = "1/minute"
+
+    def get_cache_key(self, request, view):
+        team_id = self.safely_get_team_id_from_view(view)
+        pk = view.kwargs.get("pk", "")
+        if team_id and pk:
+            return self.cache_format % {"scope": self.scope, "ident": f"{team_id}_{pk}"}
+        return super().get_cache_key(request, view)
+
+
 class MaterializationRateThrottle(PersonalApiKeyRateThrottle):
     # Rate limit materialization toggle actions (materialize / revert) per saved query per team.
     # Prevents agents from thrashing materialization state on the same query.

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -40,7 +40,7 @@ from posthog.models.activity_logging.activity_log import (
     log_activity,
 )
 from posthog.models.activity_logging.activity_page import activity_page_response
-from posthog.rate_limit import MaterializationRateThrottle
+from posthog.rate_limit import MaterializationRateThrottle, RunSavedQueryRateThrottle
 from posthog.temporal.common.client import sync_connect
 
 from products.data_warehouse.backend.data_load.saved_query_service import (
@@ -582,7 +582,11 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
-    @action(methods=["POST"], detail=True)
+    @action(
+        methods=["POST"],
+        detail=True,
+        throttle_classes=[RunSavedQueryRateThrottle],
+    )
     def run(self, request: request.Request, *args, **kwargs) -> response.Response:
         """Run this saved query."""
         saved_query = self.get_object()


### PR DESCRIPTION
## Problem

agents and mcps

## Changes

rate limit running saved queries so we don't ddos ourselves

## How did you test this code?

i didn't

## Publish to changelog?

yes