### PR TITLE
fix: reuse password when share access token is rotated

### DIFF
--- a/posthog/models/sharing_configuration.py
+++ b/posthog/models/sharing_configuration.py
@@ -64,7 +64,21 @@ class SharingConfiguration(models.Model):
             recording=self.recording,
             enabled=self.enabled,
             settings=self.settings,
+            password_required=self.password_required,
         )
+
+        # Clone active passwords to the new config
+        if self.password_required:
+            from posthog.models.share_password import SharePassword
+
+            for pw in self.share_passwords.filter(is_active=True):
+                SharePassword.objects.create(
+                    sharing_configuration=new_config,
+                    password_hash=pw.password_hash,
+                    created_by=pw.created_by,
+                    note=pw.note,
+                    is_active=True,
+                )
 
         # Expire current configuration
         self.expires_at = timezone.now() + timedelta(seconds=settings.SHARING_TOKEN_GRACE_PERIOD_SECONDS)

--- a/posthog/models/test/test_sharing_configuration_model.py
+++ b/posthog/models/test/test_sharing_configuration_model.py
@@ -2,6 +2,7 @@ from posthog.test.base import BaseTest
 
 from posthog.schema import SharingConfigurationSettings
 
+from posthog.models.share_password import SharePassword
 from posthog.models.sharing_configuration import SharingConfiguration
 
 
@@ -123,3 +124,81 @@ class TestSharingConfigurationModel(BaseTest):
         assert new_config.settings == settings_data
         assert new_config.access_token != original_config.access_token
         assert new_config.enabled == original_config.enabled
+
+    def test_rotate_access_token_preserves_password_protection(self):
+        original_config = SharingConfiguration.objects.create(
+            team=self.team,
+            enabled=True,
+            password_required=True,
+        )
+        pw, _ = SharePassword.create_password(
+            sharing_configuration=original_config,
+            created_by=self.user,
+            raw_password="test-password",
+            note="test note",
+        )
+        # Also create an inactive password that should NOT be cloned
+        inactive_pw, _ = SharePassword.create_password(
+            sharing_configuration=original_config,
+            created_by=self.user,
+            raw_password="inactive-password",
+            note="inactive",
+        )
+        inactive_pw.is_active = False
+        inactive_pw.save()
+
+        new_config = original_config.rotate_access_token()
+
+        assert new_config.password_required is True
+        assert new_config.access_token != original_config.access_token
+
+        # New config should have cloned active passwords
+        new_passwords = list(new_config.share_passwords.all())
+        assert len(new_passwords) == 1
+        assert new_passwords[0].note == "test note"
+        assert new_passwords[0].is_active is True
+        assert new_passwords[0].check_password("test-password")
+
+        # Old config passwords should be untouched
+        assert original_config.share_passwords.count() == 2
+        assert original_config.share_passwords.filter(is_active=True).count() == 1
+
+    def test_rotate_access_token_non_password_protected_stays_unprotected(self):
+        original_config = SharingConfiguration.objects.create(
+            team=self.team,
+            enabled=True,
+            password_required=False,
+        )
+
+        new_config = original_config.rotate_access_token()
+
+        assert new_config.password_required is False
+        assert new_config.share_passwords.count() == 0
+
+    def test_rotate_access_token_clones_all_active_passwords(self):
+        original_config = SharingConfiguration.objects.create(
+            team=self.team,
+            enabled=True,
+            password_required=True,
+        )
+        SharePassword.create_password(
+            sharing_configuration=original_config,
+            created_by=self.user,
+            raw_password="password-one",
+            note="first",
+        )
+        SharePassword.create_password(
+            sharing_configuration=original_config,
+            created_by=self.user,
+            raw_password="password-two",
+            note="second",
+        )
+
+        new_config = original_config.rotate_access_token()
+
+        new_passwords = list(new_config.share_passwords.order_by("note"))
+        assert len(new_passwords) == 2
+        assert new_passwords[0].note == "first"
+        assert new_passwords[0].check_password("password-one")
+        assert new_passwords[1].note == "second"
+        assert new_passwords[1].check_password("password-two")


### PR DESCRIPTION
Previously the password requirement was silently dropped.