### PR TITLE
fix: ensure permission checks are scoped to correct org

### DIFF
--- a/.semgrep/rules/cross-org-bypass-user-organization.py
+++ b/.semgrep/rules/cross-org-bypass-user-organization.py
@@ -1,0 +1,73 @@
+from rest_framework import serializers, viewsets
+from rest_framework.permissions import BasePermission
+
+
+# === SHOULD MATCH (ruleid) ===
+
+
+# A: request.user.organization in has_permission
+class BadPermission(BasePermission):
+    def has_permission(self, request, view):
+        # ruleid: cross-org-bypass-user-organization
+        org = request.user.organization
+        return True
+
+
+# B: self.context["request"].user.organization in serializer
+class BadSerializer(serializers.ModelSerializer):
+    def validate_name(self, name):
+        # ruleid: cross-org-bypass-user-organization
+        org = self.context["request"].user.organization
+        return name
+
+
+# C: self.request.user.organization in viewset
+class BadViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    def get_org(self):
+        # ruleid: cross-org-bypass-user-organization
+        return self.request.user.organization
+
+
+# === SHOULD NOT MATCH (ok) ===
+
+
+# Safe: get_organization_from_view
+class GoodPermission(BasePermission):
+    def has_permission(self, request, view):
+        # ok: cross-org-bypass-user-organization
+        org = get_organization_from_view(view)
+        return True
+
+
+# Safe: self.context["view"].organization
+class GoodSerializer(serializers.ModelSerializer):
+    def create(self, validated_data):
+        # ok: cross-org-bypass-user-organization
+        org = self.context["view"].organization
+        return super().create(validated_data)
+
+
+# Safe: self.organization in viewset
+class GoodViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    def get_org(self):
+        # ok: cross-org-bypass-user-organization
+        return self.organization
+
+
+# Safe: standalone view (not org-nested)
+def saml_view(request):
+    # ok: cross-org-bypass-user-organization
+    org = request.user.organization
+    return org
+
+
+# === KNOWN LIMITATION (todoruleid) ===
+
+
+# Aliased variable — can't catch without taint mode
+class AliasedPermission(BasePermission):
+    def has_permission(self, request, view):
+        user = request.user
+        # todoruleid: cross-org-bypass-user-organization
+        org = user.organization
+        return True

--- a/.semgrep/rules/cross-org-bypass-user-organization.yaml
+++ b/.semgrep/rules/cross-org-bypass-user-organization.yaml
@@ -5,16 +5,16 @@ rules:
           - patterns:
                 - pattern: $REQ.user.organization
                 - pattern-inside: |
-                    def has_permission(self, $REQ, $VIEW):
-                        ...
+                      def has_permission(self, $REQ, $VIEW):
+                          ...
           # B: self.context["request"].user.organization (almost always wrong in serializers)
           - pattern: self.context["request"].user.organization
           # C: self.request.user.organization in viewsets with TeamAndOrgViewSetMixin
           - patterns:
                 - pattern: self.request.user.organization
                 - pattern-inside: |
-                    class $CLASS(..., TeamAndOrgViewSetMixin, ...):
-                        ...
+                      class $CLASS(..., TeamAndOrgViewSetMixin, ...):
+                          ...
       message: >
           Do not use `request.user.organization` to determine the current org in
           org-scoped views. The user's "active" organization may differ from the

--- a/.semgrep/rules/cross-org-bypass-user-organization.yaml
+++ b/.semgrep/rules/cross-org-bypass-user-organization.yaml
@@ -1,0 +1,30 @@
+rules:
+    - id: cross-org-bypass-user-organization
+      pattern-either:
+          # A: request.user.organization in permission has_permission methods
+          - patterns:
+                - pattern: $REQ.user.organization
+                - pattern-inside: |
+                    def has_permission(self, $REQ, $VIEW):
+                        ...
+          # B: self.context["request"].user.organization (almost always wrong in serializers)
+          - pattern: self.context["request"].user.organization
+          # C: self.request.user.organization in viewsets with TeamAndOrgViewSetMixin
+          - patterns:
+                - pattern: self.request.user.organization
+                - pattern-inside: |
+                    class $CLASS(..., TeamAndOrgViewSetMixin, ...):
+                        ...
+      message: >
+          Do not use `request.user.organization` to determine the current org in
+          org-scoped views. The user's "active" organization may differ from the
+          org in the URL, allowing cross-org access. Use
+          `get_organization_from_view(view)` in permission classes,
+          `self.context["view"].organization` in serializers, or
+          `self.organization` in viewsets with TeamAndOrgViewSetMixin.
+      severity: ERROR
+      languages: [python]
+      paths:
+          exclude:
+              - '**/test*/**'
+              - '**/.semgrep/**'

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -577,6 +577,8 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return {}
 
     def _get_org(self) -> Optional[Organization]:
+        # root-router viewset with param_derived_from_user_current_team — no URL-scoped org to mismatch
+        # nosemgrep: cross-org-bypass-user-organization
         org = None if self.request.user.is_anonymous else self.request.user.organization
 
         return org

--- a/ee/api/rbac/role.py
+++ b/ee/api/rbac/role.py
@@ -2,6 +2,7 @@ from django.db import IntegrityError
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, serializers, viewsets
+from rest_framework.exceptions import NotFound
 
 from posthog.api.organization_member import OrganizationMemberSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -52,7 +53,7 @@ class RoleSerializer(serializers.ModelSerializer):
             return False
         try:
             organization = view.organization
-        except Exception:
+        except NotFound:
             return False
         return organization.default_role_id == role.id
 

--- a/ee/api/rbac/role.py
+++ b/ee/api/rbac/role.py
@@ -1,39 +1,15 @@
-from typing import cast
-
 from django.db import IntegrityError
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, serializers, viewsets
-from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from posthog.api.organization_member import OrganizationMemberSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.models import OrganizationMembership
-from posthog.models.user import User
-from posthog.permissions import TimeSensitiveActionPermission
+from posthog.permissions import OrganizationAdminWritePermissions, TimeSensitiveActionPermission
 
 from ee.models.rbac.role import Role, RoleMembership
-
-
-class RolePermissions(BasePermission):
-    """
-    Requires organization admin level to change object, allows everyone read
-    """
-
-    message = "You need to have admin level or higher."
-
-    def has_permission(self, request, view):
-        organization = request.user.organization
-
-        requesting_membership: OrganizationMembership = OrganizationMembership.objects.get(
-            user_id=cast(User, request.user).id,
-            organization=organization,
-        )
-
-        if request.method in SAFE_METHODS or requesting_membership.level >= OrganizationMembership.Level.ADMIN:
-            return True
-        return False
 
 
 class RoleSerializer(serializers.ModelSerializer):
@@ -54,7 +30,7 @@ class RoleSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "created_at", "created_by", "is_default"]
 
     def validate_name(self, name):
-        qs = Role.objects.filter(name__iexact=name, organization=self.context["request"].user.organization)
+        qs = Role.objects.filter(name__iexact=name, organization=self.context["view"].organization)
         if self.instance:
             qs = qs.exclude(pk=self.instance.pk)
         if qs.exists():
@@ -62,8 +38,7 @@ class RoleSerializer(serializers.ModelSerializer):
         return name
 
     def create(self, validated_data):
-        organization = self.context["request"].user.organization
-        validated_data["organization"] = organization
+        validated_data["organization"] = self.context["view"].organization
         return super().create(validated_data)
 
     def get_members(self, role: Role):
@@ -72,11 +47,12 @@ class RoleSerializer(serializers.ModelSerializer):
 
     def get_is_default(self, role: Role):
         """Check if this role is the default role for the organization"""
-        request = self.context.get("request")
-        if not request or not hasattr(request, "user") or not request.user.is_authenticated:
+        view = self.context.get("view")
+        if not view:
             return False
-        organization = getattr(request.user, "organization", None)
-        if not organization:
+        try:
+            organization = view.organization
+        except Exception:
             return False
         return organization.default_role_id == role.id
 
@@ -86,7 +62,7 @@ class RoleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "organization"
     serializer_class = RoleSerializer
     queryset = Role.objects.all()
-    permission_classes = [RolePermissions, TimeSensitiveActionPermission]
+    permission_classes = [OrganizationAdminWritePermissions, TimeSensitiveActionPermission]
 
 
 class RoleMembershipSerializer(serializers.ModelSerializer):
@@ -136,7 +112,7 @@ class RoleMembershipViewSet(
     viewsets.GenericViewSet,
 ):
     scope_object = "organization"
-    permission_classes = [RolePermissions, TimeSensitiveActionPermission]
+    permission_classes = [OrganizationAdminWritePermissions, TimeSensitiveActionPermission]
     serializer_class = RoleMembershipSerializer
     queryset = RoleMembership.objects.select_related("role")
     filter_rewrite_rules = {"organization_id": "role__organization_id"}

--- a/ee/api/test/test_role.py
+++ b/ee/api/test/test_role.py
@@ -8,6 +8,76 @@ from ee.api.test.base import APILicensedTest
 from ee.models.rbac.role import Role
 
 
+class TestRoleCrossOrgAuthorization(APILicensedTest):
+    """Tests for cross-organization authorization bypass on role endpoints."""
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.org_a = self.organization
+        self.org_b = Organization.objects.create(name="Org B")
+        self.org_b.update_available_product_features()
+        self.org_b.save()
+
+        # User is admin in org_a, member in org_b
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        self.org_b_membership = OrganizationMembership.objects.create(
+            user=self.user, organization=self.org_b, level=OrganizationMembership.Level.MEMBER
+        )
+
+    def _switch_active_org(self, org):
+        self.user.current_organization = org
+        self.user.save()
+
+    def test_cross_org_admin_cannot_create_roles_in_other_org(self):
+        self._switch_active_org(self.org_a)
+        res = self.client.post(f"/api/organizations/{self.org_b.id}/roles", {"name": "Hacked Role"})
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cross_org_admin_cannot_update_roles_in_other_org(self):
+        role = Role.objects.create(name="Engineering", organization=self.org_b)
+        self._switch_active_org(self.org_a)
+        res = self.client.patch(f"/api/organizations/{self.org_b.id}/roles/{role.id}", {"name": "Hacked"})
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cross_org_admin_cannot_delete_roles_in_other_org(self):
+        role = Role.objects.create(name="Engineering", organization=self.org_b)
+        self._switch_active_org(self.org_a)
+        res = self.client.delete(f"/api/organizations/{self.org_b.id}/roles/{role.id}")
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cross_org_role_creation_uses_correct_org(self):
+        """Admin in both orgs, active=A, POST to B URL → role.organization == B"""
+        self.org_b_membership.level = OrganizationMembership.Level.ADMIN
+        self.org_b_membership.save()
+        self._switch_active_org(self.org_a)
+        res = self.client.post(f"/api/organizations/{self.org_b.id}/roles", {"name": "New Role"})
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        role = Role.objects.get(id=res.json()["id"])
+        self.assertEqual(role.organization_id, self.org_b.id)
+
+    def test_cross_org_role_name_uniqueness_checks_correct_org(self):
+        """'Engineering' exists in A. Admin in both, active=A, POST to B → 201"""
+        Role.objects.create(name="Engineering", organization=self.org_a)
+        self.org_b_membership.level = OrganizationMembership.Level.ADMIN
+        self.org_b_membership.save()
+        self._switch_active_org(self.org_a)
+        res = self.client.post(f"/api/organizations/{self.org_b.id}/roles", {"name": "Engineering"})
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+    def test_member_cannot_modify_roles_after_fix(self):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        res = self.client.post(f"/api/organizations/{self.org_a.id}/roles", {"name": "Blocked"})
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_can_modify_roles_with_explicit_org_id(self):
+        res = self.client.post(f"/api/organizations/{self.org_a.id}/roles", {"name": "Allowed"})
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+
 class TestRoleAPI(APILicensedTest):
     def test_only_organization_admins_and_higher_can_create(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN

--- a/ee/api/test/test_role_membership.py
+++ b/ee/api/test/test_role_membership.py
@@ -7,6 +7,37 @@ from ee.api.test.base import APILicensedTest
 from ee.models.rbac.role import Role, RoleMembership
 
 
+class TestRoleMembershipCrossOrgAuthorization(APILicensedTest):
+    """Tests for cross-organization authorization bypass on role membership endpoints."""
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.org_a = self.organization
+        self.org_b = Organization.objects.create(name="Org B")
+        self.org_b.update_available_product_features()
+        self.org_b.save()
+
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        self.org_b_membership = OrganizationMembership.objects.create(
+            user=self.user, organization=self.org_b, level=OrganizationMembership.Level.MEMBER
+        )
+        self.org_b_role = Role.objects.create(name="Engineering", organization=self.org_b)
+        self.org_b_user = User.objects.create_and_join(self.org_b, "orgb_user@example.com", None)
+
+    def test_cross_org_admin_cannot_add_role_membership_in_other_org(self):
+        self.user.current_organization = self.org_a
+        self.user.save()
+        res = self.client.post(
+            f"/api/organizations/{self.org_b.id}/roles/{self.org_b_role.id}/role_memberships",
+            {"user_uuid": self.org_b_user.uuid},
+        )
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(RoleMembership.objects.filter(role=self.org_b_role, user=self.org_b_user).exists())
+
+
 class TestRoleMembershipAPI(APILicensedTest):
     def setUp(self):
         super().setUp()

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -306,7 +306,7 @@ class AlertSerializer(serializers.ModelSerializer):
             return attrs
 
         if msg := AlertConfiguration.check_alert_limit(
-            self.context["team_id"], self.context["request"].user.organization
+            self.context["team_id"], self.context["get_organization"]()
         ):
             raise ValidationError({"alert": [msg]})
 

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -305,9 +305,7 @@ class AlertSerializer(serializers.ModelSerializer):
         if self.context["request"].method != "POST":
             return attrs
 
-        if msg := AlertConfiguration.check_alert_limit(
-            self.context["team_id"], self.context["get_organization"]()
-        ):
+        if msg := AlertConfiguration.check_alert_limit(self.context["team_id"], self.context["get_organization"]()):
             raise ValidationError({"alert": [msg]})
 
         return attrs

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -369,7 +369,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
             raise serializers.ValidationError("whiteLabel must be a boolean")
 
         # Check if the organization has the white labelling feature available
-        use_survey_white_labelling = self.context["request"].user.organization.is_feature_available(
+        use_survey_white_labelling = self.context["get_organization"]().is_feature_available(
             AvailableFeature.WHITE_LABELLING
         )
 

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -1354,3 +1354,39 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert "organization_member:write" in response.json()["detail"]
+
+    def test_cross_org_invite_permission_bypass(self):
+        """
+        Org A has members_can_invite=True and ORGANIZATION_INVITE_SETTINGS.
+        Org B has members_can_invite=False and ORGANIZATION_INVITE_SETTINGS.
+        User is member in both, active org = A.
+        POST invite to Org B → 403.
+        """
+        org_b = Organization.objects.create(name="Org B")
+        org_b.available_product_features = [
+            {"key": AvailableFeature.ORGANIZATION_INVITE_SETTINGS},
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS},
+        ]
+        org_b.members_can_invite = False
+        org_b.save()
+        OrganizationMembership.objects.create(
+            user=self.user, organization=org_b, level=OrganizationMembership.Level.MEMBER
+        )
+
+        # Org A allows members to invite
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ORGANIZATION_INVITE_SETTINGS},
+            {"key": AvailableFeature.ADVANCED_PERMISSIONS},
+        ]
+        self.organization.members_can_invite = True
+        self.organization.save()
+
+        # Switch active org to A
+        self.user.current_organization = self.organization
+        self.user.save()
+
+        response = self.client.post(
+            f"/api/organizations/{org_b.id}/invites/",
+            {"target_email": "cross_org_test@posthog.com"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -304,10 +304,12 @@ class PremiumFeaturePermission(BasePermission):
         else:
             feature = always_feature
 
-        if not request.user or not request.user.organization:  # type: ignore
+        try:
+            organization = get_organization_from_view(view)
+        except ValueError:
             return True
 
-        if not request.user.organization.is_feature_available(feature):  # type: ignore
+        if not organization.is_feature_available(feature):
             if cloud_only_feature:
                 raise PaidFeatureException(feature)
             raise EnterpriseFeatureException(feature)
@@ -764,35 +766,25 @@ class UserCanInvitePermission(BasePermission):
     """
 
     def has_permission(self, request: Request, view) -> bool:
-        user = cast(User, request.user)
-        org_invite_settings_available = user.organization and user.organization.is_feature_available(
-            AvailableFeature.ORGANIZATION_INVITE_SETTINGS
-        )
+        try:
+            organization = get_organization_from_view(view)
+        except ValueError:
+            return True
+
+        org_invite_settings_available = organization.is_feature_available(AvailableFeature.ORGANIZATION_INVITE_SETTINGS)
 
         if not org_invite_settings_available:
             return True
 
         try:
-            membership = OrganizationMembership.objects.get(user=cast(User, user), organization=user.organization)
+            membership = OrganizationMembership.objects.get(user=cast(User, request.user), organization=organization)
         except OrganizationMembership.DoesNotExist:
             raise NotFound("Organization not found.")
 
-        members_can_invite = bool(user.organization and user.organization.members_can_invite)
+        members_can_invite = bool(organization.members_can_invite)
         user_is_admin = membership.level >= OrganizationMembership.Level.ADMIN
 
         if user_is_admin:
             return True
 
         return members_can_invite
-
-
-class OrganizationInviteSettingsPermission(BasePermission):
-    """
-    Only Admins+ can update org invite settings
-    """
-
-    def has_permission(self, request: Request, view) -> bool:
-        user = cast(User, request.user)
-        membership = user.organization_memberships.get(organization=user.organization)
-
-        return membership.level >= OrganizationMembership.Level.ADMIN


### PR DESCRIPTION
In some cases we checked the user's "current" org, rather than the org they were directly acting on (i.e. the org specified in the URL). I've added a semgrep rule to help prevent new instances of this.