### PR TITLE
feat: add Expire command to Redis pipeline framework

### DIFF
--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -1202,6 +1202,36 @@ mod integration_tests {
 
     #[tokio::test]
     #[ignore] // Requires Docker; run with: cargo test integration_tests -- --ignored
+    async fn test_pipeline_expire() {
+        let (client, _container) = create_test_client().await;
+
+        // EXPIRE on a key that exists should return true
+        let results = client
+            .pipeline()
+            .set("expirable_key", "value")
+            .expire("expirable_key", 3600)
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert!(matches!(results[0], Ok(PipelineResult::Ok)));
+        assert!(matches!(results[1], Ok(PipelineResult::Bool(true))));
+
+        // EXPIRE on a key that doesn't exist should return false
+        let results = client
+            .pipeline()
+            .expire("nonexistent_key", 3600)
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0], Ok(PipelineResult::Bool(false))));
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires Docker; run with: cargo test integration_tests -- --ignored
     async fn test_pipeline_empty() {
         let (client, _container) = create_test_client().await;
 

--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -623,8 +623,11 @@ impl RedisClient {
             PipelineCommand::Set { .. }
             | PipelineCommand::SetEx { .. }
             | PipelineCommand::Del { .. }
-            | PipelineCommand::HIncrBy { .. }
-            | PipelineCommand::Expire { .. } => Ok(PipelineResult::Ok),
+            | PipelineCommand::HIncrBy { .. } => Ok(PipelineResult::Ok),
+            PipelineCommand::Expire { .. } => {
+                // EXPIRE returns 1 if the timeout was set, 0 if the key does not exist
+                Ok(PipelineResult::Bool(matches!(raw, redis::Value::Int(1))))
+            }
             PipelineCommand::SAdd { .. } => {
                 let count: u64 = redis::from_redis_value(&raw)?;
                 Ok(PipelineResult::Count(count))

--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -561,6 +561,9 @@ impl Client for RedisClient {
                 PipelineCommand::SAdd { key, member } => {
                     pipe.cmd("SADD").arg(key).arg(member);
                 }
+                PipelineCommand::Expire { key, seconds } => {
+                    pipe.cmd("EXPIRE").arg(key).arg(*seconds);
+                }
                 PipelineCommand::ZRangeByScore { key, min, max } => {
                     pipe.cmd("ZRANGEBYSCORE").arg(key).arg(min).arg(max);
                 }
@@ -620,7 +623,8 @@ impl RedisClient {
             PipelineCommand::Set { .. }
             | PipelineCommand::SetEx { .. }
             | PipelineCommand::Del { .. }
-            | PipelineCommand::HIncrBy { .. } => Ok(PipelineResult::Ok),
+            | PipelineCommand::HIncrBy { .. }
+            | PipelineCommand::Expire { .. } => Ok(PipelineResult::Ok),
             PipelineCommand::SAdd { .. } => {
                 let count: u64 = redis::from_redis_value(&raw)?;
                 Ok(PipelineResult::Count(count))

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -19,6 +19,7 @@ pub struct MockRedisClient {
     hget_ret: HashMap<String, Result<String, CustomRedisError>>,
     scard_ret: HashMap<String, Result<u64, CustomRedisError>>,
     sadd_ret: HashMap<String, Result<(), CustomRedisError>>,
+    expire_ret: HashMap<String, Result<(), CustomRedisError>>,
     mget_ret: HashMap<String, Option<Vec<u8>>>,
     mget_error: Option<CustomRedisError>,
     calls: Arc<Mutex<Vec<MockRedisCall>>>,
@@ -39,6 +40,7 @@ impl Default for MockRedisClient {
             hget_ret: HashMap::new(),
             scard_ret: HashMap::new(),
             sadd_ret: HashMap::new(),
+            expire_ret: HashMap::new(),
             mget_ret: HashMap::new(),
             mget_error: None,
             calls: Arc::new(Mutex::new(Vec::new())),
@@ -129,6 +131,11 @@ impl MockRedisClient {
 
     pub fn sadd_ret(&mut self, key: &str, ret: Result<(), CustomRedisError>) -> Self {
         self.sadd_ret.insert(key.to_owned(), ret);
+        self.clone()
+    }
+
+    pub fn expire_ret(&mut self, key: &str, ret: Result<(), CustomRedisError>) -> Self {
+        self.expire_ret.insert(key.to_owned(), ret);
         self.clone()
     }
 
@@ -630,6 +637,14 @@ impl MockRedisClient {
             PipelineCommand::SAdd { key, member } => {
                 self.record_call("pipeline_sadd", &key, MockRedisValue::String(member));
                 Self::lookup_or_ok(&self.sadd_ret, &key).map(|_| PipelineResult::Count(1))
+            }
+            PipelineCommand::Expire { key, seconds } => {
+                self.record_call(
+                    "pipeline_expire",
+                    &key,
+                    MockRedisValue::I64(seconds as i64),
+                );
+                Self::lookup_or_ok(&self.expire_ret, &key).map(|_| PipelineResult::Ok)
             }
             PipelineCommand::ZRangeByScore { key, min, max } => {
                 self.record_call(

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -639,12 +639,9 @@ impl MockRedisClient {
                 Self::lookup_or_ok(&self.sadd_ret, &key).map(|_| PipelineResult::Count(1))
             }
             PipelineCommand::Expire { key, seconds } => {
-                self.record_call(
-                    "pipeline_expire",
-                    &key,
-                    MockRedisValue::I64(seconds as i64),
-                );
-                Self::lookup_or_ok(&self.expire_ret, &key).map(|_| PipelineResult::Ok)
+                let ttl_i64 = i64::try_from(seconds).unwrap_or(i64::MAX);
+                self.record_call("pipeline_expire", &key, MockRedisValue::I64(ttl_i64));
+                Self::lookup_or_ok(&self.expire_ret, &key).map(|_| PipelineResult::Bool(true))
             }
             PipelineCommand::ZRangeByScore { key, min, max } => {
                 self.record_call(

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -19,7 +19,7 @@ pub struct MockRedisClient {
     hget_ret: HashMap<String, Result<String, CustomRedisError>>,
     scard_ret: HashMap<String, Result<u64, CustomRedisError>>,
     sadd_ret: HashMap<String, Result<(), CustomRedisError>>,
-    expire_ret: HashMap<String, Result<(), CustomRedisError>>,
+    expire_ret: HashMap<String, Result<bool, CustomRedisError>>,
     mget_ret: HashMap<String, Option<Vec<u8>>>,
     mget_error: Option<CustomRedisError>,
     calls: Arc<Mutex<Vec<MockRedisCall>>>,
@@ -134,7 +134,7 @@ impl MockRedisClient {
         self.clone()
     }
 
-    pub fn expire_ret(&mut self, key: &str, ret: Result<(), CustomRedisError>) -> Self {
+    pub fn expire_ret(&mut self, key: &str, ret: Result<bool, CustomRedisError>) -> Self {
         self.expire_ret.insert(key.to_owned(), ret);
         self.clone()
     }
@@ -641,7 +641,7 @@ impl MockRedisClient {
             PipelineCommand::Expire { key, seconds } => {
                 let ttl_i64 = i64::try_from(seconds).unwrap_or(i64::MAX);
                 self.record_call("pipeline_expire", &key, MockRedisValue::I64(ttl_i64));
-                Self::lookup_or_ok(&self.expire_ret, &key).map(|_| PipelineResult::Bool(true))
+                Self::lookup_or_not_found(&self.expire_ret, &key).map(PipelineResult::Bool)
             }
             PipelineCommand::ZRangeByScore { key, min, max } => {
                 self.record_call(

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -87,6 +87,10 @@ pub enum PipelineCommand {
         key: String,
         member: String,
     },
+    Expire {
+        key: String,
+        seconds: u64,
+    },
     ZRangeByScore {
         key: String,
         min: String,
@@ -249,6 +253,15 @@ impl<C> Pipeline<C> {
         self
     }
 
+    /// Add an EXPIRE command to the pipeline.
+    pub fn expire(mut self, key: impl Into<String>, seconds: u64) -> Self {
+        self.commands.push(PipelineCommand::Expire {
+            key: key.into(),
+            seconds,
+        });
+        self
+    }
+
     /// Add a ZRANGEBYSCORE command to the pipeline.
     pub fn zrangebyscore(
         mut self,
@@ -359,9 +372,10 @@ mod tests {
             .hincrby("k12", "f12", 5)
             .scard("k13")
             .sadd("k14", "m14")
-            .zrangebyscore("k15", "0", "100");
+            .expire("k15", 300)
+            .zrangebyscore("k16", "0", "100");
 
-        assert_eq!(pipeline.len(), 15);
+        assert_eq!(pipeline.len(), 16);
     }
 
     #[test]

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -375,7 +375,11 @@ mod tests {
             .expire("k15", 300)
             .zrangebyscore("k16", "0", "100");
 
-        assert_eq!(pipeline.len(), 16);
+        let (_, commands) = pipeline.into_commands();
+        assert_eq!(commands.len(), 16);
+        assert!(
+            matches!(&commands[14], PipelineCommand::Expire { key, seconds } if key == "k15" && *seconds == 300)
+        );
     }
 
     #[test]

--- a/rust/common/redis/src/pipeline.rs
+++ b/rust/common/redis/src/pipeline.rs
@@ -33,7 +33,7 @@ pub enum PipelineResult {
     String(String),
     /// Raw bytes (GET raw bytes)
     Bytes(Vec<u8>),
-    /// Boolean result (SET NX EX)
+    /// Boolean result (SET NX EX, EXPIRE)
     Bool(bool),
     /// Count result (SCARD)
     Count(u64),


### PR DESCRIPTION
## Problem

The auth cache needs to set TTLs on reverse index sets to prevent unbounded memory growth. Currently there is no way to issue an `EXPIRE` command within a batched Redis pipeline round-trip — callers would need a separate network call, defeating the purpose of pipelining.

## Changes

> [!IMPORTANT]
> These are all new addition to the library. No existing callers. No risk to existing services.

- Add `PipelineCommand::Expire { key, seconds }` variant and `Pipeline::expire()` builder method (`pipeline.rs`)
- Handle `EXPIRE` in real pipeline execution and result processing (`client.rs`)
- Handle `EXPIRE` in mock pipeline with configurable `expire_ret` map for per-key error injection (`mock.rs`)
- Update `test_pipeline_all_commands` to cover the new command

## How did you test this code?

- `cargo test -p common-redis` — all 67 tests pass (including updated `test_pipeline_all_commands`)
- `cargo clippy -p common-redis --all-targets --all-features -- -D warnings` — clean

## Publish to changelog?

no

## Docs update

N/A — internal Rust crate only