### PR TITLE
fix(deduplicator): remove redunant manual RocksDB flush prior to checkpoint creation

### DIFF
--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -347,9 +347,9 @@ impl DeduplicationStore {
 
         let sequence = self.store.latest_sequence_number();
 
-        let sst_files = self.get_sst_file_names()?;
-
         self.store.create_checkpoint(checkpoint_path)?;
+
+        let sst_files = self.get_sst_file_names()?;
 
         Ok(LocalCheckpointInfo {
             sst_files,

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -333,29 +333,22 @@ impl DeduplicationStore {
         self.store.update_db_metrics(Self::TIMESTAMP_CF)
     }
 
-    /// Create a checkpoint and return metadata about the checkpoint
-    /// This ensures consistency by:
-    /// 1. Flushing WAL to disk
-    /// 2. Flushing all column families
-    /// 3. Capturing sequence number for consistency verification
-    /// 4. Creating the checkpoint with hard links
+    /// Create a checkpoint and return metadata about the checkpoint.
+    /// Consistency is ensured by:
+    /// 1. Flushing WAL to disk (explicit)
+    /// 2. Capturing sequence number for consistency verification
+    /// 3. Creating the checkpoint with hard links (internally flushes
+    ///    memtables via log_size_for_flush=0 in rust-rocksdb 0.24)
     pub fn create_checkpoint_with_metadata<P: AsRef<std::path::Path>>(
         &self,
         checkpoint_path: P,
     ) -> Result<LocalCheckpointInfo> {
-        // Step 1: Flush WAL to ensure durability
         self.store.flush_wal(true)?;
 
-        // Step 2: Flush all column families to ensure data is in SST files
-        self.flush()?;
-
-        // Step 3: Get sequence number for consistency tracking
         let sequence = self.store.latest_sequence_number();
 
-        // Step 4: Get SST files after flush
         let sst_files = self.get_sst_file_names()?;
 
-        // Step 5: Create the checkpoint (RocksDB internally handles file deletion safety)
         self.store.create_checkpoint(checkpoint_path)?;
 
         Ok(LocalCheckpointInfo {


### PR DESCRIPTION
## Problem
No-op change - we are making a redundant manual call to flush SST memtables to disk prior to checkpoint creation that the crate does internally for us.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Remove redundant call; change is a no-op
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI; smoke test in PoC env on the way
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
