### PR TITLE
fix(rbac): apply intersection of selected filters in the new access control UI

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
@@ -139,42 +139,49 @@ describe('accessControlsLogic', () => {
         })
 
         describe('combined filters', () => {
-            it('matches when a selected resource has one of the selected levels', () => {
-                const filters = {
-                    ...emptyFilters,
-                    resourceKeys: ['insight' as APIScopeObject],
-                    ruleLevels: [AccessControlLevel.Manager],
-                }
-                expect(matchesFilters(memberEntry, filters)).toBe(true)
-            })
-
-            it('rejects when no selected resource has any of the selected levels', () => {
-                const filters = {
-                    ...emptyFilters,
-                    resourceKeys: ['dashboard' as APIScopeObject],
-                    ruleLevels: [AccessControlLevel.Viewer],
-                }
-                expect(matchesFilters(roleEntry, filters)).toBe(false)
-            })
-
-            it('matches when resource has effective access at the selected level', () => {
-                const filters = {
-                    ...emptyFilters,
-                    resourceKeys: ['dashboard' as APIScopeObject],
-                    ruleLevels: [AccessControlLevel.Editor],
-                }
-                // roleEntry has dashboard=Editor, so this should match
-                expect(matchesFilters(roleEntry, filters)).toBe(true)
-            })
-
-            it('rejects when resource has no effective access even if level exists elsewhere', () => {
-                const filters = {
-                    ...emptyFilters,
-                    resourceKeys: ['insight' as APIScopeObject],
-                    ruleLevels: [AccessControlLevel.Admin],
-                }
-                // roleEntry has insight=null, so even though Admin exists on project, this should not match
-                expect(matchesFilters(roleEntry, filters)).toBe(false)
+            it.each([
+                [
+                    'matches when a selected resource has one of the selected levels',
+                    {
+                        ...emptyFilters,
+                        resourceKeys: ['insight' as APIScopeObject],
+                        ruleLevels: [AccessControlLevel.Manager],
+                    },
+                    memberEntry,
+                    true,
+                ],
+                [
+                    'rejects when no selected resource has any of the selected levels',
+                    {
+                        ...emptyFilters,
+                        resourceKeys: ['dashboard' as APIScopeObject],
+                        ruleLevels: [AccessControlLevel.Viewer],
+                    },
+                    roleEntry,
+                    false,
+                ],
+                [
+                    'matches when resource has effective access at the selected level',
+                    {
+                        ...emptyFilters,
+                        resourceKeys: ['dashboard' as APIScopeObject],
+                        ruleLevels: [AccessControlLevel.Editor],
+                    },
+                    roleEntry,
+                    true,
+                ],
+                [
+                    'rejects when resource has no effective access even if level exists elsewhere',
+                    {
+                        ...emptyFilters,
+                        resourceKeys: ['insight' as APIScopeObject],
+                        ruleLevels: [AccessControlLevel.Admin],
+                    },
+                    roleEntry,
+                    false,
+                ],
+            ])('%s', (_desc, filters, entry, expected) => {
+                expect(matchesFilters(entry, filters)).toBe(expected)
             })
         })
     })

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.test.ts
@@ -17,24 +17,24 @@ function matchesFilters(
     entry: { project: EffectiveAccessControlEntry; resources: Record<string, EffectiveAccessControlEntry> },
     filters: AccessControlFilters
 ): boolean {
-    if (filters.resourceKeys.length > 0) {
-        const hasEffectiveAccessToFilteredResource = filters.resourceKeys.some(
-            (rk) => getEffectiveLevel(entry, rk) !== null
-        )
-        if (!hasEffectiveAccessToFilteredResource) {
-            return false
-        }
+    const hasResourceFilter = filters.resourceKeys.length > 0
+    const hasLevelFilter = filters.ruleLevels.length > 0
+
+    if (hasResourceFilter && hasLevelFilter) {
+        // Intersection: at least one selected resource must have one of the selected levels
+        return filters.resourceKeys.some((rk) => {
+            const level = getEffectiveLevel(entry, rk)
+            return level !== null && (filters.ruleLevels as string[]).includes(level)
+        })
     }
 
-    if (filters.ruleLevels.length > 0) {
-        const hasMatchingLevel = filters.ruleLevels.some(
-            (rl) =>
-                getEffectiveLevel(entry, 'project' as APIScopeObject) === rl ||
-                Object.keys(entry.resources).some((r) => getEffectiveLevel(entry, r as APIScopeObject) === rl)
-        )
-        if (!hasMatchingLevel) {
-            return false
-        }
+    if (hasResourceFilter) {
+        return filters.resourceKeys.some((rk) => getEffectiveLevel(entry, rk) !== null)
+    }
+
+    if (hasLevelFilter) {
+        const allKeys = ['project', ...Object.keys(entry.resources)] as APIScopeObject[]
+        return filters.ruleLevels.some((rl) => allKeys.some((k) => getEffectiveLevel(entry, k) === rl))
     }
 
     return true
@@ -139,7 +139,7 @@ describe('accessControlsLogic', () => {
         })
 
         describe('combined filters', () => {
-            it('requires both resourceKeys and ruleLevels to match', () => {
+            it('matches when a selected resource has one of the selected levels', () => {
                 const filters = {
                     ...emptyFilters,
                     resourceKeys: ['insight' as APIScopeObject],
@@ -148,12 +148,32 @@ describe('accessControlsLogic', () => {
                 expect(matchesFilters(memberEntry, filters)).toBe(true)
             })
 
-            it('rejects when resourceKeys match but ruleLevels do not', () => {
+            it('rejects when no selected resource has any of the selected levels', () => {
                 const filters = {
                     ...emptyFilters,
                     resourceKeys: ['dashboard' as APIScopeObject],
                     ruleLevels: [AccessControlLevel.Viewer],
                 }
+                expect(matchesFilters(roleEntry, filters)).toBe(false)
+            })
+
+            it('matches when resource has effective access at the selected level', () => {
+                const filters = {
+                    ...emptyFilters,
+                    resourceKeys: ['dashboard' as APIScopeObject],
+                    ruleLevels: [AccessControlLevel.Editor],
+                }
+                // roleEntry has dashboard=Editor, so this should match
+                expect(matchesFilters(roleEntry, filters)).toBe(true)
+            })
+
+            it('rejects when resource has no effective access even if level exists elsewhere', () => {
+                const filters = {
+                    ...emptyFilters,
+                    resourceKeys: ['insight' as APIScopeObject],
+                    ruleLevels: [AccessControlLevel.Admin],
+                }
+                // roleEntry has insight=null, so even though Admin exists on project, this should not match
                 expect(matchesFilters(roleEntry, filters)).toBe(false)
             })
         })

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
@@ -52,23 +52,24 @@ function getEffectiveLevel(entry: AccessControlSettingsEntry, resourceKey: APISc
 }
 
 function matchesFilters(entry: AccessControlSettingsEntry, filters: AccessControlFilters): boolean {
-    if (filters.resourceKeys.length > 0) {
-        const hasEffectiveAccessToFilteredResource = filters.resourceKeys.some(
-            (rk) => getEffectiveLevel(entry, rk) !== null
-        )
-        if (!hasEffectiveAccessToFilteredResource) {
-            return false
-        }
+    const hasResourceFilter = filters.resourceKeys.length > 0
+    const hasLevelFilter = filters.ruleLevels.length > 0
+
+    if (hasResourceFilter && hasLevelFilter) {
+        // Intersection: at least one selected resource must have one of the selected levels
+        return filters.resourceKeys.some((rk) => {
+            const level = getEffectiveLevel(entry, rk)
+            return level !== null && (filters.ruleLevels as string[]).includes(level)
+        })
     }
 
-    if (filters.ruleLevels.length > 0) {
+    if (hasResourceFilter) {
+        return filters.resourceKeys.some((rk) => getEffectiveLevel(entry, rk) !== null)
+    }
+
+    if (hasLevelFilter) {
         const allKeys = ['project', ...Object.keys(entry.resources)] as APIScopeObject[]
-        const hasMatchingLevel = filters.ruleLevels.some((rl) =>
-            allKeys.some((k) => getEffectiveLevel(entry, k) === rl)
-        )
-        if (!hasMatchingLevel) {
-            return false
-        }
+        return filters.ruleLevels.some((rl) => allKeys.some((k) => getEffectiveLevel(entry, k) === rl))
     }
 
     return true


### PR DESCRIPTION
## Problem

Right now the filters work as OR in the new access control UI. This feels unexpected. For example, when you select a feature and a resource level, it shows rows where either that feature is present or that level exists on any feature.

## Changes

- When both filters are active, use intersection, only show entries where a selected resource has one of the selected levels
- Single-filter behavior unchanged
![2026-03-13 10 30 17](https://github.com/user-attachments/assets/f0bd2007-2878-4b4c-bad2-873c07bde089)


## How did you test this code?

Tests + manually tried to apply different filters

## Publish to changelog?

No

## Docs update

No docs update needed - this is an internal logic improvement.