### PR TITLE
fix: Remove backwards-compat team scoping for first-party OAuth clients

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -202,7 +202,7 @@ class TestOAuthAPI(APIBaseTest):
         code = parse_qs(urlparse(location).query)["code"][0]
         grant = OAuthGrant.objects.get(code=code)
 
-        self.assertIn(self.team.pk, grant.scoped_teams)
+        self.assertEqual(grant.scoped_teams, [])
         self.assertIn(str(self.organization.id), grant.scoped_organizations)
 
     def test_authorize_missing_client_id(self):

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -312,12 +312,7 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
                 # Auto-approve with all user's accessible organizations.
                 org_ids = request.user.organizations.values_list("id", flat=True)
                 credentials["scoped_organizations"] = [str(org_id) for org_id in org_ids]
-
-                # TODO(charlesvien): Populate scoped_teams for backwards compat with old
-                # Code clients that throw "No team found in OAuth scopes" when
-                # scoped_teams is empty. Remove once Code reads scoped_organizations.
-                team_ids = Team.objects.filter(organization__members=request.user).values_list("pk", flat=True)
-                credentials["scoped_teams"] = list(team_ids)
+                credentials["scoped_teams"] = []
 
                 uri, headers, body, status_code = self.create_authorization_response(
                     request=request, scopes=" ".join(scopes), credentials=credentials, allow=True


### PR DESCRIPTION
## Problem

Remove backwards-compat team scoping for first-party OAuth clients

## Changes

  1. Remove query that populated scoped_teams from user's team memberships during first-party OAuth auto-approval
  2. Set scoped_teams to an empty list now that Code reads scoped_organizations
  3. Drop the associated TODO comment

## How did you test this code?

Manually
