### PR TITLE
fix: Add mimeType to MCP server resource registration

### DIFF
--- a/services/mcp/src/resources/ui-apps.ts
+++ b/services/mcp/src/resources/ui-apps.ts
@@ -185,7 +185,7 @@ function registerApp(server: McpServer, context: Context, { name, uri, descripti
         }
     }
 
-    server.registerResource(name, uri, { description: description }, async (uri) => {
+    server.registerResource(name, uri, { mimeType: RESOURCE_MIME_TYPE, description }, async (uri) => {
         return {
             contents: [
                 {


### PR DESCRIPTION
## Problem

The UI apps resource registration was missing the required MIME type specification, which could cause issues with resource handling and content type identification in the MCP server.

## Changes

Added `mimeType: RESOURCE_MIME_TYPE` parameter to the `registerResource` call in the UI apps registration function to ensure proper content type handling.

## Publish to changelog?

No

## Docs update