### PR TITLE
fix: use JSSnippet to allow auto population of proxy domain

### DIFF
--- a/docs/onboarding/product-analytics/_snippets/js-html-snippet.tsx
+++ b/docs/onboarding/product-analytics/_snippets/js-html-snippet.tsx
@@ -1,0 +1,12 @@
+import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { BuildJsHtmlSnippetConfig, buildJsHtmlSnippet } from './js-snippet-builder'
+
+export type JSHtmlSnippetProps = BuildJsHtmlSnippetConfig
+
+export const JSHtmlSnippet = (props: JSHtmlSnippetProps): JSX.Element => {
+    const { CodeBlock } = useMDXComponents()
+    const snippet = buildJsHtmlSnippet(props)
+
+    return <CodeBlock blocks={[{ language: 'html', file: 'HTML', code: snippet }]} />
+}

--- a/docs/onboarding/product-analytics/_snippets/js-init-snippet.tsx
+++ b/docs/onboarding/product-analytics/_snippets/js-init-snippet.tsx
@@ -1,0 +1,24 @@
+import { useMDXComponents } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+export const JSInitSnippet = ({ defaultsDate }: { defaultsDate: string }): JSX.Element => {
+    const { CodeBlock, dedent } = useMDXComponents()
+
+    return (
+        <CodeBlock
+            blocks={[
+                {
+                    language: 'javascript',
+                    file: 'JavaScript',
+                    code: dedent`
+                        import posthog from 'posthog-js'
+
+                        posthog.init('<ph_project_token>', {
+                            api_host: '<ph_client_api_host>',
+                            defaults: '${defaultsDate}'
+                        })
+                    `,
+                },
+            ]}
+        />
+    )
+}

--- a/docs/onboarding/product-analytics/_snippets/js-snippet-builder.ts
+++ b/docs/onboarding/product-analytics/_snippets/js-snippet-builder.ts
@@ -1,0 +1,48 @@
+export type SnippetOption = {
+    content: string
+    enabled: boolean
+    comment?: string
+}
+
+export function snippetFunctions(methods: string[], arrayJs = '/static/array.js'): string {
+    const snippetMethods = methods.join(' ')
+
+    return `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"${arrayJs}",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="${snippetMethods}".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);`
+}
+
+export interface BuildJsHtmlSnippetConfig {
+    projectToken: string
+    methods: string[]
+    options: Record<string, SnippetOption>
+    indent?: number
+    arrayJs?: string
+    scriptAttributes?: string
+}
+
+export function buildJsHtmlSnippet({
+    projectToken,
+    methods,
+    options,
+    indent = 0,
+    arrayJs,
+    scriptAttributes,
+}: BuildJsHtmlSnippetConfig): string {
+    const scriptTag = scriptAttributes ? `<script ${scriptAttributes}>` : '<script>'
+
+    return [
+        scriptTag,
+        `    ${snippetFunctions(methods, arrayJs)}`,
+        `    posthog.init('${projectToken}', {`,
+        ...Object.entries(options)
+            .map(([key, value]) => {
+                if (value.enabled) {
+                    return `        ${key}: '${value.content}',${value.comment ? ` // ${value.comment}` : ''}`
+                }
+            })
+            .filter(Boolean),
+        `    })`,
+        '</script>',
+    ]
+        .map((x) => ' '.repeat(indent) + x)
+        .join('\n')
+}

--- a/docs/onboarding/product-analytics/index.ts
+++ b/docs/onboarding/product-analytics/index.ts
@@ -1,5 +1,12 @@
-// Snippets
+// Snippet builder
+export { buildJsHtmlSnippet, snippetFunctions } from './_snippets/js-snippet-builder'
+export type { BuildJsHtmlSnippetConfig, SnippetOption } from './_snippets/js-snippet-builder'
+
+// Snippet components
 export { JSEventCapture } from './_snippets/js-event-capture'
+export { JSHtmlSnippet } from './_snippets/js-html-snippet'
+export type { JSHtmlSnippetProps } from './_snippets/js-html-snippet'
+export { JSInitSnippet } from './_snippets/js-init-snippet'
 export { NodeEventCapture } from './_snippets/node-event-capture'
 export { PythonEventCapture } from './_snippets/python-event-capture'
 

--- a/docs/onboarding/product-analytics/web.tsx
+++ b/docs/onboarding/product-analytics/web.tsx
@@ -6,6 +6,8 @@ export const getWebSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
     const { CodeBlock, Markdown, Tab, dedent, snippets } = ctx
 
     const JSEventCapture = snippets?.JSEventCapture
+    const JSHtmlSnippet = snippets?.JSHtmlSnippet
+    const JSInitSnippet = snippets?.JSInitSnippet
 
     return [
         {
@@ -29,23 +31,7 @@ export const getWebSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                     Add this snippet to your website within the `&lt;head&gt;` tag. This can also be
                                     used in services like Google Tag Manager:
                                 </Markdown>
-                                <CodeBlock
-                                    blocks={[
-                                        {
-                                            language: 'html',
-                                            file: 'HTML',
-                                            code: dedent`
-                                                <script>
-                                                    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-                                                    posthog.init('<ph_project_token>', {
-                                                        api_host: '<ph_client_api_host>',
-                                                        defaults: '2026-01-30'
-                                                    })
-                                                </script>
-                                            `,
-                                        },
-                                    ]}
-                                />
+                                {JSHtmlSnippet && <JSHtmlSnippet />}
                             </Tab.Panel>
                             <Tab.Panel>
                                 <Markdown>
@@ -79,22 +65,7 @@ export const getWebSteps = (ctx: OnboardingComponentsContext): StepDefinition[] 
                                         },
                                     ]}
                                 />
-                                <CodeBlock
-                                    blocks={[
-                                        {
-                                            language: 'javascript',
-                                            file: 'JavaScript',
-                                            code: dedent`
-                                                import posthog from 'posthog-js'
-
-                                                posthog.init('<ph_project_token>', {
-                                                    api_host: '<ph_client_api_host>',
-                                                    defaults: '2026-01-30'
-                                                })
-                                            `,
-                                        },
-                                    ]}
-                                />
+                                {JSInitSnippet && <JSInitSnippet />}
                             </Tab.Panel>
                         </Tab.Panels>
                     </Tab.Group>

--- a/frontend/src/lib/components/JSSnippet.tsx
+++ b/frontend/src/lib/components/JSSnippet.tsx
@@ -1,6 +1,8 @@
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
 
+import { buildJsHtmlSnippet, SnippetOption } from '@posthog/shared-onboarding/product-analytics'
+
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -10,7 +12,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
 
-function snippetFunctions(arrayJs = '/static/array.js'): string {
+function getPosthogMethods(): string[] {
     const methods: string[] = []
     const posthogPrototype = Object.getPrototypeOf(posthog)
     for (const key of Object.getOwnPropertyNames(posthogPrototype)) {
@@ -22,18 +24,16 @@ function snippetFunctions(arrayJs = '/static/array.js'): string {
             methods.push(key)
         }
     }
-    const snippetMethods = methods.join(' ')
-
-    return `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"${arrayJs}",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="${snippetMethods}".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);`
+    return methods
 }
 
-type SnippetOption = {
-    content: string
-    enabled: boolean
-    comment?: string
+export interface JsSnippetConfig {
+    projectToken: string
+    methods: string[]
+    options: Record<string, SnippetOption>
 }
 
-export function useJsSnippet(indent = 0, arrayJs?: string, scriptAttributes?: string): string {
+export function useJsSnippetConfig(): JsSnippetConfig {
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { preflight } = useValues(preflightLogic)
@@ -43,46 +43,44 @@ export function useJsSnippet(indent = 0, arrayJs?: string, scriptAttributes?: st
 
     const isPersonProfilesDisabled = featureFlags[FEATURE_FLAGS.PERSONLESS_EVENTS_NOT_SUPPORTED]
 
-    const options: Record<string, SnippetOption> = {
-        api_host: {
-            content: domainFor(proxyRecord),
-            comment: proxyRecord ? 'your managed reverse proxy domain' : undefined,
-            enabled: true,
-        },
-        ui_host: {
-            content: preflight?.site_url || window.location.origin,
-            comment: "necessary because you're using a proxy, this way links will point back to PostHog properly",
-            enabled: !!proxyRecord,
-        },
-        defaults: {
-            content: SDK_DEFAULTS_DATE,
-            enabled: true,
-        },
-        person_profiles: {
-            content: 'identified_only',
-            comment: "or 'always' to create profiles for anonymous users as well",
-            enabled: !isPersonProfilesDisabled,
+    return {
+        projectToken: currentTeam?.api_token ?? '',
+        methods: getPosthogMethods(),
+        options: {
+            api_host: {
+                content: domainFor(proxyRecord),
+                comment: proxyRecord ? 'your managed reverse proxy domain' : undefined,
+                enabled: true,
+            },
+            ui_host: {
+                content: preflight?.site_url || window.location.origin,
+                comment: "necessary because you're using a proxy, this way links will point back to PostHog properly",
+                enabled: !!proxyRecord,
+            },
+            defaults: {
+                content: SDK_DEFAULTS_DATE,
+                enabled: true,
+            },
+            person_profiles: {
+                content: 'identified_only',
+                comment: "or 'always' to create profiles for anonymous users as well",
+                enabled: !isPersonProfilesDisabled,
+            },
         },
     }
+}
 
-    const scriptTag = scriptAttributes ? `<script ${scriptAttributes}>` : '<script>'
+export function useJsSnippet(indent = 0, arrayJs?: string, scriptAttributes?: string): string {
+    const { projectToken, methods, options } = useJsSnippetConfig()
 
-    return [
-        scriptTag,
-        `    ${snippetFunctions(arrayJs)}`,
-        `    posthog.init('${currentTeam?.api_token}', {`,
-        ...Object.entries(options)
-            .map(([key, value]) => {
-                if (value.enabled) {
-                    return `        ${key}: '${value.content}',${value.comment ? ` // ${value.comment}` : ''}`
-                }
-            })
-            .filter(Boolean),
-        `    })`,
-        '</script>',
-    ]
-        .map((x) => ' '.repeat(indent) + x)
-        .join('\n')
+    return buildJsHtmlSnippet({
+        projectToken,
+        methods,
+        options,
+        indent,
+        arrayJs,
+        scriptAttributes,
+    })
 }
 
 export function JSSnippet(): JSX.Element {

--- a/frontend/src/scenes/onboarding/sdks/product-analytics/ProductAnalyticsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/product-analytics/ProductAnalyticsSDKInstructions.tsx
@@ -14,6 +14,8 @@ import {
     HeliconeInstallation,
     IOSInstallation,
     JSEventCapture,
+    JSHtmlSnippet,
+    JSInitSnippet,
     LangfuseInstallation,
     LaravelInstallation,
     MoEngageInstallation,
@@ -45,13 +47,28 @@ import {
     WebInstallation,
 } from '@posthog/shared-onboarding/product-analytics'
 
+import { useJsSnippetConfig } from 'lib/components/JSSnippet'
+
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
 import { SDKInstructionsMap, SDKKey, SDKTag, SDKTagOverrides } from '~/types'
 
 import { withMobileReplay, withOnboardingDocsWrapper } from '../shared/onboardingWrappers'
 
+// In-app wrappers that inject Kea store values into the shared docs snippet components
+const InAppJSHtmlSnippet = (): JSX.Element => {
+    const config = useJsSnippetConfig()
+    return <JSHtmlSnippet {...config} />
+}
+
+const InAppJSInitSnippet = (): JSX.Element => {
+    return <JSInitSnippet defaultsDate={SDK_DEFAULTS_DATE} />
+}
+
 // Snippet configurations (defined once, not recreated on render)
 const JS_WEB_SNIPPETS = {
     JSEventCapture,
+    JSHtmlSnippet: InAppJSHtmlSnippet,
+    JSInitSnippet: InAppJSInitSnippet,
 }
 
 const NODE_SNIPPETS = {

--- a/frontend/src/scenes/settings/environment/SDKSetupInstructions.tsx
+++ b/frontend/src/scenes/settings/environment/SDKSetupInstructions.tsx
@@ -17,6 +17,8 @@ import {
     GoogleTagManagerInstallation,
     IOSInstallation,
     JSEventCapture,
+    JSHtmlSnippet,
+    JSInitSnippet,
     LaravelInstallation,
     NextJSInstallation,
     NodeEventCapture,
@@ -38,14 +40,29 @@ import {
 } from '@posthog/shared-onboarding/product-analytics'
 import type { StepDefinition } from '@posthog/shared-onboarding/steps'
 
+import { useJsSnippetConfig } from 'lib/components/JSSnippet'
 import { Link } from 'lib/lemon-ui/Link'
 import { OnboardingDocsContentWrapper } from 'scenes/onboarding/OnboardingDocsContentWrapper'
 import SetupWizardBanner from 'scenes/onboarding/sdks/sdk-install-instructions/components/SetupWizardBanner'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
 import { SDKKey } from '~/types'
 
-const JS_WEB_SNIPPETS = { JSEventCapture }
+const InAppJSHtmlSnippet = (): JSX.Element => {
+    const config = useJsSnippetConfig()
+    return <JSHtmlSnippet {...config} />
+}
+
+const InAppJSInitSnippet = (): JSX.Element => {
+    return <JSInitSnippet defaultsDate={SDK_DEFAULTS_DATE} />
+}
+
+const JS_WEB_SNIPPETS = {
+    JSEventCapture,
+    JSHtmlSnippet: InAppJSHtmlSnippet,
+    JSInitSnippet: InAppJSInitSnippet,
+}
 const NODE_SNIPPETS = { NodeEventCapture }
 const PYTHON_SNIPPETS = { PythonEventCapture }
 


### PR DESCRIPTION
## Problem

We had a good JSSNippet that we weren't using with the shared rendering. This also meant we were missing cool features like adding in proxy host automatically.

## Changes

A messy way to properly reuse the snippet logic, so we stop having multiple JSSnippets... I think this does what we want, but tbh the JSSNippet is so complicated I can't tell lol

## How did you test this code?

Tested by manually verifying both app onboarding and https://github.com/PostHog/posthog.com/pull/15715 locally

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
