### PR TITLE
feat(deduplicator): expose rocksdb SST compression internal configs

### DIFF
--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -5,7 +5,7 @@ use bytesize::ByteSize;
 use common_continuous_profiling::ContinuousProfilingConfig;
 use envconfig::Envconfig;
 
-use crate::rocksdb::store::RocksDbConfig;
+use crate::rocksdb::store::{parse_compression_per_level, parse_compression_type, RocksDbConfig};
 
 /// Pipeline type for the deduplicator service.
 ///
@@ -111,6 +111,13 @@ pub struct Config {
     pub rocksdb_l0_slowdown_writes_trigger: Option<i32>,
     pub rocksdb_l0_stop_writes_trigger: Option<i32>,
     pub rocksdb_write_buffer_manager_allow_stall: Option<bool>,
+
+    // RocksDB compression (optional — omit to keep LZ4 everywhere, matching compiled-in defaults)
+    #[envconfig(default = "lz4")]
+    pub rocksdb_compression_type: String,
+    pub rocksdb_compression_per_level: Option<String>,
+    pub rocksdb_bottommost_compression_type: Option<String>,
+    pub rocksdb_universal_compression_size_percent: Option<i32>,
 
     #[envconfig(default = "1073741824")]
     // 1GB default, supports: raw bytes, scientific notation (9.663676416e+09), or units (9Gi, 1GB)
@@ -472,7 +479,7 @@ impl Config {
             }
             None => defaults.max_background_jobs,
         };
-        RocksDbConfig {
+        let config = RocksDbConfig {
             shared_cache_size_bytes: self
                 .rocksdb_shared_cache_size_bytes
                 .unwrap_or(defaults.shared_cache_size_bytes),
@@ -501,7 +508,59 @@ impl Config {
             write_buffer_manager_allow_stall: self
                 .rocksdb_write_buffer_manager_allow_stall
                 .unwrap_or(defaults.write_buffer_manager_allow_stall),
+            compression_type: parse_compression_type(&self.rocksdb_compression_type)
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        value = self.rocksdb_compression_type,
+                        error = %e,
+                        "invalid ROCKSDB_COMPRESSION_TYPE, using default (lz4)"
+                    );
+                    defaults.compression_type
+                }),
+            compression_per_level: self
+                .rocksdb_compression_per_level
+                .as_deref()
+                .map(|s| {
+                    parse_compression_per_level(s).unwrap_or_else(|e| {
+                        tracing::warn!(
+                            value = s,
+                            error = %e,
+                            "invalid ROCKSDB_COMPRESSION_PER_LEVEL, ignoring"
+                        );
+                        defaults.compression_per_level.clone().unwrap_or_default()
+                    })
+                })
+                .filter(|v| !v.is_empty()),
+            bottommost_compression_type: self
+                .rocksdb_bottommost_compression_type
+                .as_deref()
+                .and_then(|s| {
+                    parse_compression_type(s)
+                        .map_err(|e| {
+                            tracing::warn!(
+                                value = s,
+                                error = %e,
+                                "invalid ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE, ignoring"
+                            );
+                            e
+                        })
+                        .ok()
+                }),
+            universal_compression_size_percent: self
+                .rocksdb_universal_compression_size_percent
+                .unwrap_or(defaults.universal_compression_size_percent),
+        };
+
+        if config.compression_per_level.is_some() && config.universal_compression_size_percent < 0 {
+            tracing::warn!(
+                "ROCKSDB_COMPRESSION_PER_LEVEL is set but ROCKSDB_UNIVERSAL_COMPRESSION_SIZE_PERCENT \
+                 is < 0 (compress-all). Per-level settings will be IGNORED by RocksDB in Universal \
+                 compaction mode. Set ROCKSDB_UNIVERSAL_COMPRESSION_SIZE_PERCENT=0 to enable \
+                 per-level compression."
+            );
         }
+
+        config
     }
 
     // Check multiple conditions for safe checkpoint export enablement
@@ -841,5 +900,73 @@ mod tests {
         config.s3_endpoint = None;
         config.aws_region = None;
         assert!(!config.checkpoint_import_enabled());
+    }
+
+    #[test]
+    fn test_build_rocksdb_config_default_compression() {
+        let config = Config::init_with_defaults().unwrap();
+        let rocksdb = config.build_rocksdb_config();
+
+        assert_eq!(rocksdb.compression_type, rocksdb::DBCompressionType::Lz4);
+        assert!(rocksdb.compression_per_level.is_none());
+        assert!(rocksdb.bottommost_compression_type.is_none());
+        assert_eq!(rocksdb.universal_compression_size_percent, -1);
+    }
+
+    #[test]
+    fn test_build_rocksdb_config_compression_per_level() {
+        let mut config = Config::init_with_defaults().unwrap();
+        config.rocksdb_compression_per_level = Some("none,none,lz4,lz4,lz4".to_string());
+        config.rocksdb_universal_compression_size_percent = Some(0);
+        let rocksdb = config.build_rocksdb_config();
+
+        let expected = vec![
+            rocksdb::DBCompressionType::None,
+            rocksdb::DBCompressionType::None,
+            rocksdb::DBCompressionType::Lz4,
+            rocksdb::DBCompressionType::Lz4,
+            rocksdb::DBCompressionType::Lz4,
+        ];
+        assert_eq!(rocksdb.compression_per_level.unwrap(), expected);
+        assert_eq!(rocksdb.universal_compression_size_percent, 0);
+    }
+
+    #[test]
+    fn test_build_rocksdb_config_bottommost_compression() {
+        let mut config = Config::init_with_defaults().unwrap();
+        config.rocksdb_bottommost_compression_type = Some("zstd".to_string());
+        let rocksdb = config.build_rocksdb_config();
+
+        assert_eq!(
+            rocksdb.bottommost_compression_type.unwrap(),
+            rocksdb::DBCompressionType::Zstd
+        );
+    }
+
+    #[test]
+    fn test_build_rocksdb_config_invalid_compression_type_falls_back() {
+        let mut config = Config::init_with_defaults().unwrap();
+        config.rocksdb_compression_type = "brotli".to_string();
+        let rocksdb = config.build_rocksdb_config();
+
+        assert_eq!(rocksdb.compression_type, rocksdb::DBCompressionType::Lz4);
+    }
+
+    #[test]
+    fn test_build_rocksdb_config_invalid_per_level_ignored() {
+        let mut config = Config::init_with_defaults().unwrap();
+        config.rocksdb_compression_per_level = Some("none,invalid,lz4".to_string());
+        let rocksdb = config.build_rocksdb_config();
+
+        assert!(rocksdb.compression_per_level.is_none());
+    }
+
+    #[test]
+    fn test_build_rocksdb_config_invalid_bottommost_ignored() {
+        let mut config = Config::init_with_defaults().unwrap();
+        config.rocksdb_bottommost_compression_type = Some("invalid".to_string());
+        let rocksdb = config.build_rocksdb_config();
+
+        assert!(rocksdb.bottommost_compression_type.is_none());
     }
 }

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -226,7 +226,9 @@ fn rocksdb_options(config: &RocksDbConfig) -> Options {
     }
     if let Some(bottommost) = config.bottommost_compression_type {
         opts.set_bottommost_compression_type(bottommost);
-        opts.set_bottommost_zstd_max_train_bytes(0, true);
+        if bottommost == DBCompressionType::Zstd {
+            opts.set_bottommost_zstd_max_train_bytes(0, true);
+        }
     }
 
     // Limit background jobs to reduce I/O contention when many partitions share a disk

--- a/rust/kafka-deduplicator/src/rocksdb/store.rs
+++ b/rust/kafka-deduplicator/src/rocksdb/store.rs
@@ -6,8 +6,8 @@ use std::{
 use anyhow::{Context, Result};
 use rocksdb::{
     checkpoint::Checkpoint, BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor,
-    DBWithThreadMode, MultiThreaded, Options, SliceTransform, WriteBatch, WriteBufferManager,
-    WriteOptions,
+    DBCompressionType, DBWithThreadMode, MultiThreaded, Options, SliceTransform, WriteBatch,
+    WriteBufferManager, WriteOptions,
 };
 use std::time::Instant;
 use tracing::error;
@@ -52,7 +52,25 @@ const UNIVERSAL_SIZE_RATIO: i32 = 10; // Allow 10% size difference before compac
 const UNIVERSAL_MIN_MERGE_WIDTH: i32 = 2;
 const UNIVERSAL_MAX_MERGE_WIDTH: i32 = 16;
 const UNIVERSAL_MAX_SIZE_AMPLIFICATION_PERCENT: i32 = 200; // Allow 2x space amplification
-const UNIVERSAL_COMPRESSION_SIZE_PERCENT: i32 = -1; // Compress all levels
+const DEFAULT_UNIVERSAL_COMPRESSION_SIZE_PERCENT: i32 = -1; // Compress all levels
+
+// ── Compression type parsing ─────────────────────────────────────────────────
+
+pub fn parse_compression_type(s: &str) -> Result<DBCompressionType> {
+    match s.to_lowercase().trim() {
+        "none" => Ok(DBCompressionType::None),
+        "snappy" => Ok(DBCompressionType::Snappy),
+        "zlib" => Ok(DBCompressionType::Zlib),
+        "lz4" => Ok(DBCompressionType::Lz4),
+        "lz4hc" => Ok(DBCompressionType::Lz4hc),
+        "zstd" => Ok(DBCompressionType::Zstd),
+        other => anyhow::bail!("unknown compression type: {other}"),
+    }
+}
+
+pub fn parse_compression_per_level(s: &str) -> Result<Vec<DBCompressionType>> {
+    s.split(',').map(parse_compression_type).collect()
+}
 
 /// RocksDB tuning knobs exposed as env vars for per-deploy overrides.
 /// Concrete types — all values fully resolved at construction time.
@@ -71,6 +89,16 @@ pub struct RocksDbConfig {
     /// Whether the write buffer manager should stall writes when memory is full.
     /// false = backpressure handled at Kafka level instead.
     pub write_buffer_manager_allow_stall: bool,
+    /// Default compression type applied to all SST levels when compression_per_level is None.
+    pub compression_type: DBCompressionType,
+    /// Per-level compression overrides. When set, takes precedence over compression_type.
+    /// In Universal compaction, universal_compression_size_percent must be >= 0 for this to take effect.
+    pub compression_per_level: Option<Vec<DBCompressionType>>,
+    /// Compression override for the bottommost sorted run (e.g. Zstd for cold data).
+    pub bottommost_compression_type: Option<DBCompressionType>,
+    /// Controls what fraction of data is compressed in Universal compaction.
+    /// -1 = compress all (per-level settings ignored), >= 0 = enable per-level compression.
+    pub universal_compression_size_percent: i32,
 }
 
 impl Default for RocksDbConfig {
@@ -89,6 +117,10 @@ impl Default for RocksDbConfig {
             l0_slowdown_writes_trigger: DEFAULT_L0_SLOWDOWN_WRITES_TRIGGER,
             l0_stop_writes_trigger: DEFAULT_L0_STOP_WRITES_TRIGGER,
             write_buffer_manager_allow_stall: false,
+            compression_type: DBCompressionType::Lz4,
+            compression_per_level: None,
+            bottommost_compression_type: None,
+            universal_compression_size_percent: DEFAULT_UNIVERSAL_COMPRESSION_SIZE_PERCENT,
         }
     }
 }
@@ -150,7 +182,7 @@ fn rocksdb_options(config: &RocksDbConfig) -> Options {
     universal_opts.set_min_merge_width(UNIVERSAL_MIN_MERGE_WIDTH);
     universal_opts.set_max_merge_width(UNIVERSAL_MAX_MERGE_WIDTH);
     universal_opts.set_max_size_amplification_percent(UNIVERSAL_MAX_SIZE_AMPLIFICATION_PERCENT);
-    universal_opts.set_compression_size_percent(UNIVERSAL_COMPRESSION_SIZE_PERCENT);
+    universal_opts.set_compression_size_percent(config.universal_compression_size_percent);
     opts.set_universal_compaction_options(&universal_opts);
 
     let mut block_opts = block_based_table_factory();
@@ -187,7 +219,15 @@ fn rocksdb_options(config: &RocksDbConfig) -> Options {
     opts.set_level_zero_slowdown_writes_trigger(config.l0_slowdown_writes_trigger);
     opts.set_level_zero_stop_writes_trigger(config.l0_stop_writes_trigger);
 
-    opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    if let Some(ref per_level) = config.compression_per_level {
+        opts.set_compression_per_level(per_level);
+    } else {
+        opts.set_compression_type(config.compression_type);
+    }
+    if let Some(bottommost) = config.bottommost_compression_type {
+        opts.set_bottommost_compression_type(bottommost);
+        opts.set_bottommost_zstd_max_train_bytes(0, true);
+    }
 
     // Limit background jobs to reduce I/O contention when many partitions share a disk
     opts.increase_parallelism(config.max_background_jobs);
@@ -902,5 +942,90 @@ mod tests {
 
         // Delta should account for all files in phase2 (either added or unchanged)
         assert!(total_delta_files >= total_phase2_files || sst_files_phase2.is_empty());
+    }
+
+    #[test]
+    fn test_parse_compression_type_valid() {
+        assert_eq!(
+            parse_compression_type("none").unwrap(),
+            DBCompressionType::None
+        );
+        assert_eq!(
+            parse_compression_type("lz4").unwrap(),
+            DBCompressionType::Lz4
+        );
+        assert_eq!(
+            parse_compression_type("lz4hc").unwrap(),
+            DBCompressionType::Lz4hc
+        );
+        assert_eq!(
+            parse_compression_type("zstd").unwrap(),
+            DBCompressionType::Zstd
+        );
+        assert_eq!(
+            parse_compression_type("snappy").unwrap(),
+            DBCompressionType::Snappy
+        );
+        assert_eq!(
+            parse_compression_type("zlib").unwrap(),
+            DBCompressionType::Zlib
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_type_case_insensitive() {
+        assert_eq!(
+            parse_compression_type("LZ4").unwrap(),
+            DBCompressionType::Lz4
+        );
+        assert_eq!(
+            parse_compression_type("Zstd").unwrap(),
+            DBCompressionType::Zstd
+        );
+        assert_eq!(
+            parse_compression_type("  lz4  ").unwrap(),
+            DBCompressionType::Lz4
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_type_invalid() {
+        assert!(parse_compression_type("brotli").is_err());
+        assert!(parse_compression_type("").is_err());
+    }
+
+    #[test]
+    fn test_parse_compression_per_level() {
+        let levels = parse_compression_per_level("none,none,lz4,lz4,lz4,lz4,lz4").unwrap();
+        assert_eq!(
+            levels,
+            vec![
+                DBCompressionType::None,
+                DBCompressionType::None,
+                DBCompressionType::Lz4,
+                DBCompressionType::Lz4,
+                DBCompressionType::Lz4,
+                DBCompressionType::Lz4,
+                DBCompressionType::Lz4,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_per_level_mixed() {
+        let levels = parse_compression_per_level("none,lz4,zstd").unwrap();
+        assert_eq!(
+            levels,
+            vec![
+                DBCompressionType::None,
+                DBCompressionType::Lz4,
+                DBCompressionType::Zstd,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_per_level_invalid_entry() {
+        assert!(parse_compression_per_level("none,invalid,lz4").is_err());
     }
 }

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -43,7 +43,7 @@ impl DeduplicationStore {
         // Create metrics helper for the RocksDB store
         let metrics = MetricsHelper::with_partition(&topic, partition);
 
-        let cf_descriptors = Self::get_cf_descriptors();
+        let cf_descriptors = Self::get_cf_descriptors(&config.rocksdb);
         let store = RocksDbStore::new(&config.path, cf_descriptors, metrics, &config.rocksdb)?;
 
         Ok(Self {
@@ -53,7 +53,7 @@ impl DeduplicationStore {
         })
     }
 
-    fn get_cf_descriptors() -> Vec<ColumnFamilyDescriptor> {
+    fn get_cf_descriptors(rocksdb_config: &RocksDbConfig) -> Vec<ColumnFamilyDescriptor> {
         let block_opts = block_based_table_factory();
 
         // ----- CF: TimestampKey (prefix = 8-byte BE timestamp)
@@ -63,8 +63,11 @@ impl DeduplicationStore {
         ts_cf_opts.set_write_buffer_size(8 * 1024 * 1024);
         ts_cf_opts.set_max_write_buffer_number(3);
         // IMPORTANT: CF options don't inherit from DB options, must set compression explicitly
-        // LZ4 is ~2x faster than Snappy for both compression and decompression
-        ts_cf_opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+        if let Some(ref per_level) = rocksdb_config.compression_per_level {
+            ts_cf_opts.set_compression_per_level(per_level);
+        } else {
+            ts_cf_opts.set_compression_type(rocksdb_config.compression_type);
+        }
 
         vec![ColumnFamilyDescriptor::new(Self::TIMESTAMP_CF, ts_cf_opts)]
     }

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -68,6 +68,9 @@ impl DeduplicationStore {
         } else {
             ts_cf_opts.set_compression_type(rocksdb_config.compression_type);
         }
+        if let Some(bottommost) = rocksdb_config.bottommost_compression_type {
+            ts_cf_opts.set_bottommost_compression_type(bottommost);
+        }
 
         vec![ColumnFamilyDescriptor::new(Self::TIMESTAMP_CF, ts_cf_opts)]
     }


### PR DESCRIPTION
## Problem
Profiling has shown LZ4 compression to be one of the top 3 sources of CPU utilization. It may turn out to be useful to configure compression of RocksDB SST files at different size/compaction levels with more granularity to reduce CPU during checkpoint export.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Expose the relevant env vars for rockdb crate config in the app, as prep
* No actual config changes in this iteration
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. If we turn these knobs, will smoke test and observe in PoC deploy env
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
