### PR TITLE
feat: add Prometheus counter for PBKDF2 legacy API key auth

### DIFF
--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -28,7 +28,12 @@ from posthog.clickhouse.query_tagging import tag_queries
 from posthog.helpers.two_factor_session import enforce_two_factor
 from posthog.jwt import PosthogJwtAudience, decode_jwt
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication, OAuthApplicationAuthBrand
-from posthog.models.personal_api_key import PERSONAL_API_KEY_MODES_TO_TRY, PersonalAPIKey, hash_key_value
+from posthog.models.personal_api_key import (
+    PERSONAL_API_KEY_AUTH_COUNTER,
+    PERSONAL_API_KEY_MODES_TO_TRY,
+    PersonalAPIKey,
+    hash_key_value,
+)
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.user import User
 from posthog.models.webauthn_credential import WebauthnCredential
@@ -224,6 +229,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
                     .get(secure_value=secure_value)
                 )
                 mode_used = mode
+                PERSONAL_API_KEY_AUTH_COUNTER.labels(hash_mode=mode).inc()
                 break
             except PersonalAPIKey.DoesNotExist:
                 pass

--- a/posthog/models/personal_api_key.py
+++ b/posthog/models/personal_api_key.py
@@ -23,7 +23,7 @@ PERSONAL_API_KEY_MODES_TO_TRY: tuple[tuple[ModeType, Optional[int]], ...] = (
 LEGACY_PERSONAL_API_KEY_SALT = "posthog_personal_api_key"
 
 PERSONAL_API_KEY_AUTH_COUNTER = Counter(
-    "posthog_personal_api_key_auth_total",
+    "personal_api_key_hash_mode_total",
     "Successful personal API key authentications by hash mode",
     labelnames=["hash_mode"],
 )

--- a/posthog/models/personal_api_key.py
+++ b/posthog/models/personal_api_key.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.utils import timezone
 
 from django_deprecate_fields import deprecate_field
+from prometheus_client import Counter
 
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
@@ -20,6 +21,12 @@ PERSONAL_API_KEY_MODES_TO_TRY: tuple[tuple[ModeType, Optional[int]], ...] = (
 )
 
 LEGACY_PERSONAL_API_KEY_SALT = "posthog_personal_api_key"
+
+PERSONAL_API_KEY_AUTH_COUNTER = Counter(
+    "posthog_personal_api_key_auth_total",
+    "Successful personal API key authentications by hash mode",
+    labelnames=["hash_mode"],
+)
 
 
 def hash_key_value(value: str, mode: ModeType = "sha256", iterations: Optional[int] = None) -> str:

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -1,4 +1,8 @@
-use crate::{api::errors::FlagError, router::State as AppState, team::team_models::Team};
+use crate::{
+    api::errors::FlagError, metrics::consts::PERSONAL_API_KEY_HASH_MODE_COUNTER,
+    router::State as AppState, team::team_models::Team,
+};
+use common_metrics::inc;
 use axum::http::HeaderMap;
 use common_database::PostgresReader;
 use tracing::{debug, warn};
@@ -261,6 +265,12 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
                 scoped_teams = ?scoped_teams,
                 scoped_organizations = ?scoped_organizations,
                 "Personal API key validated successfully"
+            );
+
+            inc(
+                PERSONAL_API_KEY_HASH_MODE_COUNTER,
+                &[("hash_mode".to_string(), mode.to_string())],
+                1,
             );
 
             return Ok(());

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -2,9 +2,9 @@ use crate::{
     api::errors::FlagError, metrics::consts::PERSONAL_API_KEY_HASH_MODE_COUNTER,
     router::State as AppState, team::team_models::Team,
 };
-use common_metrics::inc;
 use axum::http::HeaderMap;
 use common_database::PostgresReader;
+use common_metrics::inc;
 use tracing::{debug, warn};
 
 /// Token prefix constants

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -84,7 +84,7 @@ pub const FLAG_DEFINITIONS_AUTH_COUNTER: &str = "flags_flag_definitions_auth_tot
 
 // Personal API key hash mode used for successful authentication
 // Labels: hash_mode (sha256, pbkdf2)
-pub const PERSONAL_API_KEY_HASH_MODE_COUNTER: &str = "flags_personal_api_key_hash_mode_total";
+pub const PERSONAL_API_KEY_HASH_MODE_COUNTER: &str = "personal_api_key_hash_mode_total";
 
 // Request-level timeout (tower TimeoutLayer killed the request before completion)
 pub const FLAG_REQUEST_TIMEOUT_COUNTER: &str = "flags_request_timeout_total";

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -82,6 +82,10 @@ pub const FLAG_DEFINITIONS_ETAG_COUNTER: &str = "flags_flag_definitions_etag_tot
 // Labels: method (secret_api_key, personal_api_key) — Rust only supports these two; Python also tracks oauth, jwt, session, other
 pub const FLAG_DEFINITIONS_AUTH_COUNTER: &str = "flags_flag_definitions_auth_total";
 
+// Personal API key hash mode used for successful authentication
+// Labels: hash_mode (sha256, pbkdf2)
+pub const PERSONAL_API_KEY_HASH_MODE_COUNTER: &str = "flags_personal_api_key_hash_mode_total";
+
 // Request-level timeout (tower TimeoutLayer killed the request before completion)
 pub const FLAG_REQUEST_TIMEOUT_COUNTER: &str = "flags_request_timeout_total";
 


### PR DESCRIPTION
## Problem

We want to understand how many legacy PBKDF2 personal API keys are being used with local evaluation.

## Changes

Add a Prometheus counter with a `hash_mode` label (sha256 / pbkdf2) that increments on successful personal API key authentication, in both Python and Rust:

- **Python** (`personal_api_key_hash_mode_total`): defined in `posthog/models/personal_api_key.py`, incremented in the DRF auth path (`posthog/auth.py`)
- **Rust** (`personal_api_key_hash_mode_total`): incremented in `validate_personal_api_key_with_scopes_for_team` (`rust/feature-flags/src/api/auth.rs`)

## How did you test this code?

This is adding a metric.

- Python: existing tests in `posthog/api/test/test_personal_api_keys.py` cover the auth paths
- Rust: existing tests in `rust/feature-flags/src/api/auth.rs` cover the auth flow

## Publish to changelog?

No

## Docs update

No docs changes needed.