### PR TITLE
chore(mcp): support multi-server Grafana MCP setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,12 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - Use American English spelling
 - When mentioning PostHog products, the product names should use Sentence casing, not Title Casing. For example, 'Product analytics', not 'Product Analytics'. Any other buttons, tab text, tooltips, etc should also all use Sentence casing. For example, 'Save as view' instead of 'Save As View'.
 
+## Grafana
+
+When querying Grafana, default to `grafana` (US).
+If a `grafana-eu` server is available, use it for EU queries when the user specifies EU. Otherwise, inform the user that only the US region is configured.
+Always state which region (US or EU) was queried in your response.
+
 ## Skills
 
 Skills are created inside [.agents/skills](.agents/skills/) by default and then symlinked to [.claude/skills](.claude/skills). Make sure you always treat `.agents/skills` as the source of truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,12 +99,6 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - Use American English spelling
 - When mentioning PostHog products, the product names should use Sentence casing, not Title Casing. For example, 'Product analytics', not 'Product Analytics'. Any other buttons, tab text, tooltips, etc should also all use Sentence casing. For example, 'Save as view' instead of 'Save As View'.
 
-## Grafana
-
-When querying Grafana, default to `grafana` (US).
-If a `grafana-eu` server is available, use it for EU queries when the user specifies EU. Otherwise, inform the user that only the US region is configured.
-Always state which region (US or EU) was queried in your response.
-
 ## Skills
 
 Skills are created inside [.agents/skills](.agents/skills/) by default and then symlinked to [.claude/skills](.claude/skills). Make sure you always treat `.agents/skills` as the source of truth.

--- a/infra-scripts/mcp/README.md
+++ b/infra-scripts/mcp/README.md
@@ -61,24 +61,9 @@ grafana-token dev <your-dev-token>  # optional
 
 ### 4. Configure your MCP client
 
-#### Claude Code
+Add the wrapper script to your MCP client configuration. See the [Usage](#usage) section for single-server and multi-server configuration examples.
 
-Add to your Claude Code MCP configuration (`~/.claude/settings.json` or project's `.claude/settings.json`):
-
-```json
-{
-  "mcpServers": {
-    "grafana": {
-      "command": "/Users/YOUR_USERNAME/dev/posthog/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
-      "args": []
-    }
-  }
-}
-```
-
-#### Cursor / VS Code
-
-Add to your MCP settings:
+For a basic single-server setup, add to your MCP settings (`~/.config/claude-code/.mcp.json` for Claude Code, or your editor's MCP config):
 
 ```json
 {
@@ -93,7 +78,15 @@ Add to your MCP settings:
 
 ## Usage
 
-### Switching regions
+### Region selection
+
+The wrapper script determines which Grafana region to connect to using (in order of precedence):
+
+1. **`GRAFANA_REGION` env var** — set in your MCP client config (recommended for multi-server setups)
+2. **`~/.grafana-region` file** — set via the `grafana-region` command
+3. **Default** — `us` if neither is set
+
+#### Single-server setup (switching regions manually)
 
 Use the `grafana-region` command to switch between PostHog environments:
 
@@ -106,13 +99,60 @@ grafana-region dev      # Switch to dev environment
 
 **Important: Restart required after switching regions**
 
-MCP servers are initialized once when your AI assistant starts. The region is read from `~/.grafana-region` at startup, so changing the region file while the assistant is running has no effect until you restart.
+MCP servers are initialized once when your AI assistant starts. The region is read at startup, so changing the region while the assistant is running has no effect until you restart.
 
 To restart and apply the new region:
 
 - **Claude Code**: Type `/exit` to quit, then restart Claude Code
 - **Cursor**: Close and reopen the editor, or restart the MCP server from settings
 - **VS Code**: Reload the window (`Cmd+Shift+P` → "Developer: Reload Window")
+
+#### Multi-server setup (both regions simultaneously)
+
+Run two MCP server instances with the `GRAFANA_REGION` env var so both regions are available without restarting.
+You can also use `-disable-*` flags to reduce the tool surface per server (see `mcp-grafana --help` for the full list).
+
+##### Claude Code
+
+Add to `~/.config/claude-code/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "/Users/YOUR_USERNAME/dev/posthog/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
+      "args": ["-disable-admin", "-disable-alerting", "-disable-incident", "-disable-oncall"],
+      "env": { "GRAFANA_REGION": "us" }
+    },
+    "grafana-eu": {
+      "command": "/Users/YOUR_USERNAME/dev/posthog/posthog/infra-scripts/mcp/mcp-grafana-wrapper.sh",
+      "args": ["-disable-admin", "-disable-alerting", "-disable-incident", "-disable-oncall"],
+      "env": { "GRAFANA_REGION": "eu" }
+    }
+  }
+}
+```
+
+#### Migrating from single-server to multi-server
+
+If you already have a single `grafana` server configured with both US and EU tokens in Keychain, run the migration script:
+
+```bash
+grafana-migrate-multi            # migrate with confirmation prompt
+grafana-migrate-multi --dry-run  # preview changes without writing
+grafana-migrate-multi --slim     # also normalize to recommended (smaller) disable-flag set
+```
+
+The script:
+
+1. Pins `GRAFANA_REGION=us` on your existing `grafana` entry
+2. Adds a `grafana-eu` entry (clone of `grafana` with `GRAFANA_REGION=eu`)
+3. Duplicates your `mcp__grafana__*` permissions for `mcp__grafana-eu__*` in `~/.claude/settings.json`
+
+With `--slim`, it also replaces the `args` on both entries with the recommended set (`-disable-admin`, `-disable-alerting`, `-disable-incident`, `-disable-oncall`), removing any extra disable flags you may have accumulated.
+
+Backups of modified files are saved with a `.bak` extension.
+After migrating, restart your MCP client. The `grafana-region` command is no longer needed since each server has its region pinned via env var.
 
 ### Checking token status
 

--- a/infra-scripts/mcp/grafana-migrate-multi
+++ b/infra-scripts/mcp/grafana-migrate-multi
@@ -146,6 +146,8 @@ for path, data, servers in mcp_configs:
 
     if "grafana-eu" not in servers:
         changes.append("Add new 'grafana-eu' entry (clone of 'grafana' with GRAFANA_REGION=eu)")
+    elif servers["grafana-eu"].get("env", {}).get("GRAFANA_REGION") != "eu":
+        changes.append("Pin GRAFANA_REGION=eu on existing 'grafana-eu' entry")
 
     if slim:
         if grafana.get("args", []) != SLIM_ARGS:
@@ -188,7 +190,11 @@ if settings_changes:
     for p in settings_changes:
         print(f"  + Allow {p}")
     print()
-elif settings is not None and not grafana_perms:
+elif settings is None:
+    print(f"Note: {settings_path} not found — permissions will not be migrated.")
+    print("  You may need to grant permissions manually after restarting.")
+    print()
+elif not grafana_perms:
     print(f"Note: No mcp__grafana__* permissions found in {settings_path}.")
     print("  You may need to add permissions manually after restarting.")
     print()
@@ -213,13 +219,17 @@ if confirm.strip().lower() != "y":
 for path, data, servers, _changes in all_mcp_changes:
     grafana = servers["grafana"]
 
-    shutil.copy2(path, path + ".bak")
+    bak_path = path + ".bak"
+    if not os.path.exists(bak_path):
+        shutil.copy2(path, bak_path)
 
     # Clone for EU before mutating the US entry
     if "grafana-eu" not in servers:
         eu_entry = copy.deepcopy(grafana)
         eu_entry.setdefault("env", {})["GRAFANA_REGION"] = "eu"
         servers["grafana-eu"] = eu_entry
+    else:
+        servers["grafana-eu"].setdefault("env", {})["GRAFANA_REGION"] = "eu"
 
     # Pin GRAFANA_REGION on existing entry
     grafana.setdefault("env", {})["GRAFANA_REGION"] = "us"
@@ -237,7 +247,9 @@ for path, data, servers, _changes in all_mcp_changes:
 # --- Apply settings changes ---
 
 if settings_changes and settings is not None:
-    shutil.copy2(settings_path, settings_path + ".bak")
+    bak_path = settings_path + ".bak"
+    if not os.path.exists(bak_path):
+        shutil.copy2(settings_path, bak_path)
 
     if "permissions" not in settings:
         settings["permissions"] = {}

--- a/infra-scripts/mcp/grafana-migrate-multi
+++ b/infra-scripts/mcp/grafana-migrate-multi
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Migrate from single-server Grafana MCP setup to multi-server (US + EU simultaneous)
+#
+# Usage:
+#   grafana-migrate-multi            # Run migration with confirmation prompt
+#   grafana-migrate-multi --dry-run  # Show what would change without writing
+#   grafana-migrate-multi --slim     # Also normalize to recommended (smaller) disable-flag set
+#
+# This script automates the steps in the README under "Migrating from single-server
+# to multi-server". It is idempotent and safe to run multiple times.
+#
+# Scans for 'grafana' MCP entries in:
+#   - ~/.config/claude-code/.mcp.json  (Claude Code global config)
+#   - .claude.json                     (Claude Code project config, in current directory)
+#
+# Prerequisites:
+#   - macOS (uses Keychain for token verification)
+#   - US and EU tokens stored in Keychain (see grafana-token)
+#   - At least one MCP config file with a 'grafana' entry
+
+set -euo pipefail
+
+SETTINGS_JSON="$HOME/.claude/settings.json"
+DRY_RUN=false
+SLIM=false
+
+show_usage() {
+    echo "Usage: grafana-migrate-multi [--dry-run] [--slim]"
+    echo ""
+    echo "Migrates your Grafana MCP setup from a single server to multi-server"
+    echo "(US + EU available simultaneously, no restart needed to switch regions)."
+    echo ""
+    echo "Scans for MCP config in:"
+    echo "  ~/.config/claude-code/.mcp.json  (Claude Code global)"
+    echo "  .claude.json                     (Claude Code project, current directory)"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run  Show what would change without writing"
+    echo "  --slim     Normalize args to the recommended (smaller) disable-flag set"
+    echo "  -h, --help Show this help message"
+    echo ""
+    echo "Prerequisites:"
+    echo "  - US and EU tokens in Keychain (use grafana-token to add them)"
+    echo "  - Existing 'grafana' entry in at least one MCP config file"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true ;;
+        --slim)    SLIM=true ;;
+        -h|--help) show_usage; exit 0 ;;
+        *) echo "Error: Unknown argument '$1'" >&2; echo ""; show_usage; exit 1 ;;
+    esac
+    shift
+done
+
+# macOS check
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "Error: This script requires macOS Keychain." >&2
+    exit 1
+fi
+
+# Token checks
+missing_tokens=()
+if ! security find-generic-password -a "$USER" -s "grafana-service-account-token-us" &>/dev/null; then
+    missing_tokens+=("us")
+fi
+if ! security find-generic-password -a "$USER" -s "grafana-service-account-token-eu" &>/dev/null; then
+    missing_tokens+=("eu")
+fi
+
+if [ ${#missing_tokens[@]} -gt 0 ]; then
+    echo "Error: Missing Grafana tokens for: ${missing_tokens[*]}" >&2
+    echo "" >&2
+    for region in "${missing_tokens[@]}"; do
+        echo "  Add with: grafana-token $region <your-token>" >&2
+    done
+    exit 1
+fi
+
+# Build list of MCP config files to check
+MCP_FILES=()
+GLOBAL_MCP="$HOME/.config/claude-code/.mcp.json"
+PROJECT_MCP=".claude.json"
+
+if [ -f "$GLOBAL_MCP" ]; then
+    MCP_FILES+=("$GLOBAL_MCP")
+fi
+if [ -f "$PROJECT_MCP" ]; then
+    MCP_FILES+=("$PWD/$PROJECT_MCP")
+fi
+
+if [ ${#MCP_FILES[@]} -eq 0 ]; then
+    echo "Error: No MCP config files found." >&2
+    echo "Checked:" >&2
+    echo "  $GLOBAL_MCP" >&2
+    echo "  $PWD/$PROJECT_MCP" >&2
+    echo "Set up a single-server Grafana MCP first (see README)." >&2
+    exit 1
+fi
+
+# Analyze and optionally apply changes
+python3 - "$DRY_RUN" "$SLIM" "$SETTINGS_JSON" "${MCP_FILES[@]}" << 'PYEOF'
+import copy, json, sys, os, shutil
+
+dry_run = sys.argv[1] == "true"
+slim = sys.argv[2] == "true"
+settings_path = sys.argv[3]
+mcp_paths = sys.argv[4:]
+
+SLIM_ARGS = ["-disable-admin", "-disable-alerting", "-disable-incident", "-disable-oncall"]
+
+# --- Load MCP config files and find ones with a 'grafana' entry ---
+
+mcp_configs = []  # list of (path, data, servers) tuples
+for path in mcp_paths:
+    with open(path) as f:
+        data = json.load(f)
+    servers = data.get("mcpServers", {})
+    if "grafana" in servers:
+        mcp_configs.append((path, data, servers))
+
+if not mcp_configs:
+    checked = "\n  ".join(mcp_paths)
+    print(f"Error: No 'grafana' entry found in any MCP config file.\nChecked:\n  {checked}", file=sys.stderr)
+    sys.exit(1)
+
+# --- Load settings ---
+
+settings = None
+if os.path.isfile(settings_path):
+    with open(settings_path) as f:
+        settings = json.load(f)
+
+# --- Analyze MCP changes across all config files ---
+
+all_mcp_changes = []  # list of (path, data, servers, changes_list) tuples
+
+for path, data, servers in mcp_configs:
+    changes = []
+    grafana = servers["grafana"]
+    env = grafana.get("env", {})
+
+    if env.get("GRAFANA_REGION") != "us":
+        changes.append("Pin GRAFANA_REGION=us on existing 'grafana' entry")
+
+    if "grafana-eu" not in servers:
+        changes.append("Add new 'grafana-eu' entry (clone of 'grafana' with GRAFANA_REGION=eu)")
+
+    if slim:
+        if grafana.get("args", []) != SLIM_ARGS:
+            changes.append(f"Normalize 'grafana' args to recommended set: {' '.join(SLIM_ARGS)}")
+        eu_entry = servers.get("grafana-eu")
+        if eu_entry is None or eu_entry.get("args", []) != SLIM_ARGS:
+            changes.append(f"Normalize 'grafana-eu' args to recommended set: {' '.join(SLIM_ARGS)}")
+
+    if changes:
+        all_mcp_changes.append((path, data, servers, changes))
+
+# --- Analyze settings changes ---
+
+settings_changes = []
+if settings is not None:
+    allow = settings.get("permissions", {}).get("allow", [])
+    existing = set(allow)
+    grafana_perms = [p for p in allow if p.startswith("mcp__grafana__")]
+    for perm in grafana_perms:
+        eu_perm = perm.replace("mcp__grafana__", "mcp__grafana-eu__", 1)
+        if eu_perm not in existing:
+            settings_changes.append(eu_perm)
+
+# --- Check if anything to do ---
+
+if not all_mcp_changes and not settings_changes:
+    print("Already migrated, nothing to do.")
+    sys.exit(0)
+
+# --- Print summary ---
+
+for path, _data, _servers, changes in all_mcp_changes:
+    print(f"Changes to {path}:")
+    for c in changes:
+        print(f"  + {c}")
+    print()
+
+if settings_changes:
+    print(f"Changes to {settings_path}:")
+    for p in settings_changes:
+        print(f"  + Allow {p}")
+    print()
+elif settings is not None and not grafana_perms:
+    print(f"Note: No mcp__grafana__* permissions found in {settings_path}.")
+    print("  You may need to add permissions manually after restarting.")
+    print()
+
+if dry_run:
+    print("(Dry run -- no changes written)")
+    sys.exit(0)
+
+# --- Prompt for confirmation ---
+
+try:
+    confirm = input("Apply these changes? [y/N] ")
+except EOFError:
+    confirm = ""
+
+if confirm.strip().lower() != "y":
+    print("Aborted.")
+    sys.exit(0)
+
+# --- Apply MCP changes ---
+
+for path, data, servers, _changes in all_mcp_changes:
+    grafana = servers["grafana"]
+
+    shutil.copy2(path, path + ".bak")
+
+    # Clone for EU before mutating the US entry
+    if "grafana-eu" not in servers:
+        eu_entry = copy.deepcopy(grafana)
+        eu_entry.setdefault("env", {})["GRAFANA_REGION"] = "eu"
+        servers["grafana-eu"] = eu_entry
+
+    # Pin GRAFANA_REGION on existing entry
+    grafana.setdefault("env", {})["GRAFANA_REGION"] = "us"
+
+    # Normalize args to recommended set
+    if slim:
+        grafana["args"] = SLIM_ARGS
+        if "grafana-eu" in servers:
+            servers["grafana-eu"]["args"] = SLIM_ARGS
+
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+# --- Apply settings changes ---
+
+if settings_changes and settings is not None:
+    shutil.copy2(settings_path, settings_path + ".bak")
+
+    if "permissions" not in settings:
+        settings["permissions"] = {}
+    if "allow" not in settings["permissions"]:
+        settings["permissions"]["allow"] = []
+
+    settings["permissions"]["allow"].extend(settings_changes)
+
+    with open(settings_path, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+
+# --- Summary ---
+
+print()
+print("Migration complete!")
+print()
+for path, _data, _servers, changes in all_mcp_changes:
+    print(f"  {path}  -- {len(changes)} change(s) applied")
+if settings_changes:
+    print(f"  {settings_path}  -- {len(settings_changes)} permission(s) added")
+print()
+print("Restart your MCP client to apply changes:")
+print("  Claude Code: type /exit then restart")
+print("  Cursor: close and reopen the editor")
+print("  VS Code: Cmd+Shift+P > Developer: Reload Window")
+PYEOF

--- a/infra-scripts/mcp/mcp-grafana-wrapper.sh
+++ b/infra-scripts/mcp/mcp-grafana-wrapper.sh
@@ -6,9 +6,9 @@
 # Grafana directly within the K8s cluster, enabling the MCP server to authenticate
 # with a service account token.
 #
-# Supports switching between prod-us, prod-eu, and dev regions via ~/.grafana-region file.
-# Use `grafana-region us`, `grafana-region eu`, or `grafana-region dev` to switch,
-# then restart your MCP client.
+# Supports switching between prod-us, prod-eu, and dev regions via GRAFANA_REGION env var
+# or ~/.grafana-region file (env var takes precedence). Use `grafana-region us`,
+# `grafana-region eu`, or `grafana-region dev` to switch, then restart your MCP client.
 #
 # Prerequisites:
 #   - kubectl configured with access to PostHog K8s clusters
@@ -33,9 +33,16 @@ else
     CURRENT_REGION="$DEFAULT_REGION"
 fi
 
+# Environment variable takes precedence over region file
+REGION_SOURCE="$REGION_FILE"
+if [ -n "${GRAFANA_REGION:-}" ]; then
+    CURRENT_REGION="$GRAFANA_REGION"
+    REGION_SOURCE="GRAFANA_REGION env var"
+fi
+
 # Validate region
 if [[ "$CURRENT_REGION" != "us" && "$CURRENT_REGION" != "eu" && "$CURRENT_REGION" != "dev" ]]; then
-    echo "Error: Invalid region '$CURRENT_REGION' in $REGION_FILE. Must be 'us', 'eu', or 'dev'." >&2
+    echo "Error: Invalid region '$CURRENT_REGION' from $REGION_SOURCE. Must be 'us', 'eu', or 'dev'." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Problem

Switching between US and EU Grafana regions requires restarting the MCP client each time, since the region is read at startup from `~/.grafana-region`. Engineers who regularly query both regions lose time on restarts.

## Changes

- **Wrapper script**: Add `GRAFANA_REGION` env var support (takes precedence over `~/.grafana-region` file), enabling two MCP server instances to run simultaneously with different regions
- **Migration script** (`grafana-migrate-multi`): Automate the conversion from single-server to multi-server setup. Scans both global (`~/.config/claude-code/.mcp.json`) and project (`.claude.json`) MCP configs, clones the `grafana` entry as `grafana-eu`, pins regions via env var, and duplicates permissions in `~/.claude/settings.json`. Supports `--dry-run` for preview and `--slim` to normalize disable-flags to the recommended smaller set
- **AGENTS.md**: Add conditional Grafana section instructing agents to default to US and use EU only when available
- **README**: Restructure docs with single-server vs multi-server setup sections, add migration instructions

## How did you test this code?

Tested the multi-server setup by running both `grafana` (US) and `grafana-eu` (EU) MCP servers simultaneously and querying Loki logs across both regions. Verified the migration script's `--dry-run` output and idempotency.

## Publish to changelog?

No

## Docs update

N/A — internal tooling only.