### PR TITLE
fix(experiments): centralize saved metrics validation

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -23,7 +23,7 @@ from posthog.models import Survey
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.cohort import Cohort
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext
-from posthog.models.experiment import Experiment, ExperimentHoldout, ExperimentSavedMetric
+from posthog.models.experiment import Experiment, ExperimentHoldout
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.signals import model_activity_signal, mutable_receiver
@@ -147,33 +147,7 @@ class ExperimentSerializer(UserAccessControlSerializerMixin, serializers.ModelSe
         return data
 
     def validate_saved_metrics_ids(self, value):
-        if value is None:
-            return value
-
-        # check value is valid json list with id and optionally metadata param
-        if not isinstance(value, list):
-            raise ValidationError("Saved metrics must be a list")
-
-        for saved_metric in value:
-            if not isinstance(saved_metric, dict):
-                raise ValidationError("Saved metric must be an object")
-            if "id" not in saved_metric:
-                raise ValidationError("Saved metric must have an id")
-            if "metadata" in saved_metric and not isinstance(saved_metric["metadata"], dict):
-                raise ValidationError("Metadata must be an object")
-
-            # metadata is optional, but if it exists, should have type key
-            # TODO: extend with other metadata keys when known
-            if "metadata" in saved_metric and "type" not in saved_metric["metadata"]:
-                raise ValidationError("Metadata must have a type key")
-
-        # check if all saved metrics exist and belong to the same team
-        saved_metrics = ExperimentSavedMetric.objects.filter(
-            id__in=[saved_metric["id"] for saved_metric in value], team_id=self.context["team_id"]
-        )
-        if saved_metrics.count() != len(value):
-            raise ValidationError("Saved metric does not exist or does not belong to this project")
-
+        ExperimentService.validate_saved_metrics_ids(value, self.context["team_id"])
         return value
 
     def validate(self, data):

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -114,6 +114,32 @@ class ExperimentService:
                 except pydantic.ValidationError as e:
                     raise ValidationError(f"Invalid metric at index {i}: {e.errors()}")
 
+    @staticmethod
+    def validate_saved_metrics_ids(saved_metrics_ids: list | None, team_id: int) -> None:
+        """Validate saved metric references accepted by the API layer."""
+        if saved_metrics_ids is None:
+            return
+
+        if not isinstance(saved_metrics_ids, list):
+            raise ValidationError("Saved metrics must be a list")
+
+        for saved_metric in saved_metrics_ids:
+            if not isinstance(saved_metric, dict):
+                raise ValidationError("Saved metric must be an object")
+            if "id" not in saved_metric:
+                raise ValidationError("Saved metric must have an id")
+            if "metadata" in saved_metric and not isinstance(saved_metric["metadata"], dict):
+                raise ValidationError("Metadata must be an object")
+            if "metadata" in saved_metric and "type" not in saved_metric["metadata"]:
+                raise ValidationError("Metadata must have a type key")
+
+        saved_metrics = ExperimentSavedMetric.objects.filter(
+            id__in=[saved_metric["id"] for saved_metric in saved_metrics_ids],
+            team_id=team_id,
+        )
+        if saved_metrics.count() != len(saved_metrics_ids):
+            raise ValidationError("Saved metric does not exist or does not belong to this project")
+
     @transaction.atomic
     def create_experiment(
         self,
@@ -146,6 +172,7 @@ class ExperimentService:
         event_source: EventSource | None = None,
     ) -> Experiment:
         """Create experiment with full validation and defaults."""
+        self.validate_saved_metrics_ids(saved_metrics_ids, self.team.id)
         is_draft = start_date is None
 
         feature_flag, used_variants = self._ensure_feature_flag(
@@ -484,6 +511,9 @@ class ExperimentService:
         ``ExperimentSerializer``.  The caller is responsible for DRF-level input
         validation (field types, metric schema, etc.) before calling this method.
         """
+        if "saved_metrics_ids" in update_data:
+            self.validate_saved_metrics_ids(update_data.get("saved_metrics_ids"), self.team.id)
+
         context = serializer_context or self._build_serializer_context()
         feature_flag = experiment.feature_flag
 

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -512,7 +512,7 @@ class ExperimentService:
         validation (field types, metric schema, etc.) before calling this method.
         """
         if "saved_metrics_ids" in update_data:
-            self.validate_saved_metrics_ids(update_data.get("saved_metrics_ids"), self.team.id)
+            self.validate_saved_metrics_ids(update_data["saved_metrics_ids"], self.team.id)
 
         context = serializer_context or self._build_serializer_context()
         feature_flag = experiment.feature_flag

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
-from posthog.models import FeatureFlag
+from posthog.models import FeatureFlag, Team
 from posthog.models.experiment import (
     Experiment,
     ExperimentHoldout,
@@ -324,6 +324,49 @@ class TestExperimentService(APIBaseTest):
         assert len(links) == 1
         assert links[0].saved_metric_id == saved_metric.id
         assert experiment.primary_metrics_ordered_uuids == ["sm-uuid"]
+
+    @parameterized.expand(
+        [
+            ("not_list", {"id": 1}, "Saved metrics must be a list"),
+            ("missing_id", [{"metadata": {"type": "primary"}}], "Saved metric must have an id"),
+            ("non_object", [[1]], "Saved metric must be an object"),
+            ("metadata_not_object", [{"id": 1, "metadata": "primary"}], "Metadata must be an object"),
+            ("metadata_missing_type", [{"id": 1, "metadata": {"xxx": "primary"}}], "Metadata must have a type key"),
+        ]
+    )
+    def test_create_experiment_validates_saved_metrics_payload(
+        self, _: str, saved_metrics_ids: object, expected_error: str
+    ) -> None:
+        self._create_flag(key="saved-metrics-invalid")
+        service = self._service()
+
+        with self.assertRaises(ValidationError) as ctx:
+            service.create_experiment(
+                name="Saved Metrics Invalid",
+                feature_flag_key="saved-metrics-invalid",
+                saved_metrics_ids=saved_metrics_ids,  # type: ignore[arg-type]
+            )
+
+        assert expected_error in str(ctx.exception)
+
+    def test_create_experiment_rejects_saved_metrics_from_another_team(self) -> None:
+        self._create_flag(key="saved-metrics-team-check")
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=other_team,
+            name="Other Team Metric",
+            query={"kind": "ExperimentMetric", "metric_type": "count", "uuid": "other-uuid", "event": "$pageview"},
+        )
+        service = self._service()
+
+        with self.assertRaises(ValidationError) as ctx:
+            service.create_experiment(
+                name="Wrong Team Metric",
+                feature_flag_key="saved-metrics-team-check",
+                saved_metrics_ids=[{"id": saved_metric.id, "metadata": {"type": "primary"}}],
+            )
+
+        assert "Saved metric does not exist or does not belong to this project" in str(ctx.exception)
 
     # ------------------------------------------------------------------
     # Service contract fields
@@ -838,6 +881,34 @@ class TestExperimentService(APIBaseTest):
         fresh_experiment = Experiment.objects.get(id=experiment.id)
         assert fresh_experiment.primary_metrics_ordered_uuids == ["sm-1"]
         assert fresh_experiment.secondary_metrics_ordered_uuids == []
+
+    def test_update_experiment_validates_saved_metrics_before_mutation(self) -> None:
+        self._create_flag(key="saved-metrics-update-validate")
+        sm1 = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name="SM1",
+            query={"kind": "ExperimentMetric", "metric_type": "count", "uuid": "sm-1", "event": "$pageview"},
+        )
+        service = self._service()
+        experiment = service.create_experiment(
+            name="Update Validation",
+            feature_flag_key="saved-metrics-update-validate",
+            saved_metrics_ids=[{"id": sm1.id, "metadata": {"type": "primary"}}],
+        )
+
+        with (
+            patch("django.db.models.query.QuerySet.delete") as delete_mock,
+            self.assertRaises(ValidationError) as ctx,
+        ):
+            service.update_experiment(
+                experiment,
+                {
+                    "saved_metrics_ids": [[sm1.id]],
+                },
+            )
+
+        assert "Saved metric must be an object" in str(ctx.exception)
+        delete_mock.assert_not_called()
 
     def test_update_experiment_validates_unknown_keys_before_saved_metric_mutation(self):
         self._create_flag(key="validate-before-mutate")


### PR DESCRIPTION
This is part of the initiative to consolidate all experiment business logic in the service layer.

## Problem
Saved metrics validation only lived in the experiments serializer, so direct `ExperimentService` callers could bypass payload and team-scoping checks.

## Changes

- Moved `saved_metrics_ids` validation into `ExperimentService`.
- Enforced it in both create and update flows.
- Left the serializer delegating to the service and added service-level tests for invalid payloads and cross-team metrics.

# Testing
- Tests added
- CI passes