### PR TITLE
feat(ph-ai): sandbox agents with optional repo and output schema

### DIFF
--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -157,22 +157,25 @@ class Task(DeletedMetaFields, models.Model):
         description: str,
         origin_product: "Task.OriginProduct",
         user_id: int,  # Will be used to validate the tasks feature flag and create a personal api key for interacting with PostHog.
-        repository: str,  # Format: "organization/repository", e.g. "posthog/posthog-js"
+        repository: str | None = None,
         create_pr: bool = True,
         mode: str = "background",
         slack_thread_context: Optional["SlackThreadContext"] = None,
         slack_thread_url: str | None = None,
         start_workflow: bool = True,
         posthog_mcp_scopes: PosthogMcpScopes = "full",
+        output_schema: dict | None = None,
     ) -> "Task":
         from products.tasks.backend.temporal.client import execute_task_processing_workflow
 
         created_by = User.objects.get(id=user_id)
 
-        github_integration = Integration.objects.filter(team=team, kind="github").first()
-
-        if not github_integration:
-            raise ValueError(f"Team {team.id} does not have a GitHub integration")
+        if repository:
+            github_integration = Integration.objects.filter(team=team, kind="github").first()
+            if not github_integration:
+                raise ValueError(f"Team {team.id} does not have a GitHub integration")
+        else:
+            github_integration = None
 
         task = Task.objects.create(
             team=team,
@@ -182,6 +185,7 @@ class Task(DeletedMetaFields, models.Model):
             created_by=created_by,
             github_integration=github_integration,
             repository=repository,
+            json_schema=output_schema,
         )
 
         extra_state: dict[str, str] | None = None

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -554,21 +554,23 @@ class DockerSandbox:
 
     def _build_agent_server_command(
         self,
-        repo_path: str,
+        repo_path: str | None,
         task_id: str,
         run_id: str,
         mode: str,
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_servers_arg: str = "",
+        output_schema_arg: str = "",
     ) -> str:
+        repo_path_arg = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
         env_prefix = f"env TWIG_INTERACTION_ORIGIN={shlex.quote(interaction_origin)} " if interaction_origin else ""
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         return (
             f"cd /scripts && "
-            f"nohup {env_prefix}npx agent-server --port {AGENT_SERVER_PORT} --repositoryPath {shlex.quote(repo_path)} "
+            f"nohup {env_prefix}npx agent-server --port {AGENT_SERVER_PORT}{repo_path_arg} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{branch_flag}{mcp_servers_arg} "
+            f"{branch_flag}{mcp_servers_arg}{output_schema_arg} "
             f"> /tmp/agent-server.log 2>&1 &"
         )
 
@@ -585,13 +587,14 @@ class DockerSandbox:
 
     def start_agent_server(
         self,
-        repository: str,
+        repository: str | None,
         task_id: str,
         run_id: str,
         mode: str = "background",
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
+        output_schema: dict | None = None,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -604,16 +607,24 @@ class DockerSandbox:
         if self._host_port is None:
             raise RuntimeError("Sandbox was not created with port exposure.")
 
-        org, repo = repository.lower().split("/")
-        repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+        # Build repository path only if repository is provided
+        if repository:
+            org, repo = repository.lower().split("/")
+            repo_path: str | None = f"/tmp/workspace/repos/{org}/{repo}"
+        else:
+            repo_path = None
 
         mcp_servers_arg = ""
         if mcp_configs:
             mcp_json = json.dumps([c.to_dict() for c in mcp_configs])
             mcp_servers_arg = f" --mcpServers {shlex.quote(mcp_json)}"
 
+        output_schema_arg = ""
+        if output_schema:
+            output_schema_arg = f" --outputSchema {shlex.quote(json.dumps(output_schema))}"
+
         command = self._build_agent_server_command(
-            repo_path, task_id, run_id, mode, interaction_origin, branch, mcp_servers_arg
+            repo_path, task_id, run_id, mode, interaction_origin, branch, mcp_servers_arg, output_schema_arg
         )
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository}")
@@ -633,7 +644,14 @@ class DockerSandbox:
             self.execute("pkill -f agent-server || true", timeout_seconds=5)
 
             command = self._build_agent_server_command(
-                repo_path, task_id, run_id, mode, interaction_origin, branch=None, mcp_servers_arg=mcp_servers_arg
+                repo_path,
+                task_id,
+                run_id,
+                mode,
+                interaction_origin,
+                branch=None,
+                mcp_servers_arg=mcp_servers_arg,
+                output_schema_arg=output_schema_arg,
             )
             if self._launch_and_check(command):
                 logger.info(f"Agent-server started on port {self._host_port} (without --baseBranch)")

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -438,13 +438,14 @@ class ModalSandbox:
 
     def start_agent_server(
         self,
-        repository: str,
+        repository: str | None,
         task_id: str,
         run_id: str,
         mode: str = "background",
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
+        output_schema: dict | None = None,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -455,21 +456,30 @@ class ModalSandbox:
         if not self.is_running():
             raise RuntimeError("Sandbox not in running state.")
 
-        org, repo = repository.lower().split("/")
-        repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+        # Build repository path only if repository is provided
+        if repository:
+            org, repo = repository.lower().split("/")
+            repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+            repo_path_arg = f" --repositoryPath {shlex.quote(repo_path)}"
+        else:
+            repo_path_arg = ""
 
         mcp_servers_arg = ""
         if mcp_configs:
             mcp_json = json.dumps([c.to_dict() for c in mcp_configs])
             mcp_servers_arg = f" --mcpServers {shlex.quote(mcp_json)}"
 
+        output_schema_arg = ""
+        if output_schema:
+            output_schema_arg = f" --outputSchema {shlex.quote(json.dumps(output_schema))}"
+
         env_prefix = f"env TWIG_INTERACTION_ORIGIN={shlex.quote(interaction_origin)} " if interaction_origin else ""
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         command = (
             f"cd /scripts && "
-            f"nohup {env_prefix}npx agent-server --port {AGENT_SERVER_PORT} --repositoryPath {shlex.quote(repo_path)} "
+            f"nohup {env_prefix}npx agent-server --port {AGENT_SERVER_PORT}{repo_path_arg} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{branch_flag}{mcp_servers_arg} "
+            f"{branch_flag}{mcp_servers_arg}{output_schema_arg} "
             f"> /tmp/agent-server.log 2>&1 &"
         )
 

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -118,13 +118,14 @@ class SandboxProtocol(Protocol):
 
     def start_agent_server(
         self,
-        repository: str,
+        repository: str | None,
         task_id: str,
         run_id: str,
         mode: str = "background",
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
+        output_schema: dict | None = None,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -49,25 +49,41 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         "get_sandbox_for_repository",
         **ctx.to_log_context(),
     ):
-        with StepTimer("snapshot_lookup") as snapshot_lookup_timer:
-            snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(ctx.github_integration_id, [ctx.repository])
-            used_snapshot = snapshot is not None
-            snapshot_lookup_timer.set_used_snapshot(used_snapshot)
-        increment_snapshot_usage(used_snapshot)
+        has_repository = bool(ctx.repository)
+
+        # Snapshot lookup - skip if no repository
+        if has_repository:
+            with StepTimer("snapshot_lookup") as snapshot_lookup_timer:
+                snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(ctx.github_integration_id, [ctx.repository])
+                used_snapshot = snapshot is not None
+                snapshot_lookup_timer.set_used_snapshot(used_snapshot)
+            increment_snapshot_usage(used_snapshot)
+        else:
+            snapshot = None
+            used_snapshot = False
+
+        if used_snapshot:
+            emit_agent_log(ctx.run_id, "info", f"Found existing environment for {ctx.repository}")
+        elif has_repository:
+            emit_agent_log(ctx.run_id, "debug", f"Creating environment from base image for {ctx.repository}")
 
         try:
             task = Task.objects.select_related("created_by").get(id=ctx.task_id)
         except Task.DoesNotExist as e:
             raise TaskNotFoundError(f"Task {ctx.task_id} not found", {"task_id": ctx.task_id}, cause=e)
 
-        try:
-            github_token = get_github_token(ctx.github_integration_id) or ""
-        except Exception as e:
-            raise GitHubAuthenticationError(
-                f"Failed to get GitHub token for integration {ctx.github_integration_id}",
-                {"github_integration_id": ctx.github_integration_id, "task_id": ctx.task_id, "error": str(e)},
-                cause=e,
-            )
+        # GitHub token - skip if no repository
+        if has_repository:
+            try:
+                github_token = get_github_token(ctx.github_integration_id) or ""
+            except Exception as e:
+                raise GitHubAuthenticationError(
+                    f"Failed to get GitHub token for integration {ctx.github_integration_id}",
+                    {"github_integration_id": ctx.github_integration_id, "task_id": ctx.task_id, "error": str(e)},
+                    cause=e,
+                )
+        else:
+            github_token = ""
 
         try:
             access_token = create_oauth_access_token(task)
@@ -79,12 +95,13 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
             )
 
         environment_variables = {
-            "GITHUB_TOKEN": github_token,
             "POSTHOG_PERSONAL_API_KEY": access_token,
             "POSTHOG_API_URL": get_sandbox_api_url(),
             "POSTHOG_PROJECT_ID": str(ctx.team_id),
             "JWT_PUBLIC_KEY": get_sandbox_jwt_public_key(),
         }
+        if github_token:
+            environment_variables["GITHUB_TOKEN"] = github_token
 
         if settings.SANDBOX_LLM_GATEWAY_URL:
             environment_variables["LLM_GATEWAY_URL"] = settings.SANDBOX_LLM_GATEWAY_URL
@@ -116,7 +133,8 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         with StepTimer("sandbox_creation", used_snapshot=used_snapshot):
             sandbox = Sandbox.create(config)
 
-        if not used_snapshot:
+        # Clone - skip if no repository
+        if not used_snapshot and has_repository:
             emit_agent_log(ctx.run_id, "info", f"Cloning {ctx.repository} into sandbox")
             with StepTimer("repository_clone", used_snapshot=used_snapshot):
                 clone_result = sandbox.clone_repository(ctx.repository, github_token=github_token)
@@ -124,7 +142,8 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
                 sandbox.destroy()
                 raise RuntimeError(f"Failed to clone repository {ctx.repository}: {clone_result.stderr}")
 
-        if ctx.branch:
+        # Branch checkout - skip if no repository
+        if ctx.branch and has_repository:
             emit_agent_log(ctx.run_id, "info", f"Checking out branch {ctx.branch}")
             org, repo = ctx.repository.lower().split("/")
             repo_path = f"/tmp/workspace/repos/{org}/{repo}"

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -27,12 +27,13 @@ class TaskProcessingContext:
     task_id: str
     run_id: str
     team_id: int
-    github_integration_id: int
-    repository: str
     distinct_id: str
+    github_integration_id: int | None = None
+    repository: str | None = None
     create_pr: bool = True
     state: dict | None = None
     _branch: str | None = None
+    output_schema: dict | None = None
 
     @property
     def mode(self) -> str:
@@ -79,27 +80,8 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
 
     task = task_run.task
 
-    if not task.github_integration_id:
-        raise TaskInvalidStateError(
-            f"Task {task.id} has no GitHub integration",
-            {"task_id": str(task.id), "run_id": run_id},
-            cause=RuntimeError(f"Task {task.id} missing github_integration_id"),
-        )
-
-    if not task.repository:
-        raise TaskInvalidStateError(
-            f"Task {task.id} has no repository configured",
-            {"task_id": str(task.id), "run_id": run_id},
-            cause=RuntimeError(f"Task {task.id} missing repository"),
-        )
-
-    repository_full_name = task.repository
-    if not repository_full_name:
-        raise TaskInvalidStateError(
-            f"Task {task.id} repository missing value",
-            {"task_id": str(task.id), "run_id": run_id},
-            cause=RuntimeError(f"Task {task.id} repository field is empty"),
-        )
+    github_integration_id = task.github_integration_id or None
+    repository_full_name = task.repository or None
 
     if not task.created_by:
         raise TaskInvalidStateError(
@@ -125,10 +107,11 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         task_id=str(task.id),
         run_id=run_id,
         team_id=task.team_id,
-        github_integration_id=task.github_integration_id,
+        github_integration_id=github_integration_id,
         repository=repository_full_name,
         distinct_id=distinct_id,
         create_pr=input.create_pr,
         state=task_run.state,
         _branch=task_run.branch,
+        output_schema=task.json_schema,
     )

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -84,6 +84,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 interaction_origin=ctx.interaction_origin,
                 branch=ctx.branch,
                 mcp_configs=mcp_configs or None,
+                output_schema=ctx.output_schema,
             )
         except Exception as e:
             raise SandboxExecutionError(


### PR DESCRIPTION
## Problem

Tasks currently require a GitHub repository and integration to function, limiting their use cases to only repository-based operations.

## Changes

- Made `repository` parameter optional in task creation and execution flow
- Updated sandbox services to handle cases where no repository is provided
- Modified agent server startup to conditionally include repository path and GitHub token
- Added support for `output_schema` parameter to define structured output formats
- Fixed package name reference in Docker sandbox from `@twig/git` to `@posthog/git`
- Updated task processing context to handle missing GitHub integration gracefully

## How did you test this code?
Part of a stack of PRs, test from the top one

## Publish to changelog?
No