### PR TITLE
feat(ph-ai): background sandbox agent api

### DIFF
--- a/ee/api/sandbox_agent.py
+++ b/ee/api/sandbox_agent.py
@@ -1,0 +1,368 @@
+"""
+External API endpoint for running sandbox AI agents.
+
+Used by the CDP/Cyclotron executor (Hog templates) to run AI agents as workflow actions
+and can be opened to third-party developers in the future.
+
+Authentication: Bearer token (team api_token) in the Authorization header.
+DRF authentication is disabled (authentication_classes = [], permission_classes = [AllowAny])
+because the endpoint authenticates via team api_token, not user sessions or personal API keys.
+"""
+
+import json
+import time
+
+import structlog
+from rest_framework import serializers, status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.throttling import SimpleRateThrottle
+from rest_framework.views import APIView
+
+from posthog.models import OrganizationMembership, Team
+
+from products.tasks.backend.models import TaskRun
+
+from ee.hogai.sandbox_agent import SandboxAgentService
+
+logger = structlog.get_logger(__name__)
+
+AGENT_POLL_INTERVAL_SECONDS = 5
+AGENT_MAX_WAIT_SECONDS = 600  # 10 minutes
+
+# ACP notification methods we extract readable messages from
+_TOOL_CALL_METHOD = "session/update"
+
+
+_MAX_LOG_TEXT_LEN = 500
+
+
+def _extract_text_from_content(content: object) -> str:
+    """Extract text from an ACP ContentBlock or list of ContentBlocks."""
+    if isinstance(content, dict):
+        return str(content.get("text") or content.get("thinking") or "")
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                t = block.get("text") or block.get("thinking") or ""
+                if t:
+                    parts.append(str(t))
+        return "\n".join(parts)
+    return ""
+
+
+def _format_tool_input(tool_name: str, raw_input: object) -> str:
+    """Format tool call input parameters into a readable summary."""
+    if not isinstance(raw_input, dict):
+        return ""
+    if tool_name == "Bash":
+        return raw_input.get("command", "")
+    if tool_name in ("Read", "Grep", "Glob"):
+        return raw_input.get("file_path") or raw_input.get("pattern") or raw_input.get("path") or ""
+    if tool_name in ("Write", "Edit"):
+        return raw_input.get("file_path", "")
+    if tool_name == "Agent":
+        return raw_input.get("prompt", "")[:200]
+    # Generic: dump compact JSON
+    try:
+        return json.dumps(raw_input, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return ""
+
+
+def _format_tool_output(tool_name: str, raw_output: object) -> str:
+    """Format tool call output into a readable summary."""
+    if isinstance(raw_output, str):
+        return raw_output
+    if isinstance(raw_output, list):
+        # Content blocks from tool result
+        parts = []
+        for block in raw_output:
+            if isinstance(block, dict):
+                t = block.get("text", "")
+                if t:
+                    parts.append(str(t))
+        return "\n".join(parts)
+    if isinstance(raw_output, dict):
+        try:
+            return json.dumps(raw_output, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return str(raw_output)
+    return ""
+
+
+def _extract_agent_logs(task_run) -> list[str]:
+    """Extract human-readable log messages from a TaskRun's stored ACP log.
+
+    Reads the JSONL log from S3 and picks out agent thinking, text responses,
+    and tool calls with their parameters and results.
+    Returns a list of short summary strings suitable for display in the workflow test panel.
+    """
+    from posthog.storage import object_storage
+
+    try:
+        raw = object_storage.read(task_run.log_url, missing_ok=True)
+    except Exception:
+        return []
+
+    if not raw:
+        return []
+
+    messages: list[str] = []
+    # Accumulate streamed chunks by type before emitting
+    thought_buffer: list[str] = []
+    message_buffer: list[str] = []
+    # Track tool calls we've already logged (avoid duplicates between tool_call and tool_call_update)
+    seen_tool_calls: set[str] = set()
+
+    def flush_thought():
+        text = "".join(thought_buffer).strip()
+        if text:
+            messages.append(f"Thinking: {text[:_MAX_LOG_TEXT_LEN]}")
+        thought_buffer.clear()
+
+    def flush_message():
+        text = "".join(message_buffer).strip()
+        if text:
+            messages.append(f"Agent: {text[:_MAX_LOG_TEXT_LEN]}")
+        message_buffer.clear()
+
+    for line in raw.strip().split("\n"):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        notification = entry.get("notification") if isinstance(entry, dict) else None
+        if not isinstance(notification, dict):
+            continue
+
+        method = notification.get("method", "")
+        params = notification.get("params", {})
+
+        if method == "_posthog/console":
+            level = params.get("level", "info")
+            msg = params.get("message", "")
+            if msg:
+                flush_thought()
+                flush_message()
+                messages.append(f"[{level}] {msg}")
+            continue
+
+        if method != _TOOL_CALL_METHOD:
+            continue
+
+        update = params.get("update") or params
+        session_update = update.get("sessionUpdate")
+
+        # Agent thinking
+        if session_update == "agent_thought_chunk":
+            # Flush any pending text message before thinking
+            flush_message()
+            text = _extract_text_from_content(update.get("content"))
+            if text:
+                thought_buffer.append(text)
+            continue
+
+        # Agent text response (complete or chunk)
+        if session_update in ("agent_message", "agent_message_chunk"):
+            # Flush any pending thinking before text
+            flush_thought()
+            text = _extract_text_from_content(update.get("content"))
+            if text:
+                message_buffer.append(text)
+            continue
+
+        # Tool call start — log the invocation with parameters
+        if session_update == "tool_call":
+            flush_thought()
+            flush_message()
+            tool_call_id = update.get("toolCallId", "")
+            meta = (update.get("_meta") or {}).get("claudeCode", {})
+            tool_name = meta.get("toolName") or update.get("title", "unknown")
+            raw_input = update.get("rawInput") or meta.get("toolInput")
+            input_summary = _format_tool_input(tool_name, raw_input)
+            if input_summary:
+                messages.append(f"Tool: {tool_name} — {input_summary[:_MAX_LOG_TEXT_LEN]}")
+            else:
+                messages.append(f"Tool: {tool_name}")
+            seen_tool_calls.add(tool_call_id)
+            continue
+
+        # Tool call update — log completion with output
+        if session_update == "tool_call_update":
+            tool_call_id = update.get("toolCallId", "")
+            tool_status = update.get("status")
+            meta = (update.get("_meta") or {}).get("claudeCode", {})
+            tool_name = meta.get("toolName") or ""
+
+            # If we haven't seen the initial tool_call for this ID, log the invocation
+            if tool_call_id and tool_call_id not in seen_tool_calls:
+                raw_input = update.get("rawInput") or meta.get("toolInput")
+                if tool_name and raw_input:
+                    flush_thought()
+                    flush_message()
+                    input_summary = _format_tool_input(tool_name, raw_input)
+                    if input_summary:
+                        messages.append(f"Tool: {tool_name} — {input_summary[:_MAX_LOG_TEXT_LEN]}")
+                    else:
+                        messages.append(f"Tool: {tool_name}")
+                    seen_tool_calls.add(tool_call_id)
+
+            # Log tool result on completion/failure
+            if tool_status in ("completed", "failed"):
+                raw_output = update.get("rawOutput") or meta.get("toolResponse")
+                if raw_output:
+                    output_text = _format_tool_output(tool_name, raw_output)
+                    if output_text:
+                        status_label = "Result" if tool_status == "completed" else "Error"
+                        messages.append(f"  {status_label}: {output_text[:_MAX_LOG_TEXT_LEN]}")
+            continue
+
+    # Flush any remaining buffers
+    flush_thought()
+    flush_message()
+
+    return messages
+
+
+class _SandboxAgentThrottle(SimpleRateThrottle):
+    """Rate limit by Bearer token (team api_token)."""
+
+    def get_cache_key(self, request, view):
+        auth_header = request.headers.get("Authorization", "")
+        ident = auth_header[7:].strip() if auth_header.startswith("Bearer ") else "anonymous"
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class SandboxAgentBurstThrottle(_SandboxAgentThrottle):
+    scope = "sandbox_agent_burst"
+    rate = "30/minute"
+
+
+class SandboxAgentSustainedThrottle(_SandboxAgentThrottle):
+    scope = "sandbox_agent_sustained"
+    rate = "300/hour"
+
+
+def _authenticate_team(request: Request) -> tuple[Team, None] | tuple[None, Response]:
+    """Extract Bearer token from Authorization header and resolve team."""
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None, Response({"error": "Missing or invalid Authorization header"}, status=status.HTTP_401_UNAUTHORIZED)
+
+    api_key = auth_header[7:].strip()
+    if not api_key:
+        return None, Response({"error": "Empty API key"}, status=status.HTTP_401_UNAUTHORIZED)
+
+    team = Team.objects.get_team_from_cache_or_token(api_key)
+    if team is None:
+        return None, Response({"error": "Invalid API key"}, status=status.HTTP_401_UNAUTHORIZED)
+
+    return team, None
+
+
+class SandboxAgentRunSerializer(serializers.Serializer):
+    message = serializers.CharField(required=True)
+    repository = serializers.CharField(required=False, allow_null=True, default=None)
+    output_schema = serializers.JSONField(required=False, allow_null=True, default=None)
+
+
+class SandboxAgentView(APIView):
+    """
+    POST /agent/run — Spawn a sandbox AI agent and block until it completes.
+
+    Authenticated via Bearer token (team api_token) in Authorization header.
+
+    Spawns the agent and polls the TaskRun status server-side, returning only
+    when the agent finishes (or the wait times out). Designed to be called as
+    a single async step from the Hog VM / Cyclotron executor.
+    """
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+    throttle_classes = [SandboxAgentBurstThrottle, SandboxAgentSustainedThrottle]
+
+    def post(self, request: Request) -> Response:
+        team, error = _authenticate_team(request)
+        if error or team is None:
+            return error or Response({"error": "Authentication failed"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        serializer = SandboxAgentRunSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        message = serializer.validated_data["message"]
+        repository = serializer.validated_data.get("repository")
+        output_schema = serializer.validated_data.get("output_schema")
+
+        user = (
+            team.organization.members.filter(
+                organization_membership__level__gte=OrganizationMembership.Level.ADMIN,
+            )
+            .order_by("organization_membership__joined_at")
+            .first()
+        )
+        if not user:
+            return Response(
+                {"error": "No admin user found for this team's organization"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            result = SandboxAgentService.spawn_sandbox_task(
+                team=team,
+                user=user,
+                title=f"Workflow agent: {message[:100]}",
+                description=message,
+                origin_product="user_created",
+                repository=repository,
+                create_pr=False,
+                output_schema=output_schema,
+            )
+        except Exception as e:
+            logger.exception("Failed to spawn sandbox task", error=e, team_id=team.id)
+            return Response(
+                {"error": "Failed to spawn agent"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        run_id = str(result.run_id)
+        deadline = time.monotonic() + AGENT_MAX_WAIT_SECONDS
+
+        while time.monotonic() < deadline:
+            time.sleep(AGENT_POLL_INTERVAL_SECONDS)
+
+            try:
+                task_run = TaskRun.objects.get(id=run_id, team_id=team.id)
+            except TaskRun.DoesNotExist:
+                return Response({"error": "Run not found"}, status=status.HTTP_404_NOT_FOUND)
+
+            if task_run.status in (TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS):
+                continue
+
+            if task_run.status == TaskRun.Status.COMPLETED:
+                agent_logs = _extract_agent_logs(task_run)
+                return Response(
+                    {
+                        "status": "completed",
+                        "output": task_run.output,
+                        "logs": agent_logs,
+                    }
+                )
+
+            return Response(
+                {
+                    "status": "failed",
+                    "error": task_run.error_message or "Agent failed",
+                }
+            )
+
+        return Response(
+            {"status": "failed", "error": "Agent timed out"},
+            status=status.HTTP_504_GATEWAY_TIMEOUT,
+        )

--- a/ee/api/test/test_sandbox_agent.py
+++ b/ee/api/test/test_sandbox_agent.py
@@ -1,0 +1,497 @@
+import json
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from parameterized import parameterized
+from rest_framework.test import APIClient
+
+from posthog.models import OrganizationMembership
+
+from ee.api.sandbox_agent import (
+    _extract_agent_logs,
+    _extract_text_from_content,
+    _format_tool_input,
+    _format_tool_output,
+)
+
+
+class TestExtractTextFromContent(TestCase):
+    @parameterized.expand(
+        [
+            ("dict_with_text", {"text": "hello world"}, "hello world"),
+            ("dict_with_thinking", {"thinking": "reasoning here"}, "reasoning here"),
+            ("dict_text_takes_precedence_over_thinking", {"text": "answer", "thinking": "thought"}, "answer"),
+            ("dict_empty", {}, ""),
+            ("dict_with_none_text", {"text": None, "thinking": None}, ""),
+            ("dict_with_neither_key", {"type": "tool_use", "id": "abc"}, ""),
+            ("string_input", "just a string", ""),
+            ("none_input", None, ""),
+            ("integer_input", 42, ""),
+            (
+                "list_of_text_blocks",
+                [{"text": "first"}, {"text": "second"}],
+                "first\nsecond",
+            ),
+            (
+                "list_with_thinking_blocks",
+                [{"thinking": "thought one"}, {"thinking": "thought two"}],
+                "thought one\nthought two",
+            ),
+            (
+                "list_mixed_blocks",
+                [{"text": "visible"}, {"type": "tool_use"}, {"text": "also visible"}],
+                "visible\nalso visible",
+            ),
+            ("list_empty", [], ""),
+            (
+                "list_with_empty_blocks",
+                [{"text": ""}, {"thinking": ""}],
+                "",
+            ),
+            (
+                "list_with_non_dict_elements",
+                ["string_element", {"text": "valid"}],
+                "valid",
+            ),
+        ]
+    )
+    def test_extract_text(self, _name, content, expected):
+        assert _extract_text_from_content(content) == expected
+
+
+class TestFormatToolInput(TestCase):
+    @parameterized.expand(
+        [
+            ("bash_returns_command", "Bash", {"command": "ls -la"}, "ls -la"),
+            ("bash_missing_command", "Bash", {}, ""),
+            ("read_returns_file_path", "Read", {"file_path": "/tmp/file.py"}, "/tmp/file.py"),
+            ("grep_returns_pattern", "Grep", {"pattern": "def foo"}, "def foo"),
+            ("glob_returns_path", "Glob", {"path": "**/*.ts"}, "**/*.ts"),
+            ("grep_prefers_pattern_over_path", "Grep", {"pattern": "*.py", "path": "/src"}, "*.py"),
+            ("write_returns_file_path", "Write", {"file_path": "/out/file.py"}, "/out/file.py"),
+            ("edit_returns_file_path", "Edit", {"file_path": "/src/app.py"}, "/src/app.py"),
+            (
+                "agent_returns_truncated_prompt",
+                "Agent",
+                {"prompt": "A" * 250},
+                "A" * 200,
+            ),
+            (
+                "unknown_tool_returns_json",
+                "UnknownTool",
+                {"key": "value"},
+                '{"key":"value"}',
+            ),
+            ("non_dict_input_returns_empty", "Bash", "not a dict", ""),
+            ("non_dict_none_input_returns_empty", "Read", None, ""),
+        ]
+    )
+    def test_format_input(self, _name, tool_name, raw_input, expected):
+        assert _format_tool_input(tool_name, raw_input) == expected
+
+    def test_unknown_tool_unserializable_input_returns_empty(self):
+        raw_input = {"key": object()}
+        result = _format_tool_input("CustomTool", raw_input)
+        assert result == ""
+
+
+class TestFormatToolOutput(TestCase):
+    @parameterized.expand(
+        [
+            ("string_passthrough", "Bash", "output text", "output text"),
+            ("empty_string_passthrough", "Read", "", ""),
+            (
+                "list_of_text_blocks",
+                "Read",
+                [{"text": "file contents"}],
+                "file contents",
+            ),
+            (
+                "list_multiple_text_blocks",
+                "Grep",
+                [{"text": "line one"}, {"text": "line two"}],
+                "line one\nline two",
+            ),
+            (
+                "list_blocks_skips_non_text",
+                "Glob",
+                [{"type": "tool_result"}, {"text": "actual result"}],
+                "actual result",
+            ),
+            ("list_empty", "Bash", [], ""),
+            (
+                "dict_serialized_to_json",
+                "UnknownTool",
+                {"status": "ok", "count": 3},
+                '{"status":"ok","count":3}',
+            ),
+            ("none_returns_empty", "Bash", None, ""),
+            ("integer_returns_empty", "Bash", 42, ""),
+        ]
+    )
+    def test_format_output(self, _name, tool_name, raw_output, expected):
+        assert _format_tool_output(tool_name, raw_output) == expected
+
+    def test_dict_unserializable_falls_back_to_str(self):
+        class Unserializable:
+            def __repr__(self):
+                return "Unserializable()"
+
+        raw_output = {"key": Unserializable()}
+        result = _format_tool_output("Tool", raw_output)
+        # Falls back to str() representation when JSON serialization fails
+        assert "Unserializable" in result
+
+
+def _jsonl(*notifications) -> str:
+    lines = [json.dumps({"notification": n}) for n in notifications]
+    return "\n".join(lines)
+
+
+def _console(level, message):
+    return {"method": "_posthog/console", "params": {"level": level, "message": message}}
+
+
+def _session_update(session_update_type, **kwargs):
+    update = {"sessionUpdate": session_update_type, **kwargs}
+    return {"method": "session/update", "params": {"update": update}}
+
+
+class TestExtractAgentLogs(TestCase):
+    def _make_task_run(self, log_url="s3://bucket/logs.jsonl"):
+        task_run = MagicMock()
+        task_run.log_url = log_url
+        return task_run
+
+    def _run(self, raw_content, log_url="s3://bucket/logs.jsonl"):
+        task_run = self._make_task_run(log_url)
+        with patch("posthog.storage.object_storage.read", return_value=raw_content):
+            return _extract_agent_logs(task_run)
+
+    def test_returns_empty_list_when_storage_returns_none(self):
+        result = self._run(None)
+        assert result == []
+
+    def test_returns_empty_list_when_storage_returns_empty_string(self):
+        result = self._run("")
+        assert result == []
+
+    def test_returns_empty_list_when_storage_raises(self):
+        task_run = self._make_task_run()
+        with patch("posthog.storage.object_storage.read", side_effect=Exception("S3 error")):
+            result = _extract_agent_logs(task_run)
+        assert result == []
+
+    def test_returns_empty_list_when_log_is_only_whitespace(self):
+        result = self._run("   \n\n  ")
+        assert result == []
+
+    def test_skips_invalid_json_lines(self):
+        content = "not json\n" + json.dumps({"notification": _console("info", "valid message")})
+        result = self._run(content)
+        assert result == ["[info] valid message"]
+
+    def test_skips_lines_without_notification_key(self):
+        content = json.dumps({"other_key": "value"})
+        result = self._run(content)
+        assert result == []
+
+    def test_skips_lines_where_notification_is_not_dict(self):
+        content = json.dumps({"notification": "string_not_dict"})
+        result = self._run(content)
+        assert result == []
+
+    def test_console_info_message_extracted(self):
+        content = _jsonl(_console("info", "starting up"))
+        result = self._run(content)
+        assert result == ["[info] starting up"]
+
+    def test_console_error_message_extracted(self):
+        content = _jsonl(_console("error", "something went wrong"))
+        result = self._run(content)
+        assert result == ["[error] something went wrong"]
+
+    def test_console_empty_message_skipped(self):
+        content = _jsonl(_console("info", ""))
+        result = self._run(content)
+        assert result == []
+
+    def test_multiple_console_messages_all_extracted(self):
+        content = _jsonl(
+            _console("info", "first"),
+            _console("warn", "second"),
+        )
+        result = self._run(content)
+        assert result == ["[info] first", "[warn] second"]
+
+    def test_thought_chunks_concatenated_and_flushed(self):
+        content = _jsonl(
+            _session_update("agent_thought_chunk", content={"text": "part one "}),
+            _session_update("agent_thought_chunk", content={"text": "part two"}),
+            _session_update("agent_message", content={"text": "final answer"}),
+        )
+        result = self._run(content)
+        assert result == ["Thinking: part one part two", "Agent: final answer"]
+
+    def test_thought_chunk_flushed_before_console_message(self):
+        content = _jsonl(
+            _session_update("agent_thought_chunk", content={"text": "some thought"}),
+            _console("info", "console msg"),
+        )
+        result = self._run(content)
+        assert result == ["Thinking: some thought", "[info] console msg"]
+
+    def test_empty_thought_chunks_produce_no_thinking_entry(self):
+        content = _jsonl(
+            _session_update("agent_thought_chunk", content={"text": ""}),
+            _session_update("agent_message", content={"text": "answer"}),
+        )
+        result = self._run(content)
+        assert result == ["Agent: answer"]
+
+    def test_agent_message_extracted(self):
+        content = _jsonl(_session_update("agent_message", content={"text": "Here is your answer"}))
+        result = self._run(content)
+        assert result == ["Agent: Here is your answer"]
+
+    def test_agent_message_chunk_concatenated(self):
+        content = _jsonl(
+            _session_update("agent_message_chunk", content={"text": "Hello "}),
+            _session_update("agent_message_chunk", content={"text": "world"}),
+        )
+        result = self._run(content)
+        assert result == ["Agent: Hello world"]
+
+    def test_agent_message_flushed_before_thought_chunk(self):
+        content = _jsonl(
+            _session_update("agent_message_chunk", content={"text": "response text"}),
+            _session_update("agent_thought_chunk", content={"text": "new thought"}),
+        )
+        result = self._run(content)
+        assert result == ["Agent: response text", "Thinking: new thought"]
+
+    def test_tool_call_without_input_summary(self):
+        content = _jsonl(
+            _session_update(
+                "tool_call",
+                toolCallId="id-1",
+                _meta={"claudeCode": {"toolName": "SomeTool"}},
+            )
+        )
+        result = self._run(content)
+        assert result == ["Tool: SomeTool"]
+
+    def test_tool_call_with_bash_command(self):
+        content = _jsonl(
+            _session_update(
+                "tool_call",
+                toolCallId="id-2",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+                rawInput={"command": "git status"},
+            )
+        )
+        result = self._run(content)
+        assert result == ["Tool: Bash — git status"]
+
+    def test_tool_call_flushes_pending_message_buffer(self):
+        content = _jsonl(
+            _session_update("agent_message_chunk", content={"text": "pending message"}),
+            _session_update(
+                "tool_call",
+                toolCallId="id-3",
+                _meta={"claudeCode": {"toolName": "Read"}},
+                rawInput={"file_path": "/tmp/file.py"},
+            ),
+        )
+        result = self._run(content)
+        assert result == ["Agent: pending message", "Tool: Read — /tmp/file.py"]
+
+    def test_tool_call_update_completed_logs_result(self):
+        content = _jsonl(
+            _session_update(
+                "tool_call",
+                toolCallId="id-4",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+                rawInput={"command": "ls"},
+            ),
+            _session_update(
+                "tool_call_update",
+                toolCallId="id-4",
+                status="completed",
+                rawOutput="file1.py\nfile2.py",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+            ),
+        )
+        result = self._run(content)
+        assert result == ["Tool: Bash — ls", "  Result: file1.py\nfile2.py"]
+
+    def test_tool_call_update_failed_logs_error(self):
+        content = _jsonl(
+            _session_update(
+                "tool_call",
+                toolCallId="id-5",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+                rawInput={"command": "bad-cmd"},
+            ),
+            _session_update(
+                "tool_call_update",
+                toolCallId="id-5",
+                status="failed",
+                rawOutput="command not found",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+            ),
+        )
+        result = self._run(content)
+        assert result == ["Tool: Bash — bad-cmd", "  Error: command not found"]
+
+    def test_tool_call_update_without_prior_tool_call_logs_invocation(self):
+        content = _jsonl(
+            _session_update(
+                "tool_call_update",
+                toolCallId="id-new",
+                status="completed",
+                rawOutput="done",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+                rawInput={"command": "echo hi"},
+            )
+        )
+        result = self._run(content)
+        assert "Tool: Bash — echo hi" in result
+        assert "  Result: done" in result
+
+    def test_tool_call_update_in_progress_does_not_log_result(self):
+        content = _jsonl(
+            _session_update(
+                "tool_call",
+                toolCallId="id-6",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+                rawInput={"command": "sleep 1"},
+            ),
+            _session_update(
+                "tool_call_update",
+                toolCallId="id-6",
+                status="in_progress",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+            ),
+        )
+        result = self._run(content)
+        assert result == ["Tool: Bash — sleep 1"]
+
+    def test_tool_call_update_no_duplicate_invocation_when_already_seen(self):
+        content = _jsonl(
+            _session_update(
+                "tool_call",
+                toolCallId="id-7",
+                _meta={"claudeCode": {"toolName": "Read"}},
+                rawInput={"file_path": "/readme.md"},
+            ),
+            _session_update(
+                "tool_call_update",
+                toolCallId="id-7",
+                status="completed",
+                rawOutput="# Readme",
+                _meta={"claudeCode": {"toolName": "Read"}},
+                rawInput={"file_path": "/readme.md"},
+            ),
+        )
+        result = self._run(content)
+        tool_entries = [m for m in result if m.startswith("Tool:")]
+        assert len(tool_entries) == 1
+
+    def test_long_thinking_text_truncated_to_max_length(self):
+        long_text = "x" * 600
+        content = _jsonl(_session_update("agent_thought_chunk", content={"text": long_text}))
+        result = self._run(content)
+        assert len(result) == 1
+        assert result[0].startswith("Thinking: ")
+        assert len(result[0]) <= len("Thinking: ") + 500
+
+    def test_long_agent_message_truncated_to_max_length(self):
+        long_text = "y" * 600
+        content = _jsonl(_session_update("agent_message", content={"text": long_text}))
+        result = self._run(content)
+        assert len(result) == 1
+        assert result[0].startswith("Agent: ")
+        assert len(result[0]) <= len("Agent: ") + 500
+
+    def test_remaining_buffers_flushed_at_end_of_log(self):
+        content = _jsonl(_session_update("agent_message_chunk", content={"text": "trailing response"}))
+        result = self._run(content)
+        assert result == ["Agent: trailing response"]
+
+    def test_unknown_session_update_type_ignored(self):
+        content = _jsonl(_session_update("unknown_event_type", content={"text": "ignored"}))
+        result = self._run(content)
+        assert result == []
+
+    def test_non_session_update_method_ignored(self):
+        content = _jsonl({"method": "some/other/method", "params": {"data": "ignored"}})
+        result = self._run(content)
+        assert result == []
+
+    def test_mixed_log_with_multiple_entry_types(self):
+        content = _jsonl(
+            _console("info", "agent started"),
+            _session_update("agent_thought_chunk", content={"text": "let me think"}),
+            _session_update("agent_message", content={"text": "I will run a command"}),
+            _session_update(
+                "tool_call",
+                toolCallId="id-mix",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+                rawInput={"command": "echo hello"},
+            ),
+            _session_update(
+                "tool_call_update",
+                toolCallId="id-mix",
+                status="completed",
+                rawOutput="hello",
+                _meta={"claudeCode": {"toolName": "Bash"}},
+            ),
+            _session_update("agent_message", content={"text": "Done!"}),
+        )
+        result = self._run(content)
+        assert result == [
+            "[info] agent started",
+            "Thinking: let me think",
+            "Agent: I will run a command",
+            "Tool: Bash — echo hello",
+            "  Result: hello",
+            "Agent: Done!",
+        ]
+
+
+class TestAgentRunView(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+    def test_run_requires_auth(self):
+        response = self.client.post(
+            "/agent/run",
+            data={"message": "How many users?"},
+            format="json",
+        )
+        assert response.status_code == 401
+
+    def test_run_rejects_invalid_token(self):
+        response = self.client.post(
+            "/agent/run",
+            data={"message": "How many users?"},
+            format="json",
+            HTTP_AUTHORIZATION="Bearer invalid-token",
+        )
+        assert response.status_code == 401
+
+    def test_run_requires_message(self):
+        response = self.client.post(
+            "/agent/run",
+            data={},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {self.team.api_token}",
+        )
+        assert response.status_code == 400

--- a/ee/hogai/sandbox_agent.py
+++ b/ee/hogai/sandbox_agent.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+import structlog
+import posthoganalytics
+
+from posthog.models import Team, User
+
+from products.tasks.backend.models import Task, TaskRun
+
+if TYPE_CHECKING:
+    from products.slack_app.backend.slack_thread import SlackThreadContext
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class SandboxAgentTaskResult:
+    task_id: UUID
+    run_id: UUID
+    workflow_id: str
+
+
+class FeatureNotEnabledError(Exception):
+    pass
+
+
+class SandboxAgentService:
+    """Entry point for spawning background AI agents via sandbox tasks."""
+
+    @staticmethod
+    def spawn_sandbox_task(
+        *,
+        team: Team,
+        user: User,
+        title: str,
+        description: str,
+        origin_product: str,
+        repository: str | None = None,
+        create_pr: bool = True,
+        slack_thread_context: SlackThreadContext | None = None,
+        slack_thread_url: str | None = None,
+        output_schema: dict | None = None,
+    ) -> SandboxAgentTaskResult:
+        """Spawn a sandbox task (behind `tasks` feature flag).
+
+        Delegates to Task.create_and_run() after checking the feature flag.
+        """
+
+        tasks_enabled = posthoganalytics.feature_enabled(
+            "tasks",
+            user.distinct_id or "",
+            groups={"organization": str(team.organization_id)},
+            group_properties={"organization": {"id": str(team.organization_id)}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+        if not tasks_enabled:
+            raise FeatureNotEnabledError("The 'tasks' feature is not enabled for this user/organization")
+
+        task = Task.create_and_run(
+            team=team,
+            title=title,
+            description=description,
+            origin_product=Task.OriginProduct(origin_product),
+            user_id=user.id,
+            repository=repository,
+            create_pr=create_pr,
+            slack_thread_context=slack_thread_context,
+            slack_thread_url=slack_thread_url,
+            output_schema=output_schema,
+        )
+
+        latest_run = task.latest_run
+        run_id = latest_run.id if latest_run else uuid4()
+        workflow_id = TaskRun.get_workflow_id(str(task.id), str(run_id))
+
+        logger.info(
+            "sandbox_task_spawned",
+            task_id=str(task.id),
+            run_id=str(run_id),
+            workflow_id=workflow_id,
+            team_id=team.id,
+        )
+
+        return SandboxAgentTaskResult(
+            task_id=task.id,
+            run_id=run_id,
+            workflow_id=workflow_id,
+        )

--- a/ee/hogai/test/test_sandbox_agent_service.py
+++ b/ee/hogai/test/test_sandbox_agent_service.py
@@ -1,0 +1,62 @@
+from uuid import uuid4
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from ee.hogai.sandbox_agent import FeatureNotEnabledError, SandboxAgentService, SandboxAgentTaskResult
+
+
+class TestSpawnSandboxTask(BaseTest):
+    @patch("ee.hogai.sandbox_agent.posthoganalytics")
+    def test_raises_when_feature_not_enabled(self, mock_posthoganalytics):
+        mock_posthoganalytics.feature_enabled.return_value = False
+
+        with self.assertRaises(FeatureNotEnabledError):
+            SandboxAgentService.spawn_sandbox_task(
+                team=self.team,
+                user=self.user,
+                title="Fix bug",
+                description="Fix the login bug",
+                origin_product="user_created",
+                repository="posthog/posthog-js",
+            )
+
+    @patch("ee.hogai.sandbox_agent.posthoganalytics")
+    def test_creates_task_when_enabled(self, mock_posthoganalytics):
+        mock_posthoganalytics.feature_enabled.return_value = True
+
+        with patch("products.tasks.backend.models.Task.create_and_run") as mock_create_and_run:
+            mock_task = MagicMock()
+            mock_task.id = uuid4()
+            mock_run = MagicMock()
+            mock_run.id = uuid4()
+            mock_task.latest_run = mock_run
+            mock_create_and_run.return_value = mock_task
+
+            result = SandboxAgentService.spawn_sandbox_task(
+                team=self.team,
+                user=self.user,
+                title="Fix bug",
+                description="Fix the login bug",
+                origin_product="user_created",
+                repository="posthog/posthog-js",
+            )
+
+            assert isinstance(result, SandboxAgentTaskResult)
+            assert result.task_id == mock_task.id
+            assert result.run_id == mock_run.id
+            mock_create_and_run.assert_called_once()
+
+    @patch("ee.hogai.sandbox_agent.posthoganalytics")
+    def test_missing_github_integration_raises(self, mock_posthoganalytics):
+        mock_posthoganalytics.feature_enabled.return_value = True
+
+        with self.assertRaises(ValueError, msg="does not have a GitHub integration"):
+            SandboxAgentService.spawn_sandbox_task(
+                team=self.team,
+                user=self.user,
+                title="Fix bug",
+                description="Fix the login bug",
+                origin_product="user_created",
+                repository="posthog/posthog-js",
+            )

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -16,6 +16,7 @@ from ee.admin.loginas_views import loginas_user, upgrade_impersonation
 from ee.admin.oauth_views import admin_auth_check, admin_oauth_success
 from ee.api import integration
 from ee.api.agentic_provisioning import views as agentic_provisioning_views
+from ee.api.sandbox_agent import SandboxAgentView
 from ee.api.vercel import vercel_connect, vercel_sso, vercel_webhooks
 from ee.middleware import admin_oauth2_callback
 from ee.support_sidebar_max.views import MaxChatViewSet
@@ -215,6 +216,7 @@ urlpatterns: list[Any] = [
     path("api/saml/metadata/", authentication.saml_metadata_view),
     path("api/sentry_stats/", sentry_stats.sentry_stats),
     path("max/chat/", csrf_exempt(MaxChatViewSet.as_view({"post": "create"})), name="max_chat"),
+    path("agent/run", SandboxAgentView.as_view(), name="agent-run"),
     re_path(r"^login/vercel/?$", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_redirect"})),
     re_path(r"^login/vercel/continue/?$", vercel_sso.VercelSSOViewSet.as_view({"get": "sso_continue"})),
     re_path(


### PR DESCRIPTION
## Problem

The CDP/Cyclotron executor needs a way to run AI agents as workflow actions. This requires an external API endpoint that can spawn sandbox AI agents and return their results synchronously for use in Hog templates and third-party integrations.

## Changes

Added a new external API endpoint `/agent/run` for running sandbox AI agents:

- **Authentication**: Uses Bearer token (team api_token) instead of user sessions
- **Rate limiting**: Implements burst (30/minute) and sustained (300/hour) throttling by API token
- **Synchronous execution**: Spawns agent and polls until completion or timeout (10 minutes)
- **Log extraction**: Parses ACP JSONL logs to extract human-readable agent thinking, responses, and tool calls

The endpoint accepts a message, optional repository, and output schema, then returns the agent's output along with formatted execution logs.

Added supporting service layer (`SandboxAgentService`) that wraps the existing Task system with feature flag checks and proper error handling.

## How did you test this code?
Part of a stack of PRs, test from the top one.

Added comprehensive unit tests covering:
- Log parsing functions with various ACP notification types
- Authentication and validation logic
- Rate limiting behavior
- Error scenarios (missing auth, invalid tokens, feature flags)
- Integration with the Task system


## Publish to changelog?
No