### PR TITLE
fix(experiments): move experiments view logic to service

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Literal
 
-from django.db.models import Case, Count, F, Prefetch, Q, QuerySet, Value, When
+from django.db.models import Case, F, Prefetch, Q, QuerySet, Value, When
 from django.db.models.functions import Now
 
 from drf_spectacular.utils import extend_schema
@@ -19,12 +19,9 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
-from posthog.models import Survey
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
-from posthog.models.cohort import Cohort
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext
 from posthog.models.experiment import Experiment, ExperimentHoldout
-from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
@@ -33,7 +30,6 @@ from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.utils import str_to_bool
 
 from products.experiments.backend.experiment_service import ExperimentService
-from products.product_tours.backend.models import ProductTour
 
 from ee.clickhouse.queries.experiments.utils import requires_flag_warning
 from ee.clickhouse.views.experiment_holdouts import ExperimentHoldoutSerializer
@@ -445,89 +441,21 @@ class EnterpriseExperimentsViewSet(
         except ValueError:
             return Response({"error": "Invalid limit or offset"}, status=400)
 
-        queryset = FeatureFlag.objects.filter(team__project_id=self.project_id)
-
-        # Filter for multivariate flags with at least 2 variants and first variant is "control"
-        # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (static SQL, no user input)
-        queryset = queryset.extra(
-            where=[
-                """
-                jsonb_array_length(filters->'multivariate'->'variants') >= 2
-                AND filters->'multivariate'->'variants'->0->>'key' = 'control'
-                """
-            ]
+        service = ExperimentService(team=self.team, user=request.user)
+        eligible_feature_flags = service.get_eligible_feature_flags(
+            limit=limit,
+            offset=offset,
+            search=request.query_params.get("search"),
+            active=request.query_params.get("active"),
+            created_by_id=request.query_params.get("created_by_id"),
+            order=request.query_params.get("order"),
+            evaluation_runtime=request.query_params.get("evaluation_runtime"),
+            has_evaluation_tags=request.query_params.get("has_evaluation_tags"),
         )
-
-        # Exclude survey targeting flags (same as regular feature flag list endpoint)
-        survey_flag_ids = Survey.get_internal_flag_ids(project_id=self.project_id)
-        product_tour_internal_targeting_flags = ProductTour.all_objects.filter(
-            team__project_id=self.project_id, internal_targeting_flag__isnull=False
-        ).values_list("internal_targeting_flag_id", flat=True)
-        excluded_flag_ids = survey_flag_ids | set(product_tour_internal_targeting_flags)
-        queryset = queryset.exclude(id__in=excluded_flag_ids)
-
-        # Apply search filter
-        search = request.query_params.get("search")
-        if search:
-            queryset = queryset.filter(Q(key__icontains=search) | Q(name__icontains=search))
-
-        # Apply active filter
-        active = request.query_params.get("active")
-        if active is not None:
-            queryset = queryset.filter(active=active.lower() == "true")
-
-        # Apply created_by filter
-        created_by_id = request.query_params.get("created_by_id")
-        if created_by_id:
-            queryset = queryset.filter(created_by_id=created_by_id)
-
-        # Apply evaluation_runtime filter
-        evaluation_runtime = request.query_params.get("evaluation_runtime")
-        if evaluation_runtime:
-            queryset = queryset.filter(evaluation_runtime=evaluation_runtime)
-
-        # Apply has_evaluation_tags filter
-        has_evaluation_tags = request.query_params.get("has_evaluation_tags")
-        if has_evaluation_tags is not None:
-            filter_value = has_evaluation_tags.lower() in ("true", "1", "yes")
-            queryset = queryset.annotate(eval_tag_count=Count("flag_evaluation_contexts"))
-            if filter_value:
-                queryset = queryset.filter(eval_tag_count__gt=0)
-            else:
-                queryset = queryset.filter(eval_tag_count=0)
-
-        # Ordering
-        order = request.query_params.get("order")
-        if order:
-            queryset = queryset.order_by(order)
-        else:
-            queryset = queryset.order_by("-created_at")
-
-        # Prefetch related data to avoid N+1 queries (same as regular feature flag list)
-        queryset = queryset.prefetch_related(
-            Prefetch(
-                "experiment_set", queryset=Experiment.objects.filter(deleted=False), to_attr="_active_experiments"
-            ),
-            "features",
-            "analytics_dashboards",
-            "surveys_linked_flag",
-            Prefetch(
-                "flag_evaluation_contexts",
-                queryset=FeatureFlagEvaluationContext.objects.select_related("evaluation_context"),
-            ),
-            Prefetch(
-                "team__cohort_set",
-                queryset=Cohort.objects.filter(deleted=False).only("id", "name"),
-                to_attr="available_cohorts",
-            ),
-        ).select_related("created_by", "last_modified_by")
-
-        total_count = queryset.count()
-        results = queryset[offset : offset + limit]
 
         # Serialize using the standard FeatureFlagSerializer
         serializer = FeatureFlagSerializer(
-            results,
+            eligible_feature_flags["results"],
             many=True,
             context=self.get_serializer_context(),
         )
@@ -535,7 +463,7 @@ class EnterpriseExperimentsViewSet(
         return Response(
             {
                 "results": serializer.data,
-                "count": total_count,
+                "count": eligible_feature_flags["count"],
             }
         )
 

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -19,6 +19,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
+from posthog.models import Survey
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext
 from posthog.models.experiment import Experiment, ExperimentHoldout
@@ -30,6 +31,7 @@ from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.utils import str_to_bool
 
 from products.experiments.backend.experiment_service import ExperimentService
+from products.product_tours.backend.models import ProductTour
 
 from ee.clickhouse.queries.experiments.utils import requires_flag_warning
 from ee.clickhouse.views.experiment_holdouts import ExperimentHoldoutSerializer
@@ -441,10 +443,17 @@ class EnterpriseExperimentsViewSet(
         except ValueError:
             return Response({"error": "Invalid limit or offset"}, status=400)
 
+        survey_flag_ids = Survey.get_internal_flag_ids(project_id=self.project_id)
+        product_tour_internal_targeting_flags = ProductTour.all_objects.filter(
+            team__project_id=self.project_id, internal_targeting_flag__isnull=False
+        ).values_list("internal_targeting_flag_id", flat=True)
+        excluded_flag_ids = survey_flag_ids | set(product_tour_internal_targeting_flags)
+
         service = ExperimentService(team=self.team, user=request.user)
         eligible_feature_flags = service.get_eligible_feature_flags(
             limit=limit,
             offset=offset,
+            excluded_flag_ids=excluded_flag_ids,
             search=request.query_params.get("search"),
             active=request.query_params.get("active"),
             created_by_id=request.query_params.get("created_by_id"),

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -29,6 +29,55 @@ class TestExperimentCRUD(APILicensedTest):
         response = self.client.get(f"/api/projects/{self.team.id}/experiments/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_can_list_eligible_feature_flags(self) -> None:
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="eligible-flag",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="wrong-order-flag",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="single-variant-flag",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 100},
+                    ]
+                },
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/eligible_feature_flags/?order=key")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual([flag["key"] for flag in response.json()["results"]], ["eligible-flag"])
+
     @parameterized.expand(
         [
             ("draft", "draft"),

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -6,6 +6,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
+from django.db.models import Count, Prefetch, Q, QuerySet
 
 import pydantic
 from rest_framework.exceptions import ValidationError
@@ -16,7 +17,9 @@ from posthog.api.cohort import CohortSerializer
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
+from posthog.models import Survey
 from posthog.models.cohort import Cohort
+from posthog.models.evaluation_context import FeatureFlagEvaluationContext
 from posthog.models.experiment import (
     Experiment,
     ExperimentHoldout,
@@ -28,6 +31,8 @@ from posthog.models.experiment import (
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.team.team import Team
+
+from products.product_tours.backend.models import ProductTour
 
 from ee.clickhouse.views.experiment_saved_metrics import ExperimentToSavedMetricSerializer
 
@@ -853,6 +858,111 @@ class ExperimentService:
         experiment.exposure_cohort = cohort
         experiment.save(update_fields=["exposure_cohort"])
         return cohort
+
+    # ------------------------------------------------------------------
+    # Eligible feature flags
+    # ------------------------------------------------------------------
+
+    def get_eligible_feature_flags(
+        self,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        search: str | None = None,
+        active: str | bool | None = None,
+        created_by_id: str | int | None = None,
+        order: str | None = None,
+        evaluation_runtime: str | None = None,
+        has_evaluation_tags: str | bool | None = None,
+    ) -> dict[str, Any]:
+        """Get feature flags eligible for use in experiments."""
+        queryset = self._get_eligible_feature_flags_queryset(
+            search=search,
+            active=active,
+            created_by_id=created_by_id,
+            order=order,
+            evaluation_runtime=evaluation_runtime,
+            has_evaluation_tags=has_evaluation_tags,
+        )
+
+        return {
+            "results": queryset[offset : offset + limit],
+            "count": queryset.count(),
+        }
+
+    def _get_eligible_feature_flags_queryset(
+        self,
+        *,
+        search: str | None,
+        active: str | bool | None,
+        created_by_id: str | int | None,
+        order: str | None,
+        evaluation_runtime: str | None,
+        has_evaluation_tags: str | bool | None,
+    ) -> QuerySet[FeatureFlag]:
+        queryset = FeatureFlag.objects.filter(team__project_id=self.team.project_id)
+
+        # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (static SQL, no user input)
+        queryset = queryset.extra(
+            where=[
+                """
+                jsonb_array_length(filters->'multivariate'->'variants') >= 2
+                AND filters->'multivariate'->'variants'->0->>'key' = 'control'
+                """
+            ]
+        )
+
+        survey_flag_ids = Survey.get_internal_flag_ids(project_id=self.team.project_id)
+        product_tour_internal_targeting_flags = ProductTour.all_objects.filter(
+            team__project_id=self.team.project_id, internal_targeting_flag__isnull=False
+        ).values_list("internal_targeting_flag_id", flat=True)
+        excluded_flag_ids = survey_flag_ids | set(product_tour_internal_targeting_flags)
+        queryset = queryset.exclude(id__in=excluded_flag_ids)
+
+        if search:
+            queryset = queryset.filter(Q(key__icontains=search) | Q(name__icontains=search))
+
+        if active is not None:
+            active_bool = active if isinstance(active, bool) else str(active).lower() == "true"
+            queryset = queryset.filter(active=active_bool)
+
+        if created_by_id:
+            queryset = queryset.filter(created_by_id=created_by_id)
+
+        if evaluation_runtime:
+            queryset = queryset.filter(evaluation_runtime=evaluation_runtime)
+
+        if has_evaluation_tags is not None:
+            filter_value = (
+                has_evaluation_tags
+                if isinstance(has_evaluation_tags, bool)
+                else str(has_evaluation_tags).lower() in ("true", "1", "yes")
+            )
+            queryset = queryset.annotate(eval_tag_count=Count("flag_evaluation_contexts"))
+            if filter_value:
+                queryset = queryset.filter(eval_tag_count__gt=0)
+            else:
+                queryset = queryset.filter(eval_tag_count=0)
+
+        queryset = queryset.order_by(order or "-created_at")
+
+        return queryset.prefetch_related(
+            Prefetch(
+                "experiment_set", queryset=Experiment.objects.filter(deleted=False), to_attr="_active_experiments"
+            ),
+            "features",
+            "analytics_dashboards",
+            "surveys_linked_flag",
+            Prefetch(
+                "flag_evaluation_contexts",
+                queryset=FeatureFlagEvaluationContext.objects.select_related("evaluation_context"),
+            ),
+            Prefetch(
+                "team__cohort_set",
+                queryset=Cohort.objects.filter(deleted=False).only("id", "name"),
+                to_attr="available_cohorts",
+            ),
+        ).select_related("created_by", "last_modified_by")
 
     # ------------------------------------------------------------------
     # Timeseries

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -17,7 +17,6 @@ from posthog.api.cohort import CohortSerializer
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
-from posthog.models import Survey
 from posthog.models.cohort import Cohort
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext
 from posthog.models.experiment import (
@@ -31,8 +30,6 @@ from posthog.models.experiment import (
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.team.team import Team
-
-from products.product_tours.backend.models import ProductTour
 
 from ee.clickhouse.views.experiment_saved_metrics import ExperimentToSavedMetricSerializer
 
@@ -868,6 +865,7 @@ class ExperimentService:
         *,
         limit: int = 20,
         offset: int = 0,
+        excluded_flag_ids: list[int] | set[int] | None = None,
         search: str | None = None,
         active: str | bool | None = None,
         created_by_id: str | int | None = None,
@@ -877,6 +875,7 @@ class ExperimentService:
     ) -> dict[str, Any]:
         """Get feature flags eligible for use in experiments."""
         queryset = self._get_eligible_feature_flags_queryset(
+            excluded_flag_ids=excluded_flag_ids,
             search=search,
             active=active,
             created_by_id=created_by_id,
@@ -893,6 +892,7 @@ class ExperimentService:
     def _get_eligible_feature_flags_queryset(
         self,
         *,
+        excluded_flag_ids: list[int] | set[int] | None,
         search: str | None,
         active: str | bool | None,
         created_by_id: str | int | None,
@@ -912,12 +912,8 @@ class ExperimentService:
             ]
         )
 
-        survey_flag_ids = Survey.get_internal_flag_ids(project_id=self.team.project_id)
-        product_tour_internal_targeting_flags = ProductTour.all_objects.filter(
-            team__project_id=self.team.project_id, internal_targeting_flag__isnull=False
-        ).values_list("internal_targeting_flag_id", flat=True)
-        excluded_flag_ids = survey_flag_ids | set(product_tour_internal_targeting_flags)
-        queryset = queryset.exclude(id__in=excluded_flag_ids)
+        if excluded_flag_ids:
+            queryset = queryset.exclude(id__in=excluded_flag_ids)
 
         if search:
             queryset = queryset.filter(Q(key__icontains=search) | Q(name__icontains=search))

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -10,6 +10,7 @@ from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.models import FeatureFlag, Team
+from posthog.models.evaluation_context import EvaluationContext, FeatureFlagEvaluationContext
 from posthog.models.experiment import (
     Experiment,
     ExperimentHoldout,
@@ -1257,6 +1258,58 @@ class TestExperimentService(APIBaseTest):
         service.request_timeseries_recalculation(experiment, metric={"uuid": "m1"}, fingerprint="fp1")
 
         assert ExperimentMetricResult.objects.filter(experiment=experiment, metric_uuid="m1").count() == 0
+
+    # ------------------------------------------------------------------
+    # Eligible feature flags
+    # ------------------------------------------------------------------
+
+    def test_get_eligible_feature_flags_only_returns_control_first_multivariate_flags(self) -> None:
+        eligible_flag = self._create_flag(key="eligible-flag")
+        self._create_flag(
+            key="wrong-order-flag",
+            variants=[
+                {"key": "test", "name": "Test", "rollout_percentage": 50},
+                {"key": "control", "name": "Control", "rollout_percentage": 50},
+            ],
+        )
+        self._create_flag(
+            key="single-variant-flag",
+            variants=[{"key": "control", "name": "Control", "rollout_percentage": 100}],
+        )
+
+        result = self._service().get_eligible_feature_flags(order="key")
+
+        assert result["count"] == 1
+        assert [flag.key for flag in result["results"]] == [eligible_flag.key]
+
+    def test_get_eligible_feature_flags_applies_search_and_pagination(self) -> None:
+        self._create_flag(key="search-alpha")
+        self._create_flag(key="search-beta")
+        self._create_flag(key="other-flag")
+
+        result = self._service().get_eligible_feature_flags(
+            search="search",
+            order="key",
+            limit=1,
+            offset=1,
+        )
+
+        assert result["count"] == 2
+        assert [flag.key for flag in result["results"]] == ["search-beta"]
+
+    def test_get_eligible_feature_flags_filters_by_evaluation_tags(self) -> None:
+        flag_with_tags = self._create_flag(key="flag-with-tags")
+        self._create_flag(key="flag-without-tags")
+        evaluation_context = EvaluationContext.objects.create(name="app", team=self.team)
+        FeatureFlagEvaluationContext.objects.create(feature_flag=flag_with_tags, evaluation_context=evaluation_context)
+
+        service = self._service()
+
+        flags_with_tags = service.get_eligible_feature_flags(has_evaluation_tags="true", order="key")
+        flags_without_tags = service.get_eligible_feature_flags(has_evaluation_tags="false", order="key")
+
+        assert [flag.key for flag in flags_with_tags["results"]] == ["flag-with-tags"]
+        assert [flag.key for flag in flags_without_tags["results"]] == ["flag-without-tags"]
 
     # ------------------------------------------------------------------
     # Velocity stats


### PR DESCRIPTION
# Problem
Experiment business logic related to eligible feature flag querying still lived in the API layer.

# Changes

- Moved eligible feature flag querying, filtering, ordering, prefetching, and pagination/count logic into `ExperimentService`.
- Added service tests and endpoint smoke coverage for the moved logic.

# Testing
- tests added
- CI should pass