### PR TITLE
fix: include email via $set in report_user_action events

### DIFF
--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -346,6 +346,7 @@ def report_user_action(
         properties = {}
     if request is not None:
         properties = {**get_request_analytics_properties(request), **properties}
+    properties.setdefault("$set", {}).setdefault("email", user.email if not user.anonymize_data else None)
     posthoganalytics.capture(
         distinct_id=user.distinct_id,
         event=event,
@@ -382,6 +383,9 @@ def report_user_or_team_action(
 
     org = organization or (real_user.current_organization if real_user else None)
     tm = team or (real_user.current_team if real_user else None)
+
+    if real_user:
+        properties.setdefault("$set", {}).setdefault("email", real_user.email if not real_user.anonymize_data else None)
 
     posthoganalytics.capture(
         distinct_id=distinct_id,

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -32,6 +32,7 @@ class TestReportUserAction(BaseTest):
                     "mcp_client_version": None,
                     "mcp_protocol_version": None,
                     "mcp_oauth_client_name": None,
+                    "$set": {"email": "user1@posthog.com"},
                 },
             ),
             (
@@ -52,6 +53,7 @@ class TestReportUserAction(BaseTest):
                     "mcp_client_version": None,
                     "mcp_protocol_version": None,
                     "mcp_oauth_client_name": None,
+                    "$set": {"email": "user1@posthog.com"},
                 },
             ),
             (
@@ -73,6 +75,7 @@ class TestReportUserAction(BaseTest):
                     "mcp_client_version": "1.2.3",
                     "mcp_protocol_version": "2025-03-26",
                     "mcp_oauth_client_name": "Claude Code (posthog)",
+                    "$set": {"email": "user1@posthog.com"},
                 },
             ),
             (
@@ -90,6 +93,7 @@ class TestReportUserAction(BaseTest):
                     "mcp_protocol_version": None,
                     "mcp_oauth_client_name": None,
                     "key": "val",
+                    "$set": {"email": "user1@posthog.com"},
                 },
             ),
             (
@@ -106,6 +110,7 @@ class TestReportUserAction(BaseTest):
                     "mcp_client_version": None,
                     "mcp_protocol_version": None,
                     "mcp_oauth_client_name": None,
+                    "$set": {"email": "user1@posthog.com"},
                 },
             ),
             (
@@ -123,6 +128,7 @@ class TestReportUserAction(BaseTest):
                     "mcp_protocol_version": None,
                     "mcp_oauth_client_name": None,
                     "key": "val",
+                    "$set": {"email": "user1@posthog.com"},
                 },
             ),
         ]
@@ -141,11 +147,36 @@ class TestReportUserAction(BaseTest):
         assert captured_props == expected_properties
 
     @patch("posthog.event_usage.posthoganalytics.capture")
-    def test_no_request_passes_properties_unchanged(self, mock_capture):
+    def test_no_request_includes_email_via_set(self, mock_capture):
         report_user_action(self.user, "test event", properties={"key": "val"})
 
         mock_capture.assert_called_once()
-        assert mock_capture.call_args[1]["properties"] == {"key": "val"}
+        assert mock_capture.call_args[1]["properties"] == {"key": "val", "$set": {"email": self.user.email}}
+
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_anonymized_user_does_not_include_email(self, mock_capture):
+        self.user.anonymize_data = True
+        self.user.save()
+
+        report_user_action(self.user, "test event")
+
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args[1]["properties"]["$set"]["email"] is None
+
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_caller_set_properties_are_preserved(self, mock_capture):
+        report_user_action(self.user, "test event", properties={"$set": {"name": "Test User"}})
+
+        mock_capture.assert_called_once()
+        set_props = mock_capture.call_args[1]["properties"]["$set"]
+        assert set_props == {"name": "Test User", "email": self.user.email}
+
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_caller_email_in_set_takes_precedence(self, mock_capture):
+        report_user_action(self.user, "test event", properties={"$set": {"email": "override@example.com"}})
+
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args[1]["properties"]["$set"]["email"] == "override@example.com"
 
 
 class TestGetEventSource(BaseTest):


### PR DESCRIPTION
## Problem

`report_user_action` and `report_user_or_team_action` never set the user's email on captured analytics events. Other dedicated event functions (e.g. `report_user_signed_up`, `report_user_joined_organization`) include `"$set": user.get_analytics_metadata()` which contains the email, but these two generic functions — used by dozens of callsites — don't. This means events from systems that don't explicitly pass email in properties are missing it entirely.

## Changes

- Add `$set.email` from the authenticated user object in both `report_user_action` and `report_user_or_team_action`
- Uses `setdefault` so callers who already pass `$set` or `$set.email` aren't overridden
- Respects `user.anonymize_data` (sets email to `None` when true), consistent with `get_analytics_metadata`
- No extra DB queries — `user.email` is already loaded on the user object
- In `report_user_or_team_action`, only sets email when there's a real authenticated user (not team-only events)

## Testing

- Updated all existing parameterized tests to expect the new `$set.email` property
- Added tests for: anonymized users, caller `$set` properties preserved, caller email override takes precedence
- All 30 tests pass