### PR TITLE
Ai recordings new tab

### DIFF
--- a/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
+++ b/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
@@ -21,7 +21,7 @@ import {
     MaxErrorTrackingSearchResponse,
 } from '~/queries/schema/schema-assistant-error-tracking'
 import { AssistantTool } from '~/queries/schema/schema-assistant-messages'
-import { RecordingUniversalFilters } from '~/types'
+import { RecordingUniversalFilters, ReplayTabs } from '~/types'
 
 import { issueFiltersLogic } from 'products/error_tracking/frontend/components/IssueFilters/issueFiltersLogic'
 import {
@@ -99,6 +99,8 @@ export function RecordingsWidget({
     filters: RecordingUniversalFilters
 }): JSX.Element {
     const { onAcceptSessionFilters } = useValues(maxLogic)
+    const { activeSceneId } = useValues(sceneLogic)
+    const isOnReplayPage = activeSceneId === Scene.Replay
     const logicProps: SessionRecordingPlaylistLogicProps = {
         logicKey: `ai-recordings-widget-${toolCallId}`,
         filters,
@@ -109,6 +111,17 @@ export function RecordingsWidget({
     return (
         <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
             <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
+                {!isOnReplayPage && (
+                    <div className="flex items-center justify-between px-2 pt-2">
+                        <span className="text-xs font-semibold text-secondary">Session replay</span>
+                        <LemonButton
+                            to={urls.replay(ReplayTabs.Home, filters)}
+                            icon={<IconOpenInNew />}
+                            size="xsmall"
+                            tooltip="Open in new tab"
+                        />
+                    </div>
+                )}
                 <RecordingsFiltersSummary filters={filters} />
                 <RecordingsListContent />
                 {onAcceptSessionFilters && <AcceptFiltersBar filters={filters} onAccept={onAcceptSessionFilters} />}

--- a/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
+++ b/frontend/src/scenes/max/messages/UIPayloadAnswer.tsx
@@ -34,6 +34,7 @@ import { ERROR_TRACKING_SCENE_LOGIC_KEY } from 'products/error_tracking/frontend
 
 import { isDangerousOperationResponse, normalizeDangerousOperationResponse } from '../approvalOperationUtils'
 import { DangerousOperationApprovalCard } from '../DangerousOperationApprovalCard'
+import { maxGlobalLogic } from '../maxGlobalLogic'
 import { maxLogic } from '../maxLogic'
 import { ErrorTrackingFiltersSummary } from './ErrorTrackingFiltersSummary'
 import { ErrorTrackingIssueCard } from './ErrorTrackingIssueCard'
@@ -99,8 +100,8 @@ export function RecordingsWidget({
     filters: RecordingUniversalFilters
 }): JSX.Element {
     const { onAcceptSessionFilters } = useValues(maxLogic)
-    const { activeSceneId } = useValues(sceneLogic)
-    const isOnReplayPage = activeSceneId === Scene.Replay
+    const { registeredToolMap } = useValues(maxGlobalLogic)
+    const hasFilterSessionRecordingsTool = !!registeredToolMap['filter_session_recordings']
     const logicProps: SessionRecordingPlaylistLogicProps = {
         logicKey: `ai-recordings-widget-${toolCallId}`,
         filters,
@@ -111,7 +112,7 @@ export function RecordingsWidget({
     return (
         <BindLogic logic={sessionRecordingsPlaylistLogic} props={logicProps}>
             <MessageTemplate type="ai" wrapperClassName="w-full" boxClassName="p-0 overflow-hidden">
-                {!isOnReplayPage && (
+                {!hasFilterSessionRecordingsTool && (
                     <div className="flex items-center justify-between px-2 pt-2">
                         <span className="text-xs font-semibold text-secondary">Session replay</span>
                         <LemonButton


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users interacting with the AI `RecordingsWidget` need a way to easily navigate to the full session replay page with the current filters applied, especially when the widget is displayed outside of the dedicated replay scene. This improves discoverability and workflow efficiency.

## Changes

Adds an "Open in new tab" button to the top right of the `RecordingsWidget` in `UIPayloadAnswer.tsx`. This button:
- Is visible when the user is not currently on the Session Replay page (`Scene.Replay`).
- Navigates to the Session Replay page (`urls.replay(ReplayTabs.Home, filters)`) while preserving the active filters.
- Is hidden when already on the Session Replay page, following the convention of other Max widgets (e.g., `ErrorTrackingFiltersWidget`).

## How did you test this code?

As an agent, I have not manually tested this. The implementation follows existing patterns for similar widgets and URL generation.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

[Slack Thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1773401611108389?thread_ts=1773401611.108389&cid=C06NZEZ7V3Q)

<div><a href="https://cursor.com/agents/bc-b51dcbf5-6d5e-593a-8ee2-25c3727a32ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b51dcbf5-6d5e-593a-8ee2-25c3727a32ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->