### PR TITLE
fix(persons): skip properties timeline when no person exists

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -480,14 +480,15 @@ export function ActorRow({ actor, propertiesTimelineFilter }: ActorRowProps): JS
                             {
                                 key: 'properties',
                                 label: 'Properties',
-                                content: propertiesTimelineFilter ? (
-                                    <PropertiesTimeline actor={actor} filter={propertiesTimelineFilter} />
-                                ) : (
-                                    <PropertiesTable
-                                        type={actor.type as PropertyDefinitionType}
-                                        properties={actor.properties}
-                                    />
-                                ),
+                                content:
+                                    propertiesTimelineFilter && actor.created_at ? (
+                                        <PropertiesTimeline actor={actor} filter={propertiesTimelineFilter} />
+                                    ) : (
+                                        <PropertiesTable
+                                            type={actor.type as PropertyDefinitionType}
+                                            properties={actor.properties}
+                                        />
+                                    ),
                             },
                             ...(isSession && actor.person
                                 ? [

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -254,8 +254,13 @@ export function PersonsModal({
                                     <ActorRow
                                         key={actor.id}
                                         actor={actor}
+                                        // created_at is null for actors without a PostgreSQL Person record
+                                        // (personless mode, merged, or deleted persons) — skip the
+                                        // timeline which would 404, and show static properties instead.
                                         propertiesTimelineFilter={
-                                            actor.type == 'person' && currentTeam?.person_on_events_querying_enabled
+                                            actor.type == 'person' &&
+                                            actor.created_at &&
+                                            currentTeam?.person_on_events_querying_enabled
                                                 ? propertiesTimelineFilterFromUrl
                                                 : undefined
                                         }
@@ -480,18 +485,14 @@ export function ActorRow({ actor, propertiesTimelineFilter }: ActorRowProps): JS
                             {
                                 key: 'properties',
                                 label: 'Properties',
-                                // created_at is null for actors without a PostgreSQL Person record
-                                // (personless mode, merged, or deleted persons) — skip the timeline
-                                // request which would 404, and show static properties instead.
-                                content:
-                                    propertiesTimelineFilter && actor.created_at ? (
-                                        <PropertiesTimeline actor={actor} filter={propertiesTimelineFilter} />
-                                    ) : (
-                                        <PropertiesTable
-                                            type={actor.type as PropertyDefinitionType}
-                                            properties={actor.properties}
-                                        />
-                                    ),
+                                content: propertiesTimelineFilter ? (
+                                    <PropertiesTimeline actor={actor} filter={propertiesTimelineFilter} />
+                                ) : (
+                                    <PropertiesTable
+                                        type={actor.type as PropertyDefinitionType}
+                                        properties={actor.properties}
+                                    />
+                                ),
                             },
                             ...(isSession && actor.person
                                 ? [

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -480,6 +480,9 @@ export function ActorRow({ actor, propertiesTimelineFilter }: ActorRowProps): JS
                             {
                                 key: 'properties',
                                 label: 'Properties',
+                                // created_at is null for actors without a PostgreSQL Person record
+                                // (personless mode, merged, or deleted persons) — skip the timeline
+                                // request which would 404, and show static properties instead.
                                 content:
                                     propertiesTimelineFilter && actor.created_at ? (
                                         <PropertiesTimeline actor={actor} filter={propertiesTimelineFilter} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1416,7 +1416,7 @@ export interface CommonActorType {
     id: string | number
     properties: Record<string, any>
     /** @format date-time */
-    created_at: string
+    created_at: string | null
     matched_recordings: MatchedRecording[]
     value_at_data_point: number | null
 }


### PR DESCRIPTION
## Problem

When expanding a person row in the insight actors modal, the frontend requests the `properties_timeline` endpoint. If the person UUID exists in ClickHouse but has no corresponding record in PostgreSQL, this returns a 404 and shows an error toast: "Load result failed: Not found."

This happens in three scenarios:
- **Personless mode**: events ingested with `$process_person_profile: false`, cookieless tracking, or the `person_processing_opt_out` team setting intentionally skip Person record creation in PostgreSQL
- **Person merges**: the old person UUID is orphaned after distinct IDs are moved to the merged target
- **Person deletions**: the Person record is soft-deleted but ClickHouse events still reference the UUID

## Changes

Skip the `PropertiesTimeline` request when `actor.created_at` is falsy (indicating no PostgreSQL Person record exists) and fall back to the static `PropertiesTable` instead, which correctly shows empty properties for these actors.

## How did you test this code?

I haven't tested manually, but the code is minimal and the change seems sound.

Here's how it could be tested:
1. Find an insight with persons where one of the three scenarios above applies (easiest: use personless mode with `$process_person_profile: false`)
2. Click into a data point to open the persons modal
3. Expand a person row that has no properties or display name
4. Confirm no error toast appears and the properties tab shows an empty properties table

## Publish to changelog?

No

## Docs update

No

## 🤖 LLM context

Co-authored by Claude Code.
