### PR TITLE
fix(ds): reduce memory usage in postgres data warehouse source to prevent OOM

### DIFF
--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -100,6 +100,7 @@
     'filters',
     'name',
     'pinned',
+    'quick_filter_ids',
     'restriction_level',
     'variables',
   ])

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -511,7 +511,7 @@ def table_from_iterator(data_iterator: Iterator[dict], schema: Optional[pa.Schem
     if not batch:
         return pa.Table.from_pylist([])
 
-    processed_batch = _process_batch(list(batch), schema)
+    processed_batch = _process_batch(batch, schema)
 
     return processed_batch
 

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -525,7 +525,7 @@ def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, log
     try:
         query = sql.SQL("""
             SELECT percentile_cont(0.95) within group (order by subquery.row_size) FROM (
-                SELECT pg_column_size(t) as row_size FROM ({}) as t
+                SELECT octet_length(t::text) as row_size FROM ({}) as t
             ) as subquery
         """).format(inner_query)
 
@@ -1067,8 +1067,10 @@ def postgres_source(
                             if not rows:
                                 break
 
-                            yield table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
-                            offset += len(rows)
+                            dicts = [dict(zip(column_names, row)) for row in rows]
+                            del rows
+                            yield table_from_iterator(iter(dicts), arrow_schema)
+                            offset += len(dicts)
             except psycopg.errors.SerializationFailure as e:
                 # If we hit a SerializationFailure and we're reading from a read replica, we fallback to offset chunking
                 if using_read_replica and "conflict with recovery" in "".join(e.args):


### PR DESCRIPTION
## Problem

OOM errors when syncing wide and big Postgres tables with big text columns (like 100k+ character strings) by reducing peak memory usage during data import

## Changes

  * Changed `pg_column_size(t)` to `octet_length(t::text)` in chunk size estimation to measure decompressed row size instead of TOAST-compressed size
  * Removed unnecessary `list()` copy in `table_from_iterator` — `batch` is already a list
  * Materialized dicts from cursor rows and freed the original tuples (`del rows`) before passing to `table_from_iterator`, reducing peak memory by avoiding two copies coexisting

## How did you test this code?

Test pass
Local run ⬇️ 

### Local run results:

We went from a memory usage of:
```
...
15:09:42.516 RSS: 6192.6 MB VSZ: 429363.8 MB
15:09:47.553 RSS: 5704.5 MB VSZ: 429363.8 MB
15:09:52.571 RSS: 5542.9 MB VSZ: 429381.9 MB
15:09:57.588 RSS: 5256.0 MB VSZ: 429372.7 MB
15:10:02.602 RSS: 5203.4 MB VSZ: 429482.2 MB
15:10:07.615 RSS: 5503.5 MB VSZ: 429357.8 MB
15:10:12.628 RSS: 5321.1 MB VSZ: 429384.5 MB
15:10:17.649 RSS: 5458.6 MB VSZ: 429949.3 MB
15:10:22.669 RSS: 5650.0 MB VSZ: 430281.3 MB
15:10:27.683 RSS: 5431.0 MB VSZ: 429391.5 MB
15:10:32.717 RSS: 6007.2 MB VSZ: 430551.5 MB
15:10:37.757 RSS: 5587.8 MB VSZ: 430154.3 MB
15:10:42.774 RSS: 5658.9 MB VSZ: 429415.8 MB
15:10:47.786 RSS: 5730.0 MB VSZ: 429408.1 MB
15:10:52.802 RSS: 5246.7 MB VSZ: 429451.9 MB
15:10:57.815 RSS: 5009.6 MB VSZ: 429404.3 MB
15:11:02.833 RSS: 5122.0 MB VSZ: 429450.7 MB
15:11:07.861 RSS: 6066.2 MB VSZ: 430515.8 MB
15:11:12.893 RSS: 5441.1 MB VSZ: 429438.5 MB
15:11:17.905 RSS: 5491.3 MB VSZ: 429428.3 MB
15:11:22.946 RSS: 6386.5 MB VSZ: 430563.3 MB
15:11:27.979 RSS: 5782.3 MB VSZ: 430145.7 MB
15:11:33.013 RSS: 6046.5 MB VSZ: 429540.6 MB
15:11:38.051 RSS: 5317.7 MB VSZ: 429400.4 MB
15:11:43.075 RSS: 5086.1 MB VSZ: 429421.8 MB
15:11:48.092 RSS: 4927.3 MB VSZ: 429404.5 MB
15:11:53.108 RSS: 5092.4 MB VSZ: 429404.5 MB
15:11:58.126 RSS: 5442.0 MB VSZ: 429779.8 MB
15:12:03.143 RSS: 6393.3 MB VSZ: 430521.0 MB
...
```

to:
```
...
15:24:42.826 RSS: 2652.7 MB VSZ: 428211.8 MB
15:24:47.843 RSS: 2523.0 MB VSZ: 428192.5 MB
15:24:52.855 RSS: 2426.1 MB VSZ: 428542.1 MB
15:24:57.870 RSS: 2179.9 MB VSZ: 428810.7 MB
15:25:02.891 RSS: 1814.1 MB VSZ: 428440.0 MB
15:25:07.905 RSS: 1840.8 MB VSZ: 428439.7 MB
15:25:12.922 RSS: 1929.9 MB VSZ: 428559.9 MB
15:25:17.936 RSS: 1840.1 MB VSZ: 428439.7 MB
15:25:22.949 RSS: 1955.6 MB VSZ: 428596.5 MB
15:25:27.961 RSS: 1797.7 MB VSZ: 428440.2 MB
15:25:32.973 RSS: 1848.5 MB VSZ: 428493.7 MB
15:25:37.990 RSS: 1965.2 MB VSZ: 428575.0 MB
15:25:43.008 RSS: 1862.8 MB VSZ: 428694.2 MB
15:25:48.028 RSS: 1884.5 MB VSZ: 428685.1 MB
15:25:53.042 RSS: 1895.1 MB VSZ: 428461.8 MB
15:25:58.054 RSS: 1877.3 MB VSZ: 428459.8 MB
15:26:03.069 RSS: 1788.1 MB VSZ: 428460.2 MB
15:26:08.083 RSS: 1826.8 MB VSZ: 428476.2 MB
15:26:13.096 RSS: 1832.5 MB VSZ: 428544.7 MB
15:26:18.109 RSS: 1848.7 MB VSZ: 428537.6 MB
15:26:23.130 RSS: 1877.5 MB VSZ: 428661.5 MB
15:26:28.144 RSS: 1815.0 MB VSZ: 428772.0 MB
15:26:33.159 RSS: 1828.8 MB VSZ: 428781.6 MB
15:26:38.172 RSS: 1950.9 MB VSZ: 428758.8 MB
...
```


## Publish to changelog?

NO
