### PR TITLE
feat(llma): add quota limiting and event restrictions to OTel endpoint

### DIFF
--- a/rust/capture/src/event_restrictions/types.rs
+++ b/rust/capture/src/event_restrictions/types.rs
@@ -186,12 +186,11 @@ impl AppliedRestrictions {
         self.redirect_to_topic.as_deref()
     }
 
-    /// OR two sets of non-drop restrictions together. Used for all-or-nothing batch
-    /// processing where any span triggering a flag applies it to the whole batch.
-    /// Callers must handle `should_drop()` before calling this.
+    /// OR two sets of restrictions together. Used for all-or-nothing batch processing
+    /// where any span triggering a flag applies it to the whole batch.
     pub fn merge(self, other: AppliedRestrictions) -> Self {
         Self {
-            should_drop: false,
+            should_drop: self.should_drop || other.should_drop,
             force_overflow: self.force_overflow || other.force_overflow,
             skip_person_processing: self.skip_person_processing || other.skip_person_processing,
             redirect_to_dlq: self.redirect_to_dlq || other.redirect_to_dlq,

--- a/rust/capture/src/event_restrictions/types.rs
+++ b/rust/capture/src/event_restrictions/types.rs
@@ -185,6 +185,19 @@ impl AppliedRestrictions {
     pub fn redirect_to_topic(&self) -> Option<&str> {
         self.redirect_to_topic.as_deref()
     }
+
+    /// OR two sets of non-drop restrictions together. Used for all-or-nothing batch
+    /// processing where any span triggering a flag applies it to the whole batch.
+    /// Callers must handle `should_drop()` before calling this.
+    pub fn merge(self, other: AppliedRestrictions) -> Self {
+        Self {
+            should_drop: false,
+            force_overflow: self.force_overflow || other.force_overflow,
+            skip_person_processing: self.skip_person_processing || other.skip_person_processing,
+            redirect_to_dlq: self.redirect_to_dlq || other.redirect_to_dlq,
+            redirect_to_topic: self.redirect_to_topic.or(other.redirect_to_topic),
+        }
+    }
 }
 
 /// Filters for a restriction. AND logic between types, OR logic within each type.

--- a/rust/capture/src/event_restrictions/types.rs
+++ b/rust/capture/src/event_restrictions/types.rs
@@ -478,6 +478,105 @@ mod tests {
     }
 
     #[test]
+    fn test_applied_restrictions_merge_defaults() {
+        let a = AppliedRestrictions::default();
+        let b = AppliedRestrictions::default();
+        let merged = a.merge(b);
+        assert!(merged.is_empty());
+        assert!(!merged.should_drop());
+        assert!(!merged.force_overflow());
+        assert!(!merged.skip_person_processing());
+        assert!(!merged.redirect_to_dlq());
+        assert!(merged.redirect_to_topic().is_none());
+    }
+
+    #[test]
+    fn test_applied_restrictions_merge_should_drop_propagates() {
+        for (left, right) in [(true, false), (false, true), (true, true)] {
+            let a = AppliedRestrictions {
+                should_drop: left,
+                ..Default::default()
+            };
+            let b = AppliedRestrictions {
+                should_drop: right,
+                ..Default::default()
+            };
+            assert!(a.merge(b).should_drop());
+        }
+    }
+
+    #[test]
+    fn test_applied_restrictions_merge_boolean_flags_or() {
+        let a = AppliedRestrictions {
+            force_overflow: true,
+            ..Default::default()
+        };
+        let b = AppliedRestrictions {
+            skip_person_processing: true,
+            redirect_to_dlq: true,
+            ..Default::default()
+        };
+        let merged = a.merge(b);
+        assert!(merged.force_overflow());
+        assert!(merged.skip_person_processing());
+        assert!(merged.redirect_to_dlq());
+    }
+
+    #[test]
+    fn test_applied_restrictions_merge_redirect_to_topic_first_wins() {
+        let a = AppliedRestrictions {
+            redirect_to_topic: Some("topic_a".to_string()),
+            ..Default::default()
+        };
+        let b = AppliedRestrictions {
+            redirect_to_topic: Some("topic_b".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(a.merge(b).redirect_to_topic(), Some("topic_a"));
+    }
+
+    #[test]
+    fn test_applied_restrictions_merge_redirect_to_topic_from_right() {
+        let a = AppliedRestrictions::default();
+        let b = AppliedRestrictions {
+            redirect_to_topic: Some("topic_b".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(a.merge(b).redirect_to_topic(), Some("topic_b"));
+    }
+
+    #[test]
+    fn test_applied_restrictions_merge_accumulates_all_flags() {
+        let merged = AppliedRestrictions::default()
+            .merge(AppliedRestrictions {
+                should_drop: true,
+                ..Default::default()
+            })
+            .merge(AppliedRestrictions {
+                force_overflow: true,
+                ..Default::default()
+            })
+            .merge(AppliedRestrictions {
+                skip_person_processing: true,
+                ..Default::default()
+            })
+            .merge(AppliedRestrictions {
+                redirect_to_dlq: true,
+                ..Default::default()
+            })
+            .merge(AppliedRestrictions {
+                redirect_to_topic: Some("final_topic".to_string()),
+                ..Default::default()
+            });
+
+        assert!(merged.should_drop());
+        assert!(merged.force_overflow());
+        assert!(merged.skip_person_processing());
+        assert!(merged.redirect_to_dlq());
+        assert_eq!(merged.redirect_to_topic(), Some("final_topic"));
+    }
+
+    #[test]
     fn test_restriction_set_redirect_topic_last_wins() {
         let mut set = RestrictionSet::new();
         set.insert_redirect_to_topic("first_topic".to_string());

--- a/rust/capture/src/otel/fan_out.rs
+++ b/rust/capture/src/otel/fan_out.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, TimeZone, Utc};
+use common_types::HasEventName;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value, KeyValue};
 use serde_json::Value;
@@ -10,6 +11,19 @@ pub struct SpanEvent {
     pub distinct_id: String,
     pub properties: Value,
     pub timestamp: Option<DateTime<Utc>>,
+}
+
+impl HasEventName for SpanEvent {
+    fn event_name(&self) -> &str {
+        &self.event_name
+    }
+
+    fn has_property(&self, key: &str) -> bool {
+        self.properties
+            .as_object()
+            .map(|m| m.contains_key(key))
+            .unwrap_or(false)
+    }
 }
 
 fn any_value_to_json(value: &any_value::Value) -> Value {

--- a/rust/capture/src/otel/fan_out.rs
+++ b/rust/capture/src/otel/fan_out.rs
@@ -26,6 +26,19 @@ impl HasEventName for SpanEvent {
     }
 }
 
+impl HasEventName for &SpanEvent {
+    fn event_name(&self) -> &str {
+        &self.event_name
+    }
+
+    fn has_property(&self, key: &str) -> bool {
+        self.properties
+            .as_object()
+            .map(|m| m.contains_key(key))
+            .unwrap_or(false)
+    }
+}
+
 fn any_value_to_json(value: &any_value::Value) -> Value {
     match value {
         any_value::Value::StringValue(s) => Value::String(s.clone()),

--- a/rust/capture/src/otel/filtering.rs
+++ b/rust/capture/src/otel/filtering.rs
@@ -29,8 +29,10 @@ pub async fn check_quota(
 
     match limiter.check_and_filter(token, refs).await {
         Ok(filtered) if filtered.len() == count => Ok(()),
-        Ok(_) => {
-            report_dropped_events("otel_quota_drop", count as u64);
+        Ok(filtered) => {
+            let dropped = count - filtered.len();
+            report_dropped_events("otel_quota_drop", dropped as u64);
+            report_dropped_events("otel_all_or_nothing_drop", filtered.len() as u64);
             Err(QuotaOutcome::Dropped)
         }
         Err(CaptureError::BillingLimit) => {
@@ -62,13 +64,12 @@ pub async fn check_restrictions(
             ..Default::default()
         };
         let applied = service.get_restrictions(token, &ctx).await;
-
-        if applied.should_drop() {
-            report_dropped_events("otel_restriction_drop", span_events.len() as u64);
-            return None;
-        }
-
         merged = merged.merge(applied);
+    }
+
+    if merged.should_drop() {
+        report_dropped_events("otel_restriction_drop", span_events.len() as u64);
+        return None;
     }
 
     Some(merged)

--- a/rust/capture/src/otel/filtering.rs
+++ b/rust/capture/src/otel/filtering.rs
@@ -1,0 +1,147 @@
+use chrono::{DateTime, Utc};
+use common_types::CapturedEvent;
+use serde_json::json;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::api::CaptureError;
+use crate::event_restrictions::{AppliedRestrictions, EventContext, EventRestrictionService};
+use crate::prometheus::report_dropped_events;
+use crate::quota_limiters::CaptureQuotaLimiter;
+use crate::v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata};
+
+use super::fan_out::SpanEvent;
+
+pub enum QuotaOutcome {
+    Dropped,
+    Error(CaptureError),
+}
+
+/// All-or-nothing quota check: if ANY span would be dropped by quota, reject the entire batch.
+pub async fn check_quota(
+    limiter: &CaptureQuotaLimiter,
+    token: &str,
+    span_events: &[SpanEvent],
+) -> Result<(), QuotaOutcome> {
+    // Build lightweight wrappers to satisfy HasEventName without consuming the spans
+    let refs: Vec<SpanEventRef> = span_events.iter().map(SpanEventRef).collect();
+    let count = refs.len();
+
+    match limiter.check_and_filter(token, refs).await {
+        Ok(filtered) if filtered.len() == count => Ok(()),
+        Ok(_) => {
+            report_dropped_events("otel_quota_drop", count as u64);
+            Err(QuotaOutcome::Dropped)
+        }
+        Err(CaptureError::BillingLimit) => {
+            report_dropped_events("otel_quota_drop", count as u64);
+            Err(QuotaOutcome::Dropped)
+        }
+        Err(e) => Err(QuotaOutcome::Error(e)),
+    }
+}
+
+/// Per-span restriction checks with all-or-nothing semantics: if ANY span would be dropped,
+/// reject the entire batch. Non-drop flags are OR'd across all spans — if any span triggers
+/// a flag, it applies to the whole batch.
+///
+/// Returns `None` if any span has a drop restriction (entire batch should be rejected).
+pub async fn check_restrictions(
+    service: &EventRestrictionService,
+    token: &str,
+    now_ts: i64,
+    span_events: &[SpanEvent],
+) -> Option<AppliedRestrictions> {
+    let mut merged = AppliedRestrictions::default();
+
+    for span in span_events {
+        let ctx = EventContext {
+            event_name: Some(&span.event_name),
+            distinct_id: Some(&span.distinct_id),
+            now_ts,
+            ..Default::default()
+        };
+        let applied = service.get_restrictions(token, &ctx).await;
+
+        if applied.should_drop() {
+            report_dropped_events("otel_restriction_drop", span_events.len() as u64);
+            return None;
+        }
+
+        merged = merged.merge(applied);
+    }
+
+    Some(merged)
+}
+
+/// Build ProcessedEvents from SpanEvents, applying restriction flags uniformly to all events.
+pub fn build_events(
+    span_events: Vec<SpanEvent>,
+    token: &str,
+    client_ip: &str,
+    received_at: DateTime<Utc>,
+    restrictions: &AppliedRestrictions,
+) -> Result<Vec<ProcessedEvent>, CaptureError> {
+    let now_rfc3339 = received_at.to_rfc3339();
+    let mut processed = Vec::with_capacity(span_events.len());
+
+    for span_event in span_events {
+        let event_data = json!({
+            "event": &span_event.event_name,
+            "distinct_id": &span_event.distinct_id,
+            "properties": span_event.properties,
+        });
+
+        let data = serde_json::to_string(&event_data).map_err(|e| {
+            warn!("Failed to serialize OTel event data: {}", e);
+            CaptureError::InternalError(format!("failed to serialize event data: {e}"))
+        })?;
+
+        let timestamp = span_event.timestamp.unwrap_or(received_at);
+        let captured_event = CapturedEvent {
+            uuid: Uuid::now_v7(),
+            distinct_id: span_event.distinct_id,
+            session_id: None,
+            ip: client_ip.to_string(),
+            data,
+            now: now_rfc3339.clone(),
+            sent_at: None,
+            token: token.to_string(),
+            event: span_event.event_name.clone(),
+            timestamp,
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        let metadata = ProcessedEventMetadata {
+            data_type: DataType::AnalyticsMain,
+            session_id: None,
+            computed_timestamp: Some(timestamp),
+            event_name: span_event.event_name,
+            force_overflow: restrictions.force_overflow(),
+            skip_person_processing: restrictions.skip_person_processing(),
+            redirect_to_dlq: restrictions.redirect_to_dlq(),
+            redirect_to_topic: restrictions.redirect_to_topic().map(|s| s.to_string()),
+        };
+
+        processed.push(ProcessedEvent {
+            event: captured_event,
+            metadata,
+        });
+    }
+
+    Ok(processed)
+}
+
+/// Lightweight wrapper around a borrowed SpanEvent for quota limiting.
+struct SpanEventRef<'a>(&'a SpanEvent);
+
+impl common_types::HasEventName for SpanEventRef<'_> {
+    fn event_name(&self) -> &str {
+        &self.0.event_name
+    }
+
+    fn has_property(&self, key: &str) -> bool {
+        self.0.has_property(key)
+    }
+}

--- a/rust/capture/src/otel/filtering.rs
+++ b/rust/capture/src/otel/filtering.rs
@@ -23,8 +23,7 @@ pub async fn check_quota(
     token: &str,
     span_events: &[SpanEvent],
 ) -> Result<(), QuotaOutcome> {
-    // Build lightweight wrappers to satisfy HasEventName without consuming the spans
-    let refs: Vec<SpanEventRef> = span_events.iter().map(SpanEventRef).collect();
+    let refs: Vec<&SpanEvent> = span_events.iter().collect();
     let count = refs.len();
 
     match limiter.check_and_filter(token, refs).await {
@@ -47,13 +46,13 @@ pub async fn check_quota(
 /// reject the entire batch. Non-drop flags are OR'd across all spans — if any span triggers
 /// a flag, it applies to the whole batch.
 ///
-/// Returns `None` if any span has a drop restriction (entire batch should be rejected).
+/// Returns `Err(())` if any span has a drop restriction (entire batch should be rejected).
 pub async fn check_restrictions(
     service: &EventRestrictionService,
     token: &str,
     now_ts: i64,
     span_events: &[SpanEvent],
-) -> Option<AppliedRestrictions> {
+) -> Result<AppliedRestrictions, ()> {
     let mut merged = AppliedRestrictions::default();
 
     for span in span_events {
@@ -69,10 +68,10 @@ pub async fn check_restrictions(
 
     if merged.should_drop() {
         report_dropped_events("otel_restriction_drop", span_events.len() as u64);
-        return None;
+        return Err(());
     }
 
-    Some(merged)
+    Ok(merged)
 }
 
 /// Build ProcessedEvents from SpanEvents, applying restriction flags uniformly to all events.
@@ -132,17 +131,4 @@ pub fn build_events(
     }
 
     Ok(processed)
-}
-
-/// Lightweight wrapper around a borrowed SpanEvent for quota limiting.
-struct SpanEventRef<'a>(&'a SpanEvent);
-
-impl common_types::HasEventName for SpanEventRef<'_> {
-    fn event_name(&self) -> &str {
-        &self.0.event_name
-    }
-
-    fn has_property(&self, key: &str) -> bool {
-        self.0.has_property(key)
-    }
 }

--- a/rust/capture/src/otel/mod.rs
+++ b/rust/capture/src/otel/mod.rs
@@ -1,27 +1,25 @@
 mod event_name;
 mod fan_out;
+mod filtering;
 mod identity;
 mod ingestion;
 
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::HeaderMap;
-use axum::response::Json;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Json, Response};
 use axum_client_ip::InsecureClientIp;
 use chrono::Utc;
-use common_types::CapturedEvent;
 use metrics::counter;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use serde_json::json;
 use tracing::{debug, warn};
-use uuid::Uuid;
 
 use crate::api::{CaptureError, CaptureResponse, CaptureResponseCode};
 use crate::extractors::extract_body_with_timeout;
 use crate::prometheus::report_dropped_events;
 use crate::router::State as AppState;
 use crate::token::validate_token;
-use crate::v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata};
 
 pub const OTEL_BODY_SIZE: usize = 4 * 1024 * 1024; // 4MB
 const MAX_SPANS_PER_REQUEST: usize = 100;
@@ -35,12 +33,22 @@ fn count_spans(request: &ExportTraceServiceRequest) -> usize {
         .sum()
 }
 
+/// Return an HTTP 400 with a JSON error message.
+///
+/// Per the OTLP spec (https://opentelemetry.io/docs/specs/otlp/#failures-1), only
+/// 429/502/503/504 are retryable — all other 4xx cause the SDK to permanently drop
+/// the data. We use 400 (not 429) for quota/restriction rejections because we don't
+/// want SDKs to retry data that will always be rejected.
+fn non_retryable_rejection(message: &str) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))).into_response()
+}
+
 pub async fn otel_handler(
     State(state): State<AppState>,
     ip: Option<InsecureClientIp>,
     headers: HeaderMap,
     body: Body,
-) -> Result<Json<serde_json::Value>, CaptureError> {
+) -> Result<Json<serde_json::Value>, Response> {
     debug!("Received request to /i/v0/ai/otel endpoint");
 
     let body = extract_body_with_timeout(
@@ -50,11 +58,12 @@ pub async fn otel_handler(
         state.body_read_chunk_size_kb,
         "/i/v0/ai/otel",
     )
-    .await?;
+    .await
+    .map_err(|e| e.into_response())?;
 
     if body.is_empty() {
         warn!("OTEL endpoint received empty body");
-        return Err(CaptureError::EmptyPayload);
+        return Err(CaptureError::EmptyPayload.into_response());
     }
 
     let auth_header = headers
@@ -64,21 +73,19 @@ pub async fn otel_handler(
 
     if !auth_header.starts_with("Bearer ") {
         warn!("OTEL endpoint missing or invalid Authorization header");
-        return Err(CaptureError::NoTokenError);
+        return Err(CaptureError::NoTokenError.into_response());
     }
 
     let token = &auth_header[7..]; // Remove "Bearer " prefix
-    validate_token(token)?;
+    validate_token(token).map_err(|e| CaptureError::from(e).into_response())?;
 
     if state.token_dropper.should_drop(token, "") {
         report_dropped_events("token_dropper", 1);
         return Ok(Json(json!({})));
     }
 
-    // TODO: Add quota limiter check (needs HasEventName impl for OTel events)
-    // TODO: Add event restriction checks
-
-    let request = ingestion::parse_request(&body, &headers, OTEL_BODY_SIZE)?;
+    let request =
+        ingestion::parse_request(&body, &headers, OTEL_BODY_SIZE).map_err(|e| e.into_response())?;
 
     let span_count = count_spans(&request);
     if span_count == 0 {
@@ -91,7 +98,8 @@ pub async fn otel_handler(
         );
         return Err(CaptureError::RequestParsingError(format!(
             "Too many spans: {span_count} exceeds limit of {MAX_SPANS_PER_REQUEST}"
-        )));
+        ))
+        .into_response());
     }
     counter!("capture_ai_otel_spans_received").increment(span_count as u64);
 
@@ -103,58 +111,36 @@ pub async fn otel_handler(
         .unwrap_or_else(|| "127.0.0.1".to_string());
 
     let span_events = fan_out::expand_into_events(&request, &distinct_id);
-    let now_rfc3339 = received_at.to_rfc3339();
     let token = token.to_string();
 
-    let mut processed_events = Vec::with_capacity(span_events.len());
-    for span_event in span_events {
-        let event_data = json!({
-            "event": &span_event.event_name,
-            "distinct_id": &span_event.distinct_id,
-            "properties": span_event.properties,
-        });
-
-        let data = serde_json::to_string(&event_data).map_err(|e| {
-            warn!("Failed to serialize OTel event data: {}", e);
-            CaptureError::InternalError(format!("failed to serialize event data: {e}"))
-        })?;
-
-        let timestamp = span_event.timestamp.unwrap_or(received_at);
-        let captured_event = CapturedEvent {
-            uuid: Uuid::now_v7(),
-            distinct_id: span_event.distinct_id,
-            session_id: None,
-            ip: client_ip.clone(),
-            data,
-            now: now_rfc3339.clone(),
-            sent_at: None,
-            token: token.clone(),
-            event: span_event.event_name.clone(),
-            timestamp,
-            is_cookieless_mode: false,
-            historical_migration: false,
+    // All-or-nothing quota check: reject the entire batch if any span is over quota
+    if let Err(outcome) = filtering::check_quota(&state.quota_limiter, &token, &span_events).await {
+        return match outcome {
+            filtering::QuotaOutcome::Dropped => Err(non_retryable_rejection("quota exceeded")),
+            filtering::QuotaOutcome::Error(e) => Err(e.into_response()),
         };
-
-        let metadata = ProcessedEventMetadata {
-            data_type: DataType::AnalyticsMain,
-            session_id: None,
-            computed_timestamp: Some(timestamp),
-            event_name: span_event.event_name,
-            force_overflow: false,
-            skip_person_processing: false,
-            redirect_to_dlq: false,
-            redirect_to_topic: None,
-        };
-
-        processed_events.push(ProcessedEvent {
-            event: captured_event,
-            metadata,
-        });
     }
+
+    let restrictions = match &state.event_restriction_service {
+        Some(service) => {
+            let now_ts = state.timesource.current_time().timestamp();
+            match filtering::check_restrictions(service, &token, now_ts, &span_events).await {
+                Some(applied) => applied,
+                None => {
+                    return Err(non_retryable_rejection("event restricted"));
+                }
+            }
+        }
+        None => Default::default(),
+    };
+
+    let processed_events =
+        filtering::build_events(span_events, &token, &client_ip, received_at, &restrictions)
+            .map_err(|e| e.into_response())?;
 
     state.sink.send_batch(processed_events).await.map_err(|e| {
         warn!("Failed to send OTel events to Kafka: {:?}", e);
-        e
+        e.into_response()
     })?;
 
     counter!("capture_ai_otel_requests_success").increment(1);

--- a/rust/capture/src/otel/mod.rs
+++ b/rust/capture/src/otel/mod.rs
@@ -124,12 +124,9 @@ pub async fn otel_handler(
     let restrictions = match &state.event_restriction_service {
         Some(service) => {
             let now_ts = state.timesource.current_time().timestamp();
-            match filtering::check_restrictions(service, &token, now_ts, &span_events).await {
-                Some(applied) => applied,
-                None => {
-                    return Err(non_retryable_rejection("event restricted"));
-                }
-            }
+            filtering::check_restrictions(service, &token, now_ts, &span_events)
+                .await
+                .map_err(|_| non_retryable_rejection("event restricted"))?
         }
         None => Default::default(),
     };

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -6,7 +6,11 @@ use axum_test_helper::TestClient;
 use capture::ai_s3::MockBlobStorage;
 use capture::api::CaptureError;
 use capture::config::CaptureMode;
-use capture::quota_limiters::CaptureQuotaLimiter;
+use capture::event_restrictions::{
+    EventRestrictionService, Restriction, RestrictionFilters, RestrictionManager, RestrictionScope,
+    RestrictionType,
+};
+use capture::quota_limiters::{is_llm_event, CaptureQuotaLimiter, EventInfo};
 use capture::router::router;
 use capture::sinks::Event;
 use capture::time::TimeSource;
@@ -15,12 +19,15 @@ use chrono::{DateTime, Utc};
 use common_redis::MockRedisClient;
 use health::HealthRegistry;
 use integration_utils::DEFAULT_TEST_TIME;
+use limiters::redis::{QuotaResource, QUOTA_LIMITER_CACHE_KEY};
 use limiters::token_dropper::TokenDropper;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use opentelemetry_proto::tonic::common::v1::{any_value, AnyValue, KeyValue};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
 use prost::Message;
+use serde_json::json;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -92,20 +99,44 @@ fn make_span(
     }
 }
 
+struct TestClientOptions {
+    redis: Option<Arc<MockRedisClient>>,
+    event_restriction_service: Option<EventRestrictionService>,
+    quota_limiter: Option<CaptureQuotaLimiter>,
+}
+
+impl Default for TestClientOptions {
+    fn default() -> Self {
+        Self {
+            redis: None,
+            event_restriction_service: None,
+            quota_limiter: None,
+        }
+    }
+}
+
 fn make_test_client(sink: &CapturingSink) -> TestClient {
+    make_test_client_with_options(sink, TestClientOptions::default())
+}
+
+fn make_test_client_with_options(sink: &CapturingSink, options: TestClientOptions) -> TestClient {
     let liveness = HealthRegistry::new("otel_test");
     let timesource = FixedTime {
         time: DateTime::parse_from_rfc3339(DEFAULT_TEST_TIME)
             .expect("Invalid fixed time format")
             .with_timezone(&Utc),
     };
-    let redis = Arc::new(MockRedisClient::new());
+    let redis = options
+        .redis
+        .unwrap_or_else(|| Arc::new(MockRedisClient::new()));
 
     let mut cfg = DEFAULT_CONFIG.clone();
     cfg.capture_mode = CaptureMode::Events;
 
-    let quota_limiter =
-        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
+    let quota_limiter = options.quota_limiter.unwrap_or_else(|| {
+        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7))
+            .add_scoped_limiter(QuotaResource::LLMEvents, is_llm_event)
+    });
 
     let app = router(
         timesource,
@@ -116,7 +147,7 @@ fn make_test_client(sink: &CapturingSink) -> TestClient {
         None, // global_rate_limiter_token
         quota_limiter,
         TokenDropper::default(),
-        None,  // event_restriction_service
+        options.event_restriction_service,
         false, // metrics
         CaptureMode::Events,
         String::from("capture-otel-test"),
@@ -156,14 +187,26 @@ async fn send_request(sink: &CapturingSink, request: &ExportTraceServiceRequest)
     resp.status().as_u16()
 }
 
+async fn send_request_with_client(client: &TestClient, request: &ExportTraceServiceRequest) -> u16 {
+    let body = request.encode_to_vec();
+
+    let resp = client
+        .post(ENDPOINT)
+        .header("Content-Type", "application/x-protobuf")
+        .header("Authorization", format!("Bearer {}", TOKEN))
+        .body(body)
+        .send()
+        .await;
+
+    resp.status().as_u16()
+}
+
 fn parse_event_data(event: &ProcessedEvent) -> serde_json::Value {
     serde_json::from_str(&event.event.data).expect("event data is valid JSON")
 }
 
-#[tokio::test]
-async fn test_single_span_produces_one_event() {
-    let sink = CapturingSink::new();
-    let request = ExportTraceServiceRequest {
+fn make_single_span_request() -> ExportTraceServiceRequest {
+    ExportTraceServiceRequest {
         resource_spans: vec![ResourceSpans {
             resource: Some(Resource {
                 attributes: vec![make_kv(
@@ -188,7 +231,62 @@ async fn test_single_span_produces_one_event() {
             }],
             schema_url: String::new(),
         }],
-    };
+    }
+}
+
+fn make_two_span_request() -> ExportTraceServiceRequest {
+    ExportTraceServiceRequest {
+        resource_spans: vec![ResourceSpans {
+            resource: Some(Resource {
+                attributes: vec![make_kv(
+                    "posthog.distinct_id",
+                    any_value::Value::StringValue("user-1".to_string()),
+                )],
+                dropped_attributes_count: 0,
+            }),
+            scope_spans: vec![ScopeSpans {
+                scope: None,
+                spans: vec![
+                    make_span(
+                        vec![1; 16],
+                        vec![1; 8],
+                        vec![],
+                        1_704_067_200_000_000_000,
+                        vec![make_kv(
+                            "gen_ai.operation.name",
+                            any_value::Value::StringValue("chat".to_string()),
+                        )],
+                    ),
+                    make_span(
+                        vec![1; 16],
+                        vec![2; 8],
+                        vec![1; 8],
+                        1_704_067_200_000_000_000,
+                        vec![make_kv(
+                            "gen_ai.operation.name",
+                            any_value::Value::StringValue("embeddings".to_string()),
+                        )],
+                    ),
+                ],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    }
+}
+
+async fn make_restriction_service(restrictions: Vec<Restriction>) -> EventRestrictionService {
+    let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+    let mut manager = RestrictionManager::new();
+    manager.restrictions.insert(TOKEN.to_string(), restrictions);
+    service.update(manager).await;
+    service
+}
+
+#[tokio::test]
+async fn test_single_span_produces_one_event() {
+    let sink = CapturingSink::new();
+    let request = make_single_span_request();
 
     let status = send_request(&sink, &request).await;
     assert_eq!(status, 200);
@@ -535,4 +633,316 @@ async fn test_too_many_spans_returns_400() {
         .await;
 
     assert_eq!(resp.status().as_u16(), 400);
+}
+
+// ----------------------------------------------------------------------------
+// Quota Limiter Tests
+// ----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_quota_limit_exceeded_returns_400_with_no_events() {
+    let llm_key = format!(
+        "{}{}",
+        QUOTA_LIMITER_CACHE_KEY,
+        QuotaResource::LLMEvents.as_str()
+    );
+    let redis =
+        Arc::new(MockRedisClient::new().zrangebyscore_ret(&llm_key, vec![TOKEN.to_string()]));
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            redis: Some(redis),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 400);
+
+    let events = sink.get_events().await;
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn test_global_quota_exceeded_retains_scoped_llm_events() {
+    // When the global quota is exceeded but the scoped LLM limiter is not, the
+    // CaptureQuotaLimiter retains LLM events. Since all OTel spans are $ai_*
+    // events, they all get retained — no partial drop occurs and the batch
+    // goes through normally.
+    let global_key = format!(
+        "{}{}",
+        QUOTA_LIMITER_CACHE_KEY,
+        QuotaResource::Events.as_str()
+    );
+    let redis =
+        Arc::new(MockRedisClient::new().zrangebyscore_ret(&global_key, vec![TOKEN.to_string()]));
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            redis: Some(redis),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+}
+
+#[tokio::test]
+async fn test_both_global_and_scoped_quota_exceeded_returns_400() {
+    let llm_key = format!(
+        "{}{}",
+        QUOTA_LIMITER_CACHE_KEY,
+        QuotaResource::LLMEvents.as_str()
+    );
+    let global_key = format!(
+        "{}{}",
+        QUOTA_LIMITER_CACHE_KEY,
+        QuotaResource::Events.as_str()
+    );
+    let redis = Arc::new(
+        MockRedisClient::new()
+            .zrangebyscore_ret(&llm_key, vec![TOKEN.to_string()])
+            .zrangebyscore_ret(&global_key, vec![TOKEN.to_string()]),
+    );
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            redis: Some(redis),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 400);
+
+    let events = sink.get_events().await;
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn test_partial_quota_drop_rejects_entire_batch() {
+    // Use a custom scoped limiter that only matches $ai_generation (not $ai_embedding).
+    // When this limiter is exceeded, $ai_generation spans are dropped but $ai_embedding
+    // spans are retained → partial drop → all-or-nothing rejection returns 400.
+    let exceptions_key = format!(
+        "{}{}",
+        QUOTA_LIMITER_CACHE_KEY,
+        QuotaResource::Exceptions.as_str()
+    );
+    let redis = Arc::new(
+        MockRedisClient::new().zrangebyscore_ret(&exceptions_key, vec![TOKEN.to_string()]),
+    );
+
+    let cfg = DEFAULT_CONFIG.clone();
+    let quota_limiter =
+        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7))
+            .add_scoped_limiter(QuotaResource::Exceptions, |info: EventInfo| {
+                info.name == "$ai_generation"
+            });
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            redis: Some(redis),
+            quota_limiter: Some(quota_limiter),
+            ..Default::default()
+        },
+    );
+
+    // Send two spans: one $ai_generation, one $ai_embedding
+    let request = make_two_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 400);
+
+    let events = sink.get_events().await;
+    assert!(events.is_empty());
+}
+
+// ----------------------------------------------------------------------------
+// Event Restriction Tests
+// ----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_drop_event_restriction_returns_400() {
+    let service = make_restriction_service(vec![Restriction {
+        restriction_type: RestrictionType::DropEvent,
+        scope: RestrictionScope::AllEvents,
+        args: None,
+    }])
+    .await;
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            event_restriction_service: Some(service),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 400);
+
+    let events = sink.get_events().await;
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn test_force_overflow_restriction_sets_flag() {
+    let service = make_restriction_service(vec![Restriction {
+        restriction_type: RestrictionType::ForceOverflow,
+        scope: RestrictionScope::AllEvents,
+        args: None,
+    }])
+    .await;
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            event_restriction_service: Some(service),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+    assert!(events[0].metadata.force_overflow);
+}
+
+#[tokio::test]
+async fn test_skip_person_processing_restriction_sets_flag() {
+    let service = make_restriction_service(vec![Restriction {
+        restriction_type: RestrictionType::SkipPersonProcessing,
+        scope: RestrictionScope::AllEvents,
+        args: None,
+    }])
+    .await;
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            event_restriction_service: Some(service),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+    assert!(events[0].metadata.skip_person_processing);
+}
+
+#[tokio::test]
+async fn test_redirect_to_dlq_restriction_sets_flag() {
+    let service = make_restriction_service(vec![Restriction {
+        restriction_type: RestrictionType::RedirectToDlq,
+        scope: RestrictionScope::AllEvents,
+        args: None,
+    }])
+    .await;
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            event_restriction_service: Some(service),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+    assert!(events[0].metadata.redirect_to_dlq);
+}
+
+#[tokio::test]
+async fn test_redirect_to_topic_restriction_sets_topic() {
+    let service = make_restriction_service(vec![Restriction {
+        restriction_type: RestrictionType::RedirectToTopic,
+        scope: RestrictionScope::AllEvents,
+        args: Some(json!({"topic": "custom_topic"})),
+    }])
+    .await;
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            event_restriction_service: Some(service),
+            ..Default::default()
+        },
+    );
+
+    let request = make_single_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].metadata.redirect_to_topic,
+        Some("custom_topic".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_filtered_drop_restriction_rejects_otel_batch() {
+    let mut event_names = HashSet::new();
+    event_names.insert("$ai_generation".to_string());
+
+    let service = make_restriction_service(vec![Restriction {
+        restriction_type: RestrictionType::DropEvent,
+        scope: RestrictionScope::Filtered(RestrictionFilters {
+            event_names,
+            ..Default::default()
+        }),
+        args: None,
+    }])
+    .await;
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            event_restriction_service: Some(service),
+            ..Default::default()
+        },
+    );
+
+    let request = make_two_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 400);
+
+    // The $ai_generation span matches the filtered drop restriction, so the
+    // entire batch is rejected (all-or-nothing semantics).
+    let events = sink.get_events().await;
+    assert!(events.is_empty());
 }

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -777,140 +777,80 @@ async fn test_partial_quota_drop_rejects_entire_batch() {
 // ----------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_drop_event_restriction_returns_400() {
-    let service = make_restriction_service(vec![Restriction {
-        restriction_type: RestrictionType::DropEvent,
-        scope: RestrictionScope::AllEvents,
-        args: None,
-    }])
-    .await;
+async fn test_restriction_types() {
+    struct Case {
+        name: &'static str,
+        restriction_type: RestrictionType,
+        args: Option<serde_json::Value>,
+        expected_status: u16,
+        check: fn(&[ProcessedEvent]) -> bool,
+    }
 
-    let sink = CapturingSink::new();
-    let client = make_test_client_with_options(
-        &sink,
-        TestClientOptions {
-            event_restriction_service: Some(service),
-            ..Default::default()
+    let cases = [
+        Case {
+            name: "drop",
+            restriction_type: RestrictionType::DropEvent,
+            args: None,
+            expected_status: 400,
+            check: |events| events.is_empty(),
         },
-    );
-
-    let request = make_single_span_request();
-    let status = send_request_with_client(&client, &request).await;
-    assert_eq!(status, 400);
-
-    let events = sink.get_events().await;
-    assert!(events.is_empty());
-}
-
-#[tokio::test]
-async fn test_force_overflow_restriction_sets_flag() {
-    let service = make_restriction_service(vec![Restriction {
-        restriction_type: RestrictionType::ForceOverflow,
-        scope: RestrictionScope::AllEvents,
-        args: None,
-    }])
-    .await;
-
-    let sink = CapturingSink::new();
-    let client = make_test_client_with_options(
-        &sink,
-        TestClientOptions {
-            event_restriction_service: Some(service),
-            ..Default::default()
+        Case {
+            name: "force_overflow",
+            restriction_type: RestrictionType::ForceOverflow,
+            args: None,
+            expected_status: 200,
+            check: |events| events.len() == 1 && events[0].metadata.force_overflow,
         },
-    );
-
-    let request = make_single_span_request();
-    let status = send_request_with_client(&client, &request).await;
-    assert_eq!(status, 200);
-
-    let events = sink.get_events().await;
-    assert_eq!(events.len(), 1);
-    assert!(events[0].metadata.force_overflow);
-}
-
-#[tokio::test]
-async fn test_skip_person_processing_restriction_sets_flag() {
-    let service = make_restriction_service(vec![Restriction {
-        restriction_type: RestrictionType::SkipPersonProcessing,
-        scope: RestrictionScope::AllEvents,
-        args: None,
-    }])
-    .await;
-
-    let sink = CapturingSink::new();
-    let client = make_test_client_with_options(
-        &sink,
-        TestClientOptions {
-            event_restriction_service: Some(service),
-            ..Default::default()
+        Case {
+            name: "skip_person_processing",
+            restriction_type: RestrictionType::SkipPersonProcessing,
+            args: None,
+            expected_status: 200,
+            check: |events| events.len() == 1 && events[0].metadata.skip_person_processing,
         },
-    );
-
-    let request = make_single_span_request();
-    let status = send_request_with_client(&client, &request).await;
-    assert_eq!(status, 200);
-
-    let events = sink.get_events().await;
-    assert_eq!(events.len(), 1);
-    assert!(events[0].metadata.skip_person_processing);
-}
-
-#[tokio::test]
-async fn test_redirect_to_dlq_restriction_sets_flag() {
-    let service = make_restriction_service(vec![Restriction {
-        restriction_type: RestrictionType::RedirectToDlq,
-        scope: RestrictionScope::AllEvents,
-        args: None,
-    }])
-    .await;
-
-    let sink = CapturingSink::new();
-    let client = make_test_client_with_options(
-        &sink,
-        TestClientOptions {
-            event_restriction_service: Some(service),
-            ..Default::default()
+        Case {
+            name: "redirect_to_dlq",
+            restriction_type: RestrictionType::RedirectToDlq,
+            args: None,
+            expected_status: 200,
+            check: |events| events.len() == 1 && events[0].metadata.redirect_to_dlq,
         },
-    );
-
-    let request = make_single_span_request();
-    let status = send_request_with_client(&client, &request).await;
-    assert_eq!(status, 200);
-
-    let events = sink.get_events().await;
-    assert_eq!(events.len(), 1);
-    assert!(events[0].metadata.redirect_to_dlq);
-}
-
-#[tokio::test]
-async fn test_redirect_to_topic_restriction_sets_topic() {
-    let service = make_restriction_service(vec![Restriction {
-        restriction_type: RestrictionType::RedirectToTopic,
-        scope: RestrictionScope::AllEvents,
-        args: Some(json!({"topic": "custom_topic"})),
-    }])
-    .await;
-
-    let sink = CapturingSink::new();
-    let client = make_test_client_with_options(
-        &sink,
-        TestClientOptions {
-            event_restriction_service: Some(service),
-            ..Default::default()
+        Case {
+            name: "redirect_to_topic",
+            restriction_type: RestrictionType::RedirectToTopic,
+            args: Some(json!({"topic": "custom_topic"})),
+            expected_status: 200,
+            check: |events| {
+                events.len() == 1
+                    && events[0].metadata.redirect_to_topic == Some("custom_topic".to_string())
+            },
         },
-    );
+    ];
 
-    let request = make_single_span_request();
-    let status = send_request_with_client(&client, &request).await;
-    assert_eq!(status, 200);
+    for case in &cases {
+        let service = make_restriction_service(vec![Restriction {
+            restriction_type: case.restriction_type,
+            scope: RestrictionScope::AllEvents,
+            args: case.args.clone(),
+        }])
+        .await;
 
-    let events = sink.get_events().await;
-    assert_eq!(events.len(), 1);
-    assert_eq!(
-        events[0].metadata.redirect_to_topic,
-        Some("custom_topic".to_string())
-    );
+        let sink = CapturingSink::new();
+        let client = make_test_client_with_options(
+            &sink,
+            TestClientOptions {
+                event_restriction_service: Some(service),
+                ..Default::default()
+            },
+        );
+
+        let request = make_single_span_request();
+        let status = send_request_with_client(&client, &request).await;
+        assert_eq!(status, case.expected_status, "failed for: {}", case.name);
+
+        let events = sink.get_events().await;
+        assert!((case.check)(&events), "check failed for: {}", case.name);
+    }
 }
 
 #[tokio::test]

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -99,20 +99,11 @@ fn make_span(
     }
 }
 
+#[derive(Default)]
 struct TestClientOptions {
     redis: Option<Arc<MockRedisClient>>,
     event_restriction_service: Option<EventRestrictionService>,
     quota_limiter: Option<CaptureQuotaLimiter>,
-}
-
-impl Default for TestClientOptions {
-    fn default() -> Self {
-        Self {
-            redis: None,
-            event_restriction_service: None,
-            quota_limiter: None,
-        }
-    }
 }
 
 fn make_test_client(sink: &CapturingSink) -> TestClient {


### PR DESCRIPTION
## Problem

The OTel ingestion endpoint bypasses quota limiting and event restrictions that the main capture handler enforces. This means teams over their LLM event quota or with active event restrictions can still ingest data through the OTel path.

## Changes

- Add quota limiting with all-or-nothing batch semantics — if any span would be dropped by the quota limiter, the entire request is rejected with a non-retryable 400 (per OTLP spec, only 429/502/503/504 are retryable)
- Add event restriction checks with the same all-or-nothing semantics — non-drop flags (force_overflow, skip_person_processing, etc.) are OR’d across all spans and applied uniformly
- Extract quota/restriction/event-building logic into `filtering.rs` to keep the handler lean
- Add `AppliedRestrictions::merge()` for combining non-drop restriction flags across spans
- Register the scoped LLM quota limiter in test setup (was missing)

## How did you test this code?

Integration tests covering:
- LLM quota exceeded → 400, no events produced
- Global quota exceeded with scoped LLM limiter retaining events → 200
- Both quotas exceeded → 400
- Partial quota drop (one span type filtered) → entire batch rejected
- Each restriction type (drop, force_overflow, skip_person_processing, redirect_to_dlq, redirect_to_topic)
- Filtered drop restriction on a multi-span batch → entire batch rejected

## Publish to changelog?

No

## Docs update

No docs changes needed.