### PR TITLE
fix: Improve unsubscribe preferences page UX and copy

### DIFF
--- a/posthog/templates/message_preferences/one_click_unsubscribe_success.html
+++ b/posthog/templates/message_preferences/one_click_unsubscribe_success.html
@@ -9,13 +9,12 @@
     <body>
         {% block content %}
         <div class="min-h-screen bg-gray-50">
-            <div class="max-w-lg mx-auto py-12 px-4 sm:px-6 lg:px-8">
+            <div class="max-w-2xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
                 <div class="bg-white shadow-xl rounded-xl p-8">
-                    <h1 class="text-3xl font-bold text-gray-900 mb-2">Successfully unsubscribed</h1>
-                    <p class="text-gray-600 text-lg mb-8"><span class="font-semibold">{{ recipient.identifier|escape }}</span> has been unsubscribed from all marketing emails.</p>
-                    <p class="text-gray-600 text-lg mb-8">
-                        To manage message preferences, please visit the
-                        <a class="text-blue-600 hover:underline" href="{{ request.path }}">message preferences page</a>.
+                    <h1 class="text-2xl font-bold text-gray-900 mb-2">Successfully unsubscribed</h1>
+                    <p class="text-gray-600 text-base mb-8"><span class="font-semibold">{{ recipient.identifier|escape }}</span> has been unsubscribed from all marketing emails.</p>
+                    <p class="text-gray-600 text-base">
+                        Want to stay subscribed to some emails? <a class="text-blue-600 hover:underline" href="{{ request.path }}">Manage your preferences</a>.
                     </p>
                 </div>
             </div>

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -9,10 +9,10 @@
     <body>
         {% block content %}
         <div class="min-h-screen bg-gray-50">
-            <div class="max-w-lg mx-auto py-12 px-4 sm:px-6 lg:px-8">
-                <div class="bg-white shadow-xl rounded-xl p-8">
-                    <h1 class="text-3xl font-bold text-gray-900 mb-2">Message Preferences</h1>
-                    <p class="text-gray-600 text-lg mb-8">Manage message preferences for {{ recipient.identifier }}</p>
+            <div class="max-w-2xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+                <div class="bg-white shadow-xl rounded-xl p-8 mb-12">
+                    <h1 class="text-2xl font-bold text-gray-900 mb-2">Message preferences for {{ recipient.identifier|escape }}</h1>
+                    <p class="text-gray-600 text-base mb-8">Choose which emails you'd like to receive. Changes are only applied when you click Save preferences.</p>
 
                     <form id="preferences-form" class="space-y-6">
                         {% csrf_token %}
@@ -25,30 +25,40 @@
                                     <h3 class="text-lg font-medium text-gray-900">{{ category.name }}</h3>
                                     <p class="text-sm text-gray-500 mt-1">{{ category.description }}</p>
                                 </div>
-                                <div class="relative inline-block w-12 flex-shrink-0 align-top select-none">
-                                    <input
-                                        type="checkbox"
-                                        name="{{ category.id }}"
-                                        id="{{ category.id }}"
-                                        {% if category.status != "OPTED_OUT" %}checked{% endif %}
-                                        class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer transition-transform duration-200 ease-in-out checked:translate-x-full checked:bg-blue-500"
-                                    />
-                                    <label
-                                        for="{{ category.id }}"
-                                        class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"
-                                    ></label>
+                                <div class="flex flex-col items-end flex-shrink-0 w-40">
+                                    <div class="relative inline-block w-12 select-none">
+                                        <input
+                                            type="checkbox"
+                                            name="{{ category.id }}"
+                                            id="{{ category.id }}"
+                                            {% if category.status != "OPTED_OUT" %}checked{% endif %}
+                                            class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer transition-transform duration-200 ease-in-out checked:translate-x-full checked:bg-blue-500"
+                                        />
+                                        <label
+                                            for="{{ category.id }}"
+                                            class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"
+                                        ></label>
+                                    </div>
+                                    <span class="text-xs font-medium mt-1 text-right {% if category.status != 'OPTED_OUT' %}text-green-700{% else %}text-gray-500{% endif %}" data-status-for="{{ category.id }}">
+                                        {% if category.status != "OPTED_OUT" %}Subscribed{% else %}Not subscribed{% endif %}
+                                    </span>
                                 </div>
                             </div>
                         </div>
                         {% endfor %}
 
-                        <div class="mt-8">
+                        <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
+                            <div class="max-w-2xl mx-auto p-4">
+                            <p id="unsaved-hint" class="hidden text-sm text-amber-600 font-medium mb-2 text-center">You have unsaved changes</p>
                             <button
+                                id="save-btn"
                                 type="submit"
-                                class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out"
+                                disabled
+                                class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-default transition duration-150 ease-in-out"
                             >
                                 Save preferences
                             </button>
+                            </div>
                         </div>
                     </form>
 
@@ -77,6 +87,18 @@
                         setTimeout(() => {
                             card.style.transform = 'scale(1)'
                         }, 200)
+
+                        // Update status label
+                        const statusLabel = document.querySelector('[data-status-for="' + this.name + '"]')
+                        if (statusLabel) {
+                            statusLabel.textContent = this.checked ? 'Subscribed' : 'Not subscribed'
+                            statusLabel.className = 'text-xs font-medium mt-1 text-right ' + (this.checked ? 'text-green-700' : 'text-gray-500')
+                        }
+
+                        // Show/hide unsaved hint and enable/disable save button
+                        const anyChanged = Array.from(toggles).some(t => t.checked !== t.defaultChecked)
+                        document.getElementById('unsaved-hint').classList.toggle('hidden', !anyChanged)
+                        document.getElementById('save-btn').disabled = !anyChanged
                     })
                 })
 
@@ -106,6 +128,11 @@
                         if (data.error) {
                             throw new Error(data.error)
                         }
+
+                        // Update defaultChecked so toggles reflect the saved state
+                        toggles.forEach(t => t.defaultChecked = t.checked)
+                        document.getElementById('unsaved-hint').classList.add('hidden')
+                        document.getElementById('save-btn').disabled = true
 
                         // Enhanced success message
                         const successMsg = document.createElement('div')

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -197,7 +197,7 @@
                             errorMsg.style.transform = 'translateX(100%)'
                             setTimeout(() => errorMsg.remove(), 500)
                         }, 2500)
-                    } finally {
+
                         submitButton.disabled = false
                     }
                 })

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -80,6 +80,19 @@
                 const form = document.getElementById('preferences-form')
                 const toggles = document.querySelectorAll('.toggle-checkbox')
 
+                function updateStatusLabel(toggle) {
+                    const statusLabel = document.querySelector('[data-status-for="' + toggle.name + '"]')
+                    if (!statusLabel) return
+                    const isChanged = toggle.checked !== toggle.defaultChecked
+                    if (isChanged) {
+                        statusLabel.textContent = toggle.checked ? 'Will subscribe' : 'Will unsubscribe'
+                        statusLabel.className = 'text-xs font-medium mt-1 text-right text-amber-600'
+                    } else {
+                        statusLabel.textContent = toggle.checked ? 'Subscribed' : 'Not subscribed'
+                        statusLabel.className = 'text-xs font-medium mt-1 text-right ' + (toggle.checked ? 'text-green-700' : 'text-gray-500')
+                    }
+                }
+
                 toggles.forEach((toggle) => {
                     toggle.addEventListener('change', function () {
                         const card = this.closest('.bg-gray-50')
@@ -88,12 +101,8 @@
                             card.style.transform = 'scale(1)'
                         }, 200)
 
-                        // Update status label
-                        const statusLabel = document.querySelector('[data-status-for="' + this.name + '"]')
-                        if (statusLabel) {
-                            statusLabel.textContent = this.checked ? 'Subscribed' : 'Not subscribed'
-                            statusLabel.className = 'text-xs font-medium mt-1 text-right ' + (this.checked ? 'text-green-700' : 'text-gray-500')
-                        }
+                        // Update status label: show pending state if changed, saved state if reverted
+                        updateStatusLabel(this)
 
                         // Show/hide unsaved hint and enable/disable save button
                         const anyChanged = Array.from(toggles).some(t => t.checked !== t.defaultChecked)
@@ -129,8 +138,11 @@
                             throw new Error(data.error)
                         }
 
-                        // Update defaultChecked so toggles reflect the saved state
-                        toggles.forEach(t => t.defaultChecked = t.checked)
+                        // Update saved state and resolve all labels
+                        toggles.forEach(t => {
+                            t.defaultChecked = t.checked
+                            updateStatusLabel(t)
+                        })
                         document.getElementById('unsaved-hint').classList.add('hidden')
                         document.getElementById('save-btn').disabled = true
 


### PR DESCRIPTION
## Problem

Customer feedback reported confusion on the email unsubscribe/message preferences page:
- Unclear whether they're currently subscribed or not
- Unclear whether toggling immediately unsubscribes or requires clicking Save
- Unclear whether opening the page already unsubscribed them

## Changes

| | Before | After |
|---|---|---|
| **No changes made** | <img width="1366" height="1053" alt="messaging-preferences-before-unchanged" src="https://github.com/user-attachments/assets/2fd1be72-b626-40d8-b532-7f886a4dc980" /> | <img width="1366" height="1050" alt="messaging-preferences-after-unchanged" src="https://github.com/user-attachments/assets/307eb275-056c-460d-bc57-56f2901c1e16" /> |
| **After toggling** | <img width="1367" height="1021" alt="messaging-preferences-before-changed" src="https://github.com/user-attachments/assets/ed7a25d1-2ec6-49b3-ae60-077b517be779" /> | <img width="1352" height="1050" alt="Screenshot 2026-03-15 at 22 21 51" src="https://github.com/user-attachments/assets/ae37a1f7-9107-46e0-9736-1ca3a9c47642" /> |

- **Subscription status labels**: Each toggle now shows "Subscribed" (green) or "Not subscribed" (gray) underneath
- **Clearer copy**: Heading includes the email address and subtitle explicitly says "Changes are only applied when you click Save preferences"
- **Save button disabled until changes**: Prevents confusion about whether opening the page changed anything
- **"You have unsaved changes" hint**: Appears above the save button when toggles differ from saved state
- **Sticky save button**: Always visible, especially important on mobile
- **Post-save reset**: After successful save, unsaved hint hides and button disables; `defaultChecked` is updated so further toggles are tracked correctly
- **Unsubscribe success page**: Updated copy to encourage selective re-subscription ("Want to stay subscribed to some emails?"), consistent container width and font sizing
- **Wider container**: `max-w-lg` → `max-w-2xl` for better readability on both pages
- **XSS fix**: Added `|escape` to `recipient.identifier` in the heading of preferences as well

## How did you test this code?

1. Set up an email workflow with `{{ unsubscribe_url }}` and `{{ unsubscribe_url_one_click }}` links
2. Sent a test email to a test recipient
3. Opened the manage preferences link - verified status labels, disabled save button on load
4. Toggled categories - verified labels update, unsaved hint appears, save button enables
5. Saved changes - verified success toast, hint disappears, button disables, preferences persist on refresh
6. Clicked the one-click unsubscribe link - verified success page with updated copy
7. Clicked "Manage your preferences" - verified all toggles are off, re-subscribed and saved successfully
8. Verified sticky save button on mobile viewport

## Publish to changelog?

No