### PR TITLE
fix: hide override text when no categories exist

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -525,6 +525,12 @@ def preferences_page(request: HttpRequest, token: str) -> HttpResponse:
         for cat in categories
     ]
 
+    all_marketing_description = (
+        "Unsubscribing here overrides individual preferences."
+        if categories_templating
+        else ""
+    )
+
     context = {
         "recipient": recipient,
         "categories": [
@@ -532,8 +538,7 @@ def preferences_page(request: HttpRequest, token: str) -> HttpResponse:
             {
                 "id": ALL_MESSAGE_PREFERENCE_CATEGORY_ID,
                 "name": "All marketing communications",
-                "description": "Unsubscribing here overrides individual preferences."                if categories_templating
-                                else "",
+                "description": all_marketing_description,
                 "status": preferences.get(ALL_MESSAGE_PREFERENCE_CATEGORY_ID, PreferenceStatus.NO_PREFERENCE),
             },
         ],

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -532,7 +532,8 @@ def preferences_page(request: HttpRequest, token: str) -> HttpResponse:
             {
                 "id": ALL_MESSAGE_PREFERENCE_CATEGORY_ID,
                 "name": "All marketing communications",
-                "description": "Unsubscribing here overrides individual preferences.",
+                "description": "Unsubscribing here overrides individual preferences."                if categories_templating
+                                else "",
                 "status": preferences.get(ALL_MESSAGE_PREFERENCE_CATEGORY_ID, PreferenceStatus.NO_PREFERENCE),
             },
         ],


### PR DESCRIPTION
## Problem

The "All marketing communications" category always shows the description "Unsubscribing here overrides individual preferences." - even when there are no individual marketing categories configured. This is misleading because there are no individual preferences to override.

Closes #50985

## Changes

Made the description conditional on `categories_templating` being non-empty. When there are no categories, the description is set to an empty string instead.

## How did you test this code?

Verified the conditional logic: when `categories_templating` is an empty list (falsy), the `else` branch returns `""`. When categories exist (truthy list), the original description string is used.