### PR TITLE
fix: mobile replay shows black screen

### DIFF
--- a/common/replay-shared/src/snapshot-store/SnapshotStore.ts
+++ b/common/replay-shared/src/snapshot-store/SnapshotStore.ts
@@ -139,7 +139,14 @@ export class SnapshotStore {
 
         const fullSnapshotInfo = this.findNearestFullSnapshot(ts)
         if (!fullSnapshotInfo) {
-            return false
+            const anyLoadedHasFullSnapshots = this.entries.some(
+                (e) => e.state === 'loaded' && e.fullSnapshotTimestamps.length > 0
+            )
+            if (anyLoadedHasFullSnapshots) {
+                return false
+            }
+            const targetIndex = this.getSourceIndexForTimestamp(ts)
+            return this.entries[targetIndex]?.state === 'loaded'
         }
 
         const targetIndex = this.getSourceIndexForTimestamp(ts)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Mobile session recordings show a black screen during playback. `SnapshotStore.canPlayAt()` requires a full snapshot before allowing events to be fed to rrweb, but mobile recordings don't have full snapshots in the raw data — they're synthesized during processing. This causes `isWaitingForPlayableFullSnapshot` to stay true and `syncSnapshotsWithPlayer` to return early, so the replayer iframe never receives events.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

When `canPlayAt()` finds no full snapshot, it now checks whether any loaded source has full snapshots at all. If none do (mobile recording), it falls back to checking if the source for that timestamp is loaded.


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
