### PR TITLE
feat: add "Your subscription preferences" header to preferences page

### DIFF
--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -19,7 +19,7 @@
                         <input type="hidden" name="token" value="{{ token }}" />
 
 
-                                                <h2 class="text-xl font-semibold text-gray-800">Your active subscriptions:</h2>
+                        <h2 class="text-xl font-semibold text-gray-800">Your subscription preferences:</h2>
                         {% for category in categories %}
                         <div class="bg-gray-50 rounded-lg p-6 transition-all duration-200 hover:shadow-md">
                             <div class="flex items-start justify-between gap-4">

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -18,6 +18,8 @@
                         {% csrf_token %}
                         <input type="hidden" name="token" value="{{ token }}" />
 
+
+                                                <h2 class="text-xl font-semibold text-gray-800">Your active subscriptions:</h2>
                         {% for category in categories %}
                         <div class="bg-gray-50 rounded-lg p-6 transition-all duration-200 hover:shadow-md">
                             <div class="flex items-start justify-between gap-4">

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -17,8 +17,6 @@
                     <form id="preferences-form" class="space-y-6">
                         {% csrf_token %}
                         <input type="hidden" name="token" value="{{ token }}" />
-
-
                         <h2 class="text-xl font-semibold text-gray-800">Your subscription preferences:</h2>
                         {% for category in categories %}
                         <div class="bg-gray-50 rounded-lg p-6 transition-all duration-200 hover:shadow-md">


### PR DESCRIPTION
## Problem

The unsubscribe/preferences page lacks clear labeling for the subscription category toggles. Users can overlook or misunderstand what the toggles represent.

Closes #50986

## Changes

Added a "Your subscription preferences:" heading (`<h2>`) above the list of subscription category toggles in the preferences template. Uses existing Tailwind classes consistent with the page's styling.

## How did you test this code?

Verified the HTML structure renders correctly. The `<h2>` element is placed between the hidden form inputs and the category loop, providing immediate context before users interact with the toggles.