### PR TITLE
fix(error-tracking): fix rule index initialization in addRule listener

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/rulesLogic.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/rulesLogic.tsx
@@ -120,7 +120,7 @@ export const rulesLogic = kea<rulesLogicType>([
 
     listeners(({ props, values, actions }) => ({
         addRule: () => {
-            actions._setLocalRules([...values.localRules, createNewRule(props.ruleType, values.rules.length)])
+            actions._setLocalRules([...values.localRules, createNewRule(props.ruleType, -1)])
         },
         saveRuleSuccess: ({ payload: id }) => {
             const localRules = [...values.localRules]


### PR DESCRIPTION
## Problem

When adding a new rule, the rule index was being set to `values.rules.length`, which could cause incorrect indexing behavior. The rule should be initialized with an index of `-1` to indicate it's a new unsaved rule.

## Changes

Changed the `addRule` listener in `rulesLogic.tsx` to pass `-1` as the rule index when creating a new rule, instead of using `values.rules.length`.

## How did you test this code?

This is a straightforward logic fix. The change ensures new rules are properly initialized with the correct sentinel value (`-1`) for unsaved rules, which should be validated by existing unit tests for the rules logic.

https://claude.ai/code/session_015AjjkWjfWAqKM5Q4P64ssy