### PR TITLE
fix(devex): pr-approval-agent tuning and label retention

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -230,5 +230,6 @@ AGENTS.md @PostHog/team-devex
 .claude/agents/ingestion/ @PostHog/team-ingestion
 .agents/skills/ingestion-*/ @PostHog/team-ingestion
 .claude/skills/ingestion-*/ @PostHog/team-ingestion
+tools/pr-approval-agent/ @PostHog/team-devex
 greptile.json @PostHog/team-devex
 docs/published/developing-locally.md @PostHog/team-devex

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -91,8 +91,8 @@ jobs:
                     --body "Review agent failed — check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-apply the label to retry." \
                     --repo ${{ github.repository }}
 
-            - name: Remove label
-              if: always()
+            - name: Remove label on failure
+              if: failure()
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -62,43 +62,34 @@ jobs:
                     --output-json /tmp/review.json
 
             - name: Post review
-              if: success()
+              if: always()
               env:
                   # Use GITHUB_TOKEN for approvals so github-actions[bot] is the
                   # reviewer — its approvals count toward branch protection rules,
                   # unlike GitHub App bot approvals which show author_association NONE.
                   GH_TOKEN_APPROVE: ${{ github.token }}
-                  GH_TOKEN_COMMENT: ${{ steps.app-token.outputs.token }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
-                  VERDICT=$(jq -r '.final_verdict' /tmp/review.json)
-                  REASONING=$(jq -r '.reviewer.reasoning // "No reasoning provided"' /tmp/review.json)
                   PR=${{ github.event.pull_request.number }}
+                  VERDICT=$(jq -r '.final_verdict // ""' /tmp/review.json 2>/dev/null || echo "")
+                  REASONING=$(jq -r '.reviewer.reasoning // ""' /tmp/review.json 2>/dev/null || echo "")
 
                   if [ "$VERDICT" = "APPROVED" ]; then
                     GH_TOKEN="$GH_TOKEN_APPROVE" gh pr review "$PR" --approve --body "$REASONING" \
                       --repo ${{ github.repository }}
+                  elif [ -n "$REASONING" ]; then
+                    gh pr review "$PR" --comment --body "$REASONING" \
+                      --repo ${{ github.repository }}
                   else
-                    GH_TOKEN="$GH_TOKEN_COMMENT" gh pr review "$PR" --comment --body "$REASONING" \
+                    gh pr comment "$PR" \
+                      --body "Review agent failed — check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-apply the label to retry." \
                       --repo ${{ github.repository }}
                   fi
 
-            - name: Post failure notice
-              if: failure()
-              env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
-              run: |
-                  gh pr comment "${{ github.event.pull_request.number }}" \
-                    --body "Review agent failed — check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-apply the label to retry." \
-                    --repo ${{ github.repository }}
-
-            - name: Remove label on failure
-              if: failure()
-              env:
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
-              run: |
-                  gh pr edit "${{ github.event.pull_request.number }}" \
-                    --remove-label stamphog \
-                    --repo ${{ github.repository }}
+                  if [ "$VERDICT" != "APPROVED" ]; then
+                    gh pr edit "$PR" --remove-label stamphog \
+                      --repo ${{ github.repository }}
+                  fi
 
             - name: Upload evidence
               if: always()

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -7,9 +7,8 @@ Deterministic safety gates first, then Claude reviews for showstoppers.
 
 Add the `stamphog` label to a non-draft PR.
 The GitHub Action runs the agent and posts an approval or comment.
-The label is auto-removed after the run so it can be re-applied.
-
-Only org members (`MEMBER`/`OWNER` association) can trigger reviews.
+On approval the label stays so it's visible which PRs were stamphog'd.
+On failure the label is removed so it can be re-applied.
 
 ### Local testing
 
@@ -39,7 +38,6 @@ Uses PEP 723 inline metadata so `uv run` handles dependencies automatically.
 Prerequisites (hard gate)
   - Not draft, no merge conflicts
   - No outstanding "changes requested" reviews
-  - No failed CI checks
   │
   ▼
 Deny-list (hard gate)

--- a/tools/pr-approval-agent/github.py
+++ b/tools/pr-approval-agent/github.py
@@ -153,6 +153,7 @@ def fetch_pr(pr_number: int, repo: str, repo_root: Path | None = None) -> PRData
             }
             for r in reviews_raw
             if r.get("author_association") in ("MEMBER", "OWNER", "COLLABORATOR", "BOT")
+            or r.get("user", {}).get("type") == "Bot"
         ],
         review_comments=[
             {
@@ -164,6 +165,7 @@ def fetch_pr(pr_number: int, repo: str, repo_root: Path | None = None) -> PRData
             }
             for c in comments_raw
             if c.get("author_association") in ("MEMBER", "OWNER", "COLLABORATOR", "BOT")
+            or c.get("user", {}).get("type") == "Bot"
         ],
         check_runs=check_runs_resp.get("check_runs", []),
     )

--- a/tools/pr-approval-agent/review_pr.py
+++ b/tools/pr-approval-agent/review_pr.py
@@ -228,13 +228,8 @@ class Pipeline:
         if changes_requested:
             issues.append(f"changes requested by: {', '.join(changes_requested)}")
 
-        failed = [
-            c["name"]
-            for c in pr.check_runs
-            if c.get("conclusion") in ("failure", "cancelled", "timed_out") and c.get("status") == "completed"
-        ]
-        if failed:
-            issues.append(f"failed CI: {', '.join(failed[:5])}")
+        # CI failures are not a hard gate — CI is its own gate and the
+        # agent is often triggered before all checks finish.
 
         if issues:
             return False, "; ".join(issues)

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -122,9 +122,9 @@ REVIEWER_SYSTEM = textwrap.dedent(
       - ESCALATE: behavioral changes to business logic, API contracts, data models
 
     Review comments (inline feedback only, approval states are hidden):
-    - If there are ZERO review comments, ESCALATE — the author should
-      request reviews (Codex, Claude, Copilot, Greptile, or a human)
-      before requesting stamphog approval
+    - If there are ZERO reviews (no inline comments AND no top-level
+      reviews), ESCALATE — the author should request reviews (Codex,
+      Claude, Copilot, Greptile, or a human) before requesting stamphog
     - Substantive comments unresolved by the current diff → REFUSE
     - Bot comments with valid concerns that were ignored → ESCALATE
 
@@ -242,6 +242,16 @@ class Reviewer:
         safe_title = _sanitize_untrusted(pr.title, max_len=200)
         safe_author = _sanitize_untrusted(pr.author, max_len=50)
 
+        reviews_text = ""
+        if pr.reviews:
+            lines = []
+            for r in pr.reviews:
+                safe_user = _sanitize_untrusted(r["user"], max_len=50)
+                safe_body = _sanitize_untrusted(r.get("body", ""), max_len=500)
+                body_part = f": {safe_body}" if safe_body else ""
+                lines.append(f"  - @{safe_user} [{r['state']}]{body_part}")
+            reviews_text = "\n".join(lines)
+
         review_comments = ""
         if pr.review_comments:
             lines = []
@@ -279,6 +289,7 @@ class Reviewer:
             Size: {pr.lines_total} lines ({pr.lines_added}+/{pr.lines_deleted}-), {len(pr.files)} files
             Scope: {cl["breadth"]}
             Commit type: {cl.get("commit_type") or "unknown"}
+            Reviews: {len(pr.reviews)} top-level, {len(pr.review_comments)} inline
 
             {ownership}
 
@@ -297,7 +308,10 @@ class Reviewer:
             Changed files:
             {file_list}
 
-            Review comments:
+            Reviews:
+            {reviews_text}
+
+            Inline comments:
             {review_comments}
             --- END UNTRUSTED CONTENT ---
         """)

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -151,6 +151,15 @@ REVIEWER_SYSTEM = textwrap.dedent(
     - "Touches shared query builder — needs team review."
     - "Gates denied: touches CI workflows and migration files."
 
+    When you REFUSE or ESCALATE, tell the author what to do next so they
+    can address the concern and re-request. Be specific and practical.
+    Examples:
+    - "Get a review from a team member on [team] before re-requesting."
+    - "Address the unresolved comment on line X of file Y."
+    - "This PR touches billing code — request a human review instead."
+    - "Request a review from Codex, Claude, or a teammate first."
+    Do NOT suggest splitting PRs or restructuring to avoid gates.
+
     Your output is constrained to a JSON schema with verdict, reasoning,
     risk, and issues fields. Fill them according to the rules above.
     """

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -122,6 +122,9 @@ REVIEWER_SYSTEM = textwrap.dedent(
       - ESCALATE: behavioral changes to business logic, API contracts, data models
 
     Review comments (inline feedback only, approval states are hidden):
+    - If there are ZERO review comments, ESCALATE — the author should
+      request reviews (Codex, Claude, Copilot, Greptile, or a human)
+      before requesting stamphog approval
     - Substantive comments unresolved by the current diff → REFUSE
     - Bot comments with valid concerns that were ignored → ESCALATE
 
@@ -138,11 +141,15 @@ REVIEWER_SYSTEM = textwrap.dedent(
     - ESCALATE: not confident, or needs domain expertise
     When in doubt, ESCALATE rather than APPROVE.
 
-    IMPORTANT: The "reasoning" field is 1 sentence — your judgment call, not a
-    code review. Do NOT describe what the code does. Examples:
+    IMPORTANT: The "reasoning" field is 1-2 sentences — your judgment call, not a
+    code review. Do NOT describe what the code does. Do NOT mention internal
+    gate codes (T0, T1, T2, etc.). When gates denied the PR, explain the
+    reason in plain language so the author understands without checking logs.
+    Examples:
     - "No showstoppers, low-risk frontend fix."
     - "Missing tests for new error handling path."
     - "Touches shared query builder — needs team review."
+    - "Gates denied: touches CI workflows and migration files."
 
     Your output is constrained to a JSON schema with verdict, reasoning,
     risk, and issues fields. Fill them according to the rules above.
@@ -165,15 +172,21 @@ class Reviewer:
         diff_path = self._write_diff_file(pr)
         prompt = self._build_review_prompt(pr, classification, gate_context, diff_path)
 
+        # Gate denials and trivial PRs don't need deep exploration —
+        # just read the diff and produce a verdict.
+        quick = gate_context["gate_verdict"] == "DENIED" or classification.get("t1_subclass") == "T1a-trivial"
+
         options = ClaudeAgentOptions(
             system_prompt=REVIEWER_SYSTEM,
             allowed_tools=["Read", "Grep", "Glob"],
             disallowed_tools=["Write", "Edit", "NotebookEdit", "Bash", "Agent", "WebFetch", "WebSearch"],
             cwd=str(self.repo_root),
-            max_turns=20,
+            max_turns=3 if quick else 20,
             model=MODEL,
             permission_mode="dontAsk",
             output_format=VERDICT_SCHEMA,
+            effort="low" if quick else "high",
+            extra_args={"no-session-persistence": None},
         )
 
         structured_output = None


### PR DESCRIPTION
**CI no longer blocks.** Failing checks are not a hard gate anymore — CI is its own gate and the agent is often triggered before checks finish.

**Zero reviews → escalate.** If there are no review comments at all, the agent escalates. Authors should request reviews (Codex, Claude, Copilot, Greptile, or human) before stamphog.

**Faster on obvious cases.** Gate denials and T1a-trivial PRs use low effort + 3 max turns instead of the full 20-turn deep exploration.

**Label stays on approval.** Only removed on failure. Branch protection's "dismiss stale reviews on push" handles revocation for free.

**Misc.** Disable session persistence, plain-language denial reasons (no internal gate codes), CODEOWNERS-soft for team-devex.