### PR TITLE
chore: Add ClickHouse kill switch in Temporal Health Check Framework

### DIFF
--- a/posthog/temporal/health_checks/README.md
+++ b/posthog/temporal/health_checks/README.md
@@ -222,6 +222,11 @@ rows = execute_clickhouse_health_team_query(
 
 Default ClickHouse settings: `max_execution_time=30`, `max_threads=2`.
 
+## ClickHouse kill switch
+
+Health checks are automatically skipped when the ClickHouse kill switch is active (LIGHT or FULL).
+The `get_team_id_batches` activity returns an empty list, and the workflow completes with `total_teams: 0`.
+
 ## Admin UI
 
 Health checks can be triggered manually from the Django admin at `/admin/health_checks/`. Staff access is required. The trigger form allows overriding:

--- a/posthog/temporal/health_checks/activities.py
+++ b/posthog/temporal/health_checks/activities.py
@@ -8,6 +8,7 @@ from django.db import close_old_connections
 import structlog
 import temporalio.activity
 
+from posthog.clickhouse.client.execute import KillSwitchLevel, get_kill_switch_level
 from posthog.dags.common.health.observability import push_health_check_metrics
 from posthog.sync import database_sync_to_async
 from posthog.temporal.health_checks.models import BatchResult, HealthCheckWorkflowInputs
@@ -42,6 +43,15 @@ def _get_team_id_batches_sync(inputs: HealthCheckWorkflowInputs) -> list[list[in
     # Temporal activities run in a thread pool where DB connections can go stale
     # between executions. close_old_connections() ensures we get a fresh connection.
     close_old_connections()
+
+    kill_switch_level = get_kill_switch_level()
+    if kill_switch_level != KillSwitchLevel.OFF:
+        logger.info(
+            "skipping health check due to clickhouse kill switch",
+            kind=inputs.kind,
+            kill_switch_level=kill_switch_level.value,
+        )
+        return []
 
     if inputs.team_ids:
         team_ids = inputs.team_ids


### PR DESCRIPTION
## Problem
Health checks should have a way of backing off ClickHouse when there is high pressure on the system. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a ClickHouse kill switch check before attempting a health check activity.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
