### PR TITLE
feat: increase drag speed for dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -26,7 +26,7 @@ import { DashboardLayoutSize, DashboardMode, DashboardPlacement, DashboardType }
 import { DashboardTextItem } from './items/DashboardTextItem'
 
 const DRAG_AUTO_SCROLL_THRESHOLD = 100
-const DRAG_AUTO_SCROLL_SPEED = 8
+const DRAG_AUTO_SCROLL_SPEED = 50
 
 export function DashboardItems(): JSX.Element {
     const {


### PR DESCRIPTION
## Problem

Scroll speed when dragging an item to edge of viewport was at 8px. Quite slow. Make no so slow.

## Changes

Increase scroll speed from 8px to 50px.

## How did you test this code?

Locally.


## Publish to changelog?

No.