### PR TITLE
fix: bypass egress proxy when connecting to Clickhouse

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -285,6 +285,7 @@ def _django_db_setup(django_db_keepdb, django_db_blocker):
         verify_ssl_cert=settings.CLICKHOUSE_VERIFY,
         randomize_replica_paths=True,
     )
+    database.request_session.trust_env = False  # bypass HTTP_PROXY for internal ClickHouse
 
     if not django_db_keepdb:
         try:

--- a/posthog/management/commands/migrate_clickhouse.py
+++ b/posthog/management/commands/migrate_clickhouse.py
@@ -64,6 +64,7 @@ class Command(BaseCommand):
             verify_ssl_cert=False,
             randomize_replica_paths=settings.TEST or settings.E2E_TESTING,
         )
+        database.request_session.trust_env = False  # bypass HTTP_PROXY for internal ClickHouse
 
         if options["plan"] or options["check"]:
             print("List of clickhouse migrations to be applied:")

--- a/posthog/management/commands/setup_test_environment.py
+++ b/posthog/management/commands/setup_test_environment.py
@@ -62,6 +62,7 @@ class Command(BaseCommand):
             autocreate=False,
             randomize_replica_paths=True,
         )
+        database.request_session.trust_env = False  # bypass HTTP_PROXY for internal ClickHouse
         if database.db_exists:
             print(  # noqa: T201
                 f'Got an error creating the test ClickHouse database: database "{CLICKHOUSE_DATABASE}" already exists\n'


### PR DESCRIPTION
Clickhouse is on our internal network and so shouldn't use the egress proxy (relevant: #50730). Without this, migrations broke in dev.

https://github.com/PostHog/charts/pull/9016