### PR TITLE
feat: add bounded for drag config in dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -134,6 +134,7 @@ export function DashboardItems(): JSX.Element {
                             enabled: dashboardMode === DashboardMode.Edit && !isMobileView,
                             handle: '.CardMeta,.TextCard__body',
                             cancel: 'a,table,button,input,.Popover',
+                            bounded: true,
                         }}
                         resizeConfig={{
                             enabled: dashboardMode === DashboardMode.Edit && !isMobileView,


### PR DESCRIPTION
## Problem

When dragging items on dashboard, it is possible to drag such that the image of the tile exceeds the bounds, even though the preview layout doesnt exceed.

## Changes

Adds bounded to drag config so that drag items cannot be brought out of the container at all.
## How did you test this code?

Locally.
## Publish to changelog?
No.