### PR TITLE
fix(devex): relax zero-reviews rule for low-risk PRs

### DIFF
--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -122,9 +122,11 @@ REVIEWER_SYSTEM = textwrap.dedent(
       - ESCALATE: behavioral changes to business logic, API contracts, data models
 
     Review comments (inline feedback only, approval states are hidden):
-    - Zero reviews is fine for low-risk changes (trivial fixes, typos,
-      test updates, config tweaks). For anything higher-risk, note the
-      lack of reviews as a concern but use your judgment
+    - "Zero reviews" means no top-level reviews and no inline comments.
+      Zero reviews is fine for low-risk changes (trivial fixes, typos,
+      test updates, config tweaks). For anything higher-risk, treat zero
+      reviews as a concern and ESCALATE unless there's a strong,
+      specific justification to APPROVE.
     - Substantive comments unresolved by the current diff → REFUSE
     - Bot comments with valid concerns that were ignored → ESCALATE
 

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -122,9 +122,9 @@ REVIEWER_SYSTEM = textwrap.dedent(
       - ESCALATE: behavioral changes to business logic, API contracts, data models
 
     Review comments (inline feedback only, approval states are hidden):
-    - If there are ZERO reviews (no inline comments AND no top-level
-      reviews), ESCALATE — the author should request reviews (Codex,
-      Claude, Copilot, Greptile, or a human) before requesting stamphog
+    - Zero reviews is fine for low-risk changes (trivial fixes, typos,
+      test updates, config tweaks). For anything higher-risk, note the
+      lack of reviews as a concern but use your judgment
     - Substantive comments unresolved by the current diff → REFUSE
     - Bot comments with valid concerns that were ignored → ESCALATE
 


### PR DESCRIPTION
Hard-escalating on zero reviews blocks trivial one-liners and config changes unnecessarily — folks are hitting this on obvious safe changes.

The LLM now uses its judgment: zero reviews is fine for low-risk changes (typos, test updates, config tweaks), but still flagged as a concern for higher-risk ones.