### PR TITLE
chore(flags): remove PBKDF2 personal API key support from Rust service

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3227,7 +3227,6 @@ dependencies = [
  "opentelemetry 0.22.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk 0.22.1",
- "pbkdf2",
  "percent-encoding",
  "petgraph 0.8.3",
  "rand 0.8.5",
@@ -5964,17 +5963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5988,8 +5976,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -32,7 +32,6 @@ json5 = "1.3"
 thiserror = { workspace = true }
 sha1 = "0.10.6"
 sha2 = "0.10.8"
-pbkdf2 = { version = "0.12.2", features = ["simple"] }
 hex = "0.4.3"
 regex.workspace = true
 fancy-regex.workspace = true

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -1,10 +1,6 @@
-use crate::{
-    api::errors::FlagError, metrics::consts::PERSONAL_API_KEY_HASH_MODE_COUNTER,
-    router::State as AppState, team::team_models::Team,
-};
+use crate::{api::errors::FlagError, router::State as AppState, team::team_models::Team};
 use axum::http::HeaderMap;
 use common_database::PostgresReader;
-use common_metrics::inc;
 use tracing::{debug, warn};
 
 /// Token prefix constants
@@ -81,54 +77,16 @@ pub async fn validate_secret_api_token_for_team(
     Ok(())
 }
 
-/// Hash a personal API key value using legacy PBKDF2 mode
+/// Hash a personal API key value using SHA256
 /// Ported from PostHog's `hash_key_value` function in `posthog/models/personal_api_key.py`
-fn hash_legacy_pbkdf2_key(value: &str, iterations: u32) -> String {
-    use pbkdf2::pbkdf2_hmac;
-    use sha2::Sha256;
-
-    let salt = b"posthog_personal_api_key";
-
-    // Compute PBKDF2-HMAC-SHA256 hash
-    let mut hash = [0u8; 32]; // 256 bits / 8 = 32 bytes
-    pbkdf2_hmac::<Sha256>(value.as_bytes(), salt, iterations, &mut hash);
-
-    // Encode hash in base64 and format like Django: pbkdf2_sha256$iterations$salt$hash
-    let hash_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash);
-    format!(
-        "pbkdf2_sha256${}${}${}",
-        iterations,
-        String::from_utf8_lossy(salt),
-        hash_b64
-    )
-}
-
-/// Hash a personal API key value using the specified mode
-/// Ported from PostHog's `hash_key_value` function in `posthog/models/personal_api_key.py`
-fn hash_personal_api_key(value: &str, mode: &str, iterations: Option<u32>) -> String {
+pub(crate) fn hash_personal_api_key(value: &str) -> String {
     use sha2::{Digest, Sha256};
 
-    match mode {
-        // Current simple hashing mode
-        "sha256" => {
-            if iterations.is_some() {
-                panic!("Iterations must not be provided when using simple hashing mode");
-            }
-
-            // Inspiration on why no salt:
-            // https://github.com/jazzband/django-rest-knox/issues/188
-            let mut hasher = Sha256::new();
-            hasher.update(value.as_bytes());
-            let result = hasher.finalize();
-            format!("sha256${}", hex::encode(result))
-        }
-        // Legacy PBKDF2 mode
-        "pbkdf2" => {
-            let iterations = iterations.expect("Iterations must be provided for pbkdf2 mode");
-            hash_legacy_pbkdf2_key(value, iterations)
-        }
-        _ => panic!("Unsupported hashing mode: {mode}"),
-    }
+    // No salt — see https://github.com/jazzband/django-rest-knox/issues/188
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    let result = hasher.finalize();
+    format!("sha256${}", hex::encode(result))
 }
 
 /// Validates personal API key with feature flag scopes for a specific team
@@ -142,151 +100,131 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
 
     debug!(team_id = team.id, "Validating personal API key for team");
 
-    // Try all hashing modes to find the key
-    let modes_to_try = vec![
-        ("sha256", None),
-        ("pbkdf2", Some(260000)),
-        ("pbkdf2", Some(390000)),
-    ];
+    let secure_value = hash_personal_api_key(key);
 
     let pg_reader: PostgresReader = state.database_pools.non_persons_reader.clone();
     let mut conn = pg_reader.get_connection().await?;
 
-    for (mode, iterations) in modes_to_try {
-        let secure_value = hash_personal_api_key(key, mode, iterations);
+    // Query for PersonalAPIKey with scope validation
+    // The key must:
+    // 1. Have an active user
+    // 2. Have either no scopes (full access) OR have feature_flag:read or feature_flag:write scopes
+    let query = r#"
+        SELECT
+            pak.id as key_id,
+            pak.scopes,
+            pak.scoped_teams,
+            pak.scoped_organizations,
+            u.id as user_id,
+            u.is_active as user_is_active,
+            u.current_organization_id as user_organization_id
+        FROM posthog_personalapikey pak
+        INNER JOIN posthog_user u ON pak.user_id = u.id
+        WHERE pak.secure_value = $1
+          AND u.is_active = true
+          AND (
+              pak.scopes IS NULL
+              OR pak.scopes = '{*}'
+              OR 'feature_flag:read' = ANY(pak.scopes)
+              OR 'feature_flag:write' = ANY(pak.scopes)
+          )
+    "#;
 
-        // Query for PersonalAPIKey with scope validation
-        // The key must:
-        // 1. Have an active user
-        // 2. Have either no scopes (full access) OR have feature_flag:read or feature_flag:write scopes
-        let query = r#"
-            SELECT
-                pak.id as key_id,
-                pak.scopes,
-                pak.scoped_teams,
-                pak.scoped_organizations,
-                u.id as user_id,
-                u.is_active as user_is_active,
-                u.current_organization_id as user_organization_id
-            FROM posthog_personalapikey pak
-            INNER JOIN posthog_user u ON pak.user_id = u.id
-            WHERE pak.secure_value = $1
-              AND u.is_active = true
-              AND (
-                  pak.scopes IS NULL
-                  OR pak.scopes = '{*}'
-                  OR 'feature_flag:read' = ANY(pak.scopes)
-                  OR 'feature_flag:write' = ANY(pak.scopes)
-              )
-        "#;
+    let row = sqlx::query(query)
+        .bind(&secure_value)
+        .fetch_optional(&mut *conn)
+        .await?
+        .ok_or_else(|| {
+            warn!("Personal API key not found or doesn't have required scopes");
+            FlagError::PersonalApiKeyInvalid("Authorization header".to_string())
+        })?;
 
-        let row_result = sqlx::query(query)
-            .bind(&secure_value)
-            .fetch_optional(&mut *conn)
-            .await?;
-
-        if let Some(row) = row_result {
-            // Validate scoped_teams restriction
-            let scoped_teams: Option<Vec<i32>> = row.try_get("scoped_teams").ok();
-            if let Some(ref teams) = scoped_teams {
-                if !teams.is_empty() && !teams.contains(&team.id) {
-                    warn!(
-                        team_id = team.id,
-                        scoped_teams = ?teams,
-                        "Personal API key does not have access to this team"
-                    );
-                    return Err(FlagError::PersonalApiKeyInvalid(
-                        "Authorization header".to_string(),
-                    ));
-                }
-            }
-
-            // Validate organization access (MANDATORY for teams with organization_id)
-            // Personal API keys can only access teams in organizations where the user is a current member
-            let user_id: i32 = row.get("user_id");
-            let user_organization_id: uuid::Uuid = row.get("user_organization_id");
-            let scoped_organizations: Option<Vec<String>> =
-                row.try_get("scoped_organizations").ok();
-
-            // Handle teams with or without organization_id
-            if let Some(team_organization_id) = team.organization_id {
-                let team_organization_id_str = team_organization_id.to_string();
-
-                // Check organization access:
-                // 1. If scoped_organizations has entries, the team's org must be in the list
-                // 2. The user must always be a current member of the team's organization
-                if let Some(orgs) = scoped_organizations.as_ref() {
-                    if !orgs.is_empty() && !orgs.contains(&team_organization_id_str) {
-                        warn!(
-                            user_id = user_id,
-                            team_organization_id = %team_organization_id_str,
-                            scoped_organizations = ?orgs,
-                            "Personal API key scope does not include this organization"
-                        );
-                        return Err(FlagError::PersonalApiKeyInvalid(
-                            "Authorization header".to_string(),
-                        ));
-                    }
-                }
-
-                let has_org_access: bool = sqlx::query_scalar(
-                    "SELECT EXISTS(SELECT 1 FROM posthog_organizationmembership WHERE user_id = $1 AND organization_id = $2)"
-                )
-                .bind(user_id)
-                .bind(team_organization_id)
-                .fetch_one(&mut *conn)
-                .await?;
-
-                if !has_org_access {
-                    warn!(
-                        user_organization_id = %user_organization_id,
-                        team_organization_id = %team_organization_id_str,
-                        scoped_organizations = ?scoped_organizations,
-                        "Personal API key does not have access to this organization"
-                    );
-                    return Err(FlagError::PersonalApiKeyInvalid(
-                        "Authorization header".to_string(),
-                    ));
-                }
-            } else {
-                // Legacy team without organization_id - skip organization validation
-                debug!(
-                    team_id = team.id,
-                    user_organization_id = %user_organization_id,
-                    "Team has no organization_id, skipping organization validation (legacy team)"
-                );
-            }
-
-            debug!(
-                user_id = user_id,
+    // Validate scoped_teams restriction
+    let scoped_teams: Option<Vec<i32>> = row.try_get("scoped_teams").ok();
+    if let Some(ref teams) = scoped_teams {
+        if !teams.is_empty() && !teams.contains(&team.id) {
+            warn!(
                 team_id = team.id,
-                user_organization_id = %user_organization_id,
-                team_organization_id = ?team.organization_id,
-                scoped_teams = ?scoped_teams,
-                scoped_organizations = ?scoped_organizations,
-                "Personal API key validated successfully"
+                scoped_teams = ?teams,
+                "Personal API key does not have access to this team"
             );
-
-            inc(
-                PERSONAL_API_KEY_HASH_MODE_COUNTER,
-                &[("hash_mode".to_string(), mode.to_string())],
-                1,
-            );
-
-            return Ok(());
+            return Err(FlagError::PersonalApiKeyInvalid(
+                "Authorization header".to_string(),
+            ));
         }
     }
 
-    warn!("Personal API key not found or doesn't have required scopes");
-    Err(FlagError::PersonalApiKeyInvalid(
-        "Authorization header".to_string(),
-    ))
+    // Validate organization access (MANDATORY for teams with organization_id)
+    // Personal API keys can only access teams in organizations where the user is a current member
+    let user_id: i32 = row.get("user_id");
+    let user_organization_id: uuid::Uuid = row.get("user_organization_id");
+    let scoped_organizations: Option<Vec<String>> = row.try_get("scoped_organizations").ok();
+
+    // Handle teams with or without organization_id
+    if let Some(team_organization_id) = team.organization_id {
+        let team_organization_id_str = team_organization_id.to_string();
+
+        // Check organization access:
+        // 1. If scoped_organizations has entries, the team's org must be in the list
+        // 2. The user must always be a current member of the team's organization
+        if let Some(orgs) = scoped_organizations.as_ref() {
+            if !orgs.is_empty() && !orgs.contains(&team_organization_id_str) {
+                warn!(
+                    user_id = user_id,
+                    team_organization_id = %team_organization_id_str,
+                    scoped_organizations = ?orgs,
+                    "Personal API key scope does not include this organization"
+                );
+                return Err(FlagError::PersonalApiKeyInvalid(
+                    "Authorization header".to_string(),
+                ));
+            }
+        }
+
+        let has_org_access: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM posthog_organizationmembership WHERE user_id = $1 AND organization_id = $2)"
+        )
+        .bind(user_id)
+        .bind(team_organization_id)
+        .fetch_one(&mut *conn)
+        .await?;
+
+        if !has_org_access {
+            warn!(
+                user_organization_id = %user_organization_id,
+                team_organization_id = %team_organization_id_str,
+                scoped_organizations = ?scoped_organizations,
+                "Personal API key does not have access to this organization"
+            );
+            return Err(FlagError::PersonalApiKeyInvalid(
+                "Authorization header".to_string(),
+            ));
+        }
+    } else {
+        // Legacy team without organization_id - skip organization validation
+        debug!(
+            team_id = team.id,
+            user_organization_id = %user_organization_id,
+            "Team has no organization_id, skipping organization validation (legacy team)"
+        );
+    }
+
+    debug!(
+        user_id = user_id,
+        team_id = team.id,
+        user_organization_id = %user_organization_id,
+        team_organization_id = ?team.organization_id,
+        scoped_teams = ?scoped_teams,
+        scoped_organizations = ?scoped_organizations,
+        "Personal API key validated successfully"
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rstest::rstest;
 
     #[test]
     fn test_extract_team_secret_token_from_header() {
@@ -331,37 +269,13 @@ mod tests {
     }
 
     // Ported from PostHog's `test_hash_key_values` function in `posthog/api/test/test_personal_api_keys.py`
-    #[rstest]
-    #[case(
-        "sha256",
-        None,
-        "sha256$45af89b510a3279a817f851de5d3f95b73485d58ec2672a39e52d8aeeb014059"
-    )]
-    #[case(
-        "pbkdf2",
-        Some(1),
-        "pbkdf2_sha256$1$posthog_personal_api_key$vzzA4fHFTiUipScUeDJ4+NjuXwAWWu2AFRbk/JUs6Ck="
-    )]
-    #[case("pbkdf2", Some(260000), "pbkdf2_sha256$260000$posthog_personal_api_key$eeRy21dbVoEzYND0NVLfjXxgNeO67SeBRrwQr6bbhK4=")]
-    fn test_hash_personal_api_key(
-        #[case] algorithm: &str,
-        #[case] iterations: Option<u32>,
-        #[case] expected_hash: &str,
-    ) {
-        let result = hash_personal_api_key("test_key_12345", algorithm, iterations);
-        assert_eq!(result, expected_hash);
-    }
-
     #[test]
-    #[should_panic(expected = "Iterations must be provided for pbkdf2 mode")]
-    fn test_hash_personal_api_key_pbkdf2_requires_iterations() {
-        hash_personal_api_key("test_key", "pbkdf2", None);
-    }
-
-    #[test]
-    #[should_panic(expected = "Iterations must not be provided when using simple hashing mode")]
-    fn test_hash_personal_api_key_sha256_forbids_iterations() {
-        hash_personal_api_key("test_key", "sha256", Some(100));
+    fn test_hash_personal_api_key() {
+        let result = hash_personal_api_key("test_key_12345");
+        assert_eq!(
+            result,
+            "sha256$45af89b510a3279a817f851de5d3f95b73485d58ec2672a39e52d8aeeb014059"
+        );
     }
 
     #[test]

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -82,10 +82,6 @@ pub const FLAG_DEFINITIONS_ETAG_COUNTER: &str = "flags_flag_definitions_etag_tot
 // Labels: method (secret_api_key, personal_api_key) — Rust only supports these two; Python also tracks oauth, jwt, session, other
 pub const FLAG_DEFINITIONS_AUTH_COUNTER: &str = "flags_flag_definitions_auth_total";
 
-// Personal API key hash mode used for successful authentication
-// Labels: hash_mode (sha256, pbkdf2)
-pub const PERSONAL_API_KEY_HASH_MODE_COUNTER: &str = "personal_api_key_hash_mode_total";
-
 // Request-level timeout (tower TimeoutLayer killed the request before completion)
 pub const FLAG_REQUEST_TIMEOUT_COUNTER: &str = "flags_request_timeout_total";
 

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1189,12 +1189,7 @@ impl TestContext {
         let pak_id = format!("test_pak_{}", &uuid::Uuid::new_v4().to_string()[..8]);
         let api_key_value = format!("phx_{}", &uuid::Uuid::new_v4().to_string()[..12]);
 
-        // Hash the key using SHA256
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(api_key_value.as_bytes());
-        let hash_result = hasher.finalize();
-        let secure_value = format!("sha256${}", hex::encode(hash_result));
+        let secure_value = crate::api::auth::hash_personal_api_key(&api_key_value);
 
         let mut conn = self.non_persons_writer.get_connection().await?;
 


### PR DESCRIPTION
## Problem

The Rust feature-flags service supports three personal API key hashing modes (`SHA256`, `PBKDF2` with 260k iterations, `PBKDF2` with 390k iterations), trying each sequentially on every auth request. This adds unnecessary complexity and a slow-path dependency (`pbkdf2` crate) to a service that hasn't shipped yet.

Since Feb 2024, Django auto-upgrades any `PBKDF2` key to `SHA256` on use. Production data confirms zero `PBKDF2` keys have been used in 2+ years across US (~6,750 keys) and EU (~1,750 keys). Every actively-used key has already been upgraded.

## Changes

- Remove `hash_legacy_pbkdf2_key()` and multi-mode hashing logic from `auth.rs`
- Simplify `hash_personal_api_key()` to SHA256-only (now `pub(crate)` for reuse)
- Flatten `validate_personal_api_key_with_scopes_for_team()` from a 3-iteration loop to a single hash + query
- Remove `pbkdf2` crate dependency from `Cargo.toml`
- Remove `PERSONAL_API_KEY_HASH_MODE_COUNTER` metric (meaningless with one mode)
- Reuse `hash_personal_api_key()` in `test_utils.rs` instead of duplicating inline SHA256 hashing

## How did you test this code?

- `cargo check -p feature-flags` — compiles clean
- `cargo test -p feature-flags -- api::auth` — all 5 auth tests pass
- `cargo clippy -p feature-flags -- -D warnings` — zero warnings

## Publish to changelog?

No

## Docs update

N/A