### PR TITLE
feat(flags): pre-compute evaluation_info in hypercache

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -50,6 +50,7 @@ from posthog.models.feature_flag.feature_flag import (
     get_feature_flags,
     serialize_feature_flags,
 )
+from posthog.models.feature_flag.types import PropertyFilterType
 from posthog.models.tag import Tag
 from posthog.models.team import Team
 from posthog.storage.cache_expiry_manager import (
@@ -69,6 +70,68 @@ logger = structlog.get_logger(__name__)
 FLAGS_CACHE_EXPIRY_SORTED_SET = "flags_cache_expiry"
 
 
+def _compute_evaluation_info(flags_data: list[dict]) -> dict[str, bool]:
+    """
+    Pre-compute which database resources are needed to evaluate the given flags.
+
+    The Rust feature flags service uses these booleans to short-circuit DB calls
+    for teams whose flags never touch person properties, group properties, or
+    experience continuity. When all three are False the service can skip the
+    persons DB entirely.
+    """
+    requires_person_properties = False
+    requires_group_type_mappings = False
+    requires_experience_continuity = False
+
+    person_property_types = (PropertyFilterType.PERSON, PropertyFilterType.COHORT)
+
+    for flag in flags_data:
+        # Inactive flags evaluate to false without DB lookups, so they
+        # don't contribute to resource requirements.
+        if not flag.get("active", True):
+            continue
+
+        filters = flag.get("filters") or {}
+
+        if filters.get("aggregation_group_type_index") is not None:
+            requires_group_type_mappings = True
+
+        if flag.get("ensure_experience_continuity"):
+            requires_experience_continuity = True
+
+        # Super groups always contain person properties ($feature_enrollment/{key}),
+        # so their presence alone is sufficient.
+        if not requires_person_properties and filters.get("super_groups"):
+            requires_person_properties = True
+
+        # holdout_groups are not scanned because they only support percentage rollouts,
+        # not property filters.
+        # Scan group properties for person/group requirements.
+        if not (requires_person_properties and requires_group_type_mappings):
+            for group in filters.get("groups") or []:
+                if group.get("rollout_percentage") == 0:
+                    continue
+                for prop in group.get("properties") or []:
+                    prop_type = prop.get("type")
+                    if prop_type in person_property_types:
+                        requires_person_properties = True
+                    elif prop_type == PropertyFilterType.GROUP:
+                        requires_group_type_mappings = True
+                    if requires_person_properties and requires_group_type_mappings:
+                        break
+                if requires_person_properties and requires_group_type_mappings:
+                    break
+
+        if requires_person_properties and requires_group_type_mappings and requires_experience_continuity:
+            break
+
+    return {
+        "requires_person_properties": requires_person_properties,
+        "requires_group_type_mappings": requires_group_type_mappings,
+        "requires_experience_continuity": requires_experience_continuity,
+    }
+
+
 def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     """
     Get feature flags for the feature-flags service.
@@ -82,7 +145,9 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     in /flags would return unusable encrypted ciphertext.
 
     Returns:
-        dict: {"flags": [...]} where flags is a list of flag dictionaries
+        dict: {"flags": [...], "evaluation_info": {...}} where flags is a list of flag
+        dictionaries and evaluation_info contains pre-computed booleans for the Rust
+        flags service to short-circuit DB lookups.
     """
     # Exclude encrypted remote config flags at DB level for efficiency
     flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
@@ -96,7 +161,7 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     )
 
     # Wrap in dict for HyperCache compatibility
-    return {"flags": flags_data}
+    return {"flags": flags_data, "evaluation_info": _compute_evaluation_info(flags_data)}
 
 
 def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -114,7 +179,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
         teams: List of Team objects to load flags for
 
     Returns:
-        Dict mapping team_id to {"flags": [...]} for each team
+        Dict mapping team_id to {"flags": [...], "evaluation_info": {...}} for each team
     """
     if not teams:
         return {}
@@ -162,7 +227,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
             flag_count=len(flags_data),
         )
 
-        result[team.id] = {"flags": flags_data}
+        result[team.id] = {"flags": flags_data, "evaluation_info": _compute_evaluation_info(flags_data)}
 
     return result
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -19,6 +19,7 @@ from parameterized import parameterized
 from posthog.models import FeatureFlag, Tag, Team
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
 from posthog.models.feature_flag.flags_cache import (
+    _compute_evaluation_info,
     _get_feature_flags_for_service,
     _get_feature_flags_for_teams_batch,
     _get_team_ids_with_recently_updated_flags,
@@ -48,7 +49,14 @@ class TestServiceFlagsCache(BaseTest):
         """Test fetching flags when team has no flags."""
         result = _get_feature_flags_for_service(self.team)
 
-        assert result == {"flags": []}
+        assert result == {
+            "flags": [],
+            "evaluation_info": {
+                "requires_person_properties": False,
+                "requires_group_type_mappings": False,
+                "requires_experience_continuity": False,
+            },
+        }
 
     def test_get_feature_flags_for_service_with_flags(self):
         """Test fetching flags returns correct format for service."""
@@ -2240,3 +2248,375 @@ class TestGetTeamsWithFlagsQueryset(BaseTest):
         qs = get_teams_with_flags_queryset()
         team_ids = list(qs.values_list("id", flat=True))
         assert team_ids.count(self.team.id) == 1
+
+
+class TestComputeEvaluationInfo(BaseTest):
+    def test_empty_flags_list(self):
+        result = _compute_evaluation_info([])
+        assert result == {
+            "requires_person_properties": False,
+            "requires_group_type_mappings": False,
+            "requires_experience_continuity": False,
+        }
+
+    def test_percentage_only_flags(self):
+        flags = [
+            {
+                "key": "simple-flag",
+                "filters": {"groups": [{"properties": [], "rollout_percentage": 50}]},
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result == {
+            "requires_person_properties": False,
+            "requires_group_type_mappings": False,
+            "requires_experience_continuity": False,
+        }
+
+    def test_person_property_filter(self):
+        flags = [
+            {
+                "key": "person-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+        assert result["requires_group_type_mappings"] is False
+
+    def test_cohort_filter(self):
+        flags = [
+            {
+                "key": "cohort-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "cohort", "key": "id", "value": 1}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    def test_group_aggregation(self):
+        flags = [
+            {
+                "key": "group-flag",
+                "filters": {
+                    "aggregation_group_type_index": 0,
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+        assert result["requires_group_type_mappings"] is True
+
+    def test_experience_continuity(self):
+        flags = [
+            {
+                "key": "continuity-flag",
+                "ensure_experience_continuity": True,
+                "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]},
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_experience_continuity"] is True
+        assert result["requires_person_properties"] is False
+
+    def test_zero_rollout_with_person_properties(self):
+        flags = [
+            {
+                "key": "zero-rollout",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 0,
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+
+    def test_super_group_sets_requires_person_properties(self):
+        flags = [
+            {
+                "key": "early-access-flag",
+                "filters": {
+                    "groups": [{"properties": [], "rollout_percentage": 100}],
+                    "super_groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "$feature_enrollment/early-access-flag",
+                                    "type": "person",
+                                    "operator": "exact",
+                                    "value": ["true"],
+                                }
+                            ],
+                            "rollout_percentage": 100,
+                        }
+                    ],
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    @parameterized.expand(
+        [
+            (
+                "mixed_simple_and_person",
+                [
+                    {
+                        "key": "simple-flag",
+                        "filters": {"groups": [{"properties": [], "rollout_percentage": 50}]},
+                    },
+                    {
+                        "key": "person-flag",
+                        "filters": {
+                            "groups": [
+                                {
+                                    "rollout_percentage": 100,
+                                    "properties": [{"type": "person", "key": "email", "value": "x"}],
+                                }
+                            ]
+                        },
+                    },
+                ],
+                True,
+                False,
+                False,
+            ),
+            (
+                "all_requirements",
+                [
+                    {
+                        "key": "group-flag",
+                        "ensure_experience_continuity": True,
+                        "filters": {
+                            "aggregation_group_type_index": 1,
+                            "groups": [
+                                {
+                                    "rollout_percentage": 100,
+                                    "properties": [{"type": "person", "key": "k", "value": "v"}],
+                                }
+                            ],
+                        },
+                    },
+                ],
+                True,
+                True,
+                True,
+            ),
+        ]
+    )
+    def test_mixed_flags(self, _name, flags, expect_person, expect_group, expect_continuity):
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is expect_person
+        assert result["requires_group_type_mappings"] is expect_group
+        assert result["requires_experience_continuity"] is expect_continuity
+
+    def test_group_property_without_aggregation_index_sets_only_group_type_mappings(self):
+        flags = [
+            {
+                "key": "group-prop-no-agg",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "group", "key": "industry", "value": "tech"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+        assert result["requires_group_type_mappings"] is True
+
+    @parameterized.expand(
+        [
+            ("event", "event"),
+            ("flag", "flag"),
+        ]
+    )
+    def test_non_person_property_types_do_not_trigger_person_properties(self, _name, prop_type):
+        flags = [
+            {
+                "key": f"{prop_type}-prop-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": prop_type, "key": "url", "value": "/home"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+
+    def test_zero_rollout_skipped_but_nonzero_rollout_still_detected(self):
+        flags = [
+            {
+                "key": "multi-group-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 0,
+                            "properties": [{"type": "person", "key": "email", "value": "skip@me.com"}],
+                        },
+                        {
+                            "rollout_percentage": 50,
+                            "properties": [{"type": "person", "key": "plan", "value": "pro"}],
+                        },
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    def test_inactive_flag_excluded_from_evaluation_info(self):
+        flags = [
+            {
+                "key": "inactive-person-flag",
+                "active": False,
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            },
+            {
+                "key": "active-simple-flag",
+                "filters": {"groups": [{"properties": [], "rollout_percentage": 50}]},
+            },
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is False
+
+    def test_null_rollout_percentage_treated_as_active(self):
+        """When rollout_percentage is None (not set), the group is active and should be checked."""
+        flags = [
+            {
+                "key": "no-rollout",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                        }
+                    ]
+                },
+            }
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+
+    def _get_evaluation_info_via_service(self) -> dict:
+        result = _get_feature_flags_for_service(self.team)
+        return result.get("evaluation_info", {})
+
+    def _get_evaluation_info_via_batch(self) -> dict:
+        results = _get_feature_flags_for_teams_batch([self.team])
+        return results[self.team.id].get("evaluation_info", {})
+
+    @parameterized.expand([("service",), ("batch",)])
+    @override_settings(FLAGS_REDIS_URL="redis://test")
+    def test_response_includes_evaluation_info(self, path):
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="simple-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        info = getattr(self, f"_get_evaluation_info_via_{path}")()
+
+        assert info["requires_person_properties"] is False
+        assert info["requires_group_type_mappings"] is False
+        assert info["requires_experience_continuity"] is False
+
+    @override_settings(FLAGS_REDIS_URL="redis://test")
+    def test_batch_response_evaluation_info_for_team_with_no_flags(self):
+        FeatureFlag.objects.filter(team=self.team).delete()
+
+        info = self._get_evaluation_info_via_batch()
+
+        assert info == {
+            "requires_person_properties": False,
+            "requires_group_type_mappings": False,
+            "requires_experience_continuity": False,
+        }
+
+    @parameterized.expand([("service",), ("batch",)])
+    @override_settings(FLAGS_REDIS_URL="redis://test")
+    def test_response_evaluation_info_detects_person_properties(self, path):
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="person-flag",
+            created_by=self.user,
+            filters={
+                "groups": [
+                    {
+                        "rollout_percentage": 100,
+                        "properties": [{"type": "person", "key": "email", "value": "test@example.com"}],
+                    }
+                ]
+            },
+        )
+
+        info = getattr(self, f"_get_evaluation_info_via_{path}")()
+
+        assert info["requires_person_properties"] is True
+
+    def test_group_type_mapping_detected_when_person_properties_already_set(self):
+        """Group property in a later flag must set requires_group_type_mappings even
+        when requires_person_properties was already set by an earlier flag."""
+        flags = [
+            {
+                "key": "person-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "person", "key": "email", "value": "a@b.com"}],
+                        }
+                    ]
+                },
+            },
+            {
+                "key": "group-flag",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [{"type": "group", "key": "industry", "value": "tech"}],
+                        }
+                    ]
+                },
+            },
+        ]
+        result = _compute_evaluation_info(flags)
+        assert result["requires_person_properties"] is True
+        assert result["requires_group_type_mappings"] is True


### PR DESCRIPTION
## Problem

The Rust feature-flags service currently has no way to know upfront whether a team's flags require person properties, group type mappings, or experience continuity. This means it always prepares for the worst case, making DB queries that may be unnecessary for teams with simple percentage-only rollouts.

## Changes

Add `_compute_evaluation_info()` to the flags hypercache, which pre-computes three booleans at cache-build time:

- `requires_person_properties` — true if any active flag uses person/cohort property filters, super groups, or group-aggregated flags with person property filters
- `requires_group_type_mappings` — true if any active flag has `aggregation_group_type_index` set or uses group-type property filters
- `requires_experience_continuity` — true if any active flag has `ensure_experience_continuity` enabled

The `evaluation_info` dict is included alongside `flags` in the hypercache payload so the Rust service can short-circuit DB queries for teams that don't need them.

Key design decisions:
- Operates on serialized flag dicts (not model instances) since it runs at cache-write time
- Skips inactive flags (they evaluate to false without DB lookups)
- Skips groups with 0% rollout (they never match)
- Group-aggregated flags set `requires_group_type_mappings` but NOT `requires_person_properties` — they hash on the group key, not the person's distinct_id

## How did you test this code?

22 unit tests covering:
- Empty flags, percentage-only flags, person/cohort/group property filters
- Group aggregation, experience continuity, super groups
- Zero rollout skipping, inactive flag exclusion, null rollout handling
- Mixed flag combinations and early-exit correctness
- Integration tests verifying both single-team and batch paths include `evaluation_info`

## Publish to changelog?

No

## Docs update

No docs update needed — this is an internal optimization for the flags service cache.