### PR TITLE
chore: enable prometheus multiprocess mode for local dev

### DIFF
--- a/bin/start-backend
+++ b/bin/start-backend
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+export PROMETHEUS_MULTIPROC_DIR=$(mktemp -d)
+trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
+
 export OBJECT_STORAGE_ENDPOINT=http://localhost:19000
 export SESSION_RECORDING_V2_S3_ENDPOINT=http://localhost:8333
 


### PR DESCRIPTION
## Summary
- Set `PROMETHEUS_MULTIPROC_DIR` in `bin/start-backend` so lazily-initialized prometheus metrics (e.g. cache hit counters) are visible on `/_metrics` locally
- Granian forks a worker subprocess; without this, each process has its own isolated registry and metrics created in the worker are invisible
- Matches the production setup in `bin/docker-server-unit`
