### PR TITLE
chore(flags): remove unused String payload from PersonalApiKeyInvalid

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -130,16 +130,14 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
           )
     "#;
 
-    let row = 
-    sqlx::query(query)
+    let row = sqlx::query(query)
         .bind(&secure_value)
         .fetch_optional(&mut *conn)
         .await?
         .ok_or_else(|| {
             warn!("Personal API key not found or doesn't have required scopes");
             FlagError::PersonalApiKeyInvalid
-        }
-)?;
+        })?;
 
     // Validate scoped_teams restriction
     let scoped_teams: Option<Vec<i32>> = row.try_get("scoped_teams").ok();

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -130,14 +130,16 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
           )
     "#;
 
-    let row = sqlx::query(query)
+    let row = 
+    sqlx::query(query)
         .bind(&secure_value)
         .fetch_optional(&mut *conn)
         .await?
         .ok_or_else(|| {
             warn!("Personal API key not found or doesn't have required scopes");
-            FlagError::PersonalApiKeyInvalid("Authorization header".to_string())
-        })?;
+            FlagError::PersonalApiKeyInvalid
+        }
+)?;
 
     // Validate scoped_teams restriction
     let scoped_teams: Option<Vec<i32>> = row.try_get("scoped_teams").ok();
@@ -148,9 +150,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
                 scoped_teams = ?teams,
                 "Personal API key does not have access to this team"
             );
-            return Err(FlagError::PersonalApiKeyInvalid(
-                "Authorization header".to_string(),
-            ));
+            return Err(FlagError::PersonalApiKeyInvalid);
         }
     }
 
@@ -175,9 +175,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
                     scoped_organizations = ?orgs,
                     "Personal API key scope does not include this organization"
                 );
-                return Err(FlagError::PersonalApiKeyInvalid(
-                    "Authorization header".to_string(),
-                ));
+                return Err(FlagError::PersonalApiKeyInvalid);
             }
         }
 
@@ -196,9 +194,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
                 scoped_organizations = ?scoped_organizations,
                 "Personal API key does not have access to this organization"
             );
-            return Err(FlagError::PersonalApiKeyInvalid(
-                "Authorization header".to_string(),
-            ));
+            return Err(FlagError::PersonalApiKeyInvalid);
         }
     } else {
         // Legacy team without organization_id - skip organization validation

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -66,8 +66,8 @@ pub enum FlagError {
     NoTokenError,
     #[error("API key is not valid")]
     TokenValidationError,
-    #[error("Personal API key found in request {0} is invalid")]
-    PersonalApiKeyInvalid(String),
+    #[error("Personal API key is invalid")]
+    PersonalApiKeyInvalid,
     #[error("Secret API token is invalid")]
     SecretApiTokenInvalid,
     #[error("No authentication credentials provided")]
@@ -160,7 +160,7 @@ impl FlagError {
             // Authentication errors (401)
             FlagError::NoTokenError => ("missing_token", 401),
             FlagError::TokenValidationError => ("invalid_token", 401),
-            FlagError::PersonalApiKeyInvalid(_) => ("personal_api_key_invalid", 401),
+            FlagError::PersonalApiKeyInvalid => ("personal_api_key_invalid", 401),
             FlagError::SecretApiTokenInvalid => ("secret_api_token_invalid", 401),
             FlagError::NoAuthenticationProvided => ("no_authentication", 401),
 
@@ -394,11 +394,11 @@ impl IntoResponse for FlagError {
             FlagError::TokenValidationError => {
                 (StatusCode::UNAUTHORIZED, "The provided API key is invalid or has expired. Please check your API key and try again.".to_string())
             }
-            FlagError::PersonalApiKeyInvalid(source) => {
+            FlagError::PersonalApiKeyInvalid => {
                 let response = AuthenticationErrorResponse {
                     error_type: "authentication_error".to_string(),
                     code: "authentication_failed".to_string(),
-                    detail: format!("Personal API key found in request {source} is invalid."),
+                    detail: "Personal API key is invalid.".to_string(),
                     attr: None,
                 };
                 return (StatusCode::UNAUTHORIZED, Json(response)).into_response();
@@ -738,7 +738,7 @@ mod tests {
             FlagError::MissingDistinctId,
             FlagError::NoTokenError,
             FlagError::TokenValidationError,
-            FlagError::PersonalApiKeyInvalid("test".to_string()),
+            FlagError::PersonalApiKeyInvalid,
             FlagError::SecretApiTokenInvalid,
             FlagError::NoAuthenticationProvided,
             FlagError::RowNotFound,
@@ -956,7 +956,7 @@ mod tests {
             FlagError::MissingDistinctId,
             FlagError::NoTokenError,
             FlagError::TokenValidationError,
-            FlagError::PersonalApiKeyInvalid("test".to_string()),
+            FlagError::PersonalApiKeyInvalid,
             FlagError::SecretApiTokenInvalid,
             FlagError::NoAuthenticationProvided,
             FlagError::RowNotFound,

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -723,7 +723,7 @@ mod tests {
         #[case(FlagError::MissingDistinctId, 400, "missing_distinct_id")]
         #[case(FlagError::NoTokenError, 401, "missing_token")]
         #[case(FlagError::TokenValidationError, 401, "invalid_token")]
-        #[case(FlagError::PersonalApiKeyInvalid("test".into()), 401, "personal_api_key_invalid")]
+        #[case(FlagError::PersonalApiKeyInvalid, 401, "personal_api_key_invalid")]
         #[case(FlagError::SecretApiTokenInvalid, 401, "secret_api_token_invalid")]
         #[case(FlagError::NoAuthenticationProvided, 401, "no_authentication")]
         #[case(FlagError::RowNotFound, 500, "row_not_found")]

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -170,10 +170,7 @@ async fn test_personal_api_key_authentication_invalid_key() {
     let body: Value = serde_json::from_str(&body_text).unwrap();
     assert_eq!(body["type"], "authentication_error");
     assert_eq!(body["code"], "authentication_failed");
-    assert_eq!(
-        body["detail"],
-        "Personal API key found in request Authorization header is invalid."
-    );
+    assert_eq!(body["detail"], "Personal API key is invalid.");
     assert_eq!(body["attr"], Value::Null);
 }
 


### PR DESCRIPTION
## Problem

`FlagError::PersonalApiKeyInvalid(String)` carried a `String` payload, but every call site passed the identical value `"Authorization header"`. The payload added no information and required unnecessary heap allocations on error paths.

The Rust port does not support auth tokens from anywhere except the Authorization header.

## Changes

- Convert `PersonalApiKeyInvalid(String)` to a unit variant `PersonalApiKeyInvalid`
- Hardcode the error detail message, aligned with the `#[error]` attribute
- Update all 4 call sites in `auth.rs`, match arms in `errors.rs`, and test cases in `errors.rs` and `canonical_log.rs`

Now consistent with sibling auth error variants (`SecretApiTokenInvalid`, `NoAuthenticationProvided`, etc.) which are already unit variants.

## How did you test this code?

- `cargo check -p feature-flags` passes
- All existing tests in the affected files remain valid (test instances updated from `PersonalApiKeyInvalid("test".to_string())` to `PersonalApiKeyInvalid`)

I'm an agent and have not tested this manually beyond code-based checks.

## Publish to changelog?

No

## Docs update

No docs changes needed.