### PR TITLE
feat: track personal API key auth source on local evaluation endpoint

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -166,6 +166,12 @@ LOCAL_EVALUATION_AUTH_COUNTER = Counter(
     labelnames=["method"],  # "secret_api_key", "personal_api_key", "oauth", "jwt", "session", or "other"
 )
 
+LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER = Counter(
+    "posthog_local_evaluation_personal_api_key_source_total",
+    "Local evaluation requests authenticated via personal API key, by source",
+    labelnames=["source"],  # "header", "body", "query_string"
+)
+
 _AUTH_METHOD_BY_CLASS: dict[type, str] = {
     ProjectSecretAPIKeyAuthentication: "secret_api_key",
     PersonalAPIKeyAuthentication: "personal_api_key",
@@ -2631,6 +2637,10 @@ class FeatureFlagViewSet(
 
         auth_method = _classify_auth_method(request.successful_authenticator)
         LOCAL_EVALUATION_AUTH_COUNTER.labels(method=auth_method).inc()
+
+        if isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication):
+            source = request.successful_authenticator.personal_api_key_source or "unknown"
+            LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source=source).inc()
 
         try:
             # Check if team is quota limited for feature flags

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -7153,6 +7153,84 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(LOCAL_EVALUATION_SECRET_KEY_IN_BODY_COUNTER._value.get(), before)
 
+    @parameterized.expand(
+        [
+            ("header", "header"),
+            ("body", "body"),
+            ("query_string", "query_string"),
+        ]
+    )
+    def test_local_evaluation_personal_api_key_source_counter(self, name, source):
+        from posthog.api.feature_flag import LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER
+
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        self.client.logout()
+        before = LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source=source)._value.get()
+
+        url = f"/api/feature_flag/local_evaluation?token={self.team.api_token}"
+        if source == "header":
+            response = self.client.get(
+                url,
+                headers={"authorization": f"Bearer {personal_api_key}"},
+            )
+        elif source == "body":
+            response = self.client.generic(  # type: ignore[assignment]
+                "GET",
+                url,
+                data=json.dumps({"personal_api_key": personal_api_key}),
+                content_type="application/json",
+            )
+        else:
+            response = self.client.get(
+                f"{url}&personal_api_key={personal_api_key}",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source=source)._value.get(),
+            before + 1,
+        )
+
+    def test_local_evaluation_personal_api_key_source_counter_not_incremented_for_secret_key(self):
+        from posthog.api.feature_flag import LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER
+
+        self.team.secret_api_token = "phs_testtokenforpaksource"
+        self.team.save()
+
+        FeatureFlag.objects.filter(team=self.team).delete()
+        FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="test-flag",
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        self.client.logout()
+        before_header = LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source="header")._value.get()
+        before_body = LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source="body")._value.get()
+
+        response = self.client.get(
+            f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
+            headers={"authorization": f"Bearer {self.team.secret_api_token}"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source="header")._value.get(), before_header
+        )
+        self.assertEqual(
+            LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source="body")._value.get(), before_body
+        )
+
 
 class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
     def test_creating_static_cohort_with_deleted_flag(self):

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -170,6 +170,18 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
 
     keyword = "Bearer"
     personal_api_key: PersonalAPIKey
+    personal_api_key_source: Optional[str] = None
+
+    # Normalized source identifiers returned by find_key_with_source
+    SOURCE_HEADER = "header"
+    SOURCE_BODY = "body"
+    SOURCE_QUERY_STRING = "query_string"
+
+    _SOURCE_DISPLAY = {
+        SOURCE_HEADER: "Authorization header",
+        SOURCE_BODY: "body",
+        SOURCE_QUERY_STRING: "query string",
+    }
 
     message = "Invalid personal API key."
 
@@ -190,13 +202,13 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
                     "pha_"
                 ):  # TRICKY: This returns None to allow the next authentication method to have a go. This should be `if not token.startswith("phx_")`, but we need to support legacy personal api keys that may not have been prefixed with phx_.
                     return None
-                return token, "Authorization header"
+                return token, cls.SOURCE_HEADER
         data = request.data if request_data is None and isinstance(request, Request) else request_data
 
         if data and "personal_api_key" in data:
-            return data["personal_api_key"], "body"
+            return data["personal_api_key"], cls.SOURCE_BODY
         if "personal_api_key" in request.GET:
-            return request.GET["personal_api_key"], "query string"
+            return request.GET["personal_api_key"], cls.SOURCE_QUERY_STRING
         return None
 
     @classmethod
@@ -234,7 +246,8 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
                 pass
 
         if not personal_api_key_object:
-            raise AuthenticationFailed(detail=f"Personal API key found in request {source} is invalid.")
+            source_display = cls._SOURCE_DISPLAY.get(source, source)
+            raise AuthenticationFailed(detail=f"Personal API key found in request {source_display} is invalid.")
 
         # Upgrade the key if it's not in the latest mode. We can do this since above we've already checked
         # that the key is valid in some mode, and we do check for all modes one by one.
@@ -243,7 +256,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             key_to_update.secure_value = hash_key_value(personal_api_key)
             key_to_update.save(update_fields=["secure_value"])
 
-        if source == "query string":
+        if source == cls.SOURCE_QUERY_STRING:
             PERSONAL_API_KEY_QUERY_PARAM_COUNTER.labels(personal_api_key_object.user.uuid).inc()
 
         return personal_api_key_object
@@ -253,6 +266,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         if not personal_api_key_with_source:
             return None
 
+        _, source = personal_api_key_with_source
         personal_api_key_object = self.validate_key(personal_api_key_with_source)
 
         now = timezone.now()
@@ -274,6 +288,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         )
 
         self.personal_api_key = personal_api_key_object
+        self.personal_api_key_source = source
 
         return personal_api_key_object.user, None
 


### PR DESCRIPTION
## Problem

We have no visibility into how personal API keys are being passed to the local evaluation endpoint — whether via Authorization header, request body, or query string. This makes it hard to understand SDK usage patterns and plan deprecation of less secure methods.

## Changes

- Normalize source identifiers as class constants on `PersonalAPIKeyAuthentication` (`SOURCE_HEADER`, `SOURCE_BODY`, `SOURCE_QUERY_STRING`) instead of using ad-hoc strings
- Store `personal_api_key_source` on the authenticator instance after successful auth
- Add a `posthog_local_evaluation_personal_api_key_source_total` Prometheus counter in the local evaluation endpoint, labeled by `source` (`header`, `body`, `query_string`), incremented only when the request authenticated via personal API key
- Add parameterized tests for the new counter (header and body sources, plus a negative test for secret key auth)

## How did you test this code?

- `pytest posthog/api/test/test_feature_flag.py -k local_evaluation` — 33 passed
- `pytest posthog/api/test/test_authentication.py` — 90 passed

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored by Claude Code.