### PR TITLE
perf(posthog): set a timeout on integration HTTP calls

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -583,6 +583,7 @@ class OauthIntegration:
                     "grant_type": "authorization_code",
                 },
                 headers={"User-Agent": "PostHog/1.0 by PostHogTeam"},
+                    timeout=10.0,
             )
         # Pinterest uses HTTP Basic Auth for token exchange (base64-encoded client_id:client_secret)
         elif kind == "pinterest-ads":
@@ -594,6 +595,7 @@ class OauthIntegration:
                     "redirect_uri": OauthIntegration.redirect_uri(kind),
                     "grant_type": "authorization_code",
                 },
+                    timeout=10.0,
             )
         elif kind == "tiktok-ads":
             # TikTok Ads uses JSON request body instead of form data and maps 'code' to 'auth_code'


### PR DESCRIPTION
Added a timeout parameter to the network call in posthog/models/integration.py to prevent indefinite hangs.

Reason: Network calls without a timeout can hang a worker indefinitely.

Validation: `/Users/tejasattarde/Desktop/gh-patchbot/.venv/bin/python -m py_compile posthog/models/integration.py`.

Context: py-http-timeout at posthog/models/integration.py:577.