### PR TITLE
fix: typeless exceptions

### DIFF
--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -45,14 +45,14 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                 title={
                     <div className="flex gap-x-1">
                         <Link onClick={() => onEventSelect(record)} subtle className="line-clamp-1">
-                            {record.properties.$exception_types[0]}
+                            {record.properties.$exception_types?.[0] ?? 'Unknown'}
                         </Link>
                         {tagRenderer(record)}
                     </div>
                 }
                 description={
                     <div className="space-y-0.5">
-                        <span className="line-clamp-1">{record.properties.$exception_values[0]}</span>
+                        <span className="line-clamp-1">{record.properties.$exception_values?.[0]}</span>
                         <div className="flex items-center">
                             <div>{renderTime(record)}</div>
                             <CustomSeparator />

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -45,14 +45,14 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                 title={
                     <div className="flex gap-x-1">
                         <Link onClick={() => onEventSelect(record)} subtle className="line-clamp-1">
-                            {record.properties.$exception_types?.[0] ?? 'Unknown'}
+                            {record.properties.$exception_types[0]}
                         </Link>
                         {tagRenderer(record)}
                     </div>
                 }
                 description={
                     <div className="space-y-0.5">
-                        <span className="line-clamp-1">{record.properties.$exception_values?.[0]}</span>
+                        <span className="line-clamp-1">{record.properties.$exception_values[0]}</span>
                         <div className="flex items-center">
                             <div>{renderTime(record)}</div>
                             <CustomSeparator />

--- a/products/error_tracking/frontend/queries.ts
+++ b/products/error_tracking/frontend/queries.ts
@@ -151,7 +151,7 @@ export const errorTrackingIssueEventsQuery = ({
     const group = filterGroup.values[0] as UniversalFiltersGroup
     const properties = [...group.values] as AnyPropertyFilter[]
 
-    let where_string = `properties.$exception_fingerprint in [${fingerprints.map((f) => `'${f}'`).join(', ')}]`
+    let where_string = `properties.$exception_fingerprint in [${fingerprints.map((f) => `'${f}'`).join(', ')}] AND isNotNull(properties.$exception_issue_id)`
     if (searchQuery) {
         // This is an ugly hack for the fact I don't think we support nested property filters in
         // the eventsquery


### PR DESCRIPTION
In some cases it is possible that customer will ingest an exception with manually set fingerprint but improper structure. Such events fail our ET ingestion pipeline but are still ingested with `$cymbal_errors` attached.

Usually you can't see such exceptions in ET tab. You can only see them in activity tab with explanation why they failed to ingest into ET. 

But there is a special case where customer sets fingerprint manually so it gets "assigned" to an existing ET issue. When you then enter that issue, entire page crashes because it tries to attach usual metadata to improperly formatted exception event.

This PR makes it so that we will only include exceptions which have issue id set (they "passed" ET ingestion pipeline)

