### PR TITLE
feat(toolbar): add custom error tracking

### DIFF
--- a/frontend/src/toolbar/flags/flagsToolbarLogic.ts
+++ b/frontend/src/toolbar/flags/flagsToolbarLogic.ts
@@ -7,7 +7,7 @@ import type { PostHog } from 'posthog-js'
 import { permanentlyMount } from 'lib/utils/kea-logic-builders'
 
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
-import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
+import { captureToolbarException, toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { CombinedFeatureFlagAndValueType } from '~/types'
 
 import type { flagsToolbarLogicType } from './flagsToolbarLogicType'
@@ -297,6 +297,7 @@ export const flagsToolbarLogic = kea<flagsToolbarLogicType>([
                 } catch (e) {
                     actions.setPayloadError(flagKey, 'Invalid JSON')
                     console.error('Invalid JSON:', e)
+                    captureToolbarException(e, 'flag_payload_parse', { flag_key: flagKey })
                 }
             },
             loadFlagsForDistinctId: async ({ distinctId }, breakpoint) => {

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -14,6 +14,7 @@ import { createRoot } from 'react-dom/client'
 
 import { disposablesPlugin } from '~/kea-disposables'
 import { ToolbarApp } from '~/toolbar/ToolbarApp'
+import { captureToolbarException } from '~/toolbar/toolbarPosthogJS'
 import { ToolbarParams } from '~/types'
 
 interface InitKeaProps {
@@ -42,6 +43,10 @@ const initKeaInToolbar = ({ routerHistory, routerLocation, beforePlugins }: Init
         loadersPlugin({
             onFailure({ error, reducerKey, actionKey }: { error: any; reducerKey: string; actionKey: string }) {
                 console.error('toolbar fetch failed', error, reducerKey, actionKey)
+                captureToolbarException(error, 'kea_loader', {
+                    reducer_key: reducerKey,
+                    action_key: actionKey,
+                })
             },
         }),
         subscriptionsPlugin,
@@ -84,10 +89,15 @@ win['ph_load_toolbar'] = async function (toolbarParams: ToolbarParams, posthog?:
                     posthog.featureFlags.overrideFeatureFlags({ flags: data.featureFlags })
                 } else {
                     console.error('[Toolbar Flags] Feature flags not found:', JSON.stringify(data))
+                    captureToolbarException(
+                        new Error(`Toolbar feature flags not found: ${JSON.stringify(data)}`),
+                        'preloaded_flags'
+                    )
                 }
             })
             .catch((error) => {
                 console.error('[Toolbar Flags] Error fetching toolbar feature flags:', error)
+                captureToolbarException(error, 'preloaded_flags_fetch')
             })
     }
 

--- a/frontend/src/toolbar/product-tours/elementInference.ts
+++ b/frontend/src/toolbar/product-tours/elementInference.ts
@@ -2,6 +2,7 @@ import { querySelectorAllDeep } from 'query-selector-shadow-dom'
 
 import { TAGS_TO_IGNORE } from 'lib/actionUtils'
 
+import { captureToolbarException } from '~/toolbar/toolbarPosthogJS'
 import { TOOLBAR_ID, elementIsVisible, getParent } from '~/toolbar/utils'
 
 export interface SelectorGroup {
@@ -295,6 +296,7 @@ export function inferSelector(
         }
     } catch (error) {
         console.error('[ElementInference] Error inferring selector:', error)
+        captureToolbarException(error, 'element_inference')
         return null
     }
 }

--- a/frontend/src/toolbar/product-tours/productToursLogic.ts
+++ b/frontend/src/toolbar/product-tours/productToursLogic.ts
@@ -21,7 +21,7 @@ import { urls } from 'scenes/urls'
 
 import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { toolbarConfigLogic, toolbarFetch } from '~/toolbar/toolbarConfigLogic'
-import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
+import { captureToolbarException, toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { ElementRect } from '~/toolbar/types'
 import { TOOLBAR_ID, elementToActionStep, getRectForElement, joinWithUiHost } from '~/toolbar/utils'
 import { captureAndUploadElementScreenshot } from '~/toolbar/utils/screenshot'
@@ -461,6 +461,7 @@ export const productToursLogic = kea<productToursLogicType>([
             const inferenceData = inferSelector(element)?.selector
             const screenshot = await captureAndUploadElementScreenshot(element).catch((e) => {
                 console.warn('[Product Tours] Failed to capture element screenshot:', e)
+                captureToolbarException(e, 'product_tour_screenshot')
                 return null
             })
 
@@ -623,6 +624,7 @@ export const productToursLogic = kea<productToursLogicType>([
                     actions.selectTour(null)
                 }
             } catch (e: any) {
+                captureToolbarException(e, 'product_tour_save')
                 lemonToast.error(e.detail || 'Failed to save tour')
             }
         },

--- a/frontend/src/toolbar/toolbarAuth.ts
+++ b/frontend/src/toolbar/toolbarAuth.ts
@@ -1,3 +1,5 @@
+import { captureToolbarException } from '~/toolbar/toolbarPosthogJS'
+
 import { toolbarConfigLogic } from './toolbarConfigLogic'
 
 type OAuthTokens = { access_token: string; refresh_token: string; expires_in: number }
@@ -22,7 +24,9 @@ export async function refreshOAuthTokens(
             })
 
             if (!response.ok) {
-                throw new Error(`Refresh failed: ${response.status}`)
+                const err = new Error(`Refresh failed: ${response.status}`)
+                captureToolbarException(err, 'token_refresh')
+                throw err
             }
 
             return await response.json()
@@ -59,7 +63,8 @@ export async function withTokenRefresh(
         }
         toolbarConfigLogic.actions.setOAuthTokens(tokens.access_token, tokens.refresh_token, clientId)
         return await retryRequest(tokens.access_token)
-    } catch {
+    } catch (e) {
+        captureToolbarException(e, 'token_refresh_retry')
         toolbarConfigLogic.actions.tokenExpired()
         return response
     }

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -3,7 +3,7 @@ import { combineUrl, encodeParams } from 'kea-router'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
-import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
+import { captureToolbarException, toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
 import { ToolbarProps } from '~/types'
 
 import { withTokenRefresh } from './toolbarAuth'
@@ -162,7 +162,8 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
                 const pkce = await generatePKCE()
                 verifier = pkce.verifier
                 challenge = pkce.challenge
-            } catch {
+            } catch (e) {
+                captureToolbarException(e, 'pkce_generation')
                 lemonToast.error('Failed to start authentication. Ensure you are on a secure (HTTPS) page.')
                 return
             }
@@ -403,6 +404,9 @@ function verifyUiHostReachability(
         })
         .catch((error: unknown) => {
             actions.setAuthStatus('error')
+            captureToolbarException(error, 'ui_host_check', {
+                error_type: classifyFetchError(error),
+            })
             toolbarPosthogJS.capture('toolbar ui host check', {
                 ...checkBaseProps,
                 status: 'error',
@@ -493,10 +497,12 @@ async function exchangeCodeForTokens(
             return true
         }
         console.error('PostHog Toolbar: token exchange failed', data.error || data)
+        captureToolbarException(new Error(`Token exchange failed: ${data.error || 'unknown'}`), 'token_exchange')
         lemonToast.error('Authentication failed. Please try again.')
         return false
     } catch (err) {
         console.error('PostHog Toolbar: token exchange network error', err)
+        captureToolbarException(err, 'token_exchange_network')
         lemonToast.error('Authentication failed due to a network error. Please try again.')
         return false
     } finally {

--- a/frontend/src/toolbar/toolbarPosthogJS.ts
+++ b/frontend/src/toolbar/toolbarPosthogJS.ts
@@ -46,6 +46,18 @@ if (runningOnPosthog && window.JS_POSTHOG_SELF_CAPTURE) {
     toolbarPosthogJS.debug()
 }
 
+/** Capture an exception with a required toolbar context tag for filtering. */
+export function captureToolbarException(
+    error: unknown,
+    context: string,
+    additionalProperties?: Record<string, unknown>
+): void {
+    toolbarPosthogJS.captureException(error, {
+        toolbar_context: context,
+        ...additionalProperties,
+    })
+}
+
 export const useToolbarFeatureFlag = (flag: FeatureFlagKey, match?: string): boolean => {
     const [flagValue, setFlagValue] = useState<boolean | string | undefined>(toolbarPosthogJS.getFeatureFlag(flag))
 

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -6,6 +6,7 @@ import { CLICK_TARGETS, CLICK_TARGET_SELECTOR, TAGS_TO_IGNORE, escapeRegex } fro
 import { cssEscape } from 'lib/utils/cssEscape'
 
 import { patch } from '~/toolbar/patch'
+import { captureToolbarException } from '~/toolbar/toolbarPosthogJS'
 import { ActionStepForm, ElementRect } from '~/toolbar/types'
 import { ActionStepType } from '~/types'
 
@@ -151,6 +152,7 @@ function computeElementQuery(element: HTMLElement, dataAttributes: string[]): st
         return slashDotDataAttrUnescape(foundSelector)
     } catch (error) {
         console.warn('Error while trying to find a selector for element', element, error)
+        captureToolbarException(error, 'element_selector_computation')
         return undefined
     }
 }
@@ -400,6 +402,7 @@ export function getElementForStep(step: ActionStepForm, allElements?: HTMLElemen
         elements = [...(querySelectorAllDeep(selector || '*', document, allElements) as unknown as HTMLElement[])]
     } catch (e) {
         console.error('Cannot use selector:', selector, '. with exception: ', e)
+        captureToolbarException(e, 'element_step_selector', { selector })
         return null
     }
 


### PR DESCRIPTION
## Problem

The toolbar runs on customer pages with no visibility into errors. When things break (auth failures, API errors, selector inference issues), we have no way to know unless a user reports it.

## Changes

- Add `captureToolbarException()` helper in `toolbarPosthogJS.ts` that sends `$exception` events with a `toolbar_context` tag for filtering
- Instrument error handling across the toolbar:
  - **Auth**: token refresh failures, PKCE generation, OAuth code exchange, UI host reachability check
  - **API**: kea loader failures, preloaded feature flags fetch
  - **Features**: flag payload parsing, product tour save/screenshot, element inference
- Move `identify()` call outside the `props.instrument` guard so exceptions are always attributed to the user

## How did you test this code?

- Manually triggered errors via a dev-only debug button in the event debug menu
- Verified exceptions appear in PostHog error tracking UI with correct `toolbar_context` values

## Publish to changelog?

No.

## Docs update

N/A