### PR TITLE
feat(flags): pre-compute flag dependencies in the Django hypercache

### DIFF
--- a/docs/internal/feature-flags/flag-evaluation-engine.md
+++ b/docs/internal/feature-flags/flag-evaluation-engine.md
@@ -45,12 +45,12 @@ pub struct FeatureFlag {
 }
 ```
 
-### EvaluationContext
+### EvaluationMetadata
 
 Pre-computed dependency metadata, built by Django at cache-write time and shipped as a top-level field alongside the flags array in the HyperCache.
 
 ```rust
-pub struct EvaluationContext {
+pub struct EvaluationMetadata {
     pub dependency_stages: Vec<Vec<i32>>,           // flag IDs grouped by stage (stage 0 first)
     pub flags_with_missing_deps: Vec<i32>,          // flag IDs with broken dependencies
     pub transitive_deps: HashMap<i32, HashSet<i32>>, // flag ID → transitive dep IDs
@@ -290,12 +290,12 @@ The dependency graph determines evaluation order so that flags are evaluated aft
 
 #### Pre-computed path (HyperCache)
 
-Django pre-computes all dependency metadata at cache-write time and ships it as a top-level `evaluation_context` alongside the flags array in the HyperCache:
+Django pre-computes all dependency metadata at cache-write time and ships it as a top-level `evaluation_metadata` alongside the flags array in the HyperCache:
 
 ```json
 {
   "flags": [...],
-  "evaluation_context": {
+  "evaluation_metadata": {
     "dependency_stages": [[3], [2], [1]],
     "flags_with_missing_deps": [5],
     "transitive_deps": {"1": [2, 3], "2": [3]}
@@ -307,11 +307,11 @@ Django pre-computes all dependency metadata at cache-write time and ships it as 
 - `flags_with_missing_deps`: Flag IDs with missing, cyclic, or transitively broken dependencies (fail closed).
 - `transitive_deps`: Flag ID → transitive dependency flag IDs. Keys are stringified ints (JSON requirement).
 
-Rust deserializes `EvaluationContext` and maps pre-grouped stages directly to `Vec<Vec<FeatureFlag>>` — no graph construction or Kahn's algorithm needed.
+Rust deserializes `EvaluationMetadata` and maps pre-grouped stages directly to `Vec<Vec<FeatureFlag>>` — no graph construction or Kahn's algorithm needed.
 
 #### Fallback path (PostgreSQL)
 
-When `evaluation_context` is absent (PG fallback, old cache entries), the service builds a DAG using `petgraph`:
+When `evaluation_metadata` is absent (PG fallback, old cache entries), the service builds a DAG using `petgraph`:
 
 1. Extract dependencies from all flag property filters
 2. Build a directed graph (edges from dependent -> dependency)
@@ -321,11 +321,11 @@ When `evaluation_context` is absent (PG fallback, old cache entries), the servic
 
 #### Backwards compatibility
 
-The two paths are fully compatible via `#[serde(default)]` on `evaluation_context`:
+The two paths are fully compatible via `#[serde(default)]` on `evaluation_metadata`:
 
-- **Old Rust + new cache**: `evaluation_context` is an unknown field, ignored. Falls back to petgraph.
-- **New Rust + old cache**: `evaluation_context` absent → `None` → falls back to petgraph.
-- **New Rust + new cache**: `evaluation_context` present → fast pre-computed path.
+- **Old Rust + new cache**: `evaluation_metadata` is an unknown field, ignored. Falls back to petgraph.
+- **New Rust + old cache**: `evaluation_metadata` absent → `None` → falls back to petgraph.
+- **New Rust + new cache**: `evaluation_metadata` present → fast pre-computed path.
 
 ### Evaluation stages
 
@@ -434,7 +434,7 @@ Property overrides from the request body are merged on top of DB-fetched propert
 
 The evaluation engine follows a lazy-but-batched approach:
 
-1. **Flag definitions**: Fetched once per request from HyperCache (Redis -> S3 -> PostgreSQL), including pre-computed `evaluation_context` when available
+1. **Flag definitions**: Fetched once per request from HyperCache (Redis -> S3 -> PostgreSQL), including pre-computed `evaluation_metadata` when available
 2. **Group type mappings**: Fetched once per request if any flag uses groups
 3. **Person properties**: Fetched once per request from PostgreSQL, merged with request overrides
 4. **Group properties**: Fetched once per request from PostgreSQL, merged with request overrides

--- a/docs/internal/feature-flags/flag-evaluation-engine.md
+++ b/docs/internal/feature-flags/flag-evaluation-engine.md
@@ -19,8 +19,8 @@ The Rust feature flags service evaluates flags using a deterministic, hash-based
    ┌──────────┐  ┌───────────┐   ┌────────────┐
    │ SHA1     │  │ Property  │   │ Dependency │
    │ hashing  │  │ matching  │   │ graph      │
-   │ (rollout │  │ (23       │   │ (petgraph  │
-   │  + vars) │  │ operators)│   │  DAG)      │
+   │ (rollout │  │ (23       │   │ (pre-built │
+   │  + vars) │  │ operators)│   │  or DAG)   │
    └──────────┘  └───────────┘   └────────────┘
 ```
 
@@ -44,6 +44,21 @@ pub struct FeatureFlag {
     pub bucketing_identifier: Option<String>,        // "distinct_id" or "device_id"
 }
 ```
+
+### EvaluationContext
+
+Pre-computed dependency metadata, built by Django at cache-write time and shipped as a top-level field alongside the flags array in the HyperCache.
+
+```rust
+pub struct EvaluationContext {
+    pub dependency_stages: Vec<Vec<i32>>,           // flag IDs grouped by stage (stage 0 first)
+    pub flags_with_missing_deps: Vec<i32>,          // flag IDs with broken dependencies
+    pub transitive_deps: HashMap<i32, HashSet<i32>>, // flag ID → transitive dep IDs
+}
+```
+
+On the wire (JSON), `transitive_deps` keys are stringified integers (`{"1": [2, 3]}`).
+Custom serde converts between this and the in-memory `HashMap<i32, HashSet<i32>>`.
 
 ### FlagFilters
 
@@ -271,13 +286,46 @@ Flags can depend on other flags via `PropertyFilter` with `prop_type: Flag` and 
 
 ### Dependency graph
 
-The service builds a directed acyclic graph (DAG) using `petgraph` to determine evaluation order:
+The dependency graph determines evaluation order so that flags are evaluated after their dependencies.
+
+#### Pre-computed path (HyperCache)
+
+Django pre-computes all dependency metadata at cache-write time and ships it as a top-level `evaluation_context` alongside the flags array in the HyperCache:
+
+```json
+{
+  "flags": [...],
+  "evaluation_context": {
+    "dependency_stages": [[3], [2], [1]],
+    "flags_with_missing_deps": [5],
+    "transitive_deps": {"1": [2, 3], "2": [3]}
+  }
+}
+```
+
+- `dependency_stages`: Flag IDs pre-grouped by evaluation stage. Stage 0 (no deps) first.
+- `flags_with_missing_deps`: Flag IDs with missing, cyclic, or transitively broken dependencies (fail closed).
+- `transitive_deps`: Flag ID → transitive dependency flag IDs. Keys are stringified ints (JSON requirement).
+
+Rust deserializes `EvaluationContext` and maps pre-grouped stages directly to `Vec<Vec<FeatureFlag>>` — no graph construction or Kahn's algorithm needed.
+
+#### Fallback path (PostgreSQL)
+
+When `evaluation_context` is absent (PG fallback, old cache entries), the service builds a DAG using `petgraph`:
 
 1. Extract dependencies from all flag property filters
 2. Build a directed graph (edges from dependent -> dependency)
 3. Detect and remove cycles (cycle-starting nodes and all their dependents are removed)
 4. Track missing dependencies (flags depending on non-existent flags)
 5. Compute topological evaluation stages using Kahn's algorithm
+
+#### Backwards compatibility
+
+The two paths are fully compatible via `#[serde(default)]` on `evaluation_context`:
+
+- **Old Rust + new cache**: `evaluation_context` is an unknown field, ignored. Falls back to petgraph.
+- **New Rust + old cache**: `evaluation_context` absent → `None` → falls back to petgraph.
+- **New Rust + new cache**: `evaluation_context` present → fast pre-computed path.
 
 ### Evaluation stages
 
@@ -386,7 +434,7 @@ Property overrides from the request body are merged on top of DB-fetched propert
 
 The evaluation engine follows a lazy-but-batched approach:
 
-1. **Flag definitions**: Fetched once per request from HyperCache (Redis -> S3 -> PostgreSQL)
+1. **Flag definitions**: Fetched once per request from HyperCache (Redis -> S3 -> PostgreSQL), including pre-computed `evaluation_context` when available
 2. **Group type mappings**: Fetched once per request if any flag uses groups
 3. **Person properties**: Fetched once per request from PostgreSQL, merged with request overrides
 4. **Group properties**: Fetched once per request from PostgreSQL, merged with request overrides
@@ -397,19 +445,19 @@ The evaluation engine follows a lazy-but-batched approach:
 
 ## Related files
 
-| File                                                         | Purpose                                         |
-| ------------------------------------------------------------ | ----------------------------------------------- |
-| `rust/feature-flags/src/handler/evaluation.rs`               | Entry point: creates matcher and calls evaluate |
-| `rust/feature-flags/src/flags/flag_matching.rs`              | Core matching engine: `FeatureFlagMatcher`      |
-| `rust/feature-flags/src/flags/flag_matching_utils.rs`        | Hash calculation, property fetching, DB queries |
-| `rust/feature-flags/src/properties/property_matching.rs`     | Property filter operator implementations        |
-| `rust/feature-flags/src/flags/flag_models.rs`                | Data models                                     |
-| `rust/feature-flags/src/flags/flag_operations.rs`            | Flag helper methods, `DependencyProvider` trait |
-| `rust/feature-flags/src/flags/flag_match_reason.rs`          | Match reason enum with priority ordering        |
-| `rust/feature-flags/src/utils/graph_utils.rs`                | Dependency graph using petgraph                 |
-| `rust/feature-flags/src/cohorts/cohort_cache_manager.rs`     | Moka-backed cohort cache                        |
-| `rust/feature-flags/src/flags/test_flag_matching.rs`         | Unit tests for flag matching                    |
-| `rust/feature-flags/tests/test_flag_matching_consistency.rs` | Cross-language consistency tests                |
+| File                                                         | Purpose                                             |
+| ------------------------------------------------------------ | --------------------------------------------------- |
+| `rust/feature-flags/src/handler/evaluation.rs`               | Entry point: creates matcher and calls evaluate     |
+| `rust/feature-flags/src/flags/flag_matching.rs`              | Core matching engine: `FeatureFlagMatcher`          |
+| `rust/feature-flags/src/flags/flag_matching_utils.rs`        | Hash calculation, property fetching, DB queries     |
+| `rust/feature-flags/src/properties/property_matching.rs`     | Property filter operator implementations            |
+| `rust/feature-flags/src/flags/flag_models.rs`                | Data models                                         |
+| `rust/feature-flags/src/flags/flag_operations.rs`            | Flag helper methods, `DependencyProvider` trait     |
+| `rust/feature-flags/src/flags/flag_match_reason.rs`          | Match reason enum with priority ordering            |
+| `rust/feature-flags/src/utils/graph_utils.rs`                | Dependency graph (pre-computed + petgraph fallback) |
+| `rust/feature-flags/src/cohorts/cohort_cache_manager.rs`     | Moka-backed cohort cache                            |
+| `rust/feature-flags/src/flags/test_flag_matching.rs`         | Unit tests for flag matching                        |
+| `rust/feature-flags/tests/test_flag_matching_consistency.rs` | Cross-language consistency tests                    |
 
 ## See also
 

--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -93,6 +93,62 @@ else:
 
 ETags are computed as SHA256 hashes of the JSON content.
 
+## Service cache (Rust)
+
+The feature-flags Rust evaluation service uses a separate HyperCache instance defined in `posthog/models/feature_flag/flags_cache.py`. Unlike the local evaluation cache (which serves SDKs with cohort definitions and group type mappings), the service cache provides raw flag data plus pre-computed dependency metadata so the Rust service can evaluate flags in the correct order without recomputing the dependency graph on every request.
+
+### Cache instance
+
+```python
+# posthog/models/feature_flag/flags_cache.py
+flags_hypercache = HyperCache(
+    namespace="feature_flags",
+    value="flags.json",
+    load_fn=lambda key: _get_feature_flags_for_service(HyperCache.team_from_key(key)),
+    cache_ttl=settings.FLAGS_CACHE_TTL,
+    cache_miss_ttl=settings.FLAGS_CACHE_MISS_TTL,
+    cache_alias=FLAGS_DEDICATED_CACHE_ALIAS if FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES else None,
+    batch_load_fn=_get_feature_flags_for_teams_batch,
+    expiry_sorted_set_key=FLAGS_CACHE_EXPIRY_SORTED_SET,
+)
+```
+
+The `_get_feature_flags_for_service` function fetches all flags for a team (including inactive, but excluding deleted and encrypted remote config flags) and returns the cache payload. The Rust service filters out inactive flags at request time via `filtered_out_flag_ids`.
+
+### Cache payload structure
+
+```json
+{
+  "flags": [
+    /* serialized flag dicts */
+  ],
+  "evaluation_context": {
+    "dependency_stages": [[1, 5], [3], [7]],
+    "flags_with_missing_deps": [9, 12],
+    "transitive_deps": { "3": [1, 5], "7": [1, 3, 5] }
+  }
+}
+```
+
+The `evaluation_context` fields:
+
+| Field                     | Type                   | Description                                                                                                                                                                                 |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dependency_stages`       | `list[list[int]]`      | Flag IDs grouped by evaluation order. Stage 0 contains flags with no dependencies; stage N depends only on flags in stages 0…N-1. Flags within the same stage can be evaluated in parallel. |
+| `flags_with_missing_deps` | `list[int]`            | Flag IDs whose dependencies are missing, cyclic, or transitively broken. The Rust service treats these as evaluation errors.                                                                |
+| `transitive_deps`         | `dict[str, list[int]]` | Map of stringified flag ID to the sorted list of all its transitive dependency flag IDs.                                                                                                    |
+
+### Dependency computation
+
+The `_compute_flag_dependencies` function in `flags_cache.py` builds the evaluation context using Kahn's algorithm (layered topological sort). The algorithm:
+
+1. Extracts direct dependencies from each flag's `filters.groups[*].properties` where `type == "flag"`.
+2. Builds an in-degree map and reverse-dependency edges across all flags.
+3. Peels layers of zero-in-degree nodes, computing transitive dependency closures as it goes. Each layer becomes one evaluation stage.
+4. Detects cycles — any flag still with in-degree > 0 after all layers are peeled is a cycle participant. Cycled flags and any flag that transitively depends on them are added to `flags_with_missing_deps`.
+
+This matches the Rust fallback path's petgraph-based cycle handling, where all cycle participants are excluded from stages (not just back-edge targets).
+
 ## Local evaluation caching
 
 Feature flag local evaluation uses two separate HyperCache instances in `posthog/models/feature_flag/local_evaluation.py`:
@@ -415,7 +471,7 @@ REMOTE_CONFIG_CDN_PURGE_DOMAINS=["cdn.example.com"]
 
 - `posthog/storage/hypercache.py` - Core HyperCache implementation
 - `posthog/models/feature_flag/local_evaluation.py` - Local evaluation caching
-- `posthog/models/feature_flag/flags_cache.py` - Flags cache, signal handlers, verification
+- `posthog/models/feature_flag/flags_cache.py` - Flags cache, signal handlers, verification, dependency computation
 - `posthog/storage/hypercache_manager.py` - Batch management operations (warm, invalidate, stats)
 - `posthog/caching/flags_redis_cache.py` - Dual-write pattern for dedicated Redis
 - `posthog/models/remote_config.py` - Remote config caching

--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -122,7 +122,7 @@ The `_get_feature_flags_for_service` function fetches all flags for a team (incl
   "flags": [
     /* serialized flag dicts */
   ],
-  "evaluation_context": {
+  "evaluation_metadata": {
     "dependency_stages": [[1, 5], [3], [7]],
     "flags_with_missing_deps": [9, 12],
     "transitive_deps": { "3": [1, 5], "7": [1, 3, 5] }
@@ -130,7 +130,7 @@ The `_get_feature_flags_for_service` function fetches all flags for a team (incl
 }
 ```
 
-The `evaluation_context` fields:
+The `evaluation_metadata` fields:
 
 | Field                     | Type                   | Description                                                                                                                                                                                 |
 | ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -140,7 +140,7 @@ The `evaluation_context` fields:
 
 ### Dependency computation
 
-The `_compute_flag_dependencies` function in `flags_cache.py` builds the evaluation context using Kahn's algorithm (layered topological sort). The algorithm:
+The `_compute_flag_dependencies` function in `flags_cache.py` builds the evaluation metadata using Kahn's algorithm (layered topological sort). The algorithm:
 
 1. Extracts direct dependencies from each flag's `filters.groups[*].properties` where `type == "flag"`.
 2. Builds an in-degree map and reverse-dependency edges across all flags.

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -82,7 +82,7 @@ def _extract_direct_dependency_ids(flag_data: dict[str, Any]) -> set[int]:
 
     dep_ids: set[int] = set()
     filters = flag_data.get("filters", {})
-    for group in filters.get("groups", []):
+    for group in filters.get("groups") or []:
         for prop in group.get("properties") or []:
             if prop.get("type") == "flag":
                 try:

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -94,7 +94,7 @@ def _extract_direct_dependency_ids(flag_data: dict[str, Any]) -> set[int]:
 
 def _compute_flag_dependencies(flags_data: list[dict[str, Any]]) -> dict[str, Any]:
     """
-    Compute flag dependency metadata and return an evaluation context.
+    Compute flag dependency metadata and return evaluation metadata.
 
     Returns a dict with:
     - dependency_stages: list of lists of flag IDs grouped by evaluation stage,
@@ -191,14 +191,14 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     in /flags would return unusable encrypted ciphertext.
 
     Returns:
-        dict: {"flags": [...], "evaluation_context": {...}} where flags is a list
-        of flag dictionaries and evaluation_context contains pre-computed dependency
+        dict: {"flags": [...], "evaluation_metadata": {...}} where flags is a list
+        of flag dictionaries and evaluation_metadata contains pre-computed dependency
         metadata (stages, missing deps, transitive deps).
     """
     # Exclude encrypted remote config flags at DB level for efficiency
     flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
     flags_data = serialize_feature_flags(flags)
-    evaluation_context = _compute_flag_dependencies(flags_data)
+    evaluation_metadata = _compute_flag_dependencies(flags_data)
 
     logger.info(
         "Loaded feature flags for service cache",
@@ -208,7 +208,7 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     )
 
     # Wrap in dict for HyperCache compatibility
-    return {"flags": flags_data, "evaluation_context": evaluation_context}
+    return {"flags": flags_data, "evaluation_metadata": evaluation_metadata}
 
 
 def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -226,7 +226,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
         teams: List of Team objects to load flags for
 
     Returns:
-        Dict mapping team_id to {"flags": [...], "evaluation_context": {...}} for each team
+        Dict mapping team_id to {"flags": [...], "evaluation_metadata": {...}} for each team
     """
     if not teams:
         return {}
@@ -266,7 +266,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     for team in teams:
         team_flags = flags_by_team_id.get(team.id, [])
         flags_data = serialize_feature_flags(team_flags)
-        evaluation_context = _compute_flag_dependencies(flags_data)
+        evaluation_metadata = _compute_flag_dependencies(flags_data)
 
         logger.info(
             "Loaded feature flags for service cache (batch)",
@@ -275,7 +275,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
             flag_count=len(flags_data),
         )
 
-        result[team.id] = {"flags": flags_data, "evaluation_context": evaluation_context}
+        result[team.id] = {"flags": flags_data, "evaluation_metadata": evaluation_metadata}
 
     return result
 

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -69,13 +69,122 @@ logger = structlog.get_logger(__name__)
 FLAGS_CACHE_EXPIRY_SORTED_SET = "flags_cache_expiry"
 
 
+def _extract_direct_dependency_ids(flag_data: dict[str, Any]) -> set[int]:
+    """
+    Extract direct flag dependency IDs from a serialized flag's filters.
+
+    Scans filters.groups[*].properties for type=="flag" properties and parses
+    their key as an integer flag ID. Inactive/deleted flags return empty deps
+    to match Rust's extract_dependencies behavior.
+    """
+    if not flag_data.get("active", True) or flag_data.get("deleted", False):
+        return set()
+
+    dep_ids: set[int] = set()
+    filters = flag_data.get("filters", {})
+    for group in filters.get("groups", []):
+        for prop in group.get("properties") or []:
+            if prop.get("type") == "flag":
+                try:
+                    dep_ids.add(int(prop["key"]))
+                except (ValueError, KeyError, TypeError):
+                    continue
+    return dep_ids
+
+
+def _compute_flag_dependencies(flags_data: list[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Compute flag dependency metadata and return an evaluation context.
+
+    Returns a dict with:
+    - dependency_stages: list of lists of flag IDs grouped by evaluation stage,
+      stage 0 (no deps) first. Flags in the same stage can be evaluated in parallel.
+    - flags_with_missing_deps: sorted list of flag IDs with missing, cyclic, or
+      transitively broken dependencies.
+    - transitive_deps: dict mapping stringified flag ID to sorted list of all
+      transitive dependency flag IDs.
+
+    Uses Kahn's algorithm (layered topological sort) to match the Rust fallback
+    path's petgraph-based cycle handling: all cycle participants are excluded
+    from stages, not just back-edge targets.
+    """
+    id_to_flag: dict[int, dict[str, Any]] = {}
+    for flag in flags_data:
+        flag_id = flag.get("id")
+        if flag_id is not None:
+            id_to_flag[flag_id] = flag
+
+    # Build direct dependency edges, filtering to known flags only
+    direct_deps: dict[int, set[int]] = {}
+    for flag_id in id_to_flag:
+        direct_deps[flag_id] = _extract_direct_dependency_ids(id_to_flag[flag_id])
+
+    # Track flags with missing dependencies (dep ID not in id_to_flag)
+    has_missing: dict[int, bool] = {
+        fid: any(dep_id not in id_to_flag for dep_id in deps) for fid, deps in direct_deps.items()
+    }
+
+    # Build in-degree map (only count edges to known flags)
+    in_degree: dict[int, int] = dict.fromkeys(id_to_flag, 0)
+    # reverse_deps: flag_id → set of flags that depend on it
+    reverse_deps: dict[int, set[int]] = {fid: set() for fid in id_to_flag}
+    for flag_id, deps in direct_deps.items():
+        for dep_id in deps:
+            if dep_id in id_to_flag:
+                in_degree[flag_id] += 1
+                reverse_deps[dep_id].add(flag_id)
+
+    # Kahn's algorithm: peel layers of zero-in-degree nodes
+    dependency_stages: list[list[int]] = []
+    transitive_deps: dict[int, set[int]] = {}
+    queue = sorted(fid for fid, deg in in_degree.items() if deg == 0)
+
+    while queue:
+        for fid in queue:
+            # Compute transitive deps: union of each dep's transitive closure + direct deps
+            td: set[int] = set()
+            for dep_id in direct_deps[fid]:
+                if dep_id in id_to_flag:
+                    td.add(dep_id)
+                    td.update(transitive_deps[dep_id])
+                    if has_missing[dep_id]:
+                        has_missing[fid] = True
+            transitive_deps[fid] = td
+
+        dependency_stages.append(queue)
+
+        next_queue: list[int] = []
+        for fid in queue:
+            for dependent_id in reverse_deps[fid]:
+                in_degree[dependent_id] -= 1
+                if in_degree[dependent_id] == 0:
+                    next_queue.append(dependent_id)
+        queue = sorted(next_queue)
+
+    # Flags still with in_degree > 0 are in cycles. Mark them and propagate
+    # has_missing to any already-processed flag that depends on a cycled flag.
+    cycled_flags = {fid for fid, deg in in_degree.items() if deg > 0}
+    for fid in cycled_flags:
+        has_missing[fid] = True
+    if cycled_flags:
+        for fid, td in transitive_deps.items():
+            if not has_missing[fid] and td & cycled_flags:
+                has_missing[fid] = True
+
+    return {
+        "dependency_stages": dependency_stages,
+        "flags_with_missing_deps": sorted(fid for fid, m in has_missing.items() if m),
+        "transitive_deps": {str(fid): sorted(transitive_deps.get(fid, set())) for fid in id_to_flag},
+    }
+
+
 def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     """
     Get feature flags for the feature-flags service.
 
-    Fetches all active, non-deleted feature flags for the team and returns them
-    wrapped in a dict that HyperCache can serialize. The actual flag data is in the
-    "flags" key as a list of flag dictionaries.
+    Fetches all feature flags for the team (including inactive, excluding deleted)
+    and returns them wrapped in a dict that HyperCache can serialize. The actual
+    flag data is in the "flags" key as a list of flag dictionaries.
 
     Encrypted remote config flags are excluded since they can only be accessed via
     the dedicated /remote_config endpoint which handles decryption. Including them
@@ -87,6 +196,7 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     # Exclude encrypted remote config flags at DB level for efficiency
     flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
     flags_data = serialize_feature_flags(flags)
+    evaluation_context = _compute_flag_dependencies(flags_data)
 
     logger.info(
         "Loaded feature flags for service cache",
@@ -96,7 +206,7 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     )
 
     # Wrap in dict for HyperCache compatibility
-    return {"flags": flags_data}
+    return {"flags": flags_data, "evaluation_context": evaluation_context}
 
 
 def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -154,6 +264,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     for team in teams:
         team_flags = flags_by_team_id.get(team.id, [])
         flags_data = serialize_feature_flags(team_flags)
+        evaluation_context = _compute_flag_dependencies(flags_data)
 
         logger.info(
             "Loaded feature flags for service cache (batch)",
@@ -162,7 +273,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
             flag_count=len(flags_data),
         )
 
-        result[team.id] = {"flags": flags_data}
+        result[team.id] = {"flags": flags_data, "evaluation_context": evaluation_context}
 
     return result
 

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -191,7 +191,9 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     in /flags would return unusable encrypted ciphertext.
 
     Returns:
-        dict: {"flags": [...]} where flags is a list of flag dictionaries
+        dict: {"flags": [...], "evaluation_context": {...}} where flags is a list
+        of flag dictionaries and evaluation_context contains pre-computed dependency
+        metadata (stages, missing deps, transitive deps).
     """
     # Exclude encrypted remote config flags at DB level for efficiency
     flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
@@ -224,7 +226,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
         teams: List of Team objects to load flags for
 
     Returns:
-        Dict mapping team_id to {"flags": [...]} for each team
+        Dict mapping team_id to {"flags": [...], "evaluation_context": {...}} for each team
     """
     if not teams:
         return {}

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -19,6 +19,8 @@ from parameterized import parameterized
 from posthog.models import FeatureFlag, Tag, Team
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
 from posthog.models.feature_flag.flags_cache import (
+    _compute_flag_dependencies,
+    _extract_direct_dependency_ids,
     _get_feature_flags_for_service,
     _get_feature_flags_for_teams_batch,
     _get_team_ids_with_recently_updated_flags,
@@ -48,7 +50,14 @@ class TestServiceFlagsCache(BaseTest):
         """Test fetching flags when team has no flags."""
         result = _get_feature_flags_for_service(self.team)
 
-        assert result == {"flags": []}
+        assert result == {
+            "flags": [],
+            "evaluation_context": {
+                "dependency_stages": [],
+                "flags_with_missing_deps": [],
+                "transitive_deps": {},
+            },
+        }
 
     def test_get_feature_flags_for_service_with_flags(self):
         """Test fetching flags returns correct format for service."""
@@ -2240,3 +2249,288 @@ class TestGetTeamsWithFlagsQueryset(BaseTest):
         qs = get_teams_with_flags_queryset()
         team_ids = list(qs.values_list("id", flat=True))
         assert team_ids.count(self.team.id) == 1
+
+
+def _make_flag(id: int, key: str, deps: list[int] | None = None, active: bool = True, deleted: bool = False) -> dict:
+    """Helper to build a serialized flag dict with optional flag dependencies."""
+    properties = []
+    for dep_id in deps or []:
+        properties.append({"type": "flag", "key": str(dep_id), "value": ["true"], "operator": "exact"})
+    return {
+        "id": id,
+        "key": key,
+        "active": active,
+        "deleted": deleted,
+        "filters": {"groups": [{"properties": properties, "rollout_percentage": 100}]},
+    }
+
+
+class TestExtractDirectDependencyIds:
+    def test_no_dependencies(self):
+        flag = _make_flag(1, "flag_a")
+        assert _extract_direct_dependency_ids(flag) == set()
+
+    def test_single_dependency(self):
+        flag = _make_flag(1, "flag_a", deps=[2])
+        assert _extract_direct_dependency_ids(flag) == {2}
+
+    def test_multiple_dependencies(self):
+        flag = _make_flag(1, "flag_a", deps=[2, 3])
+        assert _extract_direct_dependency_ids(flag) == {2, 3}
+
+    def test_inactive_flag_returns_empty(self):
+        flag = _make_flag(1, "flag_a", deps=[2], active=False)
+        assert _extract_direct_dependency_ids(flag) == set()
+
+    def test_deleted_flag_returns_empty(self):
+        flag = _make_flag(1, "flag_a", deps=[2], deleted=True)
+        assert _extract_direct_dependency_ids(flag) == set()
+
+    def test_non_flag_properties_ignored(self):
+        flag = {
+            "id": 1,
+            "key": "flag_a",
+            "active": True,
+            "deleted": False,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {"type": "person", "key": "email", "value": "test@example.com"},
+                            {"type": "flag", "key": "2", "value": ["true"], "operator": "exact"},
+                        ]
+                    }
+                ]
+            },
+        }
+        assert _extract_direct_dependency_ids(flag) == {2}
+
+    def test_non_numeric_flag_key_ignored(self):
+        flag = {
+            "id": 1,
+            "key": "flag_a",
+            "active": True,
+            "deleted": False,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {"type": "flag", "key": "not_a_number", "value": ["true"]},
+                        ]
+                    }
+                ]
+            },
+        }
+        assert _extract_direct_dependency_ids(flag) == set()
+
+
+class TestComputeFlagDependencies:
+    def test_no_dependencies(self):
+        flags = [_make_flag(1, "flag_a"), _make_flag(2, "flag_b")]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[1, 2]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {"1": [], "2": []}
+
+    def test_linear_chain(self):
+        # A(1) -> B(2) -> C(3)
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[3]),
+            _make_flag(3, "flag_c"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[3], [2], [1]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {"1": [2, 3], "2": [3], "3": []}
+
+    def test_diamond(self):
+        # A(1) -> B(2), C(3); B(2) -> D(4); C(3) -> D(4)
+        flags = [
+            _make_flag(1, "flag_a", deps=[2, 3]),
+            _make_flag(2, "flag_b", deps=[4]),
+            _make_flag(3, "flag_c", deps=[4]),
+            _make_flag(4, "flag_d"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[4], [2, 3], [1]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {"1": [2, 3, 4], "2": [4], "3": [4], "4": []}
+
+    def test_missing_dependency(self):
+        # A(1) -> 999 (missing)
+        flags = [_make_flag(1, "flag_a", deps=[999])]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[1]]
+        assert ctx["flags_with_missing_deps"] == [1]
+        assert ctx["transitive_deps"] == {"1": []}
+
+    def test_cycle_both_flags_marked(self):
+        # A(1) -> B(2) -> A(1)
+        # Kahn's: neither flag reaches in-degree 0, so both are excluded from stages.
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[1]),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == [1, 2]
+
+    def test_transitive_missing_propagation(self):
+        # A(1) -> B(2) -> 999 (missing)
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[999]),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["flags_with_missing_deps"] == [1, 2]
+        assert ctx["dependency_stages"] == [[2], [1]]
+
+    def test_inactive_flag_empty_deps(self):
+        # Inactive A(1) has a dep on B(2), but since inactive, deps should be empty
+        flags = [
+            _make_flag(1, "flag_a", deps=[2], active=False),
+            _make_flag(2, "flag_b"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[1, 2]]
+
+    def test_dependency_on_inactive_flag_not_missing(self):
+        # A(1) -> inactive B(2). B exists so dependency is valid, but B evaluates to false.
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", active=False),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[2], [1]]
+        assert ctx["flags_with_missing_deps"] == []
+
+    def test_self_cycle(self):
+        # A(1) -> A(1)
+        flags = [_make_flag(1, "flag_a", deps=[1])]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == [1]
+
+    def test_three_node_cycle(self):
+        # A(1) -> B(2) -> C(3) -> A(1), plus D(4) -> A(1)
+        # Kahn's: A, B, C never reach in-degree 0 (cycle). D depends on cycled A,
+        # so D also never reaches in-degree 0. All excluded from stages.
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[3]),
+            _make_flag(3, "flag_c", deps=[1]),
+            _make_flag(4, "flag_d", deps=[1]),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == [1, 2, 3, 4]
+
+    def test_empty_flags_list(self):
+        ctx = _compute_flag_dependencies([])
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {}
+
+    def test_partial_missing_branch(self):
+        # A(1) -> 999 (missing), B(2) -> C(3) (valid)
+        flags = [
+            _make_flag(1, "flag_a", deps=[999]),
+            _make_flag(2, "flag_b", deps=[3]),
+            _make_flag(3, "flag_c"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["flags_with_missing_deps"] == [1]
+        assert ctx["dependency_stages"] == [[1, 3], [2]]
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestComputeFlagDependenciesIntegration(BaseTest):
+    def test_get_feature_flags_for_service_includes_dependency_fields(self):
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        result = _get_feature_flags_for_service(self.team)
+
+        assert "evaluation_context" in result
+        ctx = result["evaluation_context"]
+        assert "dependency_stages" in ctx
+        assert "flags_with_missing_deps" in ctx
+        assert "transitive_deps" in ctx
+        assert ctx["dependency_stages"] == [[flag.id]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {str(flag.id): []}
+
+        # Per-flag fields should not exist
+        flag_data = result["flags"][0]
+        assert "direct_dependency_flag_ids" not in flag_data
+        assert "dependency_flag_ids" not in flag_data
+        assert "has_missing_dependencies" not in flag_data
+
+    def test_batch_includes_dependency_fields(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        result = _get_feature_flags_for_teams_batch([self.team])
+
+        assert "evaluation_context" in result[self.team.id]
+
+    def test_service_computes_transitive_deps(self):
+        flag_c = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-c",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        flag_b = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-b",
+            created_by=self.user,
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"type": "flag", "key": str(flag_c.id), "value": ["true"], "operator": "exact"}],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+        flag_a = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            created_by=self.user,
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"type": "flag", "key": str(flag_b.id), "value": ["true"], "operator": "exact"}],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+        ctx = result["evaluation_context"]
+
+        assert sorted(ctx["transitive_deps"][str(flag_a.id)]) == sorted([flag_b.id, flag_c.id])
+        assert ctx["transitive_deps"][str(flag_b.id)] == [flag_c.id]
+        assert ctx["transitive_deps"][str(flag_c.id)] == []
+        assert ctx["dependency_stages"] == [[flag_c.id], [flag_b.id], [flag_a.id]]

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -52,7 +52,7 @@ class TestServiceFlagsCache(BaseTest):
 
         assert result == {
             "flags": [],
-            "evaluation_context": {
+            "evaluation_metadata": {
                 "dependency_stages": [],
                 "flags_with_missing_deps": [],
                 "transitive_deps": {},
@@ -2467,8 +2467,8 @@ class TestComputeFlagDependenciesIntegration(BaseTest):
         )
         result = _get_feature_flags_for_service(self.team)
 
-        assert "evaluation_context" in result
-        ctx = result["evaluation_context"]
+        assert "evaluation_metadata" in result
+        ctx = result["evaluation_metadata"]
         assert "dependency_stages" in ctx
         assert "flags_with_missing_deps" in ctx
         assert "transitive_deps" in ctx
@@ -2491,7 +2491,7 @@ class TestComputeFlagDependenciesIntegration(BaseTest):
         )
         result = _get_feature_flags_for_teams_batch([self.team])
 
-        assert "evaluation_context" in result[self.team.id]
+        assert "evaluation_metadata" in result[self.team.id]
 
     def test_service_computes_transitive_deps(self):
         flag_c = FeatureFlag.objects.create(
@@ -2528,7 +2528,7 @@ class TestComputeFlagDependenciesIntegration(BaseTest):
         )
 
         result = _get_feature_flags_for_service(self.team)
-        ctx = result["evaluation_context"]
+        ctx = result["evaluation_metadata"]
 
         assert sorted(ctx["transitive_deps"][str(flag_a.id)]) == sorted([flag_b.id, flag_c.id])
         assert ctx["transitive_deps"][str(flag_b.id)] == [flag_c.id]

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,7 +1,7 @@
 use crate::api::errors::{simplify_serde_error, FlagError};
 use crate::database::get_connection_with_metrics;
 use crate::flags::flag_models::{
-    FeatureFlag, FeatureFlagList, FeatureFlagRow, HypercacheFlagsWrapper,
+    EvaluationContext, FeatureFlag, FeatureFlagList, FeatureFlagRow, HypercacheFlagsWrapper,
 };
 use crate::metrics::consts::TOMBSTONE_COUNTER;
 use common_database::PostgresReader;
@@ -17,28 +17,28 @@ impl FeatureFlagList {
         }
     }
 
-    /// Parses a JSON Value from hypercache into a list of feature flags.
+    /// Parses a JSON Value from hypercache into flags and optional evaluation context.
     ///
     /// Handles:
     /// - Null values (returns empty vec)
     /// - Sentinel "__missing__" value (returns empty vec)
-    /// - Standard hypercache format `{"flags": [...]}`
+    /// - Standard hypercache format `{"flags": [...], "evaluation_context": {...}}`
     pub fn parse_hypercache_value(
         data: serde_json::Value,
         team_id: TeamId,
-    ) -> Result<Vec<FeatureFlag>, FlagError> {
+    ) -> Result<(Vec<FeatureFlag>, Option<EvaluationContext>), FlagError> {
         // Handle null (can happen when hypercache returns empty)
         if data.is_null() {
-            return Ok(vec![]);
+            return Ok((vec![], None));
         }
 
         // Check for the sentinel value indicating no flags for this team
         if data.as_str() == Some(HYPER_CACHE_EMPTY_VALUE) {
             tracing::debug!("Hypercache sentinel (no flags) for team {}", team_id);
-            return Ok(vec![]);
+            return Ok((vec![], None));
         }
 
-        // Parse the hypercache format: {"flags": [...]}
+        // Parse the hypercache format: {"flags": [...], "evaluation_context": {...}}
         let wrapper: HypercacheFlagsWrapper =
             serde_json::from_value(data.clone()).map_err(|e| {
                 let data_str = data.to_string();
@@ -63,7 +63,7 @@ impl FeatureFlagList {
 
         tracing::debug!("Parsed {} flags for team {}", wrapper.flags.len(), team_id);
 
-        Ok(wrapper.flags)
+        Ok((wrapper.flags, wrapper.evaluation_context))
     }
 
     /// Returns feature flags from postgres given a team_id
@@ -648,7 +648,7 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let flags = result.unwrap();
+        let (flags, _ctx) = result.unwrap();
         assert_eq!(flags.len(), 2);
         assert_eq!(flags[0].key, "test_flag");
         assert!(flags[0].active);
@@ -661,7 +661,7 @@ mod tests {
         let data = serde_json::Value::Null;
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        assert!(result.unwrap().0.is_empty());
     }
 
     #[test]
@@ -669,7 +669,7 @@ mod tests {
         let data = json!("__missing__");
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        assert!(result.unwrap().0.is_empty());
     }
 
     #[test]
@@ -677,7 +677,7 @@ mod tests {
         let data = json!({"flags": []});
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        assert!(result.unwrap().0.is_empty());
     }
 
     #[test]
@@ -751,7 +751,7 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let flags = result.unwrap();
+        let (flags, _ctx) = result.unwrap();
         assert_eq!(flags.len(), 1);
         let flag = &flags[0];
         assert_eq!(flag.id, 42);

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,7 +1,7 @@
 use crate::api::errors::{simplify_serde_error, FlagError};
 use crate::database::get_connection_with_metrics;
 use crate::flags::flag_models::{
-    EvaluationContext, FeatureFlag, FeatureFlagList, FeatureFlagRow, HypercacheFlagsWrapper,
+    EvaluationMetadata, FeatureFlag, FeatureFlagList, FeatureFlagRow, HypercacheFlagsWrapper,
 };
 use crate::metrics::consts::TOMBSTONE_COUNTER;
 use common_database::PostgresReader;
@@ -17,16 +17,16 @@ impl FeatureFlagList {
         }
     }
 
-    /// Parses a JSON Value from hypercache into flags and optional evaluation context.
+    /// Parses a JSON Value from hypercache into flags and optional evaluation metadata.
     ///
     /// Handles:
     /// - Null values (returns empty vec)
     /// - Sentinel "__missing__" value (returns empty vec)
-    /// - Standard hypercache format `{"flags": [...], "evaluation_context": {...}}`
+    /// - Standard hypercache format `{"flags": [...], "evaluation_metadata": {...}}`
     pub fn parse_hypercache_value(
         data: serde_json::Value,
         team_id: TeamId,
-    ) -> Result<(Vec<FeatureFlag>, Option<EvaluationContext>), FlagError> {
+    ) -> Result<(Vec<FeatureFlag>, Option<EvaluationMetadata>), FlagError> {
         // Handle null (can happen when hypercache returns empty)
         if data.is_null() {
             return Ok((vec![], None));
@@ -38,7 +38,7 @@ impl FeatureFlagList {
             return Ok((vec![], None));
         }
 
-        // Parse the hypercache format: {"flags": [...], "evaluation_context": {...}}
+        // Parse the hypercache format: {"flags": [...], "evaluation_metadata": {...}}
         let wrapper: HypercacheFlagsWrapper =
             serde_json::from_value(data.clone()).map_err(|e| {
                 let data_str = data.to_string();
@@ -63,7 +63,7 @@ impl FeatureFlagList {
 
         tracing::debug!("Parsed {} flags for team {}", wrapper.flags.len(), team_id);
 
-        Ok((wrapper.flags, wrapper.evaluation_context))
+        Ok((wrapper.flags, wrapper.evaluation_metadata))
     }
 
     /// Returns feature flags from postgres given a team_id

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -29,10 +29,7 @@ use crate::metrics::consts::{
 };
 use crate::properties::property_models::PropertyFilter;
 use crate::rayon_dispatcher::RayonDispatcher;
-use crate::utils::graph_utils::{
-    build_dependency_graph, filter_graph_by_keys, log_dependency_graph_operation_error,
-    DependencyGraph, DependencyGraphResult, FilteredGraphResult,
-};
+use crate::utils::graph_utils::PrecomputedDependencyGraph;
 use anyhow::Result;
 use common_metrics::{histogram, inc, timing_guard};
 use common_types::collections::HashMapExt;
@@ -330,39 +327,27 @@ impl FeatureFlagMatcher {
     ) -> Result<FlagsResponse, FlagError> {
         let eval_timer = common_metrics::timing_guard(FLAG_EVALUATION_TIME, &[]);
 
-        // Build dependency graph once - reused for both optimization check and evaluation
-        let DependencyGraphResult {
-            graph: global_dependency_graph,
-            errors: graph_errors,
-            flags_with_missing_deps: global_flags_with_missing_deps,
-        } = match build_dependency_graph(&feature_flags, self.team_id) {
+        // Build precomputed dependency graph with evaluation stages and transitive dependency map
+        let precomputed = match PrecomputedDependencyGraph::build(&feature_flags, self.team_id) {
             Some(result) => result,
             None => return Ok(FlagsResponse::new(true, HashMap::new(), None, request_id)),
         };
 
-        // Move the filter set onto the matcher now that the borrow from graph construction has ended.
-        // This is the single source of truth for "should this flag be skipped" during evaluation.
         self.filtered_out_flag_ids = feature_flags.filtered_out_flag_ids;
 
-        // Filter graph by flag_keys if specified (includes transitive dependencies)
-        let (dependency_graph, flags_with_missing_deps) = if let Some(ref keys) = flag_keys {
-            match filter_graph_by_keys(
-                &global_dependency_graph,
-                keys,
-                &global_flags_with_missing_deps,
-            ) {
-                Some(FilteredGraphResult {
-                    graph,
-                    flags_with_missing_deps,
-                }) => (graph, flags_with_missing_deps),
-                None => return Ok(FlagsResponse::new(true, HashMap::new(), None, request_id)),
-            }
+        // Filter stages by flag_keys if specified (uses pre-computed transitive dependency map)
+        let (evaluation_stages, flags_with_missing_deps) = if let Some(ref keys) = flag_keys {
+            let filtered = precomputed.filter_stages_by_keys(keys);
+            (filtered.evaluation_stages, filtered.flags_with_missing_deps)
         } else {
-            (global_dependency_graph, global_flags_with_missing_deps)
+            (
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
+            )
         };
 
-        if !graph_errors.is_empty() {
-            with_canonical_log(|log| log.dependency_graph_errors = graph_errors.len());
+        if precomputed.error_count > 0 {
+            with_canonical_log(|log| log.dependency_graph_errors = precomputed.error_count);
         }
 
         // Compute experience continuity stats from the filtered graph.
@@ -371,7 +356,7 @@ impl FeatureFlagMatcher {
             let mut continuity_count = 0;
             let mut needs_override = false;
 
-            for flag in dependency_graph.iter_nodes() {
+            for flag in evaluation_stages.iter().flatten() {
                 if !self.filtered_out_flag_ids.contains(&flag.id)
                     && flag.has_experience_continuity()
                 {
@@ -442,17 +427,16 @@ impl FeatureFlagMatcher {
             request_hash_key_override,
         };
 
-        // Pass the pre-built graph to avoid redundant graph construction
         let flags_response = self
             .evaluate_flags_with_overrides(
                 overrides,
                 request_id,
-                dependency_graph,
+                evaluation_stages,
                 flags_with_missing_deps,
             )
             .await?;
 
-        let has_cycle_errors = graph_errors.iter().any(|e| e.is_cycle());
+        let has_cycle_errors = precomputed.has_cycle_errors;
         let has_errors = flag_hash_key_override_error
             || flags_response.errors_while_computing_flags
             || has_cycle_errors;
@@ -628,20 +612,20 @@ impl FeatureFlagMatcher {
 
     /// Evaluates feature flags with property and hash key overrides.
     ///
-    /// Takes a pre-built dependency graph which should already be filtered by flag_keys if needed.
-    /// The graph determines which flags are evaluated and in what order.
+    /// Takes pre-computed evaluation stages which should already be filtered by flag_keys if needed.
+    /// The stages determine which flags are evaluated and in what order.
     pub async fn evaluate_flags_with_overrides(
         &mut self,
         overrides: FlagEvaluationOverrides,
         request_id: Uuid,
-        dependency_graph: DependencyGraph<FeatureFlag>,
+        evaluation_stages: Vec<Vec<FeatureFlag>>,
         flags_with_missing_deps: HashSet<i32>,
     ) -> Result<FlagsResponse, FlagError> {
         let mut errors_while_computing_flags = overrides.hash_key_override_error;
         let mut evaluated_flags_map = HashMap::new();
 
-        // Collect flags from the graph for preparation steps
-        let flags: Vec<&FeatureFlag> = dependency_graph.iter_nodes().collect();
+        // Collect flags from evaluation stages for preparation steps
+        let flags: Vec<&FeatureFlag> = evaluation_stages.iter().flatten().collect();
 
         // Handle hash key override errors by creating error responses for flags that need experience continuity
         if overrides.hash_key_override_error && overrides.hash_key_overrides.is_none() {
@@ -677,19 +661,22 @@ impl FeatureFlagMatcher {
                 .add_flag_evaluation_result(flag_id, FlagValue::Boolean(false));
         }
 
-        // Step 3: Evaluate flags using the dependency graph
-        let graph_evaluation_errors = self
-            .evaluate_flags_with_dependency_graph(
-                dependency_graph,
-                &overrides.person_property_overrides,
-                &overrides.group_property_overrides,
-                &overrides.hash_key_overrides,
-                &overrides.request_hash_key_override,
-                &mut evaluated_flags_map,
-                &flags_with_missing_deps,
-            )
-            .await?;
-        errors_while_computing_flags |= graph_evaluation_errors;
+        // Step 3: Evaluate flags stage by stage in dependency order
+        for stage in evaluation_stages {
+            let (level_evaluated_flags_map, level_errors) = self
+                .evaluate_flags_in_level(
+                    stage,
+                    &mut evaluated_flags_map,
+                    &overrides.person_property_overrides,
+                    &overrides.group_property_overrides,
+                    &overrides.hash_key_overrides,
+                    &overrides.request_hash_key_override,
+                    &flags_with_missing_deps,
+                )
+                .await?;
+            errors_while_computing_flags |= level_errors;
+            evaluated_flags_map.extend(level_evaluated_flags_map);
+        }
 
         Ok(FlagsResponse::new(
             errors_while_computing_flags,
@@ -697,49 +684,6 @@ impl FeatureFlagMatcher {
             None,
             request_id,
         ))
-    }
-
-    /// Evaluates flags using the provided dependency graph.
-    /// Returns true if there were errors during evaluation.
-    #[allow(clippy::too_many_arguments)]
-    async fn evaluate_flags_with_dependency_graph(
-        &mut self,
-        flag_dependency_graph: DependencyGraph<FeatureFlag>,
-        person_property_overrides: &Option<HashMap<String, Value>>,
-        group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
-        hash_key_overrides: &Option<HashMap<String, String>>,
-        request_hash_key_override: &Option<String>,
-        evaluated_flags_map: &mut HashMap<String, FlagDetails>,
-        flags_with_missing_deps: &HashSet<i32>,
-    ) -> Result<bool, FlagError> {
-        // Consume the graph to get owned flags in evaluation order
-        let evaluation_stages = match flag_dependency_graph.into_evaluation_stages() {
-            Ok(stages) => stages,
-            Err(e) => {
-                log_dependency_graph_operation_error("get evaluation stages", &e, self.team_id);
-                return Ok(true);
-            }
-        };
-
-        // Evaluate flags in dependency order
-        let mut errors_while_computing_flags = false;
-        for stage in evaluation_stages {
-            let (level_evaluated_flags_map, level_errors) = self
-                .evaluate_flags_in_level(
-                    stage,
-                    evaluated_flags_map,
-                    person_property_overrides,
-                    group_property_overrides,
-                    hash_key_overrides,
-                    request_hash_key_override,
-                    flags_with_missing_deps,
-                )
-                .await?;
-            errors_while_computing_flags |= level_errors;
-            evaluated_flags_map.extend(level_evaluated_flags_map);
-        }
-
-        Ok(errors_while_computing_flags)
     }
 
     /// Prepares evaluation state for flags that require database properties.

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -62,7 +62,7 @@ where
 /// Pre-computed dependency metadata, built by Django at cache-write time.
 /// Shipped as a top-level field alongside the flags array in the hypercache.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct EvaluationContext {
+pub struct EvaluationMetadata {
     /// Flag IDs grouped by evaluation stage. Stage 0 (no deps) first.
     pub dependency_stages: Vec<Vec<i32>>,
     /// Flag IDs with missing, cyclic, or transitively broken dependencies.
@@ -80,7 +80,7 @@ pub struct EvaluationContext {
 pub struct HypercacheFlagsWrapper {
     pub flags: Vec<FeatureFlag>,
     #[serde(default)]
-    pub evaluation_context: Option<EvaluationContext>,
+    pub evaluation_metadata: Option<EvaluationMetadata>,
 }
 
 /// New holdout format: `{"id": 42, "exclusion_percentage": 10}`.
@@ -244,5 +244,5 @@ pub struct FeatureFlagList {
     /// Present when the cache was written by new Django code; absent for PG fallback
     /// or old cache entries.
     #[serde(skip)]
-    pub evaluation_context: Option<EvaluationContext>,
+    pub evaluation_metadata: Option<EvaluationMetadata>,
 }

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -1,12 +1,86 @@
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
 
 use crate::properties::property_models::PropertyFilter;
+
+/// Deserializes a JSON object with string keys into `HashMap<i32, HashSet<i32>>`.
+/// JSON only supports string keys, so Python serializes `{1: [2, 3]}` as `{"1": [2, 3]}`.
+fn deserialize_string_keyed_i32_map<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<i32, HashSet<i32>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringKeyedMapVisitor;
+
+    impl<'de> Visitor<'de> for StringKeyedMapVisitor {
+        type Value = HashMap<i32, HashSet<i32>>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a map with string-encoded i32 keys")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
+            while let Some((key, value)) = access.next_entry::<String, Vec<i32>>()? {
+                let id = key.parse::<i32>().map_err(de::Error::custom)?;
+                map.insert(id, value.into_iter().collect());
+            }
+            Ok(map)
+        }
+    }
+
+    deserializer.deserialize_map(StringKeyedMapVisitor)
+}
+
+/// Serializes `HashMap<i32, HashSet<i32>>` back to JSON with string keys.
+fn serialize_string_keyed_i32_map<S>(
+    map: &HashMap<i32, HashSet<i32>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut ser_map = serializer.serialize_map(Some(map.len()))?;
+    for (k, v) in map {
+        let sorted: Vec<i32> = {
+            let mut s: Vec<i32> = v.iter().copied().collect();
+            s.sort_unstable();
+            s
+        };
+        ser_map.serialize_entry(&k.to_string(), &sorted)?;
+    }
+    ser_map.end()
+}
+
+/// Pre-computed dependency metadata, built by Django at cache-write time.
+/// Shipped as a top-level field alongside the flags array in the hypercache.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EvaluationContext {
+    /// Flag IDs grouped by evaluation stage. Stage 0 (no deps) first.
+    pub dependency_stages: Vec<Vec<i32>>,
+    /// Flag IDs with missing, cyclic, or transitively broken dependencies.
+    pub flags_with_missing_deps: Vec<i32>,
+    /// Flag ID → transitive dependency flag IDs.
+    #[serde(
+        deserialize_with = "deserialize_string_keyed_i32_map",
+        serialize_with = "serialize_string_keyed_i32_map"
+    )]
+    pub transitive_deps: HashMap<i32, HashSet<i32>>,
+}
 
 /// Wrapper struct for deserializing hypercache format: {"flags": [...]}
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HypercacheFlagsWrapper {
     pub flags: Vec<FeatureFlag>,
+    #[serde(default)]
+    pub evaluation_context: Option<EvaluationContext>,
 }
 
 /// New holdout format: `{"id": 42, "exclusion_percentage": 10}`.
@@ -166,4 +240,9 @@ pub struct FeatureFlagList {
     /// Not serialized — this is a request-scoped concern, not a cache concern.
     #[serde(skip)]
     pub filtered_out_flag_ids: HashSet<i32>,
+    /// Pre-computed dependency metadata from Django's hypercache.
+    /// Present when the cache was written by new Django code; absent for PG fallback
+    /// or old cache entries.
+    #[serde(skip)]
+    pub evaluation_context: Option<EvaluationContext>,
 }

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -48,7 +48,10 @@ where
     S: Serializer,
 {
     let mut ser_map = serializer.serialize_map(Some(map.len()))?;
-    for (k, v) in map {
+    let mut keys: Vec<&i32> = map.keys().collect();
+    keys.sort_unstable();
+    for k in keys {
+        let v = &map[k];
         let sorted: Vec<i32> = {
             let mut s: Vec<i32> = v.iter().copied().collect();
             s.sort_unstable();

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -160,7 +160,10 @@ impl FlagService {
             .get_with_source_or_fallback(&key, || async move {
                 // Fallback: load from PostgreSQL and convert to JSON Value
                 let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
-                let wrapper = crate::flags::flag_models::HypercacheFlagsWrapper { flags };
+                let wrapper = crate::flags::flag_models::HypercacheFlagsWrapper {
+                    flags,
+                    evaluation_context: None,
+                };
                 let value = serde_json::to_value(&wrapper).map_err(|e| {
                     tracing::error!(
                         "Failed to serialize flags from PG for team {}: {}",
@@ -174,11 +177,12 @@ impl FlagService {
             .await?;
 
         // Parse the result (from cache or fallback)
-        let flags = FeatureFlagList::parse_hypercache_value(data, team_id)?;
+        let (flags, evaluation_context) = FeatureFlagList::parse_hypercache_value(data, team_id)?;
 
         Ok(FlagResult {
             flag_list: FeatureFlagList {
                 flags,
+                evaluation_context,
                 ..Default::default()
             },
             cache_source: source,
@@ -521,6 +525,7 @@ mod tests {
         // Serialize exactly like Django does for large payloads: JSON -> Pickle -> Zstd
         let wrapper = HypercacheFlagsWrapper {
             flags: large_flags.flags.clone(),
+            evaluation_context: None,
         };
         let json_string = serde_json::to_string(&wrapper).expect("Failed to serialize to JSON");
 

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -162,7 +162,7 @@ impl FlagService {
                 let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
                 let wrapper = crate::flags::flag_models::HypercacheFlagsWrapper {
                     flags,
-                    evaluation_context: None,
+                    evaluation_metadata: None,
                 };
                 let value = serde_json::to_value(&wrapper).map_err(|e| {
                     tracing::error!(
@@ -177,12 +177,12 @@ impl FlagService {
             .await?;
 
         // Parse the result (from cache or fallback)
-        let (flags, evaluation_context) = FeatureFlagList::parse_hypercache_value(data, team_id)?;
+        let (flags, evaluation_metadata) = FeatureFlagList::parse_hypercache_value(data, team_id)?;
 
         Ok(FlagResult {
             flag_list: FeatureFlagList {
                 flags,
-                evaluation_context,
+                evaluation_metadata,
                 ..Default::default()
             },
             cache_source: source,
@@ -525,7 +525,7 @@ mod tests {
         // Serialize exactly like Django does for large payloads: JSON -> Pickle -> Zstd
         let wrapper = HypercacheFlagsWrapper {
             flags: large_flags.flags.clone(),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
         let json_string = serde_json::to_string(&wrapper).expect("Failed to serialize to JSON");
 

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -24,7 +24,7 @@ mod tests {
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
         utils::{
-            graph_utils::build_dependency_graph,
+            graph_utils::PrecomputedDependencyGraph,
             test_utils::{create_test_flag, TestContext},
         },
     };
@@ -6557,8 +6557,8 @@ mod tests {
         };
 
         // Build dependency graph for the flags
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
+            .expect("Should build dependency graph");
 
         // Test the scenario where hash key override reading fails
         // This simulates the case where we have experience continuity flags but hash override reads fail
@@ -6574,8 +6574,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 overrides,
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -6661,10 +6661,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![filtered_continuity_flag, active_normal_flag],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_context: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
+            .expect("Should build dependency graph");
 
         // Simulate a hash-key-override read failure
         let overrides = crate::flags::flag_matching::FlagEvaluationOverrides {
@@ -6681,8 +6682,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 overrides,
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -6755,8 +6756,8 @@ mod tests {
         };
 
         // Build dependency graph for the flags
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -6776,8 +6777,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -6854,10 +6855,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_context: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -6875,8 +6877,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -6950,10 +6952,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_context: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -6971,8 +6974,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -7053,8 +7056,8 @@ mod tests {
             ..Default::default()
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -7074,8 +7077,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -7144,10 +7147,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b, flag_c],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_context: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -7165,8 +7169,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -6661,7 +6661,7 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![filtered_continuity_flag, active_normal_flag],
             filtered_out_flag_ids: filtered_out.clone(),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
@@ -6855,7 +6855,7 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
@@ -6952,7 +6952,7 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)
@@ -7147,7 +7147,7 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b, flag_c],
             filtered_out_flag_ids: filtered_out.clone(),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id)

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -152,7 +152,7 @@ pub async fn update_flags_in_hypercache(
 ) -> Result<(), FlagError> {
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.flags.clone(),
-        evaluation_metadata: None,
+        evaluation_metadata: flags.evaluation_metadata.clone(),
     };
 
     // Match Django's format: JSON string -> Pickle

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -152,7 +152,7 @@ pub async fn update_flags_in_hypercache(
 ) -> Result<(), FlagError> {
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.flags.clone(),
-        evaluation_context: None,
+        evaluation_metadata: None,
     };
 
     // Match Django's format: JSON string -> Pickle

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -152,6 +152,7 @@ pub async fn update_flags_in_hypercache(
 ) -> Result<(), FlagError> {
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.flags.clone(),
+        evaluation_context: None,
     };
 
     // Match Django's format: JSON string -> Pickle

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -209,7 +209,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage when only filtered-out flags are present
@@ -224,7 +224,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone(), active_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         // Should record usage when at least one non-filtered, non-survey flag is present
@@ -239,7 +239,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_survey_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_survey_flag.id]),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage for filtered-out survey flags
@@ -254,7 +254,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone(), survey_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage when only filtered-out and survey flags are present
@@ -297,7 +297,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_tour_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_tour_flag.id]),
-            evaluation_context: None,
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage for filtered-out product tour flags

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -209,6 +209,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
+            evaluation_context: None,
         };
 
         // Should NOT record usage when only filtered-out flags are present
@@ -223,6 +224,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone(), active_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
+            evaluation_context: None,
         };
 
         // Should record usage when at least one non-filtered, non-survey flag is present
@@ -237,6 +239,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_survey_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_survey_flag.id]),
+            evaluation_context: None,
         };
 
         // Should NOT record usage for filtered-out survey flags
@@ -251,6 +254,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone(), survey_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
+            evaluation_context: None,
         };
 
         // Should NOT record usage when only filtered-out and survey flags are present
@@ -293,6 +297,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_tour_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_tour_flag.id]),
+            evaluation_context: None,
         };
 
         // Should NOT record usage for filtered-out product tour flags

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -144,7 +144,7 @@ pub async fn fetch_and_filter(
     with_canonical_log(|log| log.flags_cache_source = Some(flag_result.cache_source.as_log_str()));
 
     let flags = flag_result.flag_list.flags;
-    let evaluation_context = flag_result.flag_list.evaluation_context;
+    let evaluation_metadata = flag_result.flag_list.evaluation_metadata;
 
     // Build the filtered-out set: user-disabled, deleted, survey filter, runtime/tag mismatches.
     // This is the single source of truth for "should this flag be skipped during evaluation."
@@ -181,7 +181,7 @@ pub async fn fetch_and_filter(
     Ok(FeatureFlagList {
         flags,
         filtered_out_flag_ids,
-        evaluation_context,
+        evaluation_metadata,
     })
 }
 

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -144,6 +144,7 @@ pub async fn fetch_and_filter(
     with_canonical_log(|log| log.flags_cache_source = Some(flag_result.cache_source.as_log_str()));
 
     let flags = flag_result.flag_list.flags;
+    let evaluation_context = flag_result.flag_list.evaluation_context;
 
     // Build the filtered-out set: user-disabled, deleted, survey filter, runtime/tag mismatches.
     // This is the single source of truth for "should this flag be skipped during evaluation."
@@ -180,6 +181,7 @@ pub async fn fetch_and_filter(
     Ok(FeatureFlagList {
         flags,
         filtered_out_flag_ids,
+        evaluation_context,
     })
 }
 

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1442,14 +1442,14 @@ async fn test_fetch_and_filter_preserves_evaluation_metadata() {
     ];
 
     // Write to cache WITH evaluation_metadata
-    let eval_context = EvaluationMetadata {
+    let eval_metadata = EvaluationMetadata {
         dependency_stages: vec![vec![1], vec![2]],
         flags_with_missing_deps: vec![],
         transitive_deps: HashMap::from([(2, std::collections::HashSet::from([1]))]),
     };
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.clone(),
-        evaluation_metadata: Some(eval_context),
+        evaluation_metadata: Some(eval_metadata),
     };
     let json_string = serde_json::to_string(&wrapper).unwrap();
     let pickled_bytes = serde_pickle::to_vec(&json_string, Default::default()).unwrap();

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -12,7 +12,7 @@ use crate::{
     flags::{
         flag_analytics::SURVEY_TARGETING_FLAG_PREFIX,
         flag_models::{
-            EvaluationContext, FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup,
+            EvaluationMetadata, FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup,
             HypercacheFlagsWrapper,
         },
         flag_service::FlagService,
@@ -1395,7 +1395,7 @@ async fn test_fetch_and_filter_flags() {
 }
 
 #[tokio::test]
-async fn test_fetch_and_filter_preserves_evaluation_context() {
+async fn test_fetch_and_filter_preserves_evaluation_metadata() {
     let redis_client = setup_redis_client(None).await;
     let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None);
     let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
@@ -1441,15 +1441,15 @@ async fn test_fetch_and_filter_preserves_evaluation_context() {
         },
     ];
 
-    // Write to cache WITH an evaluation_context
-    let eval_context = EvaluationContext {
+    // Write to cache WITH evaluation_metadata
+    let eval_context = EvaluationMetadata {
         dependency_stages: vec![vec![1], vec![2]],
         flags_with_missing_deps: vec![],
         transitive_deps: HashMap::from([(2, std::collections::HashSet::from([1]))]),
     };
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.clone(),
-        evaluation_context: Some(eval_context),
+        evaluation_metadata: Some(eval_context),
     };
     let json_string = serde_json::to_string(&wrapper).unwrap();
     let pickled_bytes = serde_pickle::to_vec(&json_string, Default::default()).unwrap();
@@ -1473,10 +1473,10 @@ async fn test_fetch_and_filter_preserves_evaluation_context() {
 
     assert_eq!(result.flags.len(), 2);
     assert!(
-        result.evaluation_context.is_some(),
-        "evaluation_context should be preserved by fetch_and_filter, not dropped"
+        result.evaluation_metadata.is_some(),
+        "evaluation_metadata should be preserved by fetch_and_filter, not dropped"
     );
-    let ctx = result.evaluation_context.unwrap();
+    let ctx = result.evaluation_metadata.unwrap();
     assert_eq!(ctx.dependency_stages, vec![vec![1], vec![2]]);
     assert!(ctx.flags_with_missing_deps.is_empty());
     assert!(ctx.transitive_deps.contains_key(&2));
@@ -1709,7 +1709,7 @@ async fn test_parallel_path_matches_sequential_results() {
         feature_flags: FeatureFlagList {
             flags: flags.clone(),
             filtered_out_flag_ids: filtered_out_flag_ids.clone(),
-            evaluation_context: None,
+            evaluation_metadata: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),
@@ -1738,7 +1738,7 @@ async fn test_parallel_path_matches_sequential_results() {
         feature_flags: FeatureFlagList {
             flags,
             filtered_out_flag_ids,
-            evaluation_context: None,
+            evaluation_metadata: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -11,7 +11,10 @@ use crate::{
     config::Config,
     flags::{
         flag_analytics::SURVEY_TARGETING_FLAG_PREFIX,
-        flag_models::{FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup},
+        flag_models::{
+            EvaluationContext, FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup,
+            HypercacheFlagsWrapper,
+        },
         flag_service::FlagService,
     },
     handler::{
@@ -1391,6 +1394,94 @@ async fn test_fetch_and_filter_flags() {
         .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
 }
 
+#[tokio::test]
+async fn test_fetch_and_filter_preserves_evaluation_context() {
+    let redis_client = setup_redis_client(None).await;
+    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None);
+    let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
+    let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
+    let flag_service = FlagService::new(
+        redis_client.clone(),
+        reader.clone(),
+        team_hypercache_reader,
+        hypercache_reader,
+        NegativeCache::new(100, 300),
+    );
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.unwrap();
+
+    let flags = vec![
+        FeatureFlag {
+            id: 1,
+            key: "flag_a".to_string(),
+            name: Some("Flag A".to_string()),
+            active: true,
+            deleted: false,
+            team_id: team.id,
+            filters: FlagFilters::default(),
+            ensure_experience_continuity: Some(false),
+            version: Some(1),
+            evaluation_runtime: Some("all".to_string()),
+            evaluation_tags: None,
+            bucketing_identifier: None,
+        },
+        FeatureFlag {
+            id: 2,
+            key: "flag_b".to_string(),
+            name: Some("Flag B".to_string()),
+            active: true,
+            deleted: false,
+            team_id: team.id,
+            filters: FlagFilters::default(),
+            ensure_experience_continuity: Some(false),
+            version: Some(1),
+            evaluation_runtime: Some("all".to_string()),
+            evaluation_tags: None,
+            bucketing_identifier: None,
+        },
+    ];
+
+    // Write to cache WITH an evaluation_context
+    let eval_context = EvaluationContext {
+        dependency_stages: vec![vec![1], vec![2]],
+        flags_with_missing_deps: vec![],
+        transitive_deps: HashMap::from([(2, std::collections::HashSet::from([1]))]),
+    };
+    let wrapper = HypercacheFlagsWrapper {
+        flags: flags.clone(),
+        evaluation_context: Some(eval_context),
+    };
+    let json_string = serde_json::to_string(&wrapper).unwrap();
+    let pickled_bytes = serde_pickle::to_vec(&json_string, Default::default()).unwrap();
+    let cache_key = format!("posthog:1:cache/teams/{}/feature_flags/flags.json", team.id);
+    redis_client
+        .set_bytes(cache_key, pickled_bytes, None)
+        .await
+        .unwrap();
+
+    let query_params = FlagsQueryParams::default();
+    let result = fetch_and_filter(
+        &flag_service,
+        team.id,
+        &query_params,
+        &axum::http::HeaderMap::new(),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.flags.len(), 2);
+    assert!(
+        result.evaluation_context.is_some(),
+        "evaluation_context should be preserved by fetch_and_filter, not dropped"
+    );
+    let ctx = result.evaluation_context.unwrap();
+    assert_eq!(ctx.dependency_stages, vec![vec![1], vec![2]]);
+    assert!(ctx.flags_with_missing_deps.is_empty());
+    assert!(ctx.transitive_deps.contains_key(&2));
+}
+
 #[test]
 fn test_disable_flags_request_parsing() {
     // Test that disable_flags=true is properly parsed and detected
@@ -1618,6 +1709,7 @@ async fn test_parallel_path_matches_sequential_results() {
         feature_flags: FeatureFlagList {
             flags: flags.clone(),
             filtered_out_flag_ids: filtered_out_flag_ids.clone(),
+            evaluation_context: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),
@@ -1646,6 +1738,7 @@ async fn test_parallel_path_matches_sequential_results() {
         feature_flags: FeatureFlagList {
             flags,
             filtered_out_flag_ids,
+            evaluation_context: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -728,14 +728,14 @@ pub struct FilteredStagesResult {
 
 impl PrecomputedDependencyGraph {
     /// Builds a `PrecomputedDependencyGraph` from a flag list.
-    /// Uses the fast path when Django-precomputed `evaluation_context` is present,
+    /// Uses the fast path when Django-precomputed `evaluation_metadata` is present,
     /// falls back to full graph construction otherwise.
     /// Returns `None` only for fatal errors (same semantics as `build_dependency_graph`).
     pub fn build(
         feature_flags: &crate::flags::flag_models::FeatureFlagList,
         team_id: common_types::TeamId,
     ) -> Option<Self> {
-        if let Some(ref ctx) = feature_flags.evaluation_context {
+        if let Some(ref ctx) = feature_flags.evaluation_metadata {
             Self::build_from_precomputed(
                 &feature_flags.flags,
                 ctx,
@@ -750,11 +750,11 @@ impl PrecomputedDependencyGraph {
         }
     }
 
-    /// Fast path: consumes the top-level `EvaluationContext` directly.
+    /// Fast path: consumes the top-level `EvaluationMetadata` directly.
     /// No Kahn's algorithm, no per-flag scanning, no ID→key conversion loops.
     fn build_from_precomputed(
         flags: &[FeatureFlag],
-        ctx: &crate::flags::flag_models::EvaluationContext,
+        ctx: &crate::flags::flag_models::EvaluationMetadata,
         filtered_out_flag_ids: &HashSet<i32>,
     ) -> Option<Self> {
         let id_to_flag: HashMap<i32, &FeatureFlag> = flags.iter().map(|f| (f.id, f)).collect();

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -812,8 +812,11 @@ impl PrecomputedDependencyGraph {
     ) -> Option<Self> {
         // Extract edges from each flag's property filters.
         // Filtered-out flags (runtime mismatch, tag filter, etc.) get empty
-        // edges so their dependencies aren't followed — matching the old
-        // build_dependency_graph behavior that prevents false cycles.
+        // edges so their dependencies aren't followed, preventing false cycles.
+        // Note: unlike the old BFS-based build_dependency_graph, this includes
+        // all filtered-out flags as isolated nodes rather than only reachable
+        // ones. This is safe — unreachable nodes end up in stage 0 and are
+        // skipped during evaluation.
         let mut edges: HashMap<i32, HashSet<i32>> = HashMap::with_capacity(flags.len());
         for flag in flags {
             if filtered_out_flag_ids.contains(&flag.id) {
@@ -852,8 +855,8 @@ impl PrecomputedDependencyGraph {
             log_dependency_graph_construction_errors(&errors, team_id);
         }
 
-        let has_cycle_errors = errors.iter().any(|e| e.is_cycle());
         let cycle_count = errors.iter().filter(|e| e.is_cycle()).count();
+        let has_cycle_errors = cycle_count > 0;
         let error_count = flags_with_missing_deps.len() + cycle_count;
         let transitive_deps = Self::build_transitive_deps_map_from_graph(&graph);
         let key_to_id: HashMap<String, i32> = flags.iter().map(|f| (f.key.clone(), f.id)).collect();

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -742,7 +742,11 @@ impl PrecomputedDependencyGraph {
                 &feature_flags.filtered_out_flag_ids,
             )
         } else {
-            Self::build_from_graph(&feature_flags.flags, team_id)
+            Self::build_from_graph(
+                &feature_flags.flags,
+                &feature_flags.filtered_out_flag_ids,
+                team_id,
+            )
         }
     }
 
@@ -801,10 +805,21 @@ impl PrecomputedDependencyGraph {
 
     /// Fallback path: builds a full petgraph-based dependency graph when
     /// precomputed data is absent (old cache format or PG fallback).
-    fn build_from_graph(flags: &[FeatureFlag], team_id: common_types::TeamId) -> Option<Self> {
-        // Extract edges from each flag's property filters
+    fn build_from_graph(
+        flags: &[FeatureFlag],
+        filtered_out_flag_ids: &HashSet<i32>,
+        team_id: common_types::TeamId,
+    ) -> Option<Self> {
+        // Extract edges from each flag's property filters.
+        // Filtered-out flags (runtime mismatch, tag filter, etc.) get empty
+        // edges so their dependencies aren't followed — matching the old
+        // build_dependency_graph behavior that prevents false cycles.
         let mut edges: HashMap<i32, HashSet<i32>> = HashMap::with_capacity(flags.len());
         for flag in flags {
+            if filtered_out_flag_ids.contains(&flag.id) {
+                edges.insert(flag.id, HashSet::new());
+                continue;
+            }
             match flag.extract_dependencies() {
                 Ok(deps) => {
                     edges.insert(flag.id, deps);

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -787,7 +787,10 @@ impl PrecomputedDependencyGraph {
             .iter()
             .flat_map(|s| s.iter().map(|f| f.id))
             .collect();
-        let cycle_count = (flags.len() - filtered_out_flag_ids.len()) - flags_in_stages.len();
+        let cycle_count = flags
+            .len()
+            .saturating_sub(filtered_out_flag_ids.len())
+            .saturating_sub(flags_in_stages.len());
 
         let key_to_id: HashMap<String, i32> = flags.iter().map(|f| (f.key.clone(), f.id)).collect();
 

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -1,9 +1,10 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+#[cfg(test)]
+use petgraph::visit::EdgeRef;
 use petgraph::{
     algo::toposort,
     graph::{DiGraph, NodeIndex},
-    visit::EdgeRef,
 };
 
 use crate::api::errors::FlagError;
@@ -457,6 +458,10 @@ where
     }
 }
 
+// TODO: Remove these #[cfg(test)] items (DependencyGraphResult, build_dependency_graph,
+// FilteredGraphResult, filter_graph_by_keys) and the petgraph dependency once the
+// precomputed path is validated in production and the fallback path is removed.
+#[cfg(test)]
 /// Result of building a dependency graph, including the graph, errors, and flags with missing dependencies.
 pub struct DependencyGraphResult {
     /// The dependency graph (may include nodes with missing dependencies)
@@ -467,6 +472,7 @@ pub struct DependencyGraphResult {
     pub flags_with_missing_deps: HashSet<i32>,
 }
 
+#[cfg(test)]
 /// Builds a dependency graph for flag evaluation.
 /// Returns None only for fatal errors. Partial errors (cycles, missing dependencies)
 /// are returned in the result and nodes with missing dependencies are kept in the graph.
@@ -573,6 +579,7 @@ pub fn build_dependency_graph(
     })
 }
 
+#[cfg(test)]
 /// Result of filtering a dependency graph.
 pub struct FilteredGraphResult {
     /// The filtered dependency graph
@@ -581,6 +588,7 @@ pub struct FilteredGraphResult {
     pub flags_with_missing_deps: HashSet<i32>,
 }
 
+#[cfg(test)]
 /// Filters a dependency graph to include only the requested flags and their dependencies.
 /// Also filters the flags_with_missing_deps set to only include flags in the filtered graph.
 /// Returns None if:
@@ -681,6 +689,275 @@ pub fn filter_graph_by_keys(
         },
         flags_with_missing_deps: filtered_missing_deps,
     })
+}
+
+/// Pre-computed dependency graph data, built once when flags are loaded from cache.
+/// All fields are derived deterministically from the flag list.
+#[derive(Debug)]
+pub struct PrecomputedDependencyGraph {
+    /// Topologically sorted evaluation stages. Each inner Vec contains flags
+    /// that can be evaluated in parallel (all their dependencies appear in
+    /// earlier stages).
+    pub evaluation_stages: Vec<Vec<FeatureFlag>>,
+
+    /// Set of flag IDs whose dependencies are missing or transitively broken.
+    /// These flags evaluate to false (fail closed).
+    pub flags_with_missing_deps: HashSet<i32>,
+
+    /// For each flag ID, the set of all transitive dependency flag IDs.
+    pub transitive_deps: HashMap<i32, HashSet<i32>>,
+
+    /// Mapping from flag key to flag ID, for efficient key-based lookups.
+    pub key_to_id: HashMap<String, i32>,
+
+    /// Number of flags affected by dependency errors (missing deps + cycles).
+    pub error_count: usize,
+
+    /// Whether any graph construction errors were dependency cycles.
+    pub has_cycle_errors: bool,
+}
+
+/// Result of filtering pre-computed stages by requested flag keys.
+#[derive(Debug)]
+pub struct FilteredStagesResult {
+    /// Filtered evaluation stages containing only the requested flags and their dependencies.
+    pub evaluation_stages: Vec<Vec<FeatureFlag>>,
+    /// Subset of flags_with_missing_deps that are relevant to the filtered stages.
+    pub flags_with_missing_deps: HashSet<i32>,
+}
+
+impl PrecomputedDependencyGraph {
+    /// Builds a `PrecomputedDependencyGraph` from a flag list.
+    /// Uses the fast path when Django-precomputed `evaluation_context` is present,
+    /// falls back to full graph construction otherwise.
+    /// Returns `None` only for fatal errors (same semantics as `build_dependency_graph`).
+    pub fn build(
+        feature_flags: &crate::flags::flag_models::FeatureFlagList,
+        team_id: common_types::TeamId,
+    ) -> Option<Self> {
+        if let Some(ref ctx) = feature_flags.evaluation_context {
+            Self::build_from_precomputed(
+                &feature_flags.flags,
+                ctx,
+                &feature_flags.filtered_out_flag_ids,
+            )
+        } else {
+            Self::build_from_graph(&feature_flags.flags, team_id)
+        }
+    }
+
+    /// Fast path: consumes the top-level `EvaluationContext` directly.
+    /// No Kahn's algorithm, no per-flag scanning, no ID→key conversion loops.
+    fn build_from_precomputed(
+        flags: &[FeatureFlag],
+        ctx: &crate::flags::flag_models::EvaluationContext,
+        filtered_out_flag_ids: &HashSet<i32>,
+    ) -> Option<Self> {
+        let id_to_flag: HashMap<i32, &FeatureFlag> = flags.iter().map(|f| (f.id, f)).collect();
+
+        // Assemble stages from pre-grouped IDs, excluding runtime-filtered flags
+        let evaluation_stages: Vec<Vec<FeatureFlag>> = ctx
+            .dependency_stages
+            .iter()
+            .filter_map(|stage_ids| {
+                let stage: Vec<FeatureFlag> = stage_ids
+                    .iter()
+                    .filter(|id| !filtered_out_flag_ids.contains(id))
+                    .filter_map(|id| id_to_flag.get(id).map(|f| (*f).clone()))
+                    .collect();
+                if stage.is_empty() {
+                    None
+                } else {
+                    Some(stage)
+                }
+            })
+            .collect();
+
+        let flags_with_missing_deps: HashSet<i32> =
+            ctx.flags_with_missing_deps.iter().copied().collect();
+
+        let transitive_deps = ctx.transitive_deps.clone();
+
+        // Cycle detection: flags not in any stage
+        let flags_in_stages: HashSet<i32> = evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.id))
+            .collect();
+        let cycle_count = (flags.len() - filtered_out_flag_ids.len()) - flags_in_stages.len();
+
+        let key_to_id: HashMap<String, i32> = flags.iter().map(|f| (f.key.clone(), f.id)).collect();
+
+        // Django's flags_with_missing_deps already includes cycle participants
+        // (in_degree > 0 after Kahn's), so don't add cycle_count separately.
+        Some(Self {
+            evaluation_stages,
+            error_count: flags_with_missing_deps.len(),
+            has_cycle_errors: cycle_count > 0,
+            flags_with_missing_deps,
+            transitive_deps,
+            key_to_id,
+        })
+    }
+
+    /// Fallback path: builds a full petgraph-based dependency graph when
+    /// precomputed data is absent (old cache format or PG fallback).
+    fn build_from_graph(flags: &[FeatureFlag], team_id: common_types::TeamId) -> Option<Self> {
+        // Extract edges from each flag's property filters
+        let mut edges: HashMap<i32, HashSet<i32>> = HashMap::with_capacity(flags.len());
+        for flag in flags {
+            match flag.extract_dependencies() {
+                Ok(deps) => {
+                    edges.insert(flag.id, deps);
+                }
+                Err(e) => {
+                    log_dependency_graph_operation_error(
+                        "extract dependencies for graph fallback",
+                        &e,
+                        team_id,
+                    );
+                    return None;
+                }
+            }
+        }
+
+        let (graph, errors, flags_with_missing_deps) =
+            match DependencyGraph::from_nodes(flags.to_vec(), &edges) {
+                Ok(result) => result,
+                Err(e) => {
+                    log_dependency_graph_operation_error(
+                        "build global dependency graph",
+                        &e,
+                        team_id,
+                    );
+                    return None;
+                }
+            };
+
+        if !errors.is_empty() {
+            log_dependency_graph_construction_errors(&errors, team_id);
+        }
+
+        let has_cycle_errors = errors.iter().any(|e| e.is_cycle());
+        let cycle_count = errors.iter().filter(|e| e.is_cycle()).count();
+        let error_count = flags_with_missing_deps.len() + cycle_count;
+        let transitive_deps = Self::build_transitive_deps_map_from_graph(&graph);
+        let key_to_id: HashMap<String, i32> = flags.iter().map(|f| (f.key.clone(), f.id)).collect();
+
+        let evaluation_stages = match graph.into_evaluation_stages() {
+            Ok(stages) => stages,
+            Err(e) => {
+                log_dependency_graph_operation_error("get evaluation stages", &e, team_id);
+                return None;
+            }
+        };
+
+        Some(Self {
+            evaluation_stages,
+            flags_with_missing_deps,
+            transitive_deps,
+            key_to_id,
+            error_count,
+            has_cycle_errors,
+        })
+    }
+
+    /// Filters evaluation stages to only include the requested flags and their
+    /// transitive dependencies. Uses ID-based filtering for speed.
+    pub fn filter_stages_by_keys(&self, requested_keys: &[String]) -> FilteredStagesResult {
+        let mut needed_ids: HashSet<i32> = HashSet::new();
+        for key in requested_keys {
+            if let Some(&id) = self.key_to_id.get(key.as_str()) {
+                needed_ids.insert(id);
+                if let Some(dep_ids) = self.transitive_deps.get(&id) {
+                    needed_ids.extend(dep_ids);
+                }
+            } else {
+                warn!("Requested flag key not found: {}", key);
+                inc(
+                    FLAG_EVALUATION_ERROR_COUNTER,
+                    &[(
+                        "reason".to_string(),
+                        "missing_requested_flag_key".to_string(),
+                    )],
+                    1,
+                );
+            }
+        }
+
+        // Filter stages by flag ID, dropping empty stages
+        let evaluation_stages: Vec<Vec<FeatureFlag>> = self
+            .evaluation_stages
+            .iter()
+            .filter_map(|stage| {
+                let filtered: Vec<FeatureFlag> = stage
+                    .iter()
+                    .filter(|flag| needed_ids.contains(&flag.id))
+                    .cloned()
+                    .collect();
+                if filtered.is_empty() {
+                    None
+                } else {
+                    Some(filtered)
+                }
+            })
+            .collect();
+
+        // Filter missing deps to only include flags in the filtered stages
+        let filtered_flag_ids: HashSet<i32> = evaluation_stages
+            .iter()
+            .flat_map(|stage| stage.iter().map(|flag| flag.id))
+            .collect();
+        let flags_with_missing_deps: HashSet<i32> = self
+            .flags_with_missing_deps
+            .intersection(&filtered_flag_ids)
+            .copied()
+            .collect();
+
+        FilteredStagesResult {
+            evaluation_stages,
+            flags_with_missing_deps,
+        }
+    }
+
+    /// Builds a map from each flag ID to the set of all its transitive dependency IDs.
+    /// Used by the fallback (petgraph) path.
+    fn build_transitive_deps_map_from_graph(
+        graph: &DependencyGraph<FeatureFlag>,
+    ) -> HashMap<i32, HashSet<i32>> {
+        use petgraph::Direction::Outgoing;
+        let inner = &graph.graph;
+
+        let mut result = HashMap::new();
+        let mut visited = HashSet::new();
+        let mut stack = Vec::new();
+        for node_idx in inner.node_indices() {
+            let flag_id = inner[node_idx].id;
+            let mut deps = HashSet::new();
+            visited.clear();
+            stack.clear();
+
+            // Seed with direct dependencies
+            for neighbor in inner.neighbors_directed(node_idx, Outgoing) {
+                if visited.insert(neighbor) {
+                    stack.push(neighbor);
+                }
+            }
+
+            // DFS through transitive dependencies
+            while let Some(dep_idx) = stack.pop() {
+                deps.insert(inner[dep_idx].id);
+                for neighbor in inner.neighbors_directed(dep_idx, Outgoing) {
+                    if visited.insert(neighbor) {
+                        stack.push(neighbor);
+                    }
+                }
+            }
+
+            result.insert(flag_id, deps);
+        }
+
+        result
+    }
 }
 
 /// Handles errors during dependency graph operations.

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -1309,7 +1309,7 @@ fn make_flag_list(
     crate::flags::flag_models::FeatureFlagList {
         flags,
         filtered_out_flag_ids,
-        evaluation_context: None,
+        evaluation_metadata: None,
     }
 }
 
@@ -2528,7 +2528,7 @@ mod precomputed_dependency_graph_tests {
     }
 
     #[test]
-    fn test_deserialization_with_evaluation_context() {
+    fn test_deserialization_with_evaluation_metadata() {
         use crate::flags::flag_models::HypercacheFlagsWrapper;
 
         let json = r#"{
@@ -2536,7 +2536,7 @@ mod precomputed_dependency_graph_tests {
                 {"id": 1, "team_id": 1, "key": "test", "name": "Test",
                  "filters": {"groups": []}, "deleted": false, "active": true}
             ],
-            "evaluation_context": {
+            "evaluation_metadata": {
                 "dependency_stages": [[1]],
                 "flags_with_missing_deps": [],
                 "transitive_deps": {"1": []}
@@ -2545,7 +2545,7 @@ mod precomputed_dependency_graph_tests {
         let wrapper: HypercacheFlagsWrapper = serde_json::from_str(json).unwrap();
         assert_eq!(wrapper.flags.len(), 1);
         assert_eq!(wrapper.flags[0].key, "test");
-        let ctx = wrapper.evaluation_context.unwrap();
+        let ctx = wrapper.evaluation_metadata.unwrap();
         assert_eq!(ctx.dependency_stages, vec![vec![1]]);
         assert!(ctx.flags_with_missing_deps.is_empty());
         assert_eq!(ctx.transitive_deps[&1], HashSet::<i32>::new());
@@ -2553,7 +2553,7 @@ mod precomputed_dependency_graph_tests {
 
     #[test]
     fn test_precomputed_path_selected_when_fields_present() {
-        use crate::flags::flag_models::EvaluationContext;
+        use crate::flags::flag_models::EvaluationMetadata;
         use std::collections::HashMap;
 
         // Flags with precomputed data: A(1) -> B(2) -> C(3)
@@ -2563,7 +2563,7 @@ mod precomputed_dependency_graph_tests {
                 create_flag(2, "flag_b", HashSet::from([3]), true),
                 create_flag(3, "flag_c", HashSet::new(), true),
             ],
-            evaluation_context: Some(EvaluationContext {
+            evaluation_metadata: Some(EvaluationMetadata {
                 dependency_stages: vec![vec![3], vec![2], vec![1]],
                 flags_with_missing_deps: vec![],
                 transitive_deps: HashMap::from([
@@ -2604,7 +2604,7 @@ mod precomputed_dependency_graph_tests {
 
     #[test]
     fn test_precomputed_missing_deps_collected() {
-        use crate::flags::flag_models::EvaluationContext;
+        use crate::flags::flag_models::EvaluationMetadata;
         use std::collections::HashMap;
 
         let feature_flags = FeatureFlagList {
@@ -2613,7 +2613,7 @@ mod precomputed_dependency_graph_tests {
                 create_flag(2, "flag_b", HashSet::new(), true),
                 create_flag(3, "flag_c", HashSet::new(), true),
             ],
-            evaluation_context: Some(EvaluationContext {
+            evaluation_metadata: Some(EvaluationMetadata {
                 dependency_stages: vec![vec![2, 3], vec![1]],
                 flags_with_missing_deps: vec![1, 2],
                 transitive_deps: HashMap::from([
@@ -2634,7 +2634,7 @@ mod precomputed_dependency_graph_tests {
 
     #[test]
     fn test_fallback_path_used_without_precomputed_fields() {
-        // Flags WITHOUT evaluation_context: A -> B -> C (fallback path)
+        // Flags WITHOUT evaluation_metadata: A -> B -> C (fallback path)
         let feature_flags = FeatureFlagList {
             flags: vec![
                 create_flag(1, "flag_a", HashSet::from([2]), true),
@@ -2665,7 +2665,7 @@ mod precomputed_dependency_graph_tests {
 
     #[test]
     fn test_precomputed_equivalence_diamond() {
-        use crate::flags::flag_models::EvaluationContext;
+        use crate::flags::flag_models::EvaluationMetadata;
         use std::collections::HashMap;
 
         // Build with precomputed data and without, compare results
@@ -2685,7 +2685,7 @@ mod precomputed_dependency_graph_tests {
         };
         let fallback = PrecomputedDependencyGraph::build(&flags_no_precomputed, 1).unwrap();
 
-        // With precomputed (evaluation_context on the list)
+        // With precomputed (evaluation_metadata on the list)
         let flags_precomputed = FeatureFlagList {
             flags: vec![
                 create_flag(1, "flag_a", deps_a, true),
@@ -2693,7 +2693,7 @@ mod precomputed_dependency_graph_tests {
                 create_flag(3, "flag_c", deps_c, true),
                 create_flag(4, "flag_d", HashSet::new(), true),
             ],
-            evaluation_context: Some(EvaluationContext {
+            evaluation_metadata: Some(EvaluationMetadata {
                 dependency_stages: vec![vec![4], vec![2, 3], vec![1]],
                 flags_with_missing_deps: vec![],
                 transitive_deps: HashMap::from([
@@ -2724,7 +2724,7 @@ mod precomputed_dependency_graph_tests {
 
     #[test]
     fn test_precomputed_filter_stages_works() {
-        use crate::flags::flag_models::EvaluationContext;
+        use crate::flags::flag_models::EvaluationMetadata;
         use std::collections::HashMap;
 
         // A(1)->B(2)->C(3), D(4) independent
@@ -2735,7 +2735,7 @@ mod precomputed_dependency_graph_tests {
                 create_flag(3, "flag_c", HashSet::new(), true),
                 create_flag(4, "flag_d", HashSet::new(), true),
             ],
-            evaluation_context: Some(EvaluationContext {
+            evaluation_metadata: Some(EvaluationMetadata {
                 dependency_stages: vec![vec![3, 4], vec![2], vec![1]],
                 flags_with_missing_deps: vec![],
                 transitive_deps: HashMap::from([
@@ -2768,7 +2768,7 @@ mod precomputed_dependency_graph_tests {
 
     #[test]
     fn test_precomputed_path_handles_cycles_via_missing_deps() {
-        use crate::flags::flag_models::EvaluationContext;
+        use crate::flags::flag_models::EvaluationMetadata;
         use std::collections::HashMap;
 
         // Simulate Django output for A(1)->B(2)->A(1) cycle plus independent C(3)
@@ -2778,7 +2778,7 @@ mod precomputed_dependency_graph_tests {
                 create_flag(2, "flag_b", HashSet::from([1]), true),
                 create_flag(3, "flag_c", HashSet::new(), true),
             ],
-            evaluation_context: Some(EvaluationContext {
+            evaluation_metadata: Some(EvaluationMetadata {
                 dependency_stages: vec![vec![3]], // only C, cycled flags excluded
                 flags_with_missing_deps: vec![1, 2],
                 transitive_deps: HashMap::from([
@@ -2819,14 +2819,14 @@ mod precomputed_dependency_graph_tests {
     }
 
     #[test]
-    fn test_fallback_path_used_when_evaluation_context_absent() {
-        // Without evaluation_context, fallback path is used
+    fn test_fallback_path_used_when_evaluation_metadata_absent() {
+        // Without evaluation_metadata, fallback path is used
         let feature_flags = FeatureFlagList {
             flags: vec![
                 create_flag(1, "flag_a", HashSet::from([2]), true),
                 create_flag(2, "flag_b", HashSet::new(), true),
             ],
-            ..Default::default() // no evaluation_context
+            ..Default::default() // no evaluation_metadata
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
@@ -2850,7 +2850,7 @@ mod precomputed_dependency_graph_tests {
 
     #[test]
     fn test_filtered_out_flags_do_not_inflate_cycle_count() {
-        use crate::flags::flag_models::EvaluationContext;
+        use crate::flags::flag_models::EvaluationMetadata;
         use std::collections::HashMap;
 
         // Three flags total: flag_a(1) active, flag_b(2) active, flag_c(3) inactive.
@@ -2864,7 +2864,7 @@ mod precomputed_dependency_graph_tests {
                 create_flag(3, "flag_c", HashSet::new(), false),
             ],
             filtered_out_flag_ids: HashSet::from([3]),
-            evaluation_context: Some(EvaluationContext {
+            evaluation_metadata: Some(EvaluationMetadata {
                 dependency_stages: vec![vec![1, 2]],
                 flags_with_missing_deps: vec![],
                 transitive_deps: HashMap::from([(1, HashSet::new()), (2, HashSet::new())]),

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -1309,6 +1309,7 @@ fn make_flag_list(
     crate::flags::flag_models::FeatureFlagList {
         flags,
         filtered_out_flag_ids,
+        evaluation_context: None,
     }
 }
 
@@ -1753,5 +1754,1126 @@ mod seed_set_closure_tests {
             "Expected a CycleDetected error, got: {:?}",
             result.errors
         );
+    }
+}
+
+#[cfg(test)]
+mod precomputed_dependency_graph_tests {
+    use crate::flags::flag_models::{FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup};
+    use crate::utils::graph_utils::{
+        build_dependency_graph, filter_graph_by_keys, PrecomputedDependencyGraph,
+    };
+    use crate::utils::test_utils::create_test_flag;
+    use std::collections::HashSet;
+
+    fn create_flag(id: i32, key: &str, dependencies: HashSet<i32>, active: bool) -> FeatureFlag {
+        let mut filters = FlagFilters {
+            groups: vec![FlagPropertyGroup {
+                properties: Some(vec![]),
+                rollout_percentage: Some(100.0),
+                variant: None,
+            }],
+            multivariate: None,
+            aggregation_group_type_index: None,
+            payloads: None,
+            super_groups: None,
+            holdout_groups: None,
+            holdout: None,
+        };
+
+        for dep_id in dependencies {
+            filters.groups[0].properties.as_mut().unwrap().push(
+                crate::properties::property_models::PropertyFilter {
+                    key: dep_id.to_string(),
+                    value: Some(serde_json::json!(true)),
+                    operator: Some(crate::properties::property_models::OperatorType::Exact),
+                    prop_type: crate::properties::property_models::PropertyType::Flag,
+                    group_type_index: None,
+                    negation: None,
+                },
+            );
+        }
+
+        create_test_flag(
+            Some(id),
+            Some(1),
+            None,
+            Some(key.to_string()),
+            Some(filters),
+            None,
+            Some(active),
+            None,
+        )
+    }
+
+    /// Extracts sorted flag keys from evaluation stages for deterministic comparison.
+    fn stage_keys(stages: &[Vec<FeatureFlag>]) -> Vec<Vec<String>> {
+        stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_build_no_dependencies() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // All flags are independent, so they should be in a single stage
+        assert_eq!(precomputed.evaluation_stages.len(), 1);
+        assert_eq!(stage_keys(&precomputed.evaluation_stages)[0].len(), 3);
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert_eq!(precomputed.error_count, 0);
+        assert!(!precomputed.has_cycle_errors);
+
+        // Each flag should have no transitive dependencies
+        for id in [1, 2, 3] {
+            assert!(
+                precomputed.transitive_deps[&id].is_empty(),
+                "Flag {} should have no transitive dependencies",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_linear_chain() {
+        // flag_a -> flag_b -> flag_c (flag_a depends on flag_b, which depends on flag_c)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // Three stages: flag_c, then flag_b, then flag_a
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+
+        // Transitive deps
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3]));
+        assert_eq!(precomputed.transitive_deps[&2], HashSet::from([3]));
+        assert!(precomputed.transitive_deps[&3].is_empty());
+    }
+
+    #[test]
+    fn test_build_diamond_dependency() {
+        //   flag_a
+        //   /    \
+        // flag_b  flag_c
+        //   \    /
+        //   flag_d
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+            create_flag(2, "flag_b", HashSet::from([4]), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // Three stages: flag_d, then flag_b+flag_c, then flag_a
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_d"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b", "flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+
+        // flag_a transitively depends on all others
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3, 4]));
+        assert_eq!(precomputed.transitive_deps[&2], HashSet::from([4]));
+        assert_eq!(precomputed.transitive_deps[&3], HashSet::from([4]));
+        assert!(precomputed.transitive_deps[&4].is_empty());
+    }
+
+    #[test]
+    fn test_build_missing_dependency() {
+        // flag_a depends on flag_b (id=2), but flag_b doesn't exist
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+        assert!(!precomputed.flags_with_missing_deps.contains(&3));
+        assert!(precomputed.error_count > 0);
+    }
+
+    #[test]
+    fn test_build_transitive_missing_dependency() {
+        // flag_a -> flag_b -> (missing flag_c)
+        // flag_a should also be marked as having missing deps
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert!(
+            precomputed.flags_with_missing_deps.contains(&1),
+            "flag_a should be transitively marked as missing deps"
+        );
+        assert!(
+            precomputed.flags_with_missing_deps.contains(&2),
+            "flag_b should be directly marked as missing deps"
+        );
+    }
+
+    #[test]
+    fn test_build_empty_flag_list() {
+        let feature_flags = FeatureFlagList {
+            flags: vec![],
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert!(precomputed.evaluation_stages.is_empty());
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert!(precomputed.transitive_deps.is_empty());
+        assert_eq!(precomputed.error_count, 0);
+    }
+
+    #[test]
+    fn test_build_single_flag_no_dependencies() {
+        let flags = vec![create_flag(1, "solo_flag", HashSet::new(), true)];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert_eq!(precomputed.evaluation_stages.len(), 1);
+        assert_eq!(precomputed.evaluation_stages[0].len(), 1);
+        assert_eq!(precomputed.evaluation_stages[0][0].key, "solo_flag");
+        assert!(precomputed.transitive_deps[&1].is_empty());
+    }
+
+    #[test]
+    fn test_build_inactive_flag_skips_dependencies() {
+        // Inactive flag references non-existent dependency — should not produce errors
+        let flags = vec![
+            create_flag(1, "inactive_flag", HashSet::from([999]), false),
+            create_flag(2, "active_flag", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert_eq!(precomputed.error_count, 0);
+    }
+
+    // --- Equivalence tests: PrecomputedDependencyGraph produces the same results
+    // as the current build_dependency_graph + into_evaluation_stages path ---
+
+    #[test]
+    fn test_equivalence_linear_chain() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        // Old path
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            old_stage_keys,
+            "Pre-computed stages should match the old path"
+        );
+        assert_eq!(
+            precomputed.flags_with_missing_deps, old_result.flags_with_missing_deps,
+            "Missing deps should match the old path"
+        );
+        assert_eq!(
+            precomputed.error_count,
+            old_result.flags_with_missing_deps.len()
+                + old_result.errors.iter().filter(|e| e.is_cycle()).count(),
+            "error_count counts affected flags, not error edges"
+        );
+    }
+
+    #[test]
+    fn test_equivalence_diamond() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+            create_flag(2, "flag_b", HashSet::from([4]), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert_eq!(stage_keys(&precomputed.evaluation_stages), old_stage_keys);
+        assert_eq!(
+            precomputed.flags_with_missing_deps,
+            old_result.flags_with_missing_deps
+        );
+    }
+
+    #[test]
+    fn test_equivalence_missing_deps() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert_eq!(
+            precomputed.flags_with_missing_deps, old_result.flags_with_missing_deps,
+            "Missing deps should match between old and new paths"
+        );
+        assert_eq!(
+            precomputed.error_count,
+            old_result.flags_with_missing_deps.len()
+                + old_result.errors.iter().filter(|e| e.is_cycle()).count(),
+            "error_count counts affected flags, not error edges"
+        );
+    }
+
+    #[test]
+    fn test_equivalence_multi_root_no_deps() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // Both should produce a single stage with all flags
+        assert_eq!(precomputed.evaluation_stages.len(), old_stages.len());
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            old_stages
+                .iter()
+                .map(|stage| {
+                    let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                    keys.sort();
+                    keys
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // --- filter_stages_by_keys tests ---
+
+    #[test]
+    fn test_filter_stages_no_keys_returns_empty() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let result = precomputed.filter_stages_by_keys(&[]);
+
+        assert!(result.evaluation_stages.is_empty());
+    }
+
+    #[test]
+    fn test_filter_stages_single_flag_no_deps() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["flag_b".to_string()]);
+
+        assert_eq!(result.evaluation_stages.len(), 1);
+        assert_eq!(result.evaluation_stages[0].len(), 1);
+        assert_eq!(result.evaluation_stages[0][0].key, "flag_b");
+    }
+
+    #[test]
+    fn test_filter_stages_includes_transitive_deps() {
+        // flag_a -> flag_b -> flag_c
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // Requesting flag_a should include flag_b and flag_c but not flag_d
+        let result = precomputed.filter_stages_by_keys(&["flag_a".to_string()]);
+
+        let all_keys: HashSet<String> = result
+            .evaluation_stages
+            .iter()
+            .flat_map(|stage| stage.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(all_keys.contains("flag_c"));
+        assert!(!all_keys.contains("flag_d"));
+
+        // Stages should preserve topological order
+        assert_eq!(result.evaluation_stages.len(), 3);
+        assert_eq!(result.evaluation_stages[0][0].key, "flag_c");
+        assert_eq!(result.evaluation_stages[1][0].key, "flag_b");
+        assert_eq!(result.evaluation_stages[2][0].key, "flag_a");
+    }
+
+    #[test]
+    fn test_filter_stages_missing_key_ignored() {
+        let flags = vec![create_flag(1, "flag_a", HashSet::new(), true)];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["nonexistent".to_string()]);
+
+        assert!(result.evaluation_stages.is_empty());
+    }
+
+    #[test]
+    fn test_filter_stages_preserves_missing_deps() {
+        // flag_a -> flag_b -> (missing)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["flag_a".to_string()]);
+
+        assert!(
+            result.flags_with_missing_deps.contains(&1),
+            "flag_a should retain missing dep status after filtering"
+        );
+        assert!(
+            result.flags_with_missing_deps.contains(&2),
+            "flag_b should retain missing dep status after filtering"
+        );
+        // flag_c was not requested and should not appear
+        assert!(!result.flags_with_missing_deps.contains(&3));
+    }
+
+    #[test]
+    fn test_filter_stages_equivalence_with_filter_graph_by_keys() {
+        // Diamond: flag_a -> flag_b, flag_c -> flag_d; also flag_e (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+            create_flag(2, "flag_b", HashSet::from([4]), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+            create_flag(5, "flag_e", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+        let requested_keys = vec!["flag_a".to_string()];
+
+        // Old path: build graph, filter, then get stages
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_filtered = filter_graph_by_keys(
+            &old_result.graph,
+            &requested_keys,
+            &old_result.flags_with_missing_deps,
+        )
+        .unwrap();
+        let old_stages = old_filtered.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let new_result = precomputed.filter_stages_by_keys(&requested_keys);
+
+        assert_eq!(
+            stage_keys(&new_result.evaluation_stages),
+            old_stage_keys,
+            "Filtered stages should match between old and new paths"
+        );
+        assert_eq!(
+            new_result.flags_with_missing_deps, old_filtered.flags_with_missing_deps,
+            "Filtered missing deps should match"
+        );
+    }
+
+    #[test]
+    fn test_build_with_cycle() {
+        // flag_a -> flag_b -> flag_a (cycle), flag_c is independent
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([1]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert!(precomputed.has_cycle_errors);
+        assert!(precomputed.error_count > 0);
+
+        // Cyclic flags are removed; only flag_c should remain
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|stage| stage.iter().map(|f| f.key.clone()))
+            .collect();
+        assert!(all_keys.contains("flag_c"));
+        assert!(
+            !all_keys.contains("flag_a"),
+            "Cyclic flag should be removed"
+        );
+        assert!(
+            !all_keys.contains("flag_b"),
+            "Cyclic flag should be removed"
+        );
+    }
+
+    #[test]
+    fn test_equivalence_with_cycle() {
+        // flag_a -> flag_b -> flag_a (cycle), flag_c independent
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([1]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_has_cycles = old_result.errors.iter().any(|e| e.is_cycle());
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert_eq!(precomputed.has_cycle_errors, old_has_cycles);
+        assert_eq!(
+            precomputed.error_count,
+            old_result.flags_with_missing_deps.len()
+                + old_result.errors.iter().filter(|e| e.is_cycle()).count()
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            old_stages
+                .iter()
+                .map(|stage| {
+                    let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                    keys.sort();
+                    keys
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_filter_stages_multiple_requested_keys_shared_deps() {
+        // flag_a -> flag_c, flag_b -> flag_c, flag_d (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([3]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let result =
+            precomputed.filter_stages_by_keys(&["flag_a".to_string(), "flag_b".to_string()]);
+
+        let all_keys: HashSet<String> = result
+            .evaluation_stages
+            .iter()
+            .flat_map(|stage| stage.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(
+            all_keys.contains("flag_c"),
+            "Shared dependency should be included"
+        );
+        assert!(
+            !all_keys.contains("flag_d"),
+            "Unrelated flag should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_filter_stages_equivalence_with_missing_deps() {
+        // flag_a -> flag_b -> (missing 999), flag_c (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+        let requested_keys = vec!["flag_a".to_string()];
+
+        // Old path
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_filtered = filter_graph_by_keys(
+            &old_result.graph,
+            &requested_keys,
+            &old_result.flags_with_missing_deps,
+        )
+        .unwrap();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let new_result = precomputed.filter_stages_by_keys(&requested_keys);
+
+        assert_eq!(
+            new_result.flags_with_missing_deps, old_filtered.flags_with_missing_deps,
+            "Filtered missing deps should match between old and new paths"
+        );
+    }
+
+    #[test]
+    fn test_filter_stages_equivalence_multiple_keys() {
+        // flag_a -> flag_b, flag_c -> flag_d, flag_e (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+            create_flag(5, "flag_e", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+        let requested_keys = vec!["flag_a".to_string(), "flag_c".to_string()];
+
+        // Old path
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_filtered = filter_graph_by_keys(
+            &old_result.graph,
+            &requested_keys,
+            &old_result.flags_with_missing_deps,
+        )
+        .unwrap();
+        let old_stages = old_filtered.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let new_result = precomputed.filter_stages_by_keys(&requested_keys);
+
+        assert_eq!(
+            stage_keys(&new_result.evaluation_stages),
+            old_stage_keys,
+            "Filtered stages should match between old and new paths for multiple keys"
+        );
+    }
+
+    // --- Precomputed data tests: verify build_from_precomputed path ---
+
+    #[test]
+    fn test_deserialization_without_new_fields() {
+        let json = r#"{
+            "id": 1, "team_id": 1, "key": "test", "name": "Test",
+            "filters": {"groups": []}, "deleted": false, "active": true
+        }"#;
+        let flag: FeatureFlag = serde_json::from_str(json).unwrap();
+        assert_eq!(flag.id, 1);
+        assert_eq!(flag.key, "test");
+        assert!(flag.active);
+    }
+
+    #[test]
+    fn test_deserialization_with_evaluation_context() {
+        use crate::flags::flag_models::HypercacheFlagsWrapper;
+
+        let json = r#"{
+            "flags": [
+                {"id": 1, "team_id": 1, "key": "test", "name": "Test",
+                 "filters": {"groups": []}, "deleted": false, "active": true}
+            ],
+            "evaluation_context": {
+                "dependency_stages": [[1]],
+                "flags_with_missing_deps": [],
+                "transitive_deps": {"1": []}
+            }
+        }"#;
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_str(json).unwrap();
+        assert_eq!(wrapper.flags.len(), 1);
+        assert_eq!(wrapper.flags[0].key, "test");
+        let ctx = wrapper.evaluation_context.unwrap();
+        assert_eq!(ctx.dependency_stages, vec![vec![1]]);
+        assert!(ctx.flags_with_missing_deps.is_empty());
+        assert_eq!(ctx.transitive_deps[&1], HashSet::<i32>::new());
+    }
+
+    #[test]
+    fn test_precomputed_path_selected_when_fields_present() {
+        use crate::flags::flag_models::EvaluationContext;
+        use std::collections::HashMap;
+
+        // Flags with precomputed data: A(1) -> B(2) -> C(3)
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_context: Some(EvaluationContext {
+                dependency_stages: vec![vec![3], vec![2], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3])),
+                    (2, HashSet::from([3])),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // Verify fast path outputs (error_count=0, no cycles from precomputed)
+        assert_eq!(precomputed.error_count, 0);
+        assert!(!precomputed.has_cycle_errors);
+
+        // Verify transitive deps were built from precomputed IDs
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3]));
+        assert_eq!(precomputed.transitive_deps[&2], HashSet::from([3]));
+        assert!(precomputed.transitive_deps[&3].is_empty());
+
+        // Verify stages: flag_c first, then flag_b, then flag_a
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+    }
+
+    #[test]
+    fn test_precomputed_missing_deps_collected() {
+        use crate::flags::flag_models::EvaluationContext;
+        use std::collections::HashMap;
+
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_context: Some(EvaluationContext {
+                dependency_stages: vec![vec![2, 3], vec![1]],
+                flags_with_missing_deps: vec![1, 2],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2])),
+                    (2, HashSet::new()),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+        assert!(precomputed.flags_with_missing_deps.contains(&2));
+        assert!(!precomputed.flags_with_missing_deps.contains(&3));
+    }
+
+    #[test]
+    fn test_fallback_path_used_without_precomputed_fields() {
+        // Flags WITHOUT evaluation_context: A -> B -> C (fallback path)
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // Fallback should produce the same results
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3]));
+    }
+
+    #[test]
+    fn test_precomputed_equivalence_diamond() {
+        use crate::flags::flag_models::EvaluationContext;
+        use std::collections::HashMap;
+
+        // Build with precomputed data and without, compare results
+        let deps_a = HashSet::from([2, 3]);
+        let deps_b = HashSet::from([4]);
+        let deps_c = HashSet::from([4]);
+
+        // Without precomputed (fallback path)
+        let flags_no_precomputed = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", deps_a.clone(), true),
+                create_flag(2, "flag_b", deps_b.clone(), true),
+                create_flag(3, "flag_c", deps_c.clone(), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            ..Default::default()
+        };
+        let fallback = PrecomputedDependencyGraph::build(&flags_no_precomputed, 1).unwrap();
+
+        // With precomputed (evaluation_context on the list)
+        let flags_precomputed = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", deps_a, true),
+                create_flag(2, "flag_b", deps_b, true),
+                create_flag(3, "flag_c", deps_c, true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            evaluation_context: Some(EvaluationContext {
+                dependency_stages: vec![vec![4], vec![2, 3], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3, 4])),
+                    (2, HashSet::from([4])),
+                    (3, HashSet::from([4])),
+                    (4, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+        let precomputed = PrecomputedDependencyGraph::build(&flags_precomputed, 1).unwrap();
+
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            stage_keys(&fallback.evaluation_stages),
+            "Precomputed and fallback should produce identical stages"
+        );
+        assert_eq!(
+            precomputed.transitive_deps, fallback.transitive_deps,
+            "Transitive deps should match"
+        );
+        assert_eq!(
+            precomputed.flags_with_missing_deps,
+            fallback.flags_with_missing_deps,
+        );
+    }
+
+    #[test]
+    fn test_precomputed_filter_stages_works() {
+        use crate::flags::flag_models::EvaluationContext;
+        use std::collections::HashMap;
+
+        // A(1)->B(2)->C(3), D(4) independent
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            evaluation_context: Some(EvaluationContext {
+                dependency_stages: vec![vec![3, 4], vec![2], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3])),
+                    (2, HashSet::from([3])),
+                    (3, HashSet::new()),
+                    (4, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["flag_a".to_string()]);
+
+        let all_keys: HashSet<String> = result
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(all_keys.contains("flag_c"));
+        assert!(
+            !all_keys.contains("flag_d"),
+            "flag_d is independent, should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_precomputed_path_handles_cycles_via_missing_deps() {
+        use crate::flags::flag_models::EvaluationContext;
+        use std::collections::HashMap;
+
+        // Simulate Django output for A(1)->B(2)->A(1) cycle plus independent C(3)
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([1]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_context: Some(EvaluationContext {
+                dependency_stages: vec![vec![3]], // only C, cycled flags excluded
+                flags_with_missing_deps: vec![1, 2],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2])),
+                    (2, HashSet::from([1])),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        // Cyclic flags should be excluded from stages
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+        assert!(
+            !all_keys.contains("flag_a"),
+            "Cyclic flag should be excluded from stages"
+        );
+        assert!(
+            !all_keys.contains("flag_b"),
+            "Cyclic flag should be excluded from stages"
+        );
+        assert!(all_keys.contains("flag_c"));
+
+        // Both cyclic flags should be in missing deps
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+        assert!(precomputed.flags_with_missing_deps.contains(&2));
+        assert!(!precomputed.flags_with_missing_deps.contains(&3));
+
+        // Error count should reflect both missing deps and cycles
+        assert!(precomputed.error_count > 0);
+        assert!(precomputed.has_cycle_errors);
+    }
+
+    #[test]
+    fn test_fallback_path_used_when_evaluation_context_absent() {
+        // Without evaluation_context, fallback path is used
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+            ],
+            ..Default::default() // no evaluation_context
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+
+        // Both flags should be present
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+
+        // flag_b should be evaluated before flag_a (flag_a depends on flag_b)
+        let stages = stage_keys(&precomputed.evaluation_stages);
+        assert_eq!(stages.len(), 2);
+        assert_eq!(stages[0], vec!["flag_b"]);
+        assert_eq!(stages[1], vec!["flag_a"]);
+    }
+
+    #[test]
+    fn test_filtered_out_flags_do_not_inflate_cycle_count() {
+        use crate::flags::flag_models::EvaluationContext;
+        use std::collections::HashMap;
+
+        // Three flags total: flag_a(1) active, flag_b(2) active, flag_c(3) inactive.
+        // flag_c is in filtered_out_flag_ids and excluded from dependency_stages.
+        // Without the fix, cycle_count = flags.len(3) - flags_in_stages.len(2) = 1,
+        // falsely reporting a cycle.
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::new(), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+                create_flag(3, "flag_c", HashSet::new(), false),
+            ],
+            filtered_out_flag_ids: HashSet::from([3]),
+            evaluation_context: Some(EvaluationContext {
+                dependency_stages: vec![vec![1, 2]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([(1, HashSet::new()), (2, HashSet::new())]),
+            }),
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1).unwrap();
+
+        assert!(!precomputed.has_cycle_errors);
+        assert_eq!(precomputed.error_count, 0);
     }
 }


### PR DESCRIPTION
## Problem

The Rust feature-flag evaluation service rebuilds dependency graphs from scratch on every request using petgraph. This is wasted work — the flag list rarely changes, but the graph is reconstructed for every `/flags` call. For teams with many interdependent flags, this adds measurable latency.

## Changes

- **Django (flags_cache.py)**: Pre-compute flag dependency metadata at cache-write time using Kahn's algorithm (layered topological sort). The new `evaluation_metadata` field includes `dependency_stages`, `flags_with_missing_deps`, and `transitive_deps` — shipped alongside the flags array in the hypercache.
- **Rust (flag_models.rs)**: Add `EvaluationMetadata` struct with custom serde for string-keyed i32 maps (JSON only supports string keys). Parse the new field from hypercache via `HypercacheFlagsWrapper`.
- **Rust (graph_utils.rs)**: Add `PrecomputedDependencyGraph` that uses the fast path when `EvaluationMetadata` is present, falling back to the existing petgraph-based graph construction for old cache entries or PG fallback. Gate the old `build_dependency_graph`/`filter_graph_by_keys` behind `#[cfg(test)]`.
- **Rust (flag_matching.rs)**: Replace per-request graph construction with `PrecomputedDependencyGraph::build()`. Flatten the evaluate/graph methods — `evaluate_flags_with_dependency_graph` is inlined into `evaluate_flags_with_overrides`.
- **Tests**: Comprehensive Python and Rust tests for dependency computation, cycle detection, missing deps, and the precomputed fast path.

## How did you test this code?

- Python unit tests for `_extract_direct_dependency_ids` and `_compute_flag_dependencies` covering linear chains, diamonds, cycles, inactive flags, missing deps, and isolated flags
- Rust unit tests for `PrecomputedDependencyGraph` precomputed and fallback paths, `EvaluationMetadata` serde round-trips, and `FilteredStagesResult` filtering
- Existing Rust flag matching and graph utils tests updated and passing
- Manual testing
  - Old cache, new code.
  - New cache, old code.
  - New cache, new code.

## Publish to changelog?

no

## Docs update

Internal architecture docs updated in-PR.