### PR TITLE
chore: disable egress proxy in prometheus client

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -433,6 +433,7 @@ posthog/management/commands/test/test_add_question_ids_to_surveys.py:0: error: I
 posthog/management/commands/test/test_add_question_ids_to_surveys.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
 posthog/management/commands/test/test_add_question_ids_to_surveys.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
 posthog/management/commands/test/test_add_question_ids_to_surveys.py:0: error: Item "None" of "Any | None" has no attribute "__iter__" (not iterable)  [union-attr]
+posthog/metrics.py:0: error: Cannot assign to a method  [method-assign]
 posthog/migrations/0228_fix_tile_layouts.py:0: error: Argument 2 to "RunPython" has incompatible type "Callable[[Migration, Any], None]"; expected "_CodeCallable | None"  [arg-type]
 posthog/migrations/0237_remove_timezone_from_teams.py:0: error: Argument 2 to "RunPython" has incompatible type "Callable[[Migration, Any], None]"; expected "_CodeCallable | None"  [arg-type]
 posthog/migrations/0284_improved_caching_state_idx.py:0: error: Cannot override class variable (previously declared on base class "Migration") with instance variable  [misc]

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -37,8 +37,28 @@ TOMBSTONE_COUNTER = Counter(
 )
 
 
-def _push(settings, job, registry):
-    push_to_gateway(settings, job, registry)
+# Patch prometheus_client to bypass HTTP_PROXY/HTTPS_PROXY for pushgateway calls.
+# The pushgateway is an internal service — the outbound proxy would reject it.
+# ProxyHandler({}) tells urllib to ignore proxy env vars.
+import prometheus_client.exposition as _expo  # noqa: E402
+
+
+def _make_handler_no_proxy(url, method, timeout, headers, data, base_handler):
+    from urllib.request import ProxyHandler, Request, build_opener
+
+    def handle():
+        request = Request(url, data=data)
+        request.get_method = lambda: method  # type: ignore[assignment]
+        for k, v in headers:
+            request.add_header(k, v)
+        resp = build_opener(ProxyHandler({}), base_handler).open(request, timeout=timeout)
+        if resp.code >= 400:
+            raise OSError(f"error talking to pushgateway: {resp.code} {resp.msg}")
+
+    return handle
+
+
+_expo._make_handler = _make_handler_no_proxy  # type: ignore[attr-defined]
 
 
 @contextmanager
@@ -58,7 +78,7 @@ def pushed_metrics_registry(job_name: str):
     yield registry
     try:
         if settings.PROM_PUSHGATEWAY_ADDRESS:
-            _push(settings.PROM_PUSHGATEWAY_ADDRESS, job=job_name, registry=registry)
+            push_to_gateway(settings.PROM_PUSHGATEWAY_ADDRESS, job=job_name, registry=registry)
     except Exception as err:
         logger.exception("push_to_gateway", target=settings.PROM_PUSHGATEWAY_ADDRESS, exception=err)
         capture_exception(err)

--- a/posthog/metrics.py
+++ b/posthog/metrics.py
@@ -4,6 +4,11 @@ from contextlib import contextmanager
 from django.conf import settings
 
 import structlog
+
+# Patch prometheus_client to bypass HTTP_PROXY/HTTPS_PROXY for pushgateway calls.
+# The pushgateway is an internal service — the outbound proxy would reject it.
+# ProxyHandler({}) tells urllib to ignore proxy env vars.
+import prometheus_client.exposition as _expo
 from prometheus_client import CollectorRegistry, Counter, push_to_gateway
 
 from posthog.exceptions_capture import capture_exception
@@ -37,18 +42,12 @@ TOMBSTONE_COUNTER = Counter(
 )
 
 
-# Patch prometheus_client to bypass HTTP_PROXY/HTTPS_PROXY for pushgateway calls.
-# The pushgateway is an internal service — the outbound proxy would reject it.
-# ProxyHandler({}) tells urllib to ignore proxy env vars.
-import prometheus_client.exposition as _expo  # noqa: E402
-
-
 def _make_handler_no_proxy(url, method, timeout, headers, data, base_handler):
     from urllib.request import ProxyHandler, Request, build_opener
 
     def handle():
         request = Request(url, data=data)
-        request.get_method = lambda: method  # type: ignore[assignment]
+        request.get_method = lambda: method
         for k, v in headers:
             request.add_header(k, v)
         resp = build_opener(ProxyHandler({}), base_handler).open(request, timeout=timeout)
@@ -58,7 +57,7 @@ def _make_handler_no_proxy(url, method, timeout, headers, data, base_handler):
     return handle
 
 
-_expo._make_handler = _make_handler_no_proxy  # type: ignore[attr-defined]
+_expo._make_handler = _make_handler_no_proxy
 
 
 @contextmanager

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -6,7 +6,7 @@ from posthog.tasks.tasks import clickhouse_errors_count
 
 class TestCeleryMetrics(TestCase):
     @patch("posthog.clickhouse.client.sync_execute")
-    @patch("posthog.metrics._push")
+    @patch("posthog.metrics.push_to_gateway")
     @patch("django.conf.settings.PROM_PUSHGATEWAY_ADDRESS", value="127.0.0.1")
     def test_clickhouse_errors_count(self, _, mock_push_to_gateway, mock_sync_execute):
         mock_sync_execute.return_value = [["ch1", "1", "NO_ZOOKEEPER", 123, 60]]

--- a/posthog/test/test_metrics.py
+++ b/posthog/test/test_metrics.py
@@ -1,0 +1,85 @@
+import threading
+import http.server
+
+import prometheus_client.exposition as expo
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+from posthog.metrics import _make_handler_no_proxy, pushed_metrics_registry
+
+
+class TestPushgatewayProxyPatch:
+    def test_make_handler_is_patched(self):
+        assert expo._make_handler is _make_handler_no_proxy
+
+    def test_push_to_gateway_bypasses_proxy(self, monkeypatch):
+        monkeypatch.setenv("HTTP_PROXY", "http://bogus-proxy:9999")
+        monkeypatch.setenv("HTTPS_PROXY", "http://bogus-proxy:9999")
+
+        received: dict = {}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_PUT(self):
+                received["path"] = self.path
+                received["method"] = "PUT"
+                received["content_type"] = self.headers.get("Content-Type")
+                received["body"] = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, format, *args):
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.handle_request)
+        thread.start()
+
+        try:
+            registry = CollectorRegistry()
+            g = Gauge("test_bypass_metric", "A test gauge", registry=registry)
+            g.set(42.0)
+            push_to_gateway(f"http://127.0.0.1:{port}", job="test_job", registry=registry)
+        finally:
+            thread.join(timeout=5)
+            server.server_close()
+
+        assert received["method"] == "PUT"
+        assert "/metrics/job/test_job" in received["path"]
+        body = received["body"].decode()
+        assert "test_bypass_metric" in body
+        assert "42.0" in body
+
+    def test_pushed_metrics_registry_bypasses_proxy(self, monkeypatch, settings):
+        monkeypatch.setenv("HTTP_PROXY", "http://bogus-proxy:9999")
+        monkeypatch.setenv("HTTPS_PROXY", "http://bogus-proxy:9999")
+
+        received: dict = {}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_PUT(self):
+                received["path"] = self.path
+                received["body"] = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, format, *args):
+                pass
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.handle_request)
+        thread.start()
+
+        try:
+            settings.PROM_PUSHGATEWAY_ADDRESS = f"http://127.0.0.1:{port}"
+            with pushed_metrics_registry("ctx_job") as registry:
+                g = Gauge("test_ctx_metric", "A context gauge", registry=registry)
+                g.set(99.0)
+        finally:
+            thread.join(timeout=5)
+            server.server_close()
+
+        assert "/metrics/job/ctx_job" in received["path"]
+        body = received["body"].decode()
+        assert "test_ctx_metric" in body
+        assert "99.0" in body

--- a/posthog/test/test_metrics.py
+++ b/posthog/test/test_metrics.py
@@ -79,6 +79,7 @@ class TestPushgatewayProxyPatch:
             thread.join(timeout=5)
             server.server_close()
 
+        assert received, "HTTP server never received a request — push_to_gateway may have failed silently"
         assert "/metrics/job/ctx_job" in received["path"]
         body = received["body"].decode()
         assert "test_ctx_metric" in body


### PR DESCRIPTION
The prometheus server is on the local network and should not use the proxy, otherwise requests to it will be blocked.
