### PR TITLE
chore: remove beta label from instance settings tab

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -6,7 +6,6 @@ import { IconInfo } from '@posthog/icons'
 import { LemonBanner, Link } from '@posthog/lemon-ui'
 
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
-import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { InternalMetricsTab } from 'scenes/instance/SystemStatus/InternalMetricsTab'
 import { OverviewTab } from 'scenes/instance/SystemStatus/OverviewTab'
@@ -56,14 +55,7 @@ export function SystemStatus(): JSX.Element {
             },
             {
                 key: 'settings',
-                label: (
-                    <>
-                        Settings{' '}
-                        <LemonTag type="warning" className="ml-1 uppercase">
-                            Beta
-                        </LemonTag>
-                    </>
-                ),
+                label: 'Settings',
                 content: <InstanceConfigTab />,
             },
             {


### PR DESCRIPTION
## Summary

- Remove the beta badge from the "Settings" tab on the instance status page (`/instance/settings`)
- Clean up the now-unused `LemonTag` import

Instance settings have been marked beta for several years without any bug reports. The feature is stable.

## Test plan

- [ ] Navigate to `/instance/settings` as a staff user and confirm the tab label is just "Settings" with no beta badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)