### PR TITLE
chore(insights): Add tests for query construction bugs    

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -5574,5 +5574,26 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
             ),
         )
         response = FunnelsQueryRunner(query=query, team=self.team).calculate()
-        self.assertIsNotNone(response.results)
+
+        # Should have at least one breakdown group
         self.assertGreater(len(response.results), 0)
+
+        # Each breakdown group is a list of steps
+        first_group = response.results[0]
+        self.assertIsInstance(first_group, list)
+        self.assertEqual(len(first_group), 2)
+
+        # Step 1: user entered funnel
+        self.assertEqual(first_group[0]["count"], 1)
+        self.assertEqual(first_group[0]["order"], 0)
+
+        # Step 2: user converted
+        self.assertEqual(first_group[1]["count"], 1)
+        self.assertEqual(first_group[1]["order"], 1)
+
+        # Breakdown value should be present and non-empty
+        bv = first_group[0]["breakdown_value"]
+        self.assertIsNotNone(bv)
+        if breakdown_type in (BreakdownType.EVENT, BreakdownType.PERSON):
+            # These types box the value into a list
+            self.assertIsInstance(bv, list, f"Expected boxed breakdown_value for {breakdown_type}, got {type(bv)}")

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -16,6 +16,7 @@ from posthog.test.base import (
 
 from django.test import override_settings
 
+from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
@@ -5450,3 +5451,128 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         # person2 does NOT convert (pageleave -> unrelated -> checkout breaks strict order)
         self.assertEqual(result[0]["count"], 2)
         self.assertEqual(result[1]["count"], 1)
+
+    @freeze_time("2024-01-02T00:00:00Z")
+    def test_funnel_same_event_different_property_filters(self):
+        _create_person(distinct_ids=["user_both"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_both",
+            timestamp="2024-01-01T10:00:00Z",
+            properties={"$current_url": "/home"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_both",
+            timestamp="2024-01-01T11:00:00Z",
+            properties={"$current_url": "/pricing"},
+        )
+
+        _create_person(distinct_ids=["user_only_home"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_only_home",
+            timestamp="2024-01-01T10:00:00Z",
+            properties={"$current_url": "/home"},
+        )
+
+        query = FunnelsQuery(
+            series=[
+                EventsNode(
+                    event="$pageview",
+                    properties=[
+                        EventPropertyFilter(
+                            key="$current_url",
+                            value="/home",
+                            operator=PropertyOperator.EXACT,
+                            type="event",
+                        )
+                    ],
+                ),
+                EventsNode(
+                    event="$pageview",
+                    properties=[
+                        EventPropertyFilter(
+                            key="$current_url",
+                            value="/pricing",
+                            operator=PropertyOperator.EXACT,
+                            type="event",
+                        )
+                    ],
+                ),
+            ],
+            dateRange=DateRange(date_from="2024-01-01", date_to="2024-01-02"),
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=14, funnelWindowIntervalUnit=FunnelConversionWindowTimeUnit.DAY
+            ),
+        )
+        result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+        # Step 1: both users entered with /home
+        self.assertEqual(result[0]["count"], 2)
+        # Step 2: only user_both continued to /pricing
+        self.assertEqual(result[1]["count"], 1)
+
+    @parameterized.expand(
+        [
+            (
+                "event_breakdown",
+                BreakdownType.EVENT,
+                "$browser",
+                None,  # no group_type_index needed
+                False,  # no group setup needed
+            ),
+            (
+                "person_breakdown",
+                BreakdownType.PERSON,
+                "name",
+                None,
+                False,
+            ),
+            (
+                "group_breakdown",
+                BreakdownType.GROUP,
+                "industry",
+                0,
+                True,  # needs group setup
+            ),
+        ]
+    )
+    @freeze_time("2024-01-02T00:00:00Z")
+    def test_funnel_breakdown_value_boxing(self, _name, breakdown_type, breakdown_prop, group_type_index, needs_groups):
+        if needs_groups:
+            self._create_groups()
+
+        _create_person(distinct_ids=["bd_user1"], team_id=self.team.pk)
+        self._signup_event(
+            distinct_id="bd_user1",
+            timestamp="2024-01-01T10:00:00Z",
+            properties={"$browser": "Chrome", "$group_0": "org:5"} if needs_groups else {"$browser": "Chrome"},
+        )
+        self._add_to_cart_event(
+            distinct_id="bd_user1",
+            timestamp="2024-01-01T11:00:00Z",
+            properties={"$browser": "Chrome", "$group_0": "org:5"} if needs_groups else {"$browser": "Chrome"},
+        )
+
+        query = FunnelsQuery(
+            series=[
+                EventsNode(event="user signed up"),
+                EventsNode(event="added to cart"),
+            ],
+            dateRange=DateRange(date_from="2024-01-01", date_to="2024-01-02"),
+            funnelsFilter=FunnelsFilter(
+                funnelWindowInterval=14, funnelWindowIntervalUnit=FunnelConversionWindowTimeUnit.DAY
+            ),
+            breakdownFilter=BreakdownFilter(
+                breakdown=breakdown_prop,
+                breakdown_type=breakdown_type,
+                breakdown_group_type_index=group_type_index,
+            ),
+        )
+        response = FunnelsQueryRunner(query=query, team=self.team).calculate()
+        self.assertIsNotNone(response.results)
+        self.assertGreater(len(response.results), 0)

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -5590,15 +5590,16 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         assert first_group[1]["count"] == 1
         assert first_group[1]["order"] == 1
 
-        # Breakdown value should be present and correctly typed.
-        # The boxing bug caused GROUP breakdown values to be raw strings instead of lists.
+        # Breakdown value should be present and boxed as a list for all breakdown types.
+        # Known bug: GROUP breakdowns currently return unboxed strings instead of lists.
         bv = first_group[0]["breakdown_value"]
         assert bv is not None
-        if breakdown_type in (BreakdownType.EVENT, BreakdownType.PERSON):
+        if breakdown_type == BreakdownType.GROUP:
+            # Assert current (buggy) behavior so this test breaks when the bug is fixed,
+            # prompting update to the stricter list assertion below.
+            assert isinstance(bv, str), (
+                f"GROUP breakdown boxing bug appears fixed! "
+                f"Got list instead of str — remove this branch and use the list assertion for all types."
+            )
+        else:
             assert isinstance(bv, list), f"Expected boxed breakdown_value for {breakdown_type}, got {type(bv)}"
-        elif breakdown_type == BreakdownType.GROUP:
-            # Group breakdowns currently return unboxed strings — this documents the
-            # existing behavior. If boxing is fixed for groups, update to assert list.
-            assert isinstance(bv, (str, list)), f"Unexpected breakdown_value type for GROUP: {type(bv)}"
-            if isinstance(bv, str):
-                assert len(bv) > 0, "GROUP breakdown_value should not be empty"

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -5512,9 +5512,9 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         result = FunnelsQueryRunner(query=query, team=self.team).calculate().results
 
         # Step 1: both users entered with /home
-        self.assertEqual(result[0]["count"], 2)
+        assert result[0]["count"] == 2
         # Step 2: only user_both continued to /pricing
-        self.assertEqual(result[1]["count"], 1)
+        assert result[1]["count"] == 1
 
     @parameterized.expand(
         [
@@ -5575,25 +5575,30 @@ class TestFOSSFunnelUDF(ClickhouseTestMixin, APIBaseTest):
         )
         response = FunnelsQueryRunner(query=query, team=self.team).calculate()
 
-        # Should have at least one breakdown group
-        self.assertGreater(len(response.results), 0)
+        assert len(response.results) > 0
 
         # Each breakdown group is a list of steps
         first_group = response.results[0]
-        self.assertIsInstance(first_group, list)
-        self.assertEqual(len(first_group), 2)
+        assert isinstance(first_group, list)
+        assert len(first_group) == 2
 
         # Step 1: user entered funnel
-        self.assertEqual(first_group[0]["count"], 1)
-        self.assertEqual(first_group[0]["order"], 0)
+        assert first_group[0]["count"] == 1
+        assert first_group[0]["order"] == 0
 
         # Step 2: user converted
-        self.assertEqual(first_group[1]["count"], 1)
-        self.assertEqual(first_group[1]["order"], 1)
+        assert first_group[1]["count"] == 1
+        assert first_group[1]["order"] == 1
 
-        # Breakdown value should be present and non-empty
+        # Breakdown value should be present and correctly typed.
+        # The boxing bug caused GROUP breakdown values to be raw strings instead of lists.
         bv = first_group[0]["breakdown_value"]
-        self.assertIsNotNone(bv)
+        assert bv is not None
         if breakdown_type in (BreakdownType.EVENT, BreakdownType.PERSON):
-            # These types box the value into a list
-            self.assertIsInstance(bv, list, f"Expected boxed breakdown_value for {breakdown_type}, got {type(bv)}")
+            assert isinstance(bv, list), f"Expected boxed breakdown_value for {breakdown_type}, got {type(bv)}"
+        elif breakdown_type == BreakdownType.GROUP:
+            # Group breakdowns currently return unboxed strings — this documents the
+            # existing behavior. If boxing is fixed for groups, update to assert list.
+            assert isinstance(bv, (str, list)), f"Unexpected breakdown_value type for GROUP: {type(bv)}"
+            if isinstance(bv, str):
+                assert len(bv) > 0, "GROUP breakdown_value should not be empty"

--- a/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
@@ -10,6 +10,8 @@ from posthog.test.base import (
     snapshot_clickhouse_queries,
 )
 
+from parameterized import parameterized
+
 from posthog.schema import (
     ActionsNode,
     BreakdownFilter,
@@ -2164,6 +2166,47 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         assert not hasattr(query_runner.query, "breakdownFilter")
+
+    @parameterized.expand(
+        [
+            (
+                "week_interval_mid_week",
+                IntervalType.WEEK,
+                "2020-01-14",
+                "2020-01-19",
+            ),
+            (
+                "month_interval_mid_month",
+                IntervalType.MONTH,
+                "2020-01-14",
+                "2020-01-19",
+            ),
+        ]
+    )
+    @freeze_time("2020-01-20T00:00:00Z")
+    def test_lifecycle_interval_boundary_filtering(self, _name, interval, date_from, date_to):
+        self._create_test_events()
+
+        response = self._run_lifecycle_query(date_from, date_to, interval)
+
+        statuses = {r["status"] for r in response.results}
+        self.assertEqual(statuses, {"new", "returning", "resurrecting", "dormant"})
+
+        # Lifecycle rounds date_from to start-of-interval for status classification.
+        # Verify all four statuses are present and total counts are non-negative.
+        for result in response.results:
+            if result["status"] == "dormant":
+                self.assertTrue(all(v <= 0 for v in result["data"]))
+            else:
+                self.assertTrue(all(v >= 0 for v in result["data"]))
+
+        # At least some active persons should appear in the range
+        total_active = sum(
+            sum(max(0, v) for v in r["data"])
+            for r in response.results
+            if r["status"] in ("new", "returning", "resurrecting")
+        )
+        self.assertGreater(total_active, 0, "Should have some active persons in range")
 
 
 def assertLifecycleResults(results, expected):

--- a/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
@@ -2189,24 +2189,33 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         response = self._run_lifecycle_query(date_from, date_to, interval)
 
-        statuses = {r["status"] for r in response.results}
-        self.assertEqual(statuses, {"new", "returning", "resurrecting", "dormant"})
+        statuses = [r["status"] for r in response.results]
+        self.assertEqual(["new", "returning", "resurrecting", "dormant"], statuses)
 
-        # Lifecycle rounds date_from to start-of-interval for status classification.
-        # Verify all four statuses are present and total counts are non-negative.
-        for result in response.results:
-            if result["status"] == "dormant":
-                self.assertTrue(all(v <= 0 for v in result["data"]))
-            else:
-                self.assertTrue(all(v >= 0 for v in result["data"]))
+        by_status = {r["status"]: r for r in response.results}
 
-        # At least some active persons should appear in the range
-        total_active = sum(
-            sum(max(0, v) for v in r["data"])
-            for r in response.results
-            if r["status"] in ("new", "returning", "resurrecting")
-        )
-        self.assertGreater(total_active, 0, "Should have some active persons in range")
+        if interval == IntervalType.WEEK:
+            # Week interval with date_from=Jan 14 rounds to week start (Jan 12, Sunday-based).
+            # Two week buckets: [Jan 12, Jan 19]
+            # Test data: p1 (Jan 11,12,13,15,17,19), p2 (Jan 9,12), p3 (Jan 12), p4 (Jan 15)
+            #
+            # Week of Jan 12: p1 new (first week with events), p2 returning (had Jan 9),
+            #   p3 new, p4 not yet → new=2, returning=2
+            # Week of Jan 19: p1 returning, dormant=p2,p3,p4 (3 go dormant) → returning=1, dormant=-3
+            self.assertEqual(by_status["new"]["data"], [2.0, 0.0])
+            self.assertEqual(by_status["returning"]["data"], [2.0, 1.0])
+            self.assertEqual(by_status["resurrecting"]["data"], [0.0, 0.0])
+            self.assertEqual(by_status["dormant"]["data"], [0.0, -3.0])
+            self.assertEqual(by_status["new"]["days"], ["2020-01-12", "2020-01-19"])
+        elif interval == IntervalType.MONTH:
+            # Month interval with date_from=Jan 14 rounds to Jan 1.
+            # Single month bucket: [Jan 1]
+            # All 4 persons are new in this month (no prior month data)
+            self.assertEqual(by_status["new"]["data"], [4.0])
+            self.assertEqual(by_status["returning"]["data"], [0.0])
+            self.assertEqual(by_status["resurrecting"]["data"], [0.0])
+            self.assertEqual(by_status["dormant"]["data"], [0.0])
+            self.assertEqual(by_status["new"]["days"], ["2020-01-01"])
 
 
 def assertLifecycleResults(results, expected):

--- a/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
@@ -2190,7 +2190,7 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = self._run_lifecycle_query(date_from, date_to, interval)
 
         statuses = [r["status"] for r in response.results]
-        self.assertEqual(["new", "returning", "resurrecting", "dormant"], statuses)
+        assert statuses == ["new", "returning", "resurrecting", "dormant"]
 
         by_status = {r["status"]: r for r in response.results}
 
@@ -2202,20 +2202,20 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
             # Week of Jan 12: p1 new (first week with events), p2 returning (had Jan 9),
             #   p3 new, p4 not yet → new=2, returning=2
             # Week of Jan 19: p1 returning, dormant=p2,p3,p4 (3 go dormant) → returning=1, dormant=-3
-            self.assertEqual(by_status["new"]["data"], [2.0, 0.0])
-            self.assertEqual(by_status["returning"]["data"], [2.0, 1.0])
-            self.assertEqual(by_status["resurrecting"]["data"], [0.0, 0.0])
-            self.assertEqual(by_status["dormant"]["data"], [0.0, -3.0])
-            self.assertEqual(by_status["new"]["days"], ["2020-01-12", "2020-01-19"])
+            assert by_status["new"]["data"] == [2.0, 0.0]
+            assert by_status["returning"]["data"] == [2.0, 1.0]
+            assert by_status["resurrecting"]["data"] == [0.0, 0.0]
+            assert by_status["dormant"]["data"] == [0.0, -3.0]
+            assert by_status["new"]["days"] == ["2020-01-12", "2020-01-19"]
         elif interval == IntervalType.MONTH:
             # Month interval with date_from=Jan 14 rounds to Jan 1.
             # Single month bucket: [Jan 1]
             # All 4 persons are new in this month (no prior month data)
-            self.assertEqual(by_status["new"]["data"], [4.0])
-            self.assertEqual(by_status["returning"]["data"], [0.0])
-            self.assertEqual(by_status["resurrecting"]["data"], [0.0])
-            self.assertEqual(by_status["dormant"]["data"], [0.0])
-            self.assertEqual(by_status["new"]["days"], ["2020-01-01"])
+            assert by_status["new"]["data"] == [4.0]
+            assert by_status["returning"]["data"] == [0.0]
+            assert by_status["resurrecting"]["data"] == [0.0]
+            assert by_status["dormant"]["data"] == [0.0]
+            assert by_status["new"]["days"] == ["2020-01-01"]
 
 
 def assertLifecycleResults(results, expected):

--- a/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_lifecycle_query_runner.py
@@ -2199,8 +2199,8 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
             # Two week buckets: [Jan 12, Jan 19]
             # Test data: p1 (Jan 11,12,13,15,17,19), p2 (Jan 9,12), p3 (Jan 12), p4 (Jan 15)
             #
-            # Week of Jan 12: p1 new (first week with events), p2 returning (had Jan 9),
-            #   p3 new, p4 not yet → new=2, returning=2
+            # Week of Jan 12: p1 returning (had Jan 11 in prior week), p2 returning (had Jan 9),
+            #   p3 new, p4 new → new=2, returning=2
             # Week of Jan 19: p1 returning, dormant=p2,p3,p4 (3 go dormant) → returning=1, dormant=-3
             assert by_status["new"]["data"] == [2.0, 0.0]
             assert by_status["returning"]["data"] == [2.0, 1.0]

--- a/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
@@ -2,9 +2,18 @@ from datetime import datetime
 from pathlib import Path
 
 from freezegun import freeze_time
-from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event, snapshot_clickhouse_queries
+from posthog.test.base import (
+    BaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+    flush_persons_and_events,
+    snapshot_clickhouse_queries,
+)
 
 from django.test import override_settings
+
+from parameterized import parameterized
 
 from posthog.schema import (
     BreakdownFilter,
@@ -680,3 +689,104 @@ class TestTrendsDataWarehouseQuery(ClickhouseTestMixin, BaseTest):
 
         with freeze_time("2023-01-07"):
             TrendsQueryRunner(team=self.team, query=trends_query).calculate()
+
+    @override_settings(IN_UNIT_TESTING=True)
+    def test_trends_with_date32_timestamp_column(self):
+        table, _source, _credential, _df, self.cleanUpDataWarehouse = create_data_warehouse_table_from_csv(
+            csv_path=Path(__file__).parent / "data" / "date32_timestamp_test.csv",
+            table_name="test_date32_table",
+            table_columns={
+                "id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "timestamp_date32": {"clickhouse": "Date32", "hogql": "DateDatabaseField"},
+                "revenue_amount": {"clickhouse": "Float64", "hogql": "FloatDatabaseField"},
+                "currency_code": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+            },
+            test_bucket=TEST_BUCKET,
+            team=self.team,
+        )
+
+        trends_query = TrendsQuery(
+            kind="TrendsQuery",
+            dateRange=DateRange(date_from="2023-01-01"),
+            series=[
+                DataWarehouseNode(
+                    id=table.name,
+                    table_name=table.name,
+                    id_field="id",
+                    distinct_id_field="id",
+                    timestamp_field="timestamp_date32",
+                )
+            ],
+        )
+
+        with freeze_time("2023-01-07"):
+            response = TrendsQueryRunner(team=self.team, query=trends_query).calculate()
+
+        # 3 of 5 rows have timestamps in range (2023-01-01, 2023-01-02, 2023-01-04)
+        # 2 rows have 1970-01-01 which is outside the date range
+        total = sum(r["count"] for r in response.results)
+        self.assertEqual(total, 3)
+
+    @parameterized.expand(
+        [
+            (
+                "matching_filter",
+                ["1"],
+                # Person with email=a links to DWH row where prop_1=a, which has id=1
+                # Filter on id=1 should match
+                1,
+            ),
+            (
+                "non_matching_filter",
+                ["false"],
+                # No DWH row has id="false", so filter excludes all events
+                0,
+            ),
+        ]
+    )
+    @override_settings(IN_UNIT_TESTING=True)
+    def test_trends_dwh_person_property_filter_values(self, _name, filter_value, expected_count):
+        table_name = self.setup_data_warehouse()
+
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="persons",
+            source_table_key="properties.email",
+            joining_table_name=table_name,
+            joining_table_key="prop_1",
+            field_name=table_name,
+        )
+
+        _create_person(
+            distinct_ids=["1"],
+            team_id=self.team.pk,
+            properties={"email": "a"},
+        )
+        _create_event(
+            distinct_id="1",
+            event="$pageview",
+            timestamp="2022-12-01 00:00:00",
+            team=self.team,
+        )
+        flush_persons_and_events()
+
+        trends_query = TrendsQuery(
+            kind="TrendsQuery",
+            dateRange=DateRange(date_from="all"),
+            series=[
+                EventsNode(
+                    event="$pageview",
+                    properties=[
+                        DataWarehousePersonPropertyFilter(
+                            key=f"{table_name}.id", operator=PropertyOperator.EXACT, value=filter_value
+                        )
+                    ],
+                ),
+            ],
+        )
+
+        with freeze_time("2023-01-07"):
+            response = TrendsQueryRunner(team=self.team, query=trends_query).calculate()
+
+        total = sum(r["count"] for r in response.results)
+        self.assertEqual(total, expected_count)

--- a/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
@@ -724,8 +724,13 @@ class TestTrendsDataWarehouseQuery(ClickhouseTestMixin, BaseTest):
 
         # 3 of 5 rows have timestamps in range (2023-01-01, 2023-01-02, 2023-01-04)
         # 2 rows have 1970-01-01 which is outside the date range
-        total = sum(r["count"] for r in response.results)
-        self.assertEqual(total, 3)
+        assert len(response.results) == 1
+        assert response.results[0]["count"] == 3
+        # Verify the specific days that have data
+        days_with_data = [
+            (day, count) for day, count in zip(response.results[0]["days"], response.results[0]["data"]) if count > 0
+        ]
+        assert days_with_data == [("2023-01-01", 1), ("2023-01-02", 1), ("2023-01-04", 1)]
 
     @parameterized.expand(
         [
@@ -788,5 +793,5 @@ class TestTrendsDataWarehouseQuery(ClickhouseTestMixin, BaseTest):
         with freeze_time("2023-01-07"):
             response = TrendsQueryRunner(team=self.team, query=trends_query).calculate()
 
-        total = sum(r["count"] for r in response.results)
-        self.assertEqual(total, expected_count)
+        assert len(response.results) == 1
+        assert response.results[0]["count"] == expected_count

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -7239,8 +7239,12 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             BreakdownFilter(breakdown="$browser", breakdown_type=BreakdownType.EVENT),
         )
 
-        self.assertIsNotNone(response)
-        self.assertGreaterEqual(len(response.results), 0)
+        # Should return exactly 1 breakdown group (Chrome, from the filter)
+        self.assertEqual(len(response.results), 1)
+        self.assertEqual(response.results[0]["breakdown_value"], "Chrome")
+        # Session duration values are 0 since test events lack real session data,
+        # but getting 1 result with the correct breakdown proves the filter propagated
+        self.assertEqual(response.results[0]["count"], 0.0)
 
     @parameterized.expand(
         [

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from parameterized import parameterized
 from pydantic import ValidationError
 
 from posthog.schema import (
@@ -69,7 +70,7 @@ from posthog.hogql_queries.insights.trends.trends_query_runner import BREAKDOWN_
 from posthog.models.action.action import Action
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.group.util import create_group
-from posthog.models.team.team import Team
+from posthog.models.team.team import Team, WeekStartDay
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
 
@@ -7149,3 +7150,141 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             for day_str in result["days"]:
                 parsed = datetime.strptime(day_str[:10], "%Y-%m-%d")
                 assert parsed.weekday() < 5, f"{day_str} is a weekend day but should be filtered out"
+
+    @parameterized.expand(
+        [
+            (
+                "event_property_filter_on_browser",
+                EventPropertyFilter(key="$browser", value="Chrome", operator=PropertyOperator.EXACT, type="event"),
+                # Chrome $pageview = 6 (p1), all $pageleave = 6 → 12
+                12,
+            ),
+            (
+                "person_property_filter_on_name",
+                PersonPropertyFilter(key="name", value="p1", operator=PropertyOperator.EXACT, type="person"),
+                # p1 $pageview = 6, all $pageleave = 6 → 12
+                12,
+            ),
+            (
+                "event_property_filter_on_browser_firefox",
+                EventPropertyFilter(key="$browser", value="Firefox", operator=PropertyOperator.EXACT, type="event"),
+                # Firefox $pageview = 2 (p2), all $pageleave = 6 → 8
+                8,
+            ),
+        ]
+    )
+    @freeze_time("2020-01-20T00:00:00Z")
+    def test_group_node_property_filter_types(self, _name, property_filter, expected_count):
+        self._create_test_events()
+        flush_persons_and_events()
+
+        group_node = GroupNode(
+            operator=FilterLogicalOperator.OR_,
+            nodes=[
+                EventsNode(
+                    event="$pageview",
+                    properties=[property_filter],
+                ),
+                EventsNode(event="$pageleave"),
+            ],
+        )
+
+        response = TrendsQueryRunner(
+            query=TrendsQuery(
+                dateRange=DateRange(
+                    date_from=self.default_date_from,
+                    date_to=self.default_date_to,
+                ),
+                interval=IntervalType.DAY,
+                series=[group_node],
+            ),
+            team=self.team,
+        ).calculate()
+
+        self.assertEqual(1, len(response.results))
+        self.assertEqual(expected_count, response.results[0]["count"])
+
+    @parameterized.expand(
+        [
+            ("avg", PropertyMathType.AVG),
+            ("sum", PropertyMathType.SUM),
+            ("median", PropertyMathType.MEDIAN),
+        ]
+    )
+    @freeze_time("2020-01-20T00:00:00Z")
+    def test_session_duration_math_with_event_property_filter(self, _name, math_type):
+        self._create_test_events()
+        flush_persons_and_events()
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [
+                EventsNode(
+                    event="$pageview",
+                    math=math_type,
+                    math_property="$session_duration",
+                    properties=[
+                        EventPropertyFilter(
+                            key="$browser",
+                            value="Chrome",
+                            operator=PropertyOperator.EXACT,
+                            type="event",
+                        )
+                    ],
+                )
+            ],
+            None,
+            BreakdownFilter(breakdown="$browser", breakdown_type=BreakdownType.EVENT),
+        )
+
+        self.assertIsNotNone(response)
+        self.assertGreaterEqual(len(response.results), 0)
+
+    @parameterized.expand(
+        [
+            (
+                "mid_week_monday_start",
+                "2020-01-14",
+                "2020-01-19",
+                WeekStartDay.MONDAY,
+                # Events on or after Jan 14: Jan 15 (2), Jan 17 (1), Jan 19 (1) = 4
+                4,
+            ),
+            (
+                "mid_week_sunday_start",
+                "2020-01-14",
+                "2020-01-19",
+                WeekStartDay.SUNDAY,
+                # Events on or after Jan 14: Jan 15 (2), Jan 17 (1), Jan 19 (1) = 4
+                4,
+            ),
+            (
+                "week_boundary_monday",
+                "2020-01-13",
+                "2020-01-19",
+                WeekStartDay.MONDAY,
+                # Events on or after Jan 13: Jan 13 (1), Jan 15 (2), Jan 17 (1), Jan 19 (1) = 5
+                5,
+            ),
+        ]
+    )
+    @freeze_time("2020-01-20T00:00:00Z")
+    def test_week_interval_boundaries_with_week_start_day(
+        self, _name, date_from, date_to, week_start_day, expected_count
+    ):
+        self._create_test_events()
+
+        self.team.week_start_day = week_start_day
+        self.team.save()
+
+        response = self._run_trends_query(
+            date_from,
+            date_to,
+            IntervalType.WEEK,
+            [EventsNode(event="$pageview")],
+        )
+
+        self.assertEqual(1, len(response.results))
+        self.assertEqual(expected_count, response.results[0]["count"])

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -7201,8 +7201,8 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
         ).calculate()
 
-        self.assertEqual(1, len(response.results))
-        self.assertEqual(expected_count, response.results[0]["count"])
+        assert len(response.results) == 1
+        assert response.results[0]["count"] == expected_count
 
     @parameterized.expand(
         [
@@ -7239,12 +7239,15 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             BreakdownFilter(breakdown="$browser", breakdown_type=BreakdownType.EVENT),
         )
 
-        # Should return exactly 1 breakdown group (Chrome, from the filter)
-        self.assertEqual(len(response.results), 1)
-        self.assertEqual(response.results[0]["breakdown_value"], "Chrome")
+        # Should return exactly 1 breakdown group (Chrome, from the event property filter).
+        # The filter restricts to Chrome-only events, so only the Chrome breakdown group appears.
         # Session duration values are 0 since test events lack real session data,
-        # but getting 1 result with the correct breakdown proves the filter propagated
-        self.assertEqual(response.results[0]["count"], 0.0)
+        # but getting exactly 1 result with the correct breakdown proves the filter propagated
+        # through the session WHERE clause extractor without crashing or being dropped.
+        assert len(response.results) == 1
+        assert response.results[0]["breakdown_value"] == "Chrome"
+        assert response.results[0]["count"] == 0.0
+        assert len(response.results[0]["data"]) == 12  # 12 days from Jan 9 to Jan 20
 
     @parameterized.expand(
         [
@@ -7290,5 +7293,5 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             [EventsNode(event="$pageview")],
         )
 
-        self.assertEqual(1, len(response.results))
-        self.assertEqual(expected_count, response.results[0]["count"])
+        assert len(response.results) == 1
+        assert response.results[0]["count"] == expected_count

--- a/posthog/queries/test/test_person_query.py
+++ b/posthog/queries/test/test_person_query.py
@@ -1,0 +1,85 @@
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_person, flush_persons_and_events
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models import Filter
+from posthog.models.cohort import Cohort
+from posthog.queries.column_optimizer.column_optimizer import ColumnOptimizer
+from posthog.queries.person_query import PersonQuery
+
+
+class TestPersonQuery(ClickhouseTestMixin, APIBaseTest):
+    @freeze_time("2021-01-01T00:00:00Z")
+    def test_cohort_join_moves_into_prefiltering_subquery_with_person_property_filters(self):
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p1"],
+            properties={"in_cohort": "yes", "color": "blue"},
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p2"],
+            properties={"in_cohort": "yes", "color": "blue"},
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p3"],
+            properties={"in_cohort": "yes", "color": "red"},
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p4"],
+            properties={"in_cohort": "no", "color": "blue"},
+        )
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["p5"],
+            properties={"in_cohort": "no", "color": "red"},
+        )
+        flush_persons_and_events()
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="in_cohort_yes",
+            groups=[{"properties": [{"key": "in_cohort", "value": "yes", "type": "person"}]}],
+        )
+        cohort.calculate_people_ch(pending_version=0)
+
+        filter = Filter(
+            data={
+                "properties": [
+                    {"key": "color", "value": "blue", "type": "person"},
+                ],
+            }
+        )
+
+        column_optimizer = ColumnOptimizer(filter, self.team.pk)
+        person_query = PersonQuery(
+            filter=filter,
+            team_id=self.team.pk,
+            column_optimizer=column_optimizer,
+            cohort=cohort,
+        )
+
+        sql, params = person_query.get_query()
+
+        # When person property filters are present (causing prefiltering), the cohort INNER JOIN
+        # should be inside the prefiltering subquery, not at the top level
+        assert "AND id IN" in sql, "Expected a prefiltering subquery"
+
+        # The INNER JOIN for the cohort should appear inside the prefiltering subquery
+        prefiltering_start = sql.index("AND id IN")
+        prefiltering_end = sql.index(")", prefiltering_start + len("AND id IN ("))
+        prefiltering_subquery = sql[prefiltering_start:prefiltering_end]
+        assert "INNER JOIN" in prefiltering_subquery, (
+            "Expected the cohort INNER JOIN to be inside the prefiltering subquery"
+        )
+
+        # The top-level query should NOT have the cohort INNER JOIN (it was moved into prefiltering)
+        top_level_sql = sql[:prefiltering_start] + sql[sql.index(")", prefiltering_end) :]
+        # Count INNER JOINs outside the prefiltering subquery — should be 0
+        assert "INNER JOIN" not in top_level_sql, "Expected no top-level INNER JOIN when prefiltering is active"
+
+        # Execute the query and verify the correct number of results
+        results = sync_execute(sql, params)
+        assert len(results) == 2, f"Expected 2 persons (in cohort + color=blue), got {len(results)}"

--- a/posthog/queries/test/test_person_query.py
+++ b/posthog/queries/test/test_person_query.py
@@ -1,3 +1,5 @@
+import re
+
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_person, flush_persons_and_events
 
@@ -64,20 +66,18 @@ class TestPersonQuery(ClickhouseTestMixin, APIBaseTest):
         sql, params = person_query.get_query()
 
         # When person property filters are present (causing prefiltering), the cohort INNER JOIN
-        # should be inside the prefiltering subquery, not at the top level
-        assert "AND id IN" in sql, "Expected a prefiltering subquery"
+        # should be inside the prefiltering subquery, not at the top level.
+        # Extract the prefiltering subquery using regex to avoid brittle index-based parsing.
+        prefiltering_match = re.search(r"AND id IN\s*\((.*?)\)\s*(?:GROUP BY|$)", sql, re.DOTALL)
+        assert prefiltering_match is not None, "Expected a prefiltering subquery (AND id IN (...))"
 
-        # The INNER JOIN for the cohort should appear inside the prefiltering subquery
-        prefiltering_start = sql.index("AND id IN")
-        prefiltering_end = sql.index(")", prefiltering_start + len("AND id IN ("))
-        prefiltering_subquery = sql[prefiltering_start:prefiltering_end]
+        prefiltering_subquery = prefiltering_match.group(1)
         assert "INNER JOIN" in prefiltering_subquery, (
             "Expected the cohort INNER JOIN to be inside the prefiltering subquery"
         )
 
-        # The top-level query should NOT have the cohort INNER JOIN (it was moved into prefiltering)
-        top_level_sql = sql[:prefiltering_start] + sql[sql.index(")", prefiltering_end) :]
-        # Count INNER JOINs outside the prefiltering subquery — should be 0
+        # The top-level query (outside the prefiltering subquery) should NOT have the cohort join
+        top_level_sql = sql[: prefiltering_match.start()] + sql[prefiltering_match.end() :]
         assert "INNER JOIN" not in top_level_sql, "Expected no top-level INNER JOIN when prefiltering is active"
 
         # Execute the query and verify the correct number of results


### PR DESCRIPTION
## Problem
Over the past 6 months, we had 9 query construction bugs across trends, funnels, and lifecycle runners. 

## Changes

Adds tests that would've caught them

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
it is tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
