### PR TITLE
feat(flags): pre-compute flag dependency metadata in hypercache

### DIFF
--- a/docs/internal/feature-flags/flag-evaluation-engine.md
+++ b/docs/internal/feature-flags/flag-evaluation-engine.md
@@ -19,8 +19,8 @@ The Rust feature flags service evaluates flags using a deterministic, hash-based
    ┌──────────┐  ┌───────────┐   ┌────────────┐
    │ SHA1     │  │ Property  │   │ Dependency │
    │ hashing  │  │ matching  │   │ graph      │
-   │ (rollout │  │ (23       │   │ (petgraph  │
-   │  + vars) │  │ operators)│   │  DAG)      │
+   │ (rollout │  │ (23       │   │ (pre-built │
+   │  + vars) │  │ operators)│   │  or DAG)   │
    └──────────┘  └───────────┘   └────────────┘
 ```
 
@@ -44,6 +44,21 @@ pub struct FeatureFlag {
     pub bucketing_identifier: Option<String>,        // "distinct_id" or "device_id"
 }
 ```
+
+### EvaluationMetadata
+
+Pre-computed dependency metadata, built by Django at cache-write time and shipped as a top-level field alongside the flags array in the HyperCache.
+
+```rust
+pub struct EvaluationMetadata {
+    pub dependency_stages: Vec<Vec<i32>>,           // flag IDs grouped by stage (stage 0 first)
+    pub flags_with_missing_deps: Vec<i32>,          // flag IDs with broken dependencies
+    pub transitive_deps: HashMap<i32, HashSet<i32>>, // flag ID → transitive dep IDs
+}
+```
+
+On the wire (JSON), `transitive_deps` keys are stringified integers (`{"1": [2, 3]}`).
+Custom serde converts between this and the in-memory `HashMap<i32, HashSet<i32>>`.
 
 ### FlagFilters
 
@@ -271,13 +286,46 @@ Flags can depend on other flags via `PropertyFilter` with `prop_type: Flag` and 
 
 ### Dependency graph
 
-The service builds a directed acyclic graph (DAG) using `petgraph` to determine evaluation order:
+The dependency graph determines evaluation order so that flags are evaluated after their dependencies.
+
+#### Pre-computed path (HyperCache)
+
+Django pre-computes all dependency metadata at cache-write time and ships it as a top-level `evaluation_metadata` alongside the flags array in the HyperCache:
+
+```json
+{
+  "flags": [...],
+  "evaluation_metadata": {
+    "dependency_stages": [[3], [2], [1]],
+    "flags_with_missing_deps": [5],
+    "transitive_deps": {"1": [2, 3], "2": [3]}
+  }
+}
+```
+
+- `dependency_stages`: Flag IDs pre-grouped by evaluation stage. Stage 0 (no deps) first.
+- `flags_with_missing_deps`: Flag IDs with missing, cyclic, or transitively broken dependencies (fail closed).
+- `transitive_deps`: Flag ID → transitive dependency flag IDs. Keys are stringified ints (JSON requirement).
+
+Rust deserializes `EvaluationMetadata` and maps pre-grouped stages directly to `Vec<Vec<FeatureFlag>>` — no graph construction or Kahn's algorithm needed.
+
+#### Fallback path (PostgreSQL)
+
+When `evaluation_metadata` is absent (PG fallback, old cache entries), the service builds a DAG using `petgraph`:
 
 1. Extract dependencies from all flag property filters
 2. Build a directed graph (edges from dependent -> dependency)
 3. Detect and remove cycles (cycle-starting nodes and all their dependents are removed)
 4. Track missing dependencies (flags depending on non-existent flags)
 5. Compute topological evaluation stages using Kahn's algorithm
+
+#### Backwards compatibility
+
+The two paths are fully compatible via `#[serde(default)]` on `evaluation_metadata`:
+
+- **Old Rust + new cache**: `evaluation_metadata` is an unknown field, ignored. Falls back to petgraph.
+- **New Rust + old cache**: `evaluation_metadata` absent → `None` → falls back to petgraph.
+- **New Rust + new cache**: `evaluation_metadata` present → fast pre-computed path.
 
 ### Evaluation stages
 
@@ -386,7 +434,7 @@ Property overrides from the request body are merged on top of DB-fetched propert
 
 The evaluation engine follows a lazy-but-batched approach:
 
-1. **Flag definitions**: Fetched once per request from HyperCache (Redis -> S3 -> PostgreSQL)
+1. **Flag definitions**: Fetched once per request from HyperCache (Redis -> S3 -> PostgreSQL), including pre-computed `evaluation_metadata` when available
 2. **Group type mappings**: Fetched once per request if any flag uses groups
 3. **Person properties**: Fetched once per request from PostgreSQL, merged with request overrides
 4. **Group properties**: Fetched once per request from PostgreSQL, merged with request overrides
@@ -397,19 +445,19 @@ The evaluation engine follows a lazy-but-batched approach:
 
 ## Related files
 
-| File                                                         | Purpose                                         |
-| ------------------------------------------------------------ | ----------------------------------------------- |
-| `rust/feature-flags/src/handler/evaluation.rs`               | Entry point: creates matcher and calls evaluate |
-| `rust/feature-flags/src/flags/flag_matching.rs`              | Core matching engine: `FeatureFlagMatcher`      |
-| `rust/feature-flags/src/flags/flag_matching_utils.rs`        | Hash calculation, property fetching, DB queries |
-| `rust/feature-flags/src/properties/property_matching.rs`     | Property filter operator implementations        |
-| `rust/feature-flags/src/flags/flag_models.rs`                | Data models                                     |
-| `rust/feature-flags/src/flags/flag_operations.rs`            | Flag helper methods, `DependencyProvider` trait |
-| `rust/feature-flags/src/flags/flag_match_reason.rs`          | Match reason enum with priority ordering        |
-| `rust/feature-flags/src/utils/graph_utils.rs`                | Dependency graph using petgraph                 |
-| `rust/feature-flags/src/cohorts/cohort_cache_manager.rs`     | Moka-backed cohort cache                        |
-| `rust/feature-flags/src/flags/test_flag_matching.rs`         | Unit tests for flag matching                    |
-| `rust/feature-flags/tests/test_flag_matching_consistency.rs` | Cross-language consistency tests                |
+| File                                                         | Purpose                                             |
+| ------------------------------------------------------------ | --------------------------------------------------- |
+| `rust/feature-flags/src/handler/evaluation.rs`               | Entry point: creates matcher and calls evaluate     |
+| `rust/feature-flags/src/flags/flag_matching.rs`              | Core matching engine: `FeatureFlagMatcher`          |
+| `rust/feature-flags/src/flags/flag_matching_utils.rs`        | Hash calculation, property fetching, DB queries     |
+| `rust/feature-flags/src/properties/property_matching.rs`     | Property filter operator implementations            |
+| `rust/feature-flags/src/flags/flag_models.rs`                | Data models                                         |
+| `rust/feature-flags/src/flags/flag_operations.rs`            | Flag helper methods, `DependencyProvider` trait     |
+| `rust/feature-flags/src/flags/flag_match_reason.rs`          | Match reason enum with priority ordering            |
+| `rust/feature-flags/src/utils/graph_utils.rs`                | Dependency graph (pre-computed + petgraph fallback) |
+| `rust/feature-flags/src/cohorts/cohort_cache_manager.rs`     | Moka-backed cohort cache                            |
+| `rust/feature-flags/src/flags/test_flag_matching.rs`         | Unit tests for flag matching                        |
+| `rust/feature-flags/tests/test_flag_matching_consistency.rs` | Cross-language consistency tests                    |
 
 ## See also
 

--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -93,6 +93,62 @@ else:
 
 ETags are computed as SHA256 hashes of the JSON content.
 
+## Service cache (Rust)
+
+The feature-flags Rust evaluation service uses a separate HyperCache instance defined in `posthog/models/feature_flag/flags_cache.py`. Unlike the local evaluation cache (which serves SDKs with cohort definitions and group type mappings), the service cache provides raw flag data plus pre-computed dependency metadata so the Rust service can evaluate flags in the correct order without recomputing the dependency graph on every request.
+
+### Cache instance
+
+```python
+# posthog/models/feature_flag/flags_cache.py
+flags_hypercache = HyperCache(
+    namespace="feature_flags",
+    value="flags.json",
+    load_fn=lambda key: _get_feature_flags_for_service(HyperCache.team_from_key(key)),
+    cache_ttl=settings.FLAGS_CACHE_TTL,
+    cache_miss_ttl=settings.FLAGS_CACHE_MISS_TTL,
+    cache_alias=FLAGS_DEDICATED_CACHE_ALIAS if FLAGS_DEDICATED_CACHE_ALIAS in settings.CACHES else None,
+    batch_load_fn=_get_feature_flags_for_teams_batch,
+    expiry_sorted_set_key=FLAGS_CACHE_EXPIRY_SORTED_SET,
+)
+```
+
+The `_get_feature_flags_for_service` function fetches all flags for a team (including inactive, but excluding deleted and encrypted remote config flags) and returns the cache payload. The Rust service filters out inactive flags at request time via `filtered_out_flag_ids`.
+
+### Cache payload structure
+
+```json
+{
+  "flags": [
+    /* serialized flag dicts */
+  ],
+  "evaluation_metadata": {
+    "dependency_stages": [[1, 5], [3], [7]],
+    "flags_with_missing_deps": [9, 12],
+    "transitive_deps": { "3": [1, 5], "7": [1, 3, 5] }
+  }
+}
+```
+
+The `evaluation_metadata` fields:
+
+| Field                     | Type                   | Description                                                                                                                                                                                 |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dependency_stages`       | `list[list[int]]`      | Flag IDs grouped by evaluation order. Stage 0 contains flags with no dependencies; stage N depends only on flags in stages 0…N-1. Flags within the same stage can be evaluated in parallel. |
+| `flags_with_missing_deps` | `list[int]`            | Flag IDs whose dependencies are missing, cyclic, or transitively broken. The Rust service treats these as evaluation errors.                                                                |
+| `transitive_deps`         | `dict[str, list[int]]` | Map of stringified flag ID to the sorted list of all its transitive dependency flag IDs.                                                                                                    |
+
+### Dependency computation
+
+The `_compute_flag_dependencies` function in `flags_cache.py` builds the evaluation metadata using Kahn's algorithm (layered topological sort). The algorithm:
+
+1. Extracts direct dependencies from each flag's `filters.groups[*].properties` where `type == "flag"`.
+2. Builds an in-degree map and reverse-dependency edges across all flags.
+3. Peels layers of zero-in-degree nodes, computing transitive dependency closures as it goes. Each layer becomes one evaluation stage.
+4. Detects cycles — any flag still with in-degree > 0 after all layers are peeled is a cycle participant. Cycled flags and any flag that transitively depends on them are added to `flags_with_missing_deps`.
+
+This matches the Rust fallback path's petgraph-based cycle handling, where all cycle participants are excluded from stages (not just back-edge targets).
+
 ## Local evaluation caching
 
 Feature flag local evaluation uses two separate HyperCache instances in `posthog/models/feature_flag/local_evaluation.py`:
@@ -419,7 +475,7 @@ REMOTE_CONFIG_CDN_PURGE_DOMAINS=["cdn.example.com"]
 
 - `posthog/storage/hypercache.py` - Core HyperCache implementation
 - `posthog/models/feature_flag/local_evaluation.py` - Local evaluation caching
-- `posthog/models/feature_flag/flags_cache.py` - Flags cache, signal handlers, verification
+- `posthog/models/feature_flag/flags_cache.py` - Flags cache, signal handlers, verification, dependency computation
 - `posthog/storage/hypercache_manager.py` - Batch management operations (warm, invalidate, stats)
 - `posthog/caching/flags_redis_cache.py` - Dual-write pattern for dedicated Redis
 - `posthog/models/remote_config.py` - Remote config caching

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -69,24 +69,130 @@ logger = structlog.get_logger(__name__)
 FLAGS_CACHE_EXPIRY_SORTED_SET = "flags_cache_expiry"
 
 
+def _extract_direct_dependency_ids(flag_data: dict[str, Any]) -> set[int]:
+    """
+    Extract direct flag dependency IDs from a serialized flag's filters.
+
+    Scans filters.groups[*].properties for type=="flag" properties and parses
+    their key as an integer flag ID. Inactive/deleted flags return empty deps
+    to match Rust's extract_dependencies behavior.
+    """
+    if not flag_data.get("active", True) or flag_data.get("deleted", False):
+        return set()
+
+    dep_ids: set[int] = set()
+    filters = flag_data.get("filters", {})
+    for group in filters.get("groups") or []:
+        for prop in group.get("properties") or []:
+            if prop.get("type") == "flag":
+                try:
+                    dep_ids.add(int(prop["key"]))
+                except (ValueError, KeyError, TypeError):
+                    continue
+    return dep_ids
+
+
+def _compute_flag_dependencies(flags_data: list[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Compute flag dependency metadata and return evaluation metadata.
+
+    Returns a dict with:
+    - dependency_stages: list of lists of flag IDs grouped by evaluation stage,
+      stage 0 (no deps) first. Flags in the same stage can be evaluated in parallel.
+    - flags_with_missing_deps: sorted list of flag IDs with missing, cyclic, or
+      transitively broken dependencies.
+    - transitive_deps: dict mapping stringified flag ID to sorted list of all
+      transitive dependency flag IDs.
+
+    Uses Kahn's algorithm (layered topological sort) to match the Rust fallback
+    path's petgraph-based cycle handling: all cycle participants are excluded
+    from stages, not just back-edge targets.
+    """
+    id_to_flag: dict[int, dict[str, Any]] = {}
+    for flag in flags_data:
+        flag_id = flag["id"]
+        id_to_flag[flag_id] = flag
+
+    # Build direct dependency edges (may reference unknown flag IDs)
+    direct_deps: dict[int, set[int]] = {}
+    for flag_id in id_to_flag:
+        direct_deps[flag_id] = _extract_direct_dependency_ids(id_to_flag[flag_id])
+
+    # Track flags with missing dependencies (dep ID not in id_to_flag)
+    has_missing: dict[int, bool] = {
+        fid: any(dep_id not in id_to_flag for dep_id in deps) for fid, deps in direct_deps.items()
+    }
+
+    # Build in-degree map (only count edges to known flags)
+    in_degree: dict[int, int] = dict.fromkeys(id_to_flag, 0)
+    # reverse_deps: flag_id → set of flags that depend on it
+    reverse_deps: dict[int, set[int]] = {fid: set() for fid in id_to_flag}
+    for flag_id, deps in direct_deps.items():
+        for dep_id in deps:
+            if dep_id in id_to_flag:
+                in_degree[flag_id] += 1
+                reverse_deps[dep_id].add(flag_id)
+
+    # Kahn's algorithm: peel layers of zero-in-degree nodes
+    dependency_stages: list[list[int]] = []
+    transitive_deps: dict[int, set[int]] = {}
+    queue = sorted(fid for fid, deg in in_degree.items() if deg == 0)
+
+    while queue:
+        for fid in queue:
+            # Compute transitive deps: union of each dep's transitive closure + direct deps
+            td: set[int] = set()
+            for dep_id in direct_deps[fid]:
+                if dep_id in id_to_flag:
+                    td.add(dep_id)
+                    td.update(transitive_deps[dep_id])
+                    if has_missing[dep_id]:
+                        has_missing[fid] = True
+            transitive_deps[fid] = td
+
+        dependency_stages.append(queue)
+
+        next_queue: list[int] = []
+        for fid in queue:
+            for dependent_id in reverse_deps[fid]:
+                in_degree[dependent_id] -= 1
+                if in_degree[dependent_id] == 0:
+                    next_queue.append(dependent_id)
+        queue = sorted(next_queue)
+
+    # Flags still with in_degree > 0 are in cycles.
+    cycled_flags = {fid for fid, deg in in_degree.items() if deg > 0}
+    for fid in cycled_flags:
+        has_missing[fid] = True
+
+    return {
+        "dependency_stages": dependency_stages,
+        "flags_with_missing_deps": sorted(fid for fid, m in has_missing.items() if m),
+        "transitive_deps": {str(fid): sorted(transitive_deps.get(fid, set())) for fid in id_to_flag},
+    }
+
+
 def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     """
     Get feature flags for the feature-flags service.
 
-    Fetches all active, non-deleted feature flags for the team and returns them
-    wrapped in a dict that HyperCache can serialize. The actual flag data is in the
-    "flags" key as a list of flag dictionaries.
+    Fetches all feature flags for the team (including inactive, excluding deleted)
+    and returns them wrapped in a dict that HyperCache can serialize. The actual
+    flag data is in the "flags" key as a list of flag dictionaries.
 
     Encrypted remote config flags are excluded since they can only be accessed via
     the dedicated /remote_config endpoint which handles decryption. Including them
     in /flags would return unusable encrypted ciphertext.
 
     Returns:
-        dict: {"flags": [...]} where flags is a list of flag dictionaries
+        dict: {"flags": [...], "evaluation_metadata": {...}} where flags is a list
+        of flag dictionaries and evaluation_metadata contains pre-computed dependency
+        metadata (stages, missing deps, transitive deps).
     """
     # Exclude encrypted remote config flags at DB level for efficiency
     flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
     flags_data = serialize_feature_flags(flags)
+    evaluation_metadata = _compute_flag_dependencies(flags_data)
 
     logger.info(
         "Loaded feature flags for service cache",
@@ -96,7 +202,7 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     )
 
     # Wrap in dict for HyperCache compatibility
-    return {"flags": flags_data}
+    return {"flags": flags_data, "evaluation_metadata": evaluation_metadata}
 
 
 def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -114,7 +220,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
         teams: List of Team objects to load flags for
 
     Returns:
-        Dict mapping team_id to {"flags": [...]} for each team
+        Dict mapping team_id to {"flags": [...], "evaluation_metadata": {...}} for each team
     """
     if not teams:
         return {}
@@ -154,6 +260,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     for team in teams:
         team_flags = flags_by_team_id.get(team.id, [])
         flags_data = serialize_feature_flags(team_flags)
+        evaluation_metadata = _compute_flag_dependencies(flags_data)
 
         logger.info(
             "Loaded feature flags for service cache (batch)",
@@ -162,7 +269,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
             flag_count=len(flags_data),
         )
 
-        result[team.id] = {"flags": flags_data}
+        result[team.id] = {"flags": flags_data, "evaluation_metadata": evaluation_metadata}
 
     return result
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -19,6 +19,8 @@ from parameterized import parameterized
 from posthog.models import FeatureFlag, Tag, Team
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
 from posthog.models.feature_flag.flags_cache import (
+    _compute_flag_dependencies,
+    _extract_direct_dependency_ids,
     _get_feature_flags_for_service,
     _get_feature_flags_for_teams_batch,
     _get_team_ids_with_recently_updated_flags,
@@ -48,7 +50,14 @@ class TestServiceFlagsCache(BaseTest):
         """Test fetching flags when team has no flags."""
         result = _get_feature_flags_for_service(self.team)
 
-        assert result == {"flags": []}
+        assert result == {
+            "flags": [],
+            "evaluation_metadata": {
+                "dependency_stages": [],
+                "flags_with_missing_deps": [],
+                "transitive_deps": {},
+            },
+        }
 
     def test_get_feature_flags_for_service_with_flags(self):
         """Test fetching flags returns correct format for service."""
@@ -2240,3 +2249,284 @@ class TestGetTeamsWithFlagsQueryset(BaseTest):
         qs = get_teams_with_flags_queryset()
         team_ids = list(qs.values_list("id", flat=True))
         assert team_ids.count(self.team.id) == 1
+
+
+def _make_flag(id: int, key: str, deps: list[int] | None = None, active: bool = True, deleted: bool = False) -> dict:
+    """Helper to build a serialized flag dict with optional flag dependencies."""
+    properties = []
+    for dep_id in deps or []:
+        properties.append({"type": "flag", "key": str(dep_id), "value": ["true"], "operator": "exact"})
+    return {
+        "id": id,
+        "key": key,
+        "active": active,
+        "deleted": deleted,
+        "filters": {"groups": [{"properties": properties, "rollout_percentage": 100}]},
+    }
+
+
+class TestExtractDirectDependencyIds:
+    @parameterized.expand(
+        [
+            ("no_dependencies", _make_flag(1, "flag_a"), set()),
+            ("single_dependency", _make_flag(1, "flag_a", deps=[2]), {2}),
+            ("multiple_dependencies", _make_flag(1, "flag_a", deps=[2, 3]), {2, 3}),
+            ("inactive_flag_returns_empty", _make_flag(1, "flag_a", deps=[2], active=False), set()),
+            ("deleted_flag_returns_empty", _make_flag(1, "flag_a", deps=[2], deleted=True), set()),
+            (
+                "non_flag_properties_ignored",
+                {
+                    "id": 1,
+                    "key": "flag_a",
+                    "active": True,
+                    "deleted": False,
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    {"type": "person", "key": "email", "value": "test@example.com"},
+                                    {"type": "flag", "key": "2", "value": ["true"], "operator": "exact"},
+                                ]
+                            }
+                        ]
+                    },
+                },
+                {2},
+            ),
+            (
+                "non_numeric_flag_key_ignored",
+                {
+                    "id": 1,
+                    "key": "flag_a",
+                    "active": True,
+                    "deleted": False,
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    {"type": "flag", "key": "not_a_number", "value": ["true"]},
+                                ]
+                            }
+                        ]
+                    },
+                },
+                set(),
+            ),
+        ]
+    )
+    def test_extract_direct_dependency_ids(self, _name, flag, expected):
+        assert _extract_direct_dependency_ids(flag) == expected
+
+
+class TestComputeFlagDependencies:
+    def test_no_dependencies(self):
+        flags = [_make_flag(1, "flag_a"), _make_flag(2, "flag_b")]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[1, 2]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {"1": [], "2": []}
+
+    def test_linear_chain(self):
+        # A(1) -> B(2) -> C(3)
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[3]),
+            _make_flag(3, "flag_c"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[3], [2], [1]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {"1": [2, 3], "2": [3], "3": []}
+
+    def test_diamond(self):
+        # A(1) -> B(2), C(3); B(2) -> D(4); C(3) -> D(4)
+        flags = [
+            _make_flag(1, "flag_a", deps=[2, 3]),
+            _make_flag(2, "flag_b", deps=[4]),
+            _make_flag(3, "flag_c", deps=[4]),
+            _make_flag(4, "flag_d"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[4], [2, 3], [1]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {"1": [2, 3, 4], "2": [4], "3": [4], "4": []}
+
+    def test_missing_dependency(self):
+        # A(1) -> 999 (missing)
+        flags = [_make_flag(1, "flag_a", deps=[999])]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[1]]
+        assert ctx["flags_with_missing_deps"] == [1]
+        assert ctx["transitive_deps"] == {"1": []}
+
+    def test_cycle_both_flags_marked(self):
+        # A(1) -> B(2) -> A(1)
+        # Kahn's: neither flag reaches in-degree 0, so both are excluded from stages.
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[1]),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == [1, 2]
+
+    def test_transitive_missing_propagation(self):
+        # A(1) -> B(2) -> 999 (missing)
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[999]),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["flags_with_missing_deps"] == [1, 2]
+        assert ctx["dependency_stages"] == [[2], [1]]
+
+    def test_inactive_flag_empty_deps(self):
+        # Inactive A(1) has a dep on B(2), but since inactive, deps should be empty
+        flags = [
+            _make_flag(1, "flag_a", deps=[2], active=False),
+            _make_flag(2, "flag_b"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[1, 2]]
+
+    def test_dependency_on_inactive_flag_not_missing(self):
+        # A(1) -> inactive B(2). B exists so dependency is valid, but B evaluates to false.
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", active=False),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == [[2], [1]]
+        assert ctx["flags_with_missing_deps"] == []
+
+    def test_self_cycle(self):
+        # A(1) -> A(1)
+        flags = [_make_flag(1, "flag_a", deps=[1])]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == [1]
+
+    def test_three_node_cycle(self):
+        # A(1) -> B(2) -> C(3) -> A(1), plus D(4) -> A(1)
+        # Kahn's: A, B, C never reach in-degree 0 (cycle). D depends on cycled A,
+        # so D also never reaches in-degree 0. All excluded from stages.
+        flags = [
+            _make_flag(1, "flag_a", deps=[2]),
+            _make_flag(2, "flag_b", deps=[3]),
+            _make_flag(3, "flag_c", deps=[1]),
+            _make_flag(4, "flag_d", deps=[1]),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == [1, 2, 3, 4]
+        # Cycled flags get empty transitive deps (never peeled by Kahn's)
+        assert ctx["transitive_deps"] == {"1": [], "2": [], "3": [], "4": []}
+
+    def test_empty_flags_list(self):
+        ctx = _compute_flag_dependencies([])
+
+        assert ctx["dependency_stages"] == []
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {}
+
+    def test_partial_missing_branch(self):
+        # A(1) -> 999 (missing), B(2) -> C(3) (valid)
+        flags = [
+            _make_flag(1, "flag_a", deps=[999]),
+            _make_flag(2, "flag_b", deps=[3]),
+            _make_flag(3, "flag_c"),
+        ]
+        ctx = _compute_flag_dependencies(flags)
+
+        assert ctx["flags_with_missing_deps"] == [1]
+        assert ctx["dependency_stages"] == [[1, 3], [2]]
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestComputeFlagDependenciesIntegration(BaseTest):
+    def test_get_feature_flags_for_service_includes_dependency_fields(self):
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        result = _get_feature_flags_for_service(self.team)
+
+        assert "evaluation_metadata" in result
+        ctx = result["evaluation_metadata"]
+        assert "dependency_stages" in ctx
+        assert "flags_with_missing_deps" in ctx
+        assert "transitive_deps" in ctx
+        assert ctx["dependency_stages"] == [[flag.id]]
+        assert ctx["flags_with_missing_deps"] == []
+        assert ctx["transitive_deps"] == {str(flag.id): []}
+
+        # Per-flag fields should not exist
+        flag_data = result["flags"][0]
+        assert "direct_dependency_flag_ids" not in flag_data
+        assert "dependency_flag_ids" not in flag_data
+        assert "has_missing_dependencies" not in flag_data
+
+    def test_batch_includes_dependency_fields(self):
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        result = _get_feature_flags_for_teams_batch([self.team])
+
+        assert "evaluation_metadata" in result[self.team.id]
+
+    def test_service_computes_transitive_deps(self):
+        flag_c = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-c",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+        flag_b = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-b",
+            created_by=self.user,
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"type": "flag", "key": str(flag_c.id), "value": ["true"], "operator": "exact"}],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+        flag_a = FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            created_by=self.user,
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"type": "flag", "key": str(flag_b.id), "value": ["true"], "operator": "exact"}],
+                        "rollout_percentage": 100,
+                    }
+                ]
+            },
+        )
+
+        result = _get_feature_flags_for_service(self.team)
+        ctx = result["evaluation_metadata"]
+
+        assert sorted(ctx["transitive_deps"][str(flag_a.id)]) == sorted([flag_b.id, flag_c.id])
+        assert ctx["transitive_deps"][str(flag_b.id)] == [flag_c.id]
+        assert ctx["transitive_deps"][str(flag_c.id)] == []
+        assert ctx["dependency_stages"] == [[flag_c.id], [flag_b.id], [flag_a.id]]


### PR DESCRIPTION
## Problem

The Rust feature-flags service builds a full petgraph-based dependency graph on every request to resolve flag dependency ordering. This is redundant work — the flag list changes only when the Django hypercache is refreshed, not per-request.

## Changes

Adds pre-computed dependency metadata to the Django hypercache payload so downstream consumers (the Rust service) can skip graph construction at request time.

- **Django (`flags_cache.py`)**: Adds `_compute_flag_dependencies()` using Kahn's algorithm (layered topological sort) to pre-compute `evaluation_metadata` — dependency stages, flags with missing/cyclic deps, and transitive deps — and includes it in the hypercache payload alongside `flags`.
- **Docs**: Updates `flag-evaluation-engine.md` and `hypercache-system.md` to describe the new metadata format and evaluation flow.

The hypercache payload now includes an `evaluation_metadata` field alongside `flags`. For a chain `flag_a → flag_b → flag_c`:

```json
{
  "flags": [ ... ],
  "evaluation_metadata": {
    "dependency_stages": [[3], [2], [1]],
    "flags_with_missing_deps": [],
    "transitive_deps": {
      "1": [2, 3],
      "2": [3],
      "3": []
    }
  }
}
```

- `dependency_stages`: flags grouped by evaluation order — stage 0 has no deps, stage 1 depends only on stage 0, etc.
- `flags_with_missing_deps`: flag IDs with missing, cyclic, or transitively broken dependencies (fail closed).
- `transitive_deps`: full transitive closure per flag, used for key-based filtering.

The Rust service currently ignores unknown fields (`serde(deny_unknown_fields)` is not set), so the new `evaluation_metadata` field is safe to ship before the Rust consumer is updated. A follow-up PR on `haacked/use-prebuilt-dependencies` will add the Rust-side deserialization and fast path.

## How did you test this code?

- Extended Python unit tests in `test_flags_cache.py` covering dependency extraction, Kahn's algorithm stages, cycles, missing deps, and transitive closure (parameterized tests).

## Next steps

- [ ] Merge this PR (adds the metadata to cache — Rust ignores it)
- [ ] In a jumphost, run `python manage.py warm_flags_cache` to update every cache entry to the new format
- [ ] Merge `haacked/use-prebuilt-dependencies` (Rust consumer reads the metadata and uses the fast path)
- [ ] Remove the fallback graph-build code from the Rust service

## Publish to changelog?

no