### PR TITLE
feat(flags): record PAK last_used_at in Rust flags definitions service

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -90,12 +90,12 @@ pub(crate) fn hash_personal_api_key(value: &str) -> String {
 }
 
 /// Validates personal API key with feature flag scopes for a specific team
-/// Returns Ok(()) if the personal API key has access to the specified team
+/// Returns the PAK id (String) on success for use in last_used_at tracking
 pub async fn validate_personal_api_key_with_scopes_for_team(
     state: &AppState,
     key: &str,
     team: &Team,
-) -> Result<(), FlagError> {
+) -> Result<String, FlagError> {
     use sqlx::Row;
 
     debug!(team_id = team.id, "Validating personal API key for team");
@@ -138,6 +138,8 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
             warn!("Personal API key not found or doesn't have required scopes");
             FlagError::PersonalApiKeyInvalid
         })?;
+
+    let pak_id: String = row.get("key_id");
 
     // Validate scoped_teams restriction
     let scoped_teams: Option<Vec<i32>> = row.try_get("scoped_teams").ok();
@@ -213,7 +215,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
         "Personal API key validated successfully"
     );
 
-    Ok(())
+    Ok(pak_id)
 }
 
 #[cfg(test)]

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -26,6 +26,7 @@ use common_hypercache::{HyperCacheError, KeyType};
 use common_metrics::inc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 use tracing::{info, warn};
 
 /// Response for flag definitions endpoint
@@ -379,15 +380,28 @@ async fn authenticate_flag_definitions(
 
     // Try personal API key (with scope validation)
     if let Some(key) = auth::extract_personal_api_key(headers)? {
-        let result = auth::validate_personal_api_key_with_scopes_for_team(state, &key, team).await;
-        if result.is_ok() {
-            inc(
-                FLAG_DEFINITIONS_AUTH_COUNTER,
-                &[("method".to_string(), "personal_api_key".to_string())],
-                1,
-            );
+        let pak_id =
+            auth::validate_personal_api_key_with_scopes_for_team(state, &key, team).await?;
+        inc(
+            FLAG_DEFINITIONS_AUTH_COUNTER,
+            &[("method".to_string(), "personal_api_key".to_string())],
+            1,
+        );
+
+        if !*state.config.skip_writes {
+            // Use shared Redis, not the dedicated flags cache client —
+            // PAK last_used_at tracking is advisory and shouldn't steal
+            // capacity from the critical path.
+            let redis = state.redis_client.clone();
+            let pg_writer: Arc<dyn common_database::Client + Send + Sync> =
+                state.database_pools.non_persons_writer.clone();
+            // Redis SET NX EX is sub-millisecond, so we check inline to avoid
+            // spawning a background task on every request. Only the DB write
+            // (triggered when the key is newly set) runs in a spawned task.
+            drop(super::pak_usage::record_pak_last_used(redis, pg_writer, pak_id).await);
         }
-        return result;
+
+        return Ok(());
     }
 
     Err(FlagError::NoAuthenticationProvided)

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -4,5 +4,6 @@ pub mod errors;
 pub mod flag_definitions;
 pub mod flag_definitions_rate_limiter;
 pub mod flags_rate_limiter;
+pub mod pak_usage;
 pub mod rate_parser;
 pub mod types;

--- a/rust/feature-flags/src/api/pak_usage.rs
+++ b/rust/feature-flags/src/api/pak_usage.rs
@@ -1,0 +1,184 @@
+use common_database::Client as DatabaseClient;
+use common_redis::Client as RedisClient;
+use std::sync::Arc;
+use tracing::warn;
+
+pub const DEBOUNCE_TTL_SECONDS: u64 = 3600; // 1 hour, matching Django's debounce window
+
+/// Returns the Redis debounce key for a given PAK ID.
+pub fn debounce_key(pak_id: &str) -> String {
+    format!("posthog:pak_last_used:{pak_id}")
+}
+
+/// Debounces and records PAK last_used_at.
+///
+/// Uses Redis SET NX EX to gate updates to once per hour per PAK.
+/// When the debounce key is newly set, spawns a background task
+/// to update the database and returns its `JoinHandle`.
+pub async fn record_pak_last_used(
+    redis: Arc<dyn RedisClient + Send + Sync>,
+    pg_writer: Arc<dyn DatabaseClient + Send + Sync>,
+    pak_id: String,
+) -> Option<tokio::task::JoinHandle<()>> {
+    let key = debounce_key(&pak_id);
+    match redis
+        .set_nx_ex(key, "1".to_string(), DEBOUNCE_TTL_SECONDS)
+        .await
+    {
+        Ok(true) => Some(tokio::spawn(async move {
+            update_pak_last_used_at(pg_writer, pak_id).await;
+        })),
+        Ok(false) => None,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "Redis debounce check failed for PAK last_used_at"
+            );
+            None
+        }
+    }
+}
+
+/// Updates PAK last_used_at in the database.
+///
+/// Includes a WHERE guard as a safety net matching Django's semantics.
+pub async fn update_pak_last_used_at(
+    pg_writer: Arc<dyn DatabaseClient + Send + Sync>,
+    pak_id: String,
+) {
+    let mut conn = match pg_writer.get_connection().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            warn!(pak_id, error = %e, "Failed to acquire connection for PAK last_used_at update");
+            return;
+        }
+    };
+    if let Err(e) = sqlx::query(
+        "UPDATE posthog_personalapikey SET last_used_at = NOW() \
+         WHERE id = $1 AND (last_used_at IS NULL OR last_used_at < NOW() - INTERVAL '1 hour')",
+    )
+    .bind(&pak_id)
+    .execute(&mut *conn)
+    .await
+    {
+        warn!(pak_id, error = %e, "Failed to update PAK last_used_at");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::TestContext;
+    use common_redis::MockRedisClient;
+
+    async fn create_test_pak(ctx: &TestContext) -> String {
+        let team = ctx.insert_new_team(None).await.unwrap();
+        let org_id = ctx.get_organization_id_for_team(&team).await.unwrap();
+        let email = TestContext::generate_test_email("pak_test");
+        let user_id = ctx.create_user(&email, &org_id, team.id).await.unwrap();
+        let (pak_id, _) = ctx
+            .create_personal_api_key(user_id, "test", vec!["feature_flag:read"], None, None)
+            .await
+            .unwrap();
+        pak_id
+    }
+
+    #[tokio::test]
+    async fn test_updates_last_used_at_for_new_pak() {
+        let ctx = TestContext::new(None).await;
+        let pak_id = create_test_pak(&ctx).await;
+
+        update_pak_last_used_at(ctx.non_persons_writer.clone(), pak_id.clone()).await;
+
+        let mut conn = ctx.get_non_persons_connection().await.unwrap();
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM posthog_personalapikey WHERE id = $1 AND last_used_at IS NOT NULL",
+        )
+        .bind(&pak_id)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(count.0, 1, "last_used_at should be set after update");
+    }
+
+    #[tokio::test]
+    async fn test_skips_update_when_last_used_at_is_recent() {
+        let ctx = TestContext::new(None).await;
+        let pak_id = create_test_pak(&ctx).await;
+
+        // Set last_used_at to 30 minutes ago (within the 1-hour window)
+        let mut conn = ctx.get_non_persons_connection().await.unwrap();
+        sqlx::query(
+            "UPDATE posthog_personalapikey SET last_used_at = NOW() - INTERVAL '30 minutes' WHERE id = $1",
+        )
+        .bind(&pak_id)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        update_pak_last_used_at(ctx.non_persons_writer.clone(), pak_id.clone()).await;
+
+        // Verify last_used_at is still ~30 minutes ago, not updated to NOW()
+        let mut conn = ctx.get_non_persons_connection().await.unwrap();
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM posthog_personalapikey \
+             WHERE id = $1 AND last_used_at < NOW() - INTERVAL '25 minutes'",
+        )
+        .bind(&pak_id)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(
+            count.0, 1,
+            "last_used_at should not change when within the 1-hour window"
+        );
+    }
+
+    async fn assert_record_pak(
+        set_nx_ex_result: Result<bool, common_redis::CustomRedisError>,
+        expect_last_used_set: bool,
+    ) {
+        let ctx = TestContext::new(None).await;
+        let pak_id = create_test_pak(&ctx).await;
+        let key = debounce_key(&pak_id);
+
+        let redis: Arc<dyn RedisClient + Send + Sync> =
+            Arc::new(MockRedisClient::new().set_nx_ex_ret(&key, set_nx_ex_result));
+
+        let handle =
+            record_pak_last_used(redis, ctx.non_persons_writer.clone(), pak_id.clone()).await;
+        if let Some(h) = handle {
+            h.await.unwrap();
+        }
+
+        let null_check = if expect_last_used_set {
+            "IS NOT NULL"
+        } else {
+            "IS NULL"
+        };
+        let mut conn = ctx.get_non_persons_connection().await.unwrap();
+        let count: (i64,) = sqlx::query_as(&format!(
+            "SELECT COUNT(*) FROM posthog_personalapikey WHERE id = $1 AND last_used_at {null_check}"
+        ))
+        .bind(&pak_id)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+        assert_eq!(count.0, 1);
+    }
+
+    #[tokio::test]
+    async fn test_record_pak_last_used_writes_when_debounce_key_is_new() {
+        assert_record_pak(Ok(true), true).await;
+    }
+
+    #[tokio::test]
+    async fn test_record_pak_last_used_skips_write_when_debounce_key_exists() {
+        assert_record_pak(Ok(false), false).await;
+    }
+
+    #[tokio::test]
+    async fn test_record_pak_last_used_skips_write_on_redis_error() {
+        assert_record_pak(Err(common_redis::CustomRedisError::Timeout), false).await;
+    }
+}

--- a/rust/feature-flags/src/api/pak_usage.rs
+++ b/rust/feature-flags/src/api/pak_usage.rs
@@ -151,15 +151,12 @@ mod tests {
             h.await.unwrap();
         }
 
-        let null_check = if expect_last_used_set {
-            "IS NOT NULL"
-        } else {
-            "IS NULL"
-        };
         let mut conn = ctx.get_non_persons_connection().await.unwrap();
-        let count: (i64,) = sqlx::query_as(&format!(
-            "SELECT COUNT(*) FROM posthog_personalapikey WHERE id = $1 AND last_used_at {null_check}"
-        ))
+        let count: (i64,) = sqlx::query_as(if expect_last_used_set {
+            "SELECT COUNT(*) FROM posthog_personalapikey WHERE id = $1 AND last_used_at IS NOT NULL"
+        } else {
+            "SELECT COUNT(*) FROM posthog_personalapikey WHERE id = $1 AND last_used_at IS NULL"
+        })
         .bind(&pak_id)
         .fetch_one(&mut *conn)
         .await

--- a/rust/feature-flags/src/api/pak_usage.rs
+++ b/rust/feature-flags/src/api/pak_usage.rs
@@ -137,6 +137,7 @@ mod tests {
     async fn assert_record_pak(
         set_nx_ex_result: Result<bool, common_redis::CustomRedisError>,
         expect_last_used_set: bool,
+        expect_handle: bool,
     ) {
         let ctx = TestContext::new(None).await;
         let pak_id = create_test_pak(&ctx).await;
@@ -147,6 +148,7 @@ mod tests {
 
         let handle =
             record_pak_last_used(redis, ctx.non_persons_writer.clone(), pak_id.clone()).await;
+        assert_eq!(handle.is_some(), expect_handle);
         if let Some(h) = handle {
             h.await.unwrap();
         }
@@ -166,16 +168,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_record_pak_last_used_writes_when_debounce_key_is_new() {
-        assert_record_pak(Ok(true), true).await;
+        assert_record_pak(Ok(true), true, true).await;
     }
 
     #[tokio::test]
     async fn test_record_pak_last_used_skips_write_when_debounce_key_exists() {
-        assert_record_pak(Ok(false), false).await;
+        assert_record_pak(Ok(false), false, false).await;
     }
 
     #[tokio::test]
     async fn test_record_pak_last_used_skips_write_on_redis_error() {
-        assert_record_pak(Err(common_redis::CustomRedisError::Timeout), false).await;
+        assert_record_pak(Err(common_redis::CustomRedisError::Timeout), false, false).await;
     }
 }


### PR DESCRIPTION
## Problem

The Rust flags definitions service (`/api/feature_flags/definitions`) does not record `last_used_at` for personal API keys (PAKs), meaning that PAK usage through this endpoint goes untracked. This matters for surfacing stale or unused keys to users.

## Changes

This employs the same pattern that the `/local_evaluation` Django endpoint does. It debounces writes to `last_used_at` for one hour. One hour granularity is plenty.

- `auth.rs`: `validate_personal_api_key_with_scopes_for_team` now returns the PAK `id` (String) on success instead of `()`, so callers can use it for usage tracking
- `flag_definitions.rs`: after successful PAK auth, spawns a background task to record usage without blocking the request path
- `pak_usage.rs` (new): implements `record_pak_last_used` with Redis SET NX EX debouncing (1-hour window matching Django) to avoid hammering the DB on high-frequency callers

## How did you test this code?

Unit tests in `pak_usage.rs` cover:
- Skipping the DB write when the Redis debounce key already exists
- Proceeding with the DB write when the debounce key is new (mocked; real DB write verified by the mock call count)
- Graceful handling of Redis errors (warns and skips the DB write)

Manually verified that `last_used_at` is written to the DB on first request and debounced on subsequent requests within the 1-hour window.

## Publish to changelog?

Do not publish to changelog.

## Docs update

No docs update needed.