### PR TITLE
fix(llma): seamless trial-to-BYOK graduation for evaluations

### DIFF
--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from django.conf import settings
+from django.db import models
 
 import structlog
 import temporalio
@@ -265,10 +266,14 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
     model_configuration = evaluation.get("model_configuration")
 
     def _get_legacy_provider_key() -> LLMProviderKey | None:
-        """Legacy fallback for evaluations without model_configuration."""
+        """Legacy fallback for evaluations without model_configuration.
+
+        Checks active_provider_key first (explicit team-level setting), then
+        falls back to _resolve_provider_key which prefers BYOK over trial.
+        """
         config, _ = EvaluationConfig.objects.get_or_create(team_id=team_id)
 
-        # Check if team has active BYOK key
+        # Check if team has an explicitly set active BYOK key
         if config.active_provider_key:
             key = config.active_provider_key
             if key.state == LLMProviderKey.State.OK:
@@ -282,16 +287,8 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
                 non_retryable=True,
             )
 
-        # No active key - check trial quota
-        if config.trial_evals_used >= config.trial_eval_limit:
-            raise ApplicationError(
-                f"Trial evaluation limit ({config.trial_eval_limit}) reached. Add your own API key to continue.",
-                {"error_type": "trial_limit_reached", "trial_eval_limit": config.trial_eval_limit},
-                non_retryable=True,
-            )
-
-        # Trial mode - no provider key, use PostHog defaults
-        return None
+        # No explicit active key — resolve dynamically (legacy is always openai)
+        return _resolve_provider_key("openai")
 
     def _get_provider_key_by_id(key_id: str) -> LLMProviderKey:
         """Fetch a specific provider key by ID, validating team ownership."""
@@ -313,15 +310,35 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
                 non_retryable=True,
             )
 
-    def _check_trial_quota() -> None:
-        """Check if trial quota is available for PostHog key usage."""
+    def _resolve_provider_key(provider: str) -> LLMProviderKey | None:
+        """Resolve the best available key for a provider.
+
+        Prefers a BYOK key when one exists so the team's own key is always
+        used over the trial quota. Falls back to trial if no BYOK key is
+        available, and raises if trial is also exhausted.
+        """
+        # Prefer BYOK key for this provider — avoids consuming trial quota.
+        # Order by most recently used, with never-used keys last.
+        byok_key = (
+            LLMProviderKey.objects.filter(team_id=team_id, provider=provider, state=LLMProviderKey.State.OK)
+            .order_by(models.F("last_used_at").desc(nulls_last=True))
+            .first()
+        )
+        if byok_key:
+            byok_key.last_used_at = timezone.now()
+            byok_key.save(update_fields=["last_used_at"])
+            return byok_key
+
+        # No BYOK key — fall back to trial quota
         config, _ = EvaluationConfig.objects.get_or_create(team_id=team_id)
-        if config.trial_evals_used >= config.trial_eval_limit:
-            raise ApplicationError(
-                f"Trial evaluation limit ({config.trial_eval_limit}) reached. Add your own API key to continue.",
-                {"error_type": "trial_limit_reached", "trial_eval_limit": config.trial_eval_limit},
-                non_retryable=True,
-            )
+        if config.trial_evals_used < config.trial_eval_limit:
+            return None
+
+        raise ApplicationError(
+            f"Trial evaluation limit ({config.trial_eval_limit}) reached. Add your own API key to continue.",
+            {"error_type": "trial_limit_reached", "trial_eval_limit": config.trial_eval_limit},
+            non_retryable=True,
+        )
 
     # Determine provider, model, and key based on model_configuration
     if model_configuration:
@@ -332,9 +349,8 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
         if provider_key_id:
             provider_key = await database_sync_to_async(_get_provider_key_by_id)(provider_key_id)
         else:
-            # Using PostHog key - check trial quota
-            await database_sync_to_async(_check_trial_quota)()
-            provider_key = None
+            # No explicit key pinned — resolve dynamically (BYOK preferred over trial)
+            provider_key = await database_sync_to_async(_resolve_provider_key)(provider)
     else:
         # TODO(llma): Remove after migration completes - legacy evals without model_configuration
         provider = "openai"

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -343,6 +343,7 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
         )
 
     # Determine provider, model, and key based on model_configuration
+    provider_key: LLMProviderKey | None
     if model_configuration:
         provider = model_configuration["provider"]
         model = model_configuration["model"]

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -198,7 +198,6 @@ async def update_key_state_activity(key_id: str, state: str, error_message: str 
 @temporalio.activity.defn
 async def increment_trial_eval_count_activity(team_id: int) -> None:
     """Increment trial eval counter after successful execution with PostHog key"""
-    from django.db.models import F
 
     def _increment():
         EvaluationConfig.objects.filter(team_id=team_id).update(trial_evals_used=F("trial_evals_used") + 1)

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -287,8 +287,9 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
                 non_retryable=True,
             )
 
-        # No explicit active key — resolve dynamically (legacy is always openai)
-        return _resolve_provider_key("openai")
+        # No explicit active key — resolve dynamically (legacy is always openai).
+        # Pass the already-fetched config to avoid a duplicate DB query.
+        return _resolve_provider_key("openai", config=config)
 
     def _get_provider_key_by_id(key_id: str) -> LLMProviderKey:
         """Fetch a specific provider key by ID, validating team ownership."""
@@ -310,7 +311,7 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
                 non_retryable=True,
             )
 
-    def _resolve_provider_key(provider: str) -> LLMProviderKey | None:
+    def _resolve_provider_key(provider: str, config: EvaluationConfig | None = None) -> LLMProviderKey | None:
         """Resolve the best available key for a provider.
 
         Prefers a BYOK key when one exists so the team's own key is always
@@ -330,7 +331,8 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
             return byok_key
 
         # No BYOK key — fall back to trial quota
-        config, _ = EvaluationConfig.objects.get_or_create(team_id=team_id)
+        if config is None:
+            config, _ = EvaluationConfig.objects.get_or_create(team_id=team_id)
         if config.trial_evals_used < config.trial_eval_limit:
             return None
 

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from django.conf import settings
-from django.db import models
+from django.db.models import F
 
 import structlog
 import temporalio
@@ -277,8 +277,7 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
         if config.active_provider_key:
             key = config.active_provider_key
             if key.state == LLMProviderKey.State.OK:
-                key.last_used_at = timezone.now()
-                key.save(update_fields=["last_used_at"])
+                LLMProviderKey.objects.filter(id=key.id).update(last_used_at=timezone.now())
                 return key
             # Active key exists but is invalid - fail, don't fall back to trial
             raise ApplicationError(
@@ -301,8 +300,7 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
                     {"error_type": "key_invalid", "key_id": str(key.id), "key_state": key.state},
                     non_retryable=True,
                 )
-            key.last_used_at = timezone.now()
-            key.save(update_fields=["last_used_at"])
+            LLMProviderKey.objects.filter(id=key.id).update(last_used_at=timezone.now())
             return key
         except LLMProviderKey.DoesNotExist:
             raise ApplicationError(
@@ -318,16 +316,16 @@ async def execute_llm_judge_activity(inputs: ExecuteLLMJudgeInputs) -> dict[str,
         used over the trial quota. Falls back to trial if no BYOK key is
         available, and raises if trial is also exhausted.
         """
-        # Prefer BYOK key for this provider — avoids consuming trial quota.
-        # Order by most recently used, with never-used keys last.
+        # Prefer a healthy BYOK key for this provider to avoid consuming trial quota.
+        # Order by most recently used so the actively-used key is preferred.
+        # nulls_last ensures never-used keys don't sort ahead of active ones.
         byok_key = (
             LLMProviderKey.objects.filter(team_id=team_id, provider=provider, state=LLMProviderKey.State.OK)
-            .order_by(models.F("last_used_at").desc(nulls_last=True))
+            .order_by(F("last_used_at").desc(nulls_last=True))
             .first()
         )
         if byok_key:
-            byok_key.last_used_at = timezone.now()
-            byok_key.save(update_fields=["last_used_at"])
+            LLMProviderKey.objects.filter(id=byok_key.id).update(last_used_at=timezone.now())
             return byok_key
 
         # No BYOK key — fall back to trial quota

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -468,7 +468,8 @@ class TestDynamicKeyResolution:
     """When no explicit provider_key_id is set on an evaluation, the runtime
     resolves the best available key: BYOK preferred over trial."""
 
-    def _make_evaluation(self, evaluation_obj, team, model_configuration=None):
+    @staticmethod
+    def _make_evaluation(evaluation_obj, team, model_configuration=None):
         evaluation = {
             "id": str(evaluation_obj.id),
             "name": "Test Evaluation",
@@ -482,7 +483,8 @@ class TestDynamicKeyResolution:
             evaluation["model_configuration"] = model_configuration
         return evaluation
 
-    def _make_event_data(self, team):
+    @staticmethod
+    def _make_event_data(team):
         return create_mock_event_data(
             team.id,
             properties={
@@ -491,27 +493,51 @@ class TestDynamicKeyResolution:
             },
         )
 
-    def _mock_llm_client(self):
+    @staticmethod
+    def _mock_llm_client():
         return patch("posthog.temporal.llm_analytics.run_evaluation.Client")
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
-    async def test_byok_key_preferred_over_trial_even_when_trial_available(self, setup_data):
+    @pytest.mark.parametrize(
+        "byok_provider,byok_state,trial_used,has_model_config,expected_is_byok",
+        [
+            ("openai", LLMProviderKey.State.OK, 0, True, True),
+            ("anthropic", LLMProviderKey.State.OK, 0, True, False),
+            ("openai", LLMProviderKey.State.OK, 100, True, True),
+            ("openai", LLMProviderKey.State.INVALID, 0, True, False),
+            ("openai", LLMProviderKey.State.OK, 0, False, True),
+        ],
+        ids=[
+            "byok_preferred_over_trial",
+            "wrong_provider_falls_back_to_trial",
+            "trial_exhausted_uses_byok",
+            "unhealthy_key_falls_back_to_trial",
+            "legacy_path_prefers_byok",
+        ],
+    )
+    async def test_key_resolution(
+        self, setup_data, byok_provider, byok_state, trial_used, has_model_config, expected_is_byok
+    ):
         team = setup_data["team"]
 
         byok_key = await sync_to_async(LLMProviderKey.objects.create)(
             team=team,
-            provider="openai",
-            name="My Key",
-            state=LLMProviderKey.State.OK,
+            provider=byok_provider,
+            name="Test Key",
+            state=byok_state,
             encrypted_config={"api_key": "sk-test"},
         )
 
-        evaluation = self._make_evaluation(
-            setup_data["evaluation"],
-            team,
-            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
+        if trial_used:
+            config, _ = await sync_to_async(EvaluationConfig.objects.get_or_create)(team_id=team.id)
+            config.trial_evals_used = trial_used
+            await sync_to_async(config.save)(update_fields=["trial_evals_used"])
+
+        model_config = (
+            {"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None} if has_model_config else None
         )
+        evaluation = self._make_evaluation(setup_data["evaluation"], team, model_configuration=model_config)
 
         with self._mock_llm_client() as mock_client_class:
             mock_client = MagicMock()
@@ -525,82 +551,11 @@ class TestDynamicKeyResolution:
                 ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
             )
 
-            assert result["is_byok"] is True
-            assert result["key_id"] == str(byok_key.id)
-
-    @pytest.mark.asyncio
-    @pytest.mark.django_db(transaction=True)
-    async def test_falls_back_to_trial_when_no_byok_key_for_provider(self, setup_data):
-        team = setup_data["team"]
-
-        # BYOK key exists but for a different provider
-        await sync_to_async(LLMProviderKey.objects.create)(
-            team=team,
-            provider="anthropic",
-            name="Anthropic Key",
-            state=LLMProviderKey.State.OK,
-            encrypted_config={"api_key": "sk-ant-test"},
-        )
-
-        evaluation = self._make_evaluation(
-            setup_data["evaluation"],
-            team,
-            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
-        )
-
-        with self._mock_llm_client() as mock_client_class:
-            mock_client = MagicMock()
-            mock_client_class.return_value = mock_client
-            mock_response = MagicMock()
-            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
-            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
-            mock_client.complete.return_value = mock_response
-
-            result = await execute_llm_judge_activity(
-                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
-            )
-
-            # No OpenAI BYOK key, so falls back to trial
-            assert result["is_byok"] is False
-            assert result["key_id"] is None
-
-    @pytest.mark.asyncio
-    @pytest.mark.django_db(transaction=True)
-    async def test_trial_exhausted_with_byok_key_uses_byok(self, setup_data):
-        team = setup_data["team"]
-
-        byok_key = await sync_to_async(LLMProviderKey.objects.create)(
-            team=team,
-            provider="openai",
-            name="My Key",
-            state=LLMProviderKey.State.OK,
-            encrypted_config={"api_key": "sk-test"},
-        )
-
-        config, _ = await sync_to_async(EvaluationConfig.objects.get_or_create)(team_id=team.id)
-        config.trial_evals_used = 100
-        await sync_to_async(config.save)(update_fields=["trial_evals_used"])
-
-        evaluation = self._make_evaluation(
-            setup_data["evaluation"],
-            team,
-            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
-        )
-
-        with self._mock_llm_client() as mock_client_class:
-            mock_client = MagicMock()
-            mock_client_class.return_value = mock_client
-            mock_response = MagicMock()
-            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
-            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
-            mock_client.complete.return_value = mock_response
-
-            result = await execute_llm_judge_activity(
-                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
-            )
-
-            assert result["is_byok"] is True
-            assert result["key_id"] == str(byok_key.id)
+            assert result["is_byok"] is expected_is_byok
+            if expected_is_byok:
+                assert result["key_id"] == str(byok_key.id)
+            else:
+                assert result["key_id"] is None
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
@@ -624,72 +579,6 @@ class TestDynamicKeyResolution:
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
-    async def test_unhealthy_byok_keys_skipped_falls_back_to_trial(self, setup_data):
-        team = setup_data["team"]
-
-        await sync_to_async(LLMProviderKey.objects.create)(
-            team=team,
-            provider="openai",
-            name="Bad Key",
-            state=LLMProviderKey.State.INVALID,
-            encrypted_config={"api_key": "sk-bad"},
-        )
-
-        evaluation = self._make_evaluation(
-            setup_data["evaluation"],
-            team,
-            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
-        )
-
-        with self._mock_llm_client() as mock_client_class:
-            mock_client = MagicMock()
-            mock_client_class.return_value = mock_client
-            mock_response = MagicMock()
-            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
-            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
-            mock_client.complete.return_value = mock_response
-
-            result = await execute_llm_judge_activity(
-                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
-            )
-
-            # Unhealthy BYOK key skipped, falls back to trial
-            assert result["is_byok"] is False
-            assert result["key_id"] is None
-
-    @pytest.mark.asyncio
-    @pytest.mark.django_db(transaction=True)
-    async def test_legacy_path_prefers_byok_over_trial(self, setup_data):
-        team = setup_data["team"]
-
-        byok_key = await sync_to_async(LLMProviderKey.objects.create)(
-            team=team,
-            provider="openai",
-            name="My Key",
-            state=LLMProviderKey.State.OK,
-            encrypted_config={"api_key": "sk-test"},
-        )
-
-        # Legacy evaluation (no model_configuration)
-        evaluation = self._make_evaluation(setup_data["evaluation"], team)
-
-        with self._mock_llm_client() as mock_client_class:
-            mock_client = MagicMock()
-            mock_client_class.return_value = mock_client
-            mock_response = MagicMock()
-            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
-            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
-            mock_client.complete.return_value = mock_response
-
-            result = await execute_llm_judge_activity(
-                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
-            )
-
-            assert result["is_byok"] is True
-            assert result["key_id"] == str(byok_key.id)
-
-    @pytest.mark.asyncio
-    @pytest.mark.django_db(transaction=True)
     async def test_most_recently_used_byok_key_preferred(self, setup_data):
         team = setup_data["team"]
         from datetime import timedelta
@@ -698,11 +587,10 @@ class TestDynamicKeyResolution:
 
         now = timezone.now()
 
-        # Create two OK keys — the older one was used more recently
         older_key = await sync_to_async(LLMProviderKey.objects.create)(
             team=team,
             provider="openai",
-            name="Older Key",
+            name="Recently Used Key",
             state=LLMProviderKey.State.OK,
             encrypted_config={"api_key": "sk-old"},
             last_used_at=now - timedelta(minutes=5),
@@ -734,7 +622,6 @@ class TestDynamicKeyResolution:
                 ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
             )
 
-            # The recently-used key is preferred over the never-used one
             assert result["is_byok"] is True
             assert result["key_id"] == str(older_key.id)
 

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -13,7 +13,9 @@ from temporalio.exceptions import ApplicationError
 from posthog.models import Organization, Team
 
 from products.llm_analytics.backend.llm.errors import StructuredOutputParseError
+from products.llm_analytics.backend.models.evaluation_config import EvaluationConfig
 from products.llm_analytics.backend.models.evaluations import Evaluation
+from products.llm_analytics.backend.models.provider_keys import LLMProviderKey
 
 from .run_evaluation import (
     BooleanEvalResult,
@@ -460,6 +462,231 @@ class TestRunEvaluationWorkflow:
 
             assert exc_info.value.non_retryable is True
             assert exc_info.value.details[0] == {"error_type": "parse_error"}
+
+
+class TestDynamicKeyResolution:
+    """When no explicit provider_key_id is set on an evaluation, the runtime
+    resolves the best available key: BYOK preferred over trial."""
+
+    def _make_evaluation(self, evaluation_obj, team, model_configuration=None):
+        evaluation = {
+            "id": str(evaluation_obj.id),
+            "name": "Test Evaluation",
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": "Is this accurate?"},
+            "output_type": "boolean",
+            "output_config": {},
+            "team_id": team.id,
+        }
+        if model_configuration is not None:
+            evaluation["model_configuration"] = model_configuration
+        return evaluation
+
+    def _make_event_data(self, team):
+        return create_mock_event_data(
+            team.id,
+            properties={
+                "$ai_input": [{"role": "user", "content": "test"}],
+                "$ai_output_choices": [{"role": "assistant", "content": "response"}],
+            },
+        )
+
+    def _mock_llm_client(self):
+        return patch("posthog.temporal.llm_analytics.run_evaluation.Client")
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_byok_key_preferred_over_trial_even_when_trial_available(self, setup_data):
+        team = setup_data["team"]
+
+        byok_key = await sync_to_async(LLMProviderKey.objects.create)(
+            team=team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-test"},
+        )
+
+        evaluation = self._make_evaluation(
+            setup_data["evaluation"],
+            team,
+            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
+        )
+
+        with self._mock_llm_client() as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
+            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
+            mock_client.complete.return_value = mock_response
+
+            result = await execute_llm_judge_activity(
+                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
+            )
+
+            assert result["is_byok"] is True
+            assert result["key_id"] == str(byok_key.id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_falls_back_to_trial_when_no_byok_key_for_provider(self, setup_data):
+        team = setup_data["team"]
+
+        # BYOK key exists but for a different provider
+        await sync_to_async(LLMProviderKey.objects.create)(
+            team=team,
+            provider="anthropic",
+            name="Anthropic Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-ant-test"},
+        )
+
+        evaluation = self._make_evaluation(
+            setup_data["evaluation"],
+            team,
+            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
+        )
+
+        with self._mock_llm_client() as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
+            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
+            mock_client.complete.return_value = mock_response
+
+            result = await execute_llm_judge_activity(
+                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
+            )
+
+            # No OpenAI BYOK key, so falls back to trial
+            assert result["is_byok"] is False
+            assert result["key_id"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_trial_exhausted_with_byok_key_uses_byok(self, setup_data):
+        team = setup_data["team"]
+
+        byok_key = await sync_to_async(LLMProviderKey.objects.create)(
+            team=team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-test"},
+        )
+
+        config, _ = await sync_to_async(EvaluationConfig.objects.get_or_create)(team_id=team.id)
+        config.trial_evals_used = 100
+        await sync_to_async(config.save)(update_fields=["trial_evals_used"])
+
+        evaluation = self._make_evaluation(
+            setup_data["evaluation"],
+            team,
+            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
+        )
+
+        with self._mock_llm_client() as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
+            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
+            mock_client.complete.return_value = mock_response
+
+            result = await execute_llm_judge_activity(
+                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
+            )
+
+            assert result["is_byok"] is True
+            assert result["key_id"] == str(byok_key.id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_trial_exhausted_without_byok_key_raises(self, setup_data):
+        team = setup_data["team"]
+
+        config, _ = await sync_to_async(EvaluationConfig.objects.get_or_create)(team_id=team.id)
+        config.trial_evals_used = 100
+        await sync_to_async(config.save)(update_fields=["trial_evals_used"])
+
+        evaluation = self._make_evaluation(
+            setup_data["evaluation"],
+            team,
+            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
+        )
+
+        with pytest.raises(ApplicationError, match="Trial evaluation limit"):
+            await execute_llm_judge_activity(
+                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_unhealthy_byok_keys_skipped_falls_back_to_trial(self, setup_data):
+        team = setup_data["team"]
+
+        await sync_to_async(LLMProviderKey.objects.create)(
+            team=team,
+            provider="openai",
+            name="Bad Key",
+            state=LLMProviderKey.State.INVALID,
+            encrypted_config={"api_key": "sk-bad"},
+        )
+
+        evaluation = self._make_evaluation(
+            setup_data["evaluation"],
+            team,
+            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
+        )
+
+        with self._mock_llm_client() as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
+            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
+            mock_client.complete.return_value = mock_response
+
+            result = await execute_llm_judge_activity(
+                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
+            )
+
+            # Unhealthy BYOK key skipped, falls back to trial
+            assert result["is_byok"] is False
+            assert result["key_id"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_legacy_path_prefers_byok_over_trial(self, setup_data):
+        team = setup_data["team"]
+
+        byok_key = await sync_to_async(LLMProviderKey.objects.create)(
+            team=team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-test"},
+        )
+
+        # Legacy evaluation (no model_configuration)
+        evaluation = self._make_evaluation(setup_data["evaluation"], team)
+
+        with self._mock_llm_client() as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
+            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
+            mock_client.complete.return_value = mock_response
+
+            result = await execute_llm_judge_activity(
+                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
+            )
+
+            assert result["is_byok"] is True
+            assert result["key_id"] == str(byok_key.id)
 
 
 class TestExecuteHogEvalActivity:

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -590,7 +590,7 @@ class TestDynamicKeyResolution:
             name="Recently Used Key",
             state=LLMProviderKey.State.OK,
             encrypted_config={"api_key": "sk-old"},
-            last_used_at=datetime(2025, 1, 15, 11, 55),
+            last_used_at=datetime(2025, 1, 15, 11, 55, tzinfo=UTC),
         )
         await sync_to_async(LLMProviderKey.objects.create)(
             team=team,

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -1,12 +1,11 @@
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 import pytest
+from freezegun import freeze_time
 from unittest.mock import MagicMock, patch
-
-from django.utils import timezone
 
 from asgiref.sync import sync_to_async
 from parameterized import parameterized
@@ -581,9 +580,9 @@ class TestDynamicKeyResolution:
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
+    @freeze_time("2025-01-15T12:00:00Z")
     async def test_most_recently_used_byok_key_preferred(self, setup_data):
         team = setup_data["team"]
-        now = timezone.now()
 
         older_key = await sync_to_async(LLMProviderKey.objects.create)(
             team=team,
@@ -591,7 +590,7 @@ class TestDynamicKeyResolution:
             name="Recently Used Key",
             state=LLMProviderKey.State.OK,
             encrypted_config={"api_key": "sk-old"},
-            last_used_at=now - timedelta(minutes=5),
+            last_used_at=datetime(2025, 1, 15, 11, 55),
         )
         await sync_to_async(LLMProviderKey.objects.create)(
             team=team,

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -1,10 +1,12 @@
 import json
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
 
 from asgiref.sync import sync_to_async
 from parameterized import parameterized
@@ -581,10 +583,6 @@ class TestDynamicKeyResolution:
     @pytest.mark.django_db(transaction=True)
     async def test_most_recently_used_byok_key_preferred(self, setup_data):
         team = setup_data["team"]
-        from datetime import timedelta
-
-        from django.utils import timezone
-
         now = timezone.now()
 
         older_key = await sync_to_async(LLMProviderKey.objects.create)(

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -688,6 +688,56 @@ class TestDynamicKeyResolution:
             assert result["is_byok"] is True
             assert result["key_id"] == str(byok_key.id)
 
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_most_recently_used_byok_key_preferred(self, setup_data):
+        team = setup_data["team"]
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        now = timezone.now()
+
+        # Create two OK keys — the older one was used more recently
+        older_key = await sync_to_async(LLMProviderKey.objects.create)(
+            team=team,
+            provider="openai",
+            name="Older Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-old"},
+            last_used_at=now - timedelta(minutes=5),
+        )
+        await sync_to_async(LLMProviderKey.objects.create)(
+            team=team,
+            provider="openai",
+            name="Never Used Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-new"},
+            last_used_at=None,
+        )
+
+        evaluation = self._make_evaluation(
+            setup_data["evaluation"],
+            team,
+            model_configuration={"provider": "openai", "model": "gpt-5-mini", "provider_key_id": None},
+        )
+
+        with self._mock_llm_client() as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.parsed = BooleanEvalResult(verdict=True, reasoning="Good")
+            mock_response.usage = MagicMock(input_tokens=10, output_tokens=5, total_tokens=15)
+            mock_client.complete.return_value = mock_response
+
+            result = await execute_llm_judge_activity(
+                ExecuteLLMJudgeInputs(evaluation=evaluation, event_data=self._make_event_data(team))
+            )
+
+            # The recently-used key is preferred over the never-used one
+            assert result["is_byok"] is True
+            assert result["key_id"] == str(older_key.id)
+
 
 class TestExecuteHogEvalActivity:
     @pytest.mark.asyncio

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -581,10 +581,12 @@ class TestDynamicKeyResolution:
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
     @freeze_time("2025-01-15T12:00:00Z")
-    async def test_most_recently_used_byok_key_preferred(self, setup_data):
+    async def test_recently_used_key_preferred_over_never_used(self, setup_data):
+        """When multiple healthy keys exist, the most recently used one is
+        preferred over a never-used key (nulls_last ordering)."""
         team = setup_data["team"]
 
-        older_key = await sync_to_async(LLMProviderKey.objects.create)(
+        recently_used_key = await sync_to_async(LLMProviderKey.objects.create)(
             team=team,
             provider="openai",
             name="Recently Used Key",
@@ -620,7 +622,7 @@ class TestDynamicKeyResolution:
             )
 
             assert result["is_byok"] is True
-            assert result["key_id"] == str(older_key.id)
+            assert result["key_id"] == str(recently_used_key.id)
 
 
 class TestExecuteHogEvalActivity:

--- a/products/llm_analytics/backend/api/evaluation_config.py
+++ b/products/llm_analytics/backend/api/evaluation_config.py
@@ -10,6 +10,8 @@ from posthog.event_usage import report_user_action
 from posthog.permissions import AccessControlPermission
 
 from ..models.evaluation_config import EvaluationConfig
+from ..models.evaluations import Evaluation
+from ..models.model_configuration import LLMModelConfiguration
 from ..models.provider_keys import LLMProviderKey
 from .metrics import llma_track_latency
 from .provider_keys import LLMProviderKeySerializer
@@ -18,6 +20,9 @@ from .provider_keys import LLMProviderKeySerializer
 class EvaluationConfigSerializer(serializers.ModelSerializer):
     trial_evals_remaining = serializers.IntegerField(read_only=True)
     active_provider_key = LLMProviderKeySerializer(read_only=True)
+    trial_providers = serializers.SerializerMethodField(
+        help_text="Providers whose evaluations are consuming trial quota (no BYOK key available)."
+    )
 
     class Meta:
         model = EvaluationConfig
@@ -26,6 +31,7 @@ class EvaluationConfigSerializer(serializers.ModelSerializer):
             "trial_evals_used",
             "trial_evals_remaining",
             "active_provider_key",
+            "trial_providers",
             "created_at",
             "updated_at",
         ]
@@ -33,9 +39,52 @@ class EvaluationConfigSerializer(serializers.ModelSerializer):
             "trial_evals_used",
             "trial_evals_remaining",
             "active_provider_key",
+            "trial_providers",
             "created_at",
             "updated_at",
         ]
+
+    def get_trial_providers(self, obj: EvaluationConfig) -> list[str]:
+        """Return providers whose evaluations would consume trial quota.
+
+        A provider is on trial when it has active evaluations without a pinned
+        BYOK key and the team has no healthy BYOK key for that provider.
+        """
+        # Providers used by active evals without a pinned BYOK key
+        unpinned_providers = set(
+            LLMModelConfiguration.objects.filter(
+                team_id=obj.team_id,
+                provider_key__isnull=True,
+                evaluations__deleted=False,
+            )
+            .values_list("provider", flat=True)
+            .distinct()
+        )
+
+        # Legacy evaluations (no model_configuration) default to OpenAI
+        has_legacy_evals = Evaluation.objects.filter(
+            team_id=obj.team_id,
+            model_configuration__isnull=True,
+            deleted=False,
+        ).exists()
+        if has_legacy_evals:
+            unpinned_providers.add("openai")
+
+        if not unpinned_providers:
+            return []
+
+        # Providers with a healthy BYOK key
+        covered_providers = set(
+            LLMProviderKey.objects.filter(
+                team_id=obj.team_id,
+                state=LLMProviderKey.State.OK,
+                provider__in=unpinned_providers,
+            )
+            .values_list("provider", flat=True)
+            .distinct()
+        )
+
+        return sorted(unpinned_providers - covered_providers)
 
 
 class EvaluationConfigViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -102,10 +102,20 @@ class LLMProviderKeySerializer(serializers.ModelSerializer):
 
         instance = super().create(validated_data)
 
-        if set_as_active and instance.state == LLMProviderKey.State.OK:
-            config, _ = EvaluationConfig.objects.get_or_create(team=team)
-            config.active_provider_key = instance
-            config.save(update_fields=["active_provider_key", "updated_at"])
+        if instance.state == LLMProviderKey.State.OK:
+            if set_as_active:
+                config, _ = EvaluationConfig.objects.get_or_create(team=team)
+                config.active_provider_key = instance
+                config.save(update_fields=["active_provider_key", "updated_at"])
+
+            # Auto-assign this key to evaluations that were created on the
+            # trial tier for the same provider so they seamlessly graduate
+            # to BYOK without the user having to reconfigure each one.
+            LLMModelConfiguration.objects.filter(
+                team=team,
+                provider=instance.provider,
+                provider_key__isnull=True,
+            ).update(provider_key=instance)
 
         return instance
 

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -312,9 +312,13 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, v
                 )
             )
             with transaction.atomic():
+                # Disable affected evaluations and sever the model configuration
+                # link so they don't attempt to use a provider that no longer has
+                # a key. The user will need to reconfigure the evaluation to
+                # re-enable it.
                 Evaluation.objects.filter(
                     model_configuration_id__in=model_config_ids, team_id=self.team_id, deleted=False
-                ).update(enabled=False)
+                ).update(enabled=False, model_configuration=None)
                 return super().destroy(request, *args, **kwargs)
 
 

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -100,22 +100,23 @@ class LLMProviderKeySerializer(serializers.ModelSerializer):
             validated_data["state"] = state
             validated_data["error_message"] = None
 
-        instance = super().create(validated_data)
+        with transaction.atomic():
+            instance = super().create(validated_data)
 
-        if instance.state == LLMProviderKey.State.OK:
-            if set_as_active:
-                config, _ = EvaluationConfig.objects.get_or_create(team=team)
-                config.active_provider_key = instance
-                config.save(update_fields=["active_provider_key", "updated_at"])
+            if instance.state == LLMProviderKey.State.OK:
+                if set_as_active:
+                    config, _ = EvaluationConfig.objects.get_or_create(team=team)
+                    config.active_provider_key = instance
+                    config.save(update_fields=["active_provider_key", "updated_at"])
 
-            # Auto-assign this key to evaluations that were created on the
-            # trial tier for the same provider so they seamlessly graduate
-            # to BYOK without the user having to reconfigure each one.
-            LLMModelConfiguration.objects.filter(
-                team=team,
-                provider=instance.provider,
-                provider_key__isnull=True,
-            ).update(provider_key=instance)
+                # Auto-assign this key to evaluations that were created on the
+                # trial tier for the same provider so they seamlessly graduate
+                # to BYOK without the user having to reconfigure each one.
+                LLMModelConfiguration.objects.filter(
+                    team=team,
+                    provider=instance.provider,
+                    provider_key__isnull=True,
+                ).update(provider_key=instance)
 
         return instance
 

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -109,13 +109,14 @@ class LLMProviderKeySerializer(serializers.ModelSerializer):
                     config.active_provider_key = instance
                     config.save(update_fields=["active_provider_key", "updated_at"])
 
-                # Auto-assign this key to evaluations that were created on the
-                # trial tier for the same provider so they seamlessly graduate
-                # to BYOK without the user having to reconfigure each one.
+                # Auto-assign this key to active evaluations that were created
+                # on the trial tier for the same provider so they seamlessly
+                # graduate to BYOK without the user reconfiguring each one.
                 LLMModelConfiguration.objects.filter(
                     team=team,
                     provider=instance.provider,
                     provider_key__isnull=True,
+                    evaluations__deleted=False,
                 ).update(provider_key=instance)
 
         return instance
@@ -308,18 +309,15 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, v
                 return super().destroy(request, *args, **kwargs)
         else:
             with transaction.atomic():
-                model_config_ids = list(
-                    LLMModelConfiguration.objects.filter(provider_key=instance, team_id=self.team_id).values_list(
-                        "id", flat=True
-                    )
-                )
-                # Disable affected evaluations and sever the model configuration
-                # link so they don't attempt to use a provider that no longer has
-                # a key. The user will need to reconfigure the evaluation to
-                # re-enable it.
+                affected_configs = LLMModelConfiguration.objects.filter(provider_key=instance, team_id=self.team_id)
+                # Disable evaluations that use this key and null the provider_key
+                # on their model configuration. The provider/model choice is
+                # preserved so users only need to pick a new key, not reconfigure
+                # from scratch.
                 Evaluation.objects.filter(
-                    model_configuration_id__in=model_config_ids, team_id=self.team_id, deleted=False
-                ).update(enabled=False, model_configuration=None)
+                    model_configuration__in=affected_configs, team_id=self.team_id, deleted=False
+                ).update(enabled=False)
+                affected_configs.update(provider_key=None)
                 return super().destroy(request, *args, **kwargs)
 
 

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -307,12 +307,12 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, v
                 )
                 return super().destroy(request, *args, **kwargs)
         else:
-            model_config_ids = list(
-                LLMModelConfiguration.objects.filter(provider_key=instance, team_id=self.team_id).values_list(
-                    "id", flat=True
-                )
-            )
             with transaction.atomic():
+                model_config_ids = list(
+                    LLMModelConfiguration.objects.filter(provider_key=instance, team_id=self.team_id).values_list(
+                        "id", flat=True
+                    )
+                )
                 # Disable affected evaluations and sever the model configuration
                 # link so they don't attempt to use a provider that no longer has
                 # a key. The user will need to reconfigure the evaluation to

--- a/products/llm_analytics/backend/api/test/test_evaluation_config.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_config.py
@@ -2,11 +2,14 @@ from uuid import uuid4
 
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Organization, Project, Team, User
 
 from products.llm_analytics.backend.models.evaluation_config import EvaluationConfig
+from products.llm_analytics.backend.models.evaluations import Evaluation
+from products.llm_analytics.backend.models.model_configuration import LLMModelConfiguration
 from products.llm_analytics.backend.models.provider_keys import LLMProviderKey
 
 
@@ -46,10 +49,12 @@ class TestEvaluationConfigViewSet(APIBaseTest):
         self.assertIn("trial_evals_used", response.data)
         self.assertIn("trial_evals_remaining", response.data)
         self.assertIn("active_provider_key", response.data)
+        self.assertIn("trial_providers", response.data)
         self.assertEqual(response.data["trial_eval_limit"], 100)
         self.assertEqual(response.data["trial_evals_used"], 0)
         self.assertEqual(response.data["trial_evals_remaining"], 100)
         self.assertIsNone(response.data["active_provider_key"])
+        self.assertEqual(response.data["trial_providers"], [])
 
     def test_get_creates_config_if_missing(self):
         self.assertEqual(EvaluationConfig.objects.filter(team=self.team).count(), 0)
@@ -223,3 +228,98 @@ class TestEvaluationConfigViewSet(APIBaseTest):
         self.assertEqual(active_key["provider"], "openai")
         self.assertEqual(active_key["state"], "ok")
         self.assertIn("api_key_masked", active_key)
+
+
+class TestTrialProviders(APIBaseTest):
+    """Tests for the trial_providers field on the evaluation config endpoint."""
+
+    def _create_eval(self, provider: str, provider_key: LLMProviderKey | None = None, deleted: bool = False):
+        config = LLMModelConfiguration.objects.create(
+            team=self.team,
+            provider=provider,
+            model="test-model",
+            provider_key=provider_key,
+        )
+        return Evaluation.objects.create(
+            team=self.team,
+            name=f"Test {provider}",
+            evaluation_type="llm_judge",
+            output_type="boolean",
+            model_configuration=config,
+            deleted=deleted,
+        )
+
+    @parameterized.expand(
+        [
+            # (description, eval_providers, byok_providers, expected_trial_providers)
+            ("no_evals", [], [], []),
+            ("openai_eval_no_byok", ["openai"], [], ["openai"]),
+            ("openai_eval_with_openai_byok", ["openai"], ["openai"], []),
+            ("anthropic_eval_with_openai_byok", ["anthropic"], ["openai"], ["anthropic"]),
+            ("both_evals_only_anthropic_byok", ["openai", "anthropic"], ["anthropic"], ["openai"]),
+            ("both_evals_both_byok", ["openai", "anthropic"], ["openai", "anthropic"], []),
+            ("multi_provider_no_byok", ["openai", "anthropic", "gemini"], [], ["anthropic", "gemini", "openai"]),
+        ]
+    )
+    def test_trial_providers(self, _name, eval_providers, byok_providers, expected_trial_providers):
+        for provider in byok_providers:
+            LLMProviderKey.objects.create(
+                team=self.team,
+                provider=provider,
+                name=f"{provider} key",
+                state=LLMProviderKey.State.OK,
+                encrypted_config={"api_key": "sk-test"},
+                created_by=self.user,
+            )
+        for provider in eval_providers:
+            self._create_eval(provider)
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_analytics/evaluation_config/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["trial_providers"], expected_trial_providers)
+
+    def test_trial_providers_excludes_deleted_evals(self):
+        self._create_eval("openai", deleted=True)
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_analytics/evaluation_config/")
+        self.assertEqual(response.data["trial_providers"], [])
+
+    def test_trial_providers_excludes_pinned_byok_evals(self):
+        key = LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="My Key",
+            state=LLMProviderKey.State.OK,
+            encrypted_config={"api_key": "sk-test"},
+            created_by=self.user,
+        )
+        self._create_eval("openai", provider_key=key)
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_analytics/evaluation_config/")
+        self.assertEqual(response.data["trial_providers"], [])
+
+    def test_trial_providers_ignores_invalid_byok_keys(self):
+        LLMProviderKey.objects.create(
+            team=self.team,
+            provider="openai",
+            name="Bad Key",
+            state=LLMProviderKey.State.INVALID,
+            encrypted_config={"api_key": "sk-invalid"},
+            created_by=self.user,
+        )
+        self._create_eval("openai")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_analytics/evaluation_config/")
+        self.assertEqual(response.data["trial_providers"], ["openai"])
+
+    def test_trial_providers_includes_legacy_evals_as_openai(self):
+        Evaluation.objects.create(
+            team=self.team,
+            name="Legacy eval",
+            evaluation_type="llm_judge",
+            output_type="boolean",
+            model_configuration=None,
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_analytics/evaluation_config/")
+        self.assertEqual(response.data["trial_providers"], ["openai"])

--- a/products/llm_analytics/backend/api/test/test_provider_keys.py
+++ b/products/llm_analytics/backend/api/test/test_provider_keys.py
@@ -675,6 +675,15 @@ class TestLLMProviderKeyDependentConfigs(APIBaseTest):
             model="gpt-5-mini",
             provider_key=key1,
         )
+        evaluation = Evaluation.objects.create(
+            team=self.team,
+            name="Test Evaluation",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "Is this good?"},
+            output_type="boolean",
+            model_configuration=model_config,
+            enabled=True,
+        )
 
         response = self.client.delete(
             f"/api/environments/{self.team.id}/llm_analytics/provider_keys/{key1.id}/?replacement_key_id={key2.id}"
@@ -684,6 +693,11 @@ class TestLLMProviderKeyDependentConfigs(APIBaseTest):
         model_config.refresh_from_db()
         self.assertEqual(model_config.provider_key, key2)
         self.assertEqual(LLMProviderKey.objects.filter(id=key1.id).count(), 0)
+
+        # Evaluation stays enabled and keeps its model configuration when a replacement is provided
+        evaluation.refresh_from_db()
+        self.assertTrue(evaluation.enabled)
+        self.assertEqual(evaluation.model_configuration, model_config)
 
     def test_delete_without_replacement_disables_evaluations(self):
         key = LLMProviderKey.objects.create(

--- a/products/llm_analytics/backend/api/test/test_provider_keys.py
+++ b/products/llm_analytics/backend/api/test/test_provider_keys.py
@@ -395,6 +395,74 @@ class TestLLMProviderKeyViewSet(APIBaseTest):
         self.assertEqual(response.data["results"][0]["id"], str(key2.id))
         self.assertEqual(response.data["results"][1]["id"], str(key1.id))
 
+    @patch("products.llm_analytics.backend.api.provider_keys.validate_provider_key")
+    def test_creating_key_auto_assigns_to_trial_evaluations(self, mock_validate):
+        mock_validate.return_value = (LLMProviderKey.State.OK, None)
+
+        # Create two evals on trial (no provider_key) for OpenAI
+        mc1 = LLMModelConfiguration.objects.create(team=self.team, provider="openai", model="gpt-5-mini")
+        mc2 = LLMModelConfiguration.objects.create(team=self.team, provider="openai", model="gpt-5-mini")
+        # And one for a different provider that should NOT be touched
+        mc_anthropic = LLMModelConfiguration.objects.create(
+            team=self.team, provider="anthropic", model="claude-haiku-4-5"
+        )
+
+        Evaluation.objects.create(
+            team=self.team,
+            name="Eval 1",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "test"},
+            output_type="boolean",
+            model_configuration=mc1,
+        )
+        Evaluation.objects.create(
+            team=self.team,
+            name="Eval 2",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "test"},
+            output_type="boolean",
+            model_configuration=mc2,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/",
+            {"provider": "openai", "name": "My Key", "api_key": "sk-test-key-12345"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        new_key = LLMProviderKey.objects.get(id=response.data["id"])
+
+        mc1.refresh_from_db()
+        mc2.refresh_from_db()
+        mc_anthropic.refresh_from_db()
+
+        self.assertEqual(mc1.provider_key, new_key)
+        self.assertEqual(mc2.provider_key, new_key)
+        self.assertIsNone(mc_anthropic.provider_key)
+
+    @patch("products.llm_analytics.backend.api.provider_keys.validate_provider_key")
+    def test_creating_invalid_key_does_not_auto_assign(self, mock_validate):
+        mock_validate.return_value = (LLMProviderKey.State.INVALID, "Bad key")
+
+        mc = LLMModelConfiguration.objects.create(team=self.team, provider="openai", model="gpt-5-mini")
+        Evaluation.objects.create(
+            team=self.team,
+            name="Eval",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "test"},
+            output_type="boolean",
+            model_configuration=mc,
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_analytics/provider_keys/",
+            {"provider": "openai", "name": "Bad Key", "api_key": "sk-bad-key-12345"},
+        )
+        # Key creation fails validation
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        mc.refresh_from_db()
+        self.assertIsNone(mc.provider_key)
+
 
 class TestLLMProviderKeyValidationViewSet(APIBaseTest):
     def test_unauthenticated_user_cannot_validate(self):

--- a/products/llm_analytics/backend/api/test/test_provider_keys.py
+++ b/products/llm_analytics/backend/api/test/test_provider_keys.py
@@ -718,6 +718,7 @@ class TestLLMProviderKeyDependentConfigs(APIBaseTest):
 
         evaluation.refresh_from_db()
         self.assertFalse(evaluation.enabled)
+        self.assertIsNone(evaluation.model_configuration)
 
     def test_delete_with_mismatched_provider_replacement_fails(self):
         openai_key = LLMProviderKey.objects.create(

--- a/products/llm_analytics/backend/api/test/test_provider_keys.py
+++ b/products/llm_analytics/backend/api/test/test_provider_keys.py
@@ -732,7 +732,11 @@ class TestLLMProviderKeyDependentConfigs(APIBaseTest):
 
         evaluation.refresh_from_db()
         self.assertFalse(evaluation.enabled)
-        self.assertIsNone(evaluation.model_configuration)
+        # Model configuration is preserved so the user only needs to assign a
+        # new key, not reconfigure provider/model from scratch.
+        self.assertIsNotNone(evaluation.model_configuration)
+        model_config.refresh_from_db()
+        self.assertIsNone(model_config.provider_key)
 
     def test_delete_with_mismatched_provider_replacement_fails(self):
         openai_key = LLMProviderKey.objects.create(

--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -481,8 +481,8 @@ function DeleteKeyModal({
                     {hasEvaluations && !hasAlternatives && (
                         <div className="bg-warning-highlight border border-warning rounded p-3">
                             <p className="text-sm">
-                                <strong>No replacement keys available.</strong> These evaluations will be disabled after
-                                deletion.
+                                <strong>No replacement keys available.</strong> These evaluations will be disabled and
+                                their model configuration removed. You'll need to reconfigure them to re-enable.
                             </p>
                         </div>
                     )}

--- a/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/llm_analytics/frontend/settings/LLMProviderKeysSettings.tsx
@@ -481,8 +481,8 @@ function DeleteKeyModal({
                     {hasEvaluations && !hasAlternatives && (
                         <div className="bg-warning-highlight border border-warning rounded p-3">
                             <p className="text-sm">
-                                <strong>No replacement keys available.</strong> These evaluations will be disabled and
-                                their model configuration removed. You'll need to reconfigure them to re-enable.
+                                <strong>No replacement keys available.</strong> These evaluations will be disabled.
+                                You'll need to assign a new key to re-enable them.
                             </p>
                         </div>
                     )}
@@ -628,7 +628,7 @@ export function LLMProviderKeysSettings(): JSX.Element {
                             </AccessControlAction>
                         </div>
 
-                        {evaluationConfig && !evaluationConfig.active_provider_key && (
+                        {evaluationConfig && !!evaluationConfig.trial_providers?.length && (
                             <TrialUsageMeterDisplay evaluationConfig={evaluationConfig} />
                         )}
 

--- a/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
+++ b/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
@@ -9,7 +9,7 @@ import { EvaluationConfig, llmProviderKeysLogic } from './llmProviderKeysLogic'
 export function TrialUsageMeter({ showSettingsLink = false }: { showSettingsLink?: boolean }): JSX.Element | null {
     const { evaluationConfig, providerKeys, providerKeysLoading } = useValues(llmProviderKeysLogic)
 
-    // Wait for both loaders before deciding visibility to avoid a brief flash
+    // Wait for provider keys to load before deciding visibility to avoid a brief flash
     if (!evaluationConfig || providerKeysLoading) {
         return null
     }

--- a/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
+++ b/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
@@ -7,9 +7,15 @@ import { urls } from 'scenes/urls'
 import { EvaluationConfig, llmProviderKeysLogic } from './llmProviderKeysLogic'
 
 export function TrialUsageMeter({ showSettingsLink = false }: { showSettingsLink?: boolean }): JSX.Element | null {
-    const { evaluationConfig } = useValues(llmProviderKeysLogic)
+    const { evaluationConfig, providerKeys } = useValues(llmProviderKeysLogic)
 
-    if (!evaluationConfig || evaluationConfig.active_provider_key) {
+    if (!evaluationConfig) {
+        return null
+    }
+
+    // Hide when the team has any healthy BYOK key — they've graduated from trial
+    const hasHealthyByokKey = providerKeys.some((key) => key.state === 'ok')
+    if (hasHealthyByokKey) {
         return null
     }
 

--- a/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
+++ b/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
@@ -7,9 +7,10 @@ import { urls } from 'scenes/urls'
 import { EvaluationConfig, llmProviderKeysLogic } from './llmProviderKeysLogic'
 
 export function TrialUsageMeter({ showSettingsLink = false }: { showSettingsLink?: boolean }): JSX.Element | null {
-    const { evaluationConfig, providerKeys } = useValues(llmProviderKeysLogic)
+    const { evaluationConfig, providerKeys, providerKeysLoading } = useValues(llmProviderKeysLogic)
 
-    if (!evaluationConfig) {
+    // Wait for both loaders before deciding visibility to avoid a brief flash
+    if (!evaluationConfig || providerKeysLoading) {
         return null
     }
 

--- a/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
+++ b/products/llm_analytics/frontend/settings/TrialUsageMeter.tsx
@@ -4,23 +4,24 @@ import { Link } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
-import { EvaluationConfig, llmProviderKeysLogic } from './llmProviderKeysLogic'
+import { EvaluationConfig, LLM_PROVIDER_LABELS, LLMProvider, llmProviderKeysLogic } from './llmProviderKeysLogic'
 
 export function TrialUsageMeter({ showSettingsLink = false }: { showSettingsLink?: boolean }): JSX.Element | null {
-    const { evaluationConfig, providerKeys, providerKeysLoading } = useValues(llmProviderKeysLogic)
+    const { evaluationConfig } = useValues(llmProviderKeysLogic)
 
-    // Wait for provider keys to load before deciding visibility to avoid a brief flash
-    if (!evaluationConfig || providerKeysLoading) {
-        return null
-    }
-
-    // Hide when the team has any healthy BYOK key — they've graduated from trial
-    const hasHealthyByokKey = providerKeys.some((key) => key.state === 'ok')
-    if (hasHealthyByokKey) {
+    if (!evaluationConfig || !evaluationConfig.trial_providers?.length) {
         return null
     }
 
     return <TrialUsageMeterDisplay evaluationConfig={evaluationConfig} showSettingsLink={showSettingsLink} />
+}
+
+function formatProviderNames(providers: LLMProvider[]): string {
+    const names = providers.map((p) => LLM_PROVIDER_LABELS[p])
+    if (names.length === 1) {
+        return names[0]
+    }
+    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
 }
 
 export function TrialUsageMeterDisplay({
@@ -30,9 +31,18 @@ export function TrialUsageMeterDisplay({
     evaluationConfig: EvaluationConfig
     showSettingsLink?: boolean
 }): JSX.Element {
-    const { trial_eval_limit, trial_evals_remaining } = evaluationConfig
+    const { trial_eval_limit, trial_evals_remaining, trial_providers } = evaluationConfig
     const percentUsed = Math.min(((trial_eval_limit - trial_evals_remaining) / trial_eval_limit) * 100, 100)
     const isExhausted = trial_evals_remaining <= 0
+    const providerLabel = formatProviderNames(trial_providers)
+
+    const addKeyLink = showSettingsLink ? (
+        <Link to={urls.settings('environment-llm-analytics', 'llm-analytics-byok')}>
+            Add your {providerLabel} API {trial_providers.length === 1 ? 'key' : 'keys'}
+        </Link>
+    ) : (
+        `Add your ${providerLabel} API ${trial_providers.length === 1 ? 'key' : 'keys'}`
+    )
 
     return (
         <div className="rounded-lg p-4 space-y-3 border">
@@ -50,28 +60,18 @@ export function TrialUsageMeterDisplay({
                 />
             </div>
             {isExhausted ? (
-                <p className="text-sm">
-                    Trial evaluations exhausted.{' '}
-                    {showSettingsLink ? (
-                        <Link to={urls.settings('environment-llm-analytics', 'llm-analytics-byok')}>
-                            Add your OpenAI API key
-                        </Link>
-                    ) : (
-                        'Add your OpenAI API key'
-                    )}{' '}
-                    to continue running evaluations.
-                </p>
+                <p className="text-sm">Trial evaluations exhausted. {addKeyLink} to continue running evaluations.</p>
             ) : (
                 <p className="text-sm text-muted">
-                    You have {trial_evals_remaining} evaluations to try things out before{' '}
+                    Your {providerLabel} evaluations are using the trial.{' '}
                     {showSettingsLink ? (
                         <Link to={urls.settings('environment-llm-analytics', 'llm-analytics-byok')}>
-                            adding your own key
+                            Add your own {trial_providers.length === 1 ? 'key' : 'keys'}
                         </Link>
                     ) : (
-                        'adding your own key'
-                    )}
-                    .
+                        `Add your own ${trial_providers.length === 1 ? 'key' : 'keys'}`
+                    )}{' '}
+                    to avoid hitting the {trial_eval_limit} evaluation limit.
                 </p>
             )}
         </div>

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -333,10 +333,8 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                         ? `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/?replacement_key_id=${encodeURIComponent(replacementKeyId)}`
                         : `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/`
                     await api.delete(url)
-                    // If deleted key was active, reload config to reflect change
-                    if (values.evaluationConfig?.active_provider_key?.id === id) {
-                        actions.loadEvaluationConfig()
-                    }
+                    // Reload config to reflect trial_providers and active_provider_key changes
+                    actions.loadEvaluationConfig()
                     return values.providerKeys.filter((key: LLMProviderKey) => key.id !== id)
                 },
                 validateProviderKey: async ({ id }: { id: string }): Promise<LLMProviderKey[]> => {

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -370,10 +370,10 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
             (evaluationConfig: EvaluationConfig | null) => evaluationConfig?.trial_evals_remaining ?? 0,
         ],
         isTrialLimitReached: [
-            (s) => [s.evaluationConfig],
-            (evaluationConfig: EvaluationConfig | null) =>
+            (s) => [s.evaluationConfig, s.providerKeys],
+            (evaluationConfig: EvaluationConfig | null, providerKeys: LLMProviderKey[]) =>
                 evaluationConfig !== null &&
-                evaluationConfig.active_provider_key === null &&
+                !providerKeys.some((key) => key.state === 'ok') &&
                 evaluationConfig.trial_evals_remaining <= 0,
         ],
     }),

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -117,6 +117,7 @@ export interface EvaluationConfig {
     trial_evals_used: number
     trial_evals_remaining: number
     active_provider_key: LLMProviderKey | null
+    trial_providers: LLMProvider[]
     created_at: string
     updated_at: string
 }

--- a/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/llm_analytics/frontend/settings/llmProviderKeysLogic.ts
@@ -369,13 +369,6 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
             (s) => [s.evaluationConfig],
             (evaluationConfig: EvaluationConfig | null) => evaluationConfig?.trial_evals_remaining ?? 0,
         ],
-        isTrialLimitReached: [
-            (s) => [s.evaluationConfig, s.providerKeys],
-            (evaluationConfig: EvaluationConfig | null, providerKeys: LLMProviderKey[]) =>
-                evaluationConfig !== null &&
-                !providerKeys.some((key) => key.state === 'ok') &&
-                evaluationConfig.trial_evals_remaining <= 0,
-        ],
     }),
 
     listeners(({ actions, values }) => ({


### PR DESCRIPTION
## Problem

When users add their own API key after using the 100 free trial evaluations, their existing evaluations stop running silently. The `provider_key_id` on each evaluation's `model_configuration` is frozen at creation time — if it was `null` (trial), it stays null forever. Once the trial quota is exhausted, the eval fails with a non-retryable error, even though the user has a valid BYOK key configured.

Reported by a customer whose evaluator ran exactly 100 evaluations using PostHog's key, then stopped entirely.

## Changes

**Dynamic key resolution at runtime** (`run_evaluation.py`)
- Replace `_check_trial_quota()` with `_resolve_provider_key(provider)` which prefers a healthy BYOK key for the matching provider over consuming trial quota. Falls back to trial only if no BYOK key exists, and raises if trial is also exhausted.
- Legacy code path delegates to `_resolve_provider_key("openai")` when no explicit `active_provider_key` is set.
- Use atomic `UPDATE` for `last_used_at` timestamps to avoid race conditions under concurrent evaluation workers.
- Use `nulls_last` ordering so never-used keys don't sort ahead of recently-used ones.

**Auto-assign BYOK key on creation** (`provider_keys.py`)
- When a new provider key validates as OK, all active `LLMModelConfiguration` rows for that team+provider with `provider_key=null` (trial) get updated to point to the new key.

**Clean key deletion** (`provider_keys.py`)
- When deleting a key without a replacement, affected evaluations are disabled and their `model_configuration.provider_key` is nulled. The provider/model choice is preserved so users only need to assign a new key, not reconfigure from scratch.

**Per-provider trial status** (`evaluation_config.py`)
- New `trial_providers` field on the evaluation config API returns which providers are currently consuming trial quota (have active evals without a BYOK key).

**Frontend**
- `TrialUsageMeter`: Show per-provider trial status using `trial_providers` instead of the legacy `active_provider_key` check. Displays which specific providers are on trial with provider-aware copy.
- `llmProviderKeysLogic`: Add `trial_providers` to `EvaluationConfig` type, remove unused `isTrialLimitReached` selector.
- Delete key modal: Updated warning to reflect that users only need to assign a new key.

## How did you test this code?

23 new/updated tests across three files:
- **`test_run_evaluation.py`** (8 tests): BYOK preferred over trial, provider mismatch falls back to trial, trial exhausted with/without BYOK, unhealthy keys skipped, legacy path prefers BYOK, nulls_last ordering, trial exhausted raises
- **`test_provider_keys.py`** (4 tests): Auto-assign on creation scoped by provider, invalid key skips auto-assign, delete-with-replacement preserves config, delete-without-replacement disables eval and nulls provider_key
- **`test_evaluation_config.py`** (11 tests): Parameterized matrix of eval providers × BYOK providers, deleted evals excluded, pinned evals excluded, invalid keys ignored, legacy evals treated as OpenAI

## Publish to changelog?

no