### PR TITLE
fix(phrocs): kill process group on stop to prevent zombie processes

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -232,5 +232,6 @@ AGENTS.md @PostHog/team-devex
 .agents/skills/ingestion-*/ @PostHog/team-ingestion
 .claude/skills/ingestion-*/ @PostHog/team-ingestion
 tools/pr-approval-agent/ @PostHog/team-devex
+tools/phrocs/ @PostHog/team-devex
 greptile.json @PostHog/team-devex
 docs/published/developing-locally.md @PostHog/team-devex

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -501,7 +501,11 @@ func (p *Process) Stop() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.cmd != nil && p.cmd.Process != nil {
-		_ = syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM)
+		pgid := p.cmd.Process.Pid
+		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+			// Fallback: kill the direct child if the process group is gone
+			_ = p.cmd.Process.Signal(syscall.SIGTERM)
+		}
 	}
 	if p.ptmx != nil {
 		_ = p.ptmx.Close()

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -101,14 +101,15 @@ type Process struct {
 	Name string
 	Cfg  config.ProcConfig
 
-	mu           sync.Mutex
-	maxLines     int
-	status       Status
-	lines        []string
-	cmd          *exec.Cmd
-	ptmx         *os.File // pty master; nil when using pipes
-	readyPattern *regexp.Regexp
-	ready        bool // whether we've seen the ready pattern (or no pattern is set)
+	mu            sync.Mutex
+	maxLines      int
+	status        Status
+	lines         []string
+	cmd           *exec.Cmd
+	ptmx          *os.File // pty master; nil when using pipes
+	readyPattern  *regexp.Regexp
+	ready         bool // whether we've seen the ready pattern (or no pattern is set)
+	stopRequested bool // set by Stop() to catch races with in-flight Start()
 
 	startedAt time.Time
 	readyAt   time.Time
@@ -215,6 +216,7 @@ func (p *Process) Start(send func(tea.Msg)) error {
 	p.exitCode = nil
 	p.startedAt = time.Now()
 	p.readyAt = time.Time{}
+	p.stopRequested = false
 	// Reset ready flag when restarting
 	p.ready = p.readyPattern == nil
 	p.mu.Unlock()
@@ -239,6 +241,20 @@ func (p *Process) Start(send func(tea.Msg)) error {
 	p.mu.Lock()
 	p.cmd = cmd
 	p.ptmx = ptmx
+
+	// Stop() was called while pty.Start was in progress — kill immediately
+	if p.stopRequested {
+		p.killProcessGroup()
+		if p.ptmx != nil {
+			_ = p.ptmx.Close()
+			p.ptmx = nil
+		}
+		p.status = StatusStopped
+		p.mu.Unlock()
+		send(StatusMsg{Name: p.Name, Status: StatusStopped})
+		return nil
+	}
+
 	// Only set to running if proc has no ready pattern
 	if p.readyPattern == nil {
 		p.status = StatusRunning
@@ -317,13 +333,22 @@ func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
 
 	p.mu.Lock()
 	p.cmd = cmd
+
+	// Stop() was called while cmd.Start was in progress — kill immediately
+	if p.stopRequested {
+		p.killProcessGroup()
+		p.status = StatusStopped
+		p.mu.Unlock()
+		_ = pr.Close()
+		_ = pw.Close()
+		send(StatusMsg{Name: p.Name, Status: StatusStopped})
+		return nil
+	}
+
 	// Only set to running if no ready pattern
 	if p.readyPattern == nil {
 		p.status = StatusRunning
 	}
-	p.mu.Unlock()
-
-	p.mu.Lock()
 	currentStatus := p.status
 	p.mu.Unlock()
 	// Send initial status message
@@ -494,19 +519,25 @@ func collectProcessTree(ps *gops.Process) []*gops.Process {
 	return all
 }
 
+// killProcessGroup sends SIGTERM to the process group. Must be called with
+// p.mu held. Falls back to signaling the direct child if the group kill fails.
+func (p *Process) killProcessGroup() {
+	if p.cmd != nil && p.cmd.Process != nil {
+		pgid := p.cmd.Process.Pid
+		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+			_ = p.cmd.Process.Signal(syscall.SIGTERM)
+		}
+	}
+}
+
 // Sends SIGTERM to the process group and marks it as stopped.
 // Killing the process group (negative PID) ensures all descendants
 // (bash → tsx watch → node, etc.) are terminated, not just the shell.
 func (p *Process) Stop() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.cmd != nil && p.cmd.Process != nil {
-		pgid := p.cmd.Process.Pid
-		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
-			// Fallback: kill the direct child if the process group is gone
-			_ = p.cmd.Process.Signal(syscall.SIGTERM)
-		}
-	}
+	p.stopRequested = true
+	p.killProcessGroup()
 	if p.ptmx != nil {
 		_ = p.ptmx.Close()
 		p.ptmx = nil

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -226,6 +226,9 @@ func (p *Process) Start(send func(tea.Msg)) error {
 
 	cmd := exec.Command("bash", "-c", p.Cfg.Shell)
 	cmd.Env = env
+	// Give child its own process group so Stop() can kill the entire tree,
+	// preventing zombie tsx/node/vite processes when phrocs exits.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
@@ -491,12 +494,14 @@ func collectProcessTree(ps *gops.Process) []*gops.Process {
 	return all
 }
 
-// Sends SIGTERM to the process and marks it as stopped
+// Sends SIGTERM to the process group and marks it as stopped.
+// Killing the process group (negative PID) ensures all descendants
+// (bash → tsx watch → node, etc.) are terminated, not just the shell.
 func (p *Process) Stop() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.cmd != nil && p.cmd.Process != nil {
-		_ = p.cmd.Process.Signal(syscall.SIGTERM)
+		_ = syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM)
 	}
 	if p.ptmx != nil {
 		_ = p.ptmx.Close()

--- a/tools/phrocs/internal/process/proc_test.go
+++ b/tools/phrocs/internal/process/proc_test.go
@@ -1,9 +1,15 @@
 package process
 
 import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/posthog/posthog/phrocs/internal/config"
 )
 
@@ -191,6 +197,87 @@ func TestSnapshot_withReadyAt(t *testing.T) {
 	got := *snap.StartupDurationS
 	if got < want-tolerance || got > want+tolerance {
 		t.Errorf("StartupDurationS: got %f, want %f", got, want)
+	}
+}
+
+// collectMsgs returns a thread-safe send function that collects all messages.
+func collectMsgs() (func(tea.Msg), *[]tea.Msg, *sync.Mutex) {
+	var mu sync.Mutex
+	var msgs []tea.Msg
+	return func(msg tea.Msg) {
+		mu.Lock()
+		msgs = append(msgs, msg)
+		mu.Unlock()
+	}, &msgs, &mu
+}
+
+// pidAlive checks whether a PID is still running.
+func pidAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func TestStop_kills_entire_process_group(t *testing.T) {
+	// Spawn a shell that writes its grandchild's PID to stdout, then waits.
+	// "sleep 999 &" creates a grandchild; "echo $!" prints its PID.
+	p := NewProcess("test-pgkill", config.ProcConfig{
+		Shell: `sleep 999 & echo "GRANDCHILD_PID=$!"; wait`,
+	}, 1000)
+
+	send, _, _ := collectMsgs()
+	if err := p.Start(send); err != nil {
+		// PTY/fork may be unavailable in sandboxed environments
+		t.Skipf("skipping: cannot spawn subprocess: %v", err)
+	}
+
+	// Wait for the grandchild PID to appear in output
+	var grandchildPID int
+	deadline := time.After(5 * time.Second)
+	for grandchildPID == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for grandchild PID in output")
+		default:
+		}
+		for _, line := range p.Lines() {
+			if strings.HasPrefix(line, "GRANDCHILD_PID=") {
+				fmt.Sscanf(line, "GRANDCHILD_PID=%d", &grandchildPID)
+			}
+		}
+		if grandchildPID == 0 {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	parentPID := p.PID()
+	if parentPID == 0 {
+		t.Fatal("parent PID is 0 after Start")
+	}
+
+	// Both should be alive before Stop
+	if !pidAlive(parentPID) {
+		t.Fatalf("parent PID %d not alive before Stop", parentPID)
+	}
+	if !pidAlive(grandchildPID) {
+		t.Fatalf("grandchild PID %d not alive before Stop", grandchildPID)
+	}
+
+	p.Stop()
+
+	// Give the OS a moment to reap
+	time.Sleep(200 * time.Millisecond)
+
+	if pidAlive(parentPID) {
+		t.Errorf("parent PID %d still alive after Stop", parentPID)
+	}
+	if pidAlive(grandchildPID) {
+		t.Errorf("grandchild PID %d still alive after Stop — process group kill didn't work", grandchildPID)
+	}
+	if p.Status() != StatusStopped {
+		t.Errorf("status: got %s, want stopped", p.Status())
 	}
 }
 


### PR DESCRIPTION
**Problem:** when phrocs exits, `Stop()` sends SIGTERM to the direct bash child only. The actual process (tsx watch, vite, node) is a grandchild that never receives the signal and orphans. People keep having to manually kill zombie node processes via Activity Monitor.

**Fix:** set `Setpgid: true` on spawn so each child gets its own process group, then `syscall.Kill(-pgid, SIGTERM)` in `Stop()` to terminate the entire tree atomically. Same pattern as `bin/start-go-service`.

mprocs has the same issue ([pvolok/mprocs#76](https://github.com/pvolok/mprocs/issues/76)) but since it's third-party there's no clean fix — this is phrocs-only.