### PR TITLE
chore: auto-bootstrap worktrees via post-checkout hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -8,7 +8,7 @@
 [ -f .git ] || exit 0
 
 # Bootstrap husky + lint-staged so pre-commit hooks work in worktrees
-if [ ! -d node_modules/.package-lock.json ] && command -v pnpm &> /dev/null; then
+if [ ! -d node_modules/.pnpm ] && command -v pnpm &> /dev/null; then
     echo "husky: worktree detected, bootstrapping with pnpm install --frozen-lockfile --filter=. ..."
     pnpm install --frozen-lockfile --filter=.
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,14 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Args: $1=prev_ref, $2=new_ref, $3=1 if branch checkout, 0 if file checkout
+[ "$3" = "1" ] || exit 0
+
+# Detect worktree: .git is a file (not a directory) pointing to the main repo
+[ -f .git ] || exit 0
+
+# Bootstrap husky + lint-staged so pre-commit hooks work in worktrees
+if [ ! -d node_modules/.package-lock.json ] && command -v pnpm &> /dev/null; then
+    echo "husky: worktree detected, bootstrapping with pnpm install --frozen-lockfile --filter=. ..."
+    pnpm install --frozen-lockfile --filter=.
+fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -8,7 +8,8 @@
 [ -f .git ] || exit 0
 
 # Bootstrap husky + lint-staged so pre-commit hooks work in worktrees
-if [ ! -d node_modules/.pnpm ] && command -v pnpm &> /dev/null; then
-    echo "husky: worktree detected, bootstrapping with pnpm install --frozen-lockfile --filter=. ..."
+# pnpm is expected to be globally available (corepack, brew, etc.)
+if [ ! -d node_modules/.pnpm ]; then
+    echo "husky: worktree detected, bootstrapping with pnpm install ..."
     pnpm install --frozen-lockfile --filter=.
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,7 +7,7 @@
 
 # Activate Flox environment if available and not already active
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
-if command -v flox &> /dev/null && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
+if command -v flox > /dev/null 2>&1 && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
     exec "$(command -v flox)" activate -- bash -c "NODE_OPTIONS='--max-old-space-size=8192' pnpm lint-staged"
 else
     # Fallback: run without Flox (for non-Flox users or if already activated)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,6 @@
 - Environment:
   - Use flox when available — prefer `flox activate -- bash -c "<command>"` if commands fail
     - Never use `flox activate` in interactive sessions (it hangs if you try)
-  - If local hooks fail with missing Husky bootstrap files (for example `.husky/_/husky.sh`) or missing `lint-staged`, run `pnpm install --frozen-lockfile --filter=.` once in the repo root
 - Tests:
   - All tests: `pytest`
   - Single test: `pytest path/to/test.py::TestClass::test_method`


### PR DESCRIPTION
Husky registers an absolute `core.hooksPath`, so `post-checkout` fires from the main repo even in fresh worktrees. Uses that to run `pnpm install --frozen-lockfile --filter=.` automatically when a worktree is created, so `pre-commit` (lint-staged) works without manual setup.

Removes the now-unnecessary manual pnpm install guidance from AGENTS.md.