### PR TITLE
fix(replay): remove body from 204 delete response to fix 502 protocol error

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -763,7 +763,7 @@ class SessionRecordingViewSet(
             exc.status_code = 500
             raise exc
 
-        return Response({"success": True}, status=204)
+        return Response(status=204)
 
     @extend_schema(exclude=True)
     @action(methods=["POST"], detail=False, url_path="bulk_delete")


### PR DESCRIPTION
## Summary

- Recording deletion consistently returns 502 on production with `upstream connect error or disconnect/reset before headers. retried and the latest reset reason: protocol error`
- Browser timing shows ~524ms server wait time (not a timeout — the server actively rejects)
- Root cause: `Response({"success": True}, status=204)` sends a JSON body on an HTTP 204 response. HTTP 204 means "No Content" and MUST NOT include a body. Under Nginx Unit ASGI + HTTP/2, envoy enforces this strictly and resets the connection as a protocol error
- Fix: `Response(status=204)` — no body

## Test plan

- [ ] Deploy and verify single recording deletion returns 204 without 502
- [ ] Verify bulk delete (uses 200 with body — unaffected) still works
- [ ] Verify deleted recording disappears from listing after refresh