### PR TITLE
fix(devex): replace celery autoreload fork with in-process watchman thread

### DIFF
--- a/posthog/management/commands/run_autoreload_celery.py
+++ b/posthog/management/commands/run_autoreload_celery.py
@@ -122,5 +122,6 @@ class Command(BaseCommand):
                 self.style.WARNING(f"Change detected: {', '.join(sample)}{suffix} — restarting celery {process_type}")
             )
 
-            # Re-exec the entire process — replaces this process in-place
+            # Re-exec the entire process — replaces this process in-place.
+            # nosemgrep: python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
             os.execv(sys.executable, [sys.executable, *sys.argv])

--- a/posthog/management/commands/run_autoreload_celery.py
+++ b/posthog/management/commands/run_autoreload_celery.py
@@ -1,79 +1,182 @@
+import os
+import sys
+import time
+import signal
+import subprocess
 from pathlib import Path
 from typing import Literal
 
-import django
 from django.core.management.base import BaseCommand
+
+import pywatchman
 
 from posthog.tasks.utils import CeleryQueue
 
-# ❗ needs to be called *before* importing autoreload
-django.setup()
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 
-from django.utils import autoreload  # noqa: E402
+# Directories to watch for .py changes
+WATCH_DIRS = ["posthog", "ee", "products"]
+
+# Debounce: ignore changes within this window after a restart
+DEBOUNCE_SECONDS = 2
 
 
 class Command(BaseCommand):
-    help = "Run Celery wrapped in Django's auto-reload feature"
+    help = "Run Celery with watchman-based auto-reload (no fork overhead)"
 
     def add_arguments(self, parser):
         parser.add_argument("--type", type=str, choices=("worker", "beat"), help="Process type")
+        parser.add_argument("--no-reload", action="store_true", help="Disable auto-reload")
 
     def handle(self, *args, **options):
-        def run_optimized_celery():
-            # Optimize file watching - only watch core PostHog directories instead of all 66k+ files
-            # This must be called inside the reloader process
-            self._setup_limited_file_watching()
-            self.run_celery_worker(options["type"])
+        process_type: Literal["worker", "beat"] = options["type"]
 
-        autoreload.run_with_reloader(run_optimized_celery)
-
-    def _setup_limited_file_watching(self):
-        """Limit file watching to core PostHog directories instead of all 66k+ files"""
-        # Get the project root directory
-        project_root = Path(__file__).parent.parent.parent.parent
-
-        # Define directories we actually care about for Celery reloading
-        watch_dirs = [
-            project_root / "posthog",
-            project_root / "ee",
-            project_root / "products",
-        ]
-
-        # Only watch files that exist and are directories
-        watch_dirs = [d for d in watch_dirs if d.exists() and d.is_dir()]
-
-        def limited_iter_python_files():
-            """Iterator that only yields Python files from our watched directories"""
-            for watch_dir in watch_dirs:
-                for py_file in watch_dir.rglob("*.py"):
-                    if py_file.is_file():
-                        yield py_file.resolve()
-
-        # Monkey patch Django's file discovery to only watch our specific directories
-        autoreload.iter_all_python_module_files = limited_iter_python_files
-
-        self.stdout.write(
-            self.style.SUCCESS(f"📁 Optimized: Watching {len(watch_dirs)} directories instead of all Python modules")
-        )
-
-    @staticmethod
-    def run_celery_worker(type: Literal["worker", "beat"]):
-        from posthog.celery import app as celery_app
-
-        if type == "beat":
-            args = [
-                "beat",
-                "--scheduler",
-                "redbeat.RedBeatScheduler",
-            ]
-            celery_app.start(argv=args)
+        if options["no_reload"]:
+            self._run_celery_inline(process_type)
             return
 
-        args = [
-            "-A",
-            "posthog",
-            "worker",
-            "--pool=threads",
-            f"--queues={','.join(q.value for q in CeleryQueue)}",
+        self._run_with_watchman(process_type)
+
+    def _build_celery_cmd(self, process_type: Literal["worker", "beat"]) -> list[str]:
+        if process_type == "beat":
+            return [
+                sys.executable,
+                "manage.py",
+                "run_autoreload_celery",
+                "--type=beat",
+                "--no-reload",
+            ]
+
+        return [
+            sys.executable,
+            "manage.py",
+            "run_autoreload_celery",
+            "--type=worker",
+            "--no-reload",
         ]
-        celery_app.worker_main(args)
+
+    def _run_celery_inline(self, process_type: Literal["worker", "beat"]):
+        """Run celery directly in this process (no autoreload)."""
+        from posthog.celery import app as celery_app
+
+        if process_type == "beat":
+            celery_app.start(argv=["beat", "--scheduler", "redbeat.RedBeatScheduler"])
+        else:
+            celery_app.worker_main(
+                argv=[
+                    "-A",
+                    "posthog",
+                    "worker",
+                    "--pool=threads",
+                    f"--queues={','.join(q.value for q in CeleryQueue)}",
+                ]
+            )
+
+    def _run_with_watchman(self, process_type: Literal["worker", "beat"]):
+        """Watch for .py changes via watchman and restart the celery subprocess."""
+        client = pywatchman.client(timeout=5)
+        root = str(PROJECT_ROOT)
+
+        # Ensure watchman is watching the project root
+        client.query("watch-project", root)
+
+        # Subscribe to .py file changes in the relevant directories
+        sub_name = f"celery-reload-{process_type}-{os.getpid()}"
+        client.query(
+            "subscribe",
+            root,
+            sub_name,
+            {
+                "expression": [
+                    "allof",
+                    ["suffix", "py"],
+                    [
+                        "anyof",
+                        *[["dirname", d] for d in WATCH_DIRS],
+                    ],
+                    ["not", ["dirname", "__pycache__"]],
+                    ["not", ["match", "*/migrations/*"]],
+                ],
+                "fields": ["name"],
+                # Drop intermediate notifications — only need to know something changed
+                "drop": ["stat"],
+                "defer_vcs": True,
+            },
+        )
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Watching {', '.join(WATCH_DIRS)} for .py changes (celery {process_type})")
+        )
+
+        cmd = self._build_celery_cmd(process_type)
+        proc = self._start_subprocess(cmd)
+        last_restart = time.monotonic()
+
+        try:
+            while True:
+                # Block until watchman has data (1s timeout to check subprocess health)
+                try:
+                    client.receive()
+                except pywatchman.SocketTimeout:
+                    # Check if subprocess died on its own
+                    if proc.poll() is not None:
+                        self.stderr.write(
+                            self.style.WARNING(
+                                f"Celery {process_type} exited with code {proc.returncode}, restarting..."
+                            )
+                        )
+                        proc = self._start_subprocess(cmd)
+                        last_restart = time.monotonic()
+                    continue
+
+                # Get subscription notifications
+                data = client.getSubscription(sub_name)
+                if not data:
+                    continue
+
+                # Debounce
+                now = time.monotonic()
+                if now - last_restart < DEBOUNCE_SECONDS:
+                    continue
+
+                # Collect changed file names for logging
+                changed = set()
+                for notification in data:
+                    changed.update(notification.get("files", []))
+
+                if not changed:
+                    continue
+
+                sample = list(changed)[:3]
+                suffix = f" (+{len(changed) - 3} more)" if len(changed) > 3 else ""
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Change detected: {', '.join(sample)}{suffix} — restarting celery {process_type}"
+                    )
+                )
+
+                self._stop_subprocess(proc)
+                proc = self._start_subprocess(cmd)
+                last_restart = time.monotonic()
+
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self._stop_subprocess(proc)
+            try:
+                client.query("unsubscribe", root, sub_name)
+            except Exception:
+                pass
+
+    def _start_subprocess(self, cmd: list[str]) -> subprocess.Popen:
+        return subprocess.Popen(cmd, cwd=str(PROJECT_ROOT))
+
+    def _stop_subprocess(self, proc: subprocess.Popen):
+        if proc.poll() is not None:
+            return
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/posthog/management/commands/run_autoreload_celery.py
+++ b/posthog/management/commands/run_autoreload_celery.py
@@ -1,14 +1,12 @@
 import os
 import sys
 import threading
-from pathlib import Path
 from typing import Literal
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from posthog.tasks.utils import CeleryQueue
-
-PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 
 # Directories to watch for .py changes
 WATCH_DIRS = ["posthog", "ee", "products"]
@@ -59,7 +57,7 @@ class Command(BaseCommand):
 
         try:
             client = pywatchman.client(timeout=5)
-            result = client.query("watch-project", str(PROJECT_ROOT))
+            result = client.query("watch-project", settings.BASE_DIR)
             watch_root = result["watch"]
             relative_path = result.get("relative_path")
 

--- a/posthog/management/commands/run_autoreload_celery.py
+++ b/posthog/management/commands/run_autoreload_celery.py
@@ -1,8 +1,6 @@
 import os
 import sys
-import time
-import signal
-import subprocess
+import threading
 from pathlib import Path
 from typing import Literal
 
@@ -17,12 +15,9 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 # Directories to watch for .py changes
 WATCH_DIRS = ["posthog", "ee", "products"]
 
-# Debounce: ignore changes within this window after a restart
-DEBOUNCE_SECONDS = 2
-
 
 class Command(BaseCommand):
-    help = "Run Celery with watchman-based auto-reload (no fork overhead)"
+    help = "Run Celery with watchman-based auto-reload"
 
     def add_arguments(self, parser):
         parser.add_argument("--type", type=str, choices=("worker", "beat"), help="Process type")
@@ -31,32 +26,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         process_type: Literal["worker", "beat"] = options["type"]
 
-        if options["no_reload"]:
-            self._run_celery_inline(process_type)
-            return
+        if not options["no_reload"]:
+            self._start_watchman_thread(process_type)
 
-        self._run_with_watchman(process_type)
+        self._run_celery(process_type)
 
-    def _build_celery_cmd(self, process_type: Literal["worker", "beat"]) -> list[str]:
-        if process_type == "beat":
-            return [
-                sys.executable,
-                "manage.py",
-                "run_autoreload_celery",
-                "--type=beat",
-                "--no-reload",
-            ]
-
-        return [
-            sys.executable,
-            "manage.py",
-            "run_autoreload_celery",
-            "--type=worker",
-            "--no-reload",
-        ]
-
-    def _run_celery_inline(self, process_type: Literal["worker", "beat"]):
-        """Run celery directly in this process (no autoreload)."""
+    def _run_celery(self, process_type: Literal["worker", "beat"]):
         from posthog.celery import app as celery_app
 
         if process_type == "beat":
@@ -72,15 +47,24 @@ class Command(BaseCommand):
                 ]
             )
 
-    def _run_with_watchman(self, process_type: Literal["worker", "beat"]):
-        """Watch for .py changes via watchman and restart the celery subprocess."""
-        client = pywatchman.client(timeout=5)
-        root = str(PROJECT_ROOT)
+    def _start_watchman_thread(self, process_type: Literal["worker", "beat"]):
+        """Start a background thread that watches for .py changes and re-execs the process."""
+        thread = threading.Thread(
+            target=self._watchman_loop,
+            args=(process_type,),
+            daemon=True,
+        )
+        thread.start()
 
-        # Ensure watchman is watching the project root
-        client.query("watch-project", root)
+    def _watchman_loop(self, process_type: Literal["worker", "beat"]):
+        try:
+            client = pywatchman.client(timeout=5)
+            root = str(PROJECT_ROOT)
+            client.query("watch-project", root)
+        except (pywatchman.WatchmanError, pywatchman.CommandError, ConnectionError, OSError) as e:
+            self.stderr.write(self.style.WARNING(f"Watchman not available, auto-reload disabled: {e}"))
+            return
 
-        # Subscribe to .py file changes in the relevant directories
         sub_name = f"celery-reload-{process_type}-{os.getpid()}"
         client.query(
             "subscribe",
@@ -98,7 +82,6 @@ class Command(BaseCommand):
                     ["not", ["match", "*/migrations/*"]],
                 ],
                 "fields": ["name"],
-                # Drop intermediate notifications — only need to know something changed
                 "drop": ["stat"],
                 "defer_vcs": True,
             },
@@ -108,75 +91,36 @@ class Command(BaseCommand):
             self.style.SUCCESS(f"Watching {', '.join(WATCH_DIRS)} for .py changes (celery {process_type})")
         )
 
-        cmd = self._build_celery_cmd(process_type)
-        proc = self._start_subprocess(cmd)
-        last_restart = time.monotonic()
-
+        # Skip initial notification from subscription setup — watchman sends the
+        # current state of matching files immediately upon subscribing
         try:
-            while True:
-                # Block until watchman has data (1s timeout to check subprocess health)
-                try:
-                    client.receive()
-                except pywatchman.SocketTimeout:
-                    # Check if subprocess died on its own
-                    if proc.poll() is not None:
-                        self.stderr.write(
-                            self.style.WARNING(
-                                f"Celery {process_type} exited with code {proc.returncode}, restarting..."
-                            )
-                        )
-                        proc = self._start_subprocess(cmd)
-                        last_restart = time.monotonic()
-                    continue
-
-                # Get subscription notifications
-                data = client.getSubscription(sub_name)
-                if not data:
-                    continue
-
-                # Debounce
-                now = time.monotonic()
-                if now - last_restart < DEBOUNCE_SECONDS:
-                    continue
-
-                # Collect changed file names for logging
-                changed = set()
-                for notification in data:
-                    changed.update(notification.get("files", []))
-
-                if not changed:
-                    continue
-
-                sample = list(changed)[:3]
-                suffix = f" (+{len(changed) - 3} more)" if len(changed) > 3 else ""
-                self.stdout.write(
-                    self.style.WARNING(
-                        f"Change detected: {', '.join(sample)}{suffix} — restarting celery {process_type}"
-                    )
-                )
-
-                self._stop_subprocess(proc)
-                proc = self._start_subprocess(cmd)
-                last_restart = time.monotonic()
-
-        except KeyboardInterrupt:
+            client.receive()
+            client.getSubscription(sub_name)
+        except pywatchman.SocketTimeout:
             pass
-        finally:
-            self._stop_subprocess(proc)
+
+        while True:
             try:
-                client.query("unsubscribe", root, sub_name)
-            except Exception:
-                pass
+                client.receive()
+            except pywatchman.SocketTimeout:
+                continue
 
-    def _start_subprocess(self, cmd: list[str]) -> subprocess.Popen:
-        return subprocess.Popen(cmd, cwd=str(PROJECT_ROOT))
+            data = client.getSubscription(sub_name)
+            if not data:
+                continue
 
-    def _stop_subprocess(self, proc: subprocess.Popen):
-        if proc.poll() is not None:
-            return
-        proc.send_signal(signal.SIGTERM)
-        try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5)
+            changed: set[str] = set()
+            for notification in data:
+                changed.update(notification.get("files", []))
+
+            if not changed:
+                continue
+
+            sample = list(changed)[:3]
+            suffix = f" (+{len(changed) - 3} more)" if len(changed) > 3 else ""
+            self.stdout.write(
+                self.style.WARNING(f"Change detected: {', '.join(sample)}{suffix} — restarting celery {process_type}")
+            )
+
+            # Re-exec the entire process — replaces this process in-place
+            os.execv(sys.executable, [sys.executable, *sys.argv])

--- a/posthog/management/commands/run_autoreload_celery.py
+++ b/posthog/management/commands/run_autoreload_celery.py
@@ -6,8 +6,6 @@ from typing import Literal
 
 from django.core.management.base import BaseCommand
 
-import pywatchman
-
 from posthog.tasks.utils import CeleryQueue
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
@@ -20,7 +18,7 @@ class Command(BaseCommand):
     help = "Run Celery with watchman-based auto-reload"
 
     def add_arguments(self, parser):
-        parser.add_argument("--type", type=str, choices=("worker", "beat"), help="Process type")
+        parser.add_argument("--type", type=str, required=True, choices=("worker", "beat"), help="Process type")
         parser.add_argument("--no-reload", action="store_true", help="Disable auto-reload")
 
     def handle(self, *args, **options):
@@ -57,20 +55,16 @@ class Command(BaseCommand):
         thread.start()
 
     def _watchman_loop(self, process_type: Literal["worker", "beat"]):
+        import pywatchman
+
         try:
             client = pywatchman.client(timeout=5)
-            root = str(PROJECT_ROOT)
-            client.query("watch-project", root)
-        except (pywatchman.WatchmanError, pywatchman.CommandError, ConnectionError, OSError) as e:
-            self.stderr.write(self.style.WARNING(f"Watchman not available, auto-reload disabled: {e}"))
-            return
+            result = client.query("watch-project", str(PROJECT_ROOT))
+            watch_root = result["watch"]
+            relative_path = result.get("relative_path")
 
-        sub_name = f"celery-reload-{process_type}-{os.getpid()}"
-        client.query(
-            "subscribe",
-            root,
-            sub_name,
-            {
+            sub_name = f"celery-reload-{process_type}-{os.getpid()}"
+            sub_opts: dict = {
                 "expression": [
                     "allof",
                     ["suffix", "py"],
@@ -84,15 +78,21 @@ class Command(BaseCommand):
                 "fields": ["name"],
                 "drop": ["stat"],
                 "defer_vcs": True,
-            },
-        )
+            }
+            if relative_path:
+                sub_opts["relative_root"] = relative_path
+
+            client.query("subscribe", watch_root, sub_name, sub_opts)
+        except (pywatchman.WatchmanError, pywatchman.CommandError, ConnectionError, OSError) as e:
+            self.stderr.write(self.style.WARNING(f"Watchman not available, auto-reload disabled: {e}"))
+            return
 
         self.stdout.write(
             self.style.SUCCESS(f"Watching {', '.join(WATCH_DIRS)} for .py changes (celery {process_type})")
         )
 
-        # Skip initial notification from subscription setup — watchman sends the
-        # current state of matching files immediately upon subscribing
+        # Skip initial notification — watchman sends the current state of matching
+        # files immediately upon subscribing
         try:
             client.receive()
             client.getSubscription(sub_name)
@@ -104,6 +104,9 @@ class Command(BaseCommand):
                 client.receive()
             except pywatchman.SocketTimeout:
                 continue
+            except (pywatchman.WatchmanError, ConnectionError, OSError) as e:
+                self.stderr.write(self.style.WARNING(f"Watchman connection lost, auto-reload disabled: {e}"))
+                return
 
             data = client.getSubscription(sub_name)
             if not data:


### PR DESCRIPTION
**Problem**
Django's `autoreload.run_with_reloader()` forks a full Django process as the parent file watcher — ~146 MB per celery process. With worker + beat that's significant memory sitting idle just to detect .py changes.

**Fix**
Run a pywatchman subscription as a daemon thread inside the celery process itself. On file change, `os.execv()` re-execs in-place (same PID, fresh interpreter). No fork, no subprocess — single process per celery type.

- Watches `posthog/`, `ee/`, `products/` for .py changes via the already-running watchman daemon (provided by flox)
- Gracefully degrades when watchman is unavailable (CI) — logs a warning and runs without reload
- Prod is unaffected — uses `bin/docker-worker-celery`, not this command