### PR TITLE
chore: add logs to person splitting process

### DIFF
--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -5,11 +5,15 @@ from django.core.exceptions import EmptyResultSet
 from django.db import connections, models, router, transaction
 from django.db.models import F, Q
 
+import structlog
+
 from posthog.models.utils import UUIDT
 from posthog.person_db_router import PERSONS_DB_FOR_READ
 
 from ..team import Team
 from .missing_person import uuidFromDistinctId
+
+logger = structlog.get_logger(__name__)
 
 MAX_LIMIT_DISTINCT_IDS = 2500
 
@@ -271,6 +275,18 @@ class Person(models.Model):
         original_person = Person.objects.get(team_id=self.team_id, pk=self.pk)
         distinct_ids = original_person.distinct_ids
         original_person_version = original_person.version or 0
+
+        logger.info(
+            "split_person queried person",
+            person_id=self.pk,
+            person_uuid=str(original_person.uuid),
+            team_id=self.team_id,
+            version=original_person_version,
+            distinct_ids_count=len(distinct_ids),
+            main_distinct_id=main_distinct_id,
+            max_splits=max_splits,
+        )
+
         if not main_distinct_id:
             self.properties = {}
             self.save()
@@ -280,8 +296,17 @@ class Person(models.Model):
             # Split the last N distinct_ids of the list
             distinct_ids = distinct_ids[-1 * max_splits :]
 
-        for distinct_id in distinct_ids:
-            if not distinct_id == main_distinct_id:
+        ids_to_split = [did for did in distinct_ids if did != main_distinct_id]
+        logger.info(
+            "split_person will split distinct_ids",
+            person_id=self.pk,
+            team_id=self.team_id,
+            main_distinct_id=main_distinct_id,
+            ids_to_split_count=len(ids_to_split),
+        )
+
+        for distinct_id in ids_to_split:
+            try:
                 db_alias = router.db_for_write(PersonDistinctId) or "default"
                 with transaction.atomic(using=db_alias):
                     pdi = PersonDistinctId.objects.select_for_update().get(person=self, distinct_id=distinct_id)
@@ -313,6 +338,14 @@ class Person(models.Model):
                 create_person(
                     team_id=self.team_id, uuid=str(person.uuid), version=person.version, created_at=person.created_at
                 )
+            except Exception:
+                logger.exception(
+                    "split_person failed to split distinct_id",
+                    person_id=self.pk,
+                    team_id=self.team_id,
+                    distinct_id=distinct_id,
+                )
+                raise
 
 
 class PersonDistinctId(models.Model):

--- a/posthog/tasks/split_person.py
+++ b/posthog/tasks/split_person.py
@@ -1,8 +1,11 @@
 from typing import Optional, Union
 
+import structlog
 from celery import shared_task
 
 from posthog.models import Person
+
+logger = structlog.get_logger(__name__)
 
 
 @shared_task(ignore_result=True, max_retries=1)
@@ -19,6 +22,14 @@ def split_person(
     For backward compatibility during rolling deploys, if team_id looks like a string
     (old main_distinct_id position), we fall back to legacy behavior.
     """
+    logger.info(
+        "split_person task started",
+        person_id=person_id,
+        team_id=team_id,
+        main_distinct_id=main_distinct_id,
+        max_splits=max_splits,
+    )
+
     # Backward compatibility: detect old 3-arg signature (person_id, main_distinct_id, max_splits)
     # where second arg would be a string (distinct_id) or None
     if isinstance(team_id, str) or (team_id is None and main_distinct_id is None):


### PR DESCRIPTION
## Problem

Person splliting does not seem to be working reliably

## Changes

Add logs to figure out where the process is failing

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
