### PR TITLE
feat(replay): disable summarize button on home page when no filters set

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
@@ -100,6 +100,7 @@ export function Playlist({
         visiblePinnedRecordings: pinnedRecordings,
         otherRecordings,
         hasNext,
+        summarizeDisabledReason,
     } = useValues(sessionRecordingsPlaylistLogic)
     const { maybeLoadSessionRecordings, setFilters, setSelectedRecordingId, loadSessionRecordings } =
         useActions(sessionRecordingsPlaylistLogic)
@@ -333,7 +334,7 @@ export function Playlist({
                             fullWidth
                             size="small"
                             className="mt-2"
-                            disabledReason={!firstItem ? 'No recordings in the list' : undefined}
+                            disabledReason={summarizeDisabledReason}
                         >
                             Summarize these recordings
                             <LemonTag type="warning" size="small" className="ml-auto uppercase">

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -23,7 +23,6 @@ export function SessionRecordingsPlaylist({
     ...props
 }: SessionRecordingPlaylistLogicProps & {
     showContent?: boolean
-    type?: 'filters' | 'collection'
     isSynthetic?: boolean
     description?: string
 }): JSX.Element {
@@ -57,7 +56,6 @@ function HorizontalLayout({
     ...props
 }: SessionRecordingPlaylistLogicProps & {
     showContent?: boolean
-    type?: 'filters' | 'collection'
     isSynthetic?: boolean
     description?: string
 }): JSX.Element {
@@ -109,7 +107,6 @@ function VerticalLayout({
     ...props
 }: SessionRecordingPlaylistLogicProps & {
     showContent?: boolean
-    type?: 'filters' | 'collection'
     isSynthetic?: boolean
     description?: string
 }): JSX.Element {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -1238,4 +1238,89 @@ describe('sessionRecordingsPlaylistLogic', () => {
             }).toMatchValues({ totalFiltersCount: 1 })
         })
     })
+
+    describe('summarizeDisabledReason', () => {
+        it.each([
+            {
+                scenario: 'no type, no filters, no recordings',
+                props: { logicKey: 'summarize-test' },
+                hasRecordings: false,
+                hasFilters: false,
+                expected: 'No recordings in the list',
+            },
+            {
+                scenario: 'no type, no filters, has recordings',
+                props: { logicKey: 'summarize-test' },
+                hasRecordings: true,
+                hasFilters: false,
+                expected: 'Add filters to summarize recordings',
+            },
+            {
+                scenario: 'no type, has filters, has recordings',
+                props: { logicKey: 'summarize-test' },
+                hasRecordings: true,
+                hasFilters: true,
+                expected: undefined,
+            },
+            {
+                scenario: 'collection type, no filters, no recordings',
+                props: { logicKey: 'summarize-test', type: 'collection' as const },
+                hasRecordings: false,
+                hasFilters: false,
+                expected: 'No recordings in the list',
+            },
+            {
+                scenario: 'collection type, no filters, has recordings',
+                props: { logicKey: 'summarize-test', type: 'collection' as const },
+                hasRecordings: true,
+                hasFilters: false,
+                expected: undefined,
+            },
+            {
+                scenario: 'filters type, no filters, no recordings',
+                props: { logicKey: 'summarize-test', type: 'filters' as const },
+                hasRecordings: false,
+                hasFilters: false,
+                expected: 'No recordings in the list',
+            },
+            {
+                scenario: 'filters type, no filters, has recordings',
+                props: { logicKey: 'summarize-test', type: 'filters' as const },
+                hasRecordings: true,
+                hasFilters: false,
+                expected: undefined,
+            },
+        ])('$scenario -> $expected', async ({ props, hasRecordings, hasFilters, expected }) => {
+            logic = sessionRecordingsPlaylistLogic(props)
+            logic.mount()
+
+            if (hasRecordings) {
+                await expectLogic(logic).toDispatchActionsInAnyOrder(['loadSessionRecordingsSuccess'])
+            }
+
+            if (hasFilters) {
+                logic.actions.setFilters({
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        type: PropertyFilterType.LogEntry,
+                                        key: 'level',
+                                        operator: PropertyOperator.IContains,
+                                        value: ['error'],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                })
+                await expectLogic(logic).toDispatchActionsInAnyOrder(['loadSessionRecordingsSuccess'])
+            }
+
+            expectLogic(logic).toMatchValues({ summarizeDisabledReason: expected })
+        })
+    })
 })

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -531,6 +531,7 @@ export interface SessionRecordingPlaylistLogicProps {
     updateSearchParams?: boolean
     autoPlay?: boolean
     onlyPinned?: boolean
+    type?: 'filters' | 'collection'
     filters?: RecordingUniversalFilters
     onFiltersChange?: (filters: RecordingUniversalFilters) => void
     pinnedFilters?: UniversalFiltersGroup
@@ -1403,6 +1404,19 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                         ? 0
                         : 1)
                 )
+            },
+        ],
+
+        summarizeDisabledReason: [
+            (s) => [s.totalFiltersCount, s.recordings, (_, props) => props.type],
+            (totalFiltersCount, recordings, type): string | undefined => {
+                if (recordings.length === 0) {
+                    return 'No recordings in the list'
+                }
+                if (!type && totalFiltersCount === 0) {
+                    return 'Add filters to summarize recordings'
+                }
+                return undefined
             },
         ],
 


### PR DESCRIPTION
## Summary

- Disables the "Summarize these recordings" button on the replay home page when no filters are active — summarizing unfiltered recent recordings isn't useful and could be expensive
- On saved filters and collections the button remains enabled since those views have intentional curation
- Adds a `summarizeDisabledReason` selector to `sessionRecordingsPlaylistLogic` so the logic lives in kea rather than inline in the component

## Test plan

- [ ] On the replay home page with no filters: button shows disabled with "Add filters to summarize recordings"
- [ ] On the replay home page after adding a filter: button becomes enabled
- [ ] On a saved filter view: button is enabled regardless of filter count
- [ ] On a collection view: button is enabled
- [ ] When there are no recordings in the list: button shows disabled with "No recordings in the list"

🤖 Generated with [Claude Code](https://claude.com/claude-code)