### PR TITLE
fix(batch-exports): add timeout and retry policy to Azure Blob uploads

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -158,9 +158,8 @@ class AzureBlobConsumer(Consumer):
             conn_str=connection_string,
             max_single_put_size=64 * 1024 * 1024,  # 64 MiB
             max_block_size=4 * 1024 * 1024,  # 4 MiB
-            connection_timeout=30,
             read_timeout=600,
-            retry_policy=ExponentialRetry(initial_backoff=2, increment_base=3, retry_total=3),
+            retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3),
         )
         container_client = blob_service_client.get_container_client(inputs.container_name)
 

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -160,6 +160,7 @@ class AzureBlobConsumer(Consumer):
             max_block_size=4 * 1024 * 1024,  # 4 MiB
             # Increase the read timeout to 10 minutes to account for large uploads.
             read_timeout=600,
+            # Azure SDK defaults but we set them explicitly for visibility.
             retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3),
         )
         container_client = blob_service_client.get_container_client(inputs.container_name)

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -158,6 +158,7 @@ class AzureBlobConsumer(Consumer):
             conn_str=connection_string,
             max_single_put_size=64 * 1024 * 1024,  # 64 MiB
             max_block_size=4 * 1024 * 1024,  # 4 MiB
+            # Increase the read timeout to 10 minutes to account for large uploads.
             read_timeout=600,
             retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3),
         )

--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -4,7 +4,7 @@ import dataclasses
 
 from django.conf import settings
 
-from azure.storage.blob.aio import BlobServiceClient, ContainerClient
+from azure.storage.blob.aio import BlobServiceClient, ContainerClient, ExponentialRetry
 from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
@@ -158,6 +158,9 @@ class AzureBlobConsumer(Consumer):
             conn_str=connection_string,
             max_single_put_size=64 * 1024 * 1024,  # 64 MiB
             max_block_size=4 * 1024 * 1024,  # 4 MiB
+            connection_timeout=30,
+            read_timeout=600,
+            retry_policy=ExponentialRetry(initial_backoff=2, increment_base=3, retry_total=3),
         )
         container_client = blob_service_client.get_container_client(inputs.container_name)
 


### PR DESCRIPTION
## Problem

Azure Blob Storage batch exports can fail with `ServiceResponseTimeoutError` ("Timeout on reading data from socket") during large uploads.

## Changes

Adds configuration parameters to the `BlobServiceClient` in `AzureBlobConsumer.from_inputs()`:

- `read_timeout=600` — 10 min for socket reads (generous for large uploads)
- `retry_policy=ExponentialRetry(initial_backoff=15, increment_base=3, retry_total=3)` — these are the default values but added for improved visibility

## How did you test this code?

Ran the Azure tests against the local azurite container.

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Co-authored with Claude Code.