### PR TITLE
chore(llma): auto-install sentiment deps when llm_analytics intent is enabled

### DIFF
--- a/bin/download-sentiment-model
+++ b/bin/download-sentiment-model
@@ -1,58 +1,59 @@
-#!/bin/bash
-set -eo pipefail
+#!/usr/bin/env python3
+"""Download and export the sentiment ONNX model for LLM Analytics."""
 
-CACHE_DIR="${POSTHOG_SENTIMENT_MODEL_CACHE:-/tmp/posthog-sentiment-onnx-cache}"
+import os
+import sys
+from pathlib import Path
 
-REQUIRED_FILES=("model.onnx" "tokenizer.json" "config.json")
-ALL_PRESENT=true
-for f in "${REQUIRED_FILES[@]}"; do
-    if [ ! -f "$CACHE_DIR/$f" ]; then
-        ALL_PRESENT=false
-        break
-    fi
-done
-
-if [ "$ALL_PRESENT" = true ]; then
-    echo "Sentiment ONNX model already exists at $CACHE_DIR"
-    exit 0
-fi
-
-echo "Downloading and exporting sentiment ONNX model to $CACHE_DIR..."
-echo "This requires the sentiment dependency group (uv sync --group sentiment)"
-
-python3 - <<'PYEOF'
-import os, torch
-from transformers import AutoTokenizer, pipeline
-from optimum.onnxruntime import ORTModelForSequenceClassification
+CACHE_DIR = Path(os.environ.get("POSTHOG_SENTIMENT_MODEL_CACHE", "/tmp/posthog-sentiment-onnx-cache"))
+REQUIRED_FILES = ("model.onnx", "tokenizer.json", "config.json")
 
 MODEL_NAME = "cardiffnlp/twitter-roberta-base-sentiment-latest"
 MODEL_REVISION = "3216a57f2a0d9c45a2e6c20157c20c49fb4bf9c7"
 
-cache_dir = os.environ.get("POSTHOG_SENTIMENT_MODEL_CACHE", "/tmp/posthog-sentiment-onnx-cache")
-os.makedirs(cache_dir, exist_ok=True)
 
-print(f"Downloading {MODEL_NAME} (revision {MODEL_REVISION[:12]})")
-tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, revision=MODEL_REVISION)
+def main() -> None:
+    if all((CACHE_DIR / f).exists() for f in REQUIRED_FILES):
+        print(f"Sentiment ONNX model already exists at {CACHE_DIR}")
+        sys.exit(0)
 
-# PyTorch 2.9+ defaults torch.onnx.export to dynamo=True which breaks optimum
-original_export = torch.onnx.export
-def export_with_dynamo_disabled(*args, **kwargs):
-    kwargs.setdefault("dynamo", False)
-    return original_export(*args, **kwargs)
-torch.onnx.export = export_with_dynamo_disabled
+    print(f"Downloading and exporting sentiment ONNX model to {CACHE_DIR}...")
 
-print("Exporting to ONNX...")
-model = ORTModelForSequenceClassification.from_pretrained(MODEL_NAME, revision=MODEL_REVISION, export=True)
-torch.onnx.export = original_export
+    import torch
+    from optimum.onnxruntime import ORTModelForSequenceClassification
+    from transformers import AutoTokenizer, pipeline
 
-model.save_pretrained(cache_dir)
-tokenizer.save_pretrained(cache_dir)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-print("Running smoke test...")
-pipe = pipeline("sentiment-analysis", model=model, tokenizer=tokenizer, top_k=None, truncation=True, max_length=512)
-result = pipe("I love this product")[0]
-labels = {r["label"]: r["score"] for r in result}
-assert labels.get("positive", 0) > 0.5, f"Smoke test failed: expected positive > 0.5, got {labels}"
-print(f"Smoke test passed: positive={labels['positive']:.4f}")
-print(f"Model saved to {cache_dir}")
-PYEOF
+    print(f"Downloading {MODEL_NAME} (revision {MODEL_REVISION[:12]})")
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, revision=MODEL_REVISION)
+
+    # PyTorch 2.9+ defaults torch.onnx.export to dynamo=True which breaks optimum
+    original_export = torch.onnx.export
+
+    def export_with_dynamo_disabled(*args, **kwargs):
+        kwargs.setdefault("dynamo", False)
+        return original_export(*args, **kwargs)
+
+    torch.onnx.export = export_with_dynamo_disabled
+
+    print("Exporting to ONNX...")
+    model = ORTModelForSequenceClassification.from_pretrained(MODEL_NAME, revision=MODEL_REVISION, export=True)
+    torch.onnx.export = original_export
+
+    model.save_pretrained(CACHE_DIR)
+    tokenizer.save_pretrained(CACHE_DIR)
+
+    print("Running smoke test...")
+    pipe = pipeline(
+        "sentiment-analysis", model=model, tokenizer=tokenizer, top_k=None, truncation=True, max_length=512
+    )
+    result = pipe("I love this product")[0]
+    labels = {r["label"]: r["score"] for r in result}
+    assert labels.get("positive", 0) > 0.5, f"Smoke test failed: expected positive > 0.5, got {labels}"
+    print(f"Smoke test passed: positive={labels['positive']:.4f}")
+    print(f"Model saved to {CACHE_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/download-sentiment-model
+++ b/bin/download-sentiment-model
@@ -20,7 +20,7 @@ fi
 echo "Downloading and exporting sentiment ONNX model to $CACHE_DIR..."
 echo "This requires the sentiment dependency group (uv sync --group sentiment)"
 
-python - <<'PYEOF'
+python3 - <<'PYEOF'
 import os, torch
 from transformers import AutoTokenizer, pipeline
 from optimum.onnxruntime import ORTModelForSequenceClassification

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -165,6 +165,10 @@ class MprocsGenerator(ConfigGenerator):
             if name == "backend":
                 proc_config = self._add_personhog_env(proc_config, resolved)
 
+            # Special handling for temporal-worker - install uv groups when capabilities require them
+            if name == "temporal-worker":
+                proc_config = self._add_uv_groups(proc_config, resolved)
+
             # Add logging wrapper if enabled
             if source_config and source_config.log_to_files:
                 proc_config = self._add_logging(proc_config, name)
@@ -305,6 +309,29 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
             )
             proc_config["shell"] = f"{env_exports} && {original_shell}"
 
+        return proc_config
+
+    def _add_uv_groups(self, proc_config: dict[str, Any], resolved: ResolvedEnvironment) -> dict[str, Any]:
+        """Prepend uv sync --group and model download commands when uv_groups are resolved.
+
+        Currently handles the sentiment group (installs torch/optimum and downloads the ONNX model).
+        """
+        if not resolved.uv_groups:
+            return proc_config
+
+        original_shell = proc_config.get("shell", "")
+        if not original_shell:
+            return proc_config
+
+        # Build uv sync command with all resolved groups
+        group_flags = " ".join(f"--group {g}" for g in sorted(resolved.uv_groups))
+        prefix = f"uv sync {group_flags} --inexact"
+
+        # Add model download for sentiment group
+        if "sentiment" in resolved.uv_groups:
+            prefix += " && bin/download-sentiment-model"
+
+        proc_config["shell"] = f"{prefix} && {original_shell}"
         return proc_config
 
     def _add_logging(self, proc_config: dict[str, Any], process_name: str) -> dict[str, Any]:

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -329,7 +329,7 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
 
         # Add model download for sentiment group
         if "sentiment" in resolved.uv_groups:
-            prefix += " && bin/download-sentiment-model"
+            prefix += " && uv run --group sentiment bin/download-sentiment-model"
 
         proc_config["shell"] = f"{prefix} && {original_shell}"
         return proc_config

--- a/common/hogli/devenv/resolver.py
+++ b/common/hogli/devenv/resolver.py
@@ -34,6 +34,7 @@ class Capability:
     description: str
     requires: list[str] = field(default_factory=list)
     docker_profiles: list[str] = field(default_factory=list)
+    uv_groups: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -76,6 +77,7 @@ class IntentMap:
                 description=cap_data.get("description", ""),
                 requires=cap_data.get("requires", []),
                 docker_profiles=cap_data.get("docker_profiles", []),
+                uv_groups=cap_data.get("uv_groups", []),
             )
 
         intents = {}
@@ -102,6 +104,7 @@ class ResolvedEnvironment:
     capabilities: set[str]
     intents: set[str]
     docker_profiles: set[str] = field(default_factory=set)
+    uv_groups: set[str] = field(default_factory=set)
     overrides_applied: dict[str, list[str]] = field(default_factory=dict)
     unit_provenance: dict[str, str] = field(default_factory=dict)  # unit -> reason
     skip_autostart: set[str] = field(default_factory=set)  # units to include but not auto-start
@@ -114,6 +117,10 @@ class ResolvedEnvironment:
     def get_docker_profiles_list(self) -> list[str]:
         """Get sorted list of docker profiles for consistent output."""
         return sorted(self.docker_profiles)
+
+    def get_uv_groups_list(self) -> list[str]:
+        """Get sorted list of uv dependency groups for consistent output."""
+        return sorted(self.uv_groups)
 
     def get_unit_reason(self, unit: str) -> str:
         """Get human-readable reason why a unit is included."""
@@ -189,6 +196,9 @@ class IntentResolver:
         # 4. Capabilities → Docker profiles
         docker_profiles = self._capabilities_to_docker_profiles(expanded_capabilities)
 
+        # 4b. Capabilities → UV dependency groups
+        uv_groups = self._capabilities_to_uv_groups(expanded_capabilities)
+
         # 5. Apply include overrides
         for unit in include_units:
             if unit not in units:
@@ -219,6 +229,7 @@ class IntentResolver:
             capabilities=expanded_capabilities,
             intents=set(intents),
             docker_profiles=docker_profiles,
+            uv_groups=uv_groups,
             overrides_applied=overrides_applied,
             unit_provenance=unit_provenance,
             skip_autostart=set(skip_autostart),
@@ -311,6 +322,16 @@ class IntentResolver:
 
         return profiles
 
+    def _capabilities_to_uv_groups(self, capabilities: set[str]) -> set[str]:
+        """Map capabilities to their uv dependency groups."""
+        groups: set[str] = set()
+
+        for cap_name in capabilities:
+            capability = self.intent_map.capabilities[cap_name]
+            groups.update(capability.uv_groups)
+
+        return groups
+
     def get_available_intents(self) -> list[tuple[str, str]]:
         """Get list of available intents with descriptions."""
         return [(name, intent.description) for name, intent in sorted(self.intent_map.intents.items())]
@@ -347,6 +368,12 @@ class IntentResolver:
                 lines.append(f"  • {profile}")
         else:
             lines.append("\nDocker profiles: (core only)")
+
+        # UV groups
+        if resolved.uv_groups:
+            lines.append("\nPython dependency groups:")
+            for group in sorted(resolved.uv_groups):
+                lines.append(f"  • {group}")
 
         # Units
         lines.append("\nProcesses to start:")

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -88,6 +88,12 @@ capabilities:
         requires: [core_infra]
         docker_profiles: []
 
+    llm_analytics_sentiment:
+        description: 'Sentiment classification model for LLM Analytics (installs torch, optimum ~2GB)'
+        requires: [temporal_workflows]
+        docker_profiles: []
+        uv_groups: [sentiment]
+
     livestream:
         description: 'Real-time event streaming'
         requires: [event_ingestion]
@@ -207,7 +213,15 @@ intents:
 
     llm_analytics:
         description: 'LLM/AI observability and analytics'
-        capabilities: [event_ingestion, ai_capture, llm_gateway, property_definitions, temporal_workflows]
+        capabilities:
+            [
+                event_ingestion,
+                ai_capture,
+                llm_gateway,
+                property_definitions,
+                temporal_workflows,
+                llm_analytics_sentiment,
+            ]
 
     web_analytics:
         description: 'Web analytics, traffic analysis, and heatmaps'

--- a/posthog/temporal/llm_analytics/sentiment/README.md
+++ b/posthog/temporal/llm_analytics/sentiment/README.md
@@ -45,7 +45,7 @@ In production the model is baked into the Docker image at build time
 To download the model locally for development:
 
 ```bash
-bin/download-sentiment-model
+uv run --group sentiment bin/download-sentiment-model
 ```
 
 This is a no-op if the model already exists.


### PR DESCRIPTION
## Problem

Developers working on LLM Analytics locally need to manually install the sentiment Python dependencies (`torch`, `optimum`, `transformers` ~2GB) and download the ONNX model separately. The flox activation hook runs `uv sync` (without `--group sentiment`) which strips these packages on every restart, requiring repeated manual reinstallation.

## Changes

Adds `uv_groups` support to the hogli intent resolution system, parallel to the existing `docker_profiles` pattern:

- **`devenv/intent-map.yaml`**: New `llm_analytics_sentiment` capability with `uv_groups: [sentiment]`, added to the `llm_analytics` intent
- **`common/hogli/devenv/resolver.py`**: `uv_groups` field on `Capability` and `ResolvedEnvironment`, collected during resolution like `docker_profiles`
- **`common/hogli/devenv/generator.py`**: `_add_uv_groups` method prepends `uv sync --group sentiment --inexact && bin/download-sentiment-model` to the temporal-worker shell command when the capability is active
- **`bin/download-sentiment-model`**: Fixed to use `python3` instead of `python` (which doesn't exist in flox)

When `llm_analytics` is enabled via `hogli dev:setup`, the temporal-worker startup automatically installs the sentiment packages and downloads the ONNX model. No impact on developers who don't use `llm_analytics`. Packages are cached by uv so re-installs after the first are fast (~1-2s).

## How did you test this code?

- All 37 existing devenv tests pass (`pytest common/hogli/tests/test_devenv.py`)
- Verified `llm_analytics` intent resolves `uv_groups: {'sentiment'}` with temporal-worker in units
- Verified `product_analytics` intent resolves `uv_groups: set()` (no impact)
- Verified generated temporal-worker shell command includes `uv sync --group sentiment --inexact && bin/download-sentiment-model` prefix

## Publish to changelog?

No