### PR TITLE
feat(cohort): update hog functions when cohort test filter changes

### DIFF
--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -275,9 +275,6 @@ def cohort_saved(sender, instance, **kwargs):
     # this cohort in their test_account_filters (cohorts are inlined into bytecode).
     # Deletion is handled separately: the cohort API prevents deleting cohorts
     # that are referenced in test_account_filters.
-    #
-    # Quick check before dispatching: skip if the team doesn't reference any
-    # cohort in test_account_filters, avoiding unnecessary task overhead.
     team = instance.team
     if not team.test_account_filters or not any(
         f.get("type") == "cohort" for f in team.test_account_filters if isinstance(f, dict)

--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -277,7 +277,9 @@ def cohort_saved(sender, instance, **kwargs):
     # that are referenced in test_account_filters.
     team = instance.team
     if team.test_account_filters and any(
-        f.get("type") == "cohort" for f in team.test_account_filters if isinstance(f, dict)
+        f.get("type") == "cohort" and f.get("value") == instance.id
+        for f in team.test_account_filters
+        if isinstance(f, dict)
     ):
         from posthog.tasks.hog_functions import refresh_affected_hog_functions
 

--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -276,14 +276,12 @@ def cohort_saved(sender, instance, **kwargs):
     # Deletion is handled separately: the cohort API prevents deleting cohorts
     # that are referenced in test_account_filters.
     team = instance.team
-    if not team.test_account_filters or not any(
+    if team.test_account_filters and any(
         f.get("type") == "cohort" for f in team.test_account_filters if isinstance(f, dict)
     ):
-        return
+        from posthog.tasks.hog_functions import refresh_affected_hog_functions
 
-    from posthog.tasks.hog_functions import refresh_affected_hog_functions
-
-    refresh_affected_hog_functions.delay(cohort_id=instance.id)
+        refresh_affected_hog_functions.delay(cohort_id=instance.id)
 
 
 @mutable_receiver([post_save, post_delete], sender=HogFunction)

--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -269,10 +269,21 @@ def team_saved(sender, instance: Team, created, **kwargs):
     refresh_affected_hog_functions.delay(team_id=instance.id)
 
 
-@receiver([post_save, post_delete], sender="posthog.Cohort")
-def cohort_changed(sender, instance, **kwargs):
-    # When a cohort changes or is deleted, recompile hog functions for any team
-    # that uses this cohort in their test_account_filters (cohorts are inlined into bytecode)
+@receiver(post_save, sender="posthog.Cohort")
+def cohort_saved(sender, instance, **kwargs):
+    # When a cohort changes, recompile hog functions for any team that uses
+    # this cohort in their test_account_filters (cohorts are inlined into bytecode).
+    # Deletion is handled separately: the cohort API prevents deleting cohorts
+    # that are referenced in test_account_filters.
+    #
+    # Quick check before dispatching: skip if the team doesn't reference any
+    # cohort in test_account_filters, avoiding unnecessary task overhead.
+    team = instance.team
+    if not team.test_account_filters or not any(
+        f.get("type") == "cohort" for f in team.test_account_filters if isinstance(f, dict)
+    ):
+        return
+
     from posthog.tasks.hog_functions import refresh_affected_hog_functions
 
     refresh_affected_hog_functions.delay(cohort_id=instance.id)

--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -269,6 +269,15 @@ def team_saved(sender, instance: Team, created, **kwargs):
     refresh_affected_hog_functions.delay(team_id=instance.id)
 
 
+@receiver([post_save, post_delete], sender="posthog.Cohort")
+def cohort_changed(sender, instance, **kwargs):
+    # When a cohort changes or is deleted, recompile hog functions for any team
+    # that uses this cohort in their test_account_filters (cohorts are inlined into bytecode)
+    from posthog.tasks.hog_functions import refresh_affected_hog_functions
+
+    refresh_affected_hog_functions.delay(cohort_id=instance.id)
+
+
 @mutable_receiver([post_save, post_delete], sender=HogFunction)
 def team_inject_web_apps_changd(sender, instance, created=None, **kwargs):
     try:

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -307,11 +307,35 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
                 }
             },
         )
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.id}]
+        self.team.save()
 
         with patch("posthog.tasks.hog_functions.refresh_affected_hog_functions.delay") as mock_delay:
             cohort.name = "Updated name"
             cohort.save()
             mock_delay.assert_any_call(cohort_id=cohort.id)
+
+    def test_cohort_save_signal_skips_when_no_cohort_in_test_filters(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Internal users",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@posthog.com"}],
+                }
+            },
+        )
+        # Team does NOT use cohort in test_account_filters
+        self.team.test_account_filters = [
+            {"type": "person", "key": "email", "operator": "not_icontains", "value": "@posthog.com"}
+        ]
+        self.team.save()
+
+        with patch("posthog.tasks.hog_functions.refresh_affected_hog_functions.delay") as mock_delay:
+            cohort.name = "Updated name"
+            cohort.save()
+            mock_delay.assert_not_called()
 
     def test_cohort_refresh_finds_affected_teams_and_recompiles(self):
         from posthog.tasks.hog_functions import refresh_affected_hog_functions
@@ -336,6 +360,7 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
             filters={"filter_test_accounts": True},
         )
 
+        assert hog_function.filters is not None
         original_bytecode = json.dumps(hog_function.filters["bytecode"])
         assert hog_function.filters.get("bytecode_error") is None
         assert "%@posthog.com%" in original_bytecode
@@ -352,6 +377,7 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
 
         hog_function.refresh_from_db()
         assert result == 1
+        assert hog_function.filters is not None
         new_bytecode = json.dumps(hog_function.filters["bytecode"])
         assert "%@newdomain.com%" in new_bytecode
         assert "%@posthog.com%" not in new_bytecode
@@ -381,13 +407,35 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
             team=self.team,
             filters={"filter_test_accounts": True},
         )
+        assert hog_function.filters is not None
         original_bytecode = json.dumps(hog_function.filters["bytecode"])
 
         result = refresh_affected_hog_functions(cohort_id=cohort.id)
         assert result == 0
 
         hog_function.refresh_from_db()
+        assert hog_function.filters is not None
         assert json.dumps(hog_function.filters["bytecode"]) == original_bytecode
+
+    def test_cohort_refresh_handles_deleted_cohort(self):
+        from posthog.tasks.hog_functions import refresh_affected_hog_functions
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Internal users",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@posthog.com"}],
+                }
+            },
+        )
+        cohort_id = cohort.id
+        cohort.delete()
+
+        # Should not raise — just returns 0
+        result = refresh_affected_hog_functions(cohort_id=cohort_id)
+        assert result == 0
 
     @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
     def test_geoip_transformation_created_when_enabled(self, mock_get_templates):

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from django.test import TestCase
 
 from posthog.models.action.action import Action
+from posthog.models.cohort import Cohort
 from posthog.models.file_system.file_system import FileSystem
 from posthog.models.hog_functions.hog_function import HogFunction, HogFunctionType
 from posthog.models.team.team import Team
@@ -294,6 +295,90 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
         )
 
         assert json.dumps(hog_function_3.filters["bytecode"]) == f'["_H", {HOGQL_BYTECODE_VERSION}, 29]'
+
+    def test_cohort_save_signal_triggers_hog_function_refresh(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Internal users",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@posthog.com"}],
+                }
+            },
+        )
+
+        with patch("posthog.tasks.hog_functions.refresh_affected_hog_functions.delay") as mock_delay:
+            cohort.name = "Updated name"
+            cohort.save()
+            mock_delay.assert_any_call(cohort_id=cohort.id)
+
+    def test_cohort_refresh_finds_affected_teams_and_recompiles(self):
+        from posthog.tasks.hog_functions import refresh_affected_hog_functions
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Internal users",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@posthog.com"}],
+                }
+            },
+        )
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.id}]
+        self.team.save()
+
+        hog_function = HogFunction.objects.create(
+            name="func with test filter",
+            type="destination",
+            team=self.team,
+            filters={"filter_test_accounts": True},
+        )
+        original_updated_at = hog_function.updated_at
+
+        # The task should find this team and attempt to recompile its hog functions.
+        # Cohort inlining isn't on master yet so compilation produces a bytecode_error,
+        # but the key behavior is that the task found the right hog function and attempted
+        # recompilation. When cohort inlining lands, this will produce valid bytecode.
+        result = refresh_affected_hog_functions(cohort_id=cohort.id)
+
+        hog_function.refresh_from_db()
+        assert result == 0  # 0 successful compilations (cohort inlining not yet supported)
+        assert hog_function.updated_at == original_updated_at
+
+    def test_cohort_refresh_skips_unrelated_teams(self):
+        from posthog.tasks.hog_functions import refresh_affected_hog_functions
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Unrelated cohort",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@posthog.com"}],
+                }
+            },
+        )
+        # Team does NOT reference this cohort in test_account_filters
+        self.team.test_account_filters = [
+            {"type": "person", "key": "email", "operator": "not_icontains", "value": "@posthog.com"}
+        ]
+        self.team.save()
+
+        hog_function = HogFunction.objects.create(
+            name="func with test filter",
+            type="destination",
+            team=self.team,
+            filters={"filter_test_accounts": True},
+        )
+        original_bytecode = json.dumps(hog_function.filters["bytecode"])
+
+        result = refresh_affected_hog_functions(cohort_id=cohort.id)
+        assert result == 0
+
+        hog_function.refresh_from_db()
+        assert json.dumps(hog_function.filters["bytecode"]) == original_bytecode
 
     @patch("posthog.plugins.plugin_server_api.get_hog_function_templates")
     def test_geoip_transformation_created_when_enabled(self, mock_get_templates):

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -335,17 +335,26 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
             team=self.team,
             filters={"filter_test_accounts": True},
         )
-        original_updated_at = hog_function.updated_at
 
-        # The task should find this team and attempt to recompile its hog functions.
-        # Cohort inlining isn't on master yet so compilation produces a bytecode_error,
-        # but the key behavior is that the task found the right hog function and attempted
-        # recompilation. When cohort inlining lands, this will produce valid bytecode.
+        original_bytecode = json.dumps(hog_function.filters["bytecode"])
+        assert hog_function.filters.get("bytecode_error") is None
+        assert "%@posthog.com%" in original_bytecode
+
+        # Update the cohort — the task should recompile with the new filter value
+        cohort.filters = {
+            "properties": {
+                "type": "AND",
+                "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@newdomain.com"}],
+            }
+        }
+        cohort.save()
         result = refresh_affected_hog_functions(cohort_id=cohort.id)
 
         hog_function.refresh_from_db()
-        assert result == 0  # 0 successful compilations (cohort inlining not yet supported)
-        assert hog_function.updated_at == original_updated_at
+        assert result == 1
+        new_bytecode = json.dumps(hog_function.filters["bytecode"])
+        assert "%@newdomain.com%" in new_bytecode
+        assert "%@posthog.com%" not in new_bytecode
 
     def test_cohort_refresh_skips_unrelated_teams(self):
         from posthog.tasks.hog_functions import refresh_affected_hog_functions

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -327,10 +327,30 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
                 }
             },
         )
-        # Team does NOT use cohort in test_account_filters
+        # Team uses person property filters, not a cohort
         self.team.test_account_filters = [
             {"type": "person", "key": "email", "operator": "not_icontains", "value": "@posthog.com"}
         ]
+        self.team.save()
+
+        with patch("posthog.tasks.hog_functions.refresh_affected_hog_functions.delay") as mock_delay:
+            cohort.name = "Updated name"
+            cohort.save()
+            mock_delay.assert_not_called()
+
+    def test_cohort_save_signal_skips_when_different_cohort_in_test_filters(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Internal users",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [{"type": "person", "key": "email", "operator": "icontains", "value": "@posthog.com"}],
+                }
+            },
+        )
+        # Team references a different cohort ID
+        self.team.test_account_filters = [{"type": "cohort", "key": "id", "value": cohort.id + 9999}]
         self.team.save()
 
         with patch("posthog.tasks.hog_functions.refresh_affected_hog_functions.delay") as mock_delay:

--- a/posthog/models/test/test_hog_function.py
+++ b/posthog/models/test/test_hog_function.py
@@ -11,6 +11,7 @@ from posthog.models.file_system.file_system import FileSystem
 from posthog.models.hog_functions.hog_function import HogFunction, HogFunctionType
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.tasks.hog_functions import refresh_affected_hog_functions
 
 from common.hogvm.python.operation import HOGQL_BYTECODE_VERSION
 
@@ -338,8 +339,6 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
             mock_delay.assert_not_called()
 
     def test_cohort_refresh_finds_affected_teams_and_recompiles(self):
-        from posthog.tasks.hog_functions import refresh_affected_hog_functions
-
         cohort = Cohort.objects.create(
             team=self.team,
             name="Internal users",
@@ -383,8 +382,6 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
         assert "%@posthog.com%" not in new_bytecode
 
     def test_cohort_refresh_skips_unrelated_teams(self):
-        from posthog.tasks.hog_functions import refresh_affected_hog_functions
-
         cohort = Cohort.objects.create(
             team=self.team,
             name="Unrelated cohort",
@@ -418,8 +415,6 @@ class TestHogFunctionsBackgroundReloading(TestCase, QueryMatchingTest):
         assert json.dumps(hog_function.filters["bytecode"]) == original_bytecode
 
     def test_cohort_refresh_handles_deleted_cohort(self):
-        from posthog.tasks.hog_functions import refresh_affected_hog_functions
-
         cohort = Cohort.objects.create(
             team=self.team,
             name="Internal users",

--- a/posthog/tasks/hog_functions.py
+++ b/posthog/tasks/hog_functions.py
@@ -16,7 +16,9 @@ logger = get_logger(__name__)
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
-def refresh_affected_hog_functions(team_id: Optional[int] = None, action_id: Optional[int] = None) -> int:
+def refresh_affected_hog_functions(
+    team_id: Optional[int] = None, action_id: Optional[int] = None, cohort_id: Optional[int] = None
+) -> int:
     from posthog.models.hog_functions.hog_function import HogFunction
 
     affected_hog_functions: list[HogFunction] = []
@@ -29,6 +31,37 @@ def refresh_affected_hog_functions(team_id: Optional[int] = None, action_id: Opt
             .filter(team_id=action.team_id)
             .filter(filters__contains={"actions": [{"id": str(action_id)}]})
         )
+    elif cohort_id:
+        from posthog.models.cohort import Cohort
+        from posthog.models.team.team import Team
+
+        cohort = Cohort.objects.select_related("team").get(id=cohort_id)
+        # Pre-filter at DB level for teams with any cohort in test_account_filters,
+        # then verify the specific cohort ID in Python (matches pattern in posthog/api/cohort.py)
+        teams = Team.objects.filter(
+            project_id=cohort.team.project_id, test_account_filters__contains=[{"type": "cohort"}]
+        )
+        affected_team_ids: list[int] = []
+        for team in teams:
+            for f in team.test_account_filters:
+                if f.get("type") == "cohort" and f.get("value") == cohort.id:
+                    affected_team_ids.append(team.id)
+                    break
+
+        if not affected_team_ids:
+            return 0
+
+        # If multiple teams are affected, dispatch separate tasks for each beyond the first
+        if len(affected_team_ids) > 1:
+            for extra_team_id in affected_team_ids[1:]:
+                refresh_affected_hog_functions.delay(team_id=extra_team_id)
+
+        team_id = affected_team_ids[0]
+        affected_hog_functions = list(
+            HogFunction.objects.select_related("team")
+            .filter(team_id=team_id)
+            .filter(filters__contains={"filter_test_accounts": True})
+        )
     elif team_id:
         affected_hog_functions = list(
             HogFunction.objects.select_related("team")
@@ -37,7 +70,7 @@ def refresh_affected_hog_functions(team_id: Optional[int] = None, action_id: Opt
         )
 
     if team_id is None:
-        raise Exception("Either team_id or action_id must be provided")
+        raise Exception("Either team_id, action_id, or cohort_id must be provided")
 
     if not affected_hog_functions:
         return 0

--- a/posthog/tasks/hog_functions.py
+++ b/posthog/tasks/hog_functions.py
@@ -33,30 +33,18 @@ def refresh_affected_hog_functions(
         )
     elif cohort_id:
         from posthog.models.cohort import Cohort
-        from posthog.models.team.team import Team
 
         cohort = Cohort.objects.select_related("team").get(id=cohort_id)
-        # Pre-filter at DB level for teams with any cohort in test_account_filters,
-        # then verify the specific cohort ID in Python (matches pattern in posthog/api/cohort.py)
-        teams = Team.objects.filter(
-            project_id=cohort.team.project_id, test_account_filters__contains=[{"type": "cohort"}]
-        )
-        affected_team_ids: list[int] = []
-        for team in teams:
-            for f in team.test_account_filters:
-                if f.get("type") == "cohort" and f.get("value") == cohort.id:
-                    affected_team_ids.append(team.id)
-                    break
+        team = cohort.team
 
-        if not affected_team_ids:
+        # Check if this team references the cohort in its test_account_filters
+        uses_cohort = any(
+            f.get("type") == "cohort" and f.get("value") == cohort.id for f in (team.test_account_filters or [])
+        )
+        if not uses_cohort:
             return 0
 
-        # If multiple teams are affected, dispatch separate tasks for each beyond the first
-        if len(affected_team_ids) > 1:
-            for extra_team_id in affected_team_ids[1:]:
-                refresh_affected_hog_functions.delay(team_id=extra_team_id)
-
-        team_id = affected_team_ids[0]
+        team_id = team.id
         affected_hog_functions = list(
             HogFunction.objects.select_related("team")
             .filter(team_id=team_id)

--- a/posthog/tasks/hog_functions.py
+++ b/posthog/tasks/hog_functions.py
@@ -49,12 +49,9 @@ def refresh_affected_hog_functions(
             return 0
 
         team_id = team.id
-        affected_hog_functions = list(
-            HogFunction.objects.select_related("team")
-            .filter(team_id=team_id)
-            .filter(filters__contains={"filter_test_accounts": True})
-        )
-    elif team_id:
+
+    # For both cohort_id and team_id paths, find hog functions with test account filters enabled
+    if team_id and not affected_hog_functions:
         affected_hog_functions = list(
             HogFunction.objects.select_related("team")
             .filter(team_id=team_id)

--- a/posthog/tasks/hog_functions.py
+++ b/posthog/tasks/hog_functions.py
@@ -34,7 +34,11 @@ def refresh_affected_hog_functions(
     elif cohort_id:
         from posthog.models.cohort import Cohort
 
-        cohort = Cohort.objects.select_related("team").get(id=cohort_id)
+        try:
+            cohort = Cohort.objects.select_related("team").get(id=cohort_id)
+        except Cohort.DoesNotExist:
+            # Cohort was deleted between signal firing and task execution — nothing to refresh
+            return 0
         team = cohort.team
 
         # Check if this team references the cohort in its test_account_filters


### PR DESCRIPTION
## Problem
We recently added support for cohort interal/test filters in hog functions.

The problem is that now we need to make sure that the hog functions update when the cohort is updated

## Changes
Wire this up and add some tests

## How did you test this code?
Added some unit tests that saving a cohort causes the hog functions to update

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
