### PR TITLE
chore(devex): surface review thread resolution in PR approval agent

### DIFF
--- a/tools/pr-approval-agent/github.py
+++ b/tools/pr-approval-agent/github.py
@@ -67,14 +67,46 @@ def _gh_api(endpoint: str, *, paginate: bool = False) -> dict | list:
     return json.loads(result.stdout)
 
 
-def _gh_graphql(query: str) -> dict:
-    """Run a GraphQL query via gh api graphql."""
-    result = subprocess.run(
-        ["gh", "api", "graphql", "-f", f"query={query}"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+_REVIEW_THREADS_QUERY = """
+query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $threadCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 50) {
+            pageInfo { hasNextPage }
+            nodes {
+              author { login __typename }
+              authorAssociation
+              body
+              databaseId
+              replyTo { databaseId }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _gh_graphql(query: str, variables: dict | None = None) -> dict:
+    """Run a GraphQL query via gh api graphql with proper variable passing."""
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, value in (variables or {}).items():
+        if value is None:
+            cmd.extend(["-F", f"{key}=null"])
+        elif isinstance(value, int):
+            cmd.extend(["-F", f"{key}={value}"])
+        else:
+            cmd.extend(["-f", f"{key}={value}"])
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
         raise RuntimeError(f"gh api graphql failed: {result.stderr.strip()}")
     data = json.loads(result.stdout)
@@ -87,56 +119,48 @@ def _fetch_review_threads(repo: str, pr_number: int) -> list[dict]:
     """Fetch review threads with resolution status via GraphQL.
 
     Returns a flat list of comment dicts enriched with is_resolved and
-    is_outdated from their parent thread.
+    is_outdated from their parent thread. Paginates through all threads
+    and raises if any comment page is truncated.
     """
     owner, name = repo.split("/", 1)
-    query = f"""
-    {{
-      repository(owner: "{owner}", name: "{name}") {{
-        pullRequest(number: {pr_number}) {{
-          reviewThreads(first: 100) {{
-            nodes {{
-              isResolved
-              isOutdated
-              path
-              line
-              comments(first: 50) {{
-                nodes {{
-                  author {{ login __typename }}
-                  authorAssociation
-                  body
-                  databaseId
-                  replyTo {{ databaseId }}
-                }}
-              }}
-            }}
-          }}
-        }}
-      }}
-    }}
-    """
-    data = _gh_graphql(query)
-    threads = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    variables: dict = {"owner": owner, "name": name, "pr": pr_number, "threadCursor": None}
 
     comments: list[dict] = []
-    for thread in threads:
-        for c in thread["comments"]["nodes"]:
-            assoc = c.get("authorAssociation", "")
-            is_bot = (c.get("author") or {}).get("__typename") == "Bot"
-            if assoc not in _TRUSTED_ASSOCIATIONS and assoc != "BOT" and not is_bot:
-                continue
-            reply_to = c.get("replyTo")
-            comments.append(
-                {
-                    "user": (c.get("author") or {}).get("login", "ghost"),
-                    "body": c.get("body", ""),
-                    "path": thread.get("path", ""),
-                    "line": thread.get("line"),
-                    "in_reply_to_id": reply_to["databaseId"] if reply_to else None,
-                    "is_resolved": thread["isResolved"],
-                    "is_outdated": thread["isOutdated"],
-                }
-            )
+    while True:
+        data = _gh_graphql(_REVIEW_THREADS_QUERY, variables)
+        review_threads = data["data"]["repository"]["pullRequest"]["reviewThreads"]
+        threads = review_threads["nodes"]
+
+        for thread in threads:
+            comment_page = thread["comments"]
+            if comment_page["pageInfo"]["hasNextPage"]:
+                raise RuntimeError(
+                    f"Review thread on {thread.get('path')}:{thread.get('line')} "
+                    f"has >50 comments — pagination not implemented, escalate to human review"
+                )
+            for c in comment_page["nodes"]:
+                assoc = c.get("authorAssociation", "")
+                is_bot = (c.get("author") or {}).get("__typename") == "Bot"
+                if assoc not in _TRUSTED_ASSOCIATIONS and assoc != "BOT" and not is_bot:
+                    continue
+                reply_to = c.get("replyTo")
+                comments.append(
+                    {
+                        "user": (c.get("author") or {}).get("login", "ghost"),
+                        "body": c.get("body", ""),
+                        "path": thread.get("path", ""),
+                        "line": thread.get("line"),
+                        "in_reply_to_id": reply_to["databaseId"] if reply_to else None,
+                        "is_resolved": thread["isResolved"],
+                        "is_outdated": thread["isOutdated"],
+                    }
+                )
+
+        page_info = review_threads["pageInfo"]
+        if not page_info["hasNextPage"]:
+            break
+        variables["threadCursor"] = page_info["endCursor"]
+
     return comments
 
 

--- a/tools/pr-approval-agent/github.py
+++ b/tools/pr-approval-agent/github.py
@@ -51,6 +51,9 @@ class PRData:
         return any(f.get("status") == "A" for f in self.files)
 
 
+_TRUSTED_ASSOCIATIONS = {"MEMBER", "OWNER", "COLLABORATOR"}
+
+
 def _gh_api(endpoint: str, *, paginate: bool = False) -> dict | list:
     cmd = ["gh", "api", endpoint]
     if paginate:
@@ -62,6 +65,79 @@ def _gh_api(endpoint: str, *, paginate: bool = False) -> dict | list:
     if result.returncode != 0:
         raise RuntimeError(f"gh api {endpoint} failed: {result.stderr.strip()}")
     return json.loads(result.stdout)
+
+
+def _gh_graphql(query: str) -> dict:
+    """Run a GraphQL query via gh api graphql."""
+    result = subprocess.run(
+        ["gh", "api", "graphql", "-f", f"query={query}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh api graphql failed: {result.stderr.strip()}")
+    data = json.loads(result.stdout)
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL errors: {data['errors']}")
+    return data
+
+
+def _fetch_review_threads(repo: str, pr_number: int) -> list[dict]:
+    """Fetch review threads with resolution status via GraphQL.
+
+    Returns a flat list of comment dicts enriched with is_resolved and
+    is_outdated from their parent thread.
+    """
+    owner, name = repo.split("/", 1)
+    query = f"""
+    {{
+      repository(owner: "{owner}", name: "{name}") {{
+        pullRequest(number: {pr_number}) {{
+          reviewThreads(first: 100) {{
+            nodes {{
+              isResolved
+              isOutdated
+              path
+              line
+              comments(first: 50) {{
+                nodes {{
+                  author {{ login __typename }}
+                  authorAssociation
+                  body
+                  databaseId
+                  replyTo {{ databaseId }}
+                }}
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    data = _gh_graphql(query)
+    threads = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+
+    comments: list[dict] = []
+    for thread in threads:
+        for c in thread["comments"]["nodes"]:
+            assoc = c.get("authorAssociation", "")
+            is_bot = (c.get("author") or {}).get("__typename") == "Bot"
+            if assoc not in _TRUSTED_ASSOCIATIONS and assoc != "BOT" and not is_bot:
+                continue
+            reply_to = c.get("replyTo")
+            comments.append(
+                {
+                    "user": (c.get("author") or {}).get("login", "ghost"),
+                    "body": c.get("body", ""),
+                    "path": thread.get("path", ""),
+                    "line": thread.get("line"),
+                    "in_reply_to_id": reply_to["databaseId"] if reply_to else None,
+                    "is_resolved": thread["isResolved"],
+                    "is_outdated": thread["isOutdated"],
+                }
+            )
+    return comments
 
 
 def _git_diff_files(base_sha: str, head_sha: str, repo_root: Path) -> list[dict]:
@@ -123,7 +199,6 @@ def fetch_pr(pr_number: int, repo: str, repo_root: Path | None = None) -> PRData
     """Fetch PR data: metadata from API, file stats from local git."""
     pr = _gh_api(f"repos/{repo}/pulls/{pr_number}")
     reviews_raw = _gh_api(f"repos/{repo}/pulls/{pr_number}/reviews", paginate=True)
-    comments_raw = _gh_api(f"repos/{repo}/pulls/{pr_number}/comments", paginate=True)
 
     base_sha = pr["base"]["sha"]
     head_sha = pr["head"]["sha"]
@@ -132,6 +207,8 @@ def fetch_pr(pr_number: int, repo: str, repo_root: Path | None = None) -> PRData
     git_root = repo_root or Path.cwd()
     ensure_commits(pr_number, head_sha, git_root)
     files = _git_diff_files(base_sha, head_sha, git_root)
+
+    review_comments = _fetch_review_threads(repo, pr_number)
 
     return PRData(
         number=pr_number,
@@ -152,21 +229,11 @@ def fetch_pr(pr_number: int, repo: str, repo_root: Path | None = None) -> PRData
                 "body": r.get("body", ""),
             }
             for r in reviews_raw
-            if r.get("author_association") in ("MEMBER", "OWNER", "COLLABORATOR", "BOT")
+            if r.get("author_association") in _TRUSTED_ASSOCIATIONS
+            or r.get("author_association") == "BOT"
             or r.get("user", {}).get("type") == "Bot"
         ],
-        review_comments=[
-            {
-                "user": c["user"]["login"],
-                "body": c.get("body", ""),
-                "path": c.get("path", ""),
-                "line": c.get("line"),
-                "in_reply_to_id": c.get("in_reply_to_id"),
-            }
-            for c in comments_raw
-            if c.get("author_association") in ("MEMBER", "OWNER", "COLLABORATOR", "BOT")
-            or c.get("user", {}).get("type") == "Bot"
-        ],
+        review_comments=review_comments,
         check_runs=check_runs_resp.get("check_runs", []),
     )
 

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -122,12 +122,22 @@ REVIEWER_SYSTEM = textwrap.dedent(
       - ESCALATE: behavioral changes to business logic, API contracts, data models
 
     Review comments (inline feedback only, approval states are hidden):
+    - Comments are tagged [resolved], [outdated], or unmarked (unresolved).
+      Resolution status is a signal, not gospel — use your judgment.
+    - Resolved/outdated comments are usually fine, but still skim them.
+      If a resolved comment raised a serious concern (security, data
+      loss) that the diff clearly did NOT address, flag it anyway.
+    - For unresolved comments: check whether a subsequent commit or the
+      current diff already addressed the concern. Authors often fix
+      issues in follow-up commits without explicitly resolving the
+      thread. Only flag comments that remain genuinely unaddressed in
+      the current code.
+    - Substantive comments that remain unaddressed → REFUSE
     - "Zero reviews" means no top-level reviews and no inline comments.
       Zero reviews is fine for low-risk changes (trivial fixes, typos,
       test updates, config tweaks). For anything higher-risk, treat zero
       reviews as a concern and ESCALATE unless there's a strong,
       specific justification to APPROVE.
-    - Substantive comments unresolved by the current diff → REFUSE
     - Bot comments with valid concerns that were ignored → ESCALATE
 
     Tools: You have Read, Grep, and Glob (restricted to the repo directory).
@@ -270,7 +280,12 @@ class Reviewer:
                 reply = " (reply)" if c.get("in_reply_to_id") else ""
                 safe_body = _sanitize_untrusted(c["body"], max_len=500)
                 safe_user = _sanitize_untrusted(c["user"], max_len=50)
-                lines.append(f"  - @{safe_user}{reply} on {c['path']}: {safe_body}")
+                status = ""
+                if c.get("is_resolved"):
+                    status = " [resolved]"
+                elif c.get("is_outdated"):
+                    status = " [outdated]"
+                lines.append(f"  - @{safe_user}{reply}{status} on {c['path']}: {safe_body}")
             review_comments = "\n".join(lines)
 
         ownership = self._format_ownership(cl)

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -285,7 +285,8 @@ class Reviewer:
                     status = " [resolved]"
                 elif c.get("is_outdated"):
                     status = " [outdated]"
-                lines.append(f"  - @{safe_user}{reply}{status} on {c['path']}: {safe_body}")
+                safe_path = _sanitize_untrusted(c["path"], max_len=200)
+                lines.append(f"  - @{safe_user}{reply}{status} on {safe_path}: {safe_body}")
             review_comments = "\n".join(lines)
 
         ownership = self._format_ownership(cl)


### PR DESCRIPTION
**Problem**
The PR approval agent lists inline review comments without indicating whether they've been resolved or are outdated. This causes the LLM reviewer to flag old comments that the author already addressed — either by resolving the thread or by pushing a fix commit.

**Changes**
- Switch from REST (`/pulls/{n}/comments`) to GraphQL `reviewThreads` for fetching inline comments — gives us `isResolved` and `isOutdated` per thread
- Add `__typename` check to correctly identify bot users (copilot, greptile) that have `authorAssociation: CONTRIBUTOR` instead of `BOT`
- Annotate each comment in the LLM prompt with `[resolved]` or `[outdated]` tags
- Update the system prompt to treat resolution status as a signal, not gospel — the LLM still skims resolved comments for serious unaddressed concerns, and checks whether follow-up commits addressed unresolved ones before flagging

**Test plan**
- Dry-run against PRs with resolved/outdated threads, verified `is_resolved`/`is_outdated` fields populate correctly and tags appear in prompt