### PR TITLE
feat(experiments): move saved metrics logic to service

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -65,10 +65,6 @@ class ExperimentSavedMetricSerializer(
             "user_access_level",
         ]
 
-    def validate_query(self, value):
-        ExperimentSavedMetricService.validate_query(value)
-        return value
-
     def create(self, validated_data):
         tags = validated_data.pop("tags", None)
         name = validated_data.pop("name")

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -2,19 +2,8 @@ from django.db.models.functions import Lower
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
-import pydantic
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, viewsets
-from rest_framework.exceptions import ValidationError
-
-from posthog.schema import (
-    ExperimentFunnelMetric,
-    ExperimentFunnelsQuery,
-    ExperimentMeanMetric,
-    ExperimentMetricType,
-    ExperimentRatioMetric,
-    ExperimentRetentionMetric,
-    ExperimentTrendsQuery,
-)
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -23,6 +12,8 @@ from posthog.models.activity_logging.activity_log import Detail, changes_between
 from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+
+from products.experiments.backend.experiment_saved_metric_service import ExperimentSavedMetricService
 
 from ee.api.rbac.access_control import AccessControlViewSetMixin
 
@@ -75,53 +66,46 @@ class ExperimentSavedMetricSerializer(
         ]
 
     def validate_query(self, value):
-        if not value:
-            raise ValidationError("Query is required to create a saved metric")
-
-        metric_query = value
-
-        if metric_query.get("kind") not in ["ExperimentMetric", "ExperimentTrendsQuery", "ExperimentFunnelsQuery"]:
-            raise ValidationError(
-                "Metric query kind must be 'ExperimentMetric', 'ExperimentTrendsQuery' or 'ExperimentFunnelsQuery'"
-            )
-
-        # pydantic models are used to validate the query
-        try:
-            if metric_query["kind"] == "ExperimentMetric":
-                if "metric_type" not in metric_query:
-                    raise ValidationError("ExperimentMetric requires a metric_type")
-                if metric_query["metric_type"] == ExperimentMetricType.MEAN:
-                    ExperimentMeanMetric(**metric_query)
-                elif metric_query["metric_type"] == ExperimentMetricType.FUNNEL:
-                    ExperimentFunnelMetric(**metric_query)
-                elif metric_query["metric_type"] == ExperimentMetricType.RATIO:
-                    ExperimentRatioMetric(**metric_query)
-                elif metric_query["metric_type"] == ExperimentMetricType.RETENTION:
-                    ExperimentRetentionMetric(**metric_query)
-                else:
-                    raise ValidationError(
-                        "ExperimentMetric metric_type must be 'mean', 'funnel', 'ratio', or 'retention'"
-                    )
-            elif metric_query["kind"] == "ExperimentTrendsQuery":
-                ExperimentTrendsQuery(**metric_query)
-            elif metric_query["kind"] == "ExperimentFunnelsQuery":
-                ExperimentFunnelsQuery(**metric_query)
-        except pydantic.ValidationError as e:
-            raise ValidationError(str(e.errors())) from e
-
+        ExperimentSavedMetricService.validate_query(value)
         return value
 
     def create(self, validated_data):
+        tags = validated_data.pop("tags", None)
+        name = validated_data.pop("name")
+        query = validated_data.pop("query")
+        description = validated_data.pop("description", None)
+
+        if validated_data:
+            raise serializers.ValidationError(
+                f"Can't create keys: {', '.join(sorted(validated_data))} on ExperimentSavedMetric"
+            )
+
+        service = self._build_service()
+        instance = service.create_saved_metric(name=name, query=query, description=description)
+        self._attempt_set_tags(tags, instance)
+        return instance
+
+    def update(self, instance: ExperimentSavedMetric, validated_data):
+        tags = validated_data.pop("tags", None)
+        service = self._build_service()
+        instance = service.update_saved_metric(instance, validated_data)
+        self._attempt_set_tags(tags, instance)
+        return instance
+
+    def _build_service(self) -> ExperimentSavedMetricService:
         request = self.context["request"]
-        validated_data["created_by"] = request.user
-        validated_data["team_id"] = self.context["team_id"]
-        return super().create(validated_data)
+        return ExperimentSavedMetricService(team=self.context["get_team"](), user=request.user)
 
 
+@extend_schema(tags=["experiments"])
 class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
     scope_object = "experiment_saved_metric"
     queryset = ExperimentSavedMetric.objects.prefetch_related("created_by").order_by(Lower("name")).all()
     serializer_class = ExperimentSavedMetricSerializer
+
+    def perform_destroy(self, instance: ExperimentSavedMetric) -> None:
+        service = ExperimentSavedMetricService(team=self.team, user=self.request.user)
+        service.delete_saved_metric(instance)
 
 
 @mutable_receiver(model_activity_signal, sender=ExperimentSavedMetric)

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -1,11 +1,64 @@
+from unittest.mock import patch
+
 from rest_framework import status
 
 from posthog.models.experiment import Experiment, ExperimentToSavedMetric
+
+from products.experiments.backend.experiment_saved_metric_service import ExperimentSavedMetricService
 
 from ee.api.test.base import APILicensedTest
 
 
 class TestExperimentSavedMetricsCRUD(APILicensedTest):
+    def test_http_saved_metric_validation_runs_once(self) -> None:
+        original_validate_query = ExperimentSavedMetricService.validate_query.__func__
+        validate_query_call_count = 0
+
+        def counting_validate_query(cls, query: dict | None) -> None:
+            nonlocal validate_query_call_count
+            validate_query_call_count += 1
+            original_validate_query(cls, query)
+
+        with patch.object(ExperimentSavedMetricService, "validate_query", classmethod(counting_validate_query)):
+            create_response = self.client.post(
+                f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+                data={
+                    "name": "Test Experiment saved metric",
+                    "query": {
+                        "kind": "ExperimentTrendsQuery",
+                        "count_query": {
+                            "kind": "TrendsQuery",
+                            "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                        },
+                    },
+                },
+                format="json",
+            )
+
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(validate_query_call_count, 1)
+
+        saved_metric_id = create_response.json()["id"]
+        validate_query_call_count = 0
+
+        with patch.object(ExperimentSavedMetricService, "validate_query", classmethod(counting_validate_query)):
+            update_response = self.client.patch(
+                f"/api/projects/{self.team.id}/experiment_saved_metrics/{saved_metric_id}",
+                data={
+                    "query": {
+                        "kind": "ExperimentTrendsQuery",
+                        "count_query": {
+                            "kind": "TrendsQuery",
+                            "series": [{"kind": "EventsNode", "event": "$pageleave"}],
+                        },
+                    }
+                },
+                format="json",
+            )
+
+        self.assertEqual(update_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(validate_query_call_count, 1)
+
     def test_can_list_experiment_saved_metrics(self):
         response = self.client.get(f"/api/projects/{self.team.id}/experiment_saved_metrics/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -216,6 +216,39 @@ class TestExperimentSavedMetricsCRUD(APILicensedTest):
         self.assertEqual(Experiment.objects.get(pk=exp_id).saved_metrics.count(), 0)
         self.assertEqual(ExperimentToSavedMetric.objects.filter(experiment_id=exp_id).count(), 0)
 
+    def test_update_saved_metric_tags(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/",
+            data={
+                "name": "Test Experiment saved metric",
+                "description": "Test description",
+                "query": {
+                    "kind": "ExperimentTrendsQuery",
+                    "count_query": {
+                        "kind": "TrendsQuery",
+                        "series": [{"kind": "EventsNode", "event": "$pageview"}],
+                    },
+                },
+                "tags": ["tag1"],
+            },
+            format="json",
+        )
+
+        saved_metric_id = response.json()["id"]
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["tags"], ["tag1"])
+
+        update_response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiment_saved_metrics/{saved_metric_id}",
+            {
+                "tags": ["tag2", "tag3"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(update_response.status_code, status.HTTP_200_OK)
+        self.assertCountEqual(update_response.json()["tags"], ["tag2", "tag3"])
+
     def test_create_saved_metric_with_experiment_metric(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiment_saved_metrics/",

--- a/ee/clickhouse/views/test/test_experiment_saved_metrics.py
+++ b/ee/clickhouse/views/test/test_experiment_saved_metrics.py
@@ -11,13 +11,13 @@ from ee.api.test.base import APILicensedTest
 
 class TestExperimentSavedMetricsCRUD(APILicensedTest):
     def test_http_saved_metric_validation_runs_once(self) -> None:
-        original_validate_query = ExperimentSavedMetricService.validate_query.__func__
+        original_validate_query = ExperimentSavedMetricService.validate_query
         validate_query_call_count = 0
 
         def counting_validate_query(cls, query: dict | None) -> None:
             nonlocal validate_query_call_count
             validate_query_call_count += 1
-            original_validate_query(cls, query)
+            original_validate_query(query)
 
         with patch.object(ExperimentSavedMetricService, "validate_query", classmethod(counting_validate_query)):
             create_response = self.client.post(

--- a/products/experiments/backend/experiment_saved_metric_service.py
+++ b/products/experiments/backend/experiment_saved_metric_service.py
@@ -95,7 +95,9 @@ class ExperimentSavedMetricService:
 
         for attr, value in update_data.items():
             setattr(saved_metric, attr, value)
-        saved_metric.save()
+
+        if update_data:
+            saved_metric.save()
 
         return saved_metric
 

--- a/products/experiments/backend/experiment_saved_metric_service.py
+++ b/products/experiments/backend/experiment_saved_metric_service.py
@@ -1,0 +1,122 @@
+"""Experiment saved metric service — single source of truth for saved metric business logic."""
+
+from typing import Any
+
+from django.db import transaction
+
+import pydantic
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import (
+    ExperimentFunnelMetric,
+    ExperimentFunnelsQuery,
+    ExperimentMeanMetric,
+    ExperimentMetricType,
+    ExperimentRatioMetric,
+    ExperimentRetentionMetric,
+    ExperimentTrendsQuery,
+)
+
+from posthog.models.experiment import ExperimentSavedMetric
+from posthog.models.team.team import Team
+
+
+class ExperimentSavedMetricService:
+    """Single source of truth for experiment saved metric business logic."""
+
+    VALID_QUERY_KINDS = {"ExperimentMetric", "ExperimentTrendsQuery", "ExperimentFunnelsQuery"}
+
+    def __init__(self, team: Team, user: Any):
+        self.team = team
+        self.user = user
+
+    @classmethod
+    def validate_query(cls, query: dict | None) -> None:
+        """Validate saved metric queries accepted by the API layer."""
+        if not query:
+            raise ValidationError("Query is required to create a saved metric")
+
+        kind = query.get("kind")
+        if kind not in cls.VALID_QUERY_KINDS:
+            raise ValidationError(
+                "Metric query kind must be 'ExperimentMetric', 'ExperimentTrendsQuery' or 'ExperimentFunnelsQuery'"
+            )
+
+        try:
+            if kind == "ExperimentMetric":
+                if "metric_type" not in query:
+                    raise ValidationError("ExperimentMetric requires a metric_type")
+                if query["metric_type"] == ExperimentMetricType.MEAN:
+                    ExperimentMeanMetric(**query)
+                elif query["metric_type"] == ExperimentMetricType.FUNNEL:
+                    ExperimentFunnelMetric(**query)
+                elif query["metric_type"] == ExperimentMetricType.RATIO:
+                    ExperimentRatioMetric(**query)
+                elif query["metric_type"] == ExperimentMetricType.RETENTION:
+                    ExperimentRetentionMetric(**query)
+                else:
+                    raise ValidationError(
+                        "ExperimentMetric metric_type must be 'mean', 'funnel', 'ratio', or 'retention'"
+                    )
+            elif kind == "ExperimentTrendsQuery":
+                ExperimentTrendsQuery(**query)
+            elif kind == "ExperimentFunnelsQuery":
+                ExperimentFunnelsQuery(**query)
+        except pydantic.ValidationError as e:
+            raise ValidationError(str(e.errors())) from e
+
+    @transaction.atomic
+    def create_saved_metric(
+        self,
+        *,
+        name: str,
+        query: dict,
+        description: str | None = None,
+    ) -> ExperimentSavedMetric:
+        """Create a saved metric with full business-logic validation."""
+        self.validate_query(query)
+
+        return ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name=name,
+            description=description,
+            query=query,
+        )
+
+    @transaction.atomic
+    def update_saved_metric(self, saved_metric: ExperimentSavedMetric, update_data: dict) -> ExperimentSavedMetric:
+        """Update a saved metric with full business-logic validation."""
+        self._assert_team_ownership(saved_metric)
+        self._validate_update_payload(update_data)
+
+        if "query" in update_data:
+            self.validate_query(update_data["query"])
+
+        for attr, value in update_data.items():
+            setattr(saved_metric, attr, value)
+        saved_metric.save()
+
+        return saved_metric
+
+    @transaction.atomic
+    def delete_saved_metric(self, saved_metric: ExperimentSavedMetric) -> None:
+        """Delete a saved metric."""
+        self._assert_team_ownership(saved_metric)
+        saved_metric.delete()
+
+    def _assert_team_ownership(self, saved_metric: ExperimentSavedMetric) -> None:
+        if saved_metric.team_id != self.team.id:
+            raise ValidationError("Saved metric does not exist or does not belong to this project")
+
+    @staticmethod
+    def _validate_update_payload(update_data: dict) -> None:
+        expected_keys = {
+            "name",
+            "description",
+            "query",
+        }
+        extra_keys = set(update_data.keys()) - expected_keys
+
+        if extra_keys:
+            raise ValidationError(f"Can't update keys: {', '.join(sorted(extra_keys))} on ExperimentSavedMetric")

--- a/products/experiments/backend/test/test_experiment_saved_metric_service.py
+++ b/products/experiments/backend/test/test_experiment_saved_metric_service.py
@@ -89,6 +89,21 @@ class TestExperimentSavedMetricService(APIBaseTest):
         assert updated.name == "Updated saved metric"
         assert updated.description == "Updated description"
 
+    def test_update_saved_metric_skips_save_for_empty_update(self) -> None:
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Original saved metric",
+            description="Original description",
+            query=self._valid_trends_query(),
+        )
+
+        with patch("posthog.models.experiment.ExperimentSavedMetric.save") as save_mock:
+            updated = self._service().update_saved_metric(saved_metric, {})
+
+        assert updated == saved_metric
+        save_mock.assert_not_called()
+
     def test_update_saved_metric_validates_query_before_mutation(self) -> None:
         saved_metric = ExperimentSavedMetric.objects.create(
             team=self.team,

--- a/products/experiments/backend/test/test_experiment_saved_metric_service.py
+++ b/products/experiments/backend/test/test_experiment_saved_metric_service.py
@@ -1,0 +1,182 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
+
+from posthog.models import Team
+from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
+
+from products.experiments.backend.experiment_saved_metric_service import ExperimentSavedMetricService
+from products.experiments.backend.experiment_service import ExperimentService
+
+
+class TestExperimentSavedMetricService(APIBaseTest):
+    def _service(self) -> ExperimentSavedMetricService:
+        return ExperimentSavedMetricService(team=self.team, user=self.user)
+
+    def _valid_trends_query(self) -> dict:
+        return {
+            "kind": "ExperimentTrendsQuery",
+            "count_query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+        }
+
+    def test_create_saved_metric_with_minimum_fields(self) -> None:
+        saved_metric = self._service().create_saved_metric(
+            name="Service saved metric",
+            description="Created through the service",
+            query=self._valid_trends_query(),
+        )
+
+        assert saved_metric.team_id == self.team.id
+        assert saved_metric.created_by_id == self.user.id
+        assert saved_metric.name == "Service saved metric"
+        assert saved_metric.description == "Created through the service"
+        assert saved_metric.query == self._valid_trends_query()
+
+    @parameterized.expand(
+        [
+            ("missing_query", None, "Query is required to create a saved metric"),
+            (
+                "invalid_kind",
+                {"kind": "not-ExperimentTrendsQuery"},
+                "Metric query kind must be 'ExperimentMetric', 'ExperimentTrendsQuery' or 'ExperimentFunnelsQuery'",
+            ),
+            (
+                "missing_metric_type",
+                {"kind": "ExperimentMetric"},
+                "ExperimentMetric requires a metric_type",
+            ),
+            (
+                "invalid_metric_type",
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "invalid",
+                    "source": {"kind": "EventsNode", "event": "$pageview"},
+                },
+                "ExperimentMetric metric_type must be 'mean', 'funnel', 'ratio', or 'retention'",
+            ),
+        ]
+    )
+    def test_create_saved_metric_validates_query(
+        self,
+        _: str,
+        query: dict | None,
+        expected_error: str,
+    ) -> None:
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().create_saved_metric(name="Invalid saved metric", query=query)  # type: ignore[arg-type]
+
+        assert expected_error in str(ctx.exception)
+
+    def test_update_saved_metric_updates_fields(self) -> None:
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Original saved metric",
+            description="Original description",
+            query=self._valid_trends_query(),
+        )
+
+        updated = self._service().update_saved_metric(
+            saved_metric,
+            {
+                "name": "Updated saved metric",
+                "description": "Updated description",
+            },
+        )
+
+        assert updated.name == "Updated saved metric"
+        assert updated.description == "Updated description"
+
+    def test_update_saved_metric_validates_query_before_mutation(self) -> None:
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Original name",
+            description="Original description",
+            query=self._valid_trends_query(),
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().update_saved_metric(
+                saved_metric,
+                {
+                    "name": "Updated name",
+                    "query": {},
+                },
+            )
+
+        assert "Query is required to create a saved metric" in str(ctx.exception)
+        saved_metric.refresh_from_db()
+        assert saved_metric.name == "Original name"
+        assert saved_metric.query == self._valid_trends_query()
+
+    def test_update_saved_metric_rejects_unknown_keys(self) -> None:
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Original saved metric",
+            query=self._valid_trends_query(),
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().update_saved_metric(saved_metric, {"metadata": {"type": "primary"}})
+
+        assert "Can't update keys: metadata on ExperimentSavedMetric" in str(ctx.exception)
+
+    def test_update_saved_metric_rejects_metric_from_another_team(self) -> None:
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=other_team,
+            created_by=self.user,
+            name="Other team saved metric",
+            query=self._valid_trends_query(),
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().update_saved_metric(saved_metric, {"name": "Updated name"})
+
+        assert "Saved metric does not exist or does not belong to this project" in str(ctx.exception)
+
+    def test_delete_saved_metric_removes_experiment_links(self) -> None:
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Linked saved metric",
+            query={
+                "kind": "ExperimentMetric",
+                "metric_type": "mean",
+                "source": {"kind": "EventsNode", "event": "$pageview"},
+            },
+        )
+
+        experiment_service = ExperimentService(team=self.team, user=self.user)
+        experiment = experiment_service.create_experiment(
+            name="Experiment with saved metric",
+            feature_flag_key="saved-metric-service-delete",
+            saved_metrics_ids=[{"id": saved_metric.id, "metadata": {"type": "primary"}}],
+        )
+
+        assert experiment.experimenttosavedmetric_set.count() == 1
+
+        self._service().delete_saved_metric(saved_metric)
+
+        assert not ExperimentSavedMetric.objects.filter(id=saved_metric.id).exists()
+        assert ExperimentToSavedMetric.objects.filter(experiment_id=experiment.id).count() == 0
+
+    def test_update_saved_metric_does_not_delete_links_on_validation_error(self) -> None:
+        saved_metric = ExperimentSavedMetric.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Protected saved metric",
+            query=self._valid_trends_query(),
+        )
+
+        with (
+            patch("posthog.models.experiment.ExperimentSavedMetric.save") as save_mock,
+            self.assertRaises(ValidationError),
+        ):
+            self._service().update_saved_metric(saved_metric, {"query": {}})
+
+        save_mock.assert_not_called()

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -106,6 +106,63 @@ export interface PatchedExperimentHoldoutApi {
 }
 
 /**
+ * Mixin for serializers to add user access control fields
+ */
+export interface ExperimentSavedMetricApi {
+    readonly id: number
+    /** @maxLength 400 */
+    name: string
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    description?: string | null
+    query: unknown
+    readonly created_by: UserBasicApi
+    readonly created_at: string
+    readonly updated_at: string
+    tags?: unknown[]
+    /**
+     * The effective access level the user has for this object
+     * @nullable
+     */
+    readonly user_access_level: string | null
+}
+
+export interface PaginatedExperimentSavedMetricListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: ExperimentSavedMetricApi[]
+}
+
+/**
+ * Mixin for serializers to add user access control fields
+ */
+export interface PatchedExperimentSavedMetricApi {
+    readonly id?: number
+    /** @maxLength 400 */
+    name?: string
+    /**
+     * @maxLength 400
+     * @nullable
+     */
+    description?: string | null
+    query?: unknown
+    readonly created_by?: UserBasicApi
+    readonly created_at?: string
+    readonly updated_at?: string
+    tags?: unknown[]
+    /**
+     * The effective access level the user has for this object
+     * @nullable
+     */
+    readonly user_access_level?: string | null
+}
+
+/**
  * * `server` - Server
  * `client` - Client
  * `all` - All
@@ -338,6 +395,17 @@ export interface PatchedExperimentApi {
 }
 
 export type ExperimentHoldoutsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type ExperimentSavedMetricsListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -12,11 +12,15 @@ import type {
     ExperimentApi,
     ExperimentHoldoutApi,
     ExperimentHoldoutsListParams,
+    ExperimentSavedMetricApi,
+    ExperimentSavedMetricsListParams,
     ExperimentsListParams,
     PaginatedExperimentHoldoutListApi,
     PaginatedExperimentListApi,
+    PaginatedExperimentSavedMetricListApi,
     PatchedExperimentApi,
     PatchedExperimentHoldoutApi,
+    PatchedExperimentSavedMetricApi,
 } from './api.schemas'
 
 // https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
@@ -141,6 +145,116 @@ export const experimentHoldoutsDestroy = async (
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getExperimentHoldoutsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getExperimentSavedMetricsListUrl = (projectId: string, params?: ExperimentSavedMetricsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/experiment_saved_metrics/?${stringifiedParams}`
+        : `/api/projects/${projectId}/experiment_saved_metrics/`
+}
+
+export const experimentSavedMetricsList = async (
+    projectId: string,
+    params?: ExperimentSavedMetricsListParams,
+    options?: RequestInit
+): Promise<PaginatedExperimentSavedMetricListApi> => {
+    return apiMutator<PaginatedExperimentSavedMetricListApi>(getExperimentSavedMetricsListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getExperimentSavedMetricsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/experiment_saved_metrics/`
+}
+
+export const experimentSavedMetricsCreate = async (
+    projectId: string,
+    experimentSavedMetricApi: NonReadonly<ExperimentSavedMetricApi>,
+    options?: RequestInit
+): Promise<ExperimentSavedMetricApi> => {
+    return apiMutator<ExperimentSavedMetricApi>(getExperimentSavedMetricsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(experimentSavedMetricApi),
+    })
+}
+
+export const getExperimentSavedMetricsRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiment_saved_metrics/${id}/`
+}
+
+export const experimentSavedMetricsRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<ExperimentSavedMetricApi> => {
+    return apiMutator<ExperimentSavedMetricApi>(getExperimentSavedMetricsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getExperimentSavedMetricsUpdateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiment_saved_metrics/${id}/`
+}
+
+export const experimentSavedMetricsUpdate = async (
+    projectId: string,
+    id: number,
+    experimentSavedMetricApi: NonReadonly<ExperimentSavedMetricApi>,
+    options?: RequestInit
+): Promise<ExperimentSavedMetricApi> => {
+    return apiMutator<ExperimentSavedMetricApi>(getExperimentSavedMetricsUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(experimentSavedMetricApi),
+    })
+}
+
+export const getExperimentSavedMetricsPartialUpdateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiment_saved_metrics/${id}/`
+}
+
+export const experimentSavedMetricsPartialUpdate = async (
+    projectId: string,
+    id: number,
+    patchedExperimentSavedMetricApi: NonReadonly<PatchedExperimentSavedMetricApi>,
+    options?: RequestInit
+): Promise<ExperimentSavedMetricApi> => {
+    return apiMutator<ExperimentSavedMetricApi>(getExperimentSavedMetricsPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedExperimentSavedMetricApi),
+    })
+}
+
+export const getExperimentSavedMetricsDestroyUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiment_saved_metrics/${id}/`
+}
+
+export const experimentSavedMetricsDestroy = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getExperimentSavedMetricsDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
     })


### PR DESCRIPTION
## Problem

Experiment saved metrics logic still lives in the API layer.

## Changes

Move the logic over to the service layer. A mechanical change with no change in behavior.

## How did you test this code?

- Tests added
- Verified locally
  - create
  - update
  - delete
  - add / remove from experiment

## Publish to changelog?

No.
