### PR TITLE
fix(phai): lazy-init tools module to reduce worker startup time

### DIFF
--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -15,7 +15,7 @@
     "scripts": {
         "build:ui-apps": "tsx scripts/build-ui-apps.ts",
         "build:ui-apps:watch": "tsx scripts/build-ui-apps.ts --watch",
-        "build": "pnpm run build:ui-apps && wrangler check startup && cat worker-startup.cpuprofile",
+        "build": "pnpm run build:ui-apps",
         "dev": "wrangler dev",
         "dev:local-resources": "wrangler dev --var POSTHOG_MCP_LOCAL_SKILLS_URL:http://localhost:8765/skills-mcp-resources.zip",
         "deploy": "wrangler deploy",

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -24,7 +24,6 @@ import { registerResources } from '@/resources'
 import { registerUiAppResources } from '@/resources/ui-apps'
 import INSTRUCTIONS_TEMPLATE_V1 from '@/templates/instructions-v1.md'
 import INSTRUCTIONS_TEMPLATE_V2 from '@/templates/instructions-v2.md'
-import { getToolsFromContext } from '@/tools'
 import type { CloudRegion, Context, State, Tool } from '@/tools/types'
 import type { AnalyticsMetadata, WithAnalytics } from '@/ui-apps/types'
 
@@ -436,6 +435,7 @@ export class MCP extends McpAgent<Env> {
         await registerUiAppResources(this.server, context)
 
         // Register tools
+        const { getToolsFromContext } = await import('@/tools')
         const allTools = await getToolsFromContext(context, {
             features,
             version,


### PR DESCRIPTION
## Problem

The MCP worker's startup time was ~400ms due to eagerly evaluating the `@/tools` module tree (all Zod schemas, tool definitions) at the top level.

## Changes

- Move `getToolsFromContext` from a static import to a dynamic `await import()` inside `init()`, deferring module evaluation to per-session init rather than worker startup
- Remove `wrangler check startup` from the build script (moved to CI)

Measured locally with `wrangler check startup`:
| Version | Avg startup |
|---|---|
| Static import (before) | ~404 ms |
| Dynamic import (after) | ~148 ms |

~63% reduction.

## How did you test this code?

Ran `wrangler check startup` multiple times for both versions and compared CPU profile durations.

## Publish to changelog?

no