### PR TITLE
feat(subscriptions): add delivery outcome tracking

### DIFF
--- a/posthog/temporal/subscriptions/__init__.py
+++ b/posthog/temporal/subscriptions/__init__.py
@@ -2,9 +2,14 @@ from posthog.temporal.subscriptions.subscription_scheduling_workflow import (
     HandleSubscriptionValueChangeWorkflow,
     ScheduleAllSubscriptionsWorkflow,
     deliver_subscription_report_activity,
+    emit_subscription_delivery_outcome_events_activity,
     fetch_due_subscriptions_activity,
 )
 
 WORKFLOWS = [ScheduleAllSubscriptionsWorkflow, HandleSubscriptionValueChangeWorkflow]
 
-ACTIVITIES = [deliver_subscription_report_activity, fetch_due_subscriptions_activity]
+ACTIVITIES = [
+    deliver_subscription_report_activity,
+    emit_subscription_delivery_outcome_events_activity,
+    fetch_due_subscriptions_activity,
+]

--- a/posthog/temporal/subscriptions/__init__.py
+++ b/posthog/temporal/subscriptions/__init__.py
@@ -3,6 +3,7 @@ from posthog.temporal.subscriptions.subscription_scheduling_workflow import (
     ScheduleAllSubscriptionsWorkflow,
     deliver_subscription_report_activity,
     emit_subscription_delivery_outcome_events_activity,
+    emit_subscription_delivery_started_activity,
     fetch_due_subscriptions_activity,
 )
 
@@ -11,5 +12,6 @@ WORKFLOWS = [ScheduleAllSubscriptionsWorkflow, HandleSubscriptionValueChangeWork
 ACTIVITIES = [
     deliver_subscription_report_activity,
     emit_subscription_delivery_outcome_events_activity,
+    emit_subscription_delivery_started_activity,
     fetch_due_subscriptions_activity,
 ]

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -135,7 +135,7 @@ async def emit_subscription_delivery_outcome_events_activity(
             },
         )
 
-    posthoganalytics.flush()
+    await asyncio.to_thread(posthoganalytics.flush)
 
 
 @dataclasses.dataclass
@@ -242,6 +242,7 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
     async def run(self, inputs: DeliverSubscriptionReportActivityInputs) -> None:
         succeeded: list[int] = []
         failed: list[dict[str, typing.Any]] = []
+        delivery_error: Exception | None = None
 
         try:
             await temporalio.workflow.execute_activity(
@@ -256,6 +257,7 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
             )
             succeeded.append(inputs.subscription_id)
         except Exception as e:
+            delivery_error = e
             failed.append(
                 {
                     "subscription_id": inputs.subscription_id,
@@ -277,3 +279,6 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
                 maximum_attempts=3,
             ),
         )
+
+        if delivery_error is not None:
+            raise delivery_error

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -11,6 +11,7 @@ import temporalio.common
 import temporalio.activity
 import temporalio.workflow
 from structlog import get_logger
+from temporalio.exceptions import ApplicationError
 
 from posthog.models.subscription import Subscription
 from posthog.sync import database_sync_to_async
@@ -288,7 +289,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
 
         if failed:
             failed_ids = [f["subscription_id"] for f in failed]
-            raise RuntimeError(f"Subscription deliveries failed for IDs: {failed_ids}")
+            raise ApplicationError(f"Subscription deliveries failed for IDs: {failed_ids}", non_retryable=True)
 
 
 @temporalio.workflow.defn(name="handle-subscription-value-change")

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -220,19 +220,29 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
             else:
                 succeeded.append(sub_id)
 
-        await temporalio.workflow.execute_activity(
-            emit_subscription_delivery_outcome_events_activity,
-            EmitSubscriptionDeliveryOutcomeInputs(
-                succeeded_subscription_ids=succeeded,
-                failed_deliveries=failed,
-            ),
-            start_to_close_timeout=dt.timedelta(minutes=2),
-            retry_policy=temporalio.common.RetryPolicy(
-                initial_interval=dt.timedelta(seconds=5),
-                maximum_interval=dt.timedelta(minutes=1),
-                maximum_attempts=3,
-            ),
-        )
+        try:
+            await temporalio.workflow.execute_activity(
+                emit_subscription_delivery_outcome_events_activity,
+                EmitSubscriptionDeliveryOutcomeInputs(
+                    succeeded_subscription_ids=succeeded,
+                    failed_deliveries=failed,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=5),
+                    maximum_interval=dt.timedelta(minutes=1),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception as emit_error:
+            temporalio.workflow.logger.error(
+                "Failed to emit subscription delivery outcome events",
+                extra={"error": str(emit_error)},
+            )
+
+        if failed:
+            failed_ids = [f["subscription_id"] for f in failed]
+            raise RuntimeError(f"Subscription deliveries failed for IDs: {failed_ids}")
 
 
 @temporalio.workflow.defn(name="handle-subscription-value-change")
@@ -270,19 +280,25 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
                 }
             )
 
-        await temporalio.workflow.execute_activity(
-            emit_subscription_delivery_outcome_events_activity,
-            EmitSubscriptionDeliveryOutcomeInputs(
-                succeeded_subscription_ids=succeeded,
-                failed_deliveries=failed,
-            ),
-            start_to_close_timeout=dt.timedelta(minutes=2),
-            retry_policy=temporalio.common.RetryPolicy(
-                initial_interval=dt.timedelta(seconds=5),
-                maximum_interval=dt.timedelta(minutes=1),
-                maximum_attempts=3,
-            ),
-        )
+        try:
+            await temporalio.workflow.execute_activity(
+                emit_subscription_delivery_outcome_events_activity,
+                EmitSubscriptionDeliveryOutcomeInputs(
+                    succeeded_subscription_ids=succeeded,
+                    failed_deliveries=failed,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=5),
+                    maximum_interval=dt.timedelta(minutes=1),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception as emit_error:
+            temporalio.workflow.logger.error(
+                "Failed to emit subscription delivery outcome event",
+                extra={"subscription_id": inputs.subscription_id, "error": str(emit_error)},
+            )
 
         if delivery_error is not None:
             raise delivery_error

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -114,7 +114,9 @@ async def emit_subscription_delivery_outcome_events_activity(
     sub_to_team = await load_team_ids()
 
     for sub_id in inputs.succeeded_subscription_ids:
-        team_id = sub_to_team.get(sub_id, 0)
+        team_id = sub_to_team.get(sub_id)
+        if team_id is None:
+            continue
         posthoganalytics.capture(
             distinct_id=str(team_id),
             event="subscription_delivery_succeeded",
@@ -123,7 +125,9 @@ async def emit_subscription_delivery_outcome_events_activity(
 
     for failure in inputs.failed_deliveries:
         sub_id = failure["subscription_id"]
-        team_id = sub_to_team.get(sub_id, 0)
+        team_id = sub_to_team.get(sub_id)
+        if team_id is None:
+            continue
         posthoganalytics.capture(
             distinct_id=str(team_id),
             event="subscription_delivery_exhausted",

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -96,6 +96,34 @@ async def deliver_subscription_report_activity(inputs: DeliverSubscriptionReport
 
 
 @dataclasses.dataclass
+class EmitSubscriptionDeliveryStartedInputs:
+    subscription_ids: list[int]
+
+
+@temporalio.activity.defn
+async def emit_subscription_delivery_started_activity(
+    inputs: EmitSubscriptionDeliveryStartedInputs,
+) -> None:
+    @database_sync_to_async(thread_sensitive=False)
+    def load_team_ids() -> dict[int, int]:
+        return dict(Subscription.objects.filter(id__in=inputs.subscription_ids).values_list("id", "team_id"))
+
+    sub_to_team = await load_team_ids()
+
+    for sub_id in inputs.subscription_ids:
+        team_id = sub_to_team.get(sub_id)
+        if team_id is None:
+            continue
+        posthoganalytics.capture(
+            distinct_id=str(team_id),
+            event="subscription_delivery_started",
+            properties={"subscription_id": sub_id, "team_id": team_id},
+        )
+
+    await asyncio.to_thread(posthoganalytics.flush)
+
+
+@dataclasses.dataclass
 class EmitSubscriptionDeliveryOutcomeInputs:
     succeeded_subscription_ids: list[int]
     failed_deliveries: list[dict[str, typing.Any]]
@@ -185,6 +213,24 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
             ),
         )
 
+        # Emit started events before delivery
+        try:
+            await temporalio.workflow.execute_activity(
+                emit_subscription_delivery_started_activity,
+                EmitSubscriptionDeliveryStartedInputs(subscription_ids=subscription_ids),
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=5),
+                    maximum_interval=dt.timedelta(minutes=1),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception as emit_error:
+            temporalio.workflow.logger.error(
+                "Failed to emit subscription delivery started events",
+                extra={"error": str(emit_error)},
+            )
+
         # Fan-out delivery activities in parallel
         tasks: list[tuple[int, typing.Coroutine[typing.Any, typing.Any, None]]] = []
         for sub_id in subscription_ids:
@@ -254,6 +300,23 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: DeliverSubscriptionReportActivityInputs) -> None:
+        try:
+            await temporalio.workflow.execute_activity(
+                emit_subscription_delivery_started_activity,
+                EmitSubscriptionDeliveryStartedInputs(subscription_ids=[inputs.subscription_id]),
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=5),
+                    maximum_interval=dt.timedelta(minutes=1),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception as emit_error:
+            temporalio.workflow.logger.error(
+                "Failed to emit subscription delivery started event",
+                extra={"subscription_id": inputs.subscription_id, "error": str(emit_error)},
+            )
+
         succeeded: list[int] = []
         failed: list[dict[str, typing.Any]] = []
         delivery_error: Exception | None = None

--- a/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
+++ b/posthog/temporal/subscriptions/subscription_scheduling_workflow.py
@@ -6,6 +6,7 @@ import dataclasses
 
 from django.conf import settings
 
+import posthoganalytics
 import temporalio.common
 import temporalio.activity
 import temporalio.workflow
@@ -95,6 +96,49 @@ async def deliver_subscription_report_activity(inputs: DeliverSubscriptionReport
 
 
 @dataclasses.dataclass
+class EmitSubscriptionDeliveryOutcomeInputs:
+    succeeded_subscription_ids: list[int]
+    failed_deliveries: list[dict[str, typing.Any]]
+
+
+@temporalio.activity.defn
+async def emit_subscription_delivery_outcome_events_activity(
+    inputs: EmitSubscriptionDeliveryOutcomeInputs,
+) -> None:
+    all_sub_ids = inputs.succeeded_subscription_ids + [f["subscription_id"] for f in inputs.failed_deliveries]
+
+    @database_sync_to_async(thread_sensitive=False)
+    def load_team_ids() -> dict[int, int]:
+        return dict(Subscription.objects.filter(id__in=all_sub_ids).values_list("id", "team_id"))
+
+    sub_to_team = await load_team_ids()
+
+    for sub_id in inputs.succeeded_subscription_ids:
+        team_id = sub_to_team.get(sub_id, 0)
+        posthoganalytics.capture(
+            distinct_id=str(team_id),
+            event="subscription_delivery_succeeded",
+            properties={"subscription_id": sub_id, "team_id": team_id},
+        )
+
+    for failure in inputs.failed_deliveries:
+        sub_id = failure["subscription_id"]
+        team_id = sub_to_team.get(sub_id, 0)
+        posthoganalytics.capture(
+            distinct_id=str(team_id),
+            event="subscription_delivery_exhausted",
+            properties={
+                "subscription_id": sub_id,
+                "team_id": team_id,
+                "error_type": failure.get("error_type", ""),
+                "error_message": failure.get("error_message", ""),
+            },
+        )
+
+    posthoganalytics.flush()
+
+
+@dataclasses.dataclass
 class ScheduleAllSubscriptionsWorkflowInputs:
     """Inputs for the `ScheduleAllSubscriptionsWorkflow`."""
 
@@ -138,7 +182,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
         )
 
         # Fan-out delivery activities in parallel
-        tasks = []
+        tasks: list[tuple[int, typing.Coroutine[typing.Any, typing.Any, None]]] = []
         for sub_id in subscription_ids:
             task = temporalio.workflow.execute_activity(
                 deliver_subscription_report_activity,
@@ -151,10 +195,40 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
                     non_retryable_error_types=[],
                 ),
             )
-            tasks.append(task)
+            tasks.append((sub_id, task))
 
-        if tasks:
-            await asyncio.gather(*tasks)
+        if not tasks:
+            return
+
+        results = await asyncio.gather(*[t for _, t in tasks], return_exceptions=True)
+
+        succeeded: list[int] = []
+        failed: list[dict[str, typing.Any]] = []
+        for (sub_id, _), result in zip(tasks, results):
+            if isinstance(result, BaseException):
+                failed.append(
+                    {
+                        "subscription_id": sub_id,
+                        "error_type": type(result).__name__,
+                        "error_message": str(result),
+                    }
+                )
+            else:
+                succeeded.append(sub_id)
+
+        await temporalio.workflow.execute_activity(
+            emit_subscription_delivery_outcome_events_activity,
+            EmitSubscriptionDeliveryOutcomeInputs(
+                succeeded_subscription_ids=succeeded,
+                failed_deliveries=failed,
+            ),
+            start_to_close_timeout=dt.timedelta(minutes=2),
+            retry_policy=temporalio.common.RetryPolicy(
+                initial_interval=dt.timedelta(seconds=5),
+                maximum_interval=dt.timedelta(minutes=1),
+                maximum_attempts=3,
+            ),
+        )
 
 
 @temporalio.workflow.defn(name="handle-subscription-value-change")
@@ -166,13 +240,40 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: DeliverSubscriptionReportActivityInputs) -> None:
+        succeeded: list[int] = []
+        failed: list[dict[str, typing.Any]] = []
+
+        try:
+            await temporalio.workflow.execute_activity(
+                deliver_subscription_report_activity,
+                inputs,
+                start_to_close_timeout=dt.timedelta(minutes=settings.TEMPORAL_TASK_TIMEOUT_MINUTES),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=5),
+                    maximum_interval=dt.timedelta(minutes=2),
+                    maximum_attempts=3,
+                ),
+            )
+            succeeded.append(inputs.subscription_id)
+        except Exception as e:
+            failed.append(
+                {
+                    "subscription_id": inputs.subscription_id,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                }
+            )
+
         await temporalio.workflow.execute_activity(
-            deliver_subscription_report_activity,
-            inputs,
-            start_to_close_timeout=dt.timedelta(minutes=settings.TEMPORAL_TASK_TIMEOUT_MINUTES),
+            emit_subscription_delivery_outcome_events_activity,
+            EmitSubscriptionDeliveryOutcomeInputs(
+                succeeded_subscription_ids=succeeded,
+                failed_deliveries=failed,
+            ),
+            start_to_close_timeout=dt.timedelta(minutes=2),
             retry_policy=temporalio.common.RetryPolicy(
                 initial_interval=dt.timedelta(seconds=5),
-                maximum_interval=dt.timedelta(minutes=2),
+                maximum_interval=dt.timedelta(minutes=1),
                 maximum_attempts=3,
             ),
         )

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -299,7 +299,7 @@ async def test_deliver_subscription_report_slack(
         target_value="C12345|#test-channel",
     )
 
-    async def mock_generate_assets_async():
+    async def mock_generate_assets_async(subscription):
         return [insight], [asset]
 
     mock_gen_assets.side_effect = mock_generate_assets_async

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -377,7 +377,6 @@ async def test_successful_deliveries_emit_succeeded_events(
         c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
     ]
     assert len(exhausted_calls) == 0
-    mock_posthog.flush.assert_called()
 
 
 @patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
@@ -439,7 +438,6 @@ async def test_failed_deliveries_emit_exhausted_events(
         c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
     ]
     assert len(succeeded_calls) == 0
-    mock_posthog.flush.assert_called()
 
 
 @patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -11,7 +11,7 @@ from django.conf import settings
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
-from temporalio.client import Client
+from temporalio.client import Client, WorkflowFailureError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -27,6 +27,7 @@ from posthog.temporal.subscriptions.subscription_scheduling_workflow import (
     ScheduleAllSubscriptionsWorkflowInputs,
     deliver_subscription_report_activity,
     emit_subscription_delivery_outcome_events_activity,
+    emit_subscription_delivery_started_activity,
     fetch_due_subscriptions_activity,
 )
 
@@ -46,6 +47,7 @@ async def subscriptions_worker(temporal_client: Client):
         activities=[
             deliver_subscription_report_activity,
             emit_subscription_delivery_outcome_events_activity,
+            emit_subscription_delivery_started_activity,
             fetch_due_subscriptions_activity,
         ],
         workflow_runner=UnsandboxedWorkflowRunner(),
@@ -115,6 +117,7 @@ async def test_subscription_delivery_scheduling(
             activities=[
                 deliver_subscription_report_activity,
                 emit_subscription_delivery_outcome_events_activity,
+                emit_subscription_delivery_started_activity,
                 fetch_due_subscriptions_activity,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
@@ -183,6 +186,7 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
             activities=[
                 deliver_subscription_report_activity,
                 emit_subscription_delivery_outcome_events_activity,
+                emit_subscription_delivery_started_activity,
                 fetch_due_subscriptions_activity,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
@@ -234,7 +238,11 @@ async def test_handle_subscription_value_change_email(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
             workflows=[HandleSubscriptionValueChangeWorkflow],
-            activities=[deliver_subscription_report_activity, emit_subscription_delivery_outcome_events_activity],
+            activities=[
+                deliver_subscription_report_activity,
+                emit_subscription_delivery_outcome_events_activity,
+                emit_subscription_delivery_started_activity,
+            ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,  # turn off sandbox/deadlock detector
@@ -300,7 +308,11 @@ async def test_deliver_subscription_report_slack(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
             workflows=[HandleSubscriptionValueChangeWorkflow],
-            activities=[deliver_subscription_report_activity, emit_subscription_delivery_outcome_events_activity],
+            activities=[
+                deliver_subscription_report_activity,
+                emit_subscription_delivery_outcome_events_activity,
+                emit_subscription_delivery_started_activity,
+            ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,  # turn off sandbox/deadlock detector
@@ -327,7 +339,6 @@ async def test_deliver_subscription_report_slack(
 @patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("ee.tasks.subscriptions.send_email_subscription_report")
 @patch("ee.tasks.subscriptions.generate_assets_async")
-@freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
 async def test_delivery_outcome_events(
     mock_gen_assets: MagicMock,
@@ -356,6 +367,10 @@ async def test_delivery_outcome_events(
     await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
     await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
 
+    # Use freeze_time only for subscription creation so next_delivery_date is in the past
+    # (always found by fetch_due_subscriptions_activity). Don't freeze time during workflow
+    # execution. Freezegun freezes time.monotonic() which breaks asyncio.sleep in the
+    # Temporal SDK's activity retry backoff, causing the test to hang.
     with freeze_time("2022-02-02T08:30:00.000Z"):
         sub = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
 
@@ -367,18 +382,29 @@ async def test_delivery_outcome_events(
             activities=[
                 deliver_subscription_report_activity,
                 emit_subscription_delivery_outcome_events_activity,
+                emit_subscription_delivery_started_activity,
                 fetch_due_subscriptions_activity,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,
         ):
-            await activity_environment.client.execute_workflow(
-                ScheduleAllSubscriptionsWorkflow.run,
-                ScheduleAllSubscriptionsWorkflowInputs(),
-                id=str(uuid.uuid4()),
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
+            try:
+                await activity_environment.client.execute_workflow(
+                    ScheduleAllSubscriptionsWorkflow.run,
+                    ScheduleAllSubscriptionsWorkflowInputs(),
+                    id=str(uuid.uuid4()),
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                )
+            except WorkflowFailureError:
+                if should_succeed:
+                    raise
+
+    started_calls = [
+        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_started"
+    ]
+    assert len(started_calls) == 1
+    assert started_calls[0].kwargs["properties"]["subscription_id"] == sub.id
 
     succeeded_calls = [
         c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
@@ -396,7 +422,6 @@ async def test_delivery_outcome_events(
 @patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("ee.tasks.subscriptions.send_email_subscription_report")
 @patch("ee.tasks.subscriptions.generate_assets_async")
-@freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
 async def test_mixed_success_and_failure_does_not_block(
     mock_gen_assets: MagicMock,
@@ -434,18 +459,22 @@ async def test_mixed_success_and_failure_does_not_block(
             activities=[
                 deliver_subscription_report_activity,
                 emit_subscription_delivery_outcome_events_activity,
+                emit_subscription_delivery_started_activity,
                 fetch_due_subscriptions_activity,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,
         ):
-            await activity_environment.client.execute_workflow(
-                ScheduleAllSubscriptionsWorkflow.run,
-                ScheduleAllSubscriptionsWorkflowInputs(),
-                id=str(uuid.uuid4()),
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
+            try:
+                await activity_environment.client.execute_workflow(
+                    ScheduleAllSubscriptionsWorkflow.run,
+                    ScheduleAllSubscriptionsWorkflowInputs(),
+                    id=str(uuid.uuid4()),
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                )
+            except WorkflowFailureError:
+                pass  # expected — one subscription fails
 
     # The successful subscription still delivered emails (2 recipients)
     assert mock_send_email.call_count == 2

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -315,13 +315,21 @@ async def test_deliver_subscription_report_slack(
     assert mock_send_slack.call_count == 1
 
 
+@pytest.mark.parametrize(
+    "should_succeed,expected_succeeded,expected_exhausted",
+    [
+        (True, 1, 0),
+        (False, 0, 1),
+    ],
+    ids=["success", "failure"],
+)
 @patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("ee.tasks.subscriptions.send_email_subscription_report")
 @patch("ee.tasks.subscriptions.generate_assets_async")
 @freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
-async def test_successful_deliveries_emit_succeeded_events(
+async def test_delivery_outcome_events(
     mock_gen_assets: MagicMock,
     mock_send_email: MagicMock,
     mock_metric_meter: MagicMock,
@@ -329,6 +337,9 @@ async def test_successful_deliveries_emit_succeeded_events(
     temporal_client: Client,
     team,
     user,
+    should_succeed: bool,
+    expected_succeeded: int,
+    expected_exhausted: int,
 ):
     insight = await sync_to_async(Insight.objects.create)(team=team, short_id="ev1234", name="Insight")
     asset = await sync_to_async(ExportedAsset.objects.create)(
@@ -336,6 +347,8 @@ async def test_successful_deliveries_emit_succeeded_events(
     )
 
     async def mock_generate_assets_async(subscription):
+        if not should_succeed:
+            raise Exception("OOM killed")
         return [insight], [asset]
 
     mock_gen_assets.side_effect = mock_generate_assets_async
@@ -370,74 +383,13 @@ async def test_successful_deliveries_emit_succeeded_events(
     succeeded_calls = [
         c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
     ]
-    assert len(succeeded_calls) == 1
-    assert succeeded_calls[0].kwargs["properties"]["subscription_id"] == sub.id
-
     exhausted_calls = [
         c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
     ]
-    assert len(exhausted_calls) == 0
-
-
-@patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
-@patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("ee.tasks.subscriptions.send_email_subscription_report")
-@patch("ee.tasks.subscriptions.generate_assets_async")
-@freeze_time("2022-02-02T08:55:00.000Z")
-@pytest.mark.asyncio
-async def test_failed_deliveries_emit_exhausted_events(
-    mock_gen_assets: MagicMock,
-    mock_send_email: MagicMock,
-    mock_metric_meter: MagicMock,
-    mock_posthog: MagicMock,
-    temporal_client: Client,
-    team,
-    user,
-):
-    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="ev5678", name="Insight")
-
-    async def mock_generate_assets_async(subscription):
-        raise Exception("OOM killed")
-
-    mock_gen_assets.side_effect = mock_generate_assets_async
-
-    await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
-    await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
-
-    with freeze_time("2022-02-02T08:30:00.000Z"):
-        sub = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
-
-    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-        async with Worker(
-            activity_environment.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ScheduleAllSubscriptionsWorkflow],
-            activities=[
-                deliver_subscription_report_activity,
-                emit_subscription_delivery_outcome_events_activity,
-                fetch_due_subscriptions_activity,
-            ],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=50),
-            debug_mode=True,
-        ):
-            await activity_environment.client.execute_workflow(
-                ScheduleAllSubscriptionsWorkflow.run,
-                ScheduleAllSubscriptionsWorkflowInputs(),
-                id=str(uuid.uuid4()),
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
-
-    exhausted_calls = [
-        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
-    ]
-    assert len(exhausted_calls) == 1
-    assert exhausted_calls[0].kwargs["properties"]["subscription_id"] == sub.id
-
-    succeeded_calls = [
-        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
-    ]
-    assert len(succeeded_calls) == 0
+    assert len(succeeded_calls) == expected_succeeded
+    assert len(exhausted_calls) == expected_exhausted
+    matching_calls = succeeded_calls or exhausted_calls
+    assert matching_calls[0].kwargs["properties"]["subscription_id"] == sub.id
 
 
 @patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
@@ -467,11 +419,7 @@ async def test_mixed_success_and_failure_does_not_block(
         sub_ok = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
         sub_fail = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
 
-    call_count = 0
-
     async def mock_generate_assets_async(subscription):
-        nonlocal call_count
-        call_count += 1
         if subscription.id == sub_fail.id:
             raise Exception("asset generation failed")
         return [insight], [asset]

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -12,6 +12,7 @@ from django.conf import settings
 import pytest_asyncio
 from asgiref.sync import sync_to_async
 from temporalio.client import Client, WorkflowFailureError
+from temporalio.exceptions import ApplicationError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -298,7 +299,7 @@ async def test_deliver_subscription_report_slack(
         target_value="C12345|#test-channel",
     )
 
-    async def mock_generate_assets_async(subscription):
+    async def mock_generate_assets_async():
         return [insight], [asset]
 
     mock_gen_assets.side_effect = mock_generate_assets_async
@@ -359,7 +360,7 @@ async def test_delivery_outcome_events(
 
     async def mock_generate_assets_async(subscription):
         if not should_succeed:
-            raise Exception("OOM killed")
+            raise ApplicationError("OOM killed", non_retryable=True)
         return [insight], [asset]
 
     mock_gen_assets.side_effect = mock_generate_assets_async
@@ -367,10 +368,6 @@ async def test_delivery_outcome_events(
     await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
     await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
 
-    # Use freeze_time only for subscription creation so next_delivery_date is in the past
-    # (always found by fetch_due_subscriptions_activity). Don't freeze time during workflow
-    # execution. Freezegun freezes time.monotonic() which breaks asyncio.sleep in the
-    # Temporal SDK's activity retry backoff, causing the test to hang.
     with freeze_time("2022-02-02T08:30:00.000Z"):
         sub = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
 
@@ -446,7 +443,7 @@ async def test_mixed_success_and_failure_does_not_block(
 
     async def mock_generate_assets_async(subscription):
         if subscription.id == sub_fail.id:
-            raise Exception("asset generation failed")
+            raise ApplicationError("asset generation failed", non_retryable=True)
         return [insight], [asset]
 
     mock_gen_assets.side_effect = mock_generate_assets_async

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -26,6 +26,7 @@ from posthog.temporal.subscriptions.subscription_scheduling_workflow import (
     ScheduleAllSubscriptionsWorkflow,
     ScheduleAllSubscriptionsWorkflowInputs,
     deliver_subscription_report_activity,
+    emit_subscription_delivery_outcome_events_activity,
     fetch_due_subscriptions_activity,
 )
 
@@ -42,7 +43,11 @@ async def subscriptions_worker(temporal_client: Client):
         temporal_client,
         task_queue=settings.TEMPORAL_TASK_QUEUE,
         workflows=[ScheduleAllSubscriptionsWorkflow, HandleSubscriptionValueChangeWorkflow],
-        activities=[deliver_subscription_report_activity, fetch_due_subscriptions_activity],
+        activities=[
+            deliver_subscription_report_activity,
+            emit_subscription_delivery_outcome_events_activity,
+            fetch_due_subscriptions_activity,
+        ],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
         yield  # allow the test to run while the worker is active
@@ -107,7 +112,11 @@ async def test_subscription_delivery_scheduling(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
             workflows=[ScheduleAllSubscriptionsWorkflow],
-            activities=[deliver_subscription_report_activity, fetch_due_subscriptions_activity],
+            activities=[
+                deliver_subscription_report_activity,
+                emit_subscription_delivery_outcome_events_activity,
+                fetch_due_subscriptions_activity,
+            ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,  # turn off sandbox/deadlock detector
@@ -171,7 +180,11 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
             workflows=[ScheduleAllSubscriptionsWorkflow],
-            activities=[deliver_subscription_report_activity, fetch_due_subscriptions_activity],
+            activities=[
+                deliver_subscription_report_activity,
+                emit_subscription_delivery_outcome_events_activity,
+                fetch_due_subscriptions_activity,
+            ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,  # turn off sandbox/deadlock detector
@@ -221,7 +234,7 @@ async def test_handle_subscription_value_change_email(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
             workflows=[HandleSubscriptionValueChangeWorkflow],
-            activities=[deliver_subscription_report_activity],
+            activities=[deliver_subscription_report_activity, emit_subscription_delivery_outcome_events_activity],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,  # turn off sandbox/deadlock detector
@@ -287,7 +300,7 @@ async def test_deliver_subscription_report_slack(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
             workflows=[HandleSubscriptionValueChangeWorkflow],
-            activities=[deliver_subscription_report_activity],
+            activities=[deliver_subscription_report_activity, emit_subscription_delivery_outcome_events_activity],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,  # turn off sandbox/deadlock detector
@@ -300,3 +313,204 @@ async def test_deliver_subscription_report_slack(
             )
 
     assert mock_send_slack.call_count == 1
+
+
+@patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("ee.tasks.subscriptions.send_email_subscription_report")
+@patch("ee.tasks.subscriptions.generate_assets_async")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_successful_deliveries_emit_succeeded_events(
+    mock_gen_assets: MagicMock,
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_posthog: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="ev1234", name="Insight")
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team, insight_id=insight.id, export_format="image/png"
+    )
+
+    async def mock_generate_assets_async(subscription):
+        return [insight], [asset]
+
+    mock_gen_assets.side_effect = mock_generate_assets_async
+
+    await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
+    await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
+
+    with freeze_time("2022-02-02T08:30:00.000Z"):
+        sub = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[ScheduleAllSubscriptionsWorkflow],
+            activities=[
+                deliver_subscription_report_activity,
+                emit_subscription_delivery_outcome_events_activity,
+                fetch_due_subscriptions_activity,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=50),
+            debug_mode=True,
+        ):
+            await activity_environment.client.execute_workflow(
+                ScheduleAllSubscriptionsWorkflow.run,
+                ScheduleAllSubscriptionsWorkflowInputs(),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    succeeded_calls = [
+        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
+    ]
+    assert len(succeeded_calls) == 1
+    assert succeeded_calls[0].kwargs["properties"]["subscription_id"] == sub.id
+
+    exhausted_calls = [
+        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
+    ]
+    assert len(exhausted_calls) == 0
+    mock_posthog.flush.assert_called()
+
+
+@patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("ee.tasks.subscriptions.send_email_subscription_report")
+@patch("ee.tasks.subscriptions.generate_assets_async")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_failed_deliveries_emit_exhausted_events(
+    mock_gen_assets: MagicMock,
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_posthog: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="ev5678", name="Insight")
+
+    async def mock_generate_assets_async(subscription):
+        raise Exception("OOM killed")
+
+    mock_gen_assets.side_effect = mock_generate_assets_async
+
+    await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
+    await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
+
+    with freeze_time("2022-02-02T08:30:00.000Z"):
+        sub = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[ScheduleAllSubscriptionsWorkflow],
+            activities=[
+                deliver_subscription_report_activity,
+                emit_subscription_delivery_outcome_events_activity,
+                fetch_due_subscriptions_activity,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=50),
+            debug_mode=True,
+        ):
+            await activity_environment.client.execute_workflow(
+                ScheduleAllSubscriptionsWorkflow.run,
+                ScheduleAllSubscriptionsWorkflowInputs(),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    exhausted_calls = [
+        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
+    ]
+    assert len(exhausted_calls) == 1
+    assert exhausted_calls[0].kwargs["properties"]["subscription_id"] == sub.id
+
+    succeeded_calls = [
+        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
+    ]
+    assert len(succeeded_calls) == 0
+    mock_posthog.flush.assert_called()
+
+
+@patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("ee.tasks.subscriptions.send_email_subscription_report")
+@patch("ee.tasks.subscriptions.generate_assets_async")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_mixed_success_and_failure_does_not_block(
+    mock_gen_assets: MagicMock,
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_posthog: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="mx1234", name="Insight")
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team, insight_id=insight.id, export_format="image/png"
+    )
+
+    await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
+    await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
+
+    with freeze_time("2022-02-02T08:30:00.000Z"):
+        sub_ok = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+        sub_fail = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    call_count = 0
+
+    async def mock_generate_assets_async(subscription):
+        nonlocal call_count
+        call_count += 1
+        if subscription.id == sub_fail.id:
+            raise Exception("asset generation failed")
+        return [insight], [asset]
+
+    mock_gen_assets.side_effect = mock_generate_assets_async
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[ScheduleAllSubscriptionsWorkflow],
+            activities=[
+                deliver_subscription_report_activity,
+                emit_subscription_delivery_outcome_events_activity,
+                fetch_due_subscriptions_activity,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=50),
+            debug_mode=True,
+        ):
+            await activity_environment.client.execute_workflow(
+                ScheduleAllSubscriptionsWorkflow.run,
+                ScheduleAllSubscriptionsWorkflowInputs(),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    # The successful subscription still delivered emails (2 recipients)
+    assert mock_send_email.call_count == 2
+
+    succeeded_calls = [
+        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
+    ]
+    exhausted_calls = [
+        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
+    ]
+    assert len(succeeded_calls) == 1
+    assert succeeded_calls[0].kwargs["properties"]["subscription_id"] == sub_ok.id
+    assert len(exhausted_calls) == 1
+    assert exhausted_calls[0].kwargs["properties"]["subscription_id"] == sub_fail.id


### PR DESCRIPTION
## Problem

We need success and failure events to build a success-rate percentage graph in PostHog. However, subscription deliveries run as Temporal activities. When a pod OOMs, metrics emitted from within the activity may not make it out of the pod. 

## Changes

- Add a new lightweight `emit_subscription_delivery_outcome_events_activity` that batch-loads team IDs and emits `subscription_delivery_succeeded` / `subscription_delivery_exhausted` PostHog events

The event emit activity runs from the workflowlevel (not inside the delivery activity), so Temporal's server-side state persistence ensures it executes even if the delivery worker OOMs.

## How did you test this code?
- 3 new tests added:
  - Successful deliveries emit `subscription_delivery_succeeded` events
  - Failed deliveries emit `subscription_delivery_exhausted` events
  - Mixed success/failure - one failing subscription doesn't block others from delivering

## Publish to changelog?

No

## Docs update

N/A