### PR TITLE
feat(tracing): add trace capture to capture-logs service

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -50,6 +50,9 @@ services:
                         path /i/v1/logs
                         path /i/v1/logs/
                         path /i/v1/logs/*
+                        path /i/v1/traces
+                        path /i/v1/traces/
+                        path /i/v1/traces/*
                     }
 
                     @flags {

--- a/otel-collector-config.dev.yaml
+++ b/otel-collector-config.dev.yaml
@@ -60,6 +60,14 @@ exporters:
         endpoint: 'jaeger-local:4317' # Sending OTLP gRPC to Jaeger
         tls:
             insecure: true # For local communication to Jaeger
+    otlphttp: # Using the standard OTLP exporter
+        endpoint: 'http://capture-logs:4318'
+        compression: none
+        tls:
+            insecure: true # For local communication to Jaeger
+        headers:
+            # special "local" token is automatically mapped to team_id 1 in dev environments
+            authorization: Bearer phc_local
     otlphttp/logs:
         endpoint: 'http://capture-logs:4318'
         compression: none
@@ -77,7 +85,7 @@ service:
         traces:
             receivers: [otlp]
             processors: [batch]
-            exporters: [otlp]
+            exporters: [otlp, otlphttp]
         logs:
             exporters:
                 - otlphttp/logs

--- a/rust/capture-logs/src/kafka.rs
+++ b/rust/capture-logs/src/kafka.rs
@@ -1,5 +1,7 @@
 use crate::avro_schema::AVRO_SCHEMA;
 use crate::log_record::KafkaLogRow;
+use crate::trace_record::KafkaTraceRow;
+use crate::traces_avro_schema::TRACES_AVRO_SCHEMA;
 use anyhow::anyhow;
 use apache_avro::{Codec, Schema, Writer, ZstandardSettings};
 use capture::config::KafkaConfig;
@@ -108,7 +110,8 @@ impl rdkafka::ClientContext for KafkaContext {
 #[derive(Clone)]
 pub struct KafkaSink {
     producer: FutureProducer<KafkaContext>,
-    topic: String,
+    logs_topic: String,
+    traces_topic: String,
 }
 
 impl KafkaSink {
@@ -180,7 +183,8 @@ impl KafkaSink {
 
         Ok(KafkaSink {
             producer,
-            topic: config.kafka_topic,
+            logs_topic: config.kafka_topic,
+            traces_topic: config.kafka_traces_topic,
         })
     }
 
@@ -189,36 +193,30 @@ impl KafkaSink {
         self.producer.flush(Duration::new(30, 0))
     }
 
-    pub async fn write(
+    async fn write_avro_batch<T: serde::Serialize>(
         &self,
+        topic: &str,
+        avro_schema_str: &str,
         token: &str,
-        rows: Vec<KafkaLogRow>,
+        rows: &[T],
         uncompressed_bytes: u64,
         timestamps_overridden: u64,
     ) -> Result<(), anyhow::Error> {
-        if rows.is_empty() {
-            return Ok(());
-        }
-
-        if timestamps_overridden > 0 {
-            counter!("capture_logs_timestamps_overridden").increment(timestamps_overridden);
-        }
-
-        let schema = Schema::parse_str(AVRO_SCHEMA)?;
+        let schema = Schema::parse_str(avro_schema_str)?;
         let mut writer = Writer::with_codec(
             &schema,
             Vec::new(),
             Codec::Zstandard(ZstandardSettings::new(1)),
         );
 
-        for row in &rows {
+        for row in rows {
             writer.append_ser(row)?;
         }
 
         let payload: Vec<u8> = writer.into_inner()?;
 
         let future = match self.producer.send_result(FutureRecord {
-            topic: self.topic.as_str(),
+            topic,
             payload: Some(&payload),
             partition: None,
             key: None::<Vec<u8>>.as_ref(),
@@ -261,6 +259,62 @@ impl KafkaSink {
         }?;
 
         drop(future.await?);
+
+        Ok(())
+    }
+
+    pub async fn write(
+        &self,
+        token: &str,
+        rows: Vec<KafkaLogRow>,
+        uncompressed_bytes: u64,
+        timestamps_overridden: u64,
+    ) -> Result<(), anyhow::Error> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        if timestamps_overridden > 0 {
+            counter!("capture_logs_timestamps_overridden").increment(timestamps_overridden);
+        }
+
+        self.write_avro_batch(
+            &self.logs_topic,
+            AVRO_SCHEMA,
+            token,
+            &rows,
+            uncompressed_bytes,
+            timestamps_overridden,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn write_traces(
+        &self,
+        token: &str,
+        rows: Vec<KafkaTraceRow>,
+        uncompressed_bytes: u64,
+        timestamps_overridden: u64,
+    ) -> Result<(), anyhow::Error> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        if timestamps_overridden > 0 {
+            counter!("capture_traces_timestamps_overridden").increment(timestamps_overridden);
+        }
+
+        self.write_avro_batch(
+            &self.traces_topic,
+            TRACES_AVRO_SCHEMA,
+            token,
+            &rows,
+            uncompressed_bytes,
+            timestamps_overridden,
+        )
+        .await?;
 
         Ok(())
     }

--- a/rust/capture-logs/src/lib.rs
+++ b/rust/capture-logs/src/lib.rs
@@ -5,3 +5,5 @@ pub mod endpoints;
 pub mod kafka;
 pub mod log_record;
 pub mod service;
+pub mod trace_record;
+pub mod traces_avro_schema;

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -164,7 +164,7 @@ fn extract_string_from_map(attributes: &HashMap<String, String>, key: &str) -> S
     }
 }
 
-fn extract_trace_id(input: &[u8]) -> [u8; 16] {
+pub fn extract_trace_id(input: &[u8]) -> [u8; 16] {
     if input.len() == 16 {
         let mut bytes = [0; 16];
         bytes.copy_from_slice(input);
@@ -174,7 +174,7 @@ fn extract_trace_id(input: &[u8]) -> [u8; 16] {
     }
 }
 
-fn extract_span_id(input: &[u8]) -> [u8; 8] {
+pub fn extract_span_id(input: &[u8]) -> [u8; 8] {
     if input.len() == 8 {
         let mut bytes = [0; 8];
         bytes.copy_from_slice(input);
@@ -239,7 +239,7 @@ fn convert_severity_number_to_text(severity_number: i32) -> String {
     }
 }
 
-fn extract_resource_attributes(resource: Option<Resource>) -> HashMap<String, String> {
+pub fn extract_resource_attributes(resource: Option<Resource>) -> HashMap<String, String> {
     let Some(resource) = resource else {
         return HashMap::new();
     };
@@ -280,7 +280,7 @@ fn try_extract_severity(body: &str) -> Option<String> {
     None
 }
 
-fn any_value_to_json(value: AnyValue) -> JsonValue {
+pub fn any_value_to_json(value: AnyValue) -> JsonValue {
     match value.value {
         Some(value_enum) => match value_enum {
             any_value::Value::StringValue(s) => json!(s),
@@ -311,7 +311,7 @@ fn any_value_to_json(value: AnyValue) -> JsonValue {
     }
 }
 
-fn any_value_to_string(value: AnyValue) -> String {
+pub fn any_value_to_string(value: AnyValue) -> String {
     any_value_to_json(value).to_string()
 }
 

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -7,7 +7,7 @@ use capture_logs::config::Config;
 use capture_logs::endpoints::datadog;
 use capture_logs::kafka::KafkaSink;
 use capture_logs::service::Service;
-use capture_logs::service::{export_logs_http, options_handler};
+use capture_logs::service::{export_logs_http, export_traces_http, options_handler};
 use common_metrics::setup_metrics_routes;
 use std::future::ready;
 use std::net::SocketAddr;
@@ -129,6 +129,14 @@ async fn main() {
         .route(
             "/i/v1/logs",
             post(export_logs_http).options(options_handler),
+        )
+        .route(
+            "/v1/traces",
+            post(export_traces_http).options(options_handler),
+        )
+        .route(
+            "/i/v1/traces",
+            post(export_traces_http).options(options_handler),
         )
         .route(
             "/i/v1/logs/datadog",

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -1,4 +1,5 @@
 use crate::log_record::KafkaLogRow;
+use crate::trace_record::KafkaTraceRow;
 use axum::{
     extract::Query,
     extract::State,
@@ -8,6 +9,7 @@ use axum::{
 use bytes::Bytes;
 use limiters::token_dropper::TokenDropper;
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -265,5 +267,178 @@ pub async fn export_logs_http(
 /// to support various SDK versions and reverse proxy configurations.
 pub async fn options_handler(
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    Ok(Json(json!({})))
+}
+
+/// Parse OpenTelemetry trace message from JSON bytes.
+///
+/// Supports both single JSON objects and JSONL format (JSON Lines).
+/// For JSONL, multiple ExportTraceServiceRequest objects are parsed and merged
+/// into a single request by combining their resource_spans arrays.
+pub fn parse_otel_traces_message(
+    json_bytes: &Bytes,
+) -> Result<ExportTraceServiceRequest, anyhow::Error> {
+    if let Ok(mut v) = serde_json::from_slice::<Value>(json_bytes) {
+        patch_otel_json(&mut v);
+        let result: ExportTraceServiceRequest = serde_json::from_value(v)?;
+        return Ok(result);
+    }
+
+    let json_str = std::str::from_utf8(json_bytes)?;
+    let lines: Vec<&str> = json_str
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+
+    let mut merged_request = ExportTraceServiceRequest {
+        resource_spans: Vec::new(),
+    };
+
+    for line in lines {
+        let mut v: Value = serde_json::from_str(line)?;
+        patch_otel_json(&mut v);
+        let request: ExportTraceServiceRequest = serde_json::from_value(v)?;
+        merged_request
+            .resource_spans
+            .extend(request.resource_spans);
+    }
+
+    Ok(merged_request)
+}
+
+#[instrument(skip_all, fields(
+    token = tracing::field::Empty,
+    content_type = %headers.get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(""),
+    user_agent = %headers.get("user-agent")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(""),
+    content_length = %headers.get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(""),
+    content_encoding = %headers.get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")))
+]
+pub async fn export_traces_http(
+    State(service): State<Service>,
+    Query(query_params): Query<QueryParams>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    if !headers.contains_key("Authorization") && query_params.token.is_none() {
+        error!("No token provided");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "No token provided"})),
+        ));
+    }
+
+    let token = if headers.contains_key("Authorization") {
+        match headers["Authorization"]
+            .to_str()
+            .unwrap_or("")
+            .split("Bearer ")
+            .last()
+        {
+            Some(token) if !token.is_empty() => token,
+            _ => {
+                error!("No token provided");
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({"error": "No token provided"})),
+                ));
+            }
+        }
+    } else {
+        match query_params.token {
+            Some(ref token) if !token.is_empty() => token,
+            _ => {
+                error!("No token provided");
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({"error": "No token provided"})),
+                ));
+            }
+        }
+    };
+
+    if service.token_dropper.should_drop(token, "") {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Invalid token"})),
+        ));
+    }
+
+    tracing::Span::current().record("token", token);
+
+    let export_request = match ExportTraceServiceRequest::decode(body.as_ref()) {
+        Ok(request) => request,
+        Err(proto_err) => match parse_otel_traces_message(&body) {
+            Ok(request) => request,
+            Err(json_err) => {
+                if let Err(e) = File::create("/tmp/last_failed_trace_event.txt").and_then(
+                    |mut file| {
+                        file.write_all(token.as_bytes())
+                            .and_then(|_| file.write_all(&body))
+                    },
+                ) {
+                    error!("Failed to write last failed trace event to file: {}", e);
+                }
+                error!(
+                    "Failed to decode JSON: {} or Protobuf: {}",
+                    json_err, proto_err
+                );
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": format!("Failed to decode JSON: {} or Protobuf: {}", json_err, proto_err)})),
+                ));
+            }
+        },
+    };
+
+    let mut rows: Vec<KafkaTraceRow> = Vec::new();
+    let mut timestamps_overridden: u64 = 0;
+    for resource_spans in export_request.resource_spans {
+        for scope_spans in resource_spans.scope_spans {
+            for span in scope_spans.spans {
+                let (row, was_overridden) = match KafkaTraceRow::new(
+                    span,
+                    resource_spans.resource.clone(),
+                    scope_spans.scope.clone(),
+                ) {
+                    Ok(result) => result,
+                    Err(e) => {
+                        error!("Failed to create TraceRow: {e}");
+                        return Err((
+                            StatusCode::BAD_REQUEST,
+                            Json(json!({"error": "Bad input format provided"})),
+                        ));
+                    }
+                };
+                if was_overridden {
+                    timestamps_overridden += 1;
+                }
+                rows.push(row);
+            }
+        }
+    }
+
+    let row_count = rows.len();
+    if let Err(e) = service
+        .sink
+        .write_traces(token, rows, body.len() as u64, timestamps_overridden)
+        .await
+    {
+        error!("Failed to send traces to Kafka: {}", e);
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "Internal server error"})),
+        ));
+    } else {
+        debug!("Successfully sent {} traces to Kafka", row_count);
+    }
+
     Ok(Json(json!({})))
 }

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -298,9 +298,7 @@ pub fn parse_otel_traces_message(
         let mut v: Value = serde_json::from_str(line)?;
         patch_otel_json(&mut v);
         let request: ExportTraceServiceRequest = serde_json::from_value(v)?;
-        merged_request
-            .resource_spans
-            .extend(request.resource_spans);
+        merged_request.resource_spans.extend(request.resource_spans);
     }
 
     Ok(merged_request)
@@ -378,12 +376,12 @@ pub async fn export_traces_http(
         Err(proto_err) => match parse_otel_traces_message(&body) {
             Ok(request) => request,
             Err(json_err) => {
-                if let Err(e) = File::create("/tmp/last_failed_trace_event.txt").and_then(
-                    |mut file| {
+                if let Err(e) =
+                    File::create("/tmp/last_failed_trace_event.txt").and_then(|mut file| {
                         file.write_all(token.as_bytes())
                             .and_then(|_| file.write_all(&body))
-                    },
-                ) {
+                    })
+                {
                     error!("Failed to write last failed trace event to file: {}", e);
                 }
                 error!(
@@ -392,7 +390,9 @@ pub async fn export_traces_http(
                 );
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    Json(json!({"error": format!("Failed to decode JSON: {} or Protobuf: {}", json_err, proto_err)})),
+                    Json(
+                        json!({"error": format!("Failed to decode JSON: {} or Protobuf: {}", json_err, proto_err)}),
+                    ),
                 ));
             }
         },

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -1,0 +1,445 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use base64::{prelude::BASE64_STANDARD, Engine};
+use chrono::serde::ts_microseconds;
+use chrono::DateTime;
+use chrono::Utc;
+use clickhouse::Row;
+use opentelemetry_proto::tonic::{
+    common::v1::{AnyValue, InstrumentationScope},
+    resource::v1::Resource,
+    trace::v1::Span,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::log_record::{
+    any_value_to_string, extract_resource_attributes, extract_span_id, extract_trace_id,
+    override_timestamp,
+};
+
+#[derive(Row, Debug, Serialize, Deserialize)]
+pub struct KafkaTraceRow {
+    pub uuid: String,
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: String,
+    pub trace_state: String,
+    pub name: String,
+    pub kind: i32,
+    pub flags: i32,
+    #[serde(with = "ts_microseconds")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(with = "ts_microseconds")]
+    pub end_time: DateTime<Utc>,
+    #[serde(with = "ts_microseconds")]
+    pub observed_timestamp: DateTime<Utc>,
+    pub service_name: String,
+    pub resource_attributes: HashMap<String, String>,
+    pub instrumentation_scope: String,
+    pub attributes: HashMap<String, String>,
+    pub dropped_attributes_count: i32,
+    pub events: Vec<String>,
+    pub dropped_events_count: i32,
+    pub links: Vec<String>,
+    pub dropped_links_count: i32,
+    pub status_code: i32,
+}
+
+impl KafkaTraceRow {
+    pub fn new(
+        span: Span,
+        resource: Option<Resource>,
+        scope: Option<InstrumentationScope>,
+    ) -> Result<(Self, bool)> {
+        let trace_id = BASE64_STANDARD.encode(extract_trace_id(&span.trace_id));
+        let span_id = BASE64_STANDARD.encode(extract_span_id(&span.span_id));
+        let parent_span_id = BASE64_STANDARD.encode(extract_span_id(&span.parent_span_id));
+
+        let resource_attributes = extract_resource_attributes(resource);
+        let service_name = extract_string_from_resource(&resource_attributes, "service.name");
+
+        let mut attributes: HashMap<String, String> = span
+            .attributes
+            .into_iter()
+            .map(|kv| {
+                (
+                    kv.key,
+                    any_value_to_string(kv.value.unwrap_or(AnyValue {
+                        value: Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                                "".to_string(),
+                            ),
+                        ),
+                    })),
+                )
+            })
+            .collect();
+
+        let instrumentation_scope = match scope {
+            Some(s) => format!("{}@{}", s.name, s.version),
+            None => "".to_string(),
+        };
+
+        let raw_timestamp = match span.start_time_unix_nano {
+            0 => Utc::now(),
+            _ => DateTime::<Utc>::from_timestamp_nanos(span.start_time_unix_nano.try_into()?),
+        };
+        let (timestamp, original_timestamp) = override_timestamp(raw_timestamp);
+        let was_overridden = original_timestamp.is_some();
+        if let Some(original) = original_timestamp {
+            attributes.insert("$originalTimestamp".to_string(), original.to_rfc3339());
+        }
+
+        let end_time = match span.end_time_unix_nano {
+            0 => timestamp,
+            _ => DateTime::<Utc>::from_timestamp_nanos(span.end_time_unix_nano.try_into()?),
+        };
+
+        let events: Vec<String> = span
+            .events
+            .into_iter()
+            .map(|event| {
+                let attrs: HashMap<String, String> = event
+                    .attributes
+                    .into_iter()
+                    .map(|kv| {
+                        (
+                            kv.key,
+                            any_value_to_string(kv.value.unwrap_or(AnyValue {
+                                value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("".to_string())),
+                            })),
+                        )
+                    })
+                    .collect();
+                json!({
+                    "time_unix_nano": event.time_unix_nano,
+                    "name": event.name,
+                    "attributes": attrs,
+                    "dropped_attributes_count": event.dropped_attributes_count,
+                })
+                .to_string()
+            })
+            .collect();
+
+        let links: Vec<String> = span
+            .links
+            .into_iter()
+            .map(|link| {
+                let attrs: HashMap<String, String> = link
+                    .attributes
+                    .into_iter()
+                    .map(|kv| {
+                        (
+                            kv.key,
+                            any_value_to_string(kv.value.unwrap_or(AnyValue {
+                                value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("".to_string())),
+                            })),
+                        )
+                    })
+                    .collect();
+                json!({
+                    "trace_id": BASE64_STANDARD.encode(extract_trace_id(&link.trace_id)),
+                    "span_id": BASE64_STANDARD.encode(extract_span_id(&link.span_id)),
+                    "trace_state": link.trace_state,
+                    "attributes": attrs,
+                    "dropped_attributes_count": link.dropped_attributes_count,
+                    "flags": link.flags,
+                })
+                .to_string()
+            })
+            .collect();
+
+        let status_code = span
+            .status
+            .as_ref()
+            .map(|s| s.code)
+            .unwrap_or(0);
+
+        let row = Self {
+            uuid: Uuid::now_v7().to_string(),
+            trace_id,
+            span_id,
+            parent_span_id,
+            trace_state: span.trace_state,
+            name: span.name,
+            kind: span.kind,
+            flags: span.flags as i32,
+            timestamp,
+            end_time,
+            observed_timestamp: Utc::now(),
+            service_name,
+            resource_attributes,
+            instrumentation_scope,
+            attributes,
+            dropped_attributes_count: span.dropped_attributes_count as i32,
+            events,
+            dropped_events_count: span.dropped_events_count as i32,
+            links,
+            dropped_links_count: span.dropped_links_count as i32,
+            status_code,
+        };
+        debug!("trace span: {:?}", row);
+
+        Ok((row, was_overridden))
+    }
+}
+
+fn extract_string_from_resource(attributes: &HashMap<String, String>, key: &str) -> String {
+    if let Some(value) = attributes.get(key) {
+        if let Ok(serde_json::Value::String(value)) =
+            serde_json::from_str::<serde_json::Value>(value)
+        {
+            value.to_string()
+        } else {
+            value.to_string()
+        }
+    } else {
+        "".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeDelta, Utc};
+    use opentelemetry_proto::tonic::{
+        common::v1::{any_value, AnyValue, KeyValue},
+        trace::v1::{span::Event, span::Link, Status, Span},
+    };
+
+    fn make_span() -> Span {
+        let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
+        Span {
+            trace_id: vec![1u8; 16],
+            span_id: vec![2u8; 8],
+            parent_span_id: vec![3u8; 8],
+            trace_state: "vendor=foo".to_string(),
+            name: "test.operation".to_string(),
+            kind: 2, // SERVER
+            flags: 1,
+            start_time_unix_nano: now_nanos - 1_000_000_000,
+            end_time_unix_nano: now_nanos,
+            attributes: vec![KeyValue {
+                key: "http.method".to_string(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue("GET".to_string())),
+                }),
+            }],
+            dropped_attributes_count: 0,
+            events: vec![],
+            dropped_events_count: 0,
+            links: vec![],
+            dropped_links_count: 0,
+            status: Some(Status {
+                message: "".to_string(),
+                code: 1, // OK
+            }),
+        }
+    }
+
+    #[test]
+    fn test_basic_span_conversion() {
+        let span = make_span();
+        let (row, was_overridden) = KafkaTraceRow::new(span, None, None).unwrap();
+
+        assert!(!was_overridden);
+        assert!(!row.uuid.is_empty());
+        assert_eq!(row.trace_id, BASE64_STANDARD.encode([1u8; 16]));
+        assert_eq!(row.span_id, BASE64_STANDARD.encode([2u8; 8]));
+        assert_eq!(row.parent_span_id, BASE64_STANDARD.encode([3u8; 8]));
+        assert_eq!(row.trace_state, "vendor=foo");
+        assert_eq!(row.name, "test.operation");
+        assert_eq!(row.kind, 2);
+        assert_eq!(row.flags, 1);
+        assert_eq!(row.status_code, 1);
+        assert_eq!(row.attributes.get("http.method").map(|s| s.as_str()), Some("\"GET\""));
+    }
+
+    #[test]
+    fn test_empty_span_produces_valid_row() {
+        let span = Span::default();
+        let (row, was_overridden) = KafkaTraceRow::new(span, None, None).unwrap();
+
+        // Zero timestamp defaults to now, which is within range — no override
+        assert!(!was_overridden);
+        assert!(!row.uuid.is_empty());
+        assert_eq!(row.name, "");
+        assert_eq!(row.kind, 0);
+        assert_eq!(row.status_code, 0);
+        assert!(row.events.is_empty());
+        assert!(row.links.is_empty());
+    }
+
+    #[test]
+    fn test_timestamp_override_far_past() {
+        let far_past_nanos = (Utc::now() - TimeDelta::hours(48))
+            .timestamp_nanos_opt()
+            .unwrap() as u64;
+        let span = Span {
+            start_time_unix_nano: far_past_nanos,
+            end_time_unix_nano: far_past_nanos + 1_000_000,
+            ..Default::default()
+        };
+        let (row, was_overridden) = KafkaTraceRow::new(span, None, None).unwrap();
+
+        assert!(was_overridden);
+        assert!(row.attributes.contains_key("$originalTimestamp"));
+    }
+
+    #[test]
+    fn test_timestamp_within_range_not_overridden() {
+        let recent_nanos = (Utc::now() - TimeDelta::hours(1))
+            .timestamp_nanos_opt()
+            .unwrap() as u64;
+        let span = Span {
+            start_time_unix_nano: recent_nanos,
+            end_time_unix_nano: recent_nanos + 1_000_000,
+            ..Default::default()
+        };
+        let (row, was_overridden) = KafkaTraceRow::new(span, None, None).unwrap();
+
+        assert!(!was_overridden);
+        assert!(!row.attributes.contains_key("$originalTimestamp"));
+    }
+
+    #[test]
+    fn test_events_serialized_as_array_of_json_strings() {
+        let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
+        let span = Span {
+            start_time_unix_nano: now_nanos - 1_000_000,
+            end_time_unix_nano: now_nanos,
+            events: vec![
+                Event {
+                    time_unix_nano: now_nanos - 500_000,
+                    name: "db.query".to_string(),
+                    attributes: vec![KeyValue {
+                        key: "db.statement".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(any_value::Value::StringValue("SELECT 1".to_string())),
+                        }),
+                    }],
+                    dropped_attributes_count: 0,
+                },
+                Event {
+                    time_unix_nano: now_nanos - 100_000,
+                    name: "exception".to_string(),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                },
+            ],
+            ..Default::default()
+        };
+        let (row, _) = KafkaTraceRow::new(span, None, None).unwrap();
+
+        assert_eq!(row.events.len(), 2);
+        // Each element must be valid JSON
+        let e0: serde_json::Value = serde_json::from_str(&row.events[0]).unwrap();
+        assert_eq!(e0["name"], "db.query");
+        let e1: serde_json::Value = serde_json::from_str(&row.events[1]).unwrap();
+        assert_eq!(e1["name"], "exception");
+    }
+
+    #[test]
+    fn test_links_serialized_as_array_of_json_strings() {
+        let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
+        let span = Span {
+            start_time_unix_nano: now_nanos - 1_000_000,
+            end_time_unix_nano: now_nanos,
+            links: vec![Link {
+                trace_id: vec![9u8; 16],
+                span_id: vec![8u8; 8],
+                trace_state: "linked=true".to_string(),
+                attributes: vec![],
+                dropped_attributes_count: 0,
+                flags: 0,
+            }],
+            ..Default::default()
+        };
+        let (row, _) = KafkaTraceRow::new(span, None, None).unwrap();
+
+        assert_eq!(row.links.len(), 1);
+        let l0: serde_json::Value = serde_json::from_str(&row.links[0]).unwrap();
+        assert_eq!(l0["trace_id"], BASE64_STANDARD.encode([9u8; 16]));
+        assert_eq!(l0["span_id"], BASE64_STANDARD.encode([8u8; 8]));
+        assert_eq!(l0["trace_state"], "linked=true");
+    }
+
+    #[test]
+    fn test_status_code_extraction() {
+        let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
+        let span = Span {
+            start_time_unix_nano: now_nanos - 1_000_000,
+            end_time_unix_nano: now_nanos,
+            status: Some(Status {
+                message: "internal error".to_string(),
+                code: 2, // ERROR
+            }),
+            ..Default::default()
+        };
+        let (row, _) = KafkaTraceRow::new(span, None, None).unwrap();
+        assert_eq!(row.status_code, 2);
+    }
+
+    #[test]
+    fn test_parent_span_id_encoding() {
+        let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
+        let parent = vec![0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89];
+        let span = Span {
+            start_time_unix_nano: now_nanos - 1_000_000,
+            end_time_unix_nano: now_nanos,
+            parent_span_id: parent.clone(),
+            ..Default::default()
+        };
+        let (row, _) = KafkaTraceRow::new(span, None, None).unwrap();
+        assert_eq!(row.parent_span_id, BASE64_STANDARD.encode(&parent));
+    }
+
+    #[test]
+    fn test_resource_service_name_extracted() {
+        use opentelemetry_proto::tonic::{
+            common::v1::{any_value, AnyValue, KeyValue},
+            resource::v1::Resource,
+        };
+
+        let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
+        let span = Span {
+            start_time_unix_nano: now_nanos - 1_000_000,
+            end_time_unix_nano: now_nanos,
+            ..Default::default()
+        };
+        let resource = Resource {
+            attributes: vec![KeyValue {
+                key: "service.name".to_string(),
+                value: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue("my-service".to_string())),
+                }),
+            }],
+            dropped_attributes_count: 0,
+        };
+        let (row, _) = KafkaTraceRow::new(span, Some(resource), None).unwrap();
+        assert_eq!(row.service_name, "my-service");
+    }
+
+    #[test]
+    fn test_instrumentation_scope_name_version() {
+        use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
+
+        let now_nanos = Utc::now().timestamp_nanos_opt().unwrap() as u64;
+        let span = Span {
+            start_time_unix_nano: now_nanos - 1_000_000,
+            end_time_unix_nano: now_nanos,
+            ..Default::default()
+        };
+        let scope = InstrumentationScope {
+            name: "opentelemetry-rust".to_string(),
+            version: "0.22.0".to_string(),
+            ..Default::default()
+        };
+        let (row, _) = KafkaTraceRow::new(span, None, Some(scope)).unwrap();
+        assert_eq!(row.instrumentation_scope, "opentelemetry-rust@0.22.0");
+    }
+}

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -47,6 +47,7 @@ pub struct KafkaTraceRow {
     pub links: Vec<String>,
     pub dropped_links_count: i32,
     pub status_code: i32,
+    pub status_message: String,
 }
 
 impl KafkaTraceRow {
@@ -154,6 +155,7 @@ impl KafkaTraceRow {
             .collect();
 
         let status_code = span.status.as_ref().map(|s| s.code).unwrap_or(0);
+        let status_message = span.status.as_ref().map(|s| s.message.clone()).unwrap_or_default();
 
         let row = Self {
             uuid: Uuid::now_v7().to_string(),
@@ -177,6 +179,7 @@ impl KafkaTraceRow {
             links,
             dropped_links_count: span.dropped_links_count as i32,
             status_code,
+            status_message,
         };
         debug!("trace span: {:?}", row);
 

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -153,11 +153,7 @@ impl KafkaTraceRow {
             })
             .collect();
 
-        let status_code = span
-            .status
-            .as_ref()
-            .map(|s| s.code)
-            .unwrap_or(0);
+        let status_code = span.status.as_ref().map(|s| s.code).unwrap_or(0);
 
         let row = Self {
             uuid: Uuid::now_v7().to_string(),
@@ -208,7 +204,7 @@ mod tests {
     use chrono::{TimeDelta, Utc};
     use opentelemetry_proto::tonic::{
         common::v1::{any_value, AnyValue, KeyValue},
-        trace::v1::{span::Event, span::Link, Status, Span},
+        trace::v1::{span::Event, span::Link, Span, Status},
     };
 
     fn make_span() -> Span {
@@ -256,7 +252,10 @@ mod tests {
         assert_eq!(row.kind, 2);
         assert_eq!(row.flags, 1);
         assert_eq!(row.status_code, 1);
-        assert_eq!(row.attributes.get("http.method").map(|s| s.as_str()), Some("\"GET\""));
+        assert_eq!(
+            row.attributes.get("http.method").map(|s| s.as_str()),
+            Some("\"GET\"")
+        );
     }
 
     #[test]

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -155,7 +155,11 @@ impl KafkaTraceRow {
             .collect();
 
         let status_code = span.status.as_ref().map(|s| s.code).unwrap_or(0);
-        let status_message = span.status.as_ref().map(|s| s.message.clone()).unwrap_or_default();
+        let status_message = span
+            .status
+            .as_ref()
+            .map(|s| s.message.clone())
+            .unwrap_or_default();
 
         let row = Self {
             uuid: Uuid::now_v7().to_string(),

--- a/rust/capture-logs/src/traces_avro_schema.rs
+++ b/rust/capture-logs/src/traces_avro_schema.rs
@@ -1,0 +1,134 @@
+pub const TRACES_AVRO_SCHEMA: &str = r#"
+{
+"type": "record",
+"name": "TraceRecord",
+"doc": "Schema for an OTEL trace span.",
+"fields": [
+    {
+    "name": "uuid",
+    "type": ["null", "string"],
+    "doc": "Unique identifier for the span record."
+    },
+    {
+    "name": "trace_id",
+    "type": ["null", "bytes"],
+    "doc": "Identifier for the trace this span belongs to."
+    },
+    {
+    "name": "span_id",
+    "type": ["null", "bytes"],
+    "doc": "Identifier for this span within the trace."
+    },
+    {
+    "name": "parent_span_id",
+    "type": ["null", "bytes"],
+    "doc": "Identifier for the parent span, if any."
+    },
+    {
+    "name": "trace_state",
+    "type": ["null", "string"],
+    "doc": "W3C trace state string."
+    },
+    {
+    "name": "name",
+    "type": ["null", "string"],
+    "doc": "Operation name of the span."
+    },
+    {
+    "name": "kind",
+    "type": ["null", "int"],
+    "doc": "SpanKind: 0=UNSPECIFIED, 1=INTERNAL, 2=SERVER, 3=CLIENT, 4=PRODUCER, 5=CONSUMER."
+    },
+    {
+    "name": "flags",
+    "type": ["null", "int"],
+    "doc": "Trace flags as defined in W3C Trace Context specification."
+    },
+    {
+    "name": "timestamp",
+    "type": ["null", {
+        "type": "long",
+        "logicalType": "timestamp-micros"
+    }],
+    "doc": "Start time of the span, in microseconds since epoch."
+    },
+    {
+    "name": "end_time",
+    "type": ["null", {
+        "type": "long",
+        "logicalType": "timestamp-micros"
+    }],
+    "doc": "End time of the span, in microseconds since epoch."
+    },
+    {
+    "name": "observed_timestamp",
+    "type": ["null", {
+        "type": "long",
+        "logicalType": "timestamp-micros"
+    }],
+    "doc": "The timestamp when the span was received by the collector."
+    },
+    {
+    "name": "service_name",
+    "type": ["null", "string"],
+    "doc": "The name of the service that generated the span."
+    },
+    {
+    "name": "resource_attributes",
+    "type": ["null", {
+        "type": "map",
+        "values": "string"
+    }],
+    "doc": "Attributes describing the resource that produced the span."
+    },
+    {
+    "name": "instrumentation_scope",
+    "type": ["null", "string"],
+    "doc": "The name and version of the instrumentation library that captured the span."
+    },
+    {
+    "name": "attributes",
+    "type": ["null", {
+        "type": "map",
+        "values": "string"
+    }],
+    "doc": "A map of custom string-valued attributes associated with the span."
+    },
+    {
+    "name": "dropped_attributes_count",
+    "type": ["null", "int"],
+    "doc": "Number of attributes that were dropped due to limits."
+    },
+    {
+    "name": "events",
+    "type": ["null", {
+        "type": "array",
+        "items": "string"
+    }],
+    "doc": "Array of span events, each serialized as a JSON string."
+    },
+    {
+    "name": "dropped_events_count",
+    "type": ["null", "int"],
+    "doc": "Number of events that were dropped due to limits."
+    },
+    {
+    "name": "links",
+    "type": ["null", {
+        "type": "array",
+        "items": "string"
+    }],
+    "doc": "Array of span links, each serialized as a JSON string."
+    },
+    {
+    "name": "dropped_links_count",
+    "type": ["null", "int"],
+    "doc": "Number of links that were dropped due to limits."
+    },
+    {
+    "name": "status_code",
+    "type": ["null", "int"],
+    "doc": "Status code: 0=UNSET, 1=OK, 2=ERROR."
+    }
+]
+}"#;

--- a/rust/capture-logs/tests/traces_test.rs
+++ b/rust/capture-logs/tests/traces_test.rs
@@ -1,0 +1,179 @@
+use bytes::Bytes;
+use capture_logs::service::{parse_otel_traces_message, patch_otel_json};
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use prost::Message;
+use serde_json::json;
+
+// opentelemetry-proto with-serde uses hex encoding (OTLP JSON spec):
+//   traceId: 32-char hex string (16 bytes)
+//   spanId:  16-char hex string (8 bytes)
+
+#[test]
+fn test_parse_single_json_otel_traces_message() {
+    let json_data = r#"{"resourceSpans":[{"resource":{"attributes":[]},"scopeSpans":[{"scope":{"name":"test"},"spans":[{"traceId":"00000000000000000000000000000000","spanId":"0000000000000000","name":"test.span","kind":1,"startTimeUnixNano":"1000000000","endTimeUnixNano":"2000000000","status":{"code":1}}]}]}]}"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_traces_message(&bytes);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let request = result.unwrap();
+    assert_eq!(request.resource_spans.len(), 1);
+    assert_eq!(request.resource_spans[0].scope_spans.len(), 1);
+    assert_eq!(request.resource_spans[0].scope_spans[0].spans.len(), 1);
+    assert_eq!(
+        request.resource_spans[0].scope_spans[0].spans[0].name,
+        "test.span"
+    );
+}
+
+#[test]
+fn test_parse_jsonl_otel_traces_message() {
+    let jsonl_data = concat!(
+        r#"{"resourceSpans":[{"resource":{"attributes":[]},"scopeSpans":[{"scope":{"name":"svc1"},"spans":[{"traceId":"00000000000000000000000000000000","spanId":"0000000000000000","name":"span1","startTimeUnixNano":"1000000000","endTimeUnixNano":"2000000000"}]}]}]}"#,
+        "\n",
+        r#"{"resourceSpans":[{"resource":{"attributes":[]},"scopeSpans":[{"scope":{"name":"svc2"},"spans":[{"traceId":"00000000000000000000000000000000","spanId":"0000000000000000","name":"span2","startTimeUnixNano":"3000000000","endTimeUnixNano":"4000000000"}]}]}]}"#
+    );
+    let bytes = Bytes::from(jsonl_data);
+
+    let result = parse_otel_traces_message(&bytes);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let request = result.unwrap();
+    assert_eq!(request.resource_spans.len(), 2);
+    assert_eq!(
+        request.resource_spans[0].scope_spans[0].spans[0].name,
+        "span1"
+    );
+    assert_eq!(
+        request.resource_spans[1].scope_spans[0].spans[0].name,
+        "span2"
+    );
+}
+
+#[test]
+fn test_parse_jsonl_traces_with_empty_lines() {
+    let jsonl_data = concat!(
+        "\n",
+        r#"{"resourceSpans":[{"resource":{"attributes":[]},"scopeSpans":[{"scope":{"name":"svc1"},"spans":[{"traceId":"00000000000000000000000000000000","spanId":"0000000000000000","name":"span1","startTimeUnixNano":"1000000000","endTimeUnixNano":"2000000000"}]}]}]}"#,
+        "\n\n"
+    );
+    let bytes = Bytes::from(jsonl_data);
+
+    let result = parse_otel_traces_message(&bytes);
+    assert!(result.is_ok());
+    let request = result.unwrap();
+    assert_eq!(request.resource_spans.len(), 1);
+}
+
+#[test]
+fn test_parse_empty_resource_spans() {
+    let json_data = r#"{"resourceSpans":[]}"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_traces_message(&bytes);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().resource_spans.len(), 0);
+}
+
+#[test]
+fn test_parse_empty_scope_spans() {
+    let json_data = r#"{"resourceSpans":[{"resource":{"attributes":[]},"scopeSpans":[]}]}"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_traces_message(&bytes);
+    assert!(result.is_ok());
+    let request = result.unwrap();
+    assert_eq!(request.resource_spans.len(), 1);
+    assert_eq!(request.resource_spans[0].scope_spans.len(), 0);
+}
+
+#[test]
+fn test_parse_protobuf_otel_traces_message() {
+    let request = ExportTraceServiceRequest {
+        resource_spans: vec![],
+    };
+
+    let mut buf = Vec::new();
+    request.encode(&mut buf).unwrap();
+    let bytes = Bytes::from(buf);
+
+    let decoded = ExportTraceServiceRequest::decode(bytes.as_ref()).unwrap();
+    assert_eq!(decoded.resource_spans.len(), 0);
+}
+
+#[test]
+fn test_patch_otel_json_applies_to_trace_attributes() {
+    let mut json = json!({
+        "resourceSpans": [{
+            "resource": {
+                "attributes": [{
+                    "key": "service.name",
+                    "value": {}
+                }]
+            },
+            "scopeSpans": [{
+                "spans": [{
+                    "attributes": [{
+                        "key": "http.method",
+                        "value": {}
+                    }]
+                }]
+            }]
+        }]
+    });
+
+    patch_otel_json(&mut json);
+
+    assert!(json["resourceSpans"][0]["resource"]["attributes"][0]["value"].is_null());
+    assert!(
+        json["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"][0]["value"].is_null()
+    );
+}
+
+#[test]
+fn test_parse_span_with_events_and_links() {
+    let json_data = r#"{
+        "resourceSpans": [{
+            "resource": {"attributes": []},
+            "scopeSpans": [{
+                "scope": {"name": "test"},
+                "spans": [{
+                    "traceId": "00000000000000000000000000000000",
+                    "spanId": "0000000000000000",
+                    "name": "test.operation",
+                    "startTimeUnixNano": "1000000000",
+                    "endTimeUnixNano": "2000000000",
+                    "events": [{
+                        "timeUnixNano": "1500000000",
+                        "name": "exception",
+                        "attributes": []
+                    }],
+                    "links": [{
+                        "traceId": "00000000000000000000000000000000",
+                        "spanId": "0000000000000000",
+                        "traceState": ""
+                    }]
+                }]
+            }]
+        }]
+    }"#;
+    let bytes = Bytes::from(json_data);
+
+    let result = parse_otel_traces_message(&bytes);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+
+    let request = result.unwrap();
+    let span = &request.resource_spans[0].scope_spans[0].spans[0];
+    assert_eq!(span.events.len(), 1);
+    assert_eq!(span.events[0].name, "exception");
+    assert_eq!(span.links.len(), 1);
+}
+
+#[test]
+fn test_parse_invalid_json_returns_error() {
+    let invalid_data = r#"not json at all"#;
+    let bytes = Bytes::from(invalid_data);
+
+    let result = parse_otel_traces_message(&bytes);
+    assert!(result.is_err());
+}

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -270,6 +270,8 @@ pub struct KafkaConfig {
     pub kafka_hosts: String,
     #[envconfig(default = "events_plugin_ingestion")]
     pub kafka_topic: String,
+    #[envconfig(default = "ingestion-traces")]
+    pub kafka_traces_topic: String,
     #[envconfig(default = "events_plugin_ingestion_overflow")]
     pub kafka_overflow_topic: String,
     #[envconfig(default = "events_plugin_ingestion_historical")]

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -138,6 +138,7 @@ pub struct KafkaTopicConfig {
     pub replay_overflow_topic: String,
     pub dlq_topic: String,
     pub error_tracking_topic: String,
+    pub traces_topic: String,
 }
 
 impl From<&KafkaConfig> for KafkaTopicConfig {
@@ -152,6 +153,7 @@ impl From<&KafkaConfig> for KafkaTopicConfig {
             replay_overflow_topic: config.kafka_replay_overflow_topic.clone(),
             dlq_topic: config.kafka_dlq_topic.clone(),
             error_tracking_topic: config.kafka_error_tracking_topic.clone(),
+            traces_topic: config.kafka_traces_topic.clone(),
         }
     }
 }

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -880,6 +880,7 @@ mod tests {
         const CLIENT_INGESTION_WARNING_TOPIC: &str = "client_ingestion_warning";
         const REPLAY_OVERFLOW_TOPIC: &str = "replay_overflow";
         const ERROR_TRACKING_TOPIC: &str = "error_tracking_events";
+        const TRACES_TOPIC: &str = "tracing_ingestion";
 
         fn create_test_topics() -> KafkaTopicConfig {
             KafkaTopicConfig {
@@ -892,6 +893,7 @@ mod tests {
                 replay_overflow_topic: REPLAY_OVERFLOW_TOPIC.to_string(),
                 dlq_topic: DLQ_TOPIC.to_string(),
                 error_tracking_topic: ERROR_TRACKING_TOPIC.to_string(),
+                traces_topic: TRACES_TOPIC.to_string(),
             }
         }
 

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -572,6 +572,7 @@ mod tests {
             kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
             kafka_replay_overflow_topic: "session_recording_snapshot_item_overflow".to_string(),
             kafka_dlq_topic: "events_plugin_ingestion_dlq".to_string(),
+            kafka_traces_topic: "traces_ingestion".to_string(),
             kafka_tls: false,
             kafka_client_id: "".to_string(),
             kafka_metadata_max_age_ms: 60000,

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -85,6 +85,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
         kafka_replay_overflow_topic: "session_recording_snapshot_item_overflow".to_string(),
         kafka_dlq_topic: "events_plugin_ingestion_dlq".to_string(),
+        kafka_traces_topic: "ingestion_traces".to_string(),
         kafka_tls: false,
         kafka_client_id: "".to_string(),
         kafka_metadata_max_age_ms: 60000,


### PR DESCRIPTION

## Problem

We want traces - add /i/v1/traces endpoint to capture-logs
## Changes

Add OTLP trace data parsing, Avro serialization, and Kafka publishing to the Rust capture-logs service.


## How did you test this code?

end to end locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
