### PR TITLE
fix: add /api/agentic/authorize to BACKEND_ONLY_ROUTES

### DIFF
--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -32,6 +32,7 @@ export interface PrecheckResponseType {
 
 // Routes that should be handled by Django, not the React router
 const BACKEND_ONLY_ROUTES = [
+    '/api/agentic/authorize',
     '/login/vercel/continue',
     '/oauth/authorize',
     '/toolbar_oauth/authorize',


### PR DESCRIPTION
## Problem

When a user isn't logged into PostHog and Stripe opens the `/api/agentic/authorize` URL, Django's `@login_required` decorator redirects to `/login?next=/api/agentic/authorize...`. After the user logs in, the React SPA router intercepts the `next` URL and tries to handle it client-side instead of performing a full-page navigation to the Django backend endpoint. This causes the Stripe agentic provisioning OAuth flow to silently fail.

## Changes

Added `/api/agentic/authorize` to the `BACKEND_ONLY_ROUTES` array in `frontend/src/scenes/authentication/loginLogic.ts`. This tells the post-login redirect handler to use `window.location.href` (full-page navigation) instead of the React router for this route, ensuring the request reaches the Django backend.

## How did you test this code?

This was authored by an agent. No manual testing was performed. To test manually:

1. Log out of PostHog
2. Navigate to `/api/agentic/authorize?...` (with valid Stripe OAuth params)
3. Verify you are redirected to `/login?next=/api/agentic/authorize...`
4. Log in
5. Verify the browser performs a full-page navigation to `/api/agentic/authorize` (Django handles it) instead of the React SPA swallowing the route

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code (Opus 4.6).