### PR TITLE
fix: improve agentic authorize email mismatch error

### DIFF
--- a/ee/api/agentic_provisioning/test/test_authorize.py
+++ b/ee/api/agentic_provisioning/test/test_authorize.py
@@ -49,6 +49,7 @@ class TestAgenticAuthorize(APIBaseTest):
         res = self.client.get("/api/agentic/authorize?state=state_mismatch")
         assert res.status_code == 302
         assert "error=email_mismatch" in res["Location"]
+        assert "expected=ot%2A%2A%2A%40example.com" in res["Location"]
 
     def test_redirects_to_callback_with_code(self):
         self._set_pending_auth("state_ok", self.user.email)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -374,7 +374,10 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
         return HttpResponseRedirect(f"{settings.SITE_URL}?error=expired_or_invalid_state")
 
     if request.user.email != pending["email"]:
-        return HttpResponseRedirect(f"{settings.SITE_URL}?error=email_mismatch")
+        expected_email = pending["email"]
+        masked = expected_email[:2] + "***@" + expected_email.split("@")[1] if "@" in expected_email else "***"
+        params = urlencode({"error": "email_mismatch", "expected": masked})
+        return HttpResponseRedirect(f"{settings.SITE_URL}?{params}")
 
     cache.delete(pending_key)
 


### PR DESCRIPTION
## Problem

When a user is logged into PostHog with a different email than what Stripe sent in the agentic account request, the authorize endpoint silently redirects to `/?error=email_mismatch`. The user has no way to know which email they should log in with, making the error unhelpful.

## Changes

- The email mismatch redirect now includes a `expected` query parameter with a masked version of the expected email (e.g. `ot***@example.com`)
- The frontend can use this to show a message like "Please log in as ot***@example.com"
- Updated the test to verify the masked email is included in the redirect

## How did you test this code?

- Verified URL encoding of the masked email manually via Python REPL
- Updated `test_email_mismatch_redirects_with_error` to assert on the new `expected` parameter
- PostgreSQL was not running locally so tests could not be executed end-to-end, but the URL encoding was verified independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)