### PR TITLE
feat: Continous commit metadata.json

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -80,6 +80,12 @@ pub struct CheckpointConfig {
     /// This includes listing checkpoints, downloading metadata, and downloading all files.
     /// Should be less than kafka max.poll.interval.ms to prevent consumer group kicks.
     pub checkpoint_partition_import_timeout: Duration,
+
+    /// Maximum age of a local metadata.json before the local store is considered stale
+    /// and the service falls back to S3 import. Separate from checkpoint_import_window_hours
+    /// (the S3 listing window): local staleness must be tighter because if a pod was down
+    /// for longer than this, another pod likely consumed the partition and local data is behind.
+    pub local_checkpoint_max_staleness: Duration,
 }
 
 impl Default for CheckpointConfig {
@@ -108,6 +114,7 @@ impl Default for CheckpointConfig {
             max_concurrent_checkpoint_file_downloads: 1000,
             max_concurrent_checkpoint_file_uploads: 1000,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
+            local_checkpoint_max_staleness: Duration::from_secs(7200),
         }
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/config.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/config.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+/// Default maximum age (seconds) of a local metadata.json before the local store
+/// is considered stale and the service falls back to S3 import. 2 hours.
+pub const DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS: u64 = 7200;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointConfig {
     /// How often to trigger a checkpoint attempt for all locally-hosted partition stores
@@ -114,7 +118,9 @@ impl Default for CheckpointConfig {
             max_concurrent_checkpoint_file_downloads: 1000,
             max_concurrent_checkpoint_file_uploads: 1000,
             checkpoint_partition_import_timeout: Duration::from_secs(240),
-            local_checkpoint_max_staleness: Duration::from_secs(7200),
+            local_checkpoint_max_staleness: Duration::from_secs(
+                DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS,
+            ),
         }
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/import.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/import.rs
@@ -8,7 +8,6 @@ use crate::metrics_const::{
 };
 
 use anyhow::{Context, Result};
-use chrono::Utc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -96,11 +95,10 @@ impl CheckpointImporter {
     /// This method will:
     /// 1. List recent checkpoint metadata.json keys from remote storage for the topic+partition
     /// 2. For each key (newest to oldest, up to import_attempt_depth), lazily download the
-    ///    metadata.json and attempt to download all tracked files to a timestamped store
-    ///    directory: `<store_base_path>/<topic>_<partition>/<timestamp_millis>/`
+    ///    metadata.json and attempt to download all tracked files to the partition store
+    ///    directory: `<store_base_path>/<topic>/<partition>/`
     /// 3. If a checkpoint import fails, fall back to the next most recent
-    /// 4. If successful, write metadata.json and a `.imported_<timestamp>` marker to that directory,
-    ///    then return the store path
+    /// 4. If successful, write metadata.json to that directory and return the store path
     ///
     /// Metadata files are downloaded lazily (one at a time, only when needed) rather than
     /// eagerly in bulk, to reduce S3 pressure during rebalances when many partitions import
@@ -233,11 +231,21 @@ impl CheckpointImporter {
                 }
             };
 
-            let import_timestamp = Utc::now();
-            let local_attempt_path =
-                attempt.get_store_path(&self.store_base_path, import_timestamp);
+            let local_attempt_path = attempt.get_store_path(&self.store_base_path);
             let local_path_tag = local_attempt_path.to_string_lossy().to_string();
             let attempt_tag = attempt.get_attempt_path();
+
+            // If a stale store directory exists, remove it before importing.
+            // The caller already determined local data is stale or missing.
+            if local_attempt_path.exists() {
+                info!(
+                    topic = topic,
+                    partition = partition_number,
+                    path = %local_attempt_path.display(),
+                    "Removing stale local store before import"
+                );
+                let _ = tokio::fs::remove_dir_all(&local_attempt_path).await;
+            }
 
             // Create the directory for this import attempt
             if let Err(e) = tokio::fs::create_dir_all(&local_attempt_path).await {
@@ -290,26 +298,10 @@ impl CheckpointImporter {
                             )
                         })?;
 
-                    // Write .imported_<timestamp> marker (same metadata JSON) to identify this as an imported store
-                    let marker_filename =
-                        format!(".imported_{}", import_timestamp.timestamp_millis());
-                    let marker_path = local_attempt_path.join(&marker_filename);
-                    let marker_content = attempt.to_json()?;
-                    tokio::fs::write(&marker_path, marker_content)
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "Failed to write import marker file: {}",
-                                marker_path.display()
-                            )
-                        })?;
-
                     info!(
                         checkpoint = attempt_tag,
                         local_store_path = local_path_tag,
                         original_checkpoint_timestamp = %attempt.attempt_timestamp,
-                        local_store_timestamp_millis = import_timestamp.timestamp_millis(),
-                        marker_file = %marker_filename,
                         attempt_duration_secs = attempt_duration,
                         total_duration_secs = start_time.elapsed().as_secs_f64(),
                         "Successfully imported checkpoint to local directory"
@@ -682,51 +674,12 @@ mod tests {
         let import_path = result.unwrap();
         assert!(import_path.exists(), "Import path should exist");
 
-        // Verify the import path uses a current timestamp (Utc::now()), not the checkpoint's old timestamp
-        let timestamp_str = import_path.file_name().unwrap().to_str().unwrap();
-        let timestamp_millis: i64 = timestamp_str
-            .parse()
-            .expect("Path should end with timestamp millis");
-        assert!(
-            timestamp_millis >= before_import.timestamp_millis(),
-            "Import timestamp {} should be >= before_import {}",
-            timestamp_millis,
-            before_import.timestamp_millis()
+        // Verify the import path is <base>/<topic>/<partition>
+        let expected_path = store_base_path.join(topic).join(partition.to_string());
+        assert_eq!(
+            import_path, expected_path,
+            "Import path should be <base>/<topic>/<partition>"
         );
-        assert!(
-            timestamp_millis <= after_import.timestamp_millis(),
-            "Import timestamp {} should be <= after_import {}",
-            timestamp_millis,
-            after_import.timestamp_millis()
-        );
-
-        // Verify the timestamp is NOT the old checkpoint timestamp
-        assert_ne!(
-            timestamp_millis,
-            attempt_timestamp.timestamp_millis(),
-            "Import should use Utc::now(), not the checkpoint's original timestamp"
-        );
-
-        // Verify marker file exists with correct content
-        let marker_files: Vec<_> = std::fs::read_dir(&import_path)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_string_lossy().starts_with(".imported_"))
-            .collect();
-        assert_eq!(marker_files.len(), 1, "Should have exactly one marker file");
-
-        let marker_filename = marker_files[0].file_name().to_string_lossy().to_string();
-        assert!(
-            marker_filename.starts_with(".imported_"),
-            "Marker file should start with .imported_"
-        );
-
-        // Verify marker file content contains checkpoint metadata
-        let marker_content = std::fs::read_to_string(marker_files[0].path()).unwrap();
-        let marker_metadata: serde_json::Value =
-            serde_json::from_str(&marker_content).expect("Marker should contain valid JSON");
-        assert_eq!(marker_metadata["topic"], topic);
-        assert_eq!(marker_metadata["partition"], partition);
 
         // Verify the imported SST file exists
         let imported_file = import_path.join("000001.sst");
@@ -832,8 +785,8 @@ mod tests {
             Duration::from_secs(60),
         );
 
-        // Record the partition directory path
-        let partition_dir = store_base_path.join(format!("{topic}_{partition}"));
+        // Record the store path
+        let store_path = store_base_path.join(topic).join(partition.to_string());
 
         // Import should fail
         let result = importer
@@ -841,21 +794,11 @@ mod tests {
             .await;
         assert!(result.is_err(), "Import should fail");
 
-        // The partition directory might exist but should have no timestamp subdirs
-        // (the guard should have cleaned them up)
-        if partition_dir.exists() {
-            let subdirs: Vec<_> = std::fs::read_dir(&partition_dir)
-                .unwrap()
-                .filter_map(|e| e.ok())
-                .filter(|e| e.path().is_dir())
-                .collect();
-            assert!(
-                subdirs.is_empty(),
-                "Cleanup guard should have removed the timestamp directory, but found: {:?}",
-                subdirs
-            );
-        }
-        // If partition_dir doesn't exist, that's also fine - means cleanup removed everything
+        // The cleanup guard should have removed the store directory
+        assert!(
+            !store_path.exists(),
+            "Cleanup guard should have removed the store directory on failure"
+        );
     }
 
     #[test]

--- a/rust/kafka-deduplicator/src/checkpoint/metadata.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/metadata.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use chrono::{DateTime, Utc};
-use tracing::info;
+use tracing::debug;
 
 use crate::utils::format_store_path;
 
@@ -102,17 +102,23 @@ impl CheckpointMetadata {
         Ok(metadata)
     }
 
-    /// Write metadata.json directly into the given directory.
-    /// Stamps `updated_at` to `Utc::now()` before writing so the persisted
-    /// file always reflects the actual write time.
+    /// Write metadata.json atomically into the given directory.
+    ///
+    /// Writes to a temporary file first, then renames to the final path. This
+    /// prevents torn reads if another task reads metadata.json concurrently
+    /// (e.g., during rebalance restore while a commit-triggered write is in flight).
     pub async fn write_to_dir(&mut self, dir: &Path) -> Result<()> {
         self.updated_at = Utc::now();
         let json = self.to_json().context("In write_to_dir")?;
         let path = dir.join(METADATA_FILENAME);
-        tokio::fs::write(&path, json)
+        let tmp_path = dir.join(".metadata.json.tmp");
+        tokio::fs::write(&tmp_path, json)
             .await
-            .with_context(|| format!("Failed to write metadata to: {path:?}"))?;
-        info!("Saved checkpoint metadata to {:?}", path);
+            .with_context(|| format!("Failed to write temp metadata to: {tmp_path:?}"))?;
+        tokio::fs::rename(&tmp_path, &path)
+            .await
+            .with_context(|| format!("Failed to rename temp metadata to: {path:?}"))?;
+        debug!("Saved checkpoint metadata to {:?}", path);
         Ok(())
     }
 
@@ -129,25 +135,10 @@ impl CheckpointMetadata {
         format!("{}/{}/{}", self.topic, self.partition, self.id)
     }
 
-    /// Produce a path under the supplied base directory for the local RocksDB stores that
-    /// will host the imported checkpoint files. Example:
-    /// <local_store_base_path>/<topic_name>_<partition_number>/<timestamp_unix_epoch_millis>
-    ///
-    /// The caller provides the timestamp to use for the local store directory. Production code
-    /// should pass `Utc::now()` so imported checkpoints get the current timestamp (ensuring they
-    /// are "newest" and won't be superseded by accidentally created empty stores). Tests can
-    /// pass controlled timestamps for validation.
-    pub fn get_store_path(
-        &self,
-        local_store_base_path: &Path,
-        timestamp: DateTime<Utc>,
-    ) -> PathBuf {
-        format_store_path(
-            local_store_base_path,
-            &self.topic,
-            self.partition,
-            timestamp,
-        )
+    /// Produce a path under the supplied base directory for the local RocksDB store.
+    /// Example: `<local_store_base_path>/<topic>/<partition>`
+    pub fn get_store_path(&self, local_store_base_path: &Path) -> PathBuf {
+        format_store_path(local_store_base_path, &self.topic, self.partition)
     }
 
     /// Get relative path to metadata file for this checkpoint attempt,
@@ -569,7 +560,6 @@ mod tests {
     #[test]
     fn test_get_store_path() {
         let attempt_timestamp = Utc::now();
-        let timestamp_millis = attempt_timestamp.timestamp_millis();
         let topic = "events";
         let partition = 5;
 
@@ -583,28 +573,20 @@ mod tests {
         );
 
         let base_path = Path::new("/data/stores");
-        // Pass explicit timestamp - production code uses Utc::now(), tests can control the timestamp
-        let store_path = metadata.get_store_path(base_path, attempt_timestamp);
+        let store_path = metadata.get_store_path(base_path);
+        assert_eq!(store_path, PathBuf::from("/data/stores/events/5"));
 
-        // Store path should be <base>/<topic>_<partition>/<timestamp_millis>
-        let expected = base_path
-            .join(format!("{topic}_{partition}"))
-            .join(timestamp_millis.to_string());
-        assert_eq!(store_path, expected);
-
-        // Works with different base paths
         let tmp_base = Path::new("/tmp/deduplication-store");
-        let tmp_store_path = metadata.get_store_path(tmp_base, attempt_timestamp);
-        let tmp_expected = tmp_base
-            .join(format!("{topic}_{partition}"))
-            .join(timestamp_millis.to_string());
-        assert_eq!(tmp_store_path, tmp_expected);
+        let tmp_store_path = metadata.get_store_path(tmp_base);
+        assert_eq!(
+            tmp_store_path,
+            PathBuf::from("/tmp/deduplication-store/events/5")
+        );
     }
 
     #[test]
     fn test_get_store_path_with_slashes_in_topic() {
         let attempt_timestamp = Utc::now();
-        let timestamp_millis = attempt_timestamp.timestamp_millis();
         let topic = "org/team/events";
         let partition = 0;
 
@@ -618,13 +600,7 @@ mod tests {
         );
 
         let base_path = Path::new("/data/stores");
-        // Pass explicit timestamp - production code uses Utc::now(), tests can control the timestamp
-        let store_path = metadata.get_store_path(base_path, attempt_timestamp);
-
-        // Slashes in topic should be replaced with underscores for filesystem safety
-        let expected = base_path
-            .join("org_team_events_0")
-            .join(timestamp_millis.to_string());
-        assert_eq!(store_path, expected);
+        let store_path = metadata.get_store_path(base_path);
+        assert_eq!(store_path, PathBuf::from("/data/stores/org/team/events/0"));
     }
 }

--- a/rust/kafka-deduplicator/src/checkpoint/metadata.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/metadata.rs
@@ -112,9 +112,14 @@ impl CheckpointMetadata {
         let json = self.to_json().context("In write_to_dir")?;
         let path = dir.join(METADATA_FILENAME);
         let tmp_path = dir.join(".metadata.json.tmp");
-        tokio::fs::write(&tmp_path, json)
-            .await
-            .with_context(|| format!("Failed to write temp metadata to: {tmp_path:?}"))?;
+        if let Err(e) = tokio::fs::write(&tmp_path, json).await {
+            // Clean up partial tmp file on write failure
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e)
+                .with_context(|| format!("Failed to write temp metadata to: {tmp_path:?}"));
+        }
+        // rename(2) atomically replaces the destination on Unix, so concurrent
+        // readers see either the old or new file, never a partial write.
         tokio::fs::rename(&tmp_path, &path)
             .await
             .with_context(|| format!("Failed to rename temp metadata to: {path:?}"))?;
@@ -601,6 +606,7 @@ mod tests {
 
         let base_path = Path::new("/data/stores");
         let store_path = metadata.get_store_path(base_path);
-        assert_eq!(store_path, PathBuf::from("/data/stores/org/team/events/0"));
+        // Slashes are replaced with underscores to keep a two-level directory structure
+        assert_eq!(store_path, PathBuf::from("/data/stores/org_team_events/0"));
     }
 }

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -302,6 +302,12 @@ pub struct Config {
     #[envconfig(default = "240")]
     pub checkpoint_partition_import_timeout_secs: u64,
 
+    // Maximum age of a local metadata.json before we consider the local store stale
+    // and fall back to S3 import. Separate from checkpoint_import_window_hours which
+    // controls the S3 listing window.
+    #[envconfig(default = "7200")] // 2 hours
+    pub local_checkpoint_max_staleness_secs: u64,
+
     //// End checkpoint configuration ////
     //// Kafka-assigner mode configuration ////
     /// gRPC endpoint for the kafka-assigner service (e.g. "http://kafka-assigner:50051").
@@ -603,6 +609,11 @@ impl Config {
     /// Get checkpoint partition import timeout as Duration
     pub fn checkpoint_partition_import_timeout(&self) -> Duration {
         Duration::from_secs(self.checkpoint_partition_import_timeout_secs)
+    }
+
+    /// Get max staleness for local checkpoint data as Duration
+    pub fn local_checkpoint_max_staleness(&self) -> Duration {
+        Duration::from_secs(self.local_checkpoint_max_staleness_secs)
     }
 
     /// Build Kafka consumer configuration for the group-based batch consumer.

--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -22,6 +22,7 @@ use rdkafka::error::KafkaResult;
 use rdkafka::message::Message;
 use rdkafka::TopicPartitionList;
 use serde::Deserialize;
+use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot::Receiver;
 use tracing::{error, info, warn};
@@ -29,6 +30,16 @@ use tracing::{error, info, warn};
 #[async_trait]
 pub trait BatchConsumerProcessor<T>: Send + Sync {
     async fn process_batch(&self, messages: Vec<KafkaMessage<T>>) -> Result<()>;
+}
+
+/// Callback invoked after a successful Kafka offset commit.
+///
+/// Implementations receive the committed offsets (partition → next offset to consume)
+/// and can perform side effects like updating local metadata. Failures should be
+/// handled internally (non-fatal).
+#[async_trait]
+pub trait OnCommit: Send + Sync {
+    async fn on_commit(&self, offsets: &HashMap<Partition, i64>);
 }
 
 pub struct BatchConsumer<T> {
@@ -59,6 +70,9 @@ pub struct BatchConsumer<T> {
 
     // timeout for seek_partitions after checkpoint import
     seek_timeout: Duration,
+
+    // optional callback invoked after successful offset commits
+    on_commit: Option<Arc<dyn OnCommit>>,
 }
 
 impl<T> BatchConsumer<T>
@@ -71,6 +85,7 @@ where
         rebalance_handler: Arc<dyn RebalanceHandler>,
         processor: Arc<dyn BatchConsumerProcessor<T>>,
         offset_tracker: Arc<OffsetTracker>,
+        on_commit: Option<Arc<dyn OnCommit>>,
         shutdown_rx: Receiver<()>,
         topic: &str,
         batch_size: usize,
@@ -97,6 +112,7 @@ where
             batch_timeout,
             processor,
             offset_tracker,
+            on_commit,
             shutdown_rx,
             consumer_command_rx,
             seek_timeout,
@@ -234,7 +250,7 @@ where
                 // The offset tracker contains offsets that have been successfully processed
                 // by partition workers, ensuring we only commit what's been processed
                 _ = commit_interval.tick() => {
-                    Self::commit_tracked_offsets(&consumer, &self.offset_tracker);
+                    Self::commit_tracked_offsets(&consumer, &self.offset_tracker, &self.on_commit);
                 }
             }
         }
@@ -263,6 +279,7 @@ where
     fn commit_tracked_offsets(
         consumer: &StreamConsumer<BatchConsumerContext>,
         offset_tracker: &OffsetTracker,
+        on_commit: &Option<Arc<dyn OnCommit>>,
     ) {
         let offsets = match offset_tracker.get_committable_offsets() {
             Ok(offsets) => offsets,
@@ -298,6 +315,16 @@ where
                 // Update the offset tracker with the committed offsets
                 // These are used for checkpointing to track the true recovery point
                 offset_tracker.mark_committed(&offsets);
+
+                // Notify the on_commit callback (fire-and-forget).
+                // Failures are non-fatal — handled internally by the callback.
+                if let Some(callback) = on_commit {
+                    let callback = Arc::clone(callback);
+                    let offsets = offsets.clone();
+                    tokio::spawn(async move {
+                        callback.on_commit(&offsets).await;
+                    });
+                }
             }
             Err(e) => {
                 warn!("Failed to commit tracked offsets: {e:#}");

--- a/rust/kafka-deduplicator/src/kafka/offset_tracker.rs
+++ b/rust/kafka-deduplicator/src/kafka/offset_tracker.rs
@@ -270,6 +270,26 @@ impl OffsetTracker {
         }
     }
 
+    /// Initialize partition state from restored metadata (local or S3 import).
+    ///
+    /// Populates committed and producer offsets so checkpointing reflects the pre-restart
+    /// state. Only inserts if no entry exists yet — safe to call multiple times.
+    pub fn init_partition_from_metadata(
+        &self,
+        partition: &Partition,
+        consumer_offset: i64,
+        producer_offset: i64,
+    ) {
+        self.partition_state
+            .entry(partition.clone())
+            .or_insert_with(|| PartitionState {
+                processed_offset: consumer_offset,
+                last_processed_batch_id: 0,
+                committed_offset: consumer_offset,
+                producer_offset,
+            });
+    }
+
     /// Clear all partitions (during shutdown)
     pub fn clear_all(&self) {
         self.partition_state.clear();
@@ -668,5 +688,34 @@ mod tests {
         assert_eq!(tracker.get_partition_offset(&partition), None);
         assert_eq!(tracker.get_committed_offset(&partition), None);
         assert_eq!(tracker.get_producer_offset(&partition), None);
+    }
+
+    #[test]
+    fn test_init_partition_from_metadata_seeds_all_offsets() {
+        let coordinator = create_test_tracker();
+        let tracker = OffsetTracker::new(coordinator);
+        let partition = test_partition(0);
+
+        tracker.init_partition_from_metadata(&partition, 1000, 500);
+
+        assert_eq!(tracker.get_partition_offset(&partition), Some(1000));
+        assert_eq!(tracker.get_committed_offset(&partition), Some(1000));
+        assert_eq!(tracker.get_producer_offset(&partition), Some(500));
+    }
+
+    #[test]
+    fn test_init_partition_from_metadata_does_not_overwrite_existing_entry() {
+        let coordinator = create_test_tracker();
+        let tracker = OffsetTracker::new(coordinator);
+        let partition = test_partition(0);
+        let batch_id = tracker.assign_batch_id();
+
+        // Entry already exists from normal processing
+        tracker.mark_processed(&partition, batch_id, 2000);
+
+        // init should be a no-op since the entry already exists
+        tracker.init_partition_from_metadata(&partition, 1000, 500);
+
+        assert_eq!(tracker.get_partition_offset(&partition), Some(2000));
     }
 }

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -163,6 +163,11 @@ pub const PARTITION_STORE_SETUP_SKIPPED: &str = "partition_store_setup_skipped_t
 /// This is an important metric for alerting - indicates degraded deduplication quality
 pub const PARTITION_STORE_FALLBACK_EMPTY: &str = "partition_store_fallback_empty_total";
 
+/// Counter for local store restore attempts during rebalance.
+/// Labels: result (fresh | stale | missing | corrupt)
+/// `fresh` means local metadata was valid and S3 import was skipped.
+pub const LOCAL_STORE_RESTORE_COUNTER: &str = "local_store_restore_total";
+
 /// Counter for messages dropped because no store was registered for the partition
 /// Labels: topic, partition
 /// This is expected during rebalances due to rdkafka message buffering

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -6,6 +6,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use common_kafka::kafka_producer::KafkaContext;
@@ -26,7 +27,7 @@ use crate::pipelines::ingestion_events::{
 };
 use crate::processor_rebalance_handler::ProcessorRebalanceHandler;
 use crate::rebalance_tracker::RebalanceTracker;
-use crate::store_manager::StoreManager;
+use crate::store_manager::{MetadataCommitCallback, StoreManager};
 
 /// Enum wrapper for different consumer types based on pipeline and mode configuration.
 ///
@@ -65,6 +66,7 @@ pub struct PipelineBuilder {
     seek_timeout: std::time::Duration,
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
     rebalance_cleanup_parallelism: usize,
+    local_checkpoint_max_staleness: Duration,
 
     // Fail-open mode: bypass deduplication and forward events directly
     fail_open: bool,
@@ -102,6 +104,7 @@ impl PipelineBuilder {
             seek_timeout,
             checkpoint_importer: None,
             rebalance_cleanup_parallelism,
+            local_checkpoint_max_staleness: Duration::from_secs(7200),
             fail_open,
             dedup_config: None,
             main_producer: None,
@@ -111,6 +114,11 @@ impl PipelineBuilder {
 
     pub fn with_checkpoint_importer(mut self, importer: Option<Arc<CheckpointImporter>>) -> Self {
         self.checkpoint_importer = importer;
+        self
+    }
+
+    pub fn with_local_checkpoint_staleness(mut self, staleness: Duration) -> Self {
+        self.local_checkpoint_max_staleness = staleness;
         self
     }
 
@@ -217,6 +225,12 @@ impl PipelineBuilder {
             offset_tracker.clone(),
             self.checkpoint_importer,
             self.rebalance_cleanup_parallelism,
+            self.local_checkpoint_max_staleness,
+        ));
+
+        let on_commit = Arc::new(MetadataCommitCallback::new(
+            self.store_manager.clone(),
+            offset_tracker.clone(),
         ));
 
         let consumer = BatchConsumer::new(
@@ -224,6 +238,7 @@ impl PipelineBuilder {
             rebalance_handler,
             routing_processor,
             offset_tracker,
+            Some(on_commit),
             shutdown_rx,
             &self.topic,
             self.batch_size,
@@ -272,6 +287,12 @@ impl PipelineBuilder {
             offset_tracker.clone(),
             self.checkpoint_importer,
             self.rebalance_cleanup_parallelism,
+            self.local_checkpoint_max_staleness,
+        ));
+
+        let on_commit = Arc::new(MetadataCommitCallback::new(
+            self.store_manager.clone(),
+            offset_tracker.clone(),
         ));
 
         let consumer = BatchConsumer::new(
@@ -279,6 +300,7 @@ impl PipelineBuilder {
             rebalance_handler,
             routing_processor,
             offset_tracker,
+            Some(on_commit),
             shutdown_rx,
             &self.topic,
             self.batch_size,

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -16,6 +16,7 @@ use rdkafka::ClientConfig;
 use tokio::sync::oneshot;
 use tracing::info;
 
+use crate::checkpoint::config::DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS;
 use crate::checkpoint::import::CheckpointImporter;
 use crate::config::PipelineType;
 use crate::kafka::assigner::AssignerConsumer;
@@ -104,7 +105,9 @@ impl PipelineBuilder {
             seek_timeout,
             checkpoint_importer: None,
             rebalance_cleanup_parallelism,
-            local_checkpoint_max_staleness: Duration::from_secs(7200),
+            local_checkpoint_max_staleness: Duration::from_secs(
+                DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS,
+            ),
             fail_open,
             dedup_config: None,
             main_producer: None,

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -1,16 +1,18 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use futures::future::{join_all, Shared};
-use rdkafka::TopicPartitionList;
+use rdkafka::{Offset, TopicPartitionList};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::checkpoint::import::CheckpointImporter;
+use crate::checkpoint::metadata::CheckpointMetadata;
 use crate::kafka::batch_consumer::BatchConsumerProcessor;
 use crate::kafka::batch_context::{ConsumerCommand, ConsumerCommandSender};
 use crate::kafka::offset_tracker::OffsetTracker;
@@ -18,13 +20,15 @@ use crate::kafka::partition_router::{shutdown_workers, PartitionRouter};
 use crate::kafka::rebalance_handler::RebalanceHandler;
 use crate::kafka::types::Partition;
 use crate::metrics_const::{
-    CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER, PARTITION_STORE_FALLBACK_EMPTY,
-    PARTITION_STORE_SETUP_SKIPPED, REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-    REBALANCE_PARTITION_STATE_CHANGE, REBALANCE_RESUME_SKIPPED_NO_OWNED,
+    CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER, LOCAL_STORE_RESTORE_COUNTER,
+    PARTITION_STORE_FALLBACK_EMPTY, PARTITION_STORE_SETUP_SKIPPED,
+    REBALANCE_CHECKPOINT_IMPORT_COUNTER, REBALANCE_PARTITION_STATE_CHANGE,
+    REBALANCE_RESUME_SKIPPED_NO_OWNED,
 };
 use crate::rebalance_tracker::RebalanceTracker;
 use crate::store_manager::StoreManager;
 use crate::utils::async_helpers::unwrap_blocking_task;
+use crate::utils::format_store_path;
 
 /// Type alias for the shared task handle. The closure maps JoinHandle's Result to ()
 /// so it can be Clone (required by Shared).
@@ -58,10 +62,15 @@ where
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
     /// Max parallel directory deletions during rebalance cleanup
     rebalance_cleanup_parallelism: usize,
+    /// Maximum age of local metadata.json before falling back to S3 import
+    local_checkpoint_max_staleness: Duration,
     /// In-flight checkpoint import tasks (per partition). Cancel on revoke; await before resume; stale entries allow re-claim.
     partition_setup_tasks: DashMap<Partition, PartitionSetupTask>,
     /// Reason a partition got a fallback empty store (no_importer | import_failed | import_cancelled) for metrics.
     partition_fallback_reasons: Arc<DashMap<Partition, &'static str>>,
+    /// Metadata from successfully restored partitions (local or S3). Used in finalize to seed
+    /// OffsetTracker and seek consumer without re-reading metadata.json from disk.
+    partition_restored_metadata: Arc<DashMap<Partition, CheckpointMetadata>>,
 }
 
 impl<T, P> ProcessorRebalanceHandler<T, P>
@@ -75,6 +84,7 @@ where
         offset_tracker: Arc<OffsetTracker>,
         checkpoint_importer: Option<Arc<CheckpointImporter>>,
         rebalance_cleanup_parallelism: usize,
+        local_checkpoint_max_staleness: Duration,
     ) -> Self {
         Self {
             store_manager,
@@ -83,8 +93,10 @@ where
             offset_tracker,
             checkpoint_importer,
             rebalance_cleanup_parallelism,
+            local_checkpoint_max_staleness,
             partition_setup_tasks: DashMap::new(),
             partition_fallback_reasons: Arc::new(DashMap::new()),
+            partition_restored_metadata: Arc::new(DashMap::new()),
         }
     }
 
@@ -95,6 +107,7 @@ where
         offset_tracker: Arc<OffsetTracker>,
         checkpoint_importer: Option<Arc<CheckpointImporter>>,
         rebalance_cleanup_parallelism: usize,
+        local_checkpoint_max_staleness: Duration,
     ) -> Self {
         Self {
             store_manager,
@@ -103,8 +116,10 @@ where
             offset_tracker,
             checkpoint_importer,
             rebalance_cleanup_parallelism,
+            local_checkpoint_max_staleness,
             partition_setup_tasks: DashMap::new(),
             partition_fallback_reasons: Arc::new(DashMap::new()),
+            partition_restored_metadata: Arc::new(DashMap::new()),
         }
     }
 
@@ -202,6 +217,7 @@ where
                 // Handle is dropped, task continues but we won't wait for it
             }
             self.partition_fallback_reasons.remove(partition);
+            self.partition_restored_metadata.remove(partition);
         }
     }
 
@@ -226,188 +242,41 @@ where
         let coordinator = self.rebalance_tracker.clone();
         let importer = self.checkpoint_importer.clone();
         let fallback_reasons = Arc::clone(&self.partition_fallback_reasons);
+        let restored_metadata = Arc::clone(&self.partition_restored_metadata);
+        let local_max_staleness = self.local_checkpoint_max_staleness;
 
         tokio::spawn(async move {
-            // === CHECKPOINT 1: Before starting ===
-            if cancel_token.is_cancelled() || !coordinator.is_partition_owned(&partition) {
-                metrics::counter!(
-                    PARTITION_STORE_SETUP_SKIPPED,
-                    "reason" => if cancel_token.is_cancelled() { "cancelled" } else { "not_owned" },
-                    "assignment_mode" => "consumer_group",
-                )
-                .increment(1);
-                fallback_reasons.insert(partition.clone(), "import_cancelled");
+            if should_skip_setup(
+                &partition,
+                &cancel_token,
+                &coordinator,
+                &store_manager,
+                &fallback_reasons,
+            ) {
                 return;
             }
 
-            // Skip if store already exists (handles rapid revoke→assign race)
-            if store_manager
-                .get(partition.topic(), partition.partition_number())
-                .is_some()
+            if try_restore_from_local(
+                &partition,
+                &store_manager,
+                &restored_metadata,
+                local_max_staleness,
+            )
+            .await
             {
-                metrics::counter!(
-                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-                    "result" => "skipped",
-                    "reason" => "store_exists",
-                    "assignment_mode" => "consumer_group",
-                )
-                .increment(1);
                 return;
             }
 
-            // Try checkpoint import WITH per-partition cancellation token
-            // RAII cleanup guard handles partial downloads on failure/timeout/cancel
-            // Fallback empty store creation is handled centrally at resume time.
-            if let Some(ref importer) = importer {
-                match importer
-                    .import_checkpoint_for_topic_partition_cancellable(
-                        partition.topic(),
-                        partition.partition_number(),
-                        Some(&cancel_token), // Per-partition token - stops S3 download on revoke
-                    )
-                    .await
-                {
-                    Ok(path) => {
-                        // === CHECKPOINT 2: After download completes ===
-                        // Check if we should skip registration (token cancelled or ownership lost)
-                        let is_cancelled = cancel_token.is_cancelled();
-                        let is_owned = coordinator.is_partition_owned(&partition);
-
-                        if is_cancelled || !is_owned {
-                            let reason = if is_cancelled {
-                                "cancelled"
-                            } else {
-                                "not_owned"
-                            };
-                            metrics::counter!(
-                                PARTITION_STORE_SETUP_SKIPPED,
-                                "reason" => reason,
-                                "assignment_mode" => "consumer_group",
-                            )
-                            .increment(1);
-                            fallback_reasons.insert(partition.clone(), "import_cancelled");
-
-                            // Clean up the successfully imported directory since we can't use it.
-                            // With unique Utc::now() timestamps, each import attempt creates a new path,
-                            // so there's no collision risk with a new task - it will create its own directory.
-                            if path.exists() {
-                                match tokio::fs::remove_dir_all(&path).await {
-                                    Ok(_) => {
-                                        metrics::counter!(
-                                            CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
-                                            "result" => "success",
-                                            "assignment_mode" => "consumer_group",
-                                        )
-                                        .increment(1);
-                                        info!(
-                                            topic = partition.topic(),
-                                            partition = partition.partition_number(),
-                                            path = %path.display(),
-                                            reason = reason,
-                                            "Cleaned up unused checkpoint import"
-                                        );
-                                    }
-                                    Err(e) => {
-                                        metrics::counter!(
-                                            CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
-                                            "result" => "failed",
-                                            "assignment_mode" => "consumer_group",
-                                        )
-                                        .increment(1);
-                                        warn!(
-                                            topic = partition.topic(),
-                                            partition = partition.partition_number(),
-                                            path = %path.display(),
-                                            error = ?e,
-                                            "Failed to clean up checkpoint import, orphan cleaner will handle it"
-                                        );
-                                    }
-                                }
-                            }
-                            return;
-                        }
-
-                        // Register imported store (sync RocksDB open; run on blocking pool)
-                        let store_manager = store_manager.clone();
-                        let topic = partition.topic().to_string();
-                        let partition_number = partition.partition_number();
-                        let import_path = path.clone();
-                        match unwrap_blocking_task(
-                            tokio::task::spawn_blocking(move || {
-                                store_manager.restore_imported_store(
-                                    &topic,
-                                    partition_number,
-                                    &import_path,
-                                )
-                            }),
-                            "restore_imported_store task panicked",
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                metrics::counter!(
-                                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-                                    "result" => "success",
-                                    "assignment_mode" => "consumer_group",
-                                )
-                                .increment(1);
-                                info!(
-                                    topic = partition.topic(),
-                                    partition = partition.partition_number(),
-                                    path = %path.display(),
-                                    "Imported checkpoint for partition"
-                                );
-                            }
-                            Err(e) => {
-                                metrics::counter!(
-                                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-                                    "result" => "failed",
-                                    "reason" => "restore",
-                                    "assignment_mode" => "consumer_group",
-                                )
-                                .increment(1);
-                                error!(
-                                    topic = partition.topic(),
-                                    partition = partition.partition_number(),
-                                    error = %e,
-                                    "Failed to restore checkpoint"
-                                );
-                                fallback_reasons.insert(partition.clone(), "import_failed");
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        // Only log if not cancelled (expected during revoke)
-                        if !cancel_token.is_cancelled() {
-                            metrics::counter!(
-                                REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-                                "result" => "failed",
-                                "reason" => "import",
-                                "assignment_mode" => "consumer_group",
-                            )
-                            .increment(1);
-                            warn!(
-                                topic = partition.topic(),
-                                partition = partition.partition_number(),
-                                error = ?e,
-                                "Failed to import checkpoint"
-                            );
-                            fallback_reasons.insert(partition.clone(), "import_failed");
-                        } else {
-                            fallback_reasons.insert(partition.clone(), "import_cancelled");
-                        }
-                    }
-                }
-            } else {
-                metrics::counter!(
-                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
-                    "result" => "skipped",
-                    "reason" => "disabled",
-                    "assignment_mode" => "consumer_group",
-                )
-                .increment(1);
-                fallback_reasons.insert(partition.clone(), "no_importer");
-            }
+            try_import_from_s3(
+                &partition,
+                &cancel_token,
+                &coordinator,
+                &store_manager,
+                &importer,
+                &fallback_reasons,
+                &restored_metadata,
+            )
+            .await;
         })
     }
 
@@ -504,7 +373,74 @@ where
             );
         }
 
-        // Step 5: Resume consumption
+        // Step 5: Seek consumer to restored offsets and seed OffsetTracker.
+        //
+        // For each owned partition, use metadata cached during partition setup (local or S3
+        // restore). Falls back to reading metadata.json from disk if the cache entry is missing.
+        // If consumer_offset > 0, the store was restored from a prior checkpoint and we seek
+        // the consumer to that position so it resumes exactly where processing left off.
+        // We also seed OffsetTracker so the first checkpoint export reflects the correct
+        // committed and producer offsets rather than starting from zero.
+        //
+        // Partitions with no valid metadata (empty fallback stores) are naturally skipped
+        // because their consumer_offset is 0 or metadata doesn't exist.
+        let mut seek_tpl = TopicPartitionList::new();
+        for p in &owned {
+            // Use cached metadata from partition setup, fall back to disk read
+            let metadata = match self.partition_restored_metadata.remove(p) {
+                Some((_, m)) => Some(m),
+                None => {
+                    let store_path = format_store_path(
+                        self.store_manager.base_path(),
+                        p.topic(),
+                        p.partition_number(),
+                    );
+                    CheckpointMetadata::load_from_dir(&store_path).await.ok()
+                }
+            };
+
+            if let Some(metadata) = metadata {
+                if metadata.consumer_offset > 0 {
+                    self.offset_tracker.init_partition_from_metadata(
+                        p,
+                        metadata.consumer_offset,
+                        metadata.producer_offset,
+                    );
+                    seek_tpl
+                        .add_partition_offset(
+                            p.topic(),
+                            p.partition_number(),
+                            Offset::Offset(metadata.consumer_offset),
+                        )
+                        .unwrap_or_else(|e| {
+                            warn!(
+                                topic = p.topic(),
+                                partition = p.partition_number(),
+                                error = ?e,
+                                "Failed to add partition to seek list — will resume from broker offset"
+                            );
+                        });
+                    debug!(
+                        topic = p.topic(),
+                        partition = p.partition_number(),
+                        consumer_offset = metadata.consumer_offset,
+                        producer_offset = metadata.producer_offset,
+                        "Seeding OffsetTracker and seeking consumer from metadata"
+                    );
+                }
+            }
+        }
+        if seek_tpl.count() > 0 {
+            info!(
+                seek_count = seek_tpl.count(),
+                "Seeking consumer to restored offsets before resume"
+            );
+            if let Err(e) = consumer_command_tx.send(ConsumerCommand::SeekPartitions(seek_tpl)) {
+                warn!("Failed to send seek command: {e:#} — will resume from broker offsets");
+            }
+        }
+
+        // Step 6: Resume consumption
         if owned.is_empty() {
             info!("No owned partitions to resume");
             metrics::counter!(REBALANCE_RESUME_SKIPPED_NO_OWNED).increment(1);
@@ -524,6 +460,313 @@ where
         }
 
         Ok(())
+    }
+}
+
+// ============================================
+// PARTITION SETUP HELPERS
+// ============================================
+
+/// Check if partition setup should be skipped.
+///
+/// Returns `true` (skip) when the partition was cancelled, is no longer owned,
+/// or already has a registered store (rapid revoke→assign race).
+fn should_skip_setup(
+    partition: &Partition,
+    cancel_token: &CancellationToken,
+    coordinator: &Arc<RebalanceTracker>,
+    store_manager: &Arc<StoreManager>,
+    fallback_reasons: &Arc<DashMap<Partition, &'static str>>,
+) -> bool {
+    if cancel_token.is_cancelled() || !coordinator.is_partition_owned(partition) {
+        metrics::counter!(
+            PARTITION_STORE_SETUP_SKIPPED,
+            "reason" => if cancel_token.is_cancelled() { "cancelled" } else { "not_owned" },
+            "assignment_mode" => "consumer_group",
+        )
+        .increment(1);
+        fallback_reasons.insert(partition.clone(), "import_cancelled");
+        return true;
+    }
+
+    if store_manager
+        .get(partition.topic(), partition.partition_number())
+        .is_some()
+    {
+        metrics::counter!(
+            REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+            "result" => "skipped",
+            "reason" => "store_exists",
+            "assignment_mode" => "consumer_group",
+        )
+        .increment(1);
+        return true;
+    }
+
+    false
+}
+
+/// Attempt to restore from local RocksDB data.
+///
+/// Returns `true` if a fresh local store was restored (caller should skip S3 import).
+/// Returns `false` if local data is stale, missing, or corrupt (fall through to S3).
+async fn try_restore_from_local(
+    partition: &Partition,
+    store_manager: &Arc<StoreManager>,
+    restored_metadata: &Arc<DashMap<Partition, CheckpointMetadata>>,
+    local_max_staleness: Duration,
+) -> bool {
+    // metadata.json is updated on every Kafka offset commit, so its
+    // updated_at reflects the last time this pod was actively consuming.
+    let local_metadata = store_manager
+        .try_restore_local_store(
+            partition.topic(),
+            partition.partition_number(),
+            local_max_staleness,
+        )
+        .await;
+
+    if let Some(metadata) = local_metadata {
+        // Fresh local data: open RocksDB from the existing partition directory.
+        // Use spawn_blocking because RocksDB::open is a blocking operation.
+        let topic = partition.topic().to_string();
+        let partition_number = partition.partition_number();
+        let store_path = format_store_path(store_manager.base_path(), &topic, partition_number);
+        match unwrap_blocking_task(
+            tokio::task::spawn_blocking({
+                let store_manager = Arc::clone(store_manager);
+                move || store_manager.restore_imported_store(&topic, partition_number, &store_path)
+            }),
+            "restore_local_store task panicked",
+        )
+        .await
+        {
+            Ok(_) => {
+                metrics::counter!(
+                    LOCAL_STORE_RESTORE_COUNTER,
+                    "result" => "fresh",
+                )
+                .increment(1);
+                info!(
+                    topic = partition.topic(),
+                    partition = partition.partition_number(),
+                    consumer_offset = metadata.consumer_offset,
+                    producer_offset = metadata.producer_offset,
+                    "Restored local store — skipping S3 import"
+                );
+                restored_metadata.insert(partition.clone(), metadata);
+                return true;
+            }
+            Err(e) => {
+                warn!(
+                    topic = partition.topic(),
+                    partition = partition.partition_number(),
+                    error = %e,
+                    "Failed to open local store, falling back to S3 import"
+                );
+            }
+        }
+    } else {
+        // Stale, missing, or corrupt — record which and fall through to S3 import.
+        let store_path = format_store_path(
+            store_manager.base_path(),
+            partition.topic(),
+            partition.partition_number(),
+        );
+        let metadata_path = store_path.join(crate::checkpoint::metadata::METADATA_FILENAME);
+        let result_label = if !metadata_path.exists() {
+            "missing"
+        } else {
+            "stale"
+        };
+        metrics::counter!(
+            LOCAL_STORE_RESTORE_COUNTER,
+            "result" => result_label,
+        )
+        .increment(1);
+        debug!(
+            topic = partition.topic(),
+            partition = partition.partition_number(),
+            result = result_label,
+            "Local store not usable, falling back to S3 import"
+        );
+    }
+
+    false
+}
+
+/// Attempt to import a checkpoint from S3.
+///
+/// Uses the per-partition cancellation token to stop S3 downloads on revoke.
+/// Records fallback reasons on failure so finalize_rebalance_cycle can create empty stores.
+async fn try_import_from_s3(
+    partition: &Partition,
+    cancel_token: &CancellationToken,
+    coordinator: &Arc<RebalanceTracker>,
+    store_manager: &Arc<StoreManager>,
+    importer: &Option<Arc<CheckpointImporter>>,
+    fallback_reasons: &Arc<DashMap<Partition, &'static str>>,
+    restored_metadata: &Arc<DashMap<Partition, CheckpointMetadata>>,
+) {
+    let Some(importer) = importer else {
+        metrics::counter!(
+            REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+            "result" => "skipped",
+            "reason" => "disabled",
+            "assignment_mode" => "consumer_group",
+        )
+        .increment(1);
+        fallback_reasons.insert(partition.clone(), "no_importer");
+        return;
+    };
+
+    match importer
+        .import_checkpoint_for_topic_partition_cancellable(
+            partition.topic(),
+            partition.partition_number(),
+            Some(cancel_token),
+        )
+        .await
+    {
+        Ok(path) => {
+            // Check if we should skip registration (token cancelled or ownership lost)
+            let is_cancelled = cancel_token.is_cancelled();
+            let is_owned = coordinator.is_partition_owned(partition);
+
+            if is_cancelled || !is_owned {
+                let reason = if is_cancelled {
+                    "cancelled"
+                } else {
+                    "not_owned"
+                };
+                metrics::counter!(
+                    PARTITION_STORE_SETUP_SKIPPED,
+                    "reason" => reason,
+                    "assignment_mode" => "consumer_group",
+                )
+                .increment(1);
+                fallback_reasons.insert(partition.clone(), "import_cancelled");
+
+                // Clean up the successfully imported directory since we can't use it.
+                if path.exists() {
+                    match tokio::fs::remove_dir_all(&path).await {
+                        Ok(_) => {
+                            metrics::counter!(
+                                CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
+                                "result" => "success",
+                                "assignment_mode" => "consumer_group",
+                            )
+                            .increment(1);
+                            info!(
+                                topic = partition.topic(),
+                                partition = partition.partition_number(),
+                                path = %path.display(),
+                                reason = reason,
+                                "Cleaned up unused checkpoint import"
+                            );
+                        }
+                        Err(e) => {
+                            metrics::counter!(
+                                CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
+                                "result" => "failed",
+                                "assignment_mode" => "consumer_group",
+                            )
+                            .increment(1);
+                            warn!(
+                                topic = partition.topic(),
+                                partition = partition.partition_number(),
+                                path = %path.display(),
+                                error = ?e,
+                                "Failed to clean up checkpoint import, orphan cleaner will handle it"
+                            );
+                        }
+                    }
+                }
+                return;
+            }
+
+            // Register imported store (sync RocksDB open; run on blocking pool)
+            let topic = partition.topic().to_string();
+            let partition_number = partition.partition_number();
+            let import_path = path.clone();
+            match unwrap_blocking_task(
+                tokio::task::spawn_blocking({
+                    let store_manager = Arc::clone(store_manager);
+                    move || {
+                        store_manager.restore_imported_store(&topic, partition_number, &import_path)
+                    }
+                }),
+                "restore_imported_store task panicked",
+            )
+            .await
+            {
+                Ok(_) => {
+                    metrics::counter!(
+                        REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                        "result" => "success",
+                        "assignment_mode" => "consumer_group",
+                    )
+                    .increment(1);
+                    info!(
+                        topic = partition.topic(),
+                        partition = partition.partition_number(),
+                        path = %path.display(),
+                        "Imported checkpoint for partition"
+                    );
+                    // Cache metadata so finalize can seed OffsetTracker without re-reading disk
+                    match CheckpointMetadata::load_from_dir(&path).await {
+                        Ok(metadata) => {
+                            restored_metadata.insert(partition.clone(), metadata);
+                        }
+                        Err(e) => {
+                            warn!(
+                                topic = partition.topic(),
+                                partition = partition.partition_number(),
+                                error = ?e,
+                                "Failed to load metadata after import — finalize will re-read from disk"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    metrics::counter!(
+                        REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                        "result" => "failed",
+                        "reason" => "restore",
+                        "assignment_mode" => "consumer_group",
+                    )
+                    .increment(1);
+                    error!(
+                        topic = partition.topic(),
+                        partition = partition.partition_number(),
+                        error = %e,
+                        "Failed to restore checkpoint"
+                    );
+                    fallback_reasons.insert(partition.clone(), "import_failed");
+                }
+            }
+        }
+        Err(e) => {
+            // Only log if not cancelled (expected during revoke)
+            if !cancel_token.is_cancelled() {
+                metrics::counter!(
+                    REBALANCE_CHECKPOINT_IMPORT_COUNTER,
+                    "result" => "failed",
+                    "reason" => "import",
+                    "assignment_mode" => "consumer_group",
+                )
+                .increment(1);
+                warn!(
+                    topic = partition.topic(),
+                    partition = partition.partition_number(),
+                    error = ?e,
+                    "Failed to import checkpoint"
+                );
+                fallback_reasons.insert(partition.clone(), "import_failed");
+            } else {
+                fallback_reasons.insert(partition.clone(), "import_cancelled");
+            }
+        }
     }
 }
 
@@ -826,6 +1069,7 @@ mod tests {
                 offset_tracker.clone(),
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
         assert!(handler.router.is_none());
 
@@ -843,6 +1087,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
+            Duration::from_secs(7200),
         );
         assert!(handler_with_router.router.is_some());
     }
@@ -872,6 +1117,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
+            Duration::from_secs(7200),
         );
 
         // Initially no workers
@@ -935,6 +1181,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
+            Duration::from_secs(7200),
         );
 
         // Assign partition and create a store
@@ -969,7 +1216,7 @@ mod tests {
         assert_eq!(router.worker_count(), 0);
 
         // Files are NOT immediately deleted - finalize_rebalance_cycle handles this
-        let partition_dir = temp_dir.path().join("test-topic_0");
+        let partition_dir = temp_dir.path().join("test-topic").join("0");
         assert!(
             partition_dir.exists(),
             "Partition directory still exists (orphan cleaner will handle cleanup)"
@@ -1042,6 +1289,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
+            Duration::from_secs(7200),
         );
 
         // Step 1: Initial assignment
@@ -1097,7 +1345,7 @@ mod tests {
         // Create a store (this creates the directory)
         store_manager.get_or_create("test-topic", 0).await.unwrap();
 
-        let partition_dir = temp_dir.path().join("test-topic_0");
+        let partition_dir = temp_dir.path().join("test-topic").join("0");
         assert!(partition_dir.exists(), "Partition directory should exist");
 
         // Step 1: Unregister store (store is dropped, RocksDB is closed)
@@ -1140,6 +1388,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         // First assignment
@@ -1187,6 +1436,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         // Create command channel
@@ -1250,6 +1500,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         // Create command channel
@@ -1340,6 +1591,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         // Create command channel
@@ -1455,6 +1707,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         // Create command channel
@@ -1502,6 +1755,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16,
+                Duration::from_secs(7200),
             );
 
         let mut partitions = rdkafka::TopicPartitionList::new();
@@ -1545,6 +1799,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         // Create command channel
@@ -1592,7 +1847,7 @@ mod tests {
         );
 
         // Verify: the partition directory should not exist either
-        let partition_1_dir = temp_dir.path().join("test-topic_1");
+        let partition_1_dir = temp_dir.path().join("test-topic").join("1");
         assert!(
             !partition_1_dir.exists(),
             "Partition 1 directory should not exist (store creation was skipped)"
@@ -1623,6 +1878,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1734,6 +1990,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
+                Duration::from_secs(7200),
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -11,7 +11,6 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-use crate::checkpoint::config::DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS;
 use crate::checkpoint::import::CheckpointImporter;
 use crate::checkpoint::metadata::CheckpointMetadata;
 use crate::kafka::batch_consumer::BatchConsumerProcessor;

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -1036,6 +1036,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::checkpoint::config::DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS;
     use crate::kafka::batch_message::KafkaMessage;
     use crate::kafka::offset_tracker::OffsetTracker;
     use crate::kafka::partition_router::PartitionRouterConfig;

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
+use crate::checkpoint::config::DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS;
 use crate::checkpoint::import::CheckpointImporter;
 use crate::checkpoint::metadata::CheckpointMetadata;
 use crate::kafka::batch_consumer::BatchConsumerProcessor;
@@ -576,6 +577,11 @@ async fn try_restore_from_local(
         let metadata_path = store_path.join(crate::checkpoint::metadata::METADATA_FILENAME);
         let result_label = if !metadata_path.exists() {
             "missing"
+        } else if CheckpointMetadata::load_from_dir(&store_path)
+            .await
+            .is_err()
+        {
+            "corrupt"
         } else {
             "stale"
         };
@@ -1069,7 +1075,7 @@ mod tests {
                 offset_tracker.clone(),
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
         assert!(handler.router.is_none());
 
@@ -1087,7 +1093,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
-            Duration::from_secs(7200),
+            Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
         );
         assert!(handler_with_router.router.is_some());
     }
@@ -1117,7 +1123,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
-            Duration::from_secs(7200),
+            Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
         );
 
         // Initially no workers
@@ -1181,7 +1187,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
-            Duration::from_secs(7200),
+            Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
         );
 
         // Assign partition and create a store
@@ -1289,7 +1295,7 @@ mod tests {
             offset_tracker,
             None,
             16, // rebalance_cleanup_parallelism
-            Duration::from_secs(7200),
+            Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
         );
 
         // Step 1: Initial assignment
@@ -1388,7 +1394,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         // First assignment
@@ -1436,7 +1442,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         // Create command channel
@@ -1500,7 +1506,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         // Create command channel
@@ -1591,7 +1597,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         // Create command channel
@@ -1707,7 +1713,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         // Create command channel
@@ -1755,7 +1761,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16,
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         let mut partitions = rdkafka::TopicPartitionList::new();
@@ -1799,7 +1805,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         // Create command channel
@@ -1878,7 +1884,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1990,7 +1996,7 @@ mod tests {
                 offset_tracker,
                 None,
                 16, // rebalance_cleanup_parallelism
-                Duration::from_secs(7200),
+                Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -189,6 +189,7 @@ impl KafkaDeduplicatorService {
                 .max_concurrent_checkpoint_file_downloads,
             max_concurrent_checkpoint_file_uploads: config.max_concurrent_checkpoint_file_uploads,
             checkpoint_partition_import_timeout: config.checkpoint_partition_import_timeout(),
+            local_checkpoint_max_staleness: config.local_checkpoint_max_staleness(),
         };
 
         // Reset local checkpoint directory on startup (it's temporary storage)
@@ -317,7 +318,8 @@ impl KafkaDeduplicatorService {
             self.config.rebalance_cleanup_parallelism,
             self.config.fail_open,
         )
-        .with_checkpoint_importer(self.checkpoint_importer.clone());
+        .with_checkpoint_importer(self.checkpoint_importer.clone())
+        .with_local_checkpoint_staleness(self.config.local_checkpoint_max_staleness());
 
         // Configure pipeline-specific options for ingestion events
         if self.config.pipeline_type == PipelineType::IngestionEvents {

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -594,6 +594,7 @@ impl StoreManager {
             };
 
             let mut topic_has_owned = false;
+            let mut unowned_partition_paths: Vec<PathBuf> = Vec::new();
             while let Ok(Some(partition_entry)) = partition_dirs.next_entry().await {
                 let is_dir = partition_entry
                     .file_type()
@@ -608,13 +609,16 @@ impl StoreManager {
                 if owned_paths.contains(&partition_path) {
                     topic_has_owned = true;
                 } else {
-                    unowned_paths.push(partition_path);
+                    unowned_partition_paths.push(partition_path);
                 }
             }
 
-            // If no owned partitions remain under this topic dir, clean up the topic dir itself
             if !topic_has_owned {
+                // No owned partitions remain — delete the whole topic dir in one shot
                 unowned_paths.push(topic_path);
+            } else {
+                // Only delete unowned partitions; keep topic dir for owned children
+                unowned_paths.extend(unowned_partition_paths);
             }
         }
 
@@ -2291,6 +2295,7 @@ mod tests {
 
     mod try_restore_local_store_tests {
         use super::*;
+        use crate::checkpoint::config::DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS;
         use crate::checkpoint::metadata::CheckpointMetadata;
         use crate::test_utils::create_test_store_manager;
         use crate::utils::format_store_path;
@@ -2308,7 +2313,11 @@ mod tests {
             metadata.write_to_dir(&store_path).await.unwrap();
 
             let result = manager
-                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .try_restore_local_store(
+                    "test-topic",
+                    0,
+                    Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                )
                 .await;
 
             assert!(result.is_some(), "Should return metadata for fresh store");
@@ -2324,7 +2333,11 @@ mod tests {
 
             // No metadata.json written — directory doesn't even exist
             let result = manager
-                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .try_restore_local_store(
+                    "test-topic",
+                    0,
+                    Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                )
                 .await;
 
             assert!(
@@ -2361,7 +2374,11 @@ mod tests {
 
             // 2h max staleness — 3h old timestamp should be stale
             let result = manager
-                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .try_restore_local_store(
+                    "test-topic",
+                    0,
+                    Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                )
                 .await;
 
             assert!(result.is_none(), "Should return None for stale metadata");
@@ -2381,7 +2398,11 @@ mod tests {
                 .unwrap();
 
             let result = manager
-                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .try_restore_local_store(
+                    "test-topic",
+                    0,
+                    Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                )
                 .await;
 
             assert!(result.is_none(), "Should return None for corrupt metadata");

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use futures::stream::{self, StreamExt};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -23,6 +23,11 @@ pub enum StoreError {
     Other(#[from] anyhow::Error),
 }
 
+use chrono::Utc;
+
+use crate::checkpoint::metadata::CheckpointMetadata;
+use crate::kafka::batch_consumer::OnCommit;
+use crate::kafka::offset_tracker::OffsetTracker;
 use crate::kafka::types::Partition;
 use crate::metrics::MetricsHelper;
 use crate::metrics_const::{
@@ -33,14 +38,13 @@ use crate::metrics_const::{
 use crate::rebalance_tracker::RebalanceTracker;
 use crate::rocksdb::metrics_consts::ROCKSDB_OLDEST_DATA_AGE_SECONDS_GAUGE;
 use crate::store::{DeduplicationStore, DeduplicationStoreConfig};
-use crate::utils::{format_partition_dir, format_store_path};
+use crate::utils::format_store_path;
 
 /// Information about folder sizes on disk
 #[derive(Debug, Clone)]
 struct FolderInfo {
     name: String,
     size_bytes: u64,
-    subfolder_count: usize,
 }
 
 impl FolderInfo {
@@ -85,18 +89,11 @@ impl fmt::Display for CleanupStatus {
             .map(|p| p.to_string())
             .collect();
 
-        // Format folder info as compact list with sizes and subfolder counts
+        // Format folder info as compact list with sizes
         let folders: Vec<String> = self
             .folder_info
             .iter()
-            .map(|fi| {
-                format!(
-                    "{}({} subdirs):{:.2}MB",
-                    fi.name,
-                    fi.subfolder_count,
-                    fi.size_mb()
-                )
-            })
+            .map(|fi| format!("{}:{:.2}MB", fi.name, fi.size_mb()))
             .collect();
 
         write!(
@@ -394,6 +391,86 @@ impl StoreManager {
         Ok(())
     }
 
+    /// Check if a partition has fresh local data and return its metadata if so.
+    ///
+    /// Reads `metadata.json` from the partition's store directory and validates that its
+    /// `updated_at` timestamp is within `max_staleness` of now. Returns `Some(metadata)` if
+    /// the local store is fresh, `None` if stale, missing, or corrupt.
+    ///
+    /// The caller is responsible for opening RocksDB (via `restore_imported_store`) after a
+    /// `Some` return — this method only validates freshness.
+    pub async fn try_restore_local_store(
+        &self,
+        topic: &str,
+        partition: i32,
+        max_staleness: Duration,
+    ) -> Option<CheckpointMetadata> {
+        let store_path = format_store_path(&self.store_config.path, topic, partition);
+
+        let metadata = match CheckpointMetadata::load_from_dir(&store_path).await {
+            Ok(m) => m,
+            Err(_) => return None, // missing or corrupt
+        };
+
+        let age = (Utc::now() - metadata.updated_at)
+            .to_std()
+            .unwrap_or(Duration::MAX);
+
+        if age > max_staleness {
+            return None; // stale
+        }
+
+        Some(metadata)
+    }
+
+    /// Update metadata.json for a partition after a successful Kafka offset commit.
+    ///
+    /// Loads existing metadata (or creates a new skeleton if missing), updates the consumer
+    /// and producer offsets, and writes it back. Failures are non-fatal: if the store
+    /// directory doesn't exist yet or the write fails, a warning is logged and processing
+    /// continues normally.
+    pub async fn update_metadata_for_partition(
+        &self,
+        topic: &str,
+        partition: i32,
+        consumer_offset: i64,
+        producer_offset: i64,
+    ) {
+        let store_path = format_store_path(&self.store_config.path, topic, partition);
+        if !store_path.exists() {
+            return;
+        }
+
+        let mut metadata = match CheckpointMetadata::load_from_dir(&store_path).await {
+            Ok(m) => m,
+            Err(_) => {
+                // No existing metadata.json — create a skeleton for local tracking only.
+                // sequence=0 and empty files list are fine: this metadata is only used for
+                // local recovery (offsets + freshness), never for S3 restoration.
+                CheckpointMetadata::new(
+                    topic.to_string(),
+                    partition,
+                    Utc::now(),
+                    0,
+                    consumer_offset,
+                    producer_offset,
+                )
+            }
+        };
+
+        metadata.consumer_offset = consumer_offset;
+        metadata.producer_offset = producer_offset;
+
+        if let Err(e) = metadata.write_to_dir(&store_path).await {
+            warn!(
+                topic = topic,
+                partition = partition,
+                error = %e,
+                "Failed to update metadata.json after commit (non-fatal)"
+            );
+        }
+    }
+
     /// Unregister a store from the DashMap without deleting files (Step 1 of two-step cleanup).
     ///
     /// Call this BEFORE shutting down partition workers during rebalance. This prevents
@@ -427,13 +504,8 @@ impl StoreManager {
     ///
     /// Must be called after `unregister_store()` to ensure RocksDB is closed first.
     pub fn cleanup_store_files(&self, topic: &str, partition: i32) -> Result<()> {
-        let partition_dir = self
-            .store_config
-            .path
-            .join(format_partition_dir(topic, partition));
-        let partition_dir_str = partition_dir.to_string_lossy().to_string();
-
-        let partition_path = partition_dir;
+        let partition_path = format_store_path(&self.store_config.path, topic, partition);
+        let partition_dir_str = partition_path.to_string_lossy().to_string();
 
         if partition_path.exists() {
             match std::fs::remove_dir_all(&partition_path) {
@@ -483,15 +555,17 @@ impl StoreManager {
     ) -> Result<()> {
         let start = Instant::now();
 
-        // Build HashSet of owned partition dir names for O(1) lookup
-        let owned_dirs: HashSet<String> = owned
+        // Build set of owned store paths for O(1) lookup
+        let owned_paths: HashSet<PathBuf> = owned
             .iter()
-            .map(|p| format_partition_dir(p.topic(), p.partition_number()))
+            .map(|p| format_store_path(&self.store_config.path, p.topic(), p.partition_number()))
             .collect();
 
-        // Scan disk for all partition directories (tokio::fs to avoid blocking)
+        // Scan disk: <base>/<topic>/<partition>/ structure
         let base_path = &self.store_config.path;
-        let entries: Vec<PathBuf> = match tokio::fs::read_dir(base_path).await {
+        let mut unowned_paths = Vec::new();
+
+        let mut topic_dirs = match tokio::fs::read_dir(base_path).await {
             Err(e) => {
                 warn!(
                     path = %base_path.display(),
@@ -500,49 +574,56 @@ impl StoreManager {
                 );
                 return Ok(());
             }
-            Ok(mut read_dir) => {
-                let mut vec = Vec::new();
-                while let Some(entry) = read_dir
-                    .next_entry()
-                    .await
-                    .map_err(|e| {
-                        warn!(
-                            path = %base_path.display(),
-                            error = ?e,
-                            "Error reading directory entry during cleanup"
-                        );
-                    })
-                    .ok()
-                    .flatten()
-                {
-                    let is_dir = entry
-                        .file_type()
-                        .await
-                        .map(|ft| ft.is_dir())
-                        .unwrap_or(false);
-                    if !is_dir {
-                        continue;
-                    }
-                    let path = entry.path();
-                    let unowned = path
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|name| !owned_dirs.contains(name))
-                        .unwrap_or(false);
-                    if unowned {
-                        vec.push(path);
-                    }
-                }
-                vec
-            }
+            Ok(rd) => rd,
         };
 
-        if entries.is_empty() {
+        while let Ok(Some(topic_entry)) = topic_dirs.next_entry().await {
+            let is_dir = topic_entry
+                .file_type()
+                .await
+                .map(|ft| ft.is_dir())
+                .unwrap_or(false);
+            if !is_dir {
+                continue;
+            }
+
+            let topic_path = topic_entry.path();
+            let mut partition_dirs = match tokio::fs::read_dir(&topic_path).await {
+                Ok(rd) => rd,
+                Err(_) => continue,
+            };
+
+            let mut topic_has_owned = false;
+            while let Ok(Some(partition_entry)) = partition_dirs.next_entry().await {
+                let is_dir = partition_entry
+                    .file_type()
+                    .await
+                    .map(|ft| ft.is_dir())
+                    .unwrap_or(false);
+                if !is_dir {
+                    continue;
+                }
+
+                let partition_path = partition_entry.path();
+                if owned_paths.contains(&partition_path) {
+                    topic_has_owned = true;
+                } else {
+                    unowned_paths.push(partition_path);
+                }
+            }
+
+            // If no owned partitions remain under this topic dir, clean up the topic dir itself
+            if !topic_has_owned {
+                unowned_paths.push(topic_path);
+            }
+        }
+
+        if unowned_paths.is_empty() {
             debug!("No unowned partition directories to clean up");
             return Ok(());
         }
 
-        let count = entries.len();
+        let count = unowned_paths.len();
         info!(
             count = count,
             parallelism = parallelism,
@@ -550,7 +631,7 @@ impl StoreManager {
         );
 
         // Delete in parallel with bounded concurrency
-        let results: Vec<std::io::Result<()>> = stream::iter(entries)
+        let results: Vec<std::io::Result<()>> = stream::iter(unowned_paths)
             .map(|path| async move {
                 let path_str = path.display().to_string();
                 match tokio::fs::remove_dir_all(&path).await {
@@ -892,17 +973,12 @@ impl StoreManager {
         info!("All deduplication stores have been closed");
     }
 
-    /// Build the path for a store based on topic and partition
-    /// Each store gets a unique timestamp-based subdirectory to avoid conflicts
+    /// Build the path for a store based on topic and partition.
+    /// Each partition gets a single directory: `<base>/<topic>/<partition>/`
     fn build_store_path(&self, topic: &str, partition: i32) -> String {
-        format_store_path(
-            &self.store_config.path,
-            topic,
-            partition,
-            chrono::Utc::now(),
-        )
-        .to_string_lossy()
-        .to_string()
+        format_store_path(&self.store_config.path, topic, partition)
+            .to_string_lossy()
+            .to_string()
     }
 
     /// Ensure the parent directory for a store path exists
@@ -944,35 +1020,35 @@ impl StoreManager {
         assigned_partitions
             .sort_by(|a, b| a.topic.cmp(&b.topic).then(a.partition.cmp(&b.partition)));
 
-        // Get folder sizes from filesystem
+        // Get folder sizes from filesystem (<base>/<topic>/<partition>/ structure)
         let mut folder_info = Vec::new();
         let mut total_disk_usage_bytes = 0u64;
 
-        if let Ok(entries) = std::fs::read_dir(&self.store_config.path) {
-            for entry in entries.flatten() {
-                if let Ok(metadata) = entry.metadata() {
-                    if metadata.is_dir() {
-                        let partition_folder_name = entry.file_name().to_string_lossy().to_string();
-                        let folder_size =
-                            StoreManager::get_directory_size(&entry.path()).unwrap_or(0);
+        if let Ok(topic_entries) = std::fs::read_dir(&self.store_config.path) {
+            for topic_entry in topic_entries.flatten() {
+                if !topic_entry.metadata().map(|m| m.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                let topic_name = topic_entry.file_name().to_string_lossy().to_string();
 
-                        // Count timestamped subdirectories (actual store instances)
-                        let mut timestamped_stores_count = 0;
-                        if let Ok(subentries) = std::fs::read_dir(entry.path()) {
-                            timestamped_stores_count = subentries
-                                .flatten()
-                                .filter(|e| {
-                                    // Check if it's a directory and looks like a timestamp
-                                    e.metadata().map(|m| m.is_dir()).unwrap_or(false)
-                                })
-                                .count();
+                if let Ok(partition_entries) = std::fs::read_dir(topic_entry.path()) {
+                    for partition_entry in partition_entries.flatten() {
+                        if !partition_entry
+                            .metadata()
+                            .map(|m| m.is_dir())
+                            .unwrap_or(false)
+                        {
+                            continue;
                         }
+                        let partition_name =
+                            partition_entry.file_name().to_string_lossy().to_string();
+                        let folder_size =
+                            StoreManager::get_directory_size(&partition_entry.path()).unwrap_or(0);
 
                         total_disk_usage_bytes += folder_size;
                         folder_info.push(FolderInfo {
-                            name: partition_folder_name,
+                            name: format!("{topic_name}/{partition_name}"),
                             size_bytes: folder_size,
-                            subfolder_count: timestamped_stores_count,
                         });
                     }
                 }
@@ -1008,216 +1084,51 @@ impl StoreManager {
         Ok(size)
     }
 
-    /// Get the newest WAL (*.log) file modification time within a single timestamp directory.
-    /// Returns None if no WAL files are found.
-    fn get_wal_mtime(timestamp_dir: &Path) -> Option<SystemTime> {
-        let mut newest: Option<SystemTime> = None;
-
-        if let Ok(files) = std::fs::read_dir(timestamp_dir) {
-            for file_entry in files.flatten() {
-                let file_path = file_entry.path();
-                if file_path.extension().is_some_and(|e| e == "log") {
-                    if let Ok(file_meta) = file_entry.metadata() {
-                        if let Ok(mtime) = file_meta.modified() {
-                            newest = Some(newest.map_or(mtime, |n: SystemTime| n.max(mtime)));
-                        }
-                    }
-                }
-            }
-        }
-
-        newest
+    /// Get the modification time of a directory.
+    fn get_dir_mtime(dir: &Path) -> Option<SystemTime> {
+        std::fs::metadata(dir).ok().and_then(|m| m.modified().ok())
     }
 
-    /// Get the modification time of a timestamp directory.
-    /// This catches checkpoint imports in progress (directory created/modified but no LOCK/WAL yet).
-    fn get_dir_mtime(timestamp_dir: &Path) -> Option<SystemTime> {
-        std::fs::metadata(timestamp_dir)
-            .ok()
-            .and_then(|m| m.modified().ok())
-    }
-
-    /// Collect all timestamp subdirectories as cleanup candidates.
-    /// Returns Vec of (topic_partition_name, full_timestamp_dir_path, is_assigned).
-    /// Does NOT filter by safety checks - that happens during the deletion loop.
+    /// Clean up unowned partition directories that are stale.
     ///
-    /// For ASSIGNED partitions: collects all timestamp subdirs EXCEPT the active store path.
-    /// For UNASSIGNED partitions: collects all timestamp subdirs.
-    fn collect_orphan_candidates(&self) -> Vec<(String, PathBuf, bool)> {
-        let mut candidates = Vec::new();
-
-        // Build a map of partition_dir_name -> active store path for assigned partitions
-        let mut active_store_paths: std::collections::HashMap<String, PathBuf> =
-            std::collections::HashMap::new();
-        for entry in self.stores.iter() {
-            let partition = entry.key();
-            let store = entry.value();
-            let dir_name = format_partition_dir(partition.topic(), partition.partition_number());
-            active_store_paths.insert(dir_name, store.get_db_path().clone());
-        }
-
-        info!(
-            "Collecting orphan candidates. Currently assigned partitions: {:?}",
-            active_store_paths.keys().collect::<Vec<_>>()
-        );
-
-        // Scan the store directory for all partition directories
-        let Ok(partition_entries) = std::fs::read_dir(&self.store_config.path) else {
-            return candidates;
-        };
-
-        for partition_entry in partition_entries.flatten() {
-            let Ok(metadata) = partition_entry.metadata() else {
-                continue;
-            };
-            if !metadata.is_dir() {
-                continue;
-            }
-
-            let partition_dir_name = partition_entry.file_name().to_string_lossy().to_string();
-
-            // Skip if doesn't match topic_partition pattern (e.g., not a partition dir)
-            if !partition_dir_name.contains('_') {
-                continue;
-            }
-
-            // Check if this partition is assigned (has an active store)
-            let active_path = active_store_paths.get(&partition_dir_name);
-            let is_assigned = active_path.is_some();
-
-            // Enumerate all timestamp subdirectories under this partition
-            let partition_path = partition_entry.path();
-            let Ok(timestamp_entries) = std::fs::read_dir(&partition_path) else {
-                continue;
-            };
-
-            for ts_entry in timestamp_entries.flatten() {
-                let Ok(ts_metadata) = ts_entry.metadata() else {
-                    continue;
-                };
-                if !ts_metadata.is_dir() {
-                    continue;
-                }
-
-                let ts_path = ts_entry.path();
-
-                // For assigned partitions, skip the active store path
-                if let Some(active) = active_path {
-                    if &ts_path == active {
-                        continue; // Active store - never consider for deletion
-                    }
-                }
-
-                candidates.push((partition_dir_name.clone(), ts_path, is_assigned));
-            }
-        }
-
-        debug!(
-            "Found {} orphan timestamp directory candidates",
-            candidates.len()
-        );
-        candidates
-    }
-
-    /// Check if a specific timestamp directory is safe to delete as an orphan.
-    /// Returns false (NOT safe) if:
-    /// - WAL files have been modified within the staleness threshold
-    /// - Directory modified within staleness threshold (checkpoint import)
-    /// - This specific timestamp path is the currently active store
-    fn is_safe_to_delete_timestamp_dir(
-        &self,
-        timestamp_dir: &Path,
-        _parent_dir_name: &str,
-        orphan_min_staleness: Duration,
-    ) -> bool {
-        let ts_dir_display = timestamp_dir.display();
-
-        // Check 1: WAL files modified recently - store may still be active
-        // Use Duration::ZERO on elapsed() failure to be conservative (treat as just modified)
-        if let Some(wal_mtime) = Self::get_wal_mtime(timestamp_dir) {
-            let elapsed = wal_mtime.elapsed().unwrap_or(Duration::ZERO);
-            if elapsed < orphan_min_staleness {
-                info!(
-                    path = %ts_dir_display,
-                    wal_age_secs = elapsed.as_secs(),
-                    min_staleness_secs = orphan_min_staleness.as_secs(),
-                    "Orphan safety check: WAL file too recent, skipping deletion"
-                );
-                return false;
-            }
-        }
-
-        // Check 2: Directory modified recently - checkpoint import in progress
-        // Use Duration::ZERO on elapsed() failure to be conservative (treat as just modified)
-        if let Some(dir_mtime) = Self::get_dir_mtime(timestamp_dir) {
-            let elapsed = dir_mtime.elapsed().unwrap_or(Duration::ZERO);
-            if elapsed < orphan_min_staleness {
-                info!(
-                    path = %ts_dir_display,
-                    dir_age_secs = elapsed.as_secs(),
-                    min_staleness_secs = orphan_min_staleness.as_secs(),
-                    "Orphan safety check: directory too recent, skipping deletion"
-                );
-                return false;
-            }
-        }
-
-        // Check 3: Skip if this specific timestamp path is the currently active store
-        // (This is a defense-in-depth check - collect_orphan_candidates already filters these)
-        for entry in self.stores.iter() {
-            let store = entry.value();
-            if store.get_db_path() == timestamp_dir {
-                info!(
-                    path = %ts_dir_display,
-                    "Orphan safety check: this is an active store path, skipping deletion"
-                );
-                return false;
-            }
-        }
-
-        // All checks passed - safe to delete
-        true
-    }
-
-    /// Clean up orphaned timestamp directories from both assigned and unassigned partitions.
+    /// With single-directory-per-partition layout (`<base>/<topic>/<partition>/`),
+    /// this finds partition directories that don't belong to any active store
+    /// and whose directory mtime exceeds the staleness threshold.
     ///
-    /// For ASSIGNED partitions: cleans up old timestamp subdirs (not the active store).
-    /// For UNASSIGNED partitions: cleans up all timestamp subdirs.
-    ///
-    /// Safety checks before deletion:
+    /// Safety checks:
     /// 1. Skip if stores map is empty (startup race)
     /// 2. Skip if rebalancing is in progress
-    /// 3. For each candidate timestamp dir: check WAL mtime, dir mtime, and verify not active store
+    /// 3. Only delete directories older than orphan_min_staleness
     pub fn cleanup_orphaned_directories(&self, orphan_min_staleness: Duration) -> Result<u64> {
-        // Guard: skip cleanup if no stores are registered yet (startup race) or
-        // all stores were just unregistered (rebalance). This prevents deleting
-        // valid directories before partition assignment completes.
         if self.stores.is_empty() {
             debug!("Skipping orphan cleanup - no stores registered");
             return Ok(0);
         }
 
-        // Guard: skip cleanup during rebalance to avoid deleting directories
-        // that are about to be assigned to us
         if self.rebalance_tracker.is_rebalancing() {
             debug!("Skipping orphan cleanup - rebalance in progress");
             return Ok(0);
         }
 
-        // Collect timestamp subdirectories from both assigned and unassigned partitions
-        // (excluding active store paths for assigned partitions)
-        let candidates = self.collect_orphan_candidates();
-
-        if candidates.is_empty() {
-            debug!("No orphaned timestamp directories found");
-            return Ok(0);
-        }
+        // Build set of active store paths
+        let active_paths: HashSet<PathBuf> = self
+            .stores
+            .iter()
+            .map(|entry| entry.value().get_db_path().clone())
+            .collect();
 
         let mut total_freed = 0u64;
 
-        for (parent_dir_name, timestamp_path, is_assigned) in candidates {
-            // Re-check rebalance mid-loop - abort to avoid deleting directories
-            // that may be about to be assigned
+        // Scan <base>/<topic>/<partition>/ structure
+        let Ok(topic_entries) = std::fs::read_dir(&self.store_config.path) else {
+            return Ok(0);
+        };
+
+        for topic_entry in topic_entries.flatten() {
+            if !topic_entry.metadata().map(|m| m.is_dir()).unwrap_or(false) {
+                continue;
+            }
+
             if self.rebalance_tracker.is_rebalancing() {
                 info!(
                     "Aborting orphan cleanup - rebalance started. Freed {} bytes so far",
@@ -1226,55 +1137,78 @@ impl StoreManager {
                 return Ok(total_freed);
             }
 
-            // Safety checks: WAL mtime, dir mtime, verify not active store path
-            if !self.is_safe_to_delete_timestamp_dir(
-                &timestamp_path,
-                &parent_dir_name,
-                orphan_min_staleness,
-            ) {
-                debug!(
-                    path = %timestamp_path.display(),
-                    is_assigned = is_assigned,
-                    "Skipping orphan candidate - failed safety checks"
-                );
+            let topic_path = topic_entry.path();
+            let Ok(partition_entries) = std::fs::read_dir(&topic_path) else {
                 continue;
+            };
+
+            for partition_entry in partition_entries.flatten() {
+                if !partition_entry
+                    .metadata()
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+
+                let partition_path = partition_entry.path();
+
+                // Skip active stores
+                if active_paths.contains(&partition_path) {
+                    continue;
+                }
+
+                // Check staleness via directory mtime
+                let is_stale = Self::get_dir_mtime(&partition_path)
+                    .map(|mtime| mtime.elapsed().unwrap_or(Duration::ZERO) >= orphan_min_staleness)
+                    .unwrap_or(true);
+
+                if !is_stale {
+                    debug!(
+                        path = %partition_path.display(),
+                        "Skipping orphan candidate - directory too recent"
+                    );
+                    continue;
+                }
+
+                let dir_size = Self::get_directory_size(&partition_path).unwrap_or(0);
+
+                match std::fs::remove_dir_all(&partition_path) {
+                    Ok(_) => {
+                        info!(
+                            path = %partition_path.display(),
+                            size_mb = dir_size as f64 / (1024.0 * 1024.0),
+                            "Removed orphaned partition directory"
+                        );
+                        metrics::counter!(
+                            CLEANUP_OPERATIONS_COUNTER,
+                            "partition_status" => "unassigned"
+                        )
+                        .increment(1);
+                        total_freed += dir_size;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to remove orphaned partition directory {}: {}",
+                            partition_path.display(),
+                            e
+                        );
+                    }
+                }
             }
 
-            let dir_size = Self::get_directory_size(&timestamp_path).unwrap_or(0);
-
-            match std::fs::remove_dir_all(&timestamp_path) {
-                Ok(_) => {
-                    let partition_status = if is_assigned {
-                        "assigned"
-                    } else {
-                        "unassigned"
-                    };
-                    info!(
-                        partition_status = partition_status,
-                        path = %timestamp_path.display(),
-                        size_mb = dir_size as f64 / (1024.0 * 1024.0),
-                        "Removed orphaned timestamp directory"
-                    );
-                    metrics::counter!(
-                        CLEANUP_OPERATIONS_COUNTER,
-                        "partition_status" => partition_status
-                    )
-                    .increment(1);
-                    total_freed += dir_size;
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to remove orphaned timestamp directory {}: {}",
-                        timestamp_path.display(),
-                        e
-                    );
-                }
+            // Clean up empty topic directories
+            if std::fs::read_dir(&topic_path)
+                .map(|mut rd| rd.next().is_none())
+                .unwrap_or(false)
+            {
+                let _ = std::fs::remove_dir(&topic_path);
             }
         }
 
         if total_freed > 0 {
             info!(
-                "Cleaned up {:.2} MB of orphaned timestamp directories",
+                "Cleaned up {:.2} MB of orphaned partition directories",
                 total_freed as f64 / (1024.0 * 1024.0)
             );
         }
@@ -1311,6 +1245,45 @@ impl CleanupTaskHandle {
             Ok(Ok(())) => info!("Cleanup task shut down successfully"),
             Ok(Err(e)) => warn!("Cleanup task failed: {e:#}"),
             Err(_) => warn!("Cleanup task shutdown timed out"),
+        }
+    }
+}
+
+/// Bridges `OnCommit` to `StoreManager::update_metadata_for_partition`.
+///
+/// Constructed by the pipeline builder so `BatchConsumer` stays decoupled from
+/// store internals. Each committed partition triggers a metadata update;
+/// failures are non-fatal and logged inside `update_metadata_for_partition`.
+pub struct MetadataCommitCallback {
+    store_manager: Arc<StoreManager>,
+    offset_tracker: Arc<OffsetTracker>,
+}
+
+impl MetadataCommitCallback {
+    pub fn new(store_manager: Arc<StoreManager>, offset_tracker: Arc<OffsetTracker>) -> Self {
+        Self {
+            store_manager,
+            offset_tracker,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl OnCommit for MetadataCommitCallback {
+    async fn on_commit(&self, offsets: &HashMap<Partition, i64>) {
+        for (partition, consumer_offset) in offsets {
+            let producer_offset = self
+                .offset_tracker
+                .get_producer_offset(partition)
+                .unwrap_or(0);
+            self.store_manager
+                .update_metadata_for_partition(
+                    partition.topic(),
+                    partition.partition_number(),
+                    *consumer_offset,
+                    producer_offset,
+                )
+                .await;
         }
     }
 }
@@ -1694,15 +1667,19 @@ mod tests {
         manager.unregister_store("test-topic", 0);
         assert_eq!(manager.get_active_store_count(), 0);
 
-        // Rapid re-assign - pre-create new store
+        // Drop store1 to release the RocksDB lock before re-opening the same path.
+        // With flat partition paths, store1 and store2 share the same directory, so
+        // the lock must be released before the re-assign can open a new instance.
+        drop(store1);
+
+        // Rapid re-assign - pre-create new store for the same partition path
         let store2 = manager
             .get_or_create_for_rebalance("test-topic", 0)
             .await
             .unwrap();
         assert_eq!(manager.get_active_store_count(), 1);
 
-        // The new store should be fresh (different RocksDB instance with new timestamp path)
-        // But both stores should work independently
+        // The new store reuses the same partition directory and retains previously written data
         let event2 = RawEvent {
             event: "test_event_2".to_string(),
             distinct_id: Some(serde_json::Value::String("test_user_2".to_string())),
@@ -2017,7 +1994,7 @@ mod tests {
 
         // Test 1: Directory in stores map should NOT be deleted
         // (the existing test-topic_0 directory)
-        let active_dir = temp_dir.path().join("test-topic_0");
+        let active_dir = temp_dir.path().join("test-topic").join("0");
         assert!(active_dir.exists(), "Active store directory should exist");
         let freed = manager
             .cleanup_orphaned_directories(Duration::from_secs(0))
@@ -2136,74 +2113,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_orphan_cleanup_cleans_old_timestamp_dirs_under_assigned_partition() {
-        // Test that orphan cleanup removes OLD timestamp dirs under ASSIGNED partitions,
-        // but NOT the active store path.
-        let temp_dir = TempDir::new().unwrap();
-        let config = DeduplicationStoreConfig {
-            path: temp_dir.path().to_path_buf(),
-            max_capacity: 1024 * 1024 * 1024,
-            rocksdb: RocksDbConfig::default(),
-        };
-
-        let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
-
-        // Create a store for partition 0 (this will create a timestamp subdir)
-        manager.get_or_create("test-topic", 0).await.unwrap();
-        assert_eq!(manager.get_active_store_count(), 1);
-
-        // Get the active store's path
-        let active_store = manager.get("test-topic", 0).unwrap();
-        let active_path = active_store.get_db_path().clone();
-
-        // Verify active store exists and extract its timestamp for comparison
-        assert!(active_path.exists(), "Active store path should exist");
-        let active_timestamp = active_path
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-
-        // Create an OLD timestamp subdir under the same partition (simulating a previous import)
-        // Use a timestamp that is LEXICOGRAPHICALLY SMALLER than the active one to simulate
-        // a genuinely old failed import attempt
-        let partition_dir = temp_dir.path().join("test-topic_0");
-        let old_timestamp_subdir = partition_dir.join("0000000001"); // Old timestamp (before active)
-        std::fs::create_dir_all(&old_timestamp_subdir).unwrap();
-        std::fs::write(old_timestamp_subdir.join("dummy.sst"), b"old data").unwrap();
-        assert!(
-            old_timestamp_subdir.exists(),
-            "Old timestamp dir should exist"
-        );
-
-        // Sanity check: verify the old timestamp is indeed before the active one
-        assert!(
-            "0000000001" < active_timestamp.as_str(),
-            "Test setup error: old timestamp should be before active timestamp"
-        );
-
-        // Orphan cleanup should remove the OLD timestamp dir but NOT the active one
-        let freed = manager
-            .cleanup_orphaned_directories(Duration::from_secs(0))
-            .unwrap();
-
-        assert!(freed > 0, "Should have freed some bytes");
-        assert!(
-            !old_timestamp_subdir.exists(),
-            "OLD timestamp dir should be removed"
-        );
-        assert!(
-            active_path.exists(),
-            "ACTIVE store path should NOT be removed"
-        );
-        assert_eq!(
-            manager.get_active_store_count(),
-            1,
-            "Store should still be registered"
-        );
-    }
-
-    #[tokio::test]
     async fn test_orphan_cleanup_never_deletes_active_store_path() {
         // Defense-in-depth test: even if collect_orphan_candidates somehow includes
         // the active store path, is_safe_to_delete_timestamp_dir should prevent deletion.
@@ -2250,65 +2159,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_orphan_cleanup_handles_multiple_old_timestamps_under_assigned() {
-        // Test that multiple old timestamp dirs under an assigned partition are all cleaned up
-        let temp_dir = TempDir::new().unwrap();
-        let config = DeduplicationStoreConfig {
-            path: temp_dir.path().to_path_buf(),
-            max_capacity: 1024 * 1024 * 1024,
-            rocksdb: RocksDbConfig::default(),
-        };
-
-        let manager = Arc::new(StoreManager::new(config, create_test_tracker()));
-
-        // Create a store for partition 0
-        manager.get_or_create("test-topic", 0).await.unwrap();
-        let active_store = manager.get("test-topic", 0).unwrap();
-        let active_path = active_store.get_db_path().clone();
-
-        // Create multiple OLD timestamp subdirs (simulating multiple failed imports)
-        // Use timestamps that are BEFORE the active one (small numbers)
-        let partition_dir = temp_dir.path().join("test-topic_0");
-        let old_dirs: Vec<_> = (1..=3)
-            .map(|i| {
-                let old_dir = partition_dir.join(format!("000000000{}", i));
-                std::fs::create_dir_all(&old_dir).unwrap();
-                std::fs::write(old_dir.join("dummy.sst"), b"old data").unwrap();
-                old_dir
-            })
-            .collect();
-
-        // Verify all old dirs exist
-        for old_dir in &old_dirs {
-            assert!(old_dir.exists(), "Old dir should exist: {:?}", old_dir);
-        }
-
-        // Orphan cleanup should remove ALL old timestamp dirs
-        let freed = manager
-            .cleanup_orphaned_directories(Duration::from_secs(0))
-            .unwrap();
-
-        assert!(freed > 0, "Should have freed some bytes");
-
-        // All old dirs should be removed
-        for old_dir in &old_dirs {
-            assert!(
-                !old_dir.exists(),
-                "Old dir should be removed: {:?}",
-                old_dir
-            );
-        }
-
-        // Active store should still exist
-        assert!(active_path.exists(), "Active store should NOT be removed");
-        assert_eq!(manager.get_active_store_count(), 1);
-    }
-
-    #[tokio::test]
     async fn test_orphan_cleanup_mixed_assigned_and_unassigned_partitions() {
         // Test that orphan cleanup correctly handles a mix of:
-        // - Assigned partitions (clean old timestamps, keep active)
-        // - Unassigned partitions (clean all timestamps)
+        // - Assigned partitions (keep active partition dir intact)
+        // - Unassigned partitions (delete entire partition dir)
         let temp_dir = TempDir::new().unwrap();
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
@@ -2328,32 +2182,24 @@ mod tests {
         let active_store_1 = manager.get("test-topic", 1).unwrap();
         let active_path_1 = active_store_1.get_db_path().clone();
 
-        // Create old timestamp under assigned partition 0
-        let partition_0_dir = temp_dir.path().join("test-topic_0");
-        let old_ts_under_assigned = partition_0_dir.join("0000000001");
-        std::fs::create_dir_all(&old_ts_under_assigned).unwrap();
-        std::fs::write(old_ts_under_assigned.join("dummy.sst"), b"old").unwrap();
-
-        // Create an unassigned partition (partition 99) with timestamp dirs
-        let unassigned_dir = temp_dir.path().join("test-topic_99");
-        let unassigned_ts_1 = unassigned_dir.join("0000000001");
-        let unassigned_ts_2 = unassigned_dir.join("0000000002");
-        std::fs::create_dir_all(&unassigned_ts_1).unwrap();
-        std::fs::create_dir_all(&unassigned_ts_2).unwrap();
-        std::fs::write(unassigned_ts_1.join("dummy.sst"), b"orphan1").unwrap();
-        std::fs::write(unassigned_ts_2.join("dummy.sst"), b"orphan2").unwrap();
+        // Create an unassigned partition (partition 99) with some data files
+        let unassigned_dir = temp_dir.path().join("test-topic").join("99");
+        std::fs::create_dir_all(&unassigned_dir).unwrap();
+        std::fs::write(unassigned_dir.join("dummy1.sst"), b"orphan1").unwrap();
+        std::fs::write(unassigned_dir.join("dummy2.sst"), b"orphan2").unwrap();
 
         // Verify setup
-        assert!(old_ts_under_assigned.exists());
-        assert!(unassigned_ts_1.exists());
-        assert!(unassigned_ts_2.exists());
+        assert!(unassigned_dir.exists());
 
         // Run orphan cleanup
         let freed = manager
             .cleanup_orphaned_directories(Duration::from_secs(0))
             .unwrap();
 
-        assert!(freed > 0, "Should have freed bytes from orphans");
+        assert!(
+            freed > 0,
+            "Should have freed bytes from the unassigned partition"
+        );
 
         // Verify: active stores for assigned partitions are untouched
         assert!(
@@ -2365,20 +2211,10 @@ mod tests {
             "Active store for partition 1 should exist"
         );
 
-        // Verify: old timestamp under assigned partition is cleaned
+        // Verify: the unassigned partition directory is fully cleaned
         assert!(
-            !old_ts_under_assigned.exists(),
-            "Old timestamp under assigned partition should be cleaned"
-        );
-
-        // Verify: all timestamps under unassigned partition are cleaned
-        assert!(
-            !unassigned_ts_1.exists(),
-            "Unassigned partition timestamp 1 should be cleaned"
-        );
-        assert!(
-            !unassigned_ts_2.exists(),
-            "Unassigned partition timestamp 2 should be cleaned"
+            !unassigned_dir.exists(),
+            "Unassigned partition dir should be deleted"
         );
 
         // Stores still registered
@@ -2406,7 +2242,7 @@ mod tests {
 
         let store_0 = manager.get("test-topic", 0).unwrap();
         let store_path_0 = store_0.get_db_path().clone();
-        let partition_dir_0 = temp_dir.path().join("test-topic_0");
+        let partition_dir_0 = temp_dir.path().join("test-topic").join("0");
 
         // Verify store 0 exists on disk
         assert!(store_path_0.exists(), "Store 0 path should exist");
@@ -2451,5 +2287,104 @@ mod tests {
             store_1.get_db_path().exists(),
             "Store 1 should still exist (still assigned)"
         );
+    }
+
+    mod try_restore_local_store_tests {
+        use super::*;
+        use crate::checkpoint::metadata::CheckpointMetadata;
+        use crate::test_utils::create_test_store_manager;
+        use crate::utils::format_store_path;
+        use chrono::Utc;
+
+        #[tokio::test]
+        async fn test_returns_metadata_when_fresh() {
+            let temp_dir = TempDir::new().unwrap();
+            let manager = create_test_store_manager(temp_dir.path().to_path_buf());
+            let store_path = format_store_path(temp_dir.path(), "test-topic", 0);
+            tokio::fs::create_dir_all(&store_path).await.unwrap();
+
+            let mut metadata =
+                CheckpointMetadata::new("test-topic".to_string(), 0, Utc::now(), 1, 100, 50);
+            metadata.write_to_dir(&store_path).await.unwrap();
+
+            let result = manager
+                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .await;
+
+            assert!(result.is_some(), "Should return metadata for fresh store");
+            let loaded = result.unwrap();
+            assert_eq!(loaded.consumer_offset, 100);
+            assert_eq!(loaded.producer_offset, 50);
+        }
+
+        #[tokio::test]
+        async fn test_returns_none_when_missing() {
+            let temp_dir = TempDir::new().unwrap();
+            let manager = create_test_store_manager(temp_dir.path().to_path_buf());
+
+            // No metadata.json written — directory doesn't even exist
+            let result = manager
+                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .await;
+
+            assert!(
+                result.is_none(),
+                "Should return None when metadata is missing"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_returns_none_when_stale() {
+            let temp_dir = TempDir::new().unwrap();
+            let manager = create_test_store_manager(temp_dir.path().to_path_buf());
+            let store_path = format_store_path(temp_dir.path(), "test-topic", 0);
+            tokio::fs::create_dir_all(&store_path).await.unwrap();
+
+            // Write metadata with an old updated_at by setting attempt_timestamp far in the past
+            // then manually writing JSON with an old updated_at
+            let old_timestamp = Utc::now() - chrono::Duration::hours(3);
+            let json = serde_json::json!({
+                "id": CheckpointMetadata::generate_id(old_timestamp),
+                "topic": "test-topic",
+                "partition": 0,
+                "attempt_timestamp": old_timestamp,
+                "sequence": 1,
+                "consumer_offset": 50,
+                "producer_offset": 25,
+                "updated_at": old_timestamp,
+                "files": []
+            });
+            let path = store_path.join("metadata.json");
+            tokio::fs::write(&path, serde_json::to_string_pretty(&json).unwrap())
+                .await
+                .unwrap();
+
+            // 2h max staleness — 3h old timestamp should be stale
+            let result = manager
+                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .await;
+
+            assert!(result.is_none(), "Should return None for stale metadata");
+        }
+
+        #[tokio::test]
+        async fn test_returns_none_when_corrupt() {
+            let temp_dir = TempDir::new().unwrap();
+            let manager = create_test_store_manager(temp_dir.path().to_path_buf());
+            let store_path = format_store_path(temp_dir.path(), "test-topic", 0);
+            tokio::fs::create_dir_all(&store_path).await.unwrap();
+
+            // Write invalid JSON
+            let path = store_path.join("metadata.json");
+            tokio::fs::write(&path, b"not valid json at all!!!")
+                .await
+                .unwrap();
+
+            let result = manager
+                .try_restore_local_store("test-topic", 0, Duration::from_secs(7200))
+                .await;
+
+            assert!(result.is_none(), "Should return None for corrupt metadata");
+        }
     }
 }

--- a/rust/kafka-deduplicator/src/test_utils.rs
+++ b/rust/kafka-deduplicator/src/test_utils.rs
@@ -2,15 +2,31 @@
 //!
 //! This module provides common test helpers to avoid duplication across test files.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::rebalance_tracker::RebalanceTracker;
+use crate::rocksdb::store::RocksDbConfig;
+use crate::store::DeduplicationStoreConfig;
+use crate::store_manager::StoreManager;
 
 /// Creates a test `RebalanceTracker`.
 ///
 /// This is a convenience function that wraps `RebalanceTracker::new()` in an `Arc`.
 pub fn create_test_tracker() -> Arc<RebalanceTracker> {
     Arc::new(RebalanceTracker::new())
+}
+
+/// Creates a test `StoreManager` backed by the given path.
+///
+/// The caller is responsible for managing the directory lifetime (typically via `TempDir`).
+pub fn create_test_store_manager(path: PathBuf) -> Arc<StoreManager> {
+    let config = DeduplicationStoreConfig {
+        path,
+        max_capacity: 1_000_000,
+        rocksdb: RocksDbConfig::default(),
+    };
+    Arc::new(StoreManager::new(config, create_test_tracker()))
 }
 
 /// Test helpers for creating test data.

--- a/rust/kafka-deduplicator/src/utils/mod.rs
+++ b/rust/kafka-deduplicator/src/utils/mod.rs
@@ -4,8 +4,14 @@ pub mod timestamp;
 use std::path::{Path, PathBuf};
 
 /// Build the store path for a partition: `<base_path>/<topic>/<partition>/`
+///
+/// Replaces `/` in topic names with `_` to guarantee a two-level directory
+/// structure. Both `cleanup_unowned_partition_directories` and
+/// `cleanup_orphaned_directories` assume exactly `<base>/<topic>/<partition>/`.
 pub fn format_store_path(base_path: &Path, topic: &str, partition: i32) -> PathBuf {
-    base_path.join(topic).join(partition.to_string())
+    base_path
+        .join(topic.replace('/', "_"))
+        .join(partition.to_string())
 }
 
 #[cfg(test)]
@@ -23,6 +29,7 @@ mod tests {
     fn test_format_store_path_with_slashes() {
         let base = Path::new("/data/stores");
         let path = format_store_path(base, "org/events", 0);
-        assert_eq!(path, PathBuf::from("/data/stores/org/events/0"));
+        // Slashes are replaced with underscores to keep a two-level directory structure
+        assert_eq!(path, PathBuf::from("/data/stores/org_events/0"));
     }
 }

--- a/rust/kafka-deduplicator/src/utils/mod.rs
+++ b/rust/kafka-deduplicator/src/utils/mod.rs
@@ -3,65 +3,26 @@ pub mod timestamp;
 
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
-
-/// Format a topic/partition pair as a filesystem-safe directory name.
-/// Replaces `/` characters with `_` since `/` would create subdirectories.
-pub fn format_partition_dir(topic: &str, partition: i32) -> String {
-    format!("{}_{}", topic.replace('/', "_"), partition)
-}
-
-/// Build a complete store path with timestamp subdirectory.
-/// Used by both StoreManager and CheckpointMetadata to ensure consistent paths.
-pub fn format_store_path(
-    base_path: &Path,
-    topic: &str,
-    partition: i32,
-    timestamp: DateTime<Utc>,
-) -> PathBuf {
-    base_path
-        .join(format_partition_dir(topic, partition))
-        .join(timestamp.timestamp_millis().to_string())
+/// Build the store path for a partition: `<base_path>/<topic>/<partition>/`
+pub fn format_store_path(base_path: &Path, topic: &str, partition: i32) -> PathBuf {
+    base_path.join(topic).join(partition.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
-
-    #[test]
-    fn test_format_partition_dir_simple() {
-        assert_eq!(format_partition_dir("events", 0), "events_0");
-        assert_eq!(format_partition_dir("events", 42), "events_42");
-    }
-
-    #[test]
-    fn test_format_partition_dir_with_slashes() {
-        assert_eq!(format_partition_dir("org/events", 0), "org_events_0");
-        assert_eq!(format_partition_dir("a/b/c", 1), "a_b_c_1");
-    }
-
-    #[test]
-    fn test_format_partition_dir_edge_cases() {
-        assert_eq!(format_partition_dir("", 0), "_0");
-        assert_eq!(format_partition_dir("/", 0), "__0");
-        assert_eq!(format_partition_dir("events/", 0), "events__0");
-    }
 
     #[test]
     fn test_format_store_path() {
         let base = Path::new("/data/stores");
-        // 2009-02-13T23:31:30.123Z
-        let ts = Utc.timestamp_millis_opt(1234567890123).unwrap();
-        let path = format_store_path(base, "events", 5, ts);
-        assert_eq!(path, PathBuf::from("/data/stores/events_5/1234567890123"));
+        let path = format_store_path(base, "events", 5);
+        assert_eq!(path, PathBuf::from("/data/stores/events/5"));
     }
 
     #[test]
     fn test_format_store_path_with_slashes() {
         let base = Path::new("/data/stores");
-        let ts = Utc.timestamp_millis_opt(9999).unwrap();
-        let path = format_store_path(base, "org/events", 0, ts);
-        assert_eq!(path, PathBuf::from("/data/stores/org_events_0/9999"));
+        let path = format_store_path(base, "org/events", 0);
+        assert_eq!(path, PathBuf::from("/data/stores/org/events/0"));
     }
 }

--- a/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
@@ -212,12 +212,12 @@ async fn test_simple_batch_kafka_consumer() -> Result<()> {
     let coordinator = create_test_tracker();
     let processor = Arc::new(TestProcessor { sender: chan_tx });
     let offset_tracker = Arc::new(OffsetTracker::new(coordinator));
-
     let consumer = BatchConsumer::<CapturedEvent>::new(
         &config,
         handler,
         processor,
         offset_tracker,
+        None, // on_commit - not needed in tests
         shutdown_rx,
         &test_topic,
         batch_size,
@@ -521,6 +521,7 @@ async fn test_offset_commits_with_routing_processor() -> Result<()> {
         rebalance_handler,
         routing_processor,
         offset_tracker.clone(),
+        None, // on_commit - not needed in tests
         shutdown_rx,
         &test_topic,
         50, // batch size
@@ -665,12 +666,12 @@ async fn test_seek_partitions_rewinds_consumer() -> Result<()> {
     let coordinator = create_test_tracker();
     let processor = Arc::new(TestProcessor { sender: chan_tx });
     let offset_tracker = Arc::new(OffsetTracker::new(coordinator));
-
     let consumer = BatchConsumer::<CapturedEvent>::new(
         &config,
         handler.clone(),
         processor,
         offset_tracker,
+        None, // on_commit - not needed in tests
         shutdown_rx,
         &test_topic,
         10,
@@ -795,12 +796,12 @@ async fn test_seek_partitions_command_handled() -> Result<()> {
     let coordinator = create_test_tracker();
     let processor = Arc::new(NoopProcessor);
     let offset_tracker = Arc::new(OffsetTracker::new(coordinator));
-
     let consumer = BatchConsumer::<CapturedEvent>::new(
         &config,
         handler.clone(),
         processor,
         offset_tracker,
+        None, // on_commit - not needed in tests
         shutdown_rx,
         &test_topic,
         10,

--- a/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/checkpoint_integration_tests.rs
@@ -270,14 +270,10 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
 
-    // Separate marker file and metadata.json (written by importer) from S3-downloaded checkpoint files
-    let marker_files: Vec<_> = all_imported_files
-        .iter()
-        .filter(|f| f.starts_with(".imported_"))
-        .collect();
+    // Separate metadata.json (written by importer) from S3-downloaded checkpoint files
     let imported_files: Vec<_> = all_imported_files
         .iter()
-        .filter(|f| !f.starts_with(".imported_") && *f != METADATA_FILENAME)
+        .filter(|f| *f != METADATA_FILENAME)
         .cloned()
         .collect();
 
@@ -298,14 +294,6 @@ async fn test_checkpoint_export_import_via_minio() -> Result<()> {
         loaded_metadata.updated_at,
         downloaded_metadata.attempt_timestamp
     );
-
-    // Verify marker file exists (created by import to identify imported stores)
-    assert_eq!(
-        marker_files.len(),
-        1,
-        "Should have exactly one .imported_* marker file, found: {marker_files:?}"
-    );
-    info!(marker_file = ?marker_files[0], "Verified import marker file exists");
 
     info!(
         imported = imported_files.len(),
@@ -563,23 +551,12 @@ async fn test_fallback_after_failed_attempt() -> Result<()> {
     let import_path = result.unwrap();
 
     // Verify the imported checkpoint is from the OLDER (successful) checkpoint
-    // by checking the marker file contains the older checkpoint's metadata
-    let marker_files: Vec<_> = std::fs::read_dir(&import_path)
-        .expect("Should be able to read import path")
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_name().to_string_lossy().starts_with(".imported_"))
-        .collect();
-    assert_eq!(marker_files.len(), 1, "Should have exactly one marker file");
-
-    let marker_content = std::fs::read_to_string(marker_files[0].path())
-        .expect("Should be able to read marker file");
-    let marker_metadata: serde_json::Value =
-        serde_json::from_str(&marker_content).expect("Marker should contain valid JSON");
-
-    // The marker should contain the OLDER checkpoint's ID, not the newer (failed) one
+    // by checking metadata.json contains the older checkpoint's ID
+    let loaded_metadata = CheckpointMetadata::load_from_dir(&import_path)
+        .await
+        .expect("metadata.json should exist and deserialize");
     assert_eq!(
-        marker_metadata["id"].as_str().unwrap(),
-        older_metadata.id,
+        loaded_metadata.id, older_metadata.id,
         "Imported checkpoint should be from older checkpoint (fallback)"
     );
 

--- a/rust/kafka-deduplicator/tests/metadata_recovery_tests.rs
+++ b/rust/kafka-deduplicator/tests/metadata_recovery_tests.rs
@@ -1,0 +1,197 @@
+//! Integration tests for metadata.json-based local store recovery.
+//!
+//! These tests verify the end-to-end flow where metadata.json acts as the source of
+//! truth for partition state across pod restarts:
+//!
+//! 1. A running pod writes records and commits Kafka offsets (which updates metadata.json).
+//! 2. On restart, the new pod reads metadata.json, finds it fresh, and restores the local
+//!    RocksDB store directly — skipping S3 import entirely.
+//!
+//! No external infrastructure is required (no Kafka, no MinIO).
+
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use kafka_deduplicator::checkpoint::CheckpointMetadata;
+use kafka_deduplicator::kafka::offset_tracker::OffsetTracker;
+use kafka_deduplicator::kafka::types::Partition;
+use kafka_deduplicator::store::{TimestampKey, TimestampMetadata};
+use kafka_deduplicator::test_utils::test_helpers::TestRawEventBuilder;
+use kafka_deduplicator::test_utils::{create_test_store_manager, create_test_tracker};
+
+const TOPIC: &str = "test-topic";
+const PARTITION: i32 = 0;
+const MAX_STALENESS: Duration = Duration::from_secs(7200);
+
+/// Simulate a Kafka offset commit: after processing messages up to consumer_offset,
+/// the consumer commits and update_metadata_for_partition is called fire-and-forget.
+async fn simulate_commit(
+    store_manager: &kafka_deduplicator::store_manager::StoreManager,
+    consumer_offset: i64,
+    producer_offset: i64,
+) {
+    store_manager
+        .update_metadata_for_partition(TOPIC, PARTITION, consumer_offset, producer_offset)
+        .await;
+}
+
+/// Test: metadata.json is written after simulated Kafka commits and reflects the latest offsets.
+#[tokio::test]
+async fn test_metadata_written_on_simulated_commit() {
+    let base_dir = TempDir::new().unwrap();
+    let sm = create_test_store_manager(base_dir.path().to_path_buf());
+
+    // Create a store for the partition
+    sm.get_or_create_for_rebalance(TOPIC, PARTITION)
+        .await
+        .unwrap();
+
+    // Simulate first commit at offset 100
+    simulate_commit(&sm, 100, 50).await;
+
+    // metadata.json should now exist with correct offsets
+    let store_path =
+        kafka_deduplicator::utils::format_store_path(base_dir.path(), TOPIC, PARTITION);
+    let metadata = CheckpointMetadata::load_from_dir(&store_path)
+        .await
+        .expect("metadata.json should exist after commit");
+
+    assert_eq!(metadata.consumer_offset, 100);
+    assert_eq!(metadata.producer_offset, 50);
+    assert_eq!(metadata.topic, TOPIC);
+    assert_eq!(metadata.partition, PARTITION);
+
+    // Simulate a second commit advancing the offsets
+    simulate_commit(&sm, 250, 120).await;
+
+    let metadata = CheckpointMetadata::load_from_dir(&store_path)
+        .await
+        .unwrap();
+    assert_eq!(metadata.consumer_offset, 250);
+    assert_eq!(metadata.producer_offset, 120);
+}
+
+/// Test: full recovery cycle — write records, commit, restart, restore from local data.
+///
+/// Verifies that:
+/// - metadata.json written during session 1 is readable in session 2
+/// - The restored RocksDB contains the records written in session 1
+/// - The offsets from metadata.json are correct for OffsetTracker seeding
+#[tokio::test]
+async fn test_local_recovery_after_simulated_restart() {
+    let base_dir = TempDir::new().unwrap();
+    let base_path = base_dir.path().to_path_buf();
+
+    // ─── Session 1: running pod ───────────────────────────────────────────────
+
+    let sm1 = create_test_store_manager(base_path.clone());
+
+    // Assignment: pre-create store for partition
+    let store = sm1
+        .get_or_create_for_rebalance(TOPIC, PARTITION)
+        .await
+        .unwrap();
+
+    // Process some events
+    let events: Vec<_> = (0..5)
+        .map(|i| {
+            TestRawEventBuilder::new()
+                .random_uuid()
+                .distinct_id(&format!("user_{i}"))
+                .event(&format!("event_{i}"))
+                .current_timestamp()
+                .build()
+        })
+        .collect();
+
+    for event in &events {
+        let key = TimestampKey::from(event);
+        let meta = TimestampMetadata::new(event);
+        store.put_timestamp_record(&key, &meta).unwrap();
+    }
+
+    // Kafka offset commit: consumer_offset=1000, producer_offset=500
+    simulate_commit(&sm1, 1000, 500).await;
+
+    // Drop store and manager to release RocksDB lock (simulates pod going down)
+    drop(store);
+    drop(sm1);
+
+    // ─── Session 2: pod restarting ────────────────────────────────────────────
+
+    let sm2 = create_test_store_manager(base_path.clone());
+
+    // try_restore_local_store should find fresh metadata.json and return it
+    let metadata = sm2
+        .try_restore_local_store(TOPIC, PARTITION, MAX_STALENESS)
+        .await
+        .expect("should find fresh local metadata after restart");
+
+    assert_eq!(metadata.consumer_offset, 1000);
+    assert_eq!(metadata.producer_offset, 500);
+
+    // Open the existing RocksDB from the partition directory
+    let store_path = kafka_deduplicator::utils::format_store_path(&base_path, TOPIC, PARTITION);
+    sm2.restore_imported_store(TOPIC, PARTITION, &store_path)
+        .unwrap();
+
+    // Verify all records written in session 1 are accessible
+    let restored_store = sm2
+        .get(TOPIC, PARTITION)
+        .expect("store should be registered");
+    for event in &events {
+        let key = TimestampKey::from(event);
+        let record = restored_store.get_timestamp_record(&key).unwrap();
+        assert!(
+            record.is_some(),
+            "record for {} should survive restart",
+            event.event
+        );
+    }
+
+    // Verify OffsetTracker is seeded correctly from the restored metadata
+    let tracker = OffsetTracker::new(create_test_tracker());
+    let partition_key = Partition::new(TOPIC.to_string(), PARTITION);
+    tracker.init_partition_from_metadata(
+        &partition_key,
+        metadata.consumer_offset,
+        metadata.producer_offset,
+    );
+
+    assert_eq!(
+        tracker.get_committed_offset(&partition_key),
+        Some(1000),
+        "committed offset should match metadata consumer_offset"
+    );
+    assert_eq!(
+        tracker.get_producer_offset(&partition_key),
+        Some(500),
+        "producer offset should match metadata producer_offset"
+    );
+}
+
+/// Test: stale metadata.json is not used for recovery — falls back gracefully.
+///
+/// Verifies that if the metadata.json is older than max_staleness, try_restore_local_store
+/// returns None so the caller falls through to S3 import.
+#[tokio::test]
+async fn test_stale_metadata_not_used_for_recovery() {
+    let base_dir = TempDir::new().unwrap();
+    let sm = create_test_store_manager(base_dir.path().to_path_buf());
+
+    sm.get_or_create_for_rebalance(TOPIC, PARTITION)
+        .await
+        .unwrap();
+    simulate_commit(&sm, 1000, 500).await;
+
+    // A max_staleness of zero means any existing metadata is always stale
+    let result = sm
+        .try_restore_local_store(TOPIC, PARTITION, Duration::ZERO)
+        .await;
+
+    assert!(
+        result.is_none(),
+        "stale metadata should not be returned for recovery"
+    );
+}

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -46,8 +46,8 @@ use kafka_deduplicator::processor_rebalance_handler::ProcessorRebalanceHandler;
 use kafka_deduplicator::rocksdb::store::RocksDbConfig;
 use kafka_deduplicator::store::{DeduplicationStore, DeduplicationStoreConfig};
 use kafka_deduplicator::store_manager::StoreManager;
-use kafka_deduplicator::test_utils::test_helpers::TestRawEventBuilder;
 use kafka_deduplicator::test_utils::create_test_tracker;
+use kafka_deduplicator::test_utils::test_helpers::TestRawEventBuilder;
 
 mod common;
 use common::{

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -46,8 +46,8 @@ use kafka_deduplicator::processor_rebalance_handler::ProcessorRebalanceHandler;
 use kafka_deduplicator::rocksdb::store::RocksDbConfig;
 use kafka_deduplicator::store::{DeduplicationStore, DeduplicationStoreConfig};
 use kafka_deduplicator::store_manager::StoreManager;
-use kafka_deduplicator::test_utils::create_test_tracker;
 use kafka_deduplicator::test_utils::test_helpers::TestRawEventBuilder;
+use kafka_deduplicator::test_utils::create_test_tracker;
 
 mod common;
 use common::{
@@ -335,6 +335,7 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
             offset_tracker.clone(),
             Some(importer),
             16, // rebalance_cleanup_parallelism
+            Duration::from_secs(7200),
         ));
 
     // Create routing processor
@@ -360,6 +361,7 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
         rebalance_handler,
         routing_processor,
         offset_tracker.clone(),
+        None, // on_commit - not needed in tests
         shutdown_rx,
         &test_topic,
         50,
@@ -463,6 +465,7 @@ async fn test_messages_dropped_for_revoked_partition() -> Result<()> {
             offset_tracker.clone(),
             None,
             16, // rebalance_cleanup_parallelism
+            Duration::from_secs(7200),
         );
 
     // Assign partition 0
@@ -551,6 +554,7 @@ async fn test_rapid_revoke_assign_preserves_new_store() -> Result<()> {
             offset_tracker.clone(),
             None,
             16, // rebalance_cleanup_parallelism
+            Duration::from_secs(7200),
         );
 
     let mut partitions = TopicPartitionList::new();


### PR DESCRIPTION
## Problem

The kafka-deduplicator's checkpoint system uses a two-tier approach for disaster recovery: local RocksDB + metadata.json, and S3 uploads. 
However, metadata.json was only written during S3 checkpoint exports, which are infrequent (every few minutes). This meant that after a pod restart, even when local RocksDB data was perfectly intact, the service had no way to know its last committed offset and had to fall back to an expensive S3 import or start from scratch.

Additionally, the store directory layout used `<base>/<topic>_<partition>/<timestamp>/` which created new timestamped subdirectories on every import, making local restore impossible and accumulating orphan directories.

## Changes

- Simplify the store directory layout from `<base>/<topic>_<partition>/<timestamp>/` to `<base>/<topic>/<partition>/`, enabling in-place local restore across restarts
- Write metadata.json continuously on every Kafka offset commit via a fire-and-forget `OnCommit` callback trait, keeping the `updated_at` timestamp fresh for staleness detection
- Add local restore as the first restore strategy during rebalance: if metadata.json exists and is within the configurable staleness window (`local_checkpoint_max_staleness`, default 2h, probably needs tuning), open RocksDB directly and skip S3 import entirely
- Seed `OffsetTracker` from restored metadata so the Kafka consumer seeks to the correct position and checkpointing reflects the pre-restart state
- Decouple `BatchConsumer` from `StoreManager` using an `OnCommit` trait, keeping the consumer generic and the metadata write logic in `MetadataCommitCallback`
- Remove the `.imported_<timestamp>` marker file and `format_partition_dir` utility, replaced by the simpler directory layout
- Update cleanup logic to scan the new `<topic>/<partition>` two-level directory structure

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
