### PR TITLE
fix(livestream): Add write time pruning to Livstream stats

### DIFF
--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -81,14 +81,18 @@ func sessionKey(token string) string {
 	return fmt.Sprintf("livestream:sessions:%s", token)
 }
 
+func cutoffScore(ttl time.Duration) string {
+	return strconv.FormatInt(time.Now().Add(-ttl).Unix(), 10)
+}
+
 // Adds a member to a sorted set scored by the current timestamp, then sets the key expiry.
 func (s *StatsInRedis) addKey(ctx context.Context, key string, memberId string, ttl time.Duration, metricsLabel string) error {
 	now := time.Now()
 	score := float64(now.Unix())
-
-	cmds := make(rueidis.Commands, 2)
+	cmds := make(rueidis.Commands, 3)
 	cmds[0] = s.client.B().Zadd().Key(key).Gt().ScoreMember().ScoreMember(score, memberId).Build()
-	cmds[1] = s.client.B().Expire().Key(key).Seconds(int64(ttl.Seconds())).Build()
+	cmds[1] = s.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoffScore(ttl)).Build()
+	cmds[2] = s.client.B().Expire().Key(key).Seconds(int64(ttl.Seconds())).Build()
 
 	results := s.client.DoMulti(ctx, cmds...)
 
@@ -106,10 +110,8 @@ func (s *StatsInRedis) addKey(ctx context.Context, key string, memberId string, 
 // Returns a sliding-window count by first pruning entries older than the TTL then counting survivors
 func (s *StatsInRedis) getCount(ctx context.Context, key string, ttl time.Duration, metricsLabel string) (int64, error) {
 	now := time.Now()
-	cutoff := strconv.FormatFloat(float64(now.Add(-ttl).Unix()), 'f', 0, 64)
-
 	cmds := make(rueidis.Commands, 2)
-	cmds[0] = s.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoff).Build()
+	cmds[0] = s.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoffScore(ttl)).Build()
 	cmds[1] = s.client.B().Zcard().Key(key).Build()
 
 	results := s.client.DoMulti(ctx, cmds...)
@@ -150,6 +152,7 @@ func (s *StatsInRedis) flushKeys(ctx context.Context, pending map[string]map[str
 	metrics.RedisFlushTotal.WithLabelValues(metricsLabel).Inc()
 
 	now := time.Now()
+	cutoff := cutoffScore(ttl)
 	var wg sync.WaitGroup
 
 	for token, members := range pending {
@@ -158,9 +161,11 @@ func (s *StatsInRedis) flushKeys(ctx context.Context, pending map[string]map[str
 			defer wg.Done()
 
 			key := keyFn(token)
-			cmds := make(rueidis.Commands, 2)
+
+			cmds := make(rueidis.Commands, 3)
 			cmds[0] = s.client.B().Zadd().Key(key).Gt().ScoreMember().ScoreMemberIter(maps.All(members)).Build()
-			cmds[1] = s.client.B().Expire().Key(key).Seconds(int64(ttl.Seconds())).Build()
+			cmds[1] = s.client.B().Zremrangebyscore().Key(key).Min("-inf").Max(cutoff).Build()
+			cmds[2] = s.client.B().Expire().Key(key).Seconds(int64(ttl.Seconds())).Build()
 
 			results := s.client.DoMulti(ctx, cmds...)
 			for _, r := range results {

--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -85,7 +85,7 @@ func cutoffScore(ttl time.Duration) string {
 	return strconv.FormatInt(time.Now().Add(-ttl).Unix(), 10)
 }
 
-// Adds a member to a sorted set scored by the current timestamp, then sets the key expiry.
+// Adds a member to a sorted set scored by the current timestamp, prunes stale entries older than ttl, then sets the key expiry.
 func (s *StatsInRedis) addKey(ctx context.Context, key string, memberId string, ttl time.Duration, metricsLabel string) error {
 	now := time.Now()
 	score := float64(now.Unix())

--- a/livestream/events/redis_stats_test.go
+++ b/livestream/events/redis_stats_test.go
@@ -193,6 +193,29 @@ func TestUserNaturalDecay(t *testing.T) {
 	assert.Equal(t, int64(1), count, "only user2 should remain after user1 ages out")
 }
 
+func TestWriteTimePruning(t *testing.T) {
+	w, client := setupMiniredis(t)
+	ctx := context.Background()
+
+	// Seed old members past the TTL window
+	key := userKey("token_a")
+	oldScore := float64(time.Now().Add(-2 * time.Minute).Unix())
+	cmd := client.B().Zadd().Key(key).ScoreMember().
+		ScoreMember(oldScore, "stale_user1").
+		ScoreMember(oldScore, "stale_user2").
+		Build()
+	require.NoError(t, client.Do(ctx, cmd).Error())
+
+	// Write a fresh member
+	require.NoError(t, w.AddUser(ctx, "token_a", "fresh_user"))
+
+	// Verify pruning happened at write time
+	card := client.B().Zcard().Key(key).Build()
+	count, err := client.Do(ctx, card).AsInt64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "stale members should be pruned by AddUser, only fresh_user remains")
+}
+
 func TestCrossTokenIsolation(t *testing.T) {
 	w, _ := setupMiniredis(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Problem
We store distinct IDs in a sorted set with a 60s TTL to track online users for a team. For teams with constant events, that TTL never expires since we reset it on every write.  We removed stale entries on read, but if nobody polled /stats for that team, the set would grow forever.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Prune old entries on write. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, added test.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
