### PR TITLE
chore(mcp): tree-shakeable generated zod schemas

### DIFF
--- a/services/mcp/scripts/generate-orval-schemas.mjs
+++ b/services/mcp/scripts/generate-orval-schemas.mjs
@@ -184,8 +184,16 @@ export default defineConfig({
   },
 });
 `
+
     fs.writeFileSync(configFile, config)
     execSync(`pnpm exec orval --config "${configFile}"`, { stdio: 'pipe', cwd: repoRoot })
+
+    // Annotate top-level exported Zod expressions with @__PURE__ so esbuild
+    // can tree-shake unused schemas out of the bundle.
+    const generated = fs.readFileSync(outputFile, 'utf-8')
+    const annotated = generated.replace(/^(export const \w+ =) (zod\.)/gm, '$1 /* @__PURE__ */ $2')
+    fs.writeFileSync(outputFile, annotated)
+
     return moduleOutputDir
 }
 

--- a/services/mcp/src/generated/actions/api.ts
+++ b/services/mcp/src/generated/actions/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const ActionsListParams = zod.object({
+export const ActionsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,13 +16,13 @@ export const ActionsListParams = zod.object({
         ),
 })
 
-export const ActionsListQueryParams = zod.object({
+export const ActionsListQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['csv', 'json']).optional(),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })
 
-export const ActionsCreateParams = zod.object({
+export const ActionsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -30,7 +30,7 @@ export const ActionsCreateParams = zod.object({
         ),
 })
 
-export const ActionsCreateQueryParams = zod.object({
+export const ActionsCreateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['csv', 'json']).optional(),
 })
 
@@ -48,7 +48,7 @@ export const actionsCreateBodyStepsItemPropertiesItemFourTypeDefault = `event`
 export const actionsCreateBodyStepsItemPropertiesItemFourOperatorDefault = `is_date_exact`
 export const actionsCreateBodyStepsItemPropertiesItemFiveTypeDefault = `event`
 
-export const ActionsCreateBody = zod
+export const ActionsCreateBody = /* @__PURE__ */ zod
     .object({
         name: zod
             .string()
@@ -419,7 +419,7 @@ export const ActionsCreateBody = zod
     })
     .describe('Serializer mixin that handles tags for objects.')
 
-export const ActionsRetrieveParams = zod.object({
+export const ActionsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this action.'),
     project_id: zod
         .string()
@@ -428,11 +428,11 @@ export const ActionsRetrieveParams = zod.object({
         ),
 })
 
-export const ActionsRetrieveQueryParams = zod.object({
+export const ActionsRetrieveQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['csv', 'json']).optional(),
 })
 
-export const ActionsPartialUpdateParams = zod.object({
+export const ActionsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this action.'),
     project_id: zod
         .string()
@@ -441,7 +441,7 @@ export const ActionsPartialUpdateParams = zod.object({
         ),
 })
 
-export const ActionsPartialUpdateQueryParams = zod.object({
+export const ActionsPartialUpdateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['csv', 'json']).optional(),
 })
 
@@ -459,7 +459,7 @@ export const actionsPartialUpdateBodyStepsItemPropertiesItemFourTypeDefault = `e
 export const actionsPartialUpdateBodyStepsItemPropertiesItemFourOperatorDefault = `is_date_exact`
 export const actionsPartialUpdateBodyStepsItemPropertiesItemFiveTypeDefault = `event`
 
-export const ActionsPartialUpdateBody = zod
+export const ActionsPartialUpdateBody = /* @__PURE__ */ zod
     .object({
         name: zod
             .string()
@@ -835,7 +835,7 @@ export const ActionsPartialUpdateBody = zod
 /**
  * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
  */
-export const ActionsDestroyParams = zod.object({
+export const ActionsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this action.'),
     project_id: zod
         .string()
@@ -844,6 +844,6 @@ export const ActionsDestroyParams = zod.object({
         ),
 })
 
-export const ActionsDestroyQueryParams = zod.object({
+export const ActionsDestroyQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['csv', 'json']).optional(),
 })

--- a/services/mcp/src/generated/annotations/api.ts
+++ b/services/mcp/src/generated/annotations/api.ts
@@ -11,7 +11,7 @@ import * as zod from 'zod'
 /**
  * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
  */
-export const AnnotationsListParams = zod.object({
+export const AnnotationsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -19,7 +19,7 @@ export const AnnotationsListParams = zod.object({
         ),
 })
 
-export const AnnotationsListQueryParams = zod.object({
+export const AnnotationsListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     search: zod.string().optional().describe('A search term.'),
@@ -28,7 +28,7 @@ export const AnnotationsListQueryParams = zod.object({
 /**
  * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
  */
-export const AnnotationsCreateParams = zod.object({
+export const AnnotationsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -38,7 +38,7 @@ export const AnnotationsCreateParams = zod.object({
 
 export const annotationsCreateBodyContentMax = 8192
 
-export const AnnotationsCreateBody = zod.object({
+export const AnnotationsCreateBody = /* @__PURE__ */ zod.object({
     content: zod
         .string()
         .max(annotationsCreateBodyContentMax)
@@ -76,7 +76,7 @@ export const AnnotationsCreateBody = zod.object({
 /**
  * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
  */
-export const AnnotationsRetrieveParams = zod.object({
+export const AnnotationsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this annotation.'),
     project_id: zod
         .string()
@@ -88,7 +88,7 @@ export const AnnotationsRetrieveParams = zod.object({
 /**
  * Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
  */
-export const AnnotationsPartialUpdateParams = zod.object({
+export const AnnotationsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this annotation.'),
     project_id: zod
         .string()
@@ -99,7 +99,7 @@ export const AnnotationsPartialUpdateParams = zod.object({
 
 export const annotationsPartialUpdateBodyContentMax = 8192
 
-export const AnnotationsPartialUpdateBody = zod.object({
+export const AnnotationsPartialUpdateBody = /* @__PURE__ */ zod.object({
     content: zod
         .string()
         .max(annotationsPartialUpdateBodyContentMax)
@@ -137,7 +137,7 @@ export const AnnotationsPartialUpdateBody = zod.object({
 /**
  * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
  */
-export const AnnotationsDestroyParams = zod.object({
+export const AnnotationsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this annotation.'),
     project_id: zod
         .string()

--- a/services/mcp/src/generated/cdp_function_templates/api.ts
+++ b/services/mcp/src/generated/cdp_function_templates/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const HogFunctionTemplatesListParams = zod.object({
+export const HogFunctionTemplatesListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,7 +16,7 @@ export const HogFunctionTemplatesListParams = zod.object({
         ),
 })
 
-export const HogFunctionTemplatesListQueryParams = zod.object({
+export const HogFunctionTemplatesListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     template_id: zod
@@ -37,7 +37,7 @@ export const HogFunctionTemplatesListQueryParams = zod.object({
         .describe('Comma-separated list of template types to include (e.g. destination,email,sms_provider).'),
 })
 
-export const HogFunctionTemplatesRetrieveParams = zod.object({
+export const HogFunctionTemplatesRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(

--- a/services/mcp/src/generated/cdp_functions/api.ts
+++ b/services/mcp/src/generated/cdp_functions/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const HogFunctionsListParams = zod.object({
+export const HogFunctionsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,7 +16,7 @@ export const HogFunctionsListParams = zod.object({
         ),
 })
 
-export const HogFunctionsListQueryParams = zod.object({
+export const HogFunctionsListQueryParams = /* @__PURE__ */ zod.object({
     created_at: zod.string().datetime({}).optional(),
     created_by: zod.number().optional(),
     enabled: zod.boolean().optional(),
@@ -28,7 +28,7 @@ export const HogFunctionsListQueryParams = zod.object({
     updated_at: zod.string().datetime({}).optional(),
 })
 
-export const HogFunctionsCreateParams = zod.object({
+export const HogFunctionsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -54,7 +54,7 @@ export const hogFunctionsCreateBodyTemplateIdMax = 400
 export const hogFunctionsCreateBodyExecutionOrderMin = 0
 export const hogFunctionsCreateBodyExecutionOrderMax = 32767
 
-export const HogFunctionsCreateBody = zod.object({
+export const HogFunctionsCreateBody = /* @__PURE__ */ zod.object({
     type: zod
         .union([
             zod
@@ -264,7 +264,7 @@ export const HogFunctionsCreateBody = zod.object({
         .describe('Execution priority for transformations. Lower values run first.'),
 })
 
-export const HogFunctionsRetrieveParams = zod.object({
+export const HogFunctionsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this hog function.'),
     project_id: zod
         .string()
@@ -273,7 +273,7 @@ export const HogFunctionsRetrieveParams = zod.object({
         ),
 })
 
-export const HogFunctionsPartialUpdateParams = zod.object({
+export const HogFunctionsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this hog function.'),
     project_id: zod
         .string()
@@ -300,7 +300,7 @@ export const hogFunctionsPartialUpdateBodyTemplateIdMax = 400
 export const hogFunctionsPartialUpdateBodyExecutionOrderMin = 0
 export const hogFunctionsPartialUpdateBodyExecutionOrderMax = 32767
 
-export const HogFunctionsPartialUpdateBody = zod.object({
+export const HogFunctionsPartialUpdateBody = /* @__PURE__ */ zod.object({
     type: zod
         .union([
             zod
@@ -513,7 +513,7 @@ export const HogFunctionsPartialUpdateBody = zod.object({
 /**
  * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
  */
-export const HogFunctionsDestroyParams = zod.object({
+export const HogFunctionsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this hog function.'),
     project_id: zod
         .string()
@@ -522,7 +522,7 @@ export const HogFunctionsDestroyParams = zod.object({
         ),
 })
 
-export const HogFunctionsInvocationsCreateParams = zod.object({
+export const HogFunctionsInvocationsCreateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this hog function.'),
     project_id: zod
         .string()
@@ -567,7 +567,7 @@ export const hogFunctionsInvocationsCreateBodyConfigurationOneExecutionOrderMax 
 
 export const hogFunctionsInvocationsCreateBodyMockAsyncFunctionsDefault = true
 
-export const HogFunctionsInvocationsCreateBody = zod.object({
+export const HogFunctionsInvocationsCreateBody = /* @__PURE__ */ zod.object({
     configuration: zod
         .object({
             id: zod.string().optional(),
@@ -954,7 +954,7 @@ export const HogFunctionsInvocationsCreateBody = zod.object({
 /**
  * Update the execution order of multiple HogFunctions.
  */
-export const HogFunctionsRearrangePartialUpdateParams = zod.object({
+export const HogFunctionsRearrangePartialUpdateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -962,7 +962,7 @@ export const HogFunctionsRearrangePartialUpdateParams = zod.object({
         ),
 })
 
-export const HogFunctionsRearrangePartialUpdateBody = zod.object({
+export const HogFunctionsRearrangePartialUpdateBody = /* @__PURE__ */ zod.object({
     orders: zod
         .record(zod.string(), zod.number())
         .optional()

--- a/services/mcp/src/generated/cohorts/api.ts
+++ b/services/mcp/src/generated/cohorts/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const CohortsListParams = zod.object({
+export const CohortsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,12 +16,12 @@ export const CohortsListParams = zod.object({
         ),
 })
 
-export const CohortsListQueryParams = zod.object({
+export const CohortsListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })
 
-export const CohortsCreateParams = zod.object({
+export const CohortsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -38,7 +38,7 @@ export const cohortsCreateBodyFiltersOnePropertiesValuesItemTwoNegationDefault =
 export const cohortsCreateBodyFiltersOnePropertiesValuesItemThreeNegationDefault = false
 export const cohortsCreateBodyCreateStaticPersonIdsDefault = []
 
-export const CohortsCreateBody = zod.object({
+export const CohortsCreateBody = /* @__PURE__ */ zod.object({
     name: zod.string().max(cohortsCreateBodyNameMax).nullish(),
     description: zod.string().max(cohortsCreateBodyDescriptionMax).optional(),
     filters: zod
@@ -140,7 +140,7 @@ export const CohortsCreateBody = zod.object({
     _create_static_person_ids: zod.array(zod.string()).default(cohortsCreateBodyCreateStaticPersonIdsDefault),
 })
 
-export const CohortsRetrieveParams = zod.object({
+export const CohortsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this cohort.'),
     project_id: zod
         .string()
@@ -149,7 +149,7 @@ export const CohortsRetrieveParams = zod.object({
         ),
 })
 
-export const CohortsPartialUpdateParams = zod.object({
+export const CohortsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this cohort.'),
     project_id: zod
         .string()
@@ -167,7 +167,7 @@ export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemTwoNegationDe
 export const cohortsPartialUpdateBodyFiltersOnePropertiesValuesItemThreeNegationDefault = false
 export const cohortsPartialUpdateBodyCreateStaticPersonIdsDefault = []
 
-export const CohortsPartialUpdateBody = zod.object({
+export const CohortsPartialUpdateBody = /* @__PURE__ */ zod.object({
     name: zod.string().max(cohortsPartialUpdateBodyNameMax).nullish(),
     description: zod.string().max(cohortsPartialUpdateBodyDescriptionMax).optional(),
     deleted: zod.boolean().optional(),
@@ -272,7 +272,7 @@ export const CohortsPartialUpdateBody = zod.object({
     _create_static_person_ids: zod.array(zod.string()).default(cohortsPartialUpdateBodyCreateStaticPersonIdsDefault),
 })
 
-export const CohortsAddPersonsToStaticCohortPartialUpdateParams = zod.object({
+export const CohortsAddPersonsToStaticCohortPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this cohort.'),
     project_id: zod
         .string()
@@ -281,11 +281,11 @@ export const CohortsAddPersonsToStaticCohortPartialUpdateParams = zod.object({
         ),
 })
 
-export const CohortsAddPersonsToStaticCohortPartialUpdateBody = zod.object({
+export const CohortsAddPersonsToStaticCohortPartialUpdateBody = /* @__PURE__ */ zod.object({
     person_ids: zod.array(zod.string()).optional().describe('List of person UUIDs to add to the cohort'),
 })
 
-export const CohortsRemovePersonFromStaticCohortPartialUpdateParams = zod.object({
+export const CohortsRemovePersonFromStaticCohortPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this cohort.'),
     project_id: zod
         .string()
@@ -294,6 +294,6 @@ export const CohortsRemovePersonFromStaticCohortPartialUpdateParams = zod.object
         ),
 })
 
-export const CohortsRemovePersonFromStaticCohortPartialUpdateBody = zod.object({
+export const CohortsRemovePersonFromStaticCohortPartialUpdateBody = /* @__PURE__ */ zod.object({
     person_id: zod.string().optional().describe('Person UUID to remove from the cohort'),
 })

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const DashboardsListParams = zod.object({
+export const DashboardsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,13 +16,13 @@ export const DashboardsListParams = zod.object({
         ),
 })
 
-export const DashboardsListQueryParams = zod.object({
+export const DashboardsListQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })
 
-export const DashboardsCreateParams = zod.object({
+export const DashboardsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -30,7 +30,7 @@ export const DashboardsCreateParams = zod.object({
         ),
 })
 
-export const DashboardsCreateQueryParams = zod.object({
+export const DashboardsCreateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
 })
 
@@ -38,7 +38,7 @@ export const dashboardsCreateBodyNameMax = 400
 
 export const dashboardsCreateBodyDeleteInsightsDefault = false
 
-export const DashboardsCreateBody = zod
+export const DashboardsCreateBody = /* @__PURE__ */ zod
     .object({
         name: zod.string().max(dashboardsCreateBodyNameMax).nullish(),
         description: zod.string().optional(),
@@ -68,7 +68,7 @@ export const DashboardsCreateBody = zod
     })
     .describe('Serializer mixin that handles tags for objects.')
 
-export const DashboardsRetrieveParams = zod.object({
+export const DashboardsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),
     project_id: zod
         .string()
@@ -77,11 +77,11 @@ export const DashboardsRetrieveParams = zod.object({
         ),
 })
 
-export const DashboardsRetrieveQueryParams = zod.object({
+export const DashboardsRetrieveQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
 })
 
-export const DashboardsPartialUpdateParams = zod.object({
+export const DashboardsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),
     project_id: zod
         .string()
@@ -90,7 +90,7 @@ export const DashboardsPartialUpdateParams = zod.object({
         ),
 })
 
-export const DashboardsPartialUpdateQueryParams = zod.object({
+export const DashboardsPartialUpdateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
 })
 
@@ -98,7 +98,7 @@ export const dashboardsPartialUpdateBodyNameMax = 400
 
 export const dashboardsPartialUpdateBodyDeleteInsightsDefault = false
 
-export const DashboardsPartialUpdateBody = zod
+export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
     .object({
         name: zod.string().max(dashboardsPartialUpdateBodyNameMax).nullish(),
         description: zod.string().optional(),
@@ -131,7 +131,7 @@ export const DashboardsPartialUpdateBody = zod
 /**
  * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
  */
-export const DashboardsDestroyParams = zod.object({
+export const DashboardsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),
     project_id: zod
         .string()
@@ -140,11 +140,11 @@ export const DashboardsDestroyParams = zod.object({
         ),
 })
 
-export const DashboardsDestroyQueryParams = zod.object({
+export const DashboardsDestroyQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
 })
 
-export const DashboardsReorderTilesCreateParams = zod.object({
+export const DashboardsReorderTilesCreateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this dashboard.'),
     project_id: zod
         .string()
@@ -153,11 +153,11 @@ export const DashboardsReorderTilesCreateParams = zod.object({
         ),
 })
 
-export const DashboardsReorderTilesCreateQueryParams = zod.object({
+export const DashboardsReorderTilesCreateQueryParams = /* @__PURE__ */ zod.object({
     format: zod.enum(['json', 'txt']).optional(),
 })
 
-export const DashboardsReorderTilesCreateBody = zod.object({
+export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
     tile_order: zod
         .array(zod.number())
         .min(1)

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const ErrorTrackingIssuesListParams = zod.object({
+export const ErrorTrackingIssuesListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,12 +16,12 @@ export const ErrorTrackingIssuesListParams = zod.object({
         ),
 })
 
-export const ErrorTrackingIssuesListQueryParams = zod.object({
+export const ErrorTrackingIssuesListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })
 
-export const ErrorTrackingIssuesRetrieveParams = zod.object({
+export const ErrorTrackingIssuesRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this error tracking issue.'),
     project_id: zod
         .string()
@@ -30,7 +30,7 @@ export const ErrorTrackingIssuesRetrieveParams = zod.object({
         ),
 })
 
-export const ErrorTrackingIssuesPartialUpdateParams = zod.object({
+export const ErrorTrackingIssuesPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this error tracking issue.'),
     project_id: zod
         .string()
@@ -39,7 +39,7 @@ export const ErrorTrackingIssuesPartialUpdateParams = zod.object({
         ),
 })
 
-export const ErrorTrackingIssuesPartialUpdateBody = zod.object({
+export const ErrorTrackingIssuesPartialUpdateBody = /* @__PURE__ */ zod.object({
     status: zod
         .enum(['archived', 'active', 'resolved', 'pending_release', 'suppressed'])
         .optional()

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -13,7 +13,7 @@ import * as zod from 'zod'
 
 If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
-export const FeatureFlagsListParams = zod.object({
+export const FeatureFlagsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -21,7 +21,7 @@ export const FeatureFlagsListParams = zod.object({
         ),
 })
 
-export const FeatureFlagsListQueryParams = zod.object({
+export const FeatureFlagsListQueryParams = /* @__PURE__ */ zod.object({
     active: zod.enum(['STALE', 'false', 'true']).optional(),
     created_by_id: zod.string().optional().describe('The User ID which initially created the feature flag.'),
     evaluation_runtime: zod
@@ -50,7 +50,7 @@ export const FeatureFlagsListQueryParams = zod.object({
 
 If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
-export const FeatureFlagsCreateParams = zod.object({
+export const FeatureFlagsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -58,7 +58,7 @@ export const FeatureFlagsCreateParams = zod.object({
         ),
 })
 
-export const FeatureFlagsCreateBody = zod.object({
+export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
     key: zod.string().optional().describe('Feature flag key.'),
     name: zod
         .string()
@@ -342,7 +342,7 @@ export const FeatureFlagsCreateBody = zod.object({
 
 If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
-export const FeatureFlagsRetrieve2Params = zod.object({
+export const FeatureFlagsRetrieve2Params = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
     project_id: zod
         .string()
@@ -356,7 +356,7 @@ export const FeatureFlagsRetrieve2Params = zod.object({
 
 If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
-export const FeatureFlagsPartialUpdateParams = zod.object({
+export const FeatureFlagsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
     project_id: zod
         .string()
@@ -365,7 +365,7 @@ export const FeatureFlagsPartialUpdateParams = zod.object({
         ),
 })
 
-export const FeatureFlagsPartialUpdateBody = zod.object({
+export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
     key: zod.string().optional().describe('Feature flag key.'),
     name: zod
         .string()
@@ -647,7 +647,7 @@ export const FeatureFlagsPartialUpdateBody = zod.object({
 /**
  * Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true
  */
-export const FeatureFlagsDestroyParams = zod.object({
+export const FeatureFlagsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.number().describe('A unique integer value identifying this feature flag.'),
     project_id: zod
         .string()

--- a/services/mcp/src/generated/prompts/api.ts
+++ b/services/mcp/src/generated/prompts/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const LlmPromptsListParams = zod.object({
+export const LlmPromptsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,13 +16,13 @@ export const LlmPromptsListParams = zod.object({
         ),
 })
 
-export const LlmPromptsListQueryParams = zod.object({
+export const LlmPromptsListQueryParams = /* @__PURE__ */ zod.object({
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     search: zod.string().optional().describe('Optional substring filter applied to prompt names and prompt content.'),
 })
 
-export const LlmPromptsCreateParams = zod.object({
+export const LlmPromptsCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -32,7 +32,7 @@ export const LlmPromptsCreateParams = zod.object({
 
 export const llmPromptsCreateBodyNameMax = 255
 
-export const LlmPromptsCreateBody = zod.object({
+export const LlmPromptsCreateBody = /* @__PURE__ */ zod.object({
     name: zod
         .string()
         .max(llmPromptsCreateBodyNameMax)
@@ -42,7 +42,7 @@ export const LlmPromptsCreateBody = zod.object({
 
 export const llmPromptsNameRetrievePathPromptNameRegExp = new RegExp('^[^/]+$')
 
-export const LlmPromptsNameRetrieveParams = zod.object({
+export const LlmPromptsNameRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -51,7 +51,7 @@ export const LlmPromptsNameRetrieveParams = zod.object({
     prompt_name: zod.string().regex(llmPromptsNameRetrievePathPromptNameRegExp),
 })
 
-export const LlmPromptsNameRetrieveQueryParams = zod.object({
+export const LlmPromptsNameRetrieveQueryParams = /* @__PURE__ */ zod.object({
     version: zod
         .number()
         .min(1)
@@ -61,7 +61,7 @@ export const LlmPromptsNameRetrieveQueryParams = zod.object({
 
 export const llmPromptsNamePartialUpdatePathPromptNameRegExp = new RegExp('^[^/]+$')
 
-export const LlmPromptsNamePartialUpdateParams = zod.object({
+export const LlmPromptsNamePartialUpdateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -70,7 +70,7 @@ export const LlmPromptsNamePartialUpdateParams = zod.object({
     prompt_name: zod.string().regex(llmPromptsNamePartialUpdatePathPromptNameRegExp),
 })
 
-export const LlmPromptsNamePartialUpdateBody = zod.object({
+export const LlmPromptsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
     prompt: zod.unknown().optional().describe('Prompt payload to publish as a new version.'),
     base_version: zod
         .number()

--- a/services/mcp/src/generated/proxy-records/api.ts
+++ b/services/mcp/src/generated/proxy-records/api.ts
@@ -11,18 +11,18 @@ import * as zod from 'zod'
 /**
  * List all reverse proxies configured for the organization. Returns proxy records along with the maximum number allowed by the current plan.
  */
-export const ProxyRecordsListParams = zod.object({
+export const ProxyRecordsListParams = /* @__PURE__ */ zod.object({
     organization_id: zod.string(),
 })
 
 /**
  * Create a new managed reverse proxy. Provide the domain you want to proxy through. The response includes the CNAME target you need to add as a DNS record. Once the CNAME is configured, the proxy will be automatically verified and provisioned.
  */
-export const ProxyRecordsCreateParams = zod.object({
+export const ProxyRecordsCreateParams = /* @__PURE__ */ zod.object({
     organization_id: zod.string(),
 })
 
-export const ProxyRecordsCreateBody = zod.object({
+export const ProxyRecordsCreateBody = /* @__PURE__ */ zod.object({
     domain: zod
         .string()
         .describe("The custom domain to proxy through, e.g. 'e.example.com'. Must be a valid subdomain you control."),
@@ -31,7 +31,7 @@ export const ProxyRecordsCreateBody = zod.object({
 /**
  * Get details of a specific reverse proxy by ID. Returns the full configuration including domain, CNAME target, and current provisioning status.
  */
-export const ProxyRecordsRetrieveParams = zod.object({
+export const ProxyRecordsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this proxy record.'),
     organization_id: zod.string(),
 })
@@ -39,7 +39,7 @@ export const ProxyRecordsRetrieveParams = zod.object({
 /**
  * Delete a reverse proxy. For proxies in 'waiting', 'erroring', or 'timed_out' status, the record is deleted immediately. For active proxies, a deletion workflow is started to clean up the provisioned infrastructure.
  */
-export const ProxyRecordsDestroyParams = zod.object({
+export const ProxyRecordsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this proxy record.'),
     organization_id: zod.string(),
 })
@@ -47,7 +47,7 @@ export const ProxyRecordsDestroyParams = zod.object({
 /**
  * Retry provisioning a failed reverse proxy. Only available for proxies in 'erroring' or 'timed_out' status. Resets the proxy to 'waiting' status and restarts the provisioning workflow.
  */
-export const ProxyRecordsRetryCreateParams = zod.object({
+export const ProxyRecordsRetryCreateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this proxy record.'),
     organization_id: zod.string(),
 })

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -8,7 +8,7 @@
  */
 import * as zod from 'zod'
 
-export const HogFlowsListParams = zod.object({
+export const HogFlowsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(
@@ -16,7 +16,7 @@ export const HogFlowsListParams = zod.object({
         ),
 })
 
-export const HogFlowsListQueryParams = zod.object({
+export const HogFlowsListQueryParams = /* @__PURE__ */ zod.object({
     created_at: zod.string().datetime({}).optional(),
     created_by: zod.number().optional(),
     id: zod.string().optional(),
@@ -25,7 +25,7 @@ export const HogFlowsListQueryParams = zod.object({
     updated_at: zod.string().datetime({}).optional(),
 })
 
-export const HogFlowsRetrieveParams = zod.object({
+export const HogFlowsRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this hog flow.'),
     project_id: zod
         .string()


### PR DESCRIPTION
## Problem

Generated zod schemas in the MCP service are not tree-shakeable — esbuild bundles all schemas even when only a subset is imported, increasing bundle size.

## Changes

- Generate only the zod schemas needed for enabled tool inputs (not full response schemas)
- Remove unused generated schemas
- Add `/* @__PURE__ */` annotations to top-level exported zod expressions so esbuild can tree-shake unused ones

## How did you test this code?

Verified generated output contains `@__PURE__` annotations on all exported zod constants. Confirmed the annotation regex runs after Orval generation.