### PR TITLE
chore: enable info level logs for split_person task

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -93,6 +93,7 @@ LOGGING = {
         "kafka.conn": {"level": "WARN"},  # kafka-python logs are noisy
         "posthog.caching.warming": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.tasks.alerts": {"level": "INFO", "handlers": ["console"], "propagate": False},
+        "posthog.tasks.split_person": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.tasks.email": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.tasks.exports": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "posthog.tasks.llm_analytics_usage_report": {"level": "INFO", "handlers": ["console"], "propagate": False},


### PR DESCRIPTION
## Problem

We need to understand why the split_person task is not consistently working

## Changes

Enable info log level for the task

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
