### PR TITLE
feat(tasks): add TeamCodeConfig team extension and API

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -280,6 +280,7 @@ project_features_router = projects_router.register(
 # Tasks endpoints
 project_tasks_router = projects_router.register(r"tasks", tasks.TaskViewSet, "project_tasks", ["team_id"])
 project_tasks_router.register(r"runs", tasks.TaskRunViewSet, "project_task_runs", ["team_id", "task_id"])
+projects_router.register(r"code_config", tasks.TeamCodeConfigViewSet, "project_code_config", ["team_id"])
 
 # PostHog Code invites (not project-scoped)
 router.register(r"code/invites", tasks.CodeInviteViewSet, "code_invites")

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -27,6 +27,7 @@ from posthog.api.mixins import validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import ServerTimingsGathered
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.permissions import APIScopePermission
 from posthog.rate_limit import CodeInviteThrottle
 from posthog.storage import object_storage
@@ -56,9 +57,11 @@ from .serializers import (
     TaskRunSessionLogsQuerySerializer,
     TaskRunUpdateSerializer,
     TaskSerializer,
+    TeamCodeConfigSerializer,
 )
 from .services.connection_token import create_sandbox_connection_token
 from .stream.redis_stream import TaskRunRedisStream, TaskRunStreamError, get_task_run_stream_key
+from .team_code_config import TeamCodeConfig
 from .temporal.client import execute_posthog_code_agent_relay_workflow, execute_task_processing_workflow
 
 logger = logging.getLogger(__name__)
@@ -1082,3 +1085,24 @@ class CodeInviteViewSet(viewsets.ViewSet):
         # Fallback: check invite code redemption
         has_redeemed = CodeInviteRedemption.objects.filter(user=user).exists()
         return Response({"has_access": has_redeemed})
+
+
+@extend_schema(tags=["tasks"])
+class TeamCodeConfigViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
+    """API for managing team code configuration (relevant repositories)."""
+
+    scope_object = "INTERNAL"
+
+    def list(self, request, **kwargs):
+        config = get_or_create_team_extension(self.team, TeamCodeConfig)
+        return Response(TeamCodeConfigSerializer(config).data)
+
+    @action(detail=False, methods=["patch"], url_path="update")
+    def update_config(self, request, **kwargs):
+        serializer = TeamCodeConfigSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        config = get_or_create_team_extension(self.team, TeamCodeConfig)
+        if "relevant_repositories" in serializer.validated_data:
+            config.relevant_repositories = serializer.validated_data["relevant_repositories"]
+        config.save()
+        return Response(TeamCodeConfigSerializer(config).data)

--- a/products/tasks/backend/migrations/0025_teamcodeconfig.py
+++ b/products/tasks/backend/migrations/0025_teamcodeconfig.py
@@ -1,0 +1,56 @@
+import django.db.models.deletion
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1047_dashboard_quick_filter_ids"),
+        ("tasks", "0024_task_title_manually_set"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TeamCodeConfig",
+            fields=[
+                (
+                    "team",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        serialize=False,
+                        to="posthog.team",
+                    ),
+                ),
+                (
+                    "relevant_repositories",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=models.CharField(max_length=255),
+                        blank=True,
+                        default=list,
+                        help_text="List of relevant repository full names in org/repo format, e.g. posthog/posthog",
+                        size=None,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_team_code_config",
+            },
+        ),
+        migrations.AlterField(
+            model_name="task",
+            name="origin_product",
+            field=models.CharField(
+                choices=[
+                    ("error_tracking", "Error Tracking"),
+                    ("eval_clusters", "Eval Clusters"),
+                    ("user_created", "User Created"),
+                    ("slack", "Slack"),
+                    ("support_queue", "Support Queue"),
+                    ("session_summaries", "Session Summaries"),
+                    ("data_management", "Data Management"),
+                ],
+                max_length=20,
+            ),
+        ),
+    ]

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -40,6 +40,7 @@ class Task(DeletedMetaFields, models.Model):
         SLACK = "slack", "Slack"
         SUPPORT_QUEUE = "support_queue", "Support Queue"
         SESSION_SUMMARIES = "session_summaries", "Session Summaries"
+        DATA_MANAGEMENT = "data_management", "Data Management"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -333,6 +333,15 @@ class RepositoryReadinessResponseSerializer(serializers.Serializer):
     scan = ScanEvidenceSerializer(required=False, help_text="Scan evidence details")
 
 
+class TeamCodeConfigSerializer(serializers.Serializer):
+    relevant_repositories = serializers.ListField(
+        child=serializers.CharField(max_length=255),
+        required=False,
+        default=list,
+        help_text="List of relevant repository full names in org/repo format, e.g. posthog/posthog",
+    )
+
+
 class ConnectionTokenResponseSerializer(serializers.Serializer):
     """Response containing a JWT token for direct sandbox connection"""
 

--- a/products/tasks/backend/team_code_config.py
+++ b/products/tasks/backend/team_code_config.py
@@ -1,0 +1,27 @@
+import logging
+
+from django.contrib.postgres.fields import ArrayField
+from django.db import models
+
+from posthog.models.team import Team
+from posthog.models.team.extensions import register_team_extension_signal
+
+logger = logging.getLogger(__name__)
+
+
+class TeamCodeConfig(models.Model):
+    team = models.OneToOneField(Team, on_delete=models.CASCADE, primary_key=True)
+
+    relevant_repositories = ArrayField(
+        models.CharField(max_length=255),
+        default=list,
+        blank=True,
+        help_text="List of relevant repository full names in org/repo format, e.g. posthog/posthog",
+    )
+
+    class Meta:
+        app_label = "tasks"
+        db_table = "posthog_team_code_config"
+
+
+register_team_extension_signal(TeamCodeConfig, logger=logger)


### PR DESCRIPTION
## Problem

We needed a place to store per-team code configuration — specifically, which repository is the team's "relevant" one for features that scan code (like auto-updating event definitions from source). There was no model for this, and the `Team` model shouldn't get domain-specific fields.

## Changes

- New `TeamCodeConfig` team extension model (lives in the `tasks` product alongside other code-related models) with a `relevant_repositories` array field
- Django migration for the new table
- `TeamCodeConfigSerializer` and `TeamCodeConfigViewSet` exposing it under `GET/PATCH projects/:teamId/code_config/`
- Added `DATA_MANAGEMENT` to `Task.OriginProduct` choices (needed by the follow-up PR)

## How did you test this code?

No automated tests added — the model and API are straightforward team-extension plumbing. Tested manually end-to-end as part of the full feature.

## Publish to changelog?

no

## 🤖 LLM context

This PR was co-authored with Claude Sonnet 4.6 via Claude Code. The agent split the original single-session implementation into a reviewable stack.