### PR TITLE
fix(flags): validate filter field types to prevent serde failures

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import json
+import math
 import time
 import logging
 from datetime import datetime
@@ -792,6 +793,49 @@ class FeatureFlagSerializer(
                 raise serializers.ValidationError("Feature flags must have at least one condition set (group).")
 
         aggregation_group_type_index = filters.get("aggregation_group_type_index", None)
+
+        # Validate filter field types to prevent serde deserialization failures in the
+        # Rust flag evaluation service. Non-conforming types poison the entire team's
+        # flag cache and cause 500s on every /flags request.
+        def _validate_rollout_percentage(value: Any, path: str, *, allow_null: bool = True) -> None:
+            if value is None:
+                if not allow_null:
+                    raise serializers.ValidationError(f"{path} must be a number, got null")
+                return
+            # Check bool before int/float because bool is a subclass of int
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                expected = "a number or null" if allow_null else "a number"
+                raise serializers.ValidationError(f"{path} must be {expected}, got {type(value).__name__}")
+            if not math.isfinite(value):
+                raise serializers.ValidationError(f"{path} must be finite, got {value}")
+
+        def _validate_integer(value: Any, path: str) -> None:
+            if value is not None and type(value) is not int:
+                raise serializers.ValidationError(f"{path} must be an integer or null, got {type(value).__name__}")
+
+        _validate_integer(aggregation_group_type_index, "aggregation_group_type_index")
+
+        for group_index, group in enumerate(filters.get("groups", [])):
+            variant = group.get("variant")
+            if variant is not None and not isinstance(variant, str):
+                raise serializers.ValidationError(
+                    f"groups[{group_index}].variant must be a string or null, got {type(variant).__name__}"
+                )
+
+            _validate_rollout_percentage(group.get("rollout_percentage"), f"groups[{group_index}].rollout_percentage")
+
+            for prop_index, prop in enumerate(group.get("properties", [])):
+                _validate_integer(
+                    prop.get("group_type_index"),
+                    f"groups[{group_index}].properties[{prop_index}].group_type_index",
+                )
+
+        for var_index, variant in enumerate((filters.get("multivariate") or {}).get("variants", [])):
+            _validate_rollout_percentage(
+                variant.get("rollout_percentage"),
+                f"multivariate.variants[{var_index}].rollout_percentage",
+                allow_null=False,
+            )
 
         def properties_all_match(predicate):
             return all(

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -812,7 +812,8 @@ class FeatureFlagSerializer(
                 raise serializers.ValidationError(f"{path} must be between 0 and 100, got {value}")
 
         def _validate_integer(value: Any, path: str) -> None:
-            if value is not None and type(value) is not int:
+            # Check bool before int because bool is a subclass of int
+            if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
                 raise serializers.ValidationError(f"{path} must be an integer or null, got {type(value).__name__}")
 
         _validate_integer(aggregation_group_type_index, "aggregation_group_type_index")

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -808,6 +808,8 @@ class FeatureFlagSerializer(
                 raise serializers.ValidationError(f"{path} must be {expected}, got {type(value).__name__}")
             if not math.isfinite(value):
                 raise serializers.ValidationError(f"{path} must be finite, got {value}")
+            if value < 0 or value > 100:
+                raise serializers.ValidationError(f"{path} must be between 0 and 100, got {value}")
 
         def _validate_integer(value: Any, path: str) -> None:
             if value is not None and type(value) is not int:

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -495,6 +495,169 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             request=ANY,
         )
 
+    @parameterized.expand(
+        [
+            ("false", False, "bool"),
+            ("true", True, "bool"),
+            ("string", "not_an_int", "str"),
+            ("float", 1.5, "float"),
+        ]
+    )
+    def test_non_integer_aggregation_group_type_index_rejected(self, _name, bad_value, expected_type):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "Bad index flag",
+                "key": f"bad-index-{_name}",
+                "filters": {
+                    "aggregation_group_type_index": bad_value,
+                    "groups": [{"rollout_percentage": 100}],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(expected_type, response.json()["detail"])
+
+    @parameterized.expand(
+        [
+            ("false", False, "bool"),
+            ("true", True, "bool"),
+            ("int", 42, "int"),
+        ]
+    )
+    def test_non_string_group_variant_rejected(self, _name, bad_value, expected_type):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "Bad variant flag",
+                "key": f"bad-variant-{_name}",
+                "filters": {
+                    "groups": [{"variant": bad_value, "rollout_percentage": 100}],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(expected_type, response.json()["detail"])
+
+    def test_string_group_variant_preserved(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "String variant flag",
+                "key": "string-variant-preserved",
+                "filters": {
+                    "groups": [{"variant": "control", "rollout_percentage": 100}],
+                    "multivariate": {"variants": [{"key": "control", "rollout_percentage": 100}]},
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        flag = FeatureFlag.objects.get(key="string-variant-preserved", team=self.team)
+        self.assertEqual(flag.filters["groups"][0]["variant"], "control")
+
+    @parameterized.expand(
+        [
+            ("string_int", "100"),
+            ("bool_false", False),
+            ("string_nan", "NaN"),
+            ("string_inf", "Infinity"),
+            ("float_nan", float("nan")),
+            ("float_inf", float("inf")),
+        ]
+    )
+    def test_non_numeric_group_rollout_percentage_rejected(self, _name, bad_value):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "Bad rollout flag",
+                "key": f"bad-rollout-{_name}",
+                "filters": {
+                    "groups": [{"rollout_percentage": bad_value}],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("rollout_percentage", response.json()["detail"])
+
+    def test_numeric_group_rollout_percentage_preserved(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "Numeric rollout",
+                "key": "numeric-rollout-preserved",
+                "filters": {
+                    "groups": [{"rollout_percentage": 75}],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        flag = FeatureFlag.objects.get(key="numeric-rollout-preserved", team=self.team)
+        self.assertEqual(flag.filters["groups"][0]["rollout_percentage"], 75)
+
+    # Same _validate_rollout_percentage function as group tests; smoke-testing the call site
+    @parameterized.expand(
+        [
+            ("string_int", "50"),
+            ("bool_true", True),
+            ("null", None),
+        ]
+    )
+    def test_non_numeric_variant_rollout_percentage_rejected(self, _name, bad_value):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "Bad variant rollout",
+                "key": f"bad-variant-rollout-{_name}",
+                "filters": {
+                    "groups": [{"rollout_percentage": 100}],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "control", "rollout_percentage": bad_value},
+                            {"key": "test", "rollout_percentage": 50},
+                        ]
+                    },
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("rollout_percentage", response.json()["detail"])
+
+    @parameterized.expand(
+        [
+            ("false", False, "bool"),
+            ("true", True, "bool"),
+            ("string", "not_an_int", "str"),
+            ("float", 1.5, "float"),
+        ]
+    )
+    def test_non_integer_property_group_type_index_rejected(self, _name, bad_value, expected_type):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "Bad gti flag",
+                "key": f"bad-prop-gti-{_name}",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 100,
+                            "properties": [
+                                {"key": "email", "type": "person", "value": "test", "group_type_index": bad_value}
+                            ],
+                        }
+                    ],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(expected_type, response.json()["detail"])
+
     @freeze_time("2021-08-25T22:09:14.252Z")
     @patch("posthog.api.feature_flag.report_user_action")
     def test_create_feature_flag(self, mock_report_user_action):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -583,21 +583,53 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("rollout_percentage", response.json()["detail"])
 
-    def test_numeric_group_rollout_percentage_preserved(self):
+    @parameterized.expand(
+        [
+            ("negative_one", -1),
+            ("negative_fraction", -0.1),
+            ("over_hundred", 101),
+            ("two_hundred", 200),
+            ("just_over", 100.1),
+        ]
+    )
+    def test_out_of_range_group_rollout_percentage_rejected(self, _name, bad_value):
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/",
             data={
-                "name": "Numeric rollout",
-                "key": "numeric-rollout-preserved",
+                "name": "Out of range rollout flag",
+                "key": f"oor-rollout-{_name}",
                 "filters": {
-                    "groups": [{"rollout_percentage": 75}],
+                    "groups": [{"rollout_percentage": bad_value}],
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("between 0 and 100", response.json()["detail"])
+
+    @parameterized.expand(
+        [
+            ("zero", 0, 0),
+            ("hundred", 100, 100),
+            ("seventy_five", 75, 75),
+            ("fifty_point_five", 50.5, 50.5),
+        ]
+    )
+    def test_valid_group_rollout_percentage_preserved(self, _name, value, expected):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={
+                "name": "Valid rollout",
+                "key": f"valid-rollout-{_name}",
+                "filters": {
+                    "groups": [{"rollout_percentage": value}],
                 },
             },
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        flag = FeatureFlag.objects.get(key="numeric-rollout-preserved", team=self.team)
-        self.assertEqual(flag.filters["groups"][0]["rollout_percentage"], 75)
+        flag = FeatureFlag.objects.get(key=f"valid-rollout-{_name}", team=self.team)
+        self.assertEqual(flag.filters["groups"][0]["rollout_percentage"], expected)
 
     # Same _validate_rollout_percentage function as group tests; smoke-testing the call site
     @parameterized.expand(


### PR DESCRIPTION
## Problem

The Rust flag evaluation service uses strict serde deserialization for flag definitions. When the Django API allows non-conforming types into the `filters` JSON column (e.g., boolean `false` instead of `null`, string `"100"` instead of integer `100`), the Rust service fails to parse the entire team's flag cache, returning 500 errors on every `/flags` and `/decide` request for the affected team.

## Changes

Add strict type validation in `FeatureFlagSerializer.validate_filters()` that rejects non-conforming types with 400 errors instead of silently accepting them:

- `aggregation_group_type_index`: reject non-integer types (bool, string, float)
- `group.variant`: reject non-string types (bool, int)
- `group.rollout_percentage`: reject non-numeric types (string, bool) and non-finite values (NaN, Infinity)
- `group.properties[].group_type_index`: reject non-integer types (bool, string, float)
- `multivariate.variants[].rollout_percentage`: reject non-numeric types, non-finite values, and null (non-optional in Rust model)

## How did you test this code?

22 parameterized unit tests covering all bad-value types across the validated fields, plus positive tests verifying valid values are preserved.

## Publish to changelog?

no

## Docs update

No docs changes needed.