### PR TITLE
feat(devex): Release phrocs on Github

### DIFF
--- a/.github/workflows/build-phrocs.yml
+++ b/.github/workflows/build-phrocs.yml
@@ -1,0 +1,85 @@
+# phrocs Build Workflow
+#
+# This workflow builds phrocs binaries for all supported platforms and publishes
+# them as GitHub releases.
+#
+# Download the latest version:
+#   macOS (Apple Silicon): curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-darwin-arm64 -o phrocs && chmod +x phrocs
+#   macOS (Intel):         curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-darwin-amd64 -o phrocs && chmod +x phrocs
+#   Linux (amd64):         curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-linux-amd64 -o phrocs && chmod +x phrocs
+#   Linux (arm64):         curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-linux-arm64 -o phrocs && chmod +x phrocs
+#
+# Or browse all versions at: https://github.com/PostHog/posthog/releases?q=phrocs-&expanded=true
+
+name: Build phrocs
+
+on:
+    push:
+        branches:
+            - master
+        paths:
+            - 'tools/phrocs/**'
+            - '!tools/phrocs/README.md'
+            - '.github/workflows/build-phrocs.yml'
+
+permissions:
+    contents: write
+
+jobs:
+    build:
+        runs-on: ubuntu-24.04
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Set up Go
+              uses: actions/setup-go@v6
+              with:
+                  go-version: '1.25.5'
+
+            - name: Build all platform binaries
+              run: cd tools/phrocs && make build-all
+
+            - name: Create versioned and latest releases
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  VERSION="phrocs-$(date +%Y%m%d-%H%M%S)"
+
+                  # Versioned release for history
+                  gh release create "$VERSION" \
+                      tools/phrocs/dist/phrocs-linux-amd64 \
+                      tools/phrocs/dist/phrocs-linux-arm64 \
+                      tools/phrocs/dist/phrocs-darwin-amd64 \
+                      tools/phrocs/dist/phrocs-darwin-arm64 \
+                      --title "phrocs $VERSION" \
+                      --notes "Built from commit ${{ github.sha }}" \
+                      --latest=false
+
+                  # Update floating latest release
+                  gh release delete phrocs-latest --yes || true
+                  git push origin :refs/tags/phrocs-latest || true
+                  gh release create phrocs-latest \
+                      tools/phrocs/dist/phrocs-linux-amd64 \
+                      tools/phrocs/dist/phrocs-linux-arm64 \
+                      tools/phrocs/dist/phrocs-darwin-amd64 \
+                      tools/phrocs/dist/phrocs-darwin-arm64 \
+                      --title "phrocs (latest)" \
+                      --notes "Latest phrocs build — same as $VERSION
+
+                  Download:
+                  \`\`\`sh
+                  # macOS (Apple Silicon)
+                  curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-darwin-arm64 -o phrocs && chmod +x phrocs
+
+                  # macOS (Intel)
+                  curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-darwin-amd64 -o phrocs && chmod +x phrocs
+
+                  # Linux (amd64)
+                  curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-linux-amd64 -o phrocs && chmod +x phrocs
+
+                  # Linux (arm64)
+                  curl -L https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-linux-arm64 -o phrocs && chmod +x phrocs
+                  \`\`\`" \
+                      --latest=false

--- a/.github/workflows/build-phrocs.yml
+++ b/.github/workflows/build-phrocs.yml
@@ -37,6 +37,8 @@ jobs:
               uses: actions/setup-go@v6
               with:
                   go-version: '1.25.5'
+                  cache: true
+                  cache-dependency-path: tools/phrocs/go.sum
 
             - name: Build all platform binaries
               run: cd tools/phrocs && make build-all

--- a/tools/phrocs/.gitignore
+++ b/tools/phrocs/.gitignore
@@ -1,1 +1,2 @@
 phrocs
+dist/

--- a/tools/phrocs/Makefile
+++ b/tools/phrocs/Makefile
@@ -14,19 +14,23 @@ LDFLAGS=-ldflags "-s -w"
 build: deps
 	$(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) .
 
-build-linux-amd64: deps
+build-linux-amd64:
+	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-linux-amd64 .
 
-build-linux-arm64: deps
+build-linux-arm64:
+	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-linux-arm64 .
 
-build-darwin-amd64: deps
+build-darwin-amd64:
+	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-darwin-amd64 .
 
-build-darwin-arm64: deps
+build-darwin-arm64:
+	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-darwin-arm64 .
 
-build-all: build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
+build-all: deps build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
 
 clean:
 	$(GOCLEAN)

--- a/tools/phrocs/Makefile
+++ b/tools/phrocs/Makefile
@@ -1,0 +1,40 @@
+.PHONY: build build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64 build-all clean deps test
+
+BINARY_NAME=phrocs
+DIST_DIR=dist
+
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOMOD=$(GOCMD) mod
+
+LDFLAGS=-ldflags "-s -w"
+
+build: deps
+	$(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) .
+
+build-linux-amd64: deps
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-linux-amd64 .
+
+build-linux-arm64: deps
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-linux-arm64 .
+
+build-darwin-amd64: deps
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-darwin-amd64 .
+
+build-darwin-arm64: deps
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-darwin-arm64 .
+
+build-all: build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
+
+clean:
+	$(GOCLEAN)
+	rm -rf $(DIST_DIR)
+
+deps:
+	mkdir -p $(DIST_DIR)
+	$(GOMOD) download
+
+test:
+	$(GOTEST) -v ./...

--- a/tools/phrocs/Makefile
+++ b/tools/phrocs/Makefile
@@ -15,19 +15,15 @@ build: deps
 	$(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME) .
 
 build-linux-amd64:
-	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-linux-amd64 .
 
 build-linux-arm64:
-	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-linux-arm64 .
 
 build-darwin-amd64:
-	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-darwin-amd64 .
 
 build-darwin-arm64:
-	mkdir -p $(DIST_DIR)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GOBUILD) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY_NAME)-darwin-arm64 .
 
 build-all: deps build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64


### PR DESCRIPTION
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

The code team wants to replace mprocs with phrocs, so this PR builds `phrocs` and publishes it in [github releases](https://github.com/PostHog/posthog/releases?q=phrocs-&expanded=true) to make it available to other teams. Spoke with @charlesvien about alternative approach we could take in the future (like publishing to `@posthog/phrocs`), and IMO this is the quickest way to make `phrocs` available.

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

skip-inkeep-docs

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
