### PR TITLE
perf: Related persons query

### DIFF
--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -4,7 +4,10 @@ from typing import Optional, Union
 
 from django.utils.timezone import now
 
+import posthoganalytics
+
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import Team
 from posthog.models.filters.utils import validate_group_type_index
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -49,12 +52,35 @@ class RelatedActorsQuery:
     def is_aggregating_by_groups(self) -> bool:
         return self.group_type_index is not None
 
+    def _use_optimized_related_people_query(self) -> bool:
+        return posthoganalytics.feature_enabled(
+            "optimized-related-people-query",
+            str(self.team.uuid),
+            groups={"organization": str(self.team.organization_id), "project": str(self.team.id)},
+            group_properties={
+                "organization": {"id": str(self.team.organization_id)},
+                "project": {"id": str(self.team.id)},
+            },
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
     def _query_related_people(self) -> list[SerializedPerson]:
         if not self.is_aggregating_by_groups:
             return []
 
+        if self._use_optimized_related_people_query():
+            tag_queries(name="optimized-related-people-test")
+            person_ids = self._query_related_people_optimized()
+        else:
+            tag_queries(name="optimized-related-people-control")
+            person_ids = self._query_related_people_control()
+
+        return get_serialized_people(self.team, person_ids)
+
+    def _query_related_people_control(self) -> list:
         # :KLUDGE: We need to fetch distinct_id + person properties to be able to link to user properly.
-        person_ids = self._take_first(
+        return self._take_first(
             # nosemgrep: clickhouse-injection-taint - internal SQL fragments, values parameterized
             sync_execute(
                 f"""
@@ -70,8 +96,28 @@ class RelatedActorsQuery:
             )
         )
 
-        serialized_people = get_serialized_people(self.team, person_ids)
-        return serialized_people
+    def _query_related_people_optimized(self) -> list:
+        return self._take_first(
+            # nosemgrep: clickhouse-injection-taint - internal SQL fragments, values parameterized
+            sync_execute(
+                f"""
+            SELECT DISTINCT argMax(person_id, version) AS person_id
+            FROM person_distinct_id2
+            WHERE team_id = %(team_id)s
+              AND distinct_id IN (
+                  SELECT distinct_id
+                  FROM events
+                  WHERE team_id = %(team_id)s
+                    AND timestamp > %(after)s
+                    AND timestamp < %(before)s
+                    AND {self._filter_clause}
+            )
+            GROUP BY distinct_id
+            HAVING argMax(is_deleted, version) = 0
+            """,
+                self._params,
+            )
+        )
 
     def _query_related_groups(self, group_type_index: GroupTypeIndex) -> list[SerializedGroup]:
         if group_type_index == self.group_type_index:

--- a/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
@@ -1,0 +1,36 @@
+# serializer version: 1
+# name: TestRelatedActorsQuery.test_query_related_people_control
+  '''
+  
+  SELECT DISTINCT pdi.person_id
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  WHERE team_id = 99999
+    AND timestamp > '2024-12-01T12:00:00.000000'
+    AND timestamp < '2025-03-01T12:00:00.000000'
+    AND $group_0 = 'org:1'
+  '''
+# ---
+# name: TestRelatedActorsQuery.test_query_related_people_optimized
+  '''
+  
+  SELECT DISTINCT argMax(person_id, version) AS person_id
+  FROM person_distinct_id2
+  WHERE team_id = 99999
+    AND distinct_id IN
+      (SELECT distinct_id
+       FROM events
+       WHERE team_id = 99999
+         AND timestamp > '2024-12-01T12:00:00.000000'
+         AND timestamp < '2025-03-01T12:00:00.000000'
+         AND $group_0 = 'org:1' )
+  GROUP BY distinct_id
+  HAVING argMax(is_deleted, version) = 0
+  '''
+# ---

--- a/ee/clickhouse/queries/test/test_related_actors_query.py
+++ b/ee/clickhouse/queries/test/test_related_actors_query.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from uuid import uuid4
 
 from freezegun import freeze_time
 from posthog.test.base import (
@@ -10,6 +11,10 @@ from posthog.test.base import (
     snapshot_clickhouse_queries,
 )
 from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.clickhouse.client import sync_execute
 
 from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
 
@@ -24,42 +29,33 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         self.another_person = _create_person(distinct_ids=["user2"], team=self.team)
         self.unrelated_person = _create_person(distinct_ids=["user3"], team=self.team)
         self.old_related_person = _create_person(distinct_ids=["user4"], team=self.team)
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id="user1",
-            timestamp=datetime(2025, 2, 15, 12, 0, 0),
-            properties={"$group_0": "org:1"},
-            person_id=self.person,
-        )
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id="user2",
-            timestamp=datetime(2025, 2, 15, 12, 0, 0),
-            properties={"$group_0": "org:1"},
-            person_id=self.person,
-        )
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id="user3",
-            timestamp=datetime(2025, 2, 15, 12, 0, 0),
-            properties={"$group_0": "another-org"},
-            person_id=self.unrelated_person,
-        )
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id="user4",
-            timestamp=datetime(2024, 2, 15, 12, 0, 0),
-            properties={"$group_0": "org:1"},
-            person_id=self.unrelated_person,
-        )
+        self._create_group_event("user1", "org:1", datetime(2025, 2, 15, 12, 0, 0))
+        self._create_group_event("user2", "org:1", datetime(2025, 2, 15, 12, 0, 0))
+        self._create_group_event("user3", "another-org", datetime(2025, 2, 15, 12, 0, 0))
+        self._create_group_event("user4", "org:1", datetime(2024, 2, 15, 12, 0, 0))
         flush_persons_and_events()
+
+    def _create_group_event(self, distinct_id: str, group_key: str, timestamp: datetime) -> None:
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id=distinct_id,
+            timestamp=timestamp,
+            properties={"$group_0": group_key},
+        )
+
+    def _insert_pdi2_row(self, distinct_id: str, person_id: str, version: int, is_deleted: int = 0) -> None:
+        sync_execute(
+            "INSERT INTO person_distinct_id2 (team_id, distinct_id, person_id, is_deleted, version) VALUES",
+            [(self.team.pk, distinct_id, person_id, is_deleted, version)],
+        )
 
     def _query(self) -> list:
         return RelatedActorsQuery(team=self.team, group_type_index=0, id="org:1").run()
+
+    @staticmethod
+    def _get_person_ids(results: list) -> set[str]:
+        return {r["id"] for r in results if r["type"] == "person"}
 
     @snapshot_clickhouse_queries
     @patch(f"{PATH}.posthoganalytics.feature_enabled", return_value=False)
@@ -67,9 +63,9 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         results = self._query()
 
         assert len(results) == 2
-        person = results[0]
-        assert person["type"] == "person"
-        assert person["id"] == str(self.person.uuid)
+        ids = self._get_person_ids(results)
+        assert str(self.person.uuid) in ids
+        assert str(self.another_person.uuid) in ids
 
     @snapshot_clickhouse_queries
     @patch(f"{PATH}.posthoganalytics.feature_enabled", return_value=True)
@@ -77,6 +73,57 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         results = self._query()
 
         assert len(results) == 2
-        person = results[0]
-        assert person["type"] == "person"
-        assert person["id"] == str(self.person.uuid)
+        ids = self._get_person_ids(results)
+        assert str(self.person.uuid) in ids
+        assert str(self.another_person.uuid) in ids
+
+    @parameterized.expand([("control", False), ("optimized", True)])
+    @patch(f"{PATH}.posthoganalytics.feature_enabled")
+    def test_returns_related_people(self, _name, flag_value, mock_flag):
+        mock_flag.return_value = flag_value
+
+        results = self._query()
+
+        assert len(results) == 2
+        ids = self._get_person_ids(results)
+        assert str(self.person.uuid) in ids
+        assert str(self.another_person.uuid) in ids
+        assert str(self.unrelated_person.uuid) not in ids
+        assert str(self.old_related_person.uuid) not in ids
+
+    @parameterized.expand([("control", False), ("optimized", True)])
+    @patch(f"{PATH}.posthoganalytics.feature_enabled")
+    def test_excludes_deleted_person_mapping(self, _name, flag_value, mock_flag):
+        mock_flag.return_value = flag_value
+        self._insert_pdi2_row("user2", str(self.another_person.uuid), version=100, is_deleted=1)
+
+        results = self._query()
+
+        ids = self._get_person_ids(results)
+        assert str(self.another_person.uuid) not in ids
+
+    @parameterized.expand([("control", False), ("optimized", True)])
+    @patch(f"{PATH}.posthoganalytics.feature_enabled")
+    def test_reassigned_distinct_id_resolves_to_new_person(self, _name, flag_value, mock_flag):
+        mock_flag.return_value = flag_value
+        new_person = _create_person(distinct_ids=["new_user"], team=self.team, uuid=uuid4())
+        flush_persons_and_events()
+        self._insert_pdi2_row("user1", str(new_person.uuid), version=100)
+
+        results = self._query()
+
+        ids = self._get_person_ids(results)
+        assert str(new_person.uuid) in ids
+        assert str(self.person.uuid) not in ids
+
+    @parameterized.expand([("control", False), ("optimized", True)])
+    @patch(f"{PATH}.posthoganalytics.feature_enabled")
+    def test_multiple_distinct_ids_same_person_deduped(self, _name, flag_value, mock_flag):
+        mock_flag.return_value = flag_value
+        self._insert_pdi2_row("user2", str(self.person.uuid), version=100)
+
+        results = self._query()
+
+        ids = self._get_person_ids(results)
+        assert str(self.person.uuid) in ids
+        assert len(ids) == 1

--- a/ee/clickhouse/queries/test/test_related_actors_query.py
+++ b/ee/clickhouse/queries/test/test_related_actors_query.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+from freezegun import freeze_time
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+    flush_persons_and_events,
+    snapshot_clickhouse_queries,
+)
+from unittest.mock import patch
+
+from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
+
+PATH = "ee.clickhouse.queries.related_actors_query"
+
+
+@freeze_time("2025-03-01T12:00:00Z")
+class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.person = _create_person(distinct_ids=["user1"], team=self.team)
+        self.another_person = _create_person(distinct_ids=["user2"], team=self.team)
+        self.unrelated_person = _create_person(distinct_ids=["user3"], team=self.team)
+        self.old_related_person = _create_person(distinct_ids=["user4"], team=self.team)
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user1",
+            timestamp=datetime(2025, 2, 15, 12, 0, 0),
+            properties={"$group_0": "org:1"},
+            person_id=self.person,
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user2",
+            timestamp=datetime(2025, 2, 15, 12, 0, 0),
+            properties={"$group_0": "org:1"},
+            person_id=self.person,
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user3",
+            timestamp=datetime(2025, 2, 15, 12, 0, 0),
+            properties={"$group_0": "another-org"},
+            person_id=self.unrelated_person,
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user4",
+            timestamp=datetime(2024, 2, 15, 12, 0, 0),
+            properties={"$group_0": "org:1"},
+            person_id=self.unrelated_person,
+        )
+        flush_persons_and_events()
+
+    def _query(self) -> list:
+        return RelatedActorsQuery(team=self.team, group_type_index=0, id="org:1").run()
+
+    @snapshot_clickhouse_queries
+    @patch(f"{PATH}.posthoganalytics.feature_enabled", return_value=False)
+    def test_query_related_people_control(self, _):
+        results = self._query()
+
+        assert len(results) == 2
+        person = results[0]
+        assert person["type"] == "person"
+        assert person["id"] == str(self.person.uuid)
+
+    @snapshot_clickhouse_queries
+    @patch(f"{PATH}.posthoganalytics.feature_enabled", return_value=True)
+    def test_query_related_people_optimized(self, _):
+        results = self._query()
+
+        assert len(results) == 2
+        person = results[0]
+        assert person["type"] == "person"
+        assert person["id"] == str(self.person.uuid)


### PR DESCRIPTION
## Problem

  The related persons query (used to show people related to a group) joins through `person_distinct_id2` via a subquery on every request. This can be optimized by querying `person_distinct_id2` directly with
  an `IN` subquery on event distinct_ids, avoiding the full table join. The optimization is gated behind a feature flag (`optimized-related-people-query`) for experimentation and safe rollout.

Part of https://github.com/PostHog/posthog/issues/40472
  ## Changes

  - Add an optimized query path in `RelatedActorsQuery` behind a feature flag
  - Create test file for related actors query
  - Add 4 parametrized behavioral tests (8 test cases) that run against both control and optimized paths:
    - Basic inclusion/exclusion of related people
    - Soft-deleted `person_distinct_id2` rows are excluded
    - Reassigned distinct_ids resolve to the new person
    - Multiple distinct_ids mapping to the same person are deduplicated

## How did you test this code?
Unit tests and checking in the UI if the query was working as expected
