### PR TITLE
chore(dev): Add .watchman-cookie-* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ celerybeat.pid
 common/hogvm/typescript/.parcel-cache
 common/hogvm/typescript/dist
 common/plugin_transpiler/dist
+common/replay-headless/dist
 common/storybook/dist
 coverage-*.xml
 debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ celerybeat.pid
 common/hogvm/typescript/.parcel-cache
 common/hogvm/typescript/dist
 common/plugin_transpiler/dist
-common/replay-headless/dist
 common/storybook/dist
 coverage-*.xml
 debug.log
@@ -123,6 +122,9 @@ frontend/pnpm-error.log
 frontend/public/Matter*.woff*
 frontend/tmp
 frontend/types/
+
+# Watchman cache
+.watchman-cookie-*
 
 # Dist release target dir
 target/*


### PR DESCRIPTION
## Problem

I'm getting a shitton of these files now, just running `hogli start` (which I haven't seen last week):

<img width="300" alt="CleanShot 2026-03-16 at 19 16 52@2x" src="https://github.com/user-attachments/assets/7a0aca88-a89b-42c2-ac7e-e9d039f0565b" />

## Changes

Adding `.watchman-cookie-*` to gitignore.