### PR TITLE
fix: Update OAuth client secret key and bump Stripe app to v0.1.4

### DIFF
--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -2,7 +2,7 @@
     "$schema": "https://stripe.com/stripe-app.schema.json",
     "id": "com.posthog.stripe",
     "name": "PostHog",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "icon": "./assets/logomark.png",
     "declarations": {
         "distribution_type": "public",
@@ -80,7 +80,7 @@
         "base_url": "https://us.posthog.com/api/agentic/",
         "oauth_token_endpoint": "https://us.posthog.com/api/agentic/oauth/token",
         "oauth_client_id": "3pFZtlNOg7UEBtr8t0rBAEbI8E4GBf1YqIC2L4jJ",
-        "oauth_client_secret_secret_store_key": "posthog_access_token",
+        "oauth_client_secret_secret_store_key": "oauth_client_secret",
         "account_configuration_schema": "{\"type\":\"object\",\"properties\":{\"region\":{\"type\":\"string\",\"enum\":[\"US\",\"EU\"],\"description\":\"Which PostHog region to connect the Stripe account to\"}},\"required\":[\"region\"],\"additionalProperties\":false}"
     },
     "ui_extension": {


### PR DESCRIPTION
## Problem

The Stripe app configuration was using an incorrect OAuth client secret key reference, which would prevent proper authentication with PostHog's OAuth system.

## Changes

- Updated version from 0.1.3 to 0.1.4
- Fixed `oauth_client_secret_secret_store_key` from "posthog_access_token" to "oauth_client_secret" to correctly reference the OAuth client secret in Stripe's secret store

## How did you test this code?

As an agent, I have not manually tested this configuration change. Testing would require verifying that the OAuth flow works correctly with the updated secret store key reference in the Stripe app environment.

## Publish to changelog?

No

## Docs update

No docs update needed for this configuration fix.