### PR TITLE
fix(cdp): Klime destination - add userTraits for identify

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/klime/klime.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/klime/klime.template.test.ts
@@ -18,6 +18,7 @@ describe('klime template', () => {
         userId: 'user-123',
         groupId: 'group-123',
         include_all_properties: false,
+        userTraits: {},
         properties: {},
     }
 
@@ -27,17 +28,14 @@ describe('klime template', () => {
     }
 
     it('sends a track event with correct shape', async () => {
-        const response = await tester.invoke(
-            { ...defaultInputs, include_all_properties: true },
-            {
-                event: {
-                    uuid: 'event-uuid-001',
-                    event: 'Button Clicked',
-                    properties: { $current_url: 'https://example.com', button: 'signup' },
-                    timestamp: '2024-01-01T00:00:00Z',
-                },
-            }
-        )
+        const response = await tester.invoke(defaultInputs, {
+            event: {
+                uuid: 'event-uuid-001',
+                event: 'Button Clicked',
+                properties: { $current_url: 'https://example.com', button: 'signup' },
+                timestamp: '2024-01-01T00:00:00Z',
+            },
+        })
 
         expect(response.error).toBeUndefined()
         expect(response.finished).toBe(false)
@@ -100,24 +98,18 @@ describe('klime template', () => {
         expect(parseBatchEvent(response).type).toBe('track')
     })
 
-    it.each([
-        [true, { amount: 99.99, currency: 'USD' }],
-        [false, undefined],
-    ])('track properties when include_all_properties is %s', async (includeAll, expected) => {
-        const response = await tester.invoke(
-            { ...defaultInputs, include_all_properties: includeAll },
-            {
-                event: {
-                    uuid: 'uuid-1',
-                    event: 'Purchase',
-                    properties: { $lib: 'web', amount: 99.99, currency: 'USD' },
-                    timestamp: '2024-01-01T00:00:00Z',
-                },
-            }
-        )
+    it('always includes non-$ event properties for track', async () => {
+        const response = await tester.invoke(defaultInputs, {
+            event: {
+                uuid: 'uuid-1',
+                event: 'Purchase',
+                properties: { $lib: 'web', amount: 99.99, currency: 'USD' },
+                timestamp: '2024-01-01T00:00:00Z',
+            },
+        })
 
         expect(response.error).toBeUndefined()
-        expect(parseBatchEvent(response).properties).toEqual(expected)
+        expect(parseBatchEvent(response).properties).toEqual({ amount: 99.99, currency: 'USD' })
     })
 
     it('includes non-$ person properties for identify', async () => {
@@ -140,9 +132,98 @@ describe('klime template', () => {
         expect(parseBatchEvent(response).traits).toEqual({ email: 'test@klime.com' })
     })
 
+    it('sends userTraits as traits on identify events', async () => {
+        const response = await tester.invoke(
+            {
+                ...defaultInputs,
+                action: 'identify',
+                userTraits: { email: 'alice@klime.com', name: 'Alice' },
+            },
+            {
+                event: {
+                    uuid: 'uuid-1',
+                    event: '$identify',
+                    properties: {},
+                    timestamp: '2024-01-01T00:00:00Z',
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(parseBatchEvent(response).traits).toEqual({ email: 'alice@klime.com', name: 'Alice' })
+    })
+
+    it('userTraits does not leak into group events', async () => {
+        const response = await tester.invoke(
+            {
+                ...defaultInputs,
+                action: 'group',
+                groupId: 'org-456',
+                userTraits: { email: 'should-not-appear@klime.com' },
+            },
+            {
+                event: {
+                    uuid: 'uuid-1',
+                    event: '$groupidentify',
+                    properties: {
+                        $group_key: 'org-456',
+                        $group_set: { name: 'Acme Inc' },
+                    },
+                    timestamp: '2024-01-01T00:00:00Z',
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        const batchEvent = parseBatchEvent(response)
+        expect(batchEvent.traits).toBeUndefined()
+    })
+
+    it('falls back to properties for identify when userTraits is missing (backwards compat)', async () => {
+        const response = await tester.invoke(
+            {
+                ...defaultInputs,
+                action: 'identify',
+                userTraits: {},
+                properties: { email: 'legacy@klime.com', name: 'Legacy User' },
+            },
+            {
+                event: {
+                    uuid: 'uuid-1',
+                    event: '$identify',
+                    properties: {},
+                    timestamp: '2024-01-01T00:00:00Z',
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(parseBatchEvent(response).traits).toEqual({ email: 'legacy@klime.com', name: 'Legacy User' })
+    })
+
+    it('hardcodes email and name from person when no mappings configured', async () => {
+        const response = await tester.invoke(
+            { ...defaultInputs, action: 'identify' },
+            {
+                event: {
+                    uuid: 'uuid-1',
+                    event: '$identify',
+                    properties: {},
+                    timestamp: '2024-01-01T00:00:00Z',
+                },
+                person: {
+                    properties: { email: 'fallback@klime.com', name: 'Fallback User', plan: 'pro' },
+                },
+            }
+        )
+
+        expect(response.error).toBeUndefined()
+        expect(parseBatchEvent(response).traits).toEqual({ email: 'fallback@klime.com', name: 'Fallback User' })
+    })
+
     it('includes non-$ group_set properties for group', async () => {
         const response = await tester.invoke(
-            { ...defaultInputs, action: 'group', groupId: 'org-456', include_all_properties: true },
+            { ...defaultInputs, action: 'group', groupId: 'org-456' },
             {
                 event: {
                     uuid: 'uuid-1',
@@ -163,7 +244,7 @@ describe('klime template', () => {
 
     it('uses $group_key over inputs.groupId for $groupidentify events', async () => {
         const response = await tester.invoke(
-            { ...defaultInputs, action: 'automatic', groupId: 'wrong-group', include_all_properties: true },
+            { ...defaultInputs, action: 'automatic', groupId: 'wrong-group' },
             {
                 event: {
                     uuid: 'uuid-1',

--- a/nodejs/src/cdp/templates/_destinations/klime/klime.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/klime/klime.template.test.ts
@@ -176,7 +176,8 @@ describe('klime template', () => {
 
         expect(response.error).toBeUndefined()
         const batchEvent = parseBatchEvent(response)
-        expect(batchEvent.traits).toBeUndefined()
+        expect(batchEvent.traits).toEqual({ name: 'Acme Inc' })
+        expect(batchEvent.traits).not.toHaveProperty('email')
     })
 
     it('falls back to properties for identify when userTraits is missing (backwards compat)', async () => {

--- a/nodejs/src/cdp/templates/_destinations/klime/klime.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/klime/klime.template.test.ts
@@ -201,7 +201,7 @@ describe('klime template', () => {
         expect(parseBatchEvent(response).traits).toEqual({ email: 'legacy@klime.com', name: 'Legacy User' })
     })
 
-    it('hardcodes email and name from person when no mappings configured', async () => {
+    it('sends no traits when no mappings configured and include_all_properties is false', async () => {
         const response = await tester.invoke(
             { ...defaultInputs, action: 'identify' },
             {
@@ -218,7 +218,7 @@ describe('klime template', () => {
         )
 
         expect(response.error).toBeUndefined()
-        expect(parseBatchEvent(response).traits).toEqual({ email: 'fallback@klime.com', name: 'Fallback User' })
+        expect(parseBatchEvent(response).traits).toBeUndefined()
     })
 
     it('includes non-$ group_set properties for group', async () => {

--- a/nodejs/src/cdp/templates/_destinations/klime/klime.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/klime/klime.template.ts
@@ -74,12 +74,6 @@ if (action == 'track') {
             traits[key] := value
         }
     }
-    if (empty(traits.email) and not empty(person.properties.email)) {
-        traits['email'] := person.properties.email
-    }
-    if (empty(traits.name) and not empty(person.properties.name)) {
-        traits['name'] := person.properties.name
-    }
     if (not empty(traits)) {
         payload['traits'] := traits
     }

--- a/nodejs/src/cdp/templates/_destinations/klime/klime.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/klime/klime.template.ts
@@ -39,11 +39,9 @@ if (action == 'track') {
         payload['groupId'] := inputs.groupId
     }
     let props := {}
-    if (inputs.include_all_properties) {
-        for (let key, value in event.properties) {
-            if (not key like '$%') {
-                props[key] := value
-            }
+    for (let key, value in event.properties) {
+        if (not key like '$%') {
+            props[key] := value
         }
     }
     for (let key, value in inputs.properties) {
@@ -67,10 +65,20 @@ if (action == 'track') {
             }
         }
     }
-    for (let key, value in inputs.properties) {
+    let identifyMapping := inputs.userTraits
+    if (empty(identifyMapping)) {
+        identifyMapping := inputs.properties
+    }
+    for (let key, value in identifyMapping) {
         if (not empty(value)) {
             traits[key] := value
         }
+    }
+    if (empty(traits.email) and not empty(person.properties.email)) {
+        traits['email'] := person.properties.email
+    }
+    if (empty(traits.name) and not empty(person.properties.name)) {
+        traits['name'] := person.properties.name
     }
     if (not empty(traits)) {
         payload['traits'] := traits
@@ -86,13 +94,11 @@ if (action == 'track') {
     }
     payload['groupId'] := gid
     let traits := {}
-    if (inputs.include_all_properties) {
-        let groupSet := event.properties.$group_set
-        if (not empty(groupSet)) {
-            for (let key, value in groupSet) {
-                if (not key like '$%') {
-                    traits[key] := value
-                }
+    let groupSet := event.properties.$group_set
+    if (not empty(groupSet)) {
+        for (let key, value in groupSet) {
+            if (not key like '$%') {
+                traits[key] := value
             }
         }
     }
@@ -176,19 +182,28 @@ if (res.status >= 400) {
         {
             key: 'include_all_properties',
             type: 'boolean',
-            label: 'Include all properties',
+            label: 'Include all person properties',
             description:
-                'If set, all event properties (for track), person properties (for identify), or group properties (for group) will be included. Individual properties can be overridden below.',
+                'If set, all person properties will be included as traits on identify events. May cause timeouts for persons with many properties.',
             default: false,
             secret: false,
             required: true,
         },
         {
+            key: 'userTraits',
+            type: 'dictionary',
+            label: 'User trait mapping',
+            description:
+                'Map of trait names to values, sent on identify events. By default sends email and name from person properties.',
+            default: { email: '{person.properties.email}', name: '{person.properties.name}' },
+            secret: false,
+            required: false,
+        },
+        {
             key: 'properties',
             type: 'dictionary',
             label: 'Property mapping',
-            description:
-                'Map of property names to values. These are sent as properties (track) or traits (identify/group).',
+            description: 'Map of property names to values. These are sent as properties (track) or traits (group).',
             default: {},
             secret: false,
             required: false,


### PR DESCRIPTION
## Problem

The Klime destination template gates **all** property/trait inclusion behind the `include_all_properties` boolean. When this is `false` (the default), three things break:

1. **Track events** send no event properties at all -- custom properties like `plan`, `amount`, `currency` are silently dropped
2. **Group events** send no group traits -- `$group_set` data (name, plan, etc.) is lost
3. **Identify events** send no user traits -- email, name, and any other person properties are missing

This means customers using the default configuration receive events in Klime with empty properties/traits, making the data nearly useless for segmentation and filtering.

## Root cause

The `include_all_properties` toggle was designed as a safety valve for `person.properties` iteration, which triggers an expensive DB lookup in HogVM and causes timeouts for persons with many properties. However, the same gate was incorrectly applied to:

- **`event.properties`** (track) -- this is already in-memory, cheap, and bounded
- **`event.properties.$group_set`** (group) -- this is a small in-event object, also in-memory

Only `person.properties` iteration (identify) actually needs the gate, but even there, iterating all person properties is not a viable approach due to the timeout risk. The `include_all_properties` toggle is effectively obsolete and should not be relied upon.

## Changes

### Track events
Removed the `include_all_properties` gate from `event.properties` iteration. Non-`$` prefixed event properties are now **always** included. This data is in-memory in the HogVM and poses no timeout risk.

### Group events
Removed the `include_all_properties` gate from `$group_set` iteration. Non-`$` prefixed group traits are now **always** included. Like event properties, `$group_set` is a small in-event object.

### Identify events
Since iterating all `person.properties` causes HogVM timeouts and `include_all_properties` is effectively unusable, we added a new `userTraits` dictionary input that gives explicit control over which person properties to send as traits. This is dedicated to identify events and separate from the shared `properties` input (which is used by track/group), preventing cross-contamination (e.g., person traits leaking into group events).

The identify logic now follows this priority chain:
1. If `include_all_properties` is true, start with all non-`$` person properties (kept for backwards compatibility, but not recommended)
2. Apply `userTraits` mapping on top (new -- defaults to `{ email, name }` from person properties)
3. If `userTraits` is empty/null, fall back to `properties` mapping (backwards compatibility for existing customers)

We intentionally avoid any direct `person.properties.X` access in the Hog code outside of the `include_all_properties` gate, since individual property access may trigger the same expensive DB lookup that causes timeouts when iterating.

### Schema changes
- `include_all_properties`: Updated label and description to clarify it only affects identify events and carries a timeout risk. We'd like to deprecate this in a future PR.
- `userTraits` (new): Dictionary input for identify trait mapping, defaults to `{ email: '{person.properties.email}', name: '{person.properties.name}' }`
- `properties`: Updated description to clarify it applies to track (as properties) and group (as traits), no longer identify

## Backwards compatibility

Existing customers who configured the Klime destination before this change will have `userTraits` as `null`/`undefined` at runtime since PostHog does not apply new input defaults to existing saved configurations. The template handles this by falling back to the `properties` mapping when `userTraits` is empty:

```hog
let identifyMapping := inputs.userTraits
if (empty(identifyMapping)) {
    identifyMapping := inputs.properties
}
```

## Questions for PostHog team
1. How are existing customer destination configurations updated when a template changes? We found that `buildInputs()` only processes keys present in the saved `inputs` object and does not iterate `inputs_schema` for defaults. This means existing Klime customers will have `userTraits: null` at runtime until they re-save their configuration. We added fallback logic to handle this, but wanted to confirm: is re-saving the only way for existing customers to pick up new input defaults? Or is there a migration/backfill mechanism we're not aware of?
2. Is `userTraits` as a new `inputs_schema` key acceptable? We modeled this after Accoil's `user_traits_mapping` pattern. Happy to adjust the naming or approach if there's a preferred convention.
