### PR TITLE
chore(flags): support ProjectSecretAPIKey for Flags in Rust

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -77,9 +77,71 @@ pub async fn validate_secret_api_token_for_team(
     Ok(())
 }
 
-/// Hash a personal API key value using SHA256
+/// Validates a project secret API key (from posthog_projectsecretapikey table) for a specific team.
+/// Returns the key ID on success.
+pub async fn validate_project_secret_api_key_for_team(
+    state: &AppState,
+    token: &str,
+    expected_team_id: i32,
+) -> Result<String, FlagError> {
+    use sqlx::Row;
+
+    debug!(
+        expected_team_id = expected_team_id,
+        "Validating project secret API key for team"
+    );
+
+    let secure_value = hash_key_value(token);
+
+    let pg_reader: PostgresReader = state.database_pools.non_persons_reader.clone();
+    let mut conn = pg_reader.get_connection().await?;
+
+    let query = r#"
+        SELECT id, team_id, scopes
+        FROM posthog_projectsecretapikey
+        WHERE secure_value = $1
+          AND (
+              scopes IS NULL
+              OR scopes = '{*}'
+              OR 'feature_flag:read' = ANY(scopes)
+              OR 'feature_flag:write' = ANY(scopes)
+          )
+    "#;
+
+    let row = sqlx::query(query)
+        .bind(&secure_value)
+        .fetch_optional(&mut *conn)
+        .await?
+        .ok_or_else(|| {
+            warn!("Project secret API key not found or doesn't have required scopes");
+            FlagError::SecretApiTokenInvalid
+        })?;
+
+    let key_id: String = row.get("id");
+    let team_id: i32 = row.get("team_id");
+
+    if team_id != expected_team_id {
+        warn!(
+            key_team_id = team_id,
+            expected_team_id = expected_team_id,
+            "Project secret API key belongs to a different team"
+        );
+        return Err(FlagError::SecretApiTokenInvalid);
+    }
+
+    debug!(
+        key_id = %key_id,
+        team_id = team_id,
+        "Project secret API key validated successfully"
+    );
+
+    Ok(key_id)
+}
+
+/// Hash an API key value using SHA256
 /// Ported from PostHog's `hash_key_value` function in `posthog/models/personal_api_key.py`
-pub(crate) fn hash_personal_api_key(value: &str) -> String {
+/// Used by both PersonalAPIKey and ProjectSecretAPIKey
+pub(crate) fn hash_key_value(value: &str) -> String {
     use sha2::{Digest, Sha256};
 
     // No salt — see https://github.com/jazzband/django-rest-knox/issues/188
@@ -100,7 +162,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
 
     debug!(team_id = team.id, "Validating personal API key for team");
 
-    let secure_value = hash_personal_api_key(key);
+    let secure_value = hash_key_value(key);
 
     let pg_reader: PostgresReader = state.database_pools.non_persons_reader.clone();
     let mut conn = pg_reader.get_connection().await?;
@@ -266,8 +328,8 @@ mod tests {
 
     // Ported from PostHog's `test_hash_key_values` function in `posthog/api/test/test_personal_api_keys.py`
     #[test]
-    fn test_hash_personal_api_key() {
-        let result = hash_personal_api_key("test_key_12345");
+    fn test_hash_key_value() {
+        let result = hash_key_value("test_key_12345");
         assert_eq!(
             result,
             "sha256$45af89b510a3279a817f851de5d3f95b73485d58ec2672a39e52d8aeeb014059"

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -97,9 +97,10 @@ pub async fn validate_project_secret_api_key_for_team(
     let mut conn = pg_reader.get_connection().await?;
 
     let query = r#"
-        SELECT id, team_id, scopes
+        SELECT id
         FROM posthog_projectsecretapikey
         WHERE secure_value = $1
+          AND team_id = $2
           AND (
               scopes IS NULL
               OR scopes = '{*}'
@@ -110,28 +111,19 @@ pub async fn validate_project_secret_api_key_for_team(
 
     let row = sqlx::query(query)
         .bind(&secure_value)
+        .bind(expected_team_id)
         .fetch_optional(&mut *conn)
         .await?
         .ok_or_else(|| {
-            warn!("Project secret API key not found or doesn't have required scopes");
+            warn!("Project secret API key not found, wrong team, or missing required scopes");
             FlagError::SecretApiTokenInvalid
         })?;
 
     let key_id: String = row.get("id");
-    let team_id: i32 = row.get("team_id");
-
-    if team_id != expected_team_id {
-        warn!(
-            key_team_id = team_id,
-            expected_team_id = expected_team_id,
-            "Project secret API key belongs to a different team"
-        );
-        return Err(FlagError::SecretApiTokenInvalid);
-    }
 
     debug!(
         key_id = %key_id,
-        team_id = team_id,
+        team_id = expected_team_id,
         "Project secret API key validated successfully"
     );
 

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -368,6 +368,7 @@ async fn authenticate_flag_definitions(
     // Secret tokens have priority over personal API keys
     if let Some(token) = auth::extract_team_secret_token(headers) {
         // Try managed project secret API key (posthog_projectsecretapikey) first
+        // TODO: track last_used_at for project secret API keys (similar to PAK path below)
         if auth::validate_project_secret_api_key_for_team(state, &token, team.id)
             .await
             .is_ok()

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -367,6 +367,20 @@ async fn authenticate_flag_definitions(
     // Try team secret token first (from Authorization header only)
     // Secret tokens have priority over personal API keys
     if let Some(token) = auth::extract_team_secret_token(headers) {
+        // Try managed project secret API key (posthog_projectsecretapikey) first
+        if auth::validate_project_secret_api_key_for_team(state, &token, team.id)
+            .await
+            .is_ok()
+        {
+            inc(
+                FLAG_DEFINITIONS_AUTH_COUNTER,
+                &[("method".to_string(), "project_secret_api_key".to_string())],
+                1,
+            );
+            return Ok(());
+        }
+
+        // Fall back to legacy secret_api_token on posthog_team
         let result = auth::validate_secret_api_token_for_team(state, &token, team.id).await;
         if result.is_ok() {
             inc(

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -1189,7 +1189,7 @@ impl TestContext {
         let pak_id = format!("test_pak_{}", &uuid::Uuid::new_v4().to_string()[..8]);
         let api_key_value = format!("phx_{}", &uuid::Uuid::new_v4().to_string()[..12]);
 
-        let secure_value = crate::api::auth::hash_personal_api_key(&api_key_value);
+        let secure_value = crate::api::auth::hash_key_value(&api_key_value);
 
         let mut conn = self.non_persons_writer.get_connection().await?;
 
@@ -1232,6 +1232,41 @@ impl TestContext {
         query.build().execute(&mut *conn).await?;
 
         Ok((pak_id, api_key_value))
+    }
+
+    /// Creates a project secret API key with hashed value (SHA256 mode)
+    pub async fn create_project_secret_api_key(
+        &self,
+        team_id: i32,
+        label: &str,
+        scopes: Option<Vec<&str>>,
+    ) -> Result<String, Error> {
+        let key_id = format!("test_psk_{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let raw_key = format!("phs_{}", &uuid::Uuid::new_v4().to_string()[..12]);
+
+        let secure_value = crate::api::auth::hash_key_value(&raw_key);
+        let mask_value = format!("...{}", &raw_key[raw_key.len().saturating_sub(5)..]);
+
+        let mut conn = self.non_persons_writer.get_connection().await?;
+
+        let scopes_vec: Option<Vec<String>> =
+            scopes.map(|s| s.iter().map(|v| v.to_string()).collect());
+
+        sqlx::query(
+            r#"INSERT INTO posthog_projectsecretapikey
+               (id, team_id, label, mask_value, secure_value, scopes, created_at)
+               VALUES ($1, $2, $3, $4, $5, $6, NOW())"#,
+        )
+        .bind(&key_id)
+        .bind(team_id)
+        .bind(label)
+        .bind(&mask_value)
+        .bind(&secure_value)
+        .bind(&scopes_vec)
+        .execute(&mut *conn)
+        .await?;
+
+        Ok(raw_key)
     }
 
     /// Creates a team with both public token and secret API token

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1719,8 +1719,17 @@ async fn test_flag_definitions_billing_limited_returns_402() {
     assert_eq!(body["code"], "payment_required");
 }
 
+#[rstest::rstest]
+#[case::valid_with_read_scope(Some(vec!["feature_flag:read"]), true, 200)]
+#[case::wrong_team(Some(vec!["feature_flag:read"]), false, 401)]
+#[case::null_scopes_full_access(None, true, 200)]
+#[case::wrong_scope(Some(vec!["insight:read"]), true, 401)]
 #[tokio::test]
-async fn test_flag_definitions_with_project_secret_api_key() {
+async fn test_flag_definitions_project_secret_api_key(
+    #[case] scopes: Option<Vec<&str>>,
+    #[case] same_team: bool,
+    #[case] expected_status: u16,
+) {
     use feature_flags::{config::Config, utils::test_utils::TestContext};
     use reqwest;
 
@@ -1729,12 +1738,21 @@ async fn test_flag_definitions_with_project_secret_api_key() {
 
     let team = context.insert_new_team(None).await.unwrap();
 
+    let key_team_id = if same_team {
+        team.id
+    } else {
+        let other_team = context.insert_new_team(None).await.unwrap();
+        other_team.id
+    };
+
     let raw_key = context
-        .create_project_secret_api_key(team.id, "Test Key", Some(vec!["feature_flag:read"]))
+        .create_project_secret_api_key(key_team_id, "Test Key", scopes)
         .await
         .unwrap();
 
-    context.populate_cache_for_team(team.id).await.unwrap();
+    if expected_status == 200 {
+        context.populate_cache_for_team(team.id).await.unwrap();
+    }
 
     let server = common::ServerHandle::for_config(config.clone()).await;
     let client = reqwest::Client::new();
@@ -1751,114 +1769,10 @@ async fn test_flag_definitions_with_project_secret_api_key() {
 
     assert_eq!(
         response.status(),
-        200,
+        expected_status,
         "Response body: {}",
         response.text().await.unwrap()
     );
-}
-
-#[tokio::test]
-async fn test_flag_definitions_with_project_secret_api_key_wrong_team() {
-    use feature_flags::{config::Config, utils::test_utils::TestContext};
-    use reqwest;
-
-    let config = Config::default_test_config();
-    let context = TestContext::new(Some(&config)).await;
-
-    let team1 = context.insert_new_team(None).await.unwrap();
-    let team2 = context.insert_new_team(None).await.unwrap();
-
-    // Create key for team2, but authenticate against team1's public token
-    let raw_key = context
-        .create_project_secret_api_key(team2.id, "Wrong Team Key", Some(vec!["feature_flag:read"]))
-        .await
-        .unwrap();
-
-    let server = common::ServerHandle::for_config(config.clone()).await;
-    let client = reqwest::Client::new();
-
-    let response = client
-        .get(format!(
-            "http://{}/flags/definitions?token={}",
-            server.addr, team1.api_token
-        ))
-        .header("Authorization", format!("Bearer {raw_key}"))
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), 401);
-}
-
-#[tokio::test]
-async fn test_flag_definitions_with_project_secret_api_key_no_scopes() {
-    use feature_flags::{config::Config, utils::test_utils::TestContext};
-    use reqwest;
-
-    let config = Config::default_test_config();
-    let context = TestContext::new(Some(&config)).await;
-
-    let team = context.insert_new_team(None).await.unwrap();
-
-    // scopes = NULL means full access
-    let raw_key = context
-        .create_project_secret_api_key(team.id, "Full Access Key", None)
-        .await
-        .unwrap();
-
-    context.populate_cache_for_team(team.id).await.unwrap();
-
-    let server = common::ServerHandle::for_config(config.clone()).await;
-    let client = reqwest::Client::new();
-
-    let response = client
-        .get(format!(
-            "http://{}/flags/definitions?token={}",
-            server.addr, team.api_token
-        ))
-        .header("Authorization", format!("Bearer {raw_key}"))
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(
-        response.status(),
-        200,
-        "Response body: {}",
-        response.text().await.unwrap()
-    );
-}
-
-#[tokio::test]
-async fn test_flag_definitions_with_project_secret_api_key_wrong_scopes() {
-    use feature_flags::{config::Config, utils::test_utils::TestContext};
-    use reqwest;
-
-    let config = Config::default_test_config();
-    let context = TestContext::new(Some(&config)).await;
-
-    let team = context.insert_new_team(None).await.unwrap();
-
-    let raw_key = context
-        .create_project_secret_api_key(team.id, "Wrong Scopes Key", Some(vec!["insight:read"]))
-        .await
-        .unwrap();
-
-    let server = common::ServerHandle::for_config(config.clone()).await;
-    let client = reqwest::Client::new();
-
-    let response = client
-        .get(format!(
-            "http://{}/flags/definitions?token={}",
-            server.addr, team.api_token
-        ))
-        .header("Authorization", format!("Bearer {raw_key}"))
-        .send()
-        .await
-        .unwrap();
-
-    // Key exists but wrong scopes — falls through to legacy, which also fails → 401
-    assert_eq!(response.status(), 401);
 }
 
 #[tokio::test]

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1718,3 +1718,183 @@ async fn test_flag_definitions_billing_limited_returns_402() {
     assert_eq!(body["type"], "quota_limited");
     assert_eq!(body["code"], "payment_required");
 }
+
+#[tokio::test]
+async fn test_flag_definitions_with_project_secret_api_key() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team = context.insert_new_team(None).await.unwrap();
+
+    let raw_key = context
+        .create_project_secret_api_key(team.id, "Test Key", Some(vec!["feature_flag:read"]))
+        .await
+        .unwrap();
+
+    context.populate_cache_for_team(team.id).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {raw_key}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Response body: {}",
+        response.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_flag_definitions_with_project_secret_api_key_wrong_team() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team1 = context.insert_new_team(None).await.unwrap();
+    let team2 = context.insert_new_team(None).await.unwrap();
+
+    // Create key for team2, but authenticate against team1's public token
+    let raw_key = context
+        .create_project_secret_api_key(team2.id, "Wrong Team Key", Some(vec!["feature_flag:read"]))
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team1.api_token
+        ))
+        .header("Authorization", format!("Bearer {raw_key}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn test_flag_definitions_with_project_secret_api_key_no_scopes() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team = context.insert_new_team(None).await.unwrap();
+
+    // scopes = NULL means full access
+    let raw_key = context
+        .create_project_secret_api_key(team.id, "Full Access Key", None)
+        .await
+        .unwrap();
+
+    context.populate_cache_for_team(team.id).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {raw_key}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Response body: {}",
+        response.text().await.unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_flag_definitions_with_project_secret_api_key_wrong_scopes() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    let team = context.insert_new_team(None).await.unwrap();
+
+    let raw_key = context
+        .create_project_secret_api_key(team.id, "Wrong Scopes Key", Some(vec!["insight:read"]))
+        .await
+        .unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {raw_key}"))
+        .send()
+        .await
+        .unwrap();
+
+    // Key exists but wrong scopes — falls through to legacy, which also fails → 401
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn test_flag_definitions_with_legacy_secret_token_fallback() {
+    use feature_flags::{config::Config, utils::test_utils::TestContext};
+    use reqwest;
+
+    let config = Config::default_test_config();
+    let context = TestContext::new(Some(&config)).await;
+
+    // create_team_with_secret_token creates a legacy phs_ token on posthog_team
+    let (team, secret_token, _) = context
+        .create_team_with_secret_token(None, None, None)
+        .await
+        .unwrap();
+
+    // Do NOT insert a project secret API key — the phs_ token should fall back to legacy
+    context.populate_cache_for_team(team.id).await.unwrap();
+
+    let server = common::ServerHandle::for_config(config.clone()).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!(
+            "http://{}/flags/definitions?token={}",
+            server.addr, team.api_token
+        ))
+        .header("Authorization", format!("Bearer {secret_token}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        200,
+        "Response body: {}",
+        response.text().await.unwrap()
+    );
+}

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -1720,10 +1720,12 @@ async fn test_flag_definitions_billing_limited_returns_402() {
 }
 
 #[rstest::rstest]
-#[case::valid_with_read_scope(Some(vec!["feature_flag:read"]), true, 200)]
-#[case::wrong_team(Some(vec!["feature_flag:read"]), false, 401)]
+#[case::read_scope(Some(vec!["feature_flag:read"]), true, 200)]
+#[case::write_scope(Some(vec!["feature_flag:write"]), true, 200)]
 #[case::null_scopes_full_access(None, true, 200)]
+#[case::wildcard_scope(Some(vec!["*"]), true, 200)]
 #[case::wrong_scope(Some(vec!["insight:read"]), true, 401)]
+#[case::wrong_team(Some(vec!["feature_flag:read"]), false, 401)]
 #[tokio::test]
 async fn test_flag_definitions_project_secret_api_key(
     #[case] scopes: Option<Vec<&str>>,


### PR DESCRIPTION
Closes #51090 

## Problem

The `/flags/definitions` Rust endpoint authenticates `phs_` tokens only against the legacy `posthog_team.secret_api_token` column. PostHog now has a managed `ProjectSecretAPIKey` model (table `posthog_projectsecretapikey`) that stores hashed secret keys per-team with scopes, so Rust must also check this table so managed project secret API keys work on the Rust endpoint.

Django's `ProjectSecretAPIKeyAuthentication` currently only looks up the legacy `Team.secret_api_token`. The `find_project_secret_api_key()` method on the model exists but isn't wired into Django's auth flow yet. This Rust implementation is intentionally ahead of Django.

## Changes

**Auth flow for `phs_` tokens** (in `authenticate_flag_definitions`):
1. Try `posthog_projectsecretapikey` (hashed lookup with scope validation) → metric `("method", "project_secret_api_key")`
2. If not found, fall back to `posthog_team.secret_api_token` (legacy) → metric `("method", "secret_api_key")`
3. Non-`phs_` tokens → PAK path (unchanged)

**`auth.rs`:**
- Renamed `hash_personal_api_key()` → `hash_key_value()` — shared by PAK and project secret key (same `sha256$<hex>` format, verified identical to Python's `hash_key_value(token, mode="sha256")` with pinned test values)
- Added `validate_project_secret_api_key_for_team()` — hashes token, queries `posthog_projectsecretapikey` by `secure_value`, validates scopes and `team_id`

**`test_utils.rs`:**
- Added `create_project_secret_api_key()` helper (follows PAK helper pattern)

**5 integration tests:**
- Valid key with `feature_flag:read` scope → 200
- Key belongs to different team → 401
- Key with `scopes = NULL` (full access) → 200
- Key with unrelated scope (`insight:read`) → 401
- Legacy `phs_` token fallback (no project key row) → 200

## How did you test this code?

All tests run via `cargo test -p feature-flags`:
- `test_hash_key_value` — renamed unit test passes
- 5 new integration tests in `test_flag_definitions.rs` pass
- Full suite (37 tests in `test_flag_definitions`) passes with no regressions

## Publish to changelog?

No

## Docs update

N/A
