### PR TITLE
chore: replace axum::async_trait re-export with direct async_trait import

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2525,6 +2525,7 @@ dependencies = [
 name = "cymbal"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "axum 0.7.9",
@@ -3193,6 +3194,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
+ "async-trait",
  "axum 0.7.9",
  "axum-client-ip",
  "base64 0.22.1",

--- a/rust/batch-import-worker/src/source/s3.rs
+++ b/rust/batch-import-worker/src/source/s3.rs
@@ -1,7 +1,7 @@
 use crate::error::ToUserError;
 use anyhow::{Context, Error};
+use async_trait::async_trait;
 use aws_sdk_s3::Client as S3Client;
-use axum::async_trait;
 use tracing::debug;
 
 use super::DataSource;

--- a/rust/batch-import-worker/src/source/s3_gzip.rs
+++ b/rust/batch-import-worker/src/source/s3_gzip.rs
@@ -1,8 +1,8 @@
 use crate::error::ToUserError;
 use crate::extractor::{ExtractedPartData, PartExtractor};
 use anyhow::{Context, Error};
+use async_trait::async_trait;
 use aws_sdk_s3::Client as S3Client;
-use axum::async_trait;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -10,6 +10,7 @@ envconfig = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 health = { path = "../common/health" }
+async-trait = { workspace = true }
 axum = { workspace = true }
 metrics = { workspace = true }
 common-metrics = { path = "../common/metrics" }

--- a/rust/cymbal/src/stages/resolution/symbol/local.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/local.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use axum::async_trait;
+use async_trait::async_trait;
 
 use common_types::error_tracking::RawFrameId;
 use moka::future::{Cache, CacheBuilder};

--- a/rust/cymbal/src/stages/resolution/symbol/mod.rs
+++ b/rust/cymbal/src/stages/resolution/symbol/mod.rs
@@ -1,4 +1,4 @@
-use axum::async_trait;
+use async_trait::async_trait;
 
 use crate::{
     error::{ProguardError, ResolveError, UnhandledError},

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::{Cursor, Read};
 
-use axum::async_trait;
+use async_trait::async_trait;
 use serde::Deserialize;
 use symbolic::debuginfo::Archive;
 use symbolic::demangle::{Demangle, DemangleOptions};

--- a/rust/cymbal/src/symbol_store/caching.rs
+++ b/rust/cymbal/src/symbol_store/caching.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, collections::HashMap, sync::Arc, time::Instant};
 
-use axum::async_trait;
+use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::metric_consts::{

--- a/rust/cymbal/src/symbol_store/chunk_id.rs
+++ b/rust/cymbal/src/symbol_store/chunk_id.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use axum::async_trait;
+use async_trait::async_trait;
 use metrics::counter;
 use sqlx::PgPool;
 use tracing::error;
@@ -203,7 +203,7 @@ impl<R> OrChunkId<R> {
 mod test {
     use std::sync::Arc;
 
-    use axum::async_trait;
+    use async_trait::async_trait;
     use chrono::Utc;
     use common_types::ClickHouseEvent;
     use mockall::predicate;

--- a/rust/cymbal/src/symbol_store/concurrency.rs
+++ b/rust/cymbal/src/symbol_store/concurrency.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Weak},
 };
 
-use axum::async_trait;
+use async_trait::async_trait;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
 use super::Provider;

--- a/rust/cymbal/src/symbol_store/hermesmap.rs
+++ b/rust/cymbal/src/symbol_store/hermesmap.rs
@@ -1,4 +1,4 @@
-use axum::async_trait;
+use async_trait::async_trait;
 use posthog_symbol_data::{read_symbol_data, HermesMap};
 
 use crate::{

--- a/rust/cymbal/src/symbol_store/mod.rs
+++ b/rust/cymbal/src/symbol_store/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::async_trait;
+use async_trait::async_trait;
 
 use chunk_id::OrChunkId;
 use reqwest::Url;

--- a/rust/cymbal/src/symbol_store/proguard.rs
+++ b/rust/cymbal/src/symbol_store/proguard.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use posthog_symbol_data::{read_symbol_data, ProguardMapping};
 
 use crate::{

--- a/rust/cymbal/src/symbol_store/s3.rs
+++ b/rust/cymbal/src/symbol_store/s3.rs
@@ -1,5 +1,5 @@
+use async_trait::async_trait;
 use aws_sdk_s3::{error::SdkError, primitives::ByteStream, Client as S3Client, Error as S3Error};
-use axum::async_trait;
 #[cfg(test)]
 use mockall::automock;
 use tracing::error;

--- a/rust/cymbal/src/symbol_store/saving.rs
+++ b/rust/cymbal/src/symbol_store/saving.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 
 use sha2::{Digest, Sha512};

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use axum::async_trait;
+use async_trait::async_trait;
 use base64::Engine;
 use posthog_symbol_data::{read_symbol_data, write_symbol_data, SourceAndMap};
 use reqwest::Url;

--- a/rust/cymbal/src/test_utils.rs
+++ b/rust/cymbal/src/test_utils.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use common_redis::MockRedisClient;
 use mockall::mock;
 use sqlx::PgPool;

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -1,7 +1,7 @@
 use core::str;
 use std::sync::Arc;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use common_types::ClickHouseEvent;
 use cymbal::{
     config::Config,

--- a/rust/cymbal/tests/utils.rs
+++ b/rust/cymbal/tests/utils.rs
@@ -8,7 +8,7 @@ use cymbal::{
     symbol_store::BlobClient,
 };
 
-use axum::async_trait;
+use async_trait::async_trait;
 use mockall::mock;
 use rdkafka::message::ToBytes;
 use reqwest::StatusCode;

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
 axum-client-ip = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }

--- a/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
+++ b/rust/feature-flags/src/cohorts/cohort_cache_manager.rs
@@ -4,7 +4,7 @@ use crate::metrics::consts::{
     COHORT_CACHE_ENTRIES_GAUGE, COHORT_CACHE_HIT_COUNTER, COHORT_CACHE_MISS_COUNTER,
     COHORT_CACHE_SIZE_BYTES_GAUGE, DB_COHORT_ERRORS_COUNTER, DB_COHORT_READS_COUNTER,
 };
-use axum::async_trait;
+use async_trait::async_trait;
 use common_database::PostgresReader;
 use common_types::TeamId;
 use moka::future::Cache;
@@ -236,7 +236,7 @@ impl From<CohortFetchError> for FlagError {
 mod tests {
     use super::*;
     use crate::utils::test_utils::TestContext;
-    use axum::async_trait;
+    use async_trait::async_trait;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use tokio::sync::Barrier;

--- a/rust/feature-flags/src/cohorts/membership/cached_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/cached_provider.rs
@@ -1,4 +1,4 @@
-use axum::async_trait;
+use async_trait::async_trait;
 use moka::future::Cache;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/rust/feature-flags/src/cohorts/membership/provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/provider.rs
@@ -1,4 +1,4 @@
-use axum::async_trait;
+use async_trait::async_trait;
 use std::collections::HashMap;
 use thiserror::Error;
 use uuid::Uuid;

--- a/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
+++ b/rust/feature-flags/src/cohorts/membership/realtime_provider.rs
@@ -1,4 +1,4 @@
-use axum::async_trait;
+use async_trait::async_trait;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -7,7 +7,7 @@ use crate::{
     team::team_models::Team,
 };
 use anyhow::Error;
-use axum::async_trait;
+use async_trait::async_trait;
 use common_database::{get_pool, Client, CustomDatabaseError};
 use common_hypercache::{HyperCacheConfig, HyperCacheReader};
 use common_redis::{Client as RedisClientTrait, RedisClient};
@@ -169,7 +169,6 @@ pub async fn setup_hypercache_reader(
 pub fn setup_hypercache_reader_with_mock_redis(
     redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
 ) -> Arc<HyperCacheReader> {
-    use axum::async_trait;
     use common_s3::{S3Client, S3Error};
 
     // Create a simple S3 client that always returns NotFound

--- a/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/batch_consumer.rs
@@ -14,7 +14,7 @@ use crate::kafka::rebalance_handler::RebalanceHandler;
 use crate::kafka::types::Partition;
 
 use anyhow::{Context, Result};
-use axum::async_trait;
+use async_trait::async_trait;
 use futures_util::StreamExt;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{CommitMode, Consumer, MessageStream, StreamConsumer};

--- a/rust/kafka-deduplicator/src/kafka/partition_router.rs
+++ b/rust/kafka-deduplicator/src/kafka/partition_router.rs
@@ -273,7 +273,7 @@ pub async fn shutdown_workers<T: Send + 'static>(workers: Vec<PartitionWorker<T>
 mod tests {
     use super::*;
     use crate::test_utils::create_test_tracker;
-    use axum::async_trait;
+    use async_trait::async_trait;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct TestProcessor {

--- a/rust/kafka-deduplicator/src/kafka/partition_worker.rs
+++ b/rust/kafka-deduplicator/src/kafka/partition_worker.rs
@@ -252,7 +252,7 @@ impl<T: Send + 'static> PartitionWorker<T> {
 mod tests {
     use super::*;
     use crate::test_utils::create_test_tracker;
-    use axum::async_trait;
+    use async_trait::async_trait;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tokio::time::{sleep, Duration};
 

--- a/rust/kafka-deduplicator/src/kafka/routing_processor.rs
+++ b/rust/kafka-deduplicator/src/kafka/routing_processor.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
-use axum::async_trait;
+use async_trait::async_trait;
 use futures::future::join_all;
 use tracing::warn;
 

--- a/rust/kafka-deduplicator/src/pipelines/clickhouse_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/clickhouse_events/processor.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use axum::async_trait;
+use async_trait::async_trait;
 use common_types::ClickHouseEvent;
 use futures::future::join_all;
 use itertools::Itertools;

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/processor.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use axum::async_trait;
+use async_trait::async_trait;
 use common_kafka::kafka_producer::KafkaContext;
 use common_types::{CapturedEvent, EventWithLibraryInfo, RawEvent};
 use futures::future::join_all;

--- a/rust/kafka-deduplicator/src/pipelines/traits.rs
+++ b/rust/kafka-deduplicator/src/pipelines/traits.rs
@@ -7,7 +7,7 @@
 //! - [`FailOpenProcessor`] - How to handle fail-open mode (bypass deduplication)
 
 use anyhow::Result;
-use axum::async_trait;
+use async_trait::async_trait;
 
 use crate::kafka::batch_message::KafkaMessage;
 use crate::pipelines::EventSimilarity;

--- a/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/batch_consumer_integration_tests.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use kafka_deduplicator::kafka::{
     batch_consumer::*,
     batch_context::{ConsumerCommand, ConsumerCommandSender},

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use axum::async_trait;
+use async_trait::async_trait;
 use chrono::Utc;
 use rdkafka::{
     admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},


### PR DESCRIPTION
## Problem

Axum 0.8 removes the `async_trait` re-export. Several Rust crates in the workspace (`feature-flags`, `cymbal`, `batch-import-worker`, `kafka-deduplicator`) import `async_trait` via `axum::async_trait`, which will break on upgrade.

> [!IMPORTANT]
> This PR doesn't upgrade us to Axum 0.8. It's just preparing us for such an upgrade in the future.

## Changes

- Replace all `use axum::async_trait` imports with `use async_trait::async_trait` across 31 `.rs` files
- Add `async-trait = { workspace = true }` to `cymbal` and `feature-flags` `Cargo.toml` (the other two crates already had it)
- Remove one redundant function-local import in `feature-flags/src/utils/test_utils.rs`

This is a no-op — axum 0.7 simply re-exports the same crate.

## How did you test this code?

`cargo check -p feature-flags` passes. The change is a mechanical import path substitution with no behavioral difference.

No publish to changelog.