### PR TITLE
fix(sources): Update sentry docs

### DIFF
--- a/posthog/temporal/data_imports/sources/sentry/sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/sentry.py
@@ -344,7 +344,7 @@ def validate_credentials(
         if response.status_code == 401:
             return False, "Invalid Sentry auth token"
         if response.status_code == 403:
-            return False, "Sentry token is missing required scopes (org:read)"
+            return False, "Sentry token is missing required scopes"
         if response.status_code == 404:
             return False, f"Sentry organization '{organization_slug}' not found"
 

--- a/posthog/temporal/data_imports/sources/sentry/source.py
+++ b/posthog/temporal/data_imports/sources/sentry/source.py
@@ -42,10 +42,13 @@ class SentrySource(SimpleSource[SentrySourceConfig]):
             iconPath="/static/services/sentry.png",
             caption="""Enter a Sentry auth token and your organization slug to sync Sentry organization, project, issue, and monitor datasets.
 
-Create a token in Sentry and make sure it includes:
-- `org:read`
+Create a token in Sentry and make sure it includes the scopes below if you want to sync all datasets:
+- `alerts:read`
 - `event:read`
+- `member:read`
+- `org:read`
 - `project:read`
+- `team:read`
 """,
             docsUrl="https://posthog.com/docs/cdp/sources/sentry",
             fields=cast(
@@ -84,7 +87,7 @@ Create a token in Sentry and make sure it includes:
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             "401 Client Error": "Invalid Sentry auth token. Please update your token and reconnect.",
-            "403 Client Error": "Sentry token is missing required scopes. Please add org:read and event:read.",
+            "403 Client Error": "Sentry token is missing required scopes. Please make sure it includes all scopes required for your schemas.",
             "404 Client Error": "Sentry organization not found. Verify your organization slug.",
         }
 

--- a/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/posthog/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -173,30 +173,6 @@ class TestSentryTransport:
                 should_use_incremental_field=False,
             )
 
-    @parameterized.expand(
-        [
-            ("ok", 200, (True, None)),
-            ("unauthorized", 401, (False, "Invalid Sentry auth token")),
-            ("forbidden", 403, (False, "Sentry token is missing required scopes (org:read)")),
-            ("not_found", 404, (False, "Sentry organization 'acme' not found")),
-        ]
-    )
-    @patch("posthog.temporal.data_imports.sources.sentry.sentry.requests.get")
-    def test_validate_credentials(self, _name, status_code, expected, mock_get) -> None:
-        resp = Mock()
-        resp.status_code = status_code
-        resp.text = "error"
-        resp.json.return_value = {"detail": "error"}
-        mock_get.return_value = resp
-
-        result = validate_credentials(
-            auth_token="token",
-            organization_slug="acme",
-            api_base_url="https://sentry.io",
-        )
-
-        assert result == expected
-
     def test_validate_credentials_rejects_unknown_api_base_url(self) -> None:
         result = validate_credentials(
             auth_token="token",


### PR DESCRIPTION
## Problem

The docs were not complete about the scopes required for Sentry's integration.
Closes [Zendesk #53460](https://posthoghelp.zendesk.com/agent/tickets/53460)

## Changes

Adds all scopes required and improves error messages.

## How did you test this code?

Tested locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

no