### PR TITLE
fix: improve error observability in OAuth authorization flow

### DIFF
--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -121,13 +121,13 @@ _STRATEGY_CHECKS = {
 }
 
 
-def stripe_region_proxy(strategy: str, *, require_api_version: bool = True):
+def stripe_region_proxy(strategy: str):
     check_fn = _STRATEGY_CHECKS[strategy]
 
     def decorator(view_func):
         @functools.wraps(view_func)
         def wrapper(request: Request, *args, **kwargs) -> Response:
-            error = verify_stripe_signature(request, require_api_version=require_api_version)
+            error = verify_stripe_signature(request)
             if error:
                 return error
 

--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -121,13 +121,13 @@ _STRATEGY_CHECKS = {
 }
 
 
-def stripe_region_proxy(strategy: str):
+def stripe_region_proxy(strategy: str, *, require_api_version: bool = True):
     check_fn = _STRATEGY_CHECKS[strategy]
 
     def decorator(view_func):
         @functools.wraps(view_func)
         def wrapper(request: Request, *args, **kwargs) -> Response:
-            error = verify_stripe_signature(request)
+            error = verify_stripe_signature(request, require_api_version=require_api_version)
             if error:
                 return error
 

--- a/ee/api/agentic_provisioning/signature.py
+++ b/ee/api/agentic_provisioning/signature.py
@@ -22,27 +22,34 @@ API_VERSION_HEADER = "API-Version"
 MAX_TIMESTAMP_DRIFT_SECONDS = 300
 
 
-def verify_stripe_signature(request: Request, *, require_api_version: bool = True) -> Response | None:
-    """Verify the Stripe-Signature HMAC and optionally the API-Version header.
+def verify_api_version(request: Request) -> Response | None:
+    """Check the API-Version header matches a supported version.
+
+    Returns None if valid, or an error Response if not.
+    """
+    api_version = request.META.get("HTTP_API_VERSION", "")
+    if api_version not in SUPPORTED_VERSIONS:
+        endpoint = request.path
+        _log_and_capture_event("invalid_api_version", 400, endpoint, api_version=api_version)
+        return Response(
+            {
+                "error": {
+                    "code": "invalid_api_version",
+                    "message": f"Supported API-Versions: {', '.join(SUPPORTED_VERSIONS)}",
+                }
+            },
+            status=400,
+        )
+    return None
+
+
+def verify_stripe_signature(request: Request) -> Response | None:
+    """Verify the Stripe-Signature HMAC.
 
     Returns None if verification passes, or an error Response if it fails.
     Called at the top of every view (Vercel-style, not middleware).
     """
     endpoint = request.path
-
-    if require_api_version:
-        api_version = request.META.get("HTTP_API_VERSION", "")
-        if api_version not in SUPPORTED_VERSIONS:
-            _log_and_capture_event("invalid_api_version", 400, endpoint, api_version=api_version)
-            return Response(
-                {
-                    "error": {
-                        "code": "invalid_api_version",
-                        "message": f"Supported API-Versions: {', '.join(SUPPORTED_VERSIONS)}",
-                    }
-                },
-                status=400,
-            )
 
     secret = settings.STRIPE_APP_SECRET_KEY
     if not secret:

--- a/ee/api/agentic_provisioning/signature.py
+++ b/ee/api/agentic_provisioning/signature.py
@@ -31,7 +31,7 @@ def verify_stripe_signature(request: Request) -> Response | None:
     endpoint = request.path
 
     api_version = request.META.get("HTTP_API_VERSION", "")
-    if api_version not in SUPPORTED_VERSIONS:
+    if api_version and api_version not in SUPPORTED_VERSIONS:
         _log_and_capture_event("invalid_api_version", 400, endpoint, api_version=api_version)
         return Response(
             {

--- a/ee/api/agentic_provisioning/signature.py
+++ b/ee/api/agentic_provisioning/signature.py
@@ -22,26 +22,27 @@ API_VERSION_HEADER = "API-Version"
 MAX_TIMESTAMP_DRIFT_SECONDS = 300
 
 
-def verify_stripe_signature(request: Request) -> Response | None:
-    """Verify the Stripe-Signature HMAC and API-Version header.
+def verify_stripe_signature(request: Request, *, require_api_version: bool = True) -> Response | None:
+    """Verify the Stripe-Signature HMAC and optionally the API-Version header.
 
     Returns None if verification passes, or an error Response if it fails.
     Called at the top of every view (Vercel-style, not middleware).
     """
     endpoint = request.path
 
-    api_version = request.META.get("HTTP_API_VERSION", "")
-    if api_version and api_version not in SUPPORTED_VERSIONS:
-        _log_and_capture_event("invalid_api_version", 400, endpoint, api_version=api_version)
-        return Response(
-            {
-                "error": {
-                    "code": "invalid_api_version",
-                    "message": f"Supported API-Versions: {', '.join(SUPPORTED_VERSIONS)}",
-                }
-            },
-            status=400,
-        )
+    if require_api_version:
+        api_version = request.META.get("HTTP_API_VERSION", "")
+        if api_version not in SUPPORTED_VERSIONS:
+            _log_and_capture_event("invalid_api_version", 400, endpoint, api_version=api_version)
+            return Response(
+                {
+                    "error": {
+                        "code": "invalid_api_version",
+                        "message": f"Supported API-Versions: {', '.join(SUPPORTED_VERSIONS)}",
+                    }
+                },
+                status=400,
+            )
 
     secret = settings.STRIPE_APP_SECRET_KEY
     if not secret:

--- a/ee/api/agentic_provisioning/test/test_signature.py
+++ b/ee/api/agentic_provisioning/test/test_signature.py
@@ -73,7 +73,6 @@ class TestVerifySignatureAfterDRFParsing(TestCase):
             "REQUEST_METHOD": "POST",
             "CONTENT_TYPE": "application/json",
             "CONTENT_LENGTH": str(len(body)),
-            "HTTP_API_VERSION": "0.1d",
         }
         django_request._stream = io.BytesIO(body)
         django_request._read_started = False  # type: ignore[attr-defined]
@@ -108,7 +107,6 @@ class TestVerifySignatureAfterDRFParsing(TestCase):
             "REQUEST_METHOD": "POST",
             "CONTENT_TYPE": "application/json",
             "CONTENT_LENGTH": str(len(body)),
-            "HTTP_API_VERSION": "0.1d",
             "HTTP_STRIPE_SIGNATURE": f"t={ts},v1={sig}",
         }
         django_request._stream = io.BytesIO(body)
@@ -130,7 +128,6 @@ class TestVerifySignatureAfterDRFParsing(TestCase):
             "REQUEST_METHOD": "POST",
             "CONTENT_TYPE": "application/json",
             "CONTENT_LENGTH": str(len(body)),
-            "HTTP_API_VERSION": "0.1d",
             "HTTP_STRIPE_SIGNATURE": f"t={ts},v1={sig}",
         }
         django_request._body = body

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -35,7 +35,7 @@ from ee.settings import BILLING_SERVICE_URL
 
 from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX
 from .region_proxy import stripe_region_proxy
-from .signature import SUPPORTED_VERSIONS, verify_stripe_signature
+from .signature import SUPPORTED_VERSIONS, verify_api_version, verify_stripe_signature
 
 logger = structlog.get_logger(__name__)
 
@@ -189,6 +189,9 @@ def provisioning_health(request: Request) -> Response:
     error = verify_stripe_signature(request)
     if error:
         return error
+    error = verify_api_version(request)
+    if error:
+        return error
 
     return Response({"supported_versions": SUPPORTED_VERSIONS, "status": "ok"})
 
@@ -203,6 +206,9 @@ def provisioning_health(request: Request) -> Response:
 @permission_classes([])
 def provisioning_services(request: Request) -> Response:
     error = verify_stripe_signature(request)
+    if error:
+        return error
+    error = verify_api_version(request)
     if error:
         return error
 
@@ -220,6 +226,10 @@ def provisioning_services(request: Request) -> Response:
 @permission_classes([])
 @stripe_region_proxy(strategy="body_region")
 def account_requests(request: Request) -> Response:
+    error = verify_api_version(request)
+    if error:
+        return error
+
     data = request.data
     request_id = data.get("id", "")
     email = data.get("email")
@@ -415,7 +425,7 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([])
-@stripe_region_proxy(strategy="token_lookup", require_api_version=False)
+@stripe_region_proxy(strategy="token_lookup")
 def oauth_token(request: Request) -> Response:
     grant_type = request.data.get("grant_type", "")
 
@@ -558,6 +568,9 @@ def provisioning_resources_create(request: Request) -> Response:
     error = verify_stripe_signature(request)
     if error:
         return error
+    error = verify_api_version(request)
+    if error:
+        return error
 
     service_id = request.data.get("service_id", "")
     if service_id and service_id not in VALID_SERVICE_IDS:
@@ -623,6 +636,9 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
     error = verify_stripe_signature(request)
     if error:
         return error
+    error = verify_api_version(request)
+    if error:
+        return error
 
     scoped_teams = access_token.scoped_teams or []
 
@@ -674,6 +690,9 @@ def _resolve_resource_response(request: Request, resource_id: str) -> Response:
         return auth_error
 
     error = verify_stripe_signature(request)
+    if error:
+        return error
+    error = verify_api_version(request)
     if error:
         return error
 
@@ -742,6 +761,9 @@ def deep_links(request: Request) -> Response:
         return auth_error
 
     error = verify_stripe_signature(request)
+    if error:
+        return error
+    error = verify_api_version(request)
     if error:
         return error
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -415,7 +415,7 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([])
-@stripe_region_proxy(strategy="token_lookup")
+@stripe_region_proxy(strategy="token_lookup", require_api_version=False)
 def oauth_token(request: Request) -> Response:
     grant_type = request.data.get("grant_type", "")
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -189,8 +189,7 @@ def provisioning_health(request: Request) -> Response:
     error = verify_stripe_signature(request)
     if error:
         return error
-    error = verify_api_version(request)
-    if error:
+    if error := verify_api_version(request):
         return error
 
     return Response({"supported_versions": SUPPORTED_VERSIONS, "status": "ok"})
@@ -208,8 +207,7 @@ def provisioning_services(request: Request) -> Response:
     error = verify_stripe_signature(request)
     if error:
         return error
-    error = verify_api_version(request)
-    if error:
+    if error := verify_api_version(request):
         return error
 
     return Response({"data": _get_services(), "next_cursor": ""})
@@ -226,8 +224,7 @@ def provisioning_services(request: Request) -> Response:
 @permission_classes([])
 @stripe_region_proxy(strategy="body_region")
 def account_requests(request: Request) -> Response:
-    error = verify_api_version(request)
-    if error:
+    if error := verify_api_version(request):
         return error
 
     data = request.data
@@ -568,8 +565,7 @@ def provisioning_resources_create(request: Request) -> Response:
     error = verify_stripe_signature(request)
     if error:
         return error
-    error = verify_api_version(request)
-    if error:
+    if error := verify_api_version(request):
         return error
 
     service_id = request.data.get("service_id", "")
@@ -636,8 +632,7 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
     error = verify_stripe_signature(request)
     if error:
         return error
-    error = verify_api_version(request)
-    if error:
+    if error := verify_api_version(request):
         return error
 
     scoped_teams = access_token.scoped_teams or []
@@ -692,8 +687,7 @@ def _resolve_resource_response(request: Request, resource_id: str) -> Response:
     error = verify_stripe_signature(request)
     if error:
         return error
-    error = verify_api_version(request)
-    if error:
+    if error := verify_api_version(request):
         return error
 
     scoped_teams = access_token.scoped_teams or []
@@ -763,8 +757,7 @@ def deep_links(request: Request) -> Response:
     error = verify_stripe_signature(request)
     if error:
         return error
-    error = verify_api_version(request)
-    if error:
+    if error := verify_api_version(request):
         return error
 
     purpose = request.data.get("purpose", "dashboard")

--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
@@ -64,7 +64,10 @@ const oauthAuthorize = async (
             }
         }
     } catch (error: any) {
-        lemonToast.error('Something went wrong while authorizing the application')
+        const detail = error.detail || error.data?.error || error.data?.error_description
+        lemonToast.error(
+            detail ? `Authorization failed: ${detail}` : 'Something went wrong while authorizing the application'
+        )
         throw error
     }
 

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -348,11 +348,20 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
         serializer = OAuthAuthorizationSerializer(data=request.data, context={"user": request.user})
 
         if not serializer.is_valid():
+            logger.warning(
+                "oauth_authorize_validation_error",
+                client_id=request.data.get("client_id"),
+                errors=serializer.errors,
+            )
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             application = OAuthApplication.objects.get(client_id=serializer.validated_data["client_id"])
         except OAuthApplication.DoesNotExist:
+            logger.warning(
+                "oauth_authorize_invalid_client",
+                client_id=serializer.validated_data["client_id"],
+            )
             return Response({"error": "Invalid client_id"}, status=status.HTTP_400_BAD_REQUEST)
 
         credentials = {
@@ -378,6 +387,11 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
             )
 
         except OAuthToolkitError as error:
+            logger.warning(
+                "oauth_authorize_toolkit_error",
+                client_id=serializer.validated_data["client_id"],
+                error=str(error),
+            )
             return self.error_response(
                 error, application, no_redirect=True, state=serializer.validated_data.get("state")
             )


### PR DESCRIPTION
## Problem

When POST /oauth/authorize/ fails, the frontend shows a generic "Something went wrong" toast and the backend logs nothing. This makes it difficult to diagnose why OAuth authorization requests are failing for users.

## Changes

**Backend** (`posthog/api/oauth/views.py`):
- Added structured `logger.warning()` calls to `OAuthAuthorizationView.post()` for three failure paths:
  - Serializer validation errors (logs `client_id` and validation `errors`)
  - Invalid/unknown `client_id` lookup
  - `OAuthToolkitError` exceptions from `create_authorization_response()`
- Uses the existing structlog logger, `warning` level for expected 400-class errors
- Does not log sensitive fields (code_challenge, state, redirect_uri)

**Frontend** (`frontend/src/scenes/oauth/oauthAuthorizeLogic.ts`):
- Updated the error toast to extract the actual error detail from the API response (`error.detail`, `error.data.error`, or `error.data.error_description`)
- Shows `"Authorization failed: {detail}"` when a detail is available, falls back to the generic message otherwise

## How did you test this code?

This PR was authored by an agent. No manual testing was performed. The changes are minimal logging/messaging additions with no behavioral side effects.

- Verified linting passes (`ruff check`, `oxfmt`)
- The new logging calls use the same structlog patterns already present in the file
- The frontend error extraction follows the `ApiError` class structure (`detail`, `data` fields)

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Co-authored by Claude Code (Opus 4.6). Single-session change focused on adding observability to a known blind spot in the OAuth authorize flow.