### PR TITLE
fix(replay): use CA cert for ClickHouse TLS instead of disabling verification

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -127,6 +127,9 @@ COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/package.json /code
 COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/assets /code/nodejs/assets
 COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/bin /code/nodejs/bin
 
+# ClickHouse CA certificate for TLS connections
+COPY --chown=posthog:posthog ee/certs/ch.crt /code/ee/certs/ch.crt
+
 # Setup ENV
 ENV NODE_ENV=production \
     BUILD_LIBRDKAFKA=0

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -303,6 +303,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CLICKHOUSE_USER: 'default',
         CLICKHOUSE_PASSWORD: undefined,
         CLICKHOUSE_SECURE: false,
+        CLICKHOUSE_CA: undefined,
         SESSION_RECORDING_V2_REPLAY_EVENTS_KAFKA_TOPIC: 'clickhouse_session_replay_events',
         SESSION_RECORDING_V2_CONSOLE_LOG_ENTRIES_KAFKA_TOPIC: 'log_entries',
         SESSION_RECORDING_V2_CONSOLE_LOG_STORE_SYNC_BATCH_LIMIT: 1000,

--- a/nodejs/src/session-recording/config.ts
+++ b/nodejs/src/session-recording/config.ts
@@ -8,6 +8,7 @@ export type SessionRecordingApiConfig = {
     CLICKHOUSE_USER: string
     CLICKHOUSE_PASSWORD: string | undefined
     CLICKHOUSE_SECURE: boolean
+    CLICKHOUSE_CA: string | undefined
 }
 
 export type SessionRecordingConfig = {

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -1,5 +1,6 @@
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
 import { ClickHouseClient, createClient as createClickHouseClient } from '@clickhouse/client'
+import fs from 'fs'
 import express from 'ultimate-express'
 
 import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS } from '../../config/kafka-topics'
@@ -122,6 +123,7 @@ export class RecordingApi {
         // Initialize ClickHouse client for block listing queries
         const chScheme = this.config.CLICKHOUSE_SECURE ? 'https' : 'http'
         const chPort = this.config.CLICKHOUSE_SECURE ? 8443 : 8123
+        const chCaCert = this.config.CLICKHOUSE_CA ? fs.readFileSync(this.config.CLICKHOUSE_CA) : undefined
         this.clickhouseClient = createClickHouseClient({
             url: `${chScheme}://${this.config.CLICKHOUSE_HOST}:${chPort}`,
             username: this.config.CLICKHOUSE_USER,
@@ -129,6 +131,7 @@ export class RecordingApi {
             database: this.config.CLICKHOUSE_DATABASE,
             request_timeout: 30_000,
             max_open_connections: 10,
+            ...(chCaCert ? { tls: { ca_cert: chCaCert } } : {}),
         })
 
         // Create the service layer

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -123,7 +123,7 @@ export class RecordingApi {
         // Initialize ClickHouse client for block listing queries
         const chScheme = this.config.CLICKHOUSE_SECURE ? 'https' : 'http'
         const chPort = this.config.CLICKHOUSE_SECURE ? 8443 : 8123
-        const chCaCert = this.config.CLICKHOUSE_CA ? fs.readFileSync(this.config.CLICKHOUSE_CA) : undefined
+        const chCaCert = this.config.CLICKHOUSE_CA ? await fs.promises.readFile(this.config.CLICKHOUSE_CA) : undefined
         this.clickhouseClient = createClickHouseClient({
             url: `${chScheme}://${this.config.CLICKHOUSE_HOST}:${chPort}`,
             username: this.config.CLICKHOUSE_USER,

--- a/nodejs/src/session-replay/recording-api/types.ts
+++ b/nodejs/src/session-replay/recording-api/types.ts
@@ -45,6 +45,7 @@ export type RecordingApiConfig = Pick<
     | 'CLICKHOUSE_USER'
     | 'CLICKHOUSE_PASSWORD'
     | 'CLICKHOUSE_SECURE'
+    | 'CLICKHOUSE_CA'
 >
 
 export interface RecordingBlock {


### PR DESCRIPTION
## Summary

- Copy `ee/certs/ch.crt` into `Dockerfile.node` so the recording-api has access to the ClickHouse CA certificate
- Add `CLICKHOUSE_CA` config option to the recording-api, matching Django's existing pattern
- When set, pass the CA cert as `tls.ca_cert` to `@clickhouse/client` for proper TLS verification
- This replaces the current `NODE_TLS_REJECT_UNAUTHORIZED=0` workaround which disables TLS verification for all outbound connections

## Follow-up

After this merges, a charts PR is needed to:
1. Set `CLICKHOUSE_CA: './ee/certs/ch.crt'` in `apps/recording-api/values.yaml`
2. Remove `NODE_TLS_REJECT_UNAUTHORIZED: '0'`

## Test plan

- [ ] Verify Node.js image builds with the cert file at `/code/ee/certs/ch.crt`
- [ ] Verify recording-api connects to ClickHouse using the CA cert (block listings return data)
- [ ] Verify `NODE_TLS_REJECT_UNAUTHORIZED` can be removed after rollout