### PR TITLE
feat(dashboard): pass explicit events for all places for dashboard edit

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -84,6 +84,9 @@ export enum DashboardEventSource {
     SceneCommonButtons = 'scene_common_buttons',
     CardEdgeHover = 'card_edge_hover',
     CardDragHandle = 'card_drag_handle',
+    DashboardFilters = 'dashboard_filters',
+    DashboardInsightColorsModal = 'dashboard_insight_colors_modal',
+    DashboardVariableOverride = 'dashboard_variable_override',
 }
 
 export enum InsightEventSource {

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -8,6 +8,7 @@ import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
@@ -75,7 +76,7 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
                             explicitDate={effectiveEditBarFilters.explicitDate}
                             onChange={(from_date, to_date, explicitDate) => {
                                 if (dashboardMode !== DashboardMode.Edit) {
-                                    setDashboardMode(DashboardMode.Edit, null)
+                                    setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
                                 }
                                 setDates(from_date, to_date, explicitDate)
                             }}
@@ -93,7 +94,7 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
                 <PropertyFilters
                     onChange={(properties) => {
                         if (dashboardMode !== DashboardMode.Edit) {
-                            setDashboardMode(DashboardMode.Edit, null)
+                            setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
                         }
                         setProperties(properties)
                     }}
@@ -125,7 +126,7 @@ export function DashboardEditBar({ showDateFilter = true, className }: Dashboard
                         showLabel={false}
                         updateBreakdownFilter={(breakdown_filter) => {
                             if (dashboardMode !== DashboardMode.Edit) {
-                                setDashboardMode(DashboardMode.Edit, null)
+                                setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
                             }
                             let saved_breakdown_filter: BreakdownFilter | null = breakdown_filter
                             // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object

--- a/frontend/src/scenes/dashboard/DashboardFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardFilters.tsx
@@ -10,6 +10,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { QuickFilterSelector } from 'lib/components/QuickFilters/QuickFilterSelector'
 import { quickFiltersLogic } from 'lib/components/QuickFilters/quickFiltersLogic'
 import { quickFiltersSectionLogic } from 'lib/components/QuickFilters/quickFiltersSectionLogic'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -48,7 +49,7 @@ export function DashboardPrimaryFilters(): JSX.Element {
                         explicitDate={effectiveEditBarFilters.explicitDate}
                         onChange={(from_date, to_date, explicitDate) => {
                             if (dashboardMode !== DashboardMode.Edit) {
-                                setDashboardMode(DashboardMode.Edit, null)
+                                setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
                             }
                             setDates(from_date, to_date, explicitDate)
                         }}

--- a/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render } from '@testing-library/react'
 import { BindLogic } from 'kea'
 
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
@@ -81,7 +82,7 @@ describe('DashboardHeader', () => {
         logic.mount()
 
         if (dashboardMode) {
-            logic.actions.setDashboardMode(dashboardMode, null)
+            logic.actions.setDashboardMode(dashboardMode, DashboardEventSource.Browser)
         }
 
         render(

--- a/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
+++ b/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
@@ -4,6 +4,7 @@ import { LemonLabel, LemonModal, LemonSelect } from '@posthog/lemon-ui'
 import { LemonButton, LemonColorPicker, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
 
 import { DataColorToken } from 'lib/colors'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { dataColorThemesLogic } from 'scenes/settings/environment/dataColorThemesLogic'
@@ -67,7 +68,7 @@ export function DashboardInsightColorsModal(): JSX.Element {
                         selectedColorToken={colorToken}
                         onSelectColorToken={(colorToken) => {
                             if (dashboardMode !== DashboardMode.Edit) {
-                                setDashboardMode(DashboardMode.Edit, null)
+                                setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardInsightColorsModal)
                             }
 
                             setBreakdownColorConfig({
@@ -96,7 +97,7 @@ export function DashboardInsightColorsModal(): JSX.Element {
                 placeholder="Defined by insight"
                 onChange={(id) => {
                     if (dashboardMode !== DashboardMode.Edit) {
-                        setDashboardMode(DashboardMode.Edit, null)
+                        setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardInsightColorsModal)
                     }
 
                     setDataColorThemeId(id)

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2239,7 +2239,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 forceRefresh: false,
             })
             if (values.dashboardMode !== DashboardMode.Edit) {
-                actions.setDashboardMode(DashboardMode.Edit, null)
+                actions.setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardVariableOverride)
             }
         },
         quickFiltersCommitted: async (_, breakpoint) => {
@@ -2496,24 +2496,24 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 : undefined
             actions.setSubscriptionMode(true, id)
             actions.setTextTileId(null)
-            actions.setDashboardMode(null, null)
+            actions.setDashboardMode(null, DashboardEventSource.Browser)
         },
 
         '/dashboard/:id': () => {
             actions.setSubscriptionMode(false, undefined)
             actions.setTextTileId(null)
             if (values.dashboardMode === DashboardMode.Sharing) {
-                actions.setDashboardMode(null, null)
+                actions.setDashboardMode(null, DashboardEventSource.Browser)
             }
         },
         '/dashboard/:id/sharing': () => {
             actions.setSubscriptionMode(false, undefined)
             actions.setTextTileId(null)
-            actions.setDashboardMode(DashboardMode.Sharing, null)
+            actions.setDashboardMode(DashboardMode.Sharing, DashboardEventSource.Browser)
         },
         '/dashboard/:id/text-tiles/:textTileId': ({ textTileId }) => {
             actions.setSubscriptionMode(false, undefined)
-            actions.setDashboardMode(null, null)
+            actions.setDashboardMode(null, DashboardEventSource.Browser)
             actions.setTextTileId(textTileId === undefined ? 'new' : textTileId !== 'new' ? Number(textTileId) : 'new')
         },
     })),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -271,7 +271,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setPageVisibility: (visible: boolean) => ({ visible }),
         setSubscriptionMode: (enabled: boolean, id?: number | 'new') => ({ enabled, id }),
         /** Set the dashboard mode, see DashboardMode for details. */
-        setDashboardMode: (mode: DashboardMode | null, source: DashboardEventSource | null) => ({ mode, source }),
+        setDashboardMode: (mode: DashboardMode | null, source: DashboardEventSource) => ({ mode, source }),
         /** Make it easier to handle organizing the layout when theres lots of tiles by zooming out */
         setLayoutZoom: (layoutZoom: number) => ({ layoutZoom }),
         /** Optimistic pin/unpin toggle. */


### PR DESCRIPTION
## Problem

<img width="2048" height="876" alt="CleanShot 2026-03-16 at 17 54 06@2x" src="https://github.com/user-attachments/assets/dee8e0e7-f71e-4f89-bc57-a228dc1e8375" />

When looking at the dashboard events for toggling edit mode, theres a high number of none for the source.

## Changes

Adds explicit source for all locations dashboard edit is toggled.

## How did you test this code?
Locally.

## Publish to changelog?
No.