### PR TITLE
fix(feature-flags): include distinctID in bootstrap for authenticated users

### DIFF
--- a/posthog/test/test_get_context_for_template.py
+++ b/posthog/test/test_get_context_for_template.py
@@ -1,6 +1,8 @@
+import json
+
 from posthog.test.base import APIBaseTest
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from posthog.utils import get_context_for_template
 
@@ -39,3 +41,23 @@ class TestGetContextForTemplate(APIBaseTest):
             )
 
         assert actual["stripe_public_key"] == "pk_test_12345"
+
+    @patch("posthog.utils.posthoganalytics.get_all_flags")
+    def test_bootstrap_includes_distinct_id_for_authenticated_users(self, mock_get_all_flags):
+        mock_get_all_flags.return_value = {"test-flag": True}
+
+        mock_request = MagicMock()
+        mock_request.user = self.user
+        mock_request.GET.get.return_value = None
+
+        with self.settings(PERSISTED_FEATURE_FLAGS=[]):
+            actual = get_context_for_template("layout", mock_request)
+
+        bootstrap = json.loads(actual["posthog_bootstrap"])
+
+        # Bootstrap should include distinctID and isIdentifiedID for authenticated users
+        # to ensure posthog-js uses the same identity for bootstrap and /decide calls
+        assert "featureFlags" in bootstrap
+        assert "distinctID" in bootstrap
+        assert bootstrap["isIdentifiedID"] is True
+        assert bootstrap["distinctID"] == str(self.user.distinct_id)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -549,8 +549,15 @@ def get_context_for_template(
             groups=groups,
             group_properties=group_properties,
         )
-        # don't forcefully set distinctID, as this breaks the link for anonymous users coming from `posthog.com`.
         posthog_bootstrap["featureFlags"] = feature_flags
+        # Include distinctID for authenticated users so posthog-js uses the same
+        # identity for both bootstrap flag reporting and /decide calls. This prevents
+        # duplicate $feature_flag_called events with different variants when
+        # hash(anonymous_id + flag_key) differs from hash(user_id + flag_key).
+        # Anonymous users from posthog.com are unaffected since posthog_distinct_id
+        # is only set when request.user is authenticated.
+        posthog_bootstrap["distinctID"] = posthog_distinct_id
+        posthog_bootstrap["isIdentifiedID"] = True
 
     # This allows immediate flag availability on the frontend, atleast for flags
     # that don't depend on any person properties. To get these flags, add person properties to the


### PR DESCRIPTION
## Summary

Fixes multi-variant experiment exposure issue caused by identity mismatch between server-side bootstrap and client-side /decide flag evaluation.

### Problem

When a logged-in user loads the PostHog app:
1. Server evaluates feature flags using `user.distinct_id` and passes them via bootstrap
2. Bootstrap payload did NOT include `distinctID`
3. posthog-js uses whatever `distinct_id` is in local persistence (often an anonymous ID from posthog.com)
4. `/decide` evaluates with the anonymous ID → different hash bucket → different variant
5. Two `$feature_flag_called` events fire (posthog-js dedupes by flag+value, not flag alone)
6. Experiment shows user exposed to both variants

Investigation by @marclzn found 5-26% unexplained multi-variant exposure on flags using bootstrap.

### Solution

Include `distinctID` and `isIdentifiedID` in the bootstrap payload for authenticated users. This ensures posthog-js uses the same identity for both bootstrap flag reporting and `/decide` calls.

Anonymous users from posthog.com are unaffected since `posthog_distinct_id` is only set when `request.user` is authenticated.

### Historical context

PR #12033 (Sep 2022) intentionally removed `distinctID` from bootstrap to preserve anonymous → identified user linking for users coming from posthog.com. This fix restores `distinctID` only for authenticated users, preserving that behavior for anonymous users.

## Changes

- `posthog/utils.py`: Add `distinctID` and `isIdentifiedID` to bootstrap payload when user is authenticated
- `posthog/test/test_get_context_for_template.py`: Add test to verify bootstrap includes distinctID for authenticated users

## Test plan

- [x] Unit test passes verifying bootstrap includes distinctID for authenticated users
- [ ] Manual test: Log in to PostHog app, check that bootstrap payload in page source includes `distinctID`
- [ ] Verify experiments no longer show multi-variant exposure for logged-in users

🤖 Generated with [Claude Code](https://claude.com/claude-code)