### PR TITLE
feat: Add cancelled state handling to MCP UI AppWrapper

### DIFF
--- a/services/mcp/src/ui-apps/components/AppWrapper.tsx
+++ b/services/mcp/src/ui-apps/components/AppWrapper.tsx
@@ -129,7 +129,8 @@ function ExpandButton({
 
 export function AppWrapper<T>({ children, ...options }: AppWrapperProps<T>): ReactElement {
     const toolResult = useToolResult<T>(options)
-    const { data, isConnected, error, openLink, app, containerDimensions, refreshContainerDimensions } = toolResult
+    const { data, isConnected, error, isCancelled, openLink, app, containerDimensions, refreshContainerDimensions } =
+        toolResult
 
     const posthogUrl =
         data && typeof data === 'object' && '_posthogUrl' in data
@@ -142,7 +143,7 @@ export function AppWrapper<T>({ children, ...options }: AppWrapperProps<T>): Rea
         }
     }, [error])
 
-    const hasContent = !error && isConnected && data
+    const hasContent = !error && !isCancelled && isConnected && data
 
     const rootStyle: React.CSSProperties = {
         display: 'flex',
@@ -159,6 +160,8 @@ export function AppWrapper<T>({ children, ...options }: AppWrapperProps<T>): Rea
     }
 
     if (!hasContent) {
+        const showError = error || isCancelled
+
         return (
             <div
                 style={{
@@ -169,10 +172,15 @@ export function AppWrapper<T>({ children, ...options }: AppWrapperProps<T>): Rea
                     gap: '0.75rem',
                 }}
             >
-                <div style={{ animation: error ? 'none' : 'loading__pulse 4s ease-in-out infinite' }}>
+                <div style={{ animation: showError ? 'none' : 'loading__pulse 4s ease-in-out infinite' }}>
                     <PostHogLogo size={40} />
                 </div>
-                {error && (
+                {isCancelled && (
+                    <span style={{ color: 'var(--color-text-secondary, #ca8a04)', fontSize: '0.8125rem' }}>
+                        Tool call was cancelled
+                    </span>
+                )}
+                {error && !isCancelled && (
                     <span style={{ color: 'var(--color-text-danger, #dc2626)', fontSize: '0.8125rem' }}>
                         {error.message}
                     </span>

--- a/services/mcp/src/ui-apps/hooks/useToolResult.ts
+++ b/services/mcp/src/ui-apps/hooks/useToolResult.ts
@@ -75,6 +75,8 @@ export interface UseToolResultReturn<T> {
     isConnected: boolean
     /** Connection or parsing error, if any */
     error: Error | null
+    /** Whether the tool call was cancelled by the user or host */
+    isCancelled: boolean
     /** The App instance for advanced usage (e.g., opening links) */
     app: App | null
     /** Callback to open a link via the host */
@@ -138,6 +140,7 @@ export function useToolResult<T = unknown>({
 }: UseToolResultOptions): UseToolResultReturn<T> {
     const [data, setData] = useState<T | null>(null)
     const [parseError, setParseError] = useState<Error | null>(null)
+    const [isCancelled, setIsCancelled] = useState(false)
     const [containerDimensions, setContainerDimensions] = useState<ContainerDimensions | null>(null)
     const hasLoggedConnection = useRef(false)
 
@@ -174,6 +177,7 @@ export function useToolResult<T = unknown>({
             // Register tool cancelled handler
             appInstance.setNotificationHandler(McpUiToolCancelledNotificationSchema, (notification) => {
                 const params = notification.params as Record<string, unknown>
+                setIsCancelled(true)
                 captureToolCancelled({
                     toolName: typeof params.toolName === 'string' ? params.toolName : undefined,
                     reason: typeof params.reason === 'string' ? params.reason : undefined,
@@ -283,6 +287,7 @@ export function useToolResult<T = unknown>({
         data,
         isConnected,
         error,
+        isCancelled,
         app,
         openLink,
         capture,


### PR DESCRIPTION
## Problem

Users need clear feedback when tool calls are cancelled in MCP UI applications. Previously, cancelled tool calls would show a generic loading state without indicating the cancellation, leading to confusion about the tool's status.

## Changes

- Added `isCancelled` state tracking to the `useToolResult` hook
- Updated the tool cancelled notification handler to set the cancellation state
- Modified `AppWrapper` to display a specific "Tool call was cancelled" message with yellow styling when a tool is cancelled
- Updated the content visibility logic to treat cancelled tools the same as errored tools (no content display)
- Ensured error messages only show when there's an actual error and the tool wasn't cancelled

## How did you test this code?

I am an agent and have not manually tested this code. The changes include proper TypeScript typing and follow the existing patterns in the codebase. Manual testing would involve triggering a tool cancellation and verifying the UI shows the appropriate cancellation message.

## Publish to changelog?

No

## Docs update

No docs update needed for this internal UI improvement.