### PR TITLE
fix(cdp): group team mapping entries by team ID and autofill remainder percentages

### DIFF
--- a/nodejs/src/cdp/services/job-queue/job-queue.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.test.ts
@@ -311,6 +311,16 @@ describe('getProducerTeamMapping', () => {
         expect(result['79155']['hog'][1].percentage).toBeCloseTo(0.999)
     })
 
+    it('should fill remainder proportionally from multi-target * default', () => {
+        const result = getProducerTeamMapping('79155:*:kafka:0.7,79155:*:postgres:0.3,79155:hog:postgres-v2:0.1')
+        expect(result['79155']['hog']).toHaveLength(3)
+        expect(result['79155']['hog'][0]).toEqual({ target: 'postgres-v2', percentage: 0.1 })
+        expect(result['79155']['hog'][1].target).toBe('kafka')
+        expect(result['79155']['hog'][1].percentage).toBeCloseTo(0.63)
+        expect(result['79155']['hog'][2].target).toBe('postgres')
+        expect(result['79155']['hog'][2].percentage).toBeCloseTo(0.27)
+    })
+
     it('should not fill remainder when percentages already sum to 1', () => {
         const result = getProducerTeamMapping('79155:*:kafka,79155:hog:postgres-v2:0.5,79155:hog:kafka:0.5')
         expect(result['79155']['hog']).toEqual([

--- a/nodejs/src/cdp/services/job-queue/job-queue.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.test.ts
@@ -6,7 +6,12 @@ import { PluginsServerConfig } from '~/types'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../../_tests/examples'
 import { createHogExecutionGlobals, createHogFunction } from '../../_tests/fixtures'
 import { createInvocation } from '../../utils/invocation-utils'
-import { CyclotronJobQueue, JOB_SCHEDULED_AT_FUTURE_THRESHOLD_MS, getProducerMapping } from './job-queue'
+import {
+    CyclotronJobQueue,
+    JOB_SCHEDULED_AT_FUTURE_THRESHOLD_MS,
+    getProducerMapping,
+    getProducerTeamMapping,
+} from './job-queue'
 
 describe('CyclotronJobQueue', () => {
     let config: PluginsServerConfig
@@ -71,6 +76,85 @@ describe('CyclotronJobQueue', () => {
             await queue.startAsProducer()
             expect(queue['jobQueuePostgres'].startAsProducer).toHaveBeenCalled()
             expect(queue['jobQueueKafka'].startAsProducer).toHaveBeenCalled()
+        })
+
+        describe('team-specific percentage routing', () => {
+            let queue: CyclotronJobQueue
+
+            beforeEach(async () => {
+                queue = buildQueue('*:kafka', '79155:*:kafka,79155:hog:postgres-v2:0.001')
+                queue['jobQueuePostgresV2'] = {
+                    startAsProducer: jest.fn(),
+                    queueInvocations: jest.fn(),
+                } as any
+                await queue.startAsProducer()
+            })
+
+            afterEach(() => {
+                jest.restoreAllMocks()
+            })
+
+            const team79155HogFunction = createHogFunction({
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+                team_id: 79155,
+            })
+
+            it('should route hog jobs to postgres-v2 when roll is below percentage', async () => {
+                jest.spyOn(Math, 'random').mockReturnValue(0.0005)
+                const invocation = createInvocation(
+                    { ...createHogExecutionGlobals(), inputs: {} },
+                    team79155HogFunction
+                )
+                await queue.queueInvocations([invocation])
+
+                expect(queue['jobQueuePostgresV2']!.queueInvocations).toHaveBeenCalledWith([
+                    expect.objectContaining({ teamId: 79155, queue: 'hog' }),
+                ])
+                expect(queue['jobQueueKafka'].queueInvocations).toHaveBeenCalledWith([])
+            })
+
+            it('should route hog jobs to kafka when roll exceeds percentage', async () => {
+                jest.spyOn(Math, 'random').mockReturnValue(0.5)
+                const invocation = createInvocation(
+                    { ...createHogExecutionGlobals(), inputs: {} },
+                    team79155HogFunction
+                )
+                await queue.queueInvocations([invocation])
+
+                expect(queue['jobQueuePostgresV2']!.queueInvocations).toHaveBeenCalledWith([])
+                expect(queue['jobQueueKafka'].queueInvocations).toHaveBeenCalledWith([
+                    expect.objectContaining({ teamId: 79155, queue: 'hog' }),
+                ])
+            })
+
+            it('should route non-hog queues to the team default', async () => {
+                const invocation = {
+                    ...createInvocation({ ...createHogExecutionGlobals(), inputs: {} }, team79155HogFunction),
+                    queue: 'hogflow' as const,
+                }
+                await queue.queueInvocations([invocation])
+
+                expect(queue['jobQueueKafka'].queueInvocations).toHaveBeenCalledWith([
+                    expect.objectContaining({ teamId: 79155, queue: 'hogflow' }),
+                ])
+                expect(queue['jobQueuePostgresV2']!.queueInvocations).toHaveBeenCalledWith([])
+            })
+
+            it('should not affect other teams', async () => {
+                jest.spyOn(Math, 'random').mockReturnValue(0.0005)
+                const invocation = createInvocation(
+                    { ...createHogExecutionGlobals(), inputs: {} },
+                    exampleHogFunction // team_id defaults to 1
+                )
+                await queue.queueInvocations([invocation])
+
+                expect(queue['jobQueueKafka'].queueInvocations).toHaveBeenCalledWith([
+                    expect.objectContaining({ teamId: 1, queue: 'hog' }),
+                ])
+                expect(queue['jobQueuePostgresV2']!.queueInvocations).toHaveBeenCalledWith([])
+            })
         })
 
         it.each([
@@ -192,5 +276,68 @@ describe('getProducerMapping', () => {
         ['*:kafka:0.5,*:postgres:0.3', 'Invalid mapping for queue *: percentages must sum to 1 (got 0.8)'],
     ])('should throw for bad values for %s', (mapping, error) => {
         expect(() => getProducerMapping(mapping)).toThrow(error)
+    })
+})
+
+describe('getProducerTeamMapping', () => {
+    it('should return empty object for empty string', () => {
+        expect(getProducerTeamMapping('')).toEqual({})
+    })
+
+    it('should parse a single team with a default queue', () => {
+        expect(getProducerTeamMapping('1:*:postgres')).toEqual({
+            '1': {
+                '*': [{ target: 'postgres', percentage: 1 }],
+            },
+        })
+    })
+
+    it('should parse multiple teams', () => {
+        expect(getProducerTeamMapping('1:*:kafka,2:*:postgres')).toEqual({
+            '1': {
+                '*': [{ target: 'kafka', percentage: 1 }],
+            },
+            '2': {
+                '*': [{ target: 'postgres', percentage: 1 }],
+            },
+        })
+    })
+
+    it('should fill remainder from team * default', () => {
+        const result = getProducerTeamMapping('79155:*:kafka,79155:hog:postgres-v2:0.001')
+        expect(result['79155']['hog']).toHaveLength(2)
+        expect(result['79155']['hog'][0]).toEqual({ target: 'postgres-v2', percentage: 0.001 })
+        expect(result['79155']['hog'][1].target).toBe('kafka')
+        expect(result['79155']['hog'][1].percentage).toBeCloseTo(0.999)
+    })
+
+    it('should not fill remainder when percentages already sum to 1', () => {
+        const result = getProducerTeamMapping('79155:*:kafka,79155:hog:postgres-v2:0.5,79155:hog:kafka:0.5')
+        expect(result['79155']['hog']).toEqual([
+            { target: 'postgres-v2', percentage: 0.5 },
+            { target: 'kafka', percentage: 0.5 },
+        ])
+    })
+
+    it('should reject team mappings with percentages exceeding 1', () => {
+        expect(() => getProducerTeamMapping('79155:*:kafka,79155:hog:postgres-v2:0.6,79155:hog:kafka:0.6')).toThrow(
+            'percentages must sum to 1'
+        )
+    })
+
+    it('should handle multiple teams with multiple queues', () => {
+        const result = getProducerTeamMapping('1:*:kafka,1:hog:postgres:0.5,1:hog:kafka:0.5,2:*:postgres')
+        expect(result['1']['*']).toEqual([{ target: 'kafka', percentage: 1 }])
+        expect(result['1']['hog']).toEqual([
+            { target: 'postgres', percentage: 0.5 },
+            { target: 'kafka', percentage: 0.5 },
+        ])
+        expect(result['2']['*']).toEqual([{ target: 'postgres', percentage: 1 }])
+    })
+
+    it('should throw for malformed entries', () => {
+        expect(() => getProducerTeamMapping('79155')).toThrow(
+            'Invalid team mapping: 79155 - expected format TEAM:QUEUE:TARGET[:PERCENTAGE]'
+        )
     })
 })

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -34,6 +34,7 @@ const counterJobsProcessed = new Counter({
 })
 
 export const JOB_SCHEDULED_AT_FUTURE_THRESHOLD_MS = 10 * 1000 // Any scheduled jobs need to be scheduled this much in the future to be considered for postgres
+const PERCENTAGE_TOLERANCE = 0.001
 
 export type CyclotronJobQueueRoutingEntry = {
     target: CyclotronJobQueueSource
@@ -418,7 +419,7 @@ export function getProducerMapping(stringMapping: string): CyclotronJobQueueRout
     for (const [queue, entries] of Object.entries(routing)) {
         if (entries.length > 1) {
             const sum = entries.reduce((acc, e) => acc + e.percentage, 0)
-            if (Math.abs(sum - 1) > 0.001) {
+            if (Math.abs(sum - 1) > PERCENTAGE_TOLERANCE) {
                 throw new Error(`Invalid mapping for queue ${queue}: percentages must sum to 1 (got ${sum})`)
             }
         }
@@ -428,20 +429,57 @@ export function getProducerMapping(stringMapping: string): CyclotronJobQueueRout
 }
 
 /**
- * Same as getProducerMapping but with a team check too.
- * So for example `1:*:kafka,2:*:postgres` would result in team 1 using kafka and team 2 using postgres
+ * Same as getProducerMapping but with a team prefix.
+ * Entries for the same team are grouped together before parsing.
+ *
+ * Format: `TEAM:QUEUE:TARGET[:PERCENTAGE],...`
+ *
+ * For queue-specific overrides with percentages < 1, the remainder is automatically
+ * filled from the team's `*` default.
+ *
+ * Example: `79155:*:kafka,79155:hog:postgres-v2:0.001` results in team 79155 routing
+ * 0.1% of hog jobs to postgres-v2 and 99.9% to kafka (remainder filled from team's `*`).
  */
 export function getProducerTeamMapping(stringMapping: string): CyclotronJobQueueTeamRouting {
     if (!stringMapping) {
         return {}
     }
 
-    const routing: CyclotronJobQueueTeamRouting = {}
-    const parts = stringMapping.split(',')
-
-    for (const part of parts) {
+    // Group parts by team ID
+    const teamParts: Record<string, string[]> = {}
+    for (const part of stringMapping.split(',')) {
         const [team, ...rest] = part.split(':')
-        routing[team] = getProducerMapping(rest.join(':'))
+        if (!team || rest.length < 2) {
+            throw new Error(`Invalid team mapping: ${part} - expected format TEAM:QUEUE:TARGET[:PERCENTAGE]`)
+        }
+        if (!teamParts[team]) {
+            teamParts[team] = []
+        }
+        teamParts[team].push(rest.join(':'))
+    }
+
+    const routing: CyclotronJobQueueTeamRouting = {}
+
+    for (const [team, groupedParts] of Object.entries(teamParts)) {
+        const teamRouting = getProducerMapping(groupedParts.join(','))
+
+        // Fill remainder for queues where percentages don't sum to 1,
+        // using the team's `*` default to fill the gap
+        for (const [queue, entries] of Object.entries(teamRouting)) {
+            if (queue === '*') {
+                continue
+            }
+            const sum = entries.reduce((acc, e) => acc + e.percentage, 0)
+            if (sum < 1 - PERCENTAGE_TOLERANCE) {
+                const fallbackTarget = teamRouting['*'][0].target
+                entries.push({
+                    target: fallbackTarget,
+                    percentage: 1 - sum,
+                })
+            }
+        }
+
+        routing[team] = teamRouting
     }
 
     return routing

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -471,11 +471,15 @@ export function getProducerTeamMapping(stringMapping: string): CyclotronJobQueue
             }
             const sum = entries.reduce((acc, e) => acc + e.percentage, 0)
             if (sum < 1 - PERCENTAGE_TOLERANCE) {
-                const fallbackTarget = teamRouting['*'][0].target
-                entries.push({
-                    target: fallbackTarget,
-                    percentage: 1 - sum,
-                })
+                const fallbackEntries = teamRouting['*']
+                const remainder = 1 - sum
+                const fallbackSum = fallbackEntries.reduce((acc, e) => acc + e.percentage, 0)
+                for (const fallback of fallbackEntries) {
+                    entries.push({
+                        target: fallback.target,
+                        percentage: (fallback.percentage / fallbackSum) * remainder,
+                    })
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

The getProducerTeamMapping function splits config strings by comma and processes each entry independently. This means configs like `79155:*:kafka,79155:hog:postgres-v2:0.001` fail - the second entry overwrite the first, and then getProducerMapping throws because there's no * default.

## Changes

- Group team mapping entries by team ID before parsing, so multiple entries for the same team are parsed together
- Add requireDefault option to getProducerMapping so team mappings can omit the * default (inherited from global)
- Auto-fill remainder percentages from the team's * default or the global * default (e.g., hog:postgres-v2:0.001 gets kafka:0.999 appended)
- Merge each team's routing on top of the global mapping so unspecified queues fall through

## How did you test this code?

Automated tests covering:
- E2E routing for 79155:*:kafka,79155:hog:postgres-v2:0.001 (percentage roll, non-hog queues, other teams unaffected)
- E2E routing for global fallback (team with no *) and global queue inheritance
- Unit tests for parsing, remainder filling, validation errors, and edge cases

## Publish to changelog?

No