### PR TITLE
chore(auth): deprecate legacy personal API key NULL scopes

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -347,6 +347,7 @@ jobs:
                       user=user,
                       label='mcp_ci_api_key',
                       secure_value=hash_key_value('e2e_demo_api_key'),
+                      scopes=["*"],
                   )
                   # Ensure common event definitions exist for MCP integration tests
                   for event_name in ['\$pageview', '\$pageleave', '\$autocapture', '\$screen']:

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -347,7 +347,7 @@ jobs:
                       user=user,
                       label='mcp_ci_api_key',
                       secure_value=hash_key_value('e2e_demo_api_key'),
-                      scopes=["*"],
+                      scopes=['*'],
                   )
                   # Ensure common event definitions exist for MCP integration tests
                   for event_name in ['\$pageview', '\$pageleave', '\$autocapture', '\$screen']:

--- a/posthog/api/personal_api_key.py
+++ b/posthog/api/personal_api_key.py
@@ -146,9 +146,7 @@ class PersonalAPIKeySerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        # TRICKY: Legacy Personal API keys have scopes=None and are shown as ["*"].
-        # An empty list [] is NOT legacy and must be preserved as-is.
-        ret["scopes"] = ["*"] if ret["scopes"] is None else ret["scopes"]
+        ret["scopes"] = ret["scopes"] or []
         return ret
 
     def create(self, validated_data: dict, **kwargs) -> PersonalAPIKey:

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -1519,6 +1519,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
             user=self.user,
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
+            scopes=["*"],
         )
 
         with freeze_time("2021-08-25T22:10:14.252"):
@@ -1541,6 +1542,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
             user=self.user,
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
+            scopes=["*"],
         )
 
         with freeze_time("2022-08-25T22:00:14.252"):
@@ -1563,6 +1565,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
             user=self.user,
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
+            scopes=["*"],
         )
 
         with freeze_time("2021-08-26T22:00:14.252"):
@@ -1580,7 +1583,9 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
         self.client.logout()
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, secure_value=hash_key_value(personal_api_key), scopes=["*"]
+        )
 
         with freeze_time("2022-08-25T22:00:14.252"):
             response = self.client.get(
@@ -1602,6 +1607,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
             user=self.user,
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
+            scopes=["*"],
         )
 
         with freeze_time("2021-08-25T21:14:14.252"):
@@ -1623,6 +1629,7 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
             user=self.user,
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
+            scopes=["*"],
         )
 
         with freeze_time("2021-08-24T21:14:14.252"):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1493,7 +1493,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             is_remote_configuration=True,
         )
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         self.client.logout()
 
@@ -3403,7 +3405,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         deleted_cohort = Cohort.objects.create(
             team=self.team,
@@ -3659,7 +3663,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         self.client.logout()
 
@@ -3771,7 +3777,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         response = self.client.get(
             f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
@@ -3957,7 +3965,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         response = self.client.get(
             f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
@@ -4112,7 +4122,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         client = redis.get_client()
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         self.client.logout()
         # `local_evaluation` is called by logged out clients!
@@ -4174,7 +4186,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         client = redis.get_client()
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         # request made while logged in, via client cookie auth
         response = self.client.get(f"/api/feature_flag?token={self.team.api_token}")
@@ -5517,7 +5531,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
     @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
     def test_rate_limits_for_local_evaluation_are_independent(self, rate_limit_enabled_mock, incr_mock):
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         for _ in range(5):
             response = self.client.get(
@@ -6227,7 +6243,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         # Clear both Redis and S3 caches
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
@@ -6273,7 +6291,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         cache.clear()
 
@@ -6306,7 +6326,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         cache.clear()
 
@@ -6363,7 +6385,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         cache.clear()
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         # Populate both cache variants
         self.client.logout()
@@ -6763,7 +6787,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -6792,7 +6818,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -6830,7 +6858,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -6862,7 +6892,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -6915,7 +6947,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -6963,7 +6997,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -7006,7 +7042,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -7044,7 +7082,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         from posthog.models.feature_flag.local_evaluation import clear_flag_definition_caches
 
@@ -7172,7 +7212,9 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="Test", user=self.user, secure_value=hash_key_value(personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="Test", user=self.user, scopes=["*"], secure_value=hash_key_value(personal_api_key)
+        )
 
         self.client.logout()
         before = LOCAL_EVALUATION_PERSONAL_API_KEY_SOURCE_COUNTER.labels(source=source)._value.get()

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -318,6 +318,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
             label="Test Key",
             secure_value=hash_key_value(token),
             mask_value=mask_key_value(token),
+            scopes=["*"],
         )
         original_secure_value = key.secure_value
 
@@ -396,6 +397,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
             label="Legacy Key",
             secure_value=legacy_hash,
             mask_value=mask_key_value(token),
+            scopes=["*"],
         )
 
         # Send alert with the token
@@ -439,6 +441,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
             label="Inactive User Key",
             secure_value=hash_key_value(token),
             mask_value=mask_key_value(token),
+            scopes=["*"],
         )
 
         # Send alert with the token

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -325,6 +325,7 @@ class TestOrganizationAPI(APIBaseTest):
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
             scoped_organizations=[other_org.id],
+            scopes=["*"],
         )
 
         response = self.client.get("/api/organizations/", headers={"authorization": f"Bearer {personal_api_key}"})

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -113,6 +113,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             label="Old Org Key",
             scoped_organizations=[str(self.organization.id)],
             last_used_at=timezone.now() - timedelta(days=14),
+            scopes=["*"],
         )
 
         # Check response with one inactive key
@@ -134,6 +135,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             label="Team Key",
             scoped_teams=[self.team.id],
             last_used_at=timezone.now() - timedelta(days=2),
+            scopes=["*"],
         )
 
         # Create a key with no scoped teams or organizations (applies to all orgs/teams)
@@ -143,6 +145,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             scoped_teams=[],
             scoped_organizations=[],
             last_used_at=timezone.now() - timedelta(days=1),
+            scopes=["*"],
         )
 
         # Check response with all keys (one org-scoped, one team-scoped, one global)
@@ -184,6 +187,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             scoped_teams=None,
             scoped_organizations=None,
             last_used_at=timezone.now() - timedelta(days=3),
+            scopes=["*"],
         )
 
         # Check response with all keys including the null scoped key
@@ -200,10 +204,14 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         other_team = Team.objects.create(organization=other_org, name="Other Team", project=self.team.project)
 
         # Create a key scoped to the other organization
-        PersonalAPIKey.objects.create(user=other_user, label="Other Org Key", scoped_organizations=[str(other_org.id)])
+        PersonalAPIKey.objects.create(
+            user=other_user, label="Other Org Key", scoped_organizations=[str(other_org.id)], scopes=["*"]
+        )
 
         # Create a key scoped to the other team
-        PersonalAPIKey.objects.create(user=other_user, label="Other Team Key", scoped_teams=[other_team.id])
+        PersonalAPIKey.objects.create(
+            user=other_user, label="Other Team Key", scoped_teams=[other_team.id], scopes=["*"]
+        )
 
         # Add the other user to our organization
         other_user.join(organization=self.organization)

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -541,13 +541,13 @@ class TestPersonalAPIKeysWithScopeAPIAuthentication(PersonalAPIKeysBaseTest):
         self.key.scopes = ["feature_flag:read"]
         self.key.save()
 
-    def test_allows_legacy_api_key_to_access_all(self):
+    def test_rejects_null_scopes_as_no_access(self):
         self.key.scopes = None
         self.key.save()
-        response = self._do_request("/api/users/@me/")
-        assert response.status_code == status.HTTP_200_OK
+        response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_rejects_empty_scopes_list_as_not_legacy(self):
+    def test_rejects_empty_scopes_list_as_no_access(self):
         self.key.scopes = []
         self.key.save()
         response = self._do_request(f"/api/projects/{self.team.id}/feature_flags/")

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -128,6 +128,7 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
             label="Test",
             user=self.user,
             secure_value=hash_key_value(generate_random_token_personal()),
+            scopes=["*"],
         )
         assert PersonalAPIKey.objects.count() == 1
         response = self.client.delete(f"/api/personal_api_keys/{key.id}/")
@@ -174,12 +175,14 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
             label=my_label,
             user=self.user,
             secure_value=hash_key_value(generate_random_token_personal()),
+            scopes=["*"],
         )
         other_user = self._create_user("abc@def.xyz")
         PersonalAPIKey.objects.create(
             label="Other test",
             user=other_user,
             secure_value=hash_key_value(generate_random_token_personal()),
+            scopes=["*"],
         )
         assert PersonalAPIKey.objects.count() == 2
         response = self.client.get("/api/personal_api_keys")
@@ -207,6 +210,7 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
             label=my_label,
             user=self.user,
             secure_value=hash_key_value(generate_random_token_personal()),
+            scopes=["*"],
         )
         response = self.client.get(f"/api/personal_api_keys/{my_key.id}/")
         assert response.status_code == 200
@@ -218,6 +222,7 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
             label="Other test",
             user=other_user,
             secure_value=hash_key_value(generate_random_token_personal()),
+            scopes=["*"],
         )
         response = self.client.get(f"/api/personal_api_keys/{other_key.id}/")
         assert response.status_code == 404
@@ -353,13 +358,17 @@ class TestPersonalAPIKeysAPIAuthentication(PersonalAPIKeysBaseTest):
         super().setUp()
         self.value_390000 = generate_random_token_personal()
         self.key_390000 = PersonalAPIKey.objects.create(
-            label="Test", user=self.user, secure_value=hash_key_value(self.value_390000, "pbkdf2", iterations=390000)
+            label="Test",
+            user=self.user,
+            secure_value=hash_key_value(self.value_390000, "pbkdf2", iterations=390000),
+            scopes=["*"],
         )
         self.value_hardcoded = "phx_0a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p"
         self.key_hardcoded = PersonalAPIKey.objects.create(
             label="Test",
             user=self.user,
             secure_value="pbkdf2_sha256$260000$posthog_personal_api_key$dUOOjl6bYdigHd+QfhYzN6P2vM01ZbFROS8dm9KRK7Y=",
+            scopes=["*"],
         )
 
     @parameterized.expand(

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -31,6 +31,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
             scoped_organizations=[other_org.id],
+            scopes=["*"],
         )
 
         response = self.client.get("/api/projects/", headers={"authorization": f"Bearer {personal_api_key}"})

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -2342,6 +2342,7 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
             scoped_teams=[other_team_in_project.id],
+            scopes=["*"],
         )
 
         response = self.client.get("/api/environments/", headers={"authorization": f"Bearer {personal_api_key}"})
@@ -2362,6 +2363,7 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             last_used_at="2021-08-25T21:09:14",
             secure_value=hash_key_value(personal_api_key),
             scoped_organizations=[other_org.id],
+            scopes=["*"],
         )
 
         response = self.client.get("/api/environments/", headers={"authorization": f"Bearer {personal_api_key}"})

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -2345,14 +2345,17 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             scopes=["*"],
         )
 
+        # Team-scoped keys cannot list all environments — they can only access specific teams directly
         response = self.client.get("/api/environments/", headers={"authorization": f"Bearer {personal_api_key}"})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            {team["id"] for team in response.json()["results"]},
-            {other_team_in_project.id},
-            "Only the scoped team listed here, the other two should be excluded",
+        # But they can access the scoped team directly
+        response = self.client.get(
+            f"/api/environments/{other_team_in_project.id}/",
+            headers={"authorization": f"Bearer {personal_api_key}"},
         )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], other_team_in_project.id)
 
     def test_teams_outside_personal_api_key_scoped_organizations_not_listed(self):
         other_org, __, team_in_other_org = Organization.objects.bootstrap(self.user)

--- a/posthog/management/commands/setup_dev.py
+++ b/posthog/management/commands/setup_dev.py
@@ -52,6 +52,7 @@ class Command(BaseCommand):
                 user=user,
                 label="e2e_demo_api_key key",
                 secure_value=hash_key_value("e2e_demo_api_key"),
+                scopes=["*"],
             )
             if not options["no_data"]:
                 create_demo_data(team)

--- a/posthog/migrations/1052_migrate_legacy_personal_api_key_scopes.py
+++ b/posthog/migrations/1052_migrate_legacy_personal_api_key_scopes.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def migrate_legacy_scopes(apps, schema_editor):
+    PersonalAPIKey = apps.get_model("posthog", "PersonalAPIKey")
+    PersonalAPIKey.objects.filter(scopes__isnull=True).update(scopes=["*"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1051_backfill_holdout_format"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_legacy_scopes, migrations.RunPython.noop, elidable=True),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1051_backfill_holdout_format
+1052_migrate_legacy_personal_api_key_scopes

--- a/posthog/models/activity_logging/personal_api_key_utils.py
+++ b/posthog/models/activity_logging/personal_api_key_utils.py
@@ -192,7 +192,7 @@ def log_personal_api_key_scope_change(
                 if log_entry["organization_id"]
                 else None,
                 team_name=get_team_name(team_id) if team_id else None,
-                scopes=after_api_key.scopes or ["*"],
+                scopes=after_api_key.scopes or [],
             ),
         )
 
@@ -260,7 +260,7 @@ def log_personal_api_key_activity(api_key: PersonalAPIKey, activity: str, user, 
                         user_name=api_key.user.get_full_name(),
                         organization_name=get_organization_name(location.org_id),
                         team_name=get_team_name(location.team_id),
-                        scopes=api_key.scopes or ["*"],
+                        scopes=api_key.scopes or [],
                     ),
                 ),
             }

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -472,11 +472,7 @@ class APIScopePermission(ScopeBasePermission):
         # API Scopes apply to PersonalAPIKeyAuthentication and OAuthAccessTokenAuthentication
 
         if isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication):
-            key_scopes = request.successful_authenticator.personal_api_key.scopes
-            # TRICKY: Legacy Personal API keys have scopes=None and are allowed to do anything.
-            # Must use `is None` — an empty list [] is NOT legacy and must be denied.
-            if key_scopes is None:
-                return True
+            key_scopes = request.successful_authenticator.personal_api_key.scopes or []
         elif isinstance(request.successful_authenticator, OAuthAccessTokenAuthentication):
             # OAuth tokens store scopes as space-separated string
             token_scope_string = request.successful_authenticator.access_token.scope

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -530,7 +530,7 @@ class APIScopePermission(ScopeBasePermission):
                 if team.id not in scoped_teams:
                     raise PermissionDenied(f"API key does not have access to the requested project: ID {team.id}.")
             except (KeyError, AttributeError):
-                raise PermissionDenied(f"API keys with scoped projects are only supported on project-based endpoints.")
+                raise PermissionDenied("API keys with scoped projects are only supported on project-based endpoints.")
 
         if scoped_organizations:
             try:

--- a/posthog/storage/team_access_cache.py
+++ b/posthog/storage/team_access_cache.py
@@ -141,7 +141,7 @@ def _load_team_access_tokens(team_token: KeyType) -> dict[str, Any] | HyperCache
                         # Unscoped keys: no team restriction (null or empty array)
                         (Q(scoped_teams__isnull=True) | Q(scoped_teams=[]))
                         & (
-                            # AND either no scope restriction OR has feature flag read/write or all access
+                            # AND has feature flag read/write or all access
                             Q(scopes__contains=["feature_flag:read"])
                             | Q(scopes__contains=["feature_flag:write"])
                             | Q(scopes__contains=["*"])

--- a/posthog/storage/team_access_cache.py
+++ b/posthog/storage/team_access_cache.py
@@ -142,9 +142,7 @@ def _load_team_access_tokens(team_token: KeyType) -> dict[str, Any] | HyperCache
                         (Q(scoped_teams__isnull=True) | Q(scoped_teams=[]))
                         & (
                             # AND either no scope restriction OR has feature flag read/write or all access
-                            Q(scopes__isnull=True)
-                            | Q(scopes=[])
-                            | Q(scopes__contains=["feature_flag:read"])
+                            Q(scopes__contains=["feature_flag:read"])
                             | Q(scopes__contains=["feature_flag:write"])
                             | Q(scopes__contains=["*"])
                         )

--- a/posthog/storage/test/test_team_access_cache.py
+++ b/posthog/storage/test/test_team_access_cache.py
@@ -2202,7 +2202,7 @@ class TestUserPersonalAPIKeyTeamLookup(TestCase):
             label="Unscoped Key 2",
             user=user,
             scoped_teams=[],  # Empty list = unscoped
-            scopes=None,  # No scopes = access to everything
+            scopes=["*"],  # All scopes
             secure_value=hash_key_value(token_value2),
             mask_value=mask_key_value(token_value2),
         )

--- a/posthog/storage/test/test_team_access_cache.py
+++ b/posthog/storage/test/test_team_access_cache.py
@@ -1310,6 +1310,7 @@ class TestWarmUserTeamsCacheTask(TestCase):
             user=user,
             secure_value=hash_key_value(token),
             mask_value=mask_key_value(token),
+            scopes=["*"],
         )
 
         # Clear any calls from the initial creation

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -44,6 +44,7 @@ class TestUserAPI(APIBaseTest):
             label="X",
             user=self.user,
             secure_value=hash_key_value(self.personal_api_key),
+            scopes=["*"],
         )
 
     def tearDown(self):
@@ -267,7 +268,9 @@ class TestUserAPI(APIBaseTest):
         # Create a new user
         new_user = create_user(email="test@posthog.com", password="1234", organization=self.organization)
         new_personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=new_user, secure_value=hash_key_value(new_personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=new_user, secure_value=hash_key_value(new_personal_api_key), scopes=["*"]
+        )
         self.client.force_login(new_user)
 
         incr_mock.reset_mock()
@@ -282,7 +285,9 @@ class TestUserAPI(APIBaseTest):
         new_team = create_team(organization=self.organization)
         new_user = create_user(email="test2@posthog.com", password="1234", organization=self.organization)
         new_personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(label="X", user=new_user, secure_value=hash_key_value(new_personal_api_key))
+        PersonalAPIKey.objects.create(
+            label="X", user=new_user, secure_value=hash_key_value(new_personal_api_key), scopes=["*"]
+        )
 
         incr_mock.reset_mock()
 

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -32,6 +32,7 @@ class TestEndpoint(ClickhouseTestMixin, APIBaseTest):
             user=self.user,
             label="Test API Key",
             secure_value=hash_key_value(self.api_key),
+            scopes=["*"],
         )
         self.sample_hogql_query = {
             "connectionId": None,

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -162,7 +162,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
     // Query for PersonalAPIKey with scope validation
     // The key must:
     // 1. Have an active user
-    // 2. Have either no scopes (full access) OR have feature_flag:read or feature_flag:write scopes
+    // 2. Have feature_flag:read, feature_flag:write, or all-access (*) scopes
     let query = r#"
         SELECT
             pak.id as key_id,
@@ -177,8 +177,7 @@ pub async fn validate_personal_api_key_with_scopes_for_team(
         WHERE pak.secure_value = $1
           AND u.is_active = true
           AND (
-              pak.scopes IS NULL
-              OR pak.scopes = '{*}'
+              pak.scopes = '{*}'
               OR 'feature_flag:read' = ANY(pak.scopes)
               OR 'feature_flag:write' = ANY(pak.scopes)
           )


### PR DESCRIPTION
## Problem

Personal API keys created before scope management was introduced have `scopes=NULL` in the database. This was treated as implicit all-access, which is error-prone.

For example, if saving the scopes ever runs into a serialization error, a common default is to use `None`. But in this case, `None` means all-access which is counter to expectations.

The existing code has been marked with "TRICKY". I don't like tricky code. We can make the code boring with a simple migration.

## Changes

- Adds a migration to backfill all `scopes=NULL` personal API keys to `scopes=["*"]` (explicit all-access)
- Removes the `scopes IS NULL → all access` special case from `APIScopePermission` — NULL is now treated as no access
- Updates the API serializer to return `[]` instead of `["*"]` when scopes is NULL
- Updates activity logging to use `or []` instead of `or ["*"]`
- Removes the `Q(scopes__isnull=True)` branch from the team access cache flag evaluation query

## How did you test this code?

Updated existing tests to reflect the new semantics: `scopes=None` now means no access rather than all access, and tests that previously relied on `None` for all-access have been updated to use `["*"]` explicitly.

## Publish to changelog?

No