### PR TITLE
fix(propdefs): cache eviction bug in PropertyDefinition for group props

### DIFF
--- a/rust/property-defs-rs/src/batch_ingestion.rs
+++ b/rust/property-defs-rs/src/batch_ingestion.rs
@@ -228,7 +228,20 @@ impl PropertyDefinitionsBatch {
         let timer = common_metrics::timing_guard(V2_PROP_DEFS_BATCH_CACHE_TIME, &[]);
 
         for update in &self.cached {
-            cache.remove(update);
+            // The shared dedup cache stores group property entries with
+            // Unresolved group types (inserted by the producer before
+            // resolution). By the time we get here the batch entries have been
+            // resolved, so we must revert to Unresolved to match the cache key.
+            let cache_key = match update {
+                Update::Property(pd) if pd.group_type_index.is_some() => {
+                    let mut reverted = pd.clone();
+                    reverted.group_type_index =
+                        reverted.group_type_index.map(|gt| gt.as_unresolved());
+                    Update::Property(reverted)
+                }
+                other => other.clone(),
+            };
+            cache.remove(&cache_key);
             metrics::counter!(V2_PROP_DEFS_CACHE_REMOVED).increment(1);
         }
 

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -148,6 +148,17 @@ impl GroupType {
             GroupType::Resolved(name, _) => GroupType::Resolved(name, index),
         }
     }
+
+    /// Returns the Unresolved form of this group type. The shared dedup cache
+    /// always stores entries as Unresolved (inserted by the producer before
+    /// resolution), so cache removal after a failed batch write must use this
+    /// form to match the original key.
+    pub fn as_unresolved(&self) -> Self {
+        match self {
+            GroupType::Unresolved(_) => self.clone(),
+            GroupType::Resolved(name, _) => GroupType::Unresolved(name.clone()),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -551,3 +551,20 @@ impl EventDefinition {
         res
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_unresolved_is_noop_for_unresolved() {
+        let gt = GroupType::Unresolved("company".into());
+        assert_eq!(gt.as_unresolved(), GroupType::Unresolved("company".into()));
+    }
+
+    #[test]
+    fn as_unresolved_strips_resolved_index() {
+        let gt = GroupType::Resolved("company".into(), 2);
+        assert_eq!(gt.as_unresolved(), GroupType::Unresolved("company".into()));
+    }
+}

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use chrono::Utc;
 use property_defs_rs::{
+    batch_ingestion::PropertyDefinitionsBatch,
     types::{
         EventDefinition, EventProperty, GroupType, PropertyDefinition, PropertyParentType,
         PropertyValueType, Update,
@@ -124,24 +127,35 @@ fn test_resolved_group_prop_cannot_remove_unresolved_cache_entry() {
 }
 
 #[test]
-fn test_as_unresolved_removes_cache_entry_across_resolve_boundary() {
-    let cache = Cache::new(10, 10, 10);
+fn test_uncache_batch_evicts_unresolved_entry_for_group_prop() {
+    let cache = Arc::new(Cache::new(10, 10, 10));
 
+    // Producer inserts the unresolved form (before resolution happens)
     let unresolved = make_group_prop_def(Some(GroupType::Unresolved("company".into())));
     cache.insert(unresolved.clone());
     assert!(cache.contains_key(&unresolved));
 
-    // Build the removal key the same way uncache_batch now does: revert
-    // group_type_index to Unresolved before removing.
-    let resolved = make_group_prop_def(Some(GroupType::Resolved("company".into(), 2)));
-    let cache_key = match &resolved {
-        Update::Property(pd) => {
-            let mut reverted = pd.clone();
-            reverted.group_type_index = reverted.group_type_index.map(|gt| gt.as_unresolved());
-            Update::Property(reverted)
-        }
-        other => other.clone(),
+    // Consumer resolves the group type, then append adds it to the batch
+    let resolved_pd = PropertyDefinition {
+        team_id: 1,
+        project_id: 1,
+        name: "company_name".into(),
+        is_numerical: false,
+        property_type: Some(PropertyValueType::String),
+        event_type: PropertyParentType::Group,
+        group_type_index: Some(GroupType::Resolved("company".into(), 2)),
+        property_type_format: None,
+        query_usage_30_day: None,
+        volume_30_day: None,
     };
-    cache.remove(&cache_key);
-    assert!(!cache.contains_key(&unresolved), "entry should be uncached");
+    let mut batch = PropertyDefinitionsBatch::new(10);
+    batch.append(resolved_pd);
+
+    // Simulate batch write failure: uncache_batch should evict the
+    // original unresolved entry so the update can be retried
+    batch.uncache_batch(&cache);
+    assert!(
+        !cache.contains_key(&unresolved),
+        "entry should be uncached after batch failure"
+    );
 }

--- a/rust/property-defs-rs/tests/update_cache.rs
+++ b/rust/property-defs-rs/tests/update_cache.rs
@@ -1,8 +1,8 @@
 use chrono::Utc;
 use property_defs_rs::{
     types::{
-        EventDefinition, EventProperty, PropertyDefinition, PropertyParentType, PropertyValueType,
-        Update,
+        EventDefinition, EventProperty, GroupType, PropertyDefinition, PropertyParentType,
+        PropertyValueType, Update,
     },
     update_cache::Cache,
 };
@@ -88,4 +88,60 @@ fn test_cache_removals() {
     assert!(!cache.contains_key(&evt_def));
     assert!(!cache.contains_key(&evt_prop));
     assert!(!cache.contains_key(&prop_def));
+}
+
+fn make_group_prop_def(group_type_index: Option<GroupType>) -> Update {
+    Update::Property(PropertyDefinition {
+        team_id: 1,
+        project_id: 1,
+        name: String::from("company_name"),
+        is_numerical: false,
+        property_type: Some(PropertyValueType::String),
+        event_type: PropertyParentType::Group,
+        group_type_index,
+        property_type_format: None,
+        query_usage_30_day: None,
+        volume_30_day: None,
+    })
+}
+
+#[test]
+fn test_resolved_group_prop_cannot_remove_unresolved_cache_entry() {
+    let cache = Cache::new(10, 10, 10);
+
+    let unresolved = make_group_prop_def(Some(GroupType::Unresolved("company".into())));
+    cache.insert(unresolved.clone());
+    assert!(cache.contains_key(&unresolved));
+
+    // Simulates what uncache_batch used to do: try to remove the resolved
+    // form. This fails because derived Eq distinguishes the variants.
+    let resolved = make_group_prop_def(Some(GroupType::Resolved("company".into(), 2)));
+    cache.remove(&resolved);
+    assert!(
+        cache.contains_key(&unresolved),
+        "stale entry should still be cached"
+    );
+}
+
+#[test]
+fn test_as_unresolved_removes_cache_entry_across_resolve_boundary() {
+    let cache = Cache::new(10, 10, 10);
+
+    let unresolved = make_group_prop_def(Some(GroupType::Unresolved("company".into())));
+    cache.insert(unresolved.clone());
+    assert!(cache.contains_key(&unresolved));
+
+    // Build the removal key the same way uncache_batch now does: revert
+    // group_type_index to Unresolved before removing.
+    let resolved = make_group_prop_def(Some(GroupType::Resolved("company".into(), 2)));
+    let cache_key = match &resolved {
+        Update::Property(pd) => {
+            let mut reverted = pd.clone();
+            reverted.group_type_index = reverted.group_type_index.map(|gt| gt.as_unresolved());
+            Update::Property(reverted)
+        }
+        other => other.clone(),
+    };
+    cache.remove(&cache_key);
+    assert!(!cache.contains_key(&unresolved), "entry should be uncached");
 }


### PR DESCRIPTION
## Problem
When a batch write of `PropertyDefinition` records exhausts retries and has failed, we attempt to evict the batch entries from the pod-local cache. This ensures the next time we see the property in the event stream for this team, it gets another chance at being written.

But! Due to our unfortunate caching strategy (optimistically cache then evict on write fail) this fails because we resolve groups after we push default entries (of `event_type: Unresolved(...)`) into the `PropertyDefinition` local cache, but a failed write will contain an identical post-resolution entry of `event_type: Resolved(..., N)` so will not be evicted.

This means many group properties never get the chance to self-heal when the next corresponding event is viewed, until the pod cache LRU evicts the entry, or the pod is cycled.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Touch up `PropertyDefinition.entry_type` values just prior to eviction, after a batch write fail.

Long term fix is to restructure the caching to happen _after_ successful writes, not before 🤦 but this is higher lift and this small fix will stop the bleeding in the meantime
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Will smoke test prior to deploy 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
