### PR TITLE
fix(storybook): error on snapshotTargetSelector with fullscreen layout

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -52,7 +52,7 @@ declare module '@storybook/types' {
              * @default ['chromium']
              */
             snapshotBrowsers?: SupportedBrowserName[]
-            /** If taking a component snapshot, you can narrow it down by specifying the selector. */
+            /** Narrow the snapshot to a specific element. Only works for component (non-fullscreen) snapshots — throws an error if used with `layout: 'fullscreen'`. */
             snapshotTargetSelector?: string
             /** specify an alternative viewport size */
             viewport?: { width: number; height: number }
@@ -402,6 +402,13 @@ async function doTakeSnapshotWithTheme(
         targetSelector?: string
     ) => Promise<void>
     if (storyContext.parameters?.layout === 'fullscreen') {
+        if (snapshotTargetSelector) {
+            throw new Error(
+                `snapshotTargetSelector is not supported with layout: 'fullscreen'. ` +
+                    `Fullscreen stories always snapshot body/main. ` +
+                    `Remove snapshotTargetSelector from testOptions or change the layout.`
+            )
+        }
         if (includeNavigationInSnapshot) {
             check = expectStoryToMatchViewportSnapshot
         } else {

--- a/frontend/src/scenes/insights/Funnels.stories.tsx
+++ b/frontend/src/scenes/insights/Funnels.stories.tsx
@@ -162,7 +162,6 @@ const waitForFunnelToStabilize: NonNullable<Story['play']> = async ({ canvasElem
 FunnelLeftToRightEditViewports.parameters = {
     testOptions: {
         waitForSelector: ['[data-attr=funnel-bar-vertical] .StepBar', '.PayGateMini'],
-        snapshotTargetSelector: '[data-attr=funnel-bar-vertical]',
         viewportWidths: ['medium', 'wide', 'superwide'],
     },
 }

--- a/frontend/src/scenes/insights/UserPaths.stories.tsx
+++ b/frontend/src/scenes/insights/UserPaths.stories.tsx
@@ -48,10 +48,6 @@ export const UserPaths: Story = createInsightStory(
 UserPaths.parameters = {
     testOptions: {
         waitForSelector: ['[data-attr=path-node-card-button]:nth-child(7)', '.Paths__canvas'],
-        // Snapshot only the path visualization canvas, not the surrounding page chrome
-        // (InsightPageHeader, SceneTitleSection, etc.) which changes frequently and causes
-        // recurring snapshot drift on master (~30% failure rate).
-        snapshotTargetSelector: '.Paths',
     },
 }
 // The Paths component uses useResizeObserver to measure canvasWidth, then destroys
@@ -80,7 +76,6 @@ export const UserPathsEdit: Story = createInsightStory(
 UserPathsEdit.parameters = {
     testOptions: {
         waitForSelector: ['[data-attr=path-node-card-button]:nth-child(7)', '.Paths__canvas'],
-        snapshotTargetSelector: '.Paths',
     },
 }
 UserPathsEdit.play = waitForPathsCanvasToStabilize
@@ -92,7 +87,6 @@ export const UserPathsEditViewports: Story = createInsightStory(
 UserPathsEditViewports.parameters = {
     testOptions: {
         waitForSelector: ['[data-attr=path-node-card-button]:nth-child(7)', '.Paths__canvas'],
-        snapshotTargetSelector: '.Paths',
         viewportWidths: ['medium', 'wide', 'superwide'],
     },
 }

--- a/frontend/src/scenes/insights/stories/TrendsLine.stories.tsx
+++ b/frontend/src/scenes/insights/stories/TrendsLine.stories.tsx
@@ -204,7 +204,6 @@ const waitForTrendsCanvasToStabilize: NonNullable<Story['play']> = async ({ canv
 TrendsLineMultiEditViewports.parameters = {
     testOptions: {
         waitForSelector: '[data-attr=trend-line-graph] > canvas',
-        snapshotTargetSelector: '[data-attr=trend-line-graph]',
         viewportWidths: ['medium', 'wide', 'superwide'],
     },
 }


### PR DESCRIPTION
## Summary

- Throws a clear error when `snapshotTargetSelector` is used in a story with `layout: 'fullscreen'` — these stories always snapshot the full body/main, so the selector is silently ignored and misleads test authors
- Updates the JSDoc comment on `snapshotTargetSelector` to document this constraint
- Removes `snapshotTargetSelector` from the affected fullscreen insight stories (`FunnelLeftToRightEditViewports`, `UserPaths*`, `TrendsLineMultiEditViewports`)

introduced in error by https://github.com/PostHog/posthog/commit/6539875e92a7b9dad7f38fe7bdd07182b48902fa

🤖 Generated with [Claude Code](https://claude.com/claude-code)