### PR TITLE
fix(filters): Stabilize infiniteListCounts selector 

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1231,15 +1231,25 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
         ],
         infiniteListCounts: [
             (s) => [
-                (state, props) =>
-                    Object.fromEntries(
-                        Object.entries(s.infiniteListLogics(state, props)).map(([groupType, logic]) => [
-                            groupType,
-                            logic.isMounted() ? logic.selectors.totalListCount(state, logic.props) : 0,
-                        ])
-                    ),
+                (state, props) => {
+                    const logics = s.infiniteListLogics(state, props)
+                    return Object.entries(logics)
+                        .map(([groupType, logic]) => {
+                            const count = logic.isMounted() ? logic.selectors.totalListCount(state, logic.props) : 0
+                            return `${groupType}:${count}`
+                        })
+                        .join(',')
+                },
             ],
-            (infiniteListCounts) => infiniteListCounts,
+            (countsString: string): Record<string, number> =>
+                countsString
+                    ? Object.fromEntries(
+                          countsString.split(',').map((entry) => {
+                              const sep = entry.lastIndexOf(':')
+                              return [entry.slice(0, sep), Number(entry.slice(sep + 1))]
+                          })
+                      )
+                    : {},
         ],
         value: [() => [(_, props) => props.value], (value) => value],
         groupType: [() => [(_, props) => props.groupType], (groupType) => groupType],


### PR DESCRIPTION
## Problem
The `infiniteListCounts` selector in `taxonomicFilterLogic` called `Object.fromEntries()` inside the input selector, creating a new object reference on every evaluation. Reselect's `inputStabilityCheck` detected this unstable input and triggered infinite re-render loops, causing timeouts in tests with the taxonomic filter.                                                                                  
                                                                                                                                                               
## Changes                                                
1. Serialize counts to a stable primitive string in the input selector (matching the existing `loadingGroupTypes` pattern)
2. Move `Object.fromEntries()` into the result function where reselect memoizes the output                        
## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
