### PR TITLE
chore(mcp): track transport type

### DIFF
--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -251,8 +251,10 @@ const handleRequest = async (
 
     let server: Promise<Response> | null = null
     if (url.pathname.startsWith('/mcp')) {
+        Object.assign(ctx.props, { transport: 'streamable-http' })
         server = MCP.serve('/mcp').fetch(request, env, ctx)
     } else if (url.pathname.startsWith('/sse')) {
+        Object.assign(ctx.props, { transport: 'sse' })
         server = MCP.serveSSE('/sse').fetch(request, env, ctx)
     }
 

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -42,6 +42,7 @@ export type RequestProperties = {
     projectId?: string
     clientUserAgent?: string
     readOnly?: boolean
+    transport?: 'streamable-http' | 'sse'
 }
 
 export class MCP extends McpAgent<Env> {
@@ -225,6 +226,7 @@ export class MCP extends McpAgent<Env> {
                     ...(this._mcpClientName ? { mcp_client_name: this._mcpClientName } : {}),
                     ...(this._mcpClientVersion ? { mcp_client_version: this._mcpClientVersion } : {}),
                     ...(this._mcpProtocolVersion ? { mcp_protocol_version: this._mcpProtocolVersion } : {}),
+                    ...(this.requestProperties.transport ? { mcp_transport: this.requestProperties.transport } : {}),
                     ...properties,
                 },
             })


### PR DESCRIPTION
## Problem

I want to know whether SSE is still used.

## Changes

- Added `transport` field to `RequestProperties` type to track the protocol used ('streamable-http' or 'sse')
- Set the transport type in `ctx.props` when routing requests to either the `/mcp` or `/sse` endpoints
- Include the transport type in MCP telemetry/logging as `mcp_transport` property

## How did you test this code?

The changes are straightforward property assignments and type additions. Existing request routing logic remains unchanged, so no new test scenarios are required. The transport property is conditionally included in telemetry only when present, maintaining backward compatibility.

## Publish to changelog?

no

https://claude.ai/code/session_01Po6PWbxCpnAW6BxPPgUNme