### PR TITLE
fix: resizer on ticket scene

### DIFF
--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -183,7 +183,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         }
                     />
                     <div className="hidden lg:block">
-                        <Resizer {...resizerLogicProps} />
+                        <Resizer {...resizerLogicProps} className="z-20" />
                     </div>
                 </div>
 


### PR DESCRIPTION
## Problem

z-index of resizer is higher than scene title


![ezgif-78ff9b7611ab1c93](https://github.com/user-attachments/assets/5ee27e1b-c1ed-4435-84e3-145fa439db02)

## Solution

pass z-20