### PR TITLE
feat(llma): add tools to read from new AI events table

### DIFF
--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.ts
@@ -115,7 +115,7 @@ export const dataTableLogic = kea<dataTableLogicType>([
                 columnsInResponse: string[] | null,
                 context: QueryContext<DataTableNode> | undefined
             ): DataTableRow[] | null => {
-                if (response && sourceKind === NodeKind.EventsQuery) {
+                if (response && (sourceKind === NodeKind.EventsQuery || sourceKind === NodeKind.AiEventsQuery)) {
                     const queryResponse = response as AnyResponseType
                     if (queryResponse) {
                         let results: any[] | null = []

--- a/frontend/src/queries/nodes/DataTable/utils.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.ts
@@ -40,7 +40,7 @@ export function defaultDataTableColumns(
 ): HogQLExpression[] {
     return kind === NodeKind.PersonsNode || kind === NodeKind.ActorsQuery
         ? getDefaultDataTablePersonColumns(personLastSeenAtEnabled)
-        : kind === NodeKind.EventsQuery
+        : kind === NodeKind.EventsQuery || kind === NodeKind.AiEventsQuery
           ? defaultDataTableEventColumns
           : kind === NodeKind.SessionsQuery
             ? defaultDataTableSessionColumns

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -376,6 +376,117 @@
             "enum": ["numeric", "duration", "duration_ms", "percentage", "percentage_scaled", "currency", "short"],
             "type": "string"
         },
+        "AiEventsQuery": {
+            "additionalProperties": false,
+            "description": "Query node for AI events that transparently chooses the `ai_events` table (within 30-day TTL) or the `events` table (beyond TTL). When using `ai_events`, property references like `properties.$ai_*` are rewritten to dedicated column names.",
+            "properties": {
+                "actionId": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Show events matching a given action"
+                },
+                "after": {
+                    "description": "Only fetch events that happened after this timestamp",
+                    "type": "string"
+                },
+                "before": {
+                    "description": "Only fetch events that happened before this timestamp",
+                    "type": "string"
+                },
+                "event": {
+                    "description": "Limit to events matching this string",
+                    "type": ["string", "null"]
+                },
+                "events": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Filter to events matching any of these event names"
+                },
+                "filterTestAccounts": {
+                    "description": "Filter test accounts",
+                    "type": "boolean"
+                },
+                "fixedProperties": {
+                    "description": "Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)",
+                    "items": {
+                        "$ref": "#/definitions/AnyFilterLike"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "const": "AiEventsQuery",
+                    "type": "string"
+                },
+                "limit": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Number of rows to return"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "offset": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Number of rows to skip before returning rows"
+                },
+                "orderBy": {
+                    "description": "Columns to order by",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "personId": {
+                    "description": "Show events for a given person",
+                    "type": "string"
+                },
+                "properties": {
+                    "description": "Properties configurable in the interface",
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
+                },
+                "response": {
+                    "$ref": "#/definitions/EventsQueryResponse"
+                },
+                "select": {
+                    "description": "Return a limited set of data. Required.",
+                    "items": {
+                        "$ref": "#/definitions/HogQLExpression"
+                    },
+                    "type": "array"
+                },
+                "source": {
+                    "$ref": "#/definitions/InsightActorsQuery",
+                    "description": "source for querying events for insights"
+                },
+                "tags": {
+                    "$ref": "#/definitions/QueryLogTags"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                },
+                "where": {
+                    "description": "HogQL filters to apply on returned data",
+                    "items": {
+                        "$ref": "#/definitions/HogQLExpression"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["kind", "select"],
+            "type": "object"
+        },
         "AlertCalculationInterval": {
             "enum": ["hourly", "daily", "weekly", "monthly"],
             "type": "string"
@@ -596,6 +707,9 @@
                 },
                 {
                     "$ref": "#/definitions/TraceNeighborsQuery"
+                },
+                {
+                    "$ref": "#/definitions/AiEventsQuery"
                 },
                 {
                     "$ref": "#/definitions/VectorSearchQuery"
@@ -10848,6 +10962,9 @@
                         },
                         {
                             "$ref": "#/definitions/EventsQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/AiEventsQuery"
                         },
                         {
                             "$ref": "#/definitions/PersonsNode"
@@ -22690,6 +22807,7 @@
                 "LogAttributesQuery",
                 "LogValuesQuery",
                 "SessionBatchEventsQuery",
+                "AiEventsQuery",
                 "DataTableNode",
                 "DataVisualizationNode",
                 "SavedInsightNode",
@@ -28717,6 +28835,9 @@
                 },
                 {
                     "$ref": "#/definitions/TraceNeighborsQuery"
+                },
+                {
+                    "$ref": "#/definitions/AiEventsQuery"
                 },
                 {
                     "$ref": "#/definitions/VectorSearchQuery"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -106,6 +106,7 @@ export enum NodeKind {
     LogAttributesQuery = 'LogAttributesQuery',
     LogValuesQuery = 'LogValuesQuery',
     SessionBatchEventsQuery = 'SessionBatchEventsQuery',
+    AiEventsQuery = 'AiEventsQuery',
 
     // Interface nodes
     DataTableNode = 'DataTableNode',
@@ -232,6 +233,7 @@ export type AnyDataNode =
     | TracesQuery
     | TraceQuery
     | TraceNeighborsQuery
+    | AiEventsQuery
     | VectorSearchQuery
     | UsageMetricsQuery
     | EndpointsUsageOverviewQuery
@@ -325,6 +327,7 @@ export type QuerySchema =
     | TracesQuery
     | TraceQuery
     | TraceNeighborsQuery
+    | AiEventsQuery
     | VectorSearchQuery
 
     // Customer analytics
@@ -864,6 +867,15 @@ export interface EventsQuery extends DataNode<EventsQueryResponse> {
     orderBy?: string[]
 }
 
+/**
+ * Query node for AI events that transparently chooses the `ai_events` table (within 30-day TTL)
+ * or the `events` table (beyond TTL). When using `ai_events`, property references like
+ * `properties.$ai_*` are rewritten to dedicated column names.
+ */
+export interface AiEventsQuery extends Omit<EventsQuery, 'kind' | 'response'>, DataNode<EventsQueryResponse> {
+    kind: NodeKind.AiEventsQuery
+}
+
 export interface SessionsQueryResponse extends AnalyticsQueryResponseBase {
     results: any[][]
     columns: any[]
@@ -968,6 +980,7 @@ export interface DataTableNode
                     | ExperimentFunnelsQuery
                     | ExperimentTrendsQuery
                     | TracesQuery
+                    | AiEventsQuery
                     | EndpointsUsageTableQuery
                 )['response']
             >
@@ -978,6 +991,7 @@ export interface DataTableNode
     source:
         | EventsNode
         | EventsQuery
+        | AiEventsQuery
         | PersonsNode
         | ActorsQuery
         | GroupsQuery

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -21,6 +21,7 @@ import {
     EndpointsUsageTrendsQuery,
     ErrorTrackingIssueCorrelationQuery,
     ErrorTrackingQuery,
+    AiEventsQuery,
     EventsNode,
     EventsQuery,
     ExperimentFunnelsQuery,
@@ -108,8 +109,8 @@ export function isGroupNode(node?: Record<string, any> | null): node is GroupNod
     return node?.kind === NodeKind.GroupNode
 }
 
-export function isEventsQuery(node?: Record<string, any> | null): node is EventsQuery {
-    return node?.kind === NodeKind.EventsQuery
+export function isEventsQuery(node?: Record<string, any> | null): node is EventsQuery | AiEventsQuery {
+    return node?.kind === NodeKind.EventsQuery || node?.kind === NodeKind.AiEventsQuery
 }
 
 export function isSessionsQuery(node?: Record<string, any> | null): node is SessionsQuery {

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -76,6 +76,7 @@ def reset_clickhouse_tables():
     from posthog.clickhouse.plugin_log_entries import TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL
     from posthog.heatmaps.sql import TRUNCATE_HEATMAPS_TABLE_SQL
     from posthog.models.ai.pg_embeddings import TRUNCATE_PG_EMBEDDINGS_TABLE_SQL
+    from posthog.models.ai_events.sql import TRUNCATE_AI_EVENTS_TABLE_SQL
     from posthog.models.app_metrics.sql import TRUNCATE_APP_METRICS_TABLE_SQL
     from posthog.models.channel_type.sql import TRUNCATE_CHANNEL_DEFINITION_TABLE_SQL
     from posthog.models.cohort.sql import TRUNCATE_COHORTPEOPLE_TABLE_SQL
@@ -121,6 +122,7 @@ def reset_clickhouse_tables():
         TRUNCATE_RAW_SESSIONS_TABLE_SQL(),
         TRUNCATE_HEATMAPS_TABLE_SQL(),
         TRUNCATE_PG_EMBEDDINGS_TABLE_SQL(),
+        TRUNCATE_AI_EVENTS_TABLE_SQL(),
     ]
 
     # Drop created Kafka tables because some tests don't expect it.

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -606,6 +606,11 @@ class FieldType(Type):
     def get_child(self, name: str | int, context: HogQLContext) -> Type:
         database_field = self.resolve_database_field(context)
         if database_field is None:
+            # For non-BaseTableType (e.g. subquery aliases), check the constant type
+            # to determine if this field supports property access (JSON / array).
+            constant_type = self.resolve_constant_type(context)
+            if isinstance(constant_type, (StringJSONType, StringArrayType)):
+                return PropertyType(chain=[name], field_type=self)
             raise ResolutionError(f'Can not access property "{name}" on field "{self.name}".')
         if isinstance(database_field, StringJSONDatabaseField):
             return PropertyType(chain=[name], field_type=self)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -56,6 +56,7 @@ from posthog.hogql.database.models import (
 from posthog.hogql.database.postgres_table import PostgresTable
 from posthog.hogql.database.postgres_utils import add_postgres_foreign_key_lazy_joins
 from posthog.hogql.database.s3_table import S3Table
+from posthog.hogql.database.schema.ai_events import AiEventsTable
 from posthog.hogql.database.schema.app_metrics2 import AppMetrics2Table
 from posthog.hogql.database.schema.channel_type import create_initial_channel_type, create_initial_domain_type
 from posthog.hogql.database.schema.cohort_membership import CohortMembershipTable
@@ -195,6 +196,7 @@ ROOT_TABLES__DO_NOT_ADD_ANY_MORE: dict[str, TableNode] = {
     "batch_export_log_entries": TableNode(name="batch_export_log_entries", table=BatchExportLogEntriesTable()),
     "sessions": TableNode(name="sessions", table=SessionsTableV1()),
     "heatmaps": TableNode(name="heatmaps", table=HeatmapsTable()),
+    "ai_events": TableNode(name="ai_events", table=AiEventsTable()),
     "exchange_rate": TableNode(name="exchange_rate", table=ExchangeRateTable()),
     "document_embeddings": TableNode(name="document_embeddings", table=DocumentEmbeddingsTable()),
     **{name: TableNode(name=name, table=table) for name, table in HOGQL_MODEL_TABLES.items()},

--- a/posthog/hogql/database/schema/ai_events.py
+++ b/posthog/hogql/database/schema/ai_events.py
@@ -1,0 +1,102 @@
+from posthog.hogql.database.models import (
+    BooleanDatabaseField,
+    DateTimeDatabaseField,
+    FieldOrTable,
+    FieldTraverser,
+    FloatDatabaseField,
+    IntegerDatabaseField,
+    LazyJoin,
+    StringDatabaseField,
+    StringJSONDatabaseField,
+    Table,
+)
+from posthog.hogql.database.schema.person_distinct_ids import (
+    PersonDistinctIdsTable,
+    join_with_person_distinct_ids_table,
+)
+
+
+class AiEventsTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        # Core
+        "uuid": StringDatabaseField(name="uuid", nullable=False),
+        "event": StringDatabaseField(name="event", nullable=False),
+        "timestamp": DateTimeDatabaseField(name="timestamp", nullable=False),
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "distinct_id": StringDatabaseField(name="distinct_id", nullable=False),
+        "person_id": StringDatabaseField(name="person_id", nullable=False),
+        "properties": StringJSONDatabaseField(name="properties", nullable=False),
+        "retention_days": IntegerDatabaseField(name="retention_days", nullable=False),
+        # Trace structure
+        "trace_id": StringDatabaseField(name="trace_id", nullable=False),
+        "session_id": StringDatabaseField(name="session_id", nullable=False),
+        "parent_id": StringDatabaseField(name="parent_id", nullable=False),
+        "span_id": StringDatabaseField(name="span_id", nullable=False),
+        "span_type": StringDatabaseField(name="span_type", nullable=False),
+        "generation_id": StringDatabaseField(name="generation_id", nullable=False),
+        # Names
+        "span_name": StringDatabaseField(name="span_name", nullable=False),
+        "trace_name": StringDatabaseField(name="trace_name", nullable=False),
+        "prompt_name": StringDatabaseField(name="prompt_name", nullable=False),
+        # Model info
+        "model": StringDatabaseField(name="model", nullable=False),
+        "provider": StringDatabaseField(name="provider", nullable=False),
+        "framework": StringDatabaseField(name="framework", nullable=False),
+        # Token counts
+        "total_tokens": IntegerDatabaseField(name="total_tokens", nullable=False),
+        "input_tokens": IntegerDatabaseField(name="input_tokens", nullable=False),
+        "output_tokens": IntegerDatabaseField(name="output_tokens", nullable=False),
+        "text_input_tokens": IntegerDatabaseField(name="text_input_tokens", nullable=False),
+        "text_output_tokens": IntegerDatabaseField(name="text_output_tokens", nullable=False),
+        "image_input_tokens": IntegerDatabaseField(name="image_input_tokens", nullable=False),
+        "image_output_tokens": IntegerDatabaseField(name="image_output_tokens", nullable=False),
+        "audio_input_tokens": IntegerDatabaseField(name="audio_input_tokens", nullable=False),
+        "audio_output_tokens": IntegerDatabaseField(name="audio_output_tokens", nullable=False),
+        "video_input_tokens": IntegerDatabaseField(name="video_input_tokens", nullable=False),
+        "video_output_tokens": IntegerDatabaseField(name="video_output_tokens", nullable=False),
+        "reasoning_tokens": IntegerDatabaseField(name="reasoning_tokens", nullable=False),
+        "cache_read_input_tokens": IntegerDatabaseField(name="cache_read_input_tokens", nullable=False),
+        "cache_creation_input_tokens": IntegerDatabaseField(name="cache_creation_input_tokens", nullable=False),
+        "web_search_count": IntegerDatabaseField(name="web_search_count", nullable=False),
+        # Costs
+        "input_cost_usd": FloatDatabaseField(name="input_cost_usd", nullable=False),
+        "output_cost_usd": FloatDatabaseField(name="output_cost_usd", nullable=False),
+        "total_cost_usd": FloatDatabaseField(name="total_cost_usd", nullable=False),
+        "request_cost_usd": FloatDatabaseField(name="request_cost_usd", nullable=False),
+        "web_search_cost_usd": FloatDatabaseField(name="web_search_cost_usd", nullable=False),
+        "audio_cost_usd": FloatDatabaseField(name="audio_cost_usd", nullable=False),
+        "image_cost_usd": FloatDatabaseField(name="image_cost_usd", nullable=False),
+        "video_cost_usd": FloatDatabaseField(name="video_cost_usd", nullable=False),
+        # Timing
+        "latency": FloatDatabaseField(name="latency", nullable=False),
+        "time_to_first_token": FloatDatabaseField(name="time_to_first_token", nullable=False),
+        # Errors
+        "is_error": BooleanDatabaseField(name="is_error", nullable=False),
+        "error": StringDatabaseField(name="error", nullable=False),
+        "error_type": StringDatabaseField(name="error_type", nullable=False),
+        "error_normalized": StringDatabaseField(name="error_normalized", nullable=False),
+        # Heavy columns (JSON strings — use StringJSONDatabaseField so HogQL
+        # handles array/object access via JSONExtract under the hood)
+        "input": StringJSONDatabaseField(name="input", nullable=False),
+        "output": StringJSONDatabaseField(name="output", nullable=False),
+        "output_choices": StringJSONDatabaseField(name="output_choices", nullable=False),
+        "input_state": StringJSONDatabaseField(name="input_state", nullable=False),
+        "output_state": StringJSONDatabaseField(name="output_state", nullable=False),
+        "tools": StringJSONDatabaseField(name="tools", nullable=False),
+        # Materialized previews
+        "input_preview": StringDatabaseField(name="input_preview", nullable=False),
+        "output_choices_preview": StringDatabaseField(name="output_choices_preview", nullable=False),
+        # Person join via person_distinct_ids
+        "pdi": LazyJoin(
+            from_field=["distinct_id"],
+            join_table=PersonDistinctIdsTable(),
+            join_function=join_with_person_distinct_ids_table,
+        ),
+        "person": FieldTraverser(chain=["pdi", "person"]),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "ai_events"
+
+    def to_printed_hogql(self):
+        return "ai_events"

--- a/posthog/hogql_queries/ai/ai_column_rewriter.py
+++ b/posthog/hogql_queries/ai/ai_column_rewriter.py
@@ -1,0 +1,114 @@
+"""AST rewriter that translates queries written against `ai_events` columns to work with the `events` table.
+
+This is the reverse of `AiPropertyRewriter`. When a query's date range extends beyond the
+`ai_events` 30-day TTL, the query must target the `events` table instead. This rewriter:
+
+1. Rewrites dedicated column references (e.g. `trace_id`) to property access
+   (e.g. `properties.$ai_trace_id`) so they resolve against the `events` table.
+2. Swaps the `ai_events` table prefix to `events` in table-qualified field chains.
+3. Replaces the FROM clause from `ai_events` to `events`.
+
+The rewriter is scope-aware: it only rewrites fields within SELECT queries that have
+`FROM ai_events`. Fields in outer queries (referencing subquery aliases) are left unchanged.
+"""
+
+from posthog.hogql import ast
+from posthog.hogql.visitor import CloningVisitor
+
+from posthog.hogql_queries.ai.ai_property_rewriter import AI_PROPERTY_TO_COLUMN
+
+# Invert AI_PROPERTY_TO_COLUMN: column_name -> property_name
+AI_COLUMN_TO_PROPERTY: dict[str, str] = {col: prop for prop, col in AI_PROPERTY_TO_COLUMN.items()}
+
+
+class AiColumnToPropertyRewriter(CloningVisitor):
+    """Rewrites `ai_events` column references to `events` property references.
+
+    Scope-aware: only rewrites fields within SELECT queries that have `FROM ai_events`.
+    Fields in outer queries (referencing subquery aliases) are left unchanged.
+
+    When `force_rewrite=True`, always rewrites regardless of scope (for standalone expressions
+    like placeholders that will be substituted into ai_events-scoped queries).
+    """
+
+    def __init__(self, force_rewrite: bool = False):
+        super().__init__()
+        self._in_ai_events_scope = force_rewrite
+
+    def visit_select_query(self, node: ast.SelectQuery) -> ast.SelectQuery:
+        was_in_scope = self._in_ai_events_scope
+        if _has_ai_events_from(node):
+            self._in_ai_events_scope = True
+        result = super().visit_select_query(node)
+        self._in_ai_events_scope = was_in_scope
+        return result
+
+    def visit_field(self, node: ast.Field) -> ast.Expr:
+        if not self._in_ai_events_scope:
+            return super().visit_field(node)
+
+        chain = node.chain
+
+        # Table-qualified: ["ai_events", "column_name", ...]
+        if len(chain) >= 2 and chain[0] == "ai_events":
+            col_name = chain[1]
+            if isinstance(col_name, str) and col_name in AI_COLUMN_TO_PROPERTY:
+                prop_name = AI_COLUMN_TO_PROPERTY[col_name]
+                new_chain: list[str | int] = ["events", "properties", prop_name, *chain[2:]]
+                return _maybe_wrap_boolean(prop_name, new_chain)
+            # Native column (timestamp, event, distinct_id, etc.) — just swap table prefix
+            return ast.Field(chain=["events", *chain[1:]])
+
+        # Bare column: ["column_name", ...]
+        if len(chain) >= 1:
+            col_name = chain[0]
+            if isinstance(col_name, str) and col_name in AI_COLUMN_TO_PROPERTY:
+                prop_name = AI_COLUMN_TO_PROPERTY[col_name]
+                new_chain = ["properties", prop_name, *chain[1:]]
+                return _maybe_wrap_boolean(prop_name, new_chain)
+
+        return super().visit_field(node)
+
+    def visit_join_expr(self, node: ast.JoinExpr) -> ast.JoinExpr:
+        new_node = super().visit_join_expr(node)
+        # Swap FROM ai_events -> FROM events
+        if isinstance(new_node.table, ast.Field) and new_node.table.chain == ["ai_events"]:
+            new_node.table = ast.Field(chain=["events"])
+        return new_node
+
+
+def _has_ai_events_from(query: ast.SelectQuery) -> bool:
+    """Check if a SELECT query has FROM ai_events."""
+    return (
+        query.select_from is not None
+        and isinstance(query.select_from.table, ast.Field)
+        and query.select_from.table.chain == ["ai_events"]
+    )
+
+
+def _maybe_wrap_boolean(prop_name: str, chain: list[str | int]) -> ast.Expr:
+    """Wrap boolean properties to preserve UInt8 semantics used in trace runner queries."""
+    if prop_name == "$ai_is_error":
+        return ast.Call(
+            name="if",
+            args=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=chain),
+                    right=ast.Constant(value="true"),
+                ),
+                ast.Constant(value=1),
+                ast.Constant(value=0),
+            ],
+        )
+    return ast.Field(chain=chain)
+
+
+def rewrite_query_for_events_table(query: ast.SelectQuery | ast.SelectSetQuery) -> ast.SelectQuery | ast.SelectSetQuery:
+    """Rewrite a query written against `ai_events` to target the `events` table."""
+    return AiColumnToPropertyRewriter(force_rewrite=False).visit(query)
+
+
+def rewrite_expr_for_events_table(expr: ast.Expr) -> ast.Expr:
+    """Rewrite a standalone expression (e.g. a placeholder value) for the events table."""
+    return AiColumnToPropertyRewriter(force_rewrite=True).visit(expr)

--- a/posthog/hogql_queries/ai/ai_events_query_runner.py
+++ b/posthog/hogql_queries/ai/ai_events_query_runner.py
@@ -1,0 +1,205 @@
+from datetime import datetime
+from typing import Any, cast
+
+from posthog.schema import AiEventsQuery, CachedEventsQueryResponse, EventsQuery, EventsQueryResponse
+
+from posthog.hogql import ast
+from posthog.hogql.visitor import CloningVisitor
+
+from posthog.hogql_queries.ai.ai_property_rewriter import AiPropertyRewriter
+from posthog.hogql_queries.ai.ai_table_resolver import (
+    is_ai_events_enabled,
+    is_within_ai_events_ttl,
+    validate_ai_event_names,
+)
+from posthog.hogql_queries.events_query_runner import EventsQueryRunner
+from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
+from posthog.hogql_queries.query_runner import QueryRunner
+from posthog.models.person.util import get_persons_by_distinct_ids
+from posthog.utils import relative_date_parse
+
+
+class AiEventsQueryRunner(QueryRunner):
+    """Query runner for AI events that transparently chooses ai_events or events table.
+
+    When the date range is within the 30-day ai_events TTL, queries the ai_events table
+    and rewrites `properties.$ai_*` references to dedicated column names.
+    Beyond the TTL, falls back to the standard events table.
+    """
+
+    query: AiEventsQuery
+    cached_response: CachedEventsQueryResponse
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._events_runner = self._create_events_runner()
+        self.paginator = HogQLHasMorePaginator.from_limit_context(
+            limit_context=self.limit_context,
+            limit=self.query.limit,
+            offset=self.query.offset,
+        )
+
+    def _create_events_runner(self) -> EventsQueryRunner:
+        events_query = EventsQuery(
+            kind="EventsQuery",
+            select=self.query.select,
+            where=self.query.where,
+            properties=self.query.properties,
+            fixedProperties=self.query.fixedProperties,
+            orderBy=self.query.orderBy,
+            limit=self.query.limit,
+            offset=self.query.offset,
+            after=self.query.after,
+            before=self.query.before,
+            event=self.query.event,
+            events=self.query.events,
+            actionId=self.query.actionId,
+            personId=self.query.personId,
+            filterTestAccounts=self.query.filterTestAccounts,
+        )
+        return EventsQueryRunner(
+            query=events_query,
+            team=self.team,
+            timings=self.timings,
+            limit_context=self.limit_context,
+            modifiers=self.modifiers,
+        )
+
+    def _should_use_ai_events_table(self) -> bool:
+        if not is_ai_events_enabled(self.team):
+            return False
+
+        after = self.query.after or "-24h"
+        if after == "all":
+            return False
+
+        now = datetime.now(tz=self.team.timezone_info)
+        date_from = relative_date_parse(after, self.team.timezone_info)
+        if not is_within_ai_events_ttl(date_from, now):
+            return False
+
+        # If 'before' is explicitly set beyond TTL, fall back to events
+        if self.query.before:
+            date_to = relative_date_parse(self.query.before, self.team.timezone_info)
+            if not is_within_ai_events_ttl(date_to, now):
+                return False
+
+        return True
+
+    def _validate(self) -> None:
+        event_names: list[str] = []
+        if self.query.event:
+            event_names.append(self.query.event)
+        if self.query.events:
+            event_names.extend(self.query.events)
+        if event_names:
+            validate_ai_event_names(event_names)
+
+    def to_query(self) -> ast.SelectQuery:
+        query_ast = self._events_runner.to_query()
+        if self._should_use_ai_events_table():
+            query_ast = self._rewrite_for_ai_events(query_ast)
+        return query_ast
+
+    def _rewrite_for_ai_events(self, query: ast.SelectQuery) -> ast.SelectQuery:
+        rewritten = cast(ast.SelectQuery, AiPropertyRewriter().visit(query))
+        rewritten = cast(ast.SelectQuery, _EventsToAiEventsTableRewriter().visit(rewritten))
+        return rewritten
+
+    def _calculate(self) -> EventsQueryResponse:
+        self._validate()
+
+        # If we should use ai_events, rewrite and execute directly
+        if self._should_use_ai_events_table():
+            query_result = self.paginator.execute_hogql_query(
+                query=self.to_query(),
+                team=self.team,
+                query_type="AiEventsQuery",
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
+
+            self._enrich_persons()
+
+            return EventsQueryResponse(
+                results=self.paginator.results,
+                columns=self._events_runner.columns(query_result.columns),
+                types=[t for _, t in query_result.types] if query_result.types else [],
+                hogql=query_result.hogql,
+                timings=self.timings.to_list(),
+                modifiers=self.modifiers,
+                **self.paginator.response_params(),
+            )
+
+        # Fall back to standard EventsQueryRunner
+        return self._events_runner.calculate()
+
+    def _enrich_persons(self) -> None:
+        """Person enrichment — duplicated from EventsQueryRunner._calculate()
+        to derisk any effect on normal event queries. Can be refactored into
+        a shared method once the ai_events migration is stable."""
+        person_indices: list[int] = []
+        for column_index, col in enumerate(self._events_runner.select_input_raw()):
+            if col.split("--")[0].strip() == "person":
+                person_indices.append(column_index)
+            if col.split("--")[0].strip() == "person_display_name":
+                for index, result in enumerate(self.paginator.results):
+                    row = list(self.paginator.results[index])
+                    row[column_index] = {
+                        "display_name": result[column_index][0],
+                        "id": str(result[column_index][1]),
+                        "distinct_id": str(result[column_index][2]),
+                    }
+                    self.paginator.results[index] = row
+
+        if len(person_indices) > 0 and len(self.paginator.results) > 0:
+            with self.timings.measure("person_column_extra_query"):
+                person_idx = person_indices[0]
+                distinct_ids = list({event[person_idx] for event in self.paginator.results})
+
+                distinct_to_person: dict[str, Any] = {}
+                batch_size = 1000
+                for i in range(0, len(distinct_ids), batch_size):
+                    batch_distinct_ids = distinct_ids[i : i + batch_size]
+                    requested_batch = set(batch_distinct_ids)
+                    persons = get_persons_by_distinct_ids(self.team.pk, batch_distinct_ids)
+                    for person in persons:
+                        if person:
+                            for person_distinct_id in person.distinct_ids:
+                                if person_distinct_id in requested_batch:
+                                    distinct_to_person[person_distinct_id] = person
+
+                for column_index in person_indices:
+                    for index, result in enumerate(self.paginator.results):
+                        distinct_id: str = result[column_index]
+                        self.paginator.results[index] = list(result)
+                        if distinct_to_person.get(distinct_id):
+                            person = distinct_to_person[distinct_id]
+                            self.paginator.results[index][column_index] = {
+                                "uuid": person.uuid,
+                                "created_at": person.created_at,
+                                "properties": person.properties or {},
+                                "distinct_id": distinct_id,
+                            }
+                        else:
+                            self.paginator.results[index][column_index] = {
+                                "distinct_id": distinct_id,
+                            }
+
+    def columns(self, result_columns: list[str]) -> list[str]:
+        return self._events_runner.columns(result_columns)
+
+
+class _EventsToAiEventsTableRewriter(CloningVisitor):
+    """Swaps all `FROM events` table references to `FROM ai_events` throughout the AST.
+
+    The EventsQueryRunner may produce nested subqueries (e.g. presorted optimization)
+    that also reference the events table, so a top-level-only swap is insufficient.
+    """
+
+    def visit_join_expr(self, node: ast.JoinExpr) -> ast.JoinExpr:
+        new_node = super().visit_join_expr(node)
+        if isinstance(new_node.table, ast.Field) and new_node.table.chain == ["events"]:
+            new_node.table = ast.Field(chain=["ai_events"])
+        return new_node

--- a/posthog/hogql_queries/ai/ai_property_rewriter.py
+++ b/posthog/hogql_queries/ai/ai_property_rewriter.py
@@ -1,0 +1,160 @@
+"""AST rewriter that transforms `properties.$ai_*` field references to dedicated `ai_events` column names.
+
+Follows the `ExprTransformer` / `CloningVisitor` pattern from
+`posthog/hogql/transforms/preaggregated_table_transformation.py`.
+"""
+
+from posthog.hogql import ast
+from posthog.hogql.visitor import CloningVisitor
+
+# Mapping from AI property names to their dedicated ai_events column names.
+# Properties not in this mapping remain as JSONExtract on the `properties` column.
+AI_PROPERTY_TO_COLUMN: dict[str, str] = {
+    # Trace structure
+    "$ai_trace_id": "trace_id",
+    "$ai_session_id": "session_id",
+    "$ai_parent_id": "parent_id",
+    "$ai_span_id": "span_id",
+    "$ai_span_type": "span_type",
+    "$ai_generation_id": "generation_id",
+    # Names
+    "$ai_span_name": "span_name",
+    "$ai_trace_name": "trace_name",
+    "$ai_prompt_name": "prompt_name",
+    # Model info
+    "$ai_model": "model",
+    "$ai_provider": "provider",
+    "$ai_framework": "framework",
+    # Token counts
+    "$ai_total_tokens": "total_tokens",
+    "$ai_input_tokens": "input_tokens",
+    "$ai_output_tokens": "output_tokens",
+    "$ai_text_input_tokens": "text_input_tokens",
+    "$ai_text_output_tokens": "text_output_tokens",
+    "$ai_image_input_tokens": "image_input_tokens",
+    "$ai_image_output_tokens": "image_output_tokens",
+    "$ai_audio_input_tokens": "audio_input_tokens",
+    "$ai_audio_output_tokens": "audio_output_tokens",
+    "$ai_video_input_tokens": "video_input_tokens",
+    "$ai_video_output_tokens": "video_output_tokens",
+    "$ai_reasoning_tokens": "reasoning_tokens",
+    "$ai_cache_read_input_tokens": "cache_read_input_tokens",
+    "$ai_cache_creation_input_tokens": "cache_creation_input_tokens",
+    "$ai_web_search_count": "web_search_count",
+    # Costs
+    "$ai_input_cost_usd": "input_cost_usd",
+    "$ai_output_cost_usd": "output_cost_usd",
+    "$ai_total_cost_usd": "total_cost_usd",
+    "$ai_request_cost_usd": "request_cost_usd",
+    "$ai_web_search_cost_usd": "web_search_cost_usd",
+    "$ai_audio_cost_usd": "audio_cost_usd",
+    "$ai_image_cost_usd": "image_cost_usd",
+    "$ai_video_cost_usd": "video_cost_usd",
+    # Timing
+    "$ai_latency": "latency",
+    "$ai_time_to_first_token": "time_to_first_token",
+    # Errors
+    "$ai_is_error": "is_error",
+    "$ai_error": "error",
+    "$ai_error_type": "error_type",
+    "$ai_error_normalized": "error_normalized",
+    # Heavy columns
+    "$ai_input": "input",
+    "$ai_output": "output",
+    "$ai_output_choices": "output_choices",
+    "$ai_input_state": "input_state",
+    "$ai_output_state": "output_state",
+    "$ai_tools": "tools",
+    # Previews
+    "$ai_input_preview": "input_preview",
+    "$ai_output_choices_preview": "output_choices_preview",
+}
+
+_BOOLEAN_PROPERTIES: frozenset[str] = frozenset({"$ai_is_error"})
+
+# Values that map to UInt8 1 (truthy) for boolean AI property columns
+_TRUTHY_VALUES: frozenset[str | bool | int] = frozenset({"true", True, "1"})
+# Values that map to UInt8 0 (falsy) for boolean AI property columns
+_FALSY_VALUES: frozenset[str | bool | int] = frozenset({"false", False, "0", ""})
+
+
+def _rewrite_property_field(chain: list[str | int]) -> tuple[list[str | int], str | None] | None:
+    """If chain matches `properties.$ai_*`, return (rewritten_chain, property_name).
+
+    Handles patterns:
+      - ["properties", "$ai_foo"]          → (["column_name"], "$ai_foo")
+      - ["events", "properties", "$ai_foo"] → (["events", "column_name"], "$ai_foo")
+
+    Returns None if the field is not a rewritable AI property.
+    """
+    if len(chain) >= 2 and chain[-2] == "properties":
+        prop_name = chain[-1]
+        if isinstance(prop_name, str) and prop_name in AI_PROPERTY_TO_COLUMN:
+            prefix = list(chain[:-2])
+            return [*prefix, AI_PROPERTY_TO_COLUMN[prop_name]], prop_name
+    return None
+
+
+def _is_boolean_property_field(node: ast.Expr) -> bool:
+    """Check if an expression is a Field referencing a boolean AI property."""
+    if not isinstance(node, ast.Field):
+        return False
+    result = _rewrite_property_field(node.chain)
+    return result is not None and result[1] in _BOOLEAN_PROPERTIES
+
+
+def _normalize_boolean_constant(value: object) -> ast.Constant | None:
+    """Convert a truthy/falsy value to a UInt8-compatible constant (1 or 0)."""
+    if value in _TRUTHY_VALUES:
+        return ast.Constant(value=1)
+    if value in _FALSY_VALUES:
+        return ast.Constant(value=0)
+    return None
+
+
+class AiPropertyRewriter(CloningVisitor):
+    """Rewrites `properties.$ai_*` field references to dedicated ai_events column references.
+
+    Boolean properties like `$ai_is_error` map to native UInt8 columns. When a boolean
+    property appears in a comparison (e.g. `properties.$ai_is_error = 'true'` or `= True`),
+    the constant is normalized to UInt8 (1/0) to match the column type. This handles both
+    hardcoded HogQL strings (value='true') and property_to_expr output (value=True).
+    """
+
+    def visit_compare_operation(self, node: ast.CompareOperation) -> ast.Expr:
+        # Intercept comparisons involving boolean AI properties before field-level
+        # rewriting, so we can normalize the constant side to UInt8.
+        left_is_bool = _is_boolean_property_field(node.left)
+        right_is_bool = _is_boolean_property_field(node.right)
+
+        if left_is_bool and isinstance(node.right, ast.Constant):
+            new_const = _normalize_boolean_constant(node.right.value)
+            if new_const is not None:
+                return ast.CompareOperation(
+                    op=node.op,
+                    left=self.visit(node.left),
+                    right=new_const,
+                )
+
+        if right_is_bool and isinstance(node.left, ast.Constant):
+            new_const = _normalize_boolean_constant(node.left.value)
+            if new_const is not None:
+                return ast.CompareOperation(
+                    op=node.op,
+                    left=new_const,
+                    right=self.visit(node.right),
+                )
+
+        return super().visit_compare_operation(node)
+
+    def visit_field(self, node: ast.Field) -> ast.Expr:
+        result = _rewrite_property_field(node.chain)
+        if result is not None:
+            chain, _prop_name = result
+            return ast.Field(chain=chain)
+        return super().visit_field(node)
+
+
+def rewrite_expr_for_ai_events_table(expr: ast.Expr) -> ast.Expr:
+    """Rewrite property references in a standalone expression to use ai_events dedicated columns."""
+    return AiPropertyRewriter().visit(expr)

--- a/posthog/hogql_queries/ai/ai_table_resolver.py
+++ b/posthog/hogql_queries/ai/ai_table_resolver.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+import posthoganalytics
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+AI_EVENTS_TTL_DAYS = 30
+
+
+def is_ai_events_enabled(team: Team) -> bool:
+    return posthoganalytics.feature_enabled(
+        "ai-events-table-rollout",
+        str(team.id),
+        groups={"organization": str(team.organization_id)},
+        group_properties={"organization": {"id": str(team.organization_id)}},
+        send_feature_flag_events=False,
+    )
+
+
+# Canonical Python list. Node.js mirror: nodejs/src/ingestion/ai/process-ai-event.ts
+AI_EVENT_NAMES = frozenset(
+    {
+        "$ai_generation",
+        "$ai_span",
+        "$ai_trace",
+        "$ai_embedding",
+        "$ai_metric",
+        "$ai_feedback",
+        "$ai_evaluation",
+    }
+)
+
+
+def is_within_ai_events_ttl(date_from: datetime, now: datetime) -> bool:
+    """True if date_from is within the ai_events TTL window.
+
+    Includes a 1-day buffer because date pickers truncate to midnight (making
+    "Last 30 days" slightly over 30 calendar days) and ai_events uses
+    ttl_only_drop_parts=1, so data survives until the full day partition expires.
+    """
+    # Strip timezone info to avoid naive/aware comparison errors
+    date_from_naive = date_from.replace(tzinfo=None)
+    now_naive = now.replace(tzinfo=None)
+    cutoff = now_naive - timedelta(days=AI_EVENTS_TTL_DAYS + 1)
+    return date_from_naive >= cutoff
+
+
+def validate_ai_event_names(events: list[str]) -> None:
+    """Raise if any event name is not a recognized AI event."""
+    invalid = set(events) - AI_EVENT_NAMES
+    if invalid:
+        raise ValueError(f"AiEventsQuery only supports AI events, got: {invalid}")

--- a/posthog/hogql_queries/ai/test/test_ai_column_rewriter.py
+++ b/posthog/hogql_queries/ai/test/test_ai_column_rewriter.py
@@ -1,0 +1,136 @@
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+
+from posthog.hogql_queries.ai.ai_column_rewriter import (
+    AI_COLUMN_TO_PROPERTY,
+    AiColumnToPropertyRewriter,
+    rewrite_expr_for_events_table,
+    rewrite_query_for_events_table,
+)
+
+
+class TestAiColumnToPropertyRewriter:
+    def test_bare_column_rewritten(self):
+        node = ast.Field(chain=["trace_id"])
+        result = AiColumnToPropertyRewriter(force_rewrite=True).visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["properties", "$ai_trace_id"]
+
+    def test_table_qualified_column_rewritten(self):
+        node = ast.Field(chain=["ai_events", "trace_id"])
+        result = AiColumnToPropertyRewriter(force_rewrite=True).visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["events", "properties", "$ai_trace_id"]
+
+    def test_native_column_keeps_table_prefix_swap(self):
+        node = ast.Field(chain=["ai_events", "timestamp"])
+        result = AiColumnToPropertyRewriter(force_rewrite=True).visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["events", "timestamp"]
+
+    def test_non_ai_column_unchanged(self):
+        node = ast.Field(chain=["event"])
+        result = AiColumnToPropertyRewriter(force_rewrite=True).visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["event"]
+
+    def test_boolean_column_wrapped(self):
+        node = ast.Field(chain=["is_error"])
+        result = AiColumnToPropertyRewriter(force_rewrite=True).visit(node)
+        assert isinstance(result, ast.Call)
+        assert result.name == "if"
+        compare = result.args[0]
+        assert isinstance(compare, ast.CompareOperation)
+        assert isinstance(compare.left, ast.Field)
+        assert compare.left.chain == ["properties", "$ai_is_error"]
+        assert isinstance(compare.right, ast.Constant)
+        assert compare.right.value == "true"
+        assert result.args[1].value == 1
+        assert result.args[2].value == 0
+
+    def test_scope_only_rewrites_in_ai_events_query(self):
+        query = parse_select("SELECT trace_id FROM ai_events")
+        result = rewrite_query_for_events_table(query)
+        assert isinstance(result, ast.SelectQuery)
+        assert isinstance(result.select[0], ast.Field)
+        assert result.select[0].chain == ["properties", "$ai_trace_id"]
+        assert result.select_from.table.chain == ["events"]
+
+    def test_scope_skips_non_ai_events_query(self):
+        query = parse_select("SELECT trace_id FROM events")
+        result = rewrite_query_for_events_table(query)
+        assert isinstance(result, ast.SelectQuery)
+        assert isinstance(result.select[0], ast.Field)
+        assert result.select[0].chain == ["trace_id"]
+
+    def test_subquery_inner_rewritten_outer_preserved(self):
+        query = parse_select("SELECT trace_id FROM (SELECT trace_id AS trace_id FROM ai_events GROUP BY trace_id)")
+        result = rewrite_query_for_events_table(query)
+        assert isinstance(result, ast.SelectQuery)
+        # Outer trace_id references the alias — NOT rewritten
+        assert isinstance(result.select[0], ast.Field)
+        assert result.select[0].chain == ["trace_id"]
+        # Inner query rewritten
+        inner = result.select_from.table
+        assert isinstance(inner, ast.SelectQuery)
+        assert inner.select_from.table.chain == ["events"]
+        # Inner SELECT: Alias(alias="trace_id", expr=Field(chain=["properties", "$ai_trace_id"]))
+        inner_select = inner.select[0]
+        assert isinstance(inner_select, ast.Alias)
+        assert inner_select.alias == "trace_id"
+        assert isinstance(inner_select.expr, ast.Field)
+        assert inner_select.expr.chain == ["properties", "$ai_trace_id"]
+
+    def test_force_rewrite_ignores_scope(self):
+        node = ast.Field(chain=["trace_id"])
+        result = AiColumnToPropertyRewriter(force_rewrite=True).visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["properties", "$ai_trace_id"]
+
+    def test_rewrite_expr_for_events_table(self):
+        expr = ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["trace_id"]),
+                    right=ast.Constant(value="abc"),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["ai_events", "timestamp"]),
+                    right=ast.Constant(value="2025-01-01"),
+                ),
+            ]
+        )
+        result = rewrite_expr_for_events_table(expr)
+        assert isinstance(result, ast.And)
+        # trace_id → properties.$ai_trace_id
+        left0 = result.exprs[0].left
+        assert isinstance(left0, ast.Field)
+        assert left0.chain == ["properties", "$ai_trace_id"]
+        # ai_events.timestamp → events.timestamp
+        left1 = result.exprs[1].left
+        assert isinstance(left1, ast.Field)
+        assert left1.chain == ["events", "timestamp"]
+
+    def test_union_all_both_branches_rewritten(self):
+        query = parse_select(
+            """
+            SELECT trace_id AS trace_id FROM ai_events
+            UNION ALL
+            SELECT trace_id AS trace_id FROM ai_events
+            """
+        )
+        result = rewrite_query_for_events_table(query)
+        assert isinstance(result, ast.SelectSetQuery)
+        # Both branches should have FROM events
+        q1 = result.initial_select_query
+        q2 = result.subsequent_select_queries[0].select_query
+        assert q1.select_from.table.chain == ["events"]
+        assert q2.select_from.table.chain == ["events"]
+
+    def test_column_to_property_mapping_is_inverse(self):
+        from posthog.hogql_queries.ai.ai_property_rewriter import AI_PROPERTY_TO_COLUMN
+
+        for prop, col in AI_PROPERTY_TO_COLUMN.items():
+            assert AI_COLUMN_TO_PROPERTY[col] == prop

--- a/posthog/hogql_queries/ai/test/test_ai_events_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_ai_events_query_runner.py
@@ -1,0 +1,224 @@
+import pytest
+from freezegun import freeze_time
+from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+from unittest.mock import patch
+
+from posthog.schema import AiEventsQuery
+
+from posthog.hogql import ast
+
+from posthog.hogql_queries.ai.ai_events_query_runner import AiEventsQueryRunner
+
+FLAG_ENABLED = patch("posthog.hogql_queries.ai.ai_events_query_runner.is_ai_events_enabled", return_value=True)
+FLAG_DISABLED = patch("posthog.hogql_queries.ai.ai_events_query_runner.is_ai_events_enabled", return_value=False)
+
+
+class TestAiEventsQueryRunner(ClickhouseTestMixin, BaseTest):
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_should_use_ai_events_table_default(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"])
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        assert runner._should_use_ai_events_table() is True
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_should_use_ai_events_table_recent(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], after="-24h")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        assert runner._should_use_ai_events_table() is True
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_should_not_use_ai_events_table_for_all(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], after="all")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        assert runner._should_use_ai_events_table() is False
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_DISABLED
+    def test_should_not_use_ai_events_table_when_flag_disabled(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], after="-24h")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        assert runner._should_use_ai_events_table() is False
+
+    def test_validate_raises_for_non_ai_events(self):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], event="$pageview")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        with pytest.raises(ValueError, match="only supports AI events"):
+            runner._validate()
+
+    def test_validate_passes_for_ai_events(self):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], event="$ai_generation")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        runner._validate()
+
+    def test_validate_passes_with_no_events(self):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"])
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        runner._validate()
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    def test_rewrite_changes_from_clause(self):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"])
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        original = runner._events_runner.to_query()
+        rewritten = runner._rewrite_for_ai_events(original)
+        assert isinstance(rewritten.select_from, ast.JoinExpr)
+        assert isinstance(rewritten.select_from.table, ast.Field)
+        assert rewritten.select_from.table.chain == ["ai_events"]
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_to_query_uses_ai_events_within_ttl(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], after="-24h")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        query_ast = runner.to_query()
+        assert isinstance(query_ast.select_from, ast.JoinExpr)
+        assert isinstance(query_ast.select_from.table, ast.Field)
+        assert query_ast.select_from.table.chain == ["ai_events"]
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_to_query_uses_events_beyond_ttl(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], after="all")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        query_ast = runner.to_query()
+        assert isinstance(query_ast.select_from, ast.JoinExpr)
+        assert isinstance(query_ast.select_from.table, ast.Field)
+        assert query_ast.select_from.table.chain == ["events"]
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_calculate_from_ai_events_table(self, _mock):
+        # _create_event writes to `events`; the MV populates `ai_events` automatically.
+        _create_event(
+            event="$ai_generation",
+            distinct_id="user1",
+            team=self.team,
+            properties={
+                "$ai_trace_id": "trace-1",
+                "$ai_model": "gpt-4",
+                "$ai_input_tokens": 100,
+                "$ai_output_tokens": 50,
+            },
+            timestamp="2026-03-12T11:00:00",
+        )
+
+        query = AiEventsQuery(
+            kind="AiEventsQuery",
+            select=["event", "timestamp"],
+            after="-24h",
+            event="$ai_generation",
+        )
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        result = runner.calculate()
+        assert len(result.results) == 1
+        assert result.results[0][0] == "$ai_generation"
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_should_not_use_ai_events_table_before_beyond_ttl(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], before="2026-01-01")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        assert runner._should_use_ai_events_table() is False
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_should_use_ai_events_table_before_within_ttl(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], before="-5d")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        assert runner._should_use_ai_events_table() is True
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_calculate_fallback_to_events_table(self, _mock):
+        _create_event(
+            event="$ai_generation",
+            distinct_id="user1",
+            team=self.team,
+            properties={
+                "$ai_trace_id": "trace-1",
+                "$ai_model": "gpt-4",
+            },
+            timestamp="2026-03-12T11:00:00",
+        )
+
+        query = AiEventsQuery(
+            kind="AiEventsQuery",
+            select=["event", "timestamp"],
+            after="all",
+            event="$ai_generation",
+        )
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        result = runner.calculate()
+        assert len(result.results) == 1
+        assert result.results[0][0] == "$ai_generation"
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_calculate_enriches_person_column(self, _mock):
+        _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["user1"],
+            properties={"email": "test@example.com"},
+        )
+        _create_event(
+            event="$ai_generation",
+            distinct_id="user1",
+            team=self.team,
+            properties={"$ai_trace_id": "trace-1"},
+            timestamp="2026-03-12T11:00:00",
+        )
+        flush_persons_and_events()
+
+        query = AiEventsQuery(
+            kind="AiEventsQuery",
+            select=["person"],
+            after="-24h",
+            event="$ai_generation",
+        )
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        result = runner.calculate()
+        assert len(result.results) == 1
+        person = result.results[0][0]
+        assert isinstance(person, dict)
+        assert person["distinct_id"] == "user1"
+        assert "uuid" in person
+        assert "created_at" in person
+        assert person["properties"]["email"] == "test@example.com"
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_ENABLED
+    def test_calculate_person_column_unknown_distinct_id(self, _mock):
+        _create_event(
+            event="$ai_generation",
+            distinct_id="unknown-user",
+            team=self.team,
+            properties={"$ai_trace_id": "trace-1"},
+            timestamp="2026-03-12T11:00:00",
+        )
+
+        query = AiEventsQuery(
+            kind="AiEventsQuery",
+            select=["person"],
+            after="-24h",
+            event="$ai_generation",
+        )
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        result = runner.calculate()
+        assert len(result.results) == 1
+        person = result.results[0][0]
+        assert isinstance(person, dict)
+        assert person["distinct_id"] == "unknown-user"
+        assert "uuid" not in person
+
+    @freeze_time("2026-03-12T12:00:00Z")
+    @FLAG_DISABLED
+    def test_to_query_falls_back_to_events_when_flag_disabled(self, _mock):
+        query = AiEventsQuery(kind="AiEventsQuery", select=["*"], after="-24h")
+        runner = AiEventsQueryRunner(query=query, team=self.team)
+        query_ast = runner.to_query()
+        assert isinstance(query_ast.select_from, ast.JoinExpr)
+        assert isinstance(query_ast.select_from.table, ast.Field)
+        assert query_ast.select_from.table.chain == ["events"]

--- a/posthog/hogql_queries/ai/test/test_ai_property_rewriter.py
+++ b/posthog/hogql_queries/ai/test/test_ai_property_rewriter.py
@@ -1,0 +1,126 @@
+import pytest
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+
+from posthog.hogql_queries.ai.ai_property_rewriter import AiPropertyRewriter, _rewrite_property_field
+
+
+class TestRewritePropertyField:
+    def test_simple_ai_property(self):
+        result = _rewrite_property_field(["properties", "$ai_trace_id"])
+        assert result is not None
+        chain, prop_name = result
+        assert chain == ["trace_id"]
+        assert prop_name == "$ai_trace_id"
+
+    def test_table_prefixed_ai_property(self):
+        result = _rewrite_property_field(["events", "properties", "$ai_model"])
+        assert result is not None
+        chain, prop_name = result
+        assert chain == ["events", "model"]
+        assert prop_name == "$ai_model"
+
+    def test_non_ai_property_returns_none(self):
+        assert _rewrite_property_field(["properties", "$browser"]) is None
+
+    def test_short_chain_returns_none(self):
+        assert _rewrite_property_field(["$ai_trace_id"]) is None
+
+    def test_non_properties_parent_returns_none(self):
+        assert _rewrite_property_field(["other", "$ai_trace_id"]) is None
+
+
+class TestAiPropertyRewriter:
+    def test_rewrites_ai_property_field(self):
+        node = ast.Field(chain=["properties", "$ai_trace_id"])
+        rewriter = AiPropertyRewriter()
+        result = rewriter.visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["trace_id"]
+
+    def test_boolean_property_rewritten_to_native_column(self):
+        node = ast.Field(chain=["properties", "$ai_is_error"])
+        rewriter = AiPropertyRewriter()
+        result = rewriter.visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["is_error"]
+
+    def test_non_ai_property_unchanged(self):
+        node = ast.Field(chain=["properties", "$browser"])
+        rewriter = AiPropertyRewriter()
+        result = rewriter.visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["properties", "$browser"]
+
+    def test_rewrite_with_table_prefix(self):
+        node = ast.Field(chain=["events", "properties", "$ai_model"])
+        rewriter = AiPropertyRewriter()
+        result = rewriter.visit(node)
+        assert isinstance(result, ast.Field)
+        assert result.chain == ["events", "model"]
+
+    def test_full_query_ast_roundtrip(self):
+        query = parse_select("SELECT properties.$ai_trace_id, properties.$browser FROM events")
+        rewriter = AiPropertyRewriter()
+        rewritten = rewriter.visit(query)
+        # First select: properties.$ai_trace_id → trace_id field
+        assert isinstance(rewritten.select[0], ast.Field)
+        assert rewritten.select[0].chain == ["trace_id"]
+        # Second select: properties.$browser left unchanged
+        assert isinstance(rewritten.select[1], ast.Field)
+        assert rewritten.select[1].chain == ["properties", "$browser"]
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("true", 1),
+            (True, 1),
+            (1, 1),
+            ("false", 0),
+            (False, 0),
+            (0, 0),
+            ("", 0),
+        ],
+    )
+    def test_boolean_comparison_normalizes_constant(self, value, expected):
+        node = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=["properties", "$ai_is_error"]),
+            right=ast.Constant(value=value),
+        )
+        rewriter = AiPropertyRewriter()
+        result = rewriter.visit(node)
+        assert isinstance(result, ast.CompareOperation)
+        assert isinstance(result.left, ast.Field)
+        assert result.left.chain == ["is_error"]
+        assert isinstance(result.right, ast.Constant)
+        assert result.right.value == expected
+
+    def test_boolean_comparison_constant_on_left(self):
+        node = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Constant(value="true"),
+            right=ast.Field(chain=["properties", "$ai_is_error"]),
+        )
+        rewriter = AiPropertyRewriter()
+        result = rewriter.visit(node)
+        assert isinstance(result, ast.CompareOperation)
+        assert isinstance(result.left, ast.Constant)
+        assert result.left.value == 1
+        assert isinstance(result.right, ast.Field)
+        assert result.right.chain == ["is_error"]
+
+    def test_non_boolean_property_comparison_unchanged(self):
+        node = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=["properties", "$ai_model"]),
+            right=ast.Constant(value="gpt-4"),
+        )
+        rewriter = AiPropertyRewriter()
+        result = rewriter.visit(node)
+        assert isinstance(result, ast.CompareOperation)
+        assert isinstance(result.left, ast.Field)
+        assert result.left.chain == ["model"]
+        assert isinstance(result.right, ast.Constant)
+        assert result.right.value == "gpt-4"

--- a/posthog/hogql_queries/ai/test/test_ai_table_resolver.py
+++ b/posthog/hogql_queries/ai/test/test_ai_table_resolver.py
@@ -1,0 +1,90 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from unittest.mock import Mock, patch
+
+from posthog.hogql_queries.ai.ai_table_resolver import (
+    AI_EVENTS_TTL_DAYS,
+    is_ai_events_enabled,
+    is_within_ai_events_ttl,
+    validate_ai_event_names,
+)
+
+
+class TestIsWithinAiEventsTtl:
+    def test_within_ttl(self):
+        now = datetime(2026, 3, 12, 12, 0, 0)
+        date_from = now - timedelta(days=20)
+        assert is_within_ai_events_ttl(date_from, now) is True
+
+    def test_at_ttl_boundary_with_buffer(self):
+        now = datetime(2026, 3, 12, 12, 0, 0)
+        # Exactly 30 days ago — within the 1-day buffer
+        date_from = now - timedelta(days=AI_EVENTS_TTL_DAYS)
+        assert is_within_ai_events_ttl(date_from, now) is True
+
+    def test_at_buffer_boundary(self):
+        now = datetime(2026, 3, 12, 12, 0, 0)
+        # Exactly 31 days ago — cutoff is TTL + 1 day, so exactly at cutoff
+        date_from = now - timedelta(days=AI_EVENTS_TTL_DAYS + 1)
+        assert is_within_ai_events_ttl(date_from, now) is True
+
+    def test_beyond_buffer(self):
+        now = datetime(2026, 3, 12, 12, 0, 0)
+        date_from = now - timedelta(days=AI_EVENTS_TTL_DAYS + 2)
+        assert is_within_ai_events_ttl(date_from, now) is False
+
+    def test_aware_datetimes(self):
+        now = datetime(2026, 3, 12, 12, 0, 0, tzinfo=UTC)
+        date_from = now - timedelta(days=20)
+        assert is_within_ai_events_ttl(date_from, now) is True
+
+    def test_mixed_naive_aware(self):
+        now = datetime(2026, 3, 12, 12, 0, 0, tzinfo=UTC)
+        date_from = datetime(2026, 2, 20, 12, 0, 0)  # naive
+        assert is_within_ai_events_ttl(date_from, now) is True
+
+
+class TestIsAiEventsEnabled:
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.posthoganalytics.feature_enabled", return_value=True)
+    def test_returns_true_when_flag_enabled(self, mock_flag):
+        team = Mock(id=123, organization_id="org_abc")
+        assert is_ai_events_enabled(team) is True
+        mock_flag.assert_called_once_with(
+            "ai-events-table-rollout",
+            "123",
+            groups={"organization": "org_abc"},
+            group_properties={"organization": {"id": "org_abc"}},
+            send_feature_flag_events=False,
+        )
+
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.posthoganalytics.feature_enabled", return_value=False)
+    def test_returns_false_when_flag_disabled(self, mock_flag):
+        team = Mock(id=456, organization_id="org_xyz")
+        assert is_ai_events_enabled(team) is False
+        mock_flag.assert_called_once_with(
+            "ai-events-table-rollout",
+            "456",
+            groups={"organization": "org_xyz"},
+            group_properties={"organization": {"id": "org_xyz"}},
+            send_feature_flag_events=False,
+        )
+
+
+class TestValidateAiEventNames:
+    def test_valid_ai_events(self):
+        validate_ai_event_names(["$ai_generation", "$ai_span", "$ai_trace"])
+
+    def test_single_valid_event(self):
+        validate_ai_event_names(["$ai_generation"])
+
+    def test_empty_list(self):
+        validate_ai_event_names([])
+
+    def test_invalid_event_raises(self):
+        with pytest.raises(ValueError, match="only supports AI events"):
+            validate_ai_event_names(["$pageview"])
+
+    def test_mixed_valid_invalid_raises(self):
+        with pytest.raises(ValueError, match="only supports AI events"):
+            validate_ai_event_names(["$ai_generation", "$pageview"])

--- a/posthog/hogql_queries/ai/utils.py
+++ b/posthog/hogql_queries/ai/utils.py
@@ -1,9 +1,52 @@
 from abc import ABC
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional, cast
+
+import orjson
+
+from posthog.schema import LLMTrace, LLMTraceEvent
 
 from posthog.caching.utils import ThresholdMode, is_stale
 from posthog.models.team.team import Team
+
+# Mapping from ai_events dedicated columns to their original property names.
+# These are stripped from the properties JSON by the MV and stored in dedicated columns.
+HEAVY_COLUMN_TO_PROPERTY: dict[str, str] = {
+    "input": "$ai_input",
+    "output": "$ai_output",
+    "output_choices": "$ai_output_choices",
+    "input_state": "$ai_input_state",
+    "output_state": "$ai_output_state",
+    "tools": "$ai_tools",
+}
+
+
+def merge_heavy_properties(
+    properties_json: str,
+    heavy_columns: dict[str, str],
+) -> dict[str, Any]:
+    """Take an ai_events row's properties JSON and heavy column values, return a complete properties dict.
+
+    The ai_events MV strips heavy properties from the JSON blob and stores them
+    in dedicated columns. This function merges them back so consumers get a
+    complete event.
+
+    ``heavy_columns`` maps column name → raw string value (as returned by
+    ClickHouse).  Empty strings are skipped (the column default when the
+    property was absent).
+    """
+    props: dict[str, Any] = orjson.loads(properties_json) if properties_json else {}
+    for column_name, raw_value in heavy_columns.items():
+        if not raw_value:
+            continue
+        prop_key = HEAVY_COLUMN_TO_PROPERTY.get(column_name)
+        if prop_key is None:
+            continue
+        try:
+            props[prop_key] = orjson.loads(raw_value)
+        except (orjson.JSONDecodeError, TypeError):
+            props[prop_key] = raw_value
+    return props
 
 
 class TaxonomyCacheMixin(ABC):
@@ -17,3 +60,78 @@ class TaxonomyCacheMixin(ABC):
 
     def cache_target_age(self, last_refresh: Optional[datetime], lazy: bool = False) -> Optional[datetime]:
         return None
+
+
+class TraceMapperMixin:
+    """Shared mapping logic for TraceQueryRunner and TracesQueryRunner."""
+
+    TRACE_FIELDS_MAPPING: dict[str, str] = {
+        "id": "id",
+        "ai_session_id": "aiSessionId",
+        "created_at": "createdAt",
+        "first_distinct_id": "distinctId",
+        "total_latency": "totalLatency",
+        "input_state_parsed": "inputState",
+        "output_state_parsed": "outputState",
+        "input_tokens": "inputTokens",
+        "output_tokens": "outputTokens",
+        "input_cost": "inputCost",
+        "output_cost": "outputCost",
+        "total_cost": "totalCost",
+        "events": "events",
+        "trace_name": "traceName",
+    }
+
+    def _map_event(self, event_tuple: tuple) -> LLMTraceEvent:
+        event_uuid, event_name, event_timestamp, event_properties, *heavy = event_tuple
+        heavy_columns = dict(zip(("input", "output", "output_choices", "input_state", "output_state", "tools"), heavy))
+        generation: dict[str, Any] = {
+            "id": str(event_uuid),
+            "event": event_name,
+            "createdAt": event_timestamp.isoformat(),
+            "properties": merge_heavy_properties(event_properties, heavy_columns),
+        }
+        return LLMTraceEvent.model_validate(generation)
+
+    def _map_trace(self, result: dict[str, Any], created_at: datetime) -> LLMTrace:
+        generations = []
+        for event_tuple in result["events"]:
+            generations.append(self._map_event(event_tuple))
+
+        trace_dict = {
+            **result,
+            "created_at": created_at.isoformat(),
+            "events": generations,
+        }
+        for raw_key, parsed_key in [("input_state", "input_state_parsed"), ("output_state", "output_state_parsed")]:
+            raw = trace_dict.get(raw_key) or None
+            trace_dict[raw_key] = raw
+            if raw is not None:
+                try:
+                    trace_dict[parsed_key] = orjson.loads(raw)
+                except (TypeError, orjson.JSONDecodeError):
+                    trace_dict[parsed_key] = raw
+        trace = LLMTrace.model_validate(
+            {
+                self.TRACE_FIELDS_MAPPING[key]: value
+                for key, value in trace_dict.items()
+                if key in self.TRACE_FIELDS_MAPPING
+            }
+        )
+        return trace
+
+    def _map_results(self, columns: list[str], query_results: list) -> list[LLMTrace]:
+        mapped_results = [dict(zip(columns, value)) for value in query_results]
+        traces = []
+
+        for result in mapped_results:
+            timestamp_dt = cast(datetime, result["first_timestamp"])
+            if (
+                timestamp_dt < self._date_range.date_from_for_filtering()
+                or timestamp_dt > self._date_range.date_to_for_filtering()
+            ):
+                continue
+
+            traces.append(self._map_trace(result, timestamp_dt))
+
+        return traces

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ConfigDict
 from posthog.schema import (
     ActorsPropertyTaxonomyQuery,
     ActorsQuery,
+    AiEventsQuery,
     CacheMissResponse,
     CalendarHeatmapQuery,
     ChartDisplayType,
@@ -181,6 +182,7 @@ RunnableQueryNode = Union[
     LifecycleQuery,
     ActorsQuery,
     EventsQuery,
+    AiEventsQuery,
     SessionBatchEventsQuery,
     HogQLQuery,
     InsightActorsQuery,
@@ -732,6 +734,16 @@ def get_query_runner(
 
         return ActorsPropertyTaxonomyQueryRunner(
             query=cast(ActorsPropertyTaxonomyQuery | dict[str, Any], query),
+            team=team,
+            timings=timings,
+            limit_context=limit_context,
+            modifiers=modifiers,
+        )
+    if kind == "AiEventsQuery":
+        from .ai.ai_events_query_runner import AiEventsQueryRunner
+
+        return AiEventsQueryRunner(
+            query=cast(AiEventsQuery | dict[str, Any], query),
             team=team,
             timings=timings,
             limit_context=limit_context,

--- a/posthog/models/ai_events/test_util.py
+++ b/posthog/models/ai_events/test_util.py
@@ -1,0 +1,196 @@
+"""Test utilities for creating AI events in the ai_events ClickHouse table."""
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from posthog.clickhouse.client import sync_execute
+
+
+def bulk_create_ai_events(events: list[dict[str, Any]]) -> None:
+    """
+    Insert AI events directly into the ai_events ClickHouse table for testing.
+    Each event dict should have: event, distinct_id, team (or team_id), properties, timestamp.
+    """
+    if not events:
+        return
+
+    inserts = []
+    params: dict[str, Any] = {}
+
+    for index, event_data in enumerate(events):
+        timestamp = event_data.get("timestamp") or datetime.now()
+        if isinstance(timestamp, str):
+            from dateutil.parser import isoparse
+
+            timestamp = isoparse(timestamp)
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=UTC)
+        timestamp_str = timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")
+
+        team_id = event_data.get("team_id") or event_data["team"].pk
+        properties = event_data.get("properties", {})
+        properties_json = json.dumps(properties)
+
+        event_uuid = str(event_data.get("event_uuid") or uuid.uuid4())
+        person_id = str(event_data.get("person_id") or uuid.uuid4())
+
+        inserts.append(
+            """(
+                %(uuid_{i})s,
+                %(event_{i})s,
+                %(timestamp_{i})s,
+                %(team_id_{i})s,
+                %(distinct_id_{i})s,
+                %(person_id_{i})s,
+                %(properties_{i})s,
+                %(trace_id_{i})s,
+                %(session_id_{i})s,
+                %(parent_id_{i})s,
+                %(span_id_{i})s,
+                %(span_type_{i})s,
+                %(generation_id_{i})s,
+                %(span_name_{i})s,
+                %(trace_name_{i})s,
+                %(prompt_name_{i})s,
+                %(model_{i})s,
+                %(provider_{i})s,
+                %(framework_{i})s,
+                %(total_tokens_{i})s,
+                %(input_tokens_{i})s,
+                %(output_tokens_{i})s,
+                %(text_input_tokens_{i})s,
+                %(text_output_tokens_{i})s,
+                %(image_input_tokens_{i})s,
+                %(image_output_tokens_{i})s,
+                %(audio_input_tokens_{i})s,
+                %(audio_output_tokens_{i})s,
+                %(video_input_tokens_{i})s,
+                %(video_output_tokens_{i})s,
+                %(reasoning_tokens_{i})s,
+                %(cache_read_input_tokens_{i})s,
+                %(cache_creation_input_tokens_{i})s,
+                %(web_search_count_{i})s,
+                %(input_cost_usd_{i})s,
+                %(output_cost_usd_{i})s,
+                %(total_cost_usd_{i})s,
+                %(request_cost_usd_{i})s,
+                %(web_search_cost_usd_{i})s,
+                %(audio_cost_usd_{i})s,
+                %(image_cost_usd_{i})s,
+                %(video_cost_usd_{i})s,
+                %(latency_{i})s,
+                %(time_to_first_token_{i})s,
+                %(is_error_{i})s,
+                %(error_{i})s,
+                %(error_type_{i})s,
+                %(error_normalized_{i})s,
+                %(input_{i})s,
+                %(output_{i})s,
+                %(output_choices_{i})s,
+                %(input_state_{i})s,
+                %(output_state_{i})s,
+                %(tools_{i})s,
+                %(retention_days_{i})s,
+                %(_timestamp_{i})s,
+                0,
+                0
+            )""".format(i=index)
+        )
+
+        def _prop(name: str, default: Any = "", _props: dict = properties) -> Any:
+            return _props.get(name, default)
+
+        def _prop_str(name: str, _props: dict = properties) -> str:
+            val = _props.get(name)
+            if val is None:
+                return ""
+            if isinstance(val, (dict, list)):
+                return json.dumps(val)
+            return str(val)
+
+        params.update(
+            {
+                f"uuid_{index}": event_uuid,
+                f"event_{index}": event_data["event"],
+                f"timestamp_{index}": timestamp_str,
+                f"team_id_{index}": team_id,
+                f"distinct_id_{index}": str(event_data["distinct_id"]),
+                f"person_id_{index}": person_id,
+                f"properties_{index}": properties_json,
+                f"trace_id_{index}": _prop_str("$ai_trace_id"),
+                f"session_id_{index}": _prop_str("$ai_session_id"),
+                f"parent_id_{index}": _prop_str("$ai_parent_id"),
+                f"span_id_{index}": _prop_str("$ai_span_id"),
+                f"span_type_{index}": _prop_str("$ai_span_type"),
+                f"generation_id_{index}": _prop_str("$ai_generation_id"),
+                f"span_name_{index}": _prop_str("$ai_span_name"),
+                f"trace_name_{index}": _prop_str("$ai_trace_name"),
+                f"prompt_name_{index}": _prop_str("$ai_prompt_name"),
+                f"model_{index}": _prop_str("$ai_model"),
+                f"provider_{index}": _prop_str("$ai_provider"),
+                f"framework_{index}": _prop_str("$ai_framework"),
+                f"total_tokens_{index}": int(_prop("$ai_total_tokens", 0) or 0),
+                f"input_tokens_{index}": int(_prop("$ai_input_tokens", 0) or 0),
+                f"output_tokens_{index}": int(_prop("$ai_output_tokens", 0) or 0),
+                f"text_input_tokens_{index}": int(_prop("$ai_text_input_tokens", 0) or 0),
+                f"text_output_tokens_{index}": int(_prop("$ai_text_output_tokens", 0) or 0),
+                f"image_input_tokens_{index}": int(_prop("$ai_image_input_tokens", 0) or 0),
+                f"image_output_tokens_{index}": int(_prop("$ai_image_output_tokens", 0) or 0),
+                f"audio_input_tokens_{index}": int(_prop("$ai_audio_input_tokens", 0) or 0),
+                f"audio_output_tokens_{index}": int(_prop("$ai_audio_output_tokens", 0) or 0),
+                f"video_input_tokens_{index}": int(_prop("$ai_video_input_tokens", 0) or 0),
+                f"video_output_tokens_{index}": int(_prop("$ai_video_output_tokens", 0) or 0),
+                f"reasoning_tokens_{index}": int(_prop("$ai_reasoning_tokens", 0) or 0),
+                f"cache_read_input_tokens_{index}": int(_prop("$ai_cache_read_input_tokens", 0) or 0),
+                f"cache_creation_input_tokens_{index}": int(_prop("$ai_cache_creation_input_tokens", 0) or 0),
+                f"web_search_count_{index}": int(_prop("$ai_web_search_count", 0) or 0),
+                f"input_cost_usd_{index}": float(_prop("$ai_input_cost_usd", 0) or 0),
+                f"output_cost_usd_{index}": float(_prop("$ai_output_cost_usd", 0) or 0),
+                f"total_cost_usd_{index}": float(_prop("$ai_total_cost_usd", 0) or 0),
+                f"request_cost_usd_{index}": float(_prop("$ai_request_cost_usd", 0) or 0),
+                f"web_search_cost_usd_{index}": float(_prop("$ai_web_search_cost_usd", 0) or 0),
+                f"audio_cost_usd_{index}": float(_prop("$ai_audio_cost_usd", 0) or 0),
+                f"image_cost_usd_{index}": float(_prop("$ai_image_cost_usd", 0) or 0),
+                f"video_cost_usd_{index}": float(_prop("$ai_video_cost_usd", 0) or 0),
+                f"latency_{index}": float(_prop("$ai_latency", 0) or 0),
+                f"time_to_first_token_{index}": float(_prop("$ai_time_to_first_token", 0) or 0),
+                f"is_error_{index}": 1 if _prop_str("$ai_is_error") == "true" else 0,
+                f"error_{index}": _prop_str("$ai_error"),
+                f"error_type_{index}": _prop_str("$ai_error_type"),
+                f"error_normalized_{index}": _prop_str("$ai_error_normalized"),
+                f"input_{index}": _prop_str("$ai_input"),
+                f"output_{index}": _prop_str("$ai_output"),
+                f"output_choices_{index}": _prop_str("$ai_output_choices"),
+                f"input_state_{index}": _prop_str("$ai_input_state"),
+                f"output_state_{index}": _prop_str("$ai_output_state"),
+                f"tools_{index}": _prop_str("$ai_tools"),
+                f"retention_days_{index}": 10000,
+                f"_timestamp_{index}": timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
+
+    query = f"""
+        INSERT INTO sharded_ai_events (
+            uuid, event, timestamp, team_id, distinct_id, person_id, properties,
+            trace_id, session_id, parent_id, span_id, span_type, generation_id,
+            span_name, trace_name, prompt_name,
+            model, provider, framework,
+            total_tokens, input_tokens, output_tokens,
+            text_input_tokens, text_output_tokens,
+            image_input_tokens, image_output_tokens,
+            audio_input_tokens, audio_output_tokens,
+            video_input_tokens, video_output_tokens,
+            reasoning_tokens, cache_read_input_tokens, cache_creation_input_tokens,
+            web_search_count,
+            input_cost_usd, output_cost_usd, total_cost_usd,
+            request_cost_usd, web_search_cost_usd, audio_cost_usd, image_cost_usd, video_cost_usd,
+            latency, time_to_first_token,
+            is_error, error, error_type, error_normalized,
+            input, output, output_choices, input_state, output_state, tools,
+            retention_days,
+            _timestamp, _offset, _partition
+        ) VALUES {", ".join(inserts)}
+    """
+    sync_execute(query, params, flush=False)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3019,6 +3019,7 @@ class NodeKind(StrEnum):
     LOG_ATTRIBUTES_QUERY = "LogAttributesQuery"
     LOG_VALUES_QUERY = "LogValuesQuery"
     SESSION_BATCH_EVENTS_QUERY = "SessionBatchEventsQuery"
+    AI_EVENTS_QUERY = "AiEventsQuery"
     DATA_TABLE_NODE = "DataTableNode"
     DATA_VISUALIZATION_NODE = "DataVisualizationNode"
     SAVED_INSIGHT_NODE = "SavedInsightNode"
@@ -19079,6 +19080,84 @@ class ActorsQuery(BaseModel):
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
+class AiEventsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actionId: int | None = Field(default=None, description="Show events matching a given action")
+    after: str | None = Field(default=None, description="Only fetch events that happened after this timestamp")
+    before: str | None = Field(
+        default=None,
+        description="Only fetch events that happened before this timestamp",
+    )
+    event: str | None = Field(default=None, description="Limit to events matching this string")
+    events: list[str] | None = Field(default=None, description="Filter to events matching any of these event names")
+    filterTestAccounts: bool | None = Field(default=None, description="Filter test accounts")
+    fixedProperties: (
+        list[
+            PropertyGroupFilter
+            | PropertyGroupFilterValue
+            | EventPropertyFilter
+            | PersonPropertyFilter
+            | ElementPropertyFilter
+            | EventMetadataPropertyFilter
+            | SessionPropertyFilter
+            | CohortPropertyFilter
+            | RecordingPropertyFilter
+            | LogEntryPropertyFilter
+            | GroupPropertyFilter
+            | FeaturePropertyFilter
+            | FlagPropertyFilter
+            | HogQLPropertyFilter
+            | EmptyPropertyFilter
+            | DataWarehousePropertyFilter
+            | DataWarehousePersonPropertyFilter
+            | ErrorTrackingIssueFilter
+            | LogPropertyFilter
+            | RevenueAnalyticsPropertyFilter
+        ]
+        | None
+    ) = Field(
+        default=None,
+        description=("Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)"),
+    )
+    kind: Literal["AiEventsQuery"] = "AiEventsQuery"
+    limit: int | None = Field(default=None, description="Number of rows to return")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    offset: int | None = Field(default=None, description="Number of rows to skip before returning rows")
+    orderBy: list[str] | None = Field(default=None, description="Columns to order by")
+    personId: str | None = Field(default=None, description="Show events for a given person")
+    properties: (
+        list[
+            EventPropertyFilter
+            | PersonPropertyFilter
+            | ElementPropertyFilter
+            | EventMetadataPropertyFilter
+            | SessionPropertyFilter
+            | CohortPropertyFilter
+            | RecordingPropertyFilter
+            | LogEntryPropertyFilter
+            | GroupPropertyFilter
+            | FeaturePropertyFilter
+            | FlagPropertyFilter
+            | HogQLPropertyFilter
+            | EmptyPropertyFilter
+            | DataWarehousePropertyFilter
+            | DataWarehousePersonPropertyFilter
+            | ErrorTrackingIssueFilter
+            | LogPropertyFilter
+            | RevenueAnalyticsPropertyFilter
+        ]
+        | None
+    ) = Field(default=None, description="Properties configurable in the interface")
+    response: EventsQueryResponse | None = None
+    select: list[str] = Field(..., description="Return a limited set of data. Required.")
+    source: InsightActorsQuery | None = Field(default=None, description="source for querying events for insights")
+    tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+    where: list[str] | None = Field(default=None, description="HogQL filters to apply on returned data")
+
+
 class EventsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -19285,6 +19364,7 @@ class DataTableNode(BaseModel):
     source: (
         EventsNode
         | EventsQuery
+        | AiEventsQuery
         | PersonsNode
         | ActorsQuery
         | GroupsQuery
@@ -19399,6 +19479,7 @@ class HogQLAutocomplete(BaseModel):
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -19479,6 +19560,7 @@ class HogQLMetadata(BaseModel):
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -19595,6 +19677,7 @@ class MaxInsightContext(BaseModel):
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -19708,6 +19791,7 @@ class QueryRequest(BaseModel):
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -19813,6 +19897,7 @@ class QuerySchemaRoot(
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -19888,6 +19973,7 @@ class QuerySchemaRoot(
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -19968,6 +20054,7 @@ class QueryUpgradeRequest(BaseModel):
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -20048,6 +20135,7 @@ class QueryUpgradeResponse(BaseModel):
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery
@@ -20254,6 +20342,7 @@ class VisualizationArtifactContent(BaseModel):
         | TracesQuery
         | TraceQuery
         | TraceNeighborsQuery
+        | AiEventsQuery
         | VectorSearchQuery
         | UsageMetricsQuery
         | EndpointsUsageOverviewQuery

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -74,8 +74,10 @@ from posthog.clickhouse.query_log_archive import (
 )
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.helpers.two_factor_session import email_mfa_token_generator
+from posthog.hogql_queries.ai.ai_table_resolver import AI_EVENT_NAMES as _AI_EVENT_TYPES
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.models import Action, Dashboard, DashboardTile, Insight, Organization, Team, User
+from posthog.models.ai_events.sql import TRUNCATE_AI_EVENTS_TABLE_SQL
 from posthog.models.channel_type.sql import (
     CHANNEL_DEFINITION_DATA_SQL,
     CHANNEL_DEFINITION_DICTIONARY_SQL,
@@ -1326,6 +1328,32 @@ class NonAtomicTestMigrations(BaseTestMigrations, NonAtomicBaseTest):
     """
 
 
+def _flush_ai_events(events: list[dict[str, Any]], person_mapping: dict) -> None:
+    """Mirror AI events into the ai_events table during tests."""
+    ai_events = [e for e in events if e.get("event") in _AI_EVENT_TYPES]
+    if not ai_events:
+        return
+
+    for event in ai_events:
+        distinct_id = event.get("distinct_id", "")
+        if distinct_id in person_mapping:
+            person = person_mapping[distinct_id]
+            event["person_id"] = str(person.uuid if hasattr(person, "uuid") else person)
+        elif "person_id" not in event:
+            team = event.get("team")
+            team_id = event.get("team_id") or (team.pk if team else None)
+            if team_id:
+                from posthog.models import PersonDistinctId
+
+                pdi = PersonDistinctId.objects.filter(team_id=team_id, distinct_id=distinct_id).first()
+                if pdi:
+                    event["person_id"] = str(pdi.person.uuid)
+
+    from posthog.models.ai_events.test_util import bulk_create_ai_events
+
+    bulk_create_ai_events(ai_events)
+
+
 def flush_persons_and_events():
     """
     Flush any created persons and events to Clickhouse
@@ -1344,6 +1372,7 @@ def flush_persons_and_events():
         persons_cache_tests.clear()
     if len(events_cache_tests) > 0:
         bulk_create_events(events_cache_tests, person_mapping)
+        _flush_ai_events(events_cache_tests, person_mapping)
         events_cache_tests.clear()
 
 
@@ -1557,6 +1586,7 @@ def reset_clickhouse_database() -> None:
             TRUNCATE_PERSON_STATIC_COHORT_TABLE_SQL(),
             TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL,
             TRUNCATE_CUSTOM_METRICS_COUNTER_EVENTS_TABLE,
+            TRUNCATE_AI_EVENTS_TABLE_SQL(),
         ]
     )
     run_clickhouse_statement_in_parallel(

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4148,6 +4148,130 @@ export namespace Schemas {
       Sandbox: 'sandbox',
     } as const;
 
+    export type AiEventsQueryKind = typeof AiEventsQueryKind[keyof typeof AiEventsQueryKind];
+
+
+    export const AiEventsQueryKind = {
+      AiEventsQuery: 'AiEventsQuery',
+    } as const;
+
+    export interface EventsQueryResponse {
+      columns: unknown[];
+      /**
+       * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
+       * @nullable
+       */
+      error?: string | null;
+      /** @nullable */
+      hasMore?: boolean | null;
+      /** Generated HogQL query. */
+      hogql: string;
+      /** @nullable */
+      limit?: number | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /**
+       * Cursor for fetching the next page of results
+       * @nullable
+       */
+      nextCursor?: string | null;
+      /** @nullable */
+      offset?: number | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: unknown[][];
+      /**
+       * Measured timings for different parts of the query generation process
+       * @nullable
+       */
+      timings?: QueryTiming[] | null;
+      types: string[];
+    }
+
+    export interface AiEventsQuery {
+      /**
+       * Show events matching a given action
+       * @nullable
+       */
+      actionId?: number | null;
+      /**
+       * Only fetch events that happened after this timestamp
+       * @nullable
+       */
+      after?: string | null;
+      /**
+       * Only fetch events that happened before this timestamp
+       * @nullable
+       */
+      before?: string | null;
+      /**
+       * Limit to events matching this string
+       * @nullable
+       */
+      event?: string | null;
+      /**
+       * Filter to events matching any of these event names
+       * @nullable
+       */
+      events?: string[] | null;
+      /**
+       * Filter test accounts
+       * @nullable
+       */
+      filterTestAccounts?: boolean | null;
+      /**
+       * Fixed properties in the query, can't be edited in the interface (e.g. scoping down by person)
+       * @nullable
+       */
+      fixedProperties?: (PropertyGroupFilter | PropertyGroupFilterValue | EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | RevenueAnalyticsPropertyFilter)[] | null;
+      kind?: AiEventsQueryKind;
+      /**
+       * Number of rows to return
+       * @nullable
+       */
+      limit?: number | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /**
+       * Number of rows to skip before returning rows
+       * @nullable
+       */
+      offset?: number | null;
+      /**
+       * Columns to order by
+       * @nullable
+       */
+      orderBy?: string[] | null;
+      /**
+       * Show events for a given person
+       * @nullable
+       */
+      personId?: string | null;
+      /**
+       * Properties configurable in the interface
+       * @nullable
+       */
+      properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | RevenueAnalyticsPropertyFilter)[] | null;
+      response?: EventsQueryResponse | null;
+      /** Return a limited set of data. Required. */
+      select: string[];
+      /** source for querying events for insights */
+      source?: InsightActorsQuery | null;
+      tags?: QueryLogTags | null;
+      /**
+       * version of the node, used for schema migrations
+       * @nullable
+       */
+      version?: number | null;
+      /**
+       * HogQL filters to apply on returned data
+       * @nullable
+       */
+      where?: string[] | null;
+    }
+
     export interface InsightsThresholdBounds {
       /** @nullable */
       lower?: number | null;
@@ -8488,41 +8612,6 @@ export namespace Schemas {
       EventsQuery: 'EventsQuery',
     } as const;
 
-    export interface EventsQueryResponse {
-      columns: unknown[];
-      /**
-       * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
-       * @nullable
-       */
-      error?: string | null;
-      /** @nullable */
-      hasMore?: boolean | null;
-      /** Generated HogQL query. */
-      hogql: string;
-      /** @nullable */
-      limit?: number | null;
-      /** Modifiers used when performing the query */
-      modifiers?: HogQLQueryModifiers | null;
-      /**
-       * Cursor for fetching the next page of results
-       * @nullable
-       */
-      nextCursor?: string | null;
-      /** @nullable */
-      offset?: number | null;
-      /** Query status indicates whether next to the provided data, a query is still running. */
-      query_status?: QueryStatus | null;
-      /** The date range used for the query */
-      resolved_date_range?: ResolvedDateRangeResponse | null;
-      results: unknown[][];
-      /**
-       * Measured timings for different parts of the query generation process
-       * @nullable
-       */
-      timings?: QueryTiming[] | null;
-      types: string[];
-    }
-
     export interface EventsQuery {
       /**
        * Show events matching a given action
@@ -10689,7 +10778,7 @@ export namespace Schemas {
        */
       showTimings?: boolean | null;
       /** Source of the events */
-      source: EventsNode | EventsQuery | PersonsNode | ActorsQuery | GroupsQuery | HogQLQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | SessionAttributionExplorerQuery | SessionsQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | ErrorTrackingQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | TracesQuery | TraceQuery | EndpointsUsageTableQuery;
+      source: EventsNode | EventsQuery | AiEventsQuery | PersonsNode | ActorsQuery | GroupsQuery | HogQLQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | SessionAttributionExplorerQuery | SessionsQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | ErrorTrackingQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | TracesQuery | TraceQuery | EndpointsUsageTableQuery;
       tags?: QueryLogTags | null;
       /**
        * version of the node, used for schema migrations
@@ -16410,7 +16499,7 @@ export namespace Schemas {
       query: string;
       response?: HogQLMetadataResponse | null;
       /** Query within which "expr" and "template" are validated. Defaults to "select * from events" */
-      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebTrendsQuery | WebAnalyticsExternalSummaryQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | null;
+      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebTrendsQuery | WebAnalyticsExternalSummaryQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | AiEventsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | null;
       tags?: QueryLogTags | null;
       /**
        * Variables to be subsituted into the query
@@ -16448,7 +16537,7 @@ export namespace Schemas {
       query: string;
       response?: HogQLAutocompleteResponse | null;
       /** Query in whose context to validate. */
-      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebTrendsQuery | WebAnalyticsExternalSummaryQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | null;
+      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebTrendsQuery | WebAnalyticsExternalSummaryQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | AiEventsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | null;
       /** Start position of the editor word */
       startPosition: number;
       tags?: QueryLogTags | null;
@@ -23708,7 +23797,7 @@ export namespace Schemas {
     ```
 
     For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | AiEventsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
       /** Whether results should be calculated sync or async, and how much to rely on the cache:
     - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
     - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
@@ -26078,11 +26167,11 @@ export namespace Schemas {
     }
 
     export interface QueryUpgradeRequest {
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | AiEventsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
     }
 
     export interface QueryUpgradeResponse {
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | AiEventsQuery | VectorSearchQuery | UsageMetricsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | PropertyValuesQuery;
     }
 
     export interface ReorderTilesRequest {


### PR DESCRIPTION
## Problem

With the `ai_events` table ([#51290](https://github.com/PostHog/posthog/pull/51290)) and write path ([#51289](https://github.com/PostHog/posthog/pull/51289)) in place, we need a read path. HogQL doesn’t know about `ai_events`, and existing queries use `properties.$ai_*` access patterns that need to be translated to dedicated column access (and back, for fallback when data is outside the 30-day TTL).

Stacks on [#51290](https://github.com/PostHog/posthog/pull/51290). Everything gated by `ai-events-table-rollout` feature flag (default OFF) — deploying changes nothing.

## Changes

- `AiEventsTable` HogQL schema with 69 fields including `StringJSONDatabaseField` for heavy columns (enables `JSONExtract` under the hood), `LazyJoin` to `PersonDistinctIdsTable`, and `FieldTraverser` for person access. Registered in `database.py`
- Two bidirectional AST rewriters:
  - `AiPropertyRewriter`: `properties.$ai_*` → dedicated columns (e.g. `properties.$ai_trace_id` → `trace_id`). Handles boolean normalization for `$ai_is_error` (string `"true"`/`"false"` → UInt8)
  - `AiColumnToPropertyRewriter`: reverse direction, scope-aware (only rewrites within `FROM ai_events` queries). Used for fallback to `events` table when data is outside TTL
- `ai_table_resolver.py`: feature flag check (`ai-events-table-rollout`), TTL validation with 1-day buffer (date pickers truncate to midnight, `ttl_only_drop_parts=1` keeps data until full partition expires), canonical `AI_EVENT_NAMES` frozenset, event name validation
- `AiEventsQueryRunner`: wraps `EventsQueryRunner`, validates only AI event names are queried, rewrites AST for `ai_events` when flag enabled + data within TTL, falls back to `EventsQueryRunner` otherwise
- `AiEventsQuery` schema type added to `schema.py`, `NodeKind`, and all relevant union types. Frontend treats it identically to `EventsQuery` in `dataTableLogic`, `utils`, and `ColumnConfigurator`
- `ast.py`: `FieldType.get_child()` enhanced to handle `StringJSONType`/`StringArrayType` from subquery aliases (enables property access on JSON columns in subqueries)
- Test infrastructure: `bulk_create_ai_events()` for direct ClickHouse insertion, `_flush_ai_events()` in test base to mirror AI events into both tables, `TRUNCATE_AI_EVENTS_TABLE_SQL` in conftest cleanup

## How did you test this code?

Unit tests for both rewriters (field chains, boolean normalization, scope awareness, UNION ALL, nested subqueries, force_rewrite mode, inverse mapping verification), TTL boundary tests, feature flag mocking, event name validation, end-to-end `AiEventsQueryRunner` tests (ai_events path, events fallback, person enrichment).

Also tested end-to-end as part of the full `ai_events` stack following [this test protocol](https://github.com/PostHog/llm-analytics-apps/blob/main/python/scripts/AI_EVENTS_MIGRATION_TEST_PLAN.md) — tried all LLM analytics features in different combinations.

## Publish to changelog?

No

## Docs update

N/A