### PR TITLE
feat(error-tracking): filter test/internal accounts from weekly digest

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1435,7 +1435,8 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
         compute_week_over_week_change,
         get_crash_free_sessions,
         get_daily_exception_counts,
-        get_exception_counts_for_org,
+        get_exception_counts,
+        get_exception_summary_for_team,
         get_new_issues_for_team,
         get_top_issues_for_team,
     )
@@ -1449,18 +1450,27 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
         logger.warning(f"Organization {org_id} not found for Error Tracking weekly digest")
         return
 
-    team_exception_counts = get_exception_counts_for_org(org.id)
-    if not team_exception_counts:
+    all_org_teams = {t.id: t for t in Team.objects.filter(organization_id=org.id)}
+    if not all_org_teams:
         return
 
-    all_org_teams = {t.id: t for t in Team.objects.filter(organization_id=org.id)}
-    excluded_project_count = len(all_org_teams) - len(team_exception_counts)
+    # Use unfiltered counts only to determine which teams have any exceptions at all
+    unfiltered_counts = get_exception_counts(list(all_org_teams.keys()))
+    team_ids_with_exceptions = {row[0] for row in unfiltered_counts}
+    if not team_ids_with_exceptions:
+        return
+
+    excluded_project_count = len(all_org_teams) - len(team_ids_with_exceptions)
 
     # Pre-compute per-team digest data only for teams that have exceptions
     team_digest_data: dict[int, dict] = {}
-    for team_id, counts in team_exception_counts.items():
+    for team_id in team_ids_with_exceptions:
         team = all_org_teams.get(team_id)
         if not team:
+            continue
+
+        counts = get_exception_summary_for_team(team)
+        if not counts or counts["exception_count"] == 0:
             continue
 
         team_digest_data[team_id] = {
@@ -1472,7 +1482,7 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
             "ingestion_failure_count": counts["ingestion_failure_count"],
             "top_issues": get_top_issues_for_team(team),
             "new_issues": get_new_issues_for_team(team),
-            "daily_counts": get_daily_exception_counts(team_id),
+            "daily_counts": get_daily_exception_counts(team),
             "crash_free": get_crash_free_sessions(team),
             "error_tracking_url": f"{settings.SITE_URL}/project/{team_id}/error_tracking?utm_source=error_tracking_weekly_digest",
             "ingestion_failures_url": build_ingestion_failures_url(team_id),
@@ -1500,7 +1510,7 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
             continue
 
         # Auto-select busiest project for first-time users
-        auto_select_project_for_user(user, org.id, team_exception_counts)
+        auto_select_project_for_user(user, org.id, team_digest_data)
         user.refresh_from_db(fields=["partial_notification_settings"])
 
         # Build per-user list of enabled teams

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -1460,8 +1460,6 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
     if not team_ids_with_exceptions:
         return
 
-    excluded_project_count = len(all_org_teams) - len(team_ids_with_exceptions)
-
     # Pre-compute per-team digest data only for teams that have exceptions
     team_digest_data: dict[int, dict] = {}
     for team_id in team_ids_with_exceptions:
@@ -1487,6 +1485,8 @@ def send_error_tracking_weekly_digest_for_org(org_id: str) -> None:
             "error_tracking_url": f"{settings.SITE_URL}/project/{team_id}/error_tracking?utm_source=error_tracking_weekly_digest",
             "ingestion_failures_url": build_ingestion_failures_url(team_id),
         }
+
+    excluded_project_count = len(all_org_teams) - len(team_digest_data)
 
     all_memberships = OrganizationMembership.objects.prefetch_related("user").filter(organization_id=org.id)
 

--- a/products/error_tracking/backend/test/test_weekly_digest.py
+++ b/products/error_tracking/backend/test/test_weekly_digest.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from uuid import uuid4
 
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
 
 from django.utils import timezone
 
@@ -16,7 +16,7 @@ from products.error_tracking.backend.weekly_digest import (
     get_crash_free_sessions,
     get_daily_exception_counts,
     get_exception_counts,
-    get_exception_counts_for_org,
+    get_exception_summary_for_team,
     get_new_issues_for_team,
     get_org_ids_with_exceptions,
     get_top_issues_for_team,
@@ -89,36 +89,24 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
             timestamp=timestamp or _days_ago(1),
         )
 
-    def test_get_exception_counts_returns_counts_per_team(self):
+    def _create_person_with_email(self, distinct_id: str, email: str) -> None:
+        _create_person(distinct_ids=[distinct_id], properties={"email": email}, team=self.team)
+
+    def _set_internal_user_filter(self) -> None:
+        self.team.test_account_filters = [
+            {"key": "email", "type": "person", "operator": "not_icontains", "value": "@internal.com"}
+        ]
+        self.team.save()
+
+    def test_get_exception_counts_returns_teams_with_exceptions(self):
         issue = self._create_issue()
-        for _ in range(3):
-            self._create_exception_event(issue_id=issue.id)
-        self._create_exception_event(issue_id=None)
+        self._create_exception_event(issue_id=issue.id)
         flush_persons_and_events()
 
         results = get_exception_counts(team_ids=[self.team.pk])
 
         assert len(results) == 1
-        team_id, exception_count, ingestion_failure_count, prev_exception_count = results[0]
-        assert team_id == self.team.pk
-        assert exception_count == 4
-        assert ingestion_failure_count == 1
-        assert prev_exception_count == 0
-
-    def test_get_exception_counts_includes_previous_week(self):
-        issue = self._create_issue()
-        for _ in range(3):
-            self._create_exception_event(issue_id=issue.id, timestamp=_days_ago(1))
-        for _ in range(5):
-            self._create_exception_event(issue_id=issue.id, timestamp=_days_ago(10))
-        flush_persons_and_events()
-
-        results = get_exception_counts(team_ids=[self.team.pk])
-
-        assert len(results) == 1
-        _, exception_count, _, prev_exception_count = results[0]
-        assert exception_count == 3
-        assert prev_exception_count == 5
+        assert results[0][0] == self.team.pk
 
     def test_get_exception_counts_excludes_old_events(self):
         issue = self._create_issue()
@@ -168,7 +156,7 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
         self._create_exception_event(issue_id=issue.id, timestamp=_days_ago(3))
         flush_persons_and_events()
 
-        result = get_daily_exception_counts(self.team.pk)
+        result = get_daily_exception_counts(self.team)
 
         assert len(result) == 7
 
@@ -185,7 +173,7 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
         assert pcts[day_3_ago] == 50
 
     def test_get_daily_exception_counts_empty(self):
-        result = get_daily_exception_counts(self.team.pk)
+        result = get_daily_exception_counts(self.team)
 
         assert len(result) == 7
         assert all(d["count"] == 0 for d in result)
@@ -279,18 +267,33 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
         org_ids = get_org_ids_with_exceptions()
         assert org_ids == []
 
-    def test_get_exception_counts_for_org(self):
+    def test_get_exception_summary_for_team(self):
         issue = self._create_issue()
         for _ in range(3):
             self._create_exception_event(issue_id=issue.id)
+        self._create_exception_event(issue_id=None)  # ingestion failure
         flush_persons_and_events()
 
-        result = get_exception_counts_for_org(self.team.organization.id)
+        result = get_exception_summary_for_team(self.team)
 
-        assert self.team.pk in result
-        assert result[self.team.pk]["exception_count"] == 3
+        assert result["exception_count"] == 4
+        assert result["ingestion_failure_count"] == 1
+        assert result["prev_exception_count"] == 0
 
-    def test_get_exception_counts_for_org_excludes_other_orgs(self):
+    def test_get_exception_summary_for_team_includes_previous_week(self):
+        issue = self._create_issue()
+        for _ in range(3):
+            self._create_exception_event(issue_id=issue.id, timestamp=_days_ago(1))
+        for _ in range(5):
+            self._create_exception_event(issue_id=issue.id, timestamp=_days_ago(10))
+        flush_persons_and_events()
+
+        result = get_exception_summary_for_team(self.team)
+
+        assert result["exception_count"] == 3
+        assert result["prev_exception_count"] == 5
+
+    def test_get_exception_summary_for_team_excludes_other_teams(self):
         other_org = Organization.objects.create(name="Other Org")
         other_team = Team.objects.create(organization=other_org, name="Other Team")
 
@@ -298,9 +301,9 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
         self._create_exception_event(issue_id=issue.id)
         flush_persons_and_events()
 
-        result = get_exception_counts_for_org(self.team.organization.id)
+        result = get_exception_summary_for_team(other_team)
 
-        assert other_team.pk not in result
+        assert result == {} or result["exception_count"] == 0
 
     def test_auto_select_project_picks_busiest(self):
         team_b = Team.objects.create(organization=self.organization, name="Team B")
@@ -339,6 +342,78 @@ class TestWeeklyDigest(ClickhouseTestMixin, APIBaseTest):
         self.user.refresh_from_db()
 
         assert "error_tracking_weekly_digest_project_enabled" not in (self.user.partial_notification_settings or {})
+
+    def test_get_exception_summary_filters_internal_users(self):
+        self._set_internal_user_filter()
+        issue = self._create_issue()
+        self._create_person_with_email("regular_user", "user@external.com")
+        self._create_person_with_email("internal_user", "bot@internal.com")
+        self._create_exception_event(issue_id=issue.id, distinct_id="regular_user")
+        self._create_exception_event(issue_id=issue.id, distinct_id="regular_user")
+        self._create_exception_event(issue_id=issue.id, distinct_id="internal_user")
+        flush_persons_and_events()
+
+        result = get_exception_summary_for_team(self.team)
+
+        assert result["exception_count"] == 2
+
+    def test_get_daily_exception_counts_filters_internal_users(self):
+        self._set_internal_user_filter()
+        issue = self._create_issue()
+        self._create_person_with_email("regular_user", "user@external.com")
+        self._create_person_with_email("internal_user", "bot@internal.com")
+        self._create_exception_event(issue_id=issue.id, distinct_id="regular_user")
+        self._create_exception_event(issue_id=issue.id, distinct_id="internal_user")
+        flush_persons_and_events()
+
+        result = get_daily_exception_counts(self.team)
+
+        assert sum(d["count"] for d in result) == 1
+
+    def test_get_top_issues_filters_internal_users(self):
+        self._set_internal_user_filter()
+        issue = self._create_issue()
+        self._create_person_with_email("regular_user", "user@external.com")
+        self._create_person_with_email("internal_user", "bot@internal.com")
+        self._create_exception_event(issue_id=issue.id, distinct_id="regular_user")
+        self._create_exception_event(issue_id=issue.id, distinct_id="internal_user")
+        self._create_exception_event(issue_id=issue.id, distinct_id="internal_user")
+        flush_persons_and_events()
+
+        result = get_top_issues_for_team(self.team)
+
+        assert len(result) == 1
+        assert result[0]["occurrence_count"] == 1
+
+    def test_get_new_issues_filters_internal_users(self):
+        self._set_internal_user_filter()
+        issue = self._create_issue()
+        self._create_person_with_email("regular_user", "user@external.com")
+        self._create_person_with_email("internal_user", "bot@internal.com")
+        self._create_exception_event(issue_id=issue.id, distinct_id="regular_user")
+        self._create_exception_event(issue_id=issue.id, distinct_id="internal_user")
+        self._create_exception_event(issue_id=issue.id, distinct_id="internal_user")
+        flush_persons_and_events()
+
+        result = get_new_issues_for_team(self.team)
+
+        assert len(result) == 1
+        assert result[0]["occurrence_count"] == 1
+
+    def test_get_crash_free_sessions_filters_internal_users(self):
+        self._set_internal_user_filter()
+        s1, s2 = str(uuid7()), str(uuid7())
+        self._create_person_with_email("regular_user", "user@external.com")
+        self._create_person_with_email("internal_user", "bot@internal.com")
+        self._create_pageview(distinct_id="regular_user", session_id=s1)
+        self._create_pageview(distinct_id="internal_user", session_id=s2)
+        self._create_exception_event(distinct_id="internal_user", session_id=s2)
+        flush_persons_and_events()
+
+        result = get_crash_free_sessions(self.team)
+
+        assert result["total_sessions"] == 1
+        assert result["crash_free_rate"] == 100.0
 
 
 class TestComputeWeekOverWeekChange:

--- a/products/error_tracking/backend/weekly_digest.py
+++ b/products/error_tracking/backend/weekly_digest.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 import structlog
 
-from posthog.schema import ProductKey
+from posthog.schema import HogQLFilters, ProductKey
 
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import Team
@@ -24,20 +24,40 @@ def get_org_ids_with_exceptions() -> list[str]:
     return org_ids
 
 
-def get_exception_counts_for_org(org_id: int) -> dict[int, dict]:
-    """Get exception counts for all teams in an org, returned as {team_id: {exception_count, ingestion_failure_count, prev_exception_count}}"""
-    org_teams = list(Team.objects.filter(organization_id=org_id).values_list("id", flat=True))
-    if not org_teams:
+def get_exception_summary_for_team(team: Team) -> dict:
+    """Get filtered exception counts, ingestion failures, and prev week count for a single team."""
+    from posthog.hogql.query import execute_hogql_query
+
+    tag_queries(product=ProductKey.ERROR_TRACKING, team_id=team.pk, name="weekly_digest:exception_summary")
+
+    try:
+        response = execute_hogql_query(
+            query="""
+                SELECT
+                    countIf(timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY) as exception_count,
+                    countIf(timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY AND issue_id IS NULL) as ingestion_failure_count,
+                    countIf(timestamp < toStartOfDay(now()) - INTERVAL 7 DAY) as prev_exception_count
+                FROM events
+                WHERE event = '$exception'
+                AND timestamp >= toStartOfDay(now()) - INTERVAL 14 DAY
+                AND timestamp < toStartOfDay(now())
+                AND {filters}
+            """,
+            team=team,
+            filters=HogQLFilters(filterTestAccounts=True),
+        )
+    except Exception:
+        logger.exception(f"Failed to query exception summary for team {team.pk}")
         return {}
 
-    results = get_exception_counts(org_teams)
+    if not response.results or not response.results[0]:
+        return {}
+
+    exception_count, ingestion_failure_count, prev_exception_count = response.results[0]
     return {
-        row[0]: {
-            "exception_count": row[1],
-            "ingestion_failure_count": row[2],
-            "prev_exception_count": row[3],
-        }
-        for row in results
+        "exception_count": exception_count,
+        "ingestion_failure_count": ingestion_failure_count,
+        "prev_exception_count": prev_exception_count,
     }
 
 
@@ -60,7 +80,7 @@ def auto_select_project_for_user(user, org_id: int, team_exception_counts: dict[
 
 
 def get_exception_counts(team_ids: list[int] | None = None) -> list:
-    """Exception counts and ingestion failures for the last 7 days"""
+    """Teams with at least one exception in the last 7 days, used for digest routing."""
     from posthog.clickhouse.client import sync_execute
 
     tag_queries(product=ProductKey.ERROR_TRACKING, name="weekly_digest:exception_counts")
@@ -72,22 +92,16 @@ def get_exception_counts(team_ids: list[int] | None = None) -> list:
         query_params["team_ids"] = team_ids
 
     # nosemgrep: clickhouse-fstring-param-audit (team_filter is built from trusted code, not user input)
-    exception_counts_query = f"""
-    SELECT
-        team_id,
-        countIf(timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY) as exception_count,
-        countIf(timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY AND mat_$exception_issue_id IS NULL) as ingestion_failure_count,
-        countIf(timestamp < toStartOfDay(now()) - INTERVAL 7 DAY) as prev_exception_count
+    query = f"""
+    SELECT DISTINCT team_id
     FROM events
     WHERE event = '$exception'
-    AND timestamp >= toStartOfDay(now()) - INTERVAL 14 DAY
+    AND timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY
     AND timestamp < toStartOfDay(now())
     {team_filter}
-    GROUP BY team_id
-    HAVING exception_count > 0
     """
 
-    results = sync_execute(exception_counts_query, query_params)
+    results = sync_execute(query, query_params)
     return results if isinstance(results, list) else []
 
 
@@ -109,8 +123,10 @@ def get_crash_free_sessions(team: Team) -> dict:
                 WHERE timestamp >= toStartOfDay(now()) - INTERVAL 14 DAY
                 AND timestamp < toStartOfDay(now())
                 AND notEmpty($session_id)
+                AND {filters}
             """,
             team=team,
+            filters=HogQLFilters(filterTestAccounts=True),
         )
     except Exception:
         logger.exception(f"Failed to query crash free sessions for team {team.pk}")
@@ -172,33 +188,35 @@ def compute_week_over_week_change(current: float, previous: float | None, higher
     }
 
 
-def get_daily_exception_counts(team_id: int) -> list[dict]:
+def get_daily_exception_counts(team: Team) -> list[dict]:
     """Get exception counts per day for the last 7 days"""
-    from posthog.clickhouse.client import sync_execute
+    from posthog.hogql.query import execute_hogql_query
 
-    tag_queries(product=ProductKey.ERROR_TRACKING, team_id=team_id, name="weekly_digest:daily_exception_counts")
+    tag_queries(product=ProductKey.ERROR_TRACKING, team_id=team.pk, name="weekly_digest:daily_exception_counts")
 
     try:
-        results = sync_execute(
-            """
+        response = execute_hogql_query(
+            query="""
             SELECT
                 toDate(timestamp) as day,
                 count() as day_count
             FROM events
             WHERE event = '$exception'
-            AND team_id = %(team_id)s
             AND timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY
             AND timestamp < toStartOfDay(now())
+            AND {filters}
             GROUP BY day
             ORDER BY day ASC
             """,
-            {"team_id": team_id},
+            team=team,
+            filters=HogQLFilters(filterTestAccounts=True),
         )
     except Exception:
-        logger.exception(f"Failed to query daily exception counts for team {team_id}")
+        logger.exception(f"Failed to query daily exception counts for team {team.pk}")
         return []
 
-    counts_by_day = {row[0].isoformat(): row[1] for row in results} if isinstance(results, list) else {}
+    results = response.results or []
+    counts_by_day = {row[0].isoformat(): row[1] for row in results}
 
     today = timezone.now().date()
     daily_counts = []
@@ -238,6 +256,7 @@ def get_top_issues_for_team(team: Team) -> list[dict]:
                     AND timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY
                     AND timestamp < toStartOfDay(now())
                     AND issue_id IS NOT NULL
+                    AND {filters}
                     GROUP BY issue_id, day
                     ORDER BY day ASC
                 )
@@ -246,6 +265,7 @@ def get_top_issues_for_team(team: Team) -> list[dict]:
                 LIMIT 5
             """,
             team=team,
+            filters=HogQLFilters(filterTestAccounts=True),
         )
     except Exception:
         logger.exception(f"Failed to query top issues for team {team.pk}")
@@ -293,6 +313,7 @@ def get_new_issues_for_team(team: Team) -> list[dict]:
                     AND timestamp >= toStartOfDay(now()) - INTERVAL 7 DAY
                     AND timestamp < toStartOfDay(now())
                     AND issue_id IN {issue_ids}
+                    AND {filters}
                     GROUP BY issue_id, day
                     ORDER BY day ASC
                 )
@@ -302,6 +323,7 @@ def get_new_issues_for_team(team: Team) -> list[dict]:
             """,
             team=team,
             placeholders={"issue_ids": ast.Constant(value=new_issue_ids)},
+            filters=HogQLFilters(filterTestAccounts=True),
         )
     except Exception:
         logger.exception(f"Failed to query new issues for team {team.pk}")


### PR DESCRIPTION
## Problem

Previously, internal/bot traffic inflated exception counts, issue rankings, crash-free session rates, and daily charts shown in the digest - giving an inaccurate picture of real user impact.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

All per-team digest queries (exception summary, daily counts, top issues, new issues, crash-free sessions) now apply team.test_account_filters via HogQLFilters(filterTestAccounts=True).

get_exception_counts_for_org is replaced by get_exception_summary_for_team (per-team HogQL) for accurate filtered counts, while the bulk get_exception_counts is kept as a lightweight routing query (DISTINCT team_id only) to determine which teams have any exceptions at all.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

python shell on a (very) small set of local data, plus the unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
