### PR TITLE
fix: Unsaved workflow fails the test

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
+++ b/products/workflows/frontend/Workflows/hogflows/panel/testing/hogFlowEditorTestLogic.ts
@@ -491,6 +491,10 @@ export const hogFlowEditorTestLogic = kea<hogFlowEditorTestLogicType>([
                 return errors
             },
             submit: async (testInvocation: HogflowTestInvocation) => {
+                if (!values.workflow.id) {
+                    lemonToast.error('Please save the workflow before testing')
+                    return
+                }
                 try {
                     const apiResponse = await api.hogFlows.createTestInvocation(values.workflow.id, {
                         configuration: values.workflowSanitized,


### PR DESCRIPTION
Fixes #50940

Testing an unsaved workflow caused `hogFlowEditorTestLogic` to call `api.hogFlows.createTestInvocation` with an undefined workflow ID, resulting in a failed or malformed API request. The root cause is that `values.workflow.id` is absent when the workflow has not yet been persisted. Adds an early return guard in the `submit` handler in `hogFlowEditorTestLogic.ts` that checks for a missing `id` and surfaces a `lemonToast.error` message prompting the user to save first. Verified by attempting to run a test on an unsaved workflow and confirming the toast appears instead of an API error.