### PR TITLE
fix(feature-flags): add proper guard for realtime cohort evaluation

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -199,8 +199,6 @@ impl InnerCohortProperty {
         target_properties: &HashMap<String, Value>,
         cohort_matches: &HashMap<CohortId, bool>,
     ) -> Result<bool, FlagError> {
-                 self.prop_type, self.values.len());
-        
         match self.prop_type {
             CohortPropertyType::OR => {
                 for (i, cohort_values) in self.values.iter().enumerate() {
@@ -231,12 +229,9 @@ fn evaluate_cohort_values(
     target_properties: &HashMap<String, Value>,
     cohort_matches: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
-             values.prop_type, values.values.len());
-    
     match values.prop_type.as_str() {
         "OR" => {
             for (i, filter) in values.values.iter().enumerate() {
-                         i, filter.key, filter.is_cohort());
                 if filter.is_cohort() {
                     // Handle cohort membership check
                     if apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)?
@@ -245,8 +240,8 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check with negation
-                    let property_result = evaluate_property_with_negation(filter, target_properties);
-                             i, property_result);
+                    let property_result =
+                        evaluate_property_with_negation(filter, target_properties);
                     if property_result {
                         return Ok(true);
                     }
@@ -256,7 +251,6 @@ fn evaluate_cohort_values(
         }
         "AND" | "property" => {
             for (i, filter) in values.values.iter().enumerate() {
-                         i, filter.key, filter.is_cohort());
                 if filter.is_cohort() {
                     // Handle cohort membership check with negation
                     let cohort_result = apply_cohort_membership_logic(
@@ -269,8 +263,8 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check with negation
-                    let property_result = evaluate_property_with_negation(filter, target_properties);
-                             i, property_result);
+                    let property_result =
+                        evaluate_property_with_negation(filter, target_properties);
                     if !property_result {
                         return Ok(false);
                     }
@@ -278,9 +272,7 @@ fn evaluate_cohort_values(
             }
             Ok(true)
         }
-        _ => {
-            Err(FlagError::CohortFiltersParsingError)
-        }
+        _ => Err(FlagError::CohortFiltersParsingError),
     }
 }
 
@@ -292,10 +284,8 @@ fn evaluate_property_with_negation(
     filter: &PropertyFilter,
     target_properties: &HashMap<String, Value>,
 ) -> bool {
-             filter.key, filter.operator, filter.value, filter.negation);
-    
     let property_value = target_properties.get(&filter.key);
-    
+
     let property_result = match_property(filter, target_properties, false).unwrap_or(false);
 
     // Apply negation if specified
@@ -304,7 +294,7 @@ fn evaluate_property_with_negation(
     } else {
         property_result
     };
-    
+
     final_result
 }
 
@@ -315,13 +305,9 @@ fn evaluate_single_cohort(
     target_properties: &HashMap<String, Value>,
     evaluation_results: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
-             cohort.id, cohort.name.as_deref().unwrap_or("unnamed"));
-    
     // Get the filters for this cohort
     let filters = match &cohort.filters {
-        Some(filters) => {
-            filters
-        },
+        Some(filters) => filters,
         None => {
             return Ok(false);
         }
@@ -329,9 +315,7 @@ fn evaluate_single_cohort(
 
     // Parse and evaluate using the hierarchical structure
     let cohort_property: CohortProperty = match serde_json::from_value(filters.clone()) {
-        Ok(prop) => {
-            prop
-        },
+        Ok(prop) => prop,
         Err(e) => {
             return Ok(false);
         }
@@ -341,7 +325,7 @@ fn evaluate_single_cohort(
     let result = cohort_property
         .properties
         .evaluate(target_properties, evaluation_results)?;
-    
+
     Ok(result)
 }
 
@@ -351,7 +335,6 @@ pub fn evaluate_dynamic_cohorts(
     cohorts: &[Cohort],
     static_cohort_matches: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
-    
     // First check if this is a static cohort
     let initial_cohort = cohorts
         .iter()
@@ -360,8 +343,6 @@ pub fn evaluate_dynamic_cohorts(
             FlagError::DependencyNotFound(DependencyType::Cohort, initial_cohort_id.into())
         })?
         .clone();
-
-             initial_cohort.name.as_deref().unwrap_or("unnamed"), initial_cohort.is_static);
 
     // If it's static, we don't need to evaluate dependencies
     if initial_cohort.is_static {
@@ -373,21 +354,17 @@ pub fn evaluate_dynamic_cohorts(
 
     // Use for_each_dependencies_first to evaluate each cohort in the correct order
     let results = graph.for_each_dependencies_first(|cohort, results, result| {
-                 cohort.id, cohort.is_static);
-        
         // If this is a static cohort dependency, use the cached result
         if cohort.is_static {
             let cached_result = static_cohort_matches
                 .get(&cohort.id)
                 .copied()
                 .unwrap_or(false);
-                     cohort.id, cached_result);
             *result = cached_result;
             return Ok(());
         }
 
         let evaluation_result = evaluate_single_cohort(cohort, target_properties, results)?;
-                 cohort.id, evaluation_result);
         *result = evaluation_result;
         Ok(())
     })?;
@@ -396,8 +373,7 @@ pub fn evaluate_dynamic_cohorts(
     let final_result = results.get(&initial_cohort_id).copied().ok_or_else(|| {
         FlagError::DependencyNotFound(DependencyType::Cohort, initial_cohort_id.into())
     })?;
-    
-             initial_cohort_id, final_result);
+
     Ok(final_result)
 }
 

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -199,9 +199,11 @@ impl InnerCohortProperty {
         target_properties: &HashMap<String, Value>,
         cohort_matches: &HashMap<CohortId, bool>,
     ) -> Result<bool, FlagError> {
+                 self.prop_type, self.values.len());
+        
         match self.prop_type {
             CohortPropertyType::OR => {
-                for cohort_values in &self.values {
+                for (i, cohort_values) in self.values.iter().enumerate() {
                     if evaluate_cohort_values(cohort_values, target_properties, cohort_matches)? {
                         return Ok(true);
                     }
@@ -209,7 +211,7 @@ impl InnerCohortProperty {
                 Ok(false)
             }
             CohortPropertyType::AND => {
-                for cohort_values in &self.values {
+                for (i, cohort_values) in self.values.iter().enumerate() {
                     if !evaluate_cohort_values(cohort_values, target_properties, cohort_matches)? {
                         return Ok(false);
                     }
@@ -229,9 +231,12 @@ fn evaluate_cohort_values(
     target_properties: &HashMap<String, Value>,
     cohort_matches: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
+             values.prop_type, values.values.len());
+    
     match values.prop_type.as_str() {
         "OR" => {
-            for filter in &values.values {
+            for (i, filter) in values.values.iter().enumerate() {
+                         i, filter.key, filter.is_cohort());
                 if filter.is_cohort() {
                     // Handle cohort membership check
                     if apply_cohort_membership_logic(std::slice::from_ref(filter), cohort_matches)?
@@ -240,7 +245,9 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check with negation
-                    if evaluate_property_with_negation(filter, target_properties) {
+                    let property_result = evaluate_property_with_negation(filter, target_properties);
+                             i, property_result);
+                    if property_result {
                         return Ok(true);
                     }
                 }
@@ -248,7 +255,8 @@ fn evaluate_cohort_values(
             Ok(false)
         }
         "AND" | "property" => {
-            for filter in &values.values {
+            for (i, filter) in values.values.iter().enumerate() {
+                         i, filter.key, filter.is_cohort());
                 if filter.is_cohort() {
                     // Handle cohort membership check with negation
                     let cohort_result = apply_cohort_membership_logic(
@@ -261,14 +269,18 @@ fn evaluate_cohort_values(
                     }
                 } else {
                     // Handle regular property check with negation
-                    if !evaluate_property_with_negation(filter, target_properties) {
+                    let property_result = evaluate_property_with_negation(filter, target_properties);
+                             i, property_result);
+                    if !property_result {
                         return Ok(false);
                     }
                 }
             }
             Ok(true)
         }
-        _ => Err(FlagError::CohortFiltersParsingError),
+        _ => {
+            Err(FlagError::CohortFiltersParsingError)
+        }
     }
 }
 
@@ -280,14 +292,20 @@ fn evaluate_property_with_negation(
     filter: &PropertyFilter,
     target_properties: &HashMap<String, Value>,
 ) -> bool {
+             filter.key, filter.operator, filter.value, filter.negation);
+    
+    let property_value = target_properties.get(&filter.key);
+    
     let property_result = match_property(filter, target_properties, false).unwrap_or(false);
 
     // Apply negation if specified
-    if filter.negation.unwrap_or(false) {
+    let final_result = if filter.negation.unwrap_or(false) {
         !property_result
     } else {
         property_result
-    }
+    };
+    
+    final_result
 }
 
 /// Evaluates a single cohort against target properties and existing evaluation results.
@@ -297,22 +315,34 @@ fn evaluate_single_cohort(
     target_properties: &HashMap<String, Value>,
     evaluation_results: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
+             cohort.id, cohort.name.as_deref().unwrap_or("unnamed"));
+    
     // Get the filters for this cohort
     let filters = match &cohort.filters {
-        Some(filters) => filters,
-        None => return Ok(false),
+        Some(filters) => {
+            filters
+        },
+        None => {
+            return Ok(false);
+        }
     };
 
     // Parse and evaluate using the hierarchical structure
     let cohort_property: CohortProperty = match serde_json::from_value(filters.clone()) {
-        Ok(prop) => prop,
-        Err(_) => return Ok(false),
+        Ok(prop) => {
+            prop
+        },
+        Err(e) => {
+            return Ok(false);
+        }
     };
 
     // Use our evaluation method that respects OR/AND structure
-    cohort_property
+    let result = cohort_property
         .properties
-        .evaluate(target_properties, evaluation_results)
+        .evaluate(target_properties, evaluation_results)?;
+    
+    Ok(result)
 }
 
 pub fn evaluate_dynamic_cohorts(
@@ -321,6 +351,7 @@ pub fn evaluate_dynamic_cohorts(
     cohorts: &[Cohort],
     static_cohort_matches: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
+    
     // First check if this is a static cohort
     let initial_cohort = cohorts
         .iter()
@@ -329,6 +360,8 @@ pub fn evaluate_dynamic_cohorts(
             FlagError::DependencyNotFound(DependencyType::Cohort, initial_cohort_id.into())
         })?
         .clone();
+
+             initial_cohort.name.as_deref().unwrap_or("unnamed"), initial_cohort.is_static);
 
     // If it's static, we don't need to evaluate dependencies
     if initial_cohort.is_static {
@@ -340,24 +373,32 @@ pub fn evaluate_dynamic_cohorts(
 
     // Use for_each_dependencies_first to evaluate each cohort in the correct order
     let results = graph.for_each_dependencies_first(|cohort, results, result| {
+                 cohort.id, cohort.is_static);
+        
         // If this is a static cohort dependency, use the cached result
         if cohort.is_static {
             let cached_result = static_cohort_matches
                 .get(&cohort.id)
                 .copied()
                 .unwrap_or(false);
+                     cohort.id, cached_result);
             *result = cached_result;
             return Ok(());
         }
 
-        *result = evaluate_single_cohort(cohort, target_properties, results)?;
+        let evaluation_result = evaluate_single_cohort(cohort, target_properties, results)?;
+                 cohort.id, evaluation_result);
+        *result = evaluation_result;
         Ok(())
     })?;
 
     // Return the evaluation result for the initial cohort
-    results.get(&initial_cohort_id).copied().ok_or_else(|| {
+    let final_result = results.get(&initial_cohort_id).copied().ok_or_else(|| {
         FlagError::DependencyNotFound(DependencyType::Cohort, initial_cohort_id.into())
-    })
+    })?;
+    
+             initial_cohort_id, final_result);
+    Ok(final_result)
 }
 
 /// Applies cohort membership logic for a set of cohort filters.

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -203,6 +203,13 @@ pub struct Config {
     #[envconfig(default = "")]
     pub behavioral_cohorts_read_database_url: String,
 
+    // Feature gate for realtime cohort evaluation. When false (default), the realtime
+    // cohort block in prepare_flag_evaluation_state is skipped entirely, even if the
+    // behavioral cohorts DB is configured and cohorts with CohortType::Realtime exist.
+    // Set to true to enable realtime cohort membership lookups on the hot path.
+    #[envconfig(from = "ENABLE_REALTIME_COHORT_EVALUATION", default = "false")]
+    pub enable_realtime_cohort_evaluation: bool,
+
     // Cache TTL for realtime cohort membership lookups (seconds).
     #[envconfig(from = "COHORT_MEMBERSHIP_CACHE_TTL_SECONDS", default = "60")]
     pub cohort_membership_cache_ttl_seconds: u64,
@@ -712,6 +719,7 @@ impl Config {
                 .to_string(),
             behavioral_cohorts_read_database_url:
                 "postgres://posthog:posthog@localhost:5432/test_posthog".to_string(),
+            enable_realtime_cohort_evaluation: false,
             cohort_membership_cache_ttl_seconds: 60,
             cohort_membership_cache_max_entries: 50_000,
             max_concurrency: 1000,

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1231,7 +1231,6 @@ impl FeatureFlagMatcher {
 
         if flag.get_group_type_index().is_some() && hashed_id.is_empty() {
             // This is a group-based flag but we don't have the group key
-            if is_debug_flag {}
             return Ok(FeatureFlagMatch {
                 matches: false,
                 variant: None,
@@ -1285,7 +1284,6 @@ impl FeatureFlagMatcher {
         // group-based flags. This is because early access enrollment is a person-level concept.
         // The API validates that group-based flags cannot have early access features attached.
         if let Some(super_groups) = &flag.filters.super_groups {
-            if is_debug_flag {}
             if let Some(super_condition) = super_groups.first() {
                 // Only fetch person properties if the super condition has property filters
                 // Super conditions are used for feature enrollment (aka early access features)
@@ -1295,7 +1293,6 @@ impl FeatureFlagMatcher {
                     .as_ref()
                     .is_some_and(|p| !p.is_empty())
                 {
-                    if is_debug_flag {}
                     let person_properties = self.get_person_properties(property_overrides)?;
                     let super_condition_evaluation = self.is_super_condition_match(
                         flag,
@@ -1305,7 +1302,6 @@ impl FeatureFlagMatcher {
                     )?;
 
                     if super_condition_evaluation.should_evaluate {
-                        if is_debug_flag {}
                         let payload = self.get_matching_payload(None, flag);
                         return Ok(FeatureFlagMatch {
                             matches: super_condition_evaluation.is_match,
@@ -1317,7 +1313,6 @@ impl FeatureFlagMatcher {
                     }
                     // if no match, continue to normal conditions
                 } else {
-                    if is_debug_flag {}
                 }
             }
         }
@@ -1349,12 +1344,8 @@ impl FeatureFlagMatcher {
         let conditions: Vec<(usize, &FlagPropertyGroup)> =
             flag.get_conditions().iter().enumerate().collect();
 
-        if is_debug_flag {}
-
         let condition_timer = common_metrics::timing_guard(FLAG_EVALUATE_ALL_CONDITIONS_TIME, &[]);
         for (index, condition) in conditions {
-            if is_debug_flag {}
-
             // Lazily compute properties only when a condition actually needs them.
             // A condition needs properties if it has non-empty property filters that aren't
             // purely flag-value filters (which don't require person/group properties).
@@ -1378,8 +1369,6 @@ impl FeatureFlagMatcher {
                 hash_key_overrides,
                 request_hash_key_override,
             )?;
-
-            if is_debug_flag {}
 
             // Update highest_match and highest_index
             let (new_highest_match, new_highest_index) = self
@@ -1420,7 +1409,6 @@ impl FeatureFlagMatcher {
                 };
                 let payload = self.get_matching_payload(variant.as_deref(), flag);
 
-                if is_debug_flag {}
                 return Ok(FeatureFlagMatch {
                     matches: true,
                     variant,
@@ -1433,7 +1421,6 @@ impl FeatureFlagMatcher {
 
         condition_timer.label("outcome", "success").fin();
         // Return with the highest_match reason and index even if no conditions matched
-        if is_debug_flag {}
         Ok(FeatureFlagMatch {
             matches: false,
             variant: None,
@@ -1479,14 +1466,10 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
-        let is_debug_flag = feature_flag.key == "real-users";
         let rollout_percentage = condition.rollout_percentage.unwrap_or(100.0);
-        if is_debug_flag {}
 
         if let Some(flag_property_filters) = &condition.properties {
-            if is_debug_flag {}
             if flag_property_filters.is_empty() {
-                if is_debug_flag {}
                 return self.check_rollout(
                     feature_flag,
                     rollout_percentage,
@@ -1502,15 +1485,12 @@ impl FeatureFlagMatcher {
                     .cloned()
                     .partition(|prop| prop.depends_on_feature_flag());
 
-            if is_debug_flag {}
-
             if !flag_value_filters.is_empty()
                 && !all_flag_condition_properties_match(
                     &flag_value_filters,
                     &self.flag_evaluation_state.flag_evaluation_results,
                 )
             {
-                if is_debug_flag {}
                 return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
             }
 
@@ -1521,11 +1501,8 @@ impl FeatureFlagMatcher {
                     .cloned()
                     .partition(|prop| prop.is_cohort());
 
-            if is_debug_flag {}
-
             // Evaluate non-cohort filters first, since they're cheaper to evaluate and we can return early if they don't match
             if !all_properties_match(&non_cohort_filters, merged_properties) {
-                if is_debug_flag {}
                 return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
             }
 
@@ -1534,27 +1511,17 @@ impl FeatureFlagMatcher {
                 let cohorts = match &self.flag_evaluation_state.cohorts {
                     Some(cohorts) => cohorts.clone(),
                     None => {
-                        if is_debug_flag {}
                         return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
                     }
                 };
-                if is_debug_flag {
-                    for filter in &cohort_filters {
-                        if let Some(cohort_id) = filter.get_cohort_id() {}
-                    }
-                }
                 if !self.evaluate_cohort_filters(&cohort_filters, merged_properties, cohorts)? {
-                    if is_debug_flag {}
                     return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
                 } else {
-                    if is_debug_flag {}
                 }
             }
         } else {
-            if is_debug_flag {}
         }
 
-        if is_debug_flag {}
         self.check_rollout(
             feature_flag,
             rollout_percentage,
@@ -1863,11 +1830,7 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
-        let is_debug_flag = feature_flag.key == "real-users";
-        if is_debug_flag {}
-
         if rollout_percentage == 100.0 {
-            if is_debug_flag {}
             return Ok((true, FeatureFlagMatchReason::ConditionMatch));
         }
         let hash = self.get_hash(
@@ -1877,13 +1840,10 @@ impl FeatureFlagMatcher {
             request_hash_key_override,
         )?;
         let threshold = rollout_percentage / 100.0;
-        if is_debug_flag {}
 
         if hash <= threshold {
-            if is_debug_flag {}
             Ok((true, FeatureFlagMatchReason::ConditionMatch))
         } else {
-            if is_debug_flag {}
             Ok((false, FeatureFlagMatchReason::OutOfRolloutBound))
         }
     }

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -3,6 +3,7 @@ use crate::api::types::{FlagDetails, FlagValue, FlagsResponse, FromFeatureAndMat
 use crate::cohorts::cohort_cache_manager::CohortCacheManager;
 use crate::cohorts::cohort_models::{Cohort, CohortId};
 use crate::cohorts::cohort_operations::{apply_cohort_membership_logic, evaluate_dynamic_cohorts};
+use crate::cohorts::membership::{CohortMembershipProvider, NoOpCohortMembershipProvider};
 use crate::database::PostgresRouter;
 use crate::flags::flag_group_type_mapping::{GroupTypeIndex, GroupTypeMappingCache};
 use crate::flags::flag_match_reason::FeatureFlagMatchReason;
@@ -24,8 +25,9 @@ use crate::metrics::consts::{
     FLAG_EVALUATE_ALL_CONDITIONS_TIME, FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME,
     FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED, FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER,
     FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME, FLAG_GROUP_DB_FETCH_TIME,
-    FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER, PROPERTY_CACHE_HITS_COUNTER,
-    PROPERTY_CACHE_MISSES_COUNTER,
+    FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER,
+    FLAG_REALTIME_COHORT_QUERY_ERROR_COUNTER, FLAG_REALTIME_COHORT_QUERY_TIME,
+    PROPERTY_CACHE_HITS_COUNTER, PROPERTY_CACHE_MISSES_COUNTER,
 };
 use crate::properties::property_models::PropertyFilter;
 use crate::rayon_dispatcher::RayonDispatcher;
@@ -136,14 +138,18 @@ impl FeatureFlagMatch {
 pub struct FlagEvaluationState {
     /// The person ID associated with the distinct_id being evaluated
     person_id: Option<PersonId>,
+    /// The person UUID, needed for realtime cohort membership lookups
+    person_uuid: Option<Uuid>,
     /// Properties associated with the person, fetched from the database
     pub(crate) person_properties: Option<HashMap<String, Value>>,
     /// Properties for each group type involved in flag evaluation
     group_properties: HashMap<GroupTypeIndex, HashMap<String, Value>>,
     /// Cohorts for the current request
     cohorts: Option<Vec<Cohort>>,
-    /// Cache of static cohort membership results to avoid repeated DB lookups
-    static_cohort_matches: Option<HashMap<CohortId, bool>>,
+    /// Cache of cohort membership results (both static and realtime) to avoid repeated lookups.
+    /// Static results come from `posthog_cohortpeople`, realtime results from `cohort_membership`.
+    /// The two sources produce disjoint key sets partitioned by `CohortType`.
+    cohort_matches: Option<HashMap<CohortId, bool>>,
     /// Cache of flag evaluation results to avoid repeated DB lookups
     flag_evaluation_results: HashMap<FeatureFlagId, FlagValue>,
 }
@@ -161,12 +167,20 @@ impl FlagEvaluationState {
         &self.group_properties
     }
 
-    pub fn get_static_cohort_matches(&self) -> Option<&HashMap<CohortId, bool>> {
-        self.static_cohort_matches.as_ref()
+    pub fn get_cohort_matches(&self) -> Option<&HashMap<CohortId, bool>> {
+        self.cohort_matches.as_ref()
+    }
+
+    pub fn get_person_uuid(&self) -> Option<Uuid> {
+        self.person_uuid
     }
 
     pub fn set_person_id(&mut self, id: PersonId) {
         self.person_id = Some(id);
+    }
+
+    pub fn set_person_uuid(&mut self, uuid: Uuid) {
+        self.person_uuid = Some(uuid);
     }
 
     pub fn set_person_properties(&mut self, properties: HashMap<String, Value>) {
@@ -185,8 +199,17 @@ impl FlagEvaluationState {
         self.group_properties.insert(group_type_index, properties);
     }
 
-    pub fn set_static_cohort_matches(&mut self, matches: HashMap<CohortId, bool>) {
-        self.static_cohort_matches = Some(matches);
+    pub fn set_cohort_matches(&mut self, matches: HashMap<CohortId, bool>) {
+        self.cohort_matches = Some(matches);
+    }
+
+    /// Merge additional cohort membership results into the existing map.
+    /// Used to add realtime cohort results after static results are already set.
+    pub fn merge_cohort_matches(&mut self, additional: HashMap<CohortId, bool>) {
+        match &mut self.cohort_matches {
+            Some(existing) => existing.extend(additional),
+            None => self.cohort_matches = Some(additional),
+        }
     }
 
     pub fn add_flag_evaluation_result(&mut self, flag_id: FeatureFlagId, flag_value: FlagValue) {
@@ -239,6 +262,9 @@ pub struct FeatureFlagMatcher {
     /// Flag IDs that should be skipped during evaluation.
     /// Populated once per request from `FeatureFlagList::filtered_out_flag_ids`.
     pub(crate) filtered_out_flag_ids: HashSet<i32>,
+    /// Provider for realtime/behavioral cohort membership lookups.
+    /// Queries the behavioral cohorts database for cohorts with CohortType::Realtime or Behavioral.
+    cohort_membership_provider: Arc<dyn CohortMembershipProvider>,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving
@@ -281,6 +307,7 @@ impl FeatureFlagMatcher {
                 .unwrap_or_else(|| GroupTypeMappingCache::new(team_id)),
             groups: groups.unwrap_or_default(),
             flag_evaluation_state: FlagEvaluationState::default(),
+            cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
             parallel_eval_threshold: DEFAULT_PARALLEL_EVAL_THRESHOLD,
             rayon_dispatcher: None,
             skip_writes: false,
@@ -300,6 +327,14 @@ impl FeatureFlagMatcher {
 
     pub fn with_skip_writes(mut self, skip_writes: bool) -> Self {
         self.skip_writes = skip_writes;
+        self
+    }
+
+    pub fn with_cohort_membership_provider(
+        mut self,
+        provider: Arc<dyn CohortMembershipProvider>,
+    ) -> Self {
+        self.cohort_membership_provider = provider;
         self
     }
 
@@ -582,10 +617,8 @@ impl FeatureFlagMatcher {
         }
     }
 
-    /// Evaluates cohort filters
-    /// Uses the static cohort results from the cache, and
-    /// evaluates dynamic cohorts based on the provided properties
-    /// (converts dynamic cohorts into property filters and then evaluates them)
+    /// Evaluates cohort filters using cached membership results (both static and realtime)
+    /// and evaluates dynamic cohorts based on the provided properties.
     pub fn evaluate_cohort_filters(
         &self,
         cohort_property_filters: &[PropertyFilter],
@@ -595,14 +628,13 @@ impl FeatureFlagMatcher {
         // Track cohort evaluations in canonical log
         with_canonical_log(|log| log.eval.cohorts_evaluated += cohort_property_filters.len());
 
-        // Get cached static cohort results or evaluate them if not cached
-        let static_cohort_matches = match self.flag_evaluation_state.get_static_cohort_matches() {
+        // Get cached cohort results (static + realtime, merged during prepare_flag_evaluation_state)
+        let cached_matches = match self.flag_evaluation_state.get_cohort_matches() {
             Some(matches) => matches.clone(),
-            None => HashMap::new(), // NB: this happens if a flag has static cohort filters but is targeting an anonymous user.  Shouldn't error, just return empty.
+            None => HashMap::new(), // Happens when targeting an anonymous user with no person record
         };
 
-        // Store all cohort match results, starting with static cohort results
-        let mut cohort_matches = static_cohort_matches;
+        let mut cohort_matches = cached_matches;
 
         // For any cohorts not yet evaluated (i.e., dynamic ones), evaluate them
         for filter in cohort_property_filters {
@@ -1838,6 +1870,7 @@ impl FeatureFlagMatcher {
     /// Prepares all database-sourced data needed for flag evaluation.
     /// This includes:
     /// - Static cohort memberships
+    /// - Realtime cohort memberships (via behavioral cohorts database)
     /// - Group type mappings
     /// - Person and group properties
     ///
@@ -1852,6 +1885,8 @@ impl FeatureFlagMatcher {
         self.flag_evaluation_state.set_cohorts(cohorts.clone());
 
         // Get static cohort IDs
+        // NOTE: relies on `is_static` and `uses_realtime_membership()` being mutually exclusive
+        // (a cohort with is_static=true should never have CohortType::Realtime/Behavioral).
         let static_cohort_ids: Vec<CohortId> = cohorts
             .iter()
             .filter(|c| c.is_static)
@@ -1879,7 +1914,6 @@ impl FeatureFlagMatcher {
             Ok(_) => {
                 inc(DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, &[], 1);
                 db_fetch_timer.label("outcome", "success").fin();
-                Ok(())
             }
             Err(e) => {
                 error!(
@@ -1887,9 +1921,72 @@ impl FeatureFlagMatcher {
                     self.team_id, self.distinct_id, e
                 );
                 db_fetch_timer.label("outcome", "error").fin();
-                Err(e)
+                return Err(e);
             }
         }
+
+        // Fetch realtime cohort memberships for Realtime/Behavioral cohorts.
+        // This is a separate DB call to the behavioral cohorts database, isolated from
+        // the static cohort path above which uses the persons_reader pool.
+        let realtime_cohort_ids: Vec<CohortId> = cohorts
+            .iter()
+            .filter(|c| c.uses_realtime_membership())
+            .map(|c| c.id)
+            .collect();
+
+        if !realtime_cohort_ids.is_empty() {
+            with_canonical_log(|log| {
+                log.realtime_cohorts_evaluated += realtime_cohort_ids.len();
+            });
+
+            let all_non_member = || -> HashMap<CohortId, bool> {
+                realtime_cohort_ids.iter().map(|id| (*id, false)).collect()
+            };
+
+            let realtime_memberships = if let Some(person_uuid) =
+                self.flag_evaluation_state.get_person_uuid()
+            {
+                let query_labels = [("team_id".to_string(), self.team_id.to_string())];
+                let realtime_timer = timing_guard(FLAG_REALTIME_COHORT_QUERY_TIME, &query_labels);
+                let realtime_start = std::time::Instant::now();
+
+                let result = self
+                    .cohort_membership_provider
+                    .check_memberships(self.team_id, person_uuid, &realtime_cohort_ids)
+                    .await;
+
+                let duration = realtime_start.elapsed();
+                realtime_timer.fin();
+                with_canonical_log(|log| {
+                    log.realtime_cohort_queries += 1;
+                    log.realtime_cohort_query_time_ms += duration.as_millis() as u64;
+                });
+
+                match result {
+                    Ok(memberships) => memberships,
+                    Err(e) => {
+                        inc(FLAG_REALTIME_COHORT_QUERY_ERROR_COUNTER, &query_labels, 1);
+                        warn!(
+                            team_id = self.team_id,
+                            person_uuid = %person_uuid,
+                            realtime_cohort_count = realtime_cohort_ids.len(),
+                            error = %e,
+                            "Realtime cohort membership lookup failed, treating all as non-members"
+                        );
+                        // Graceful degradation: treat all realtime cohorts as non-members
+                        all_non_member()
+                    }
+                }
+            } else {
+                // No person UUID available (anonymous user). Realtime cohorts return false.
+                all_non_member()
+            };
+
+            self.flag_evaluation_state
+                .merge_cohort_matches(realtime_memberships);
+        }
+
+        Ok(())
     }
 
     /// Builds a paired mapping from group type index to group key for flag

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -265,6 +265,9 @@ pub struct FeatureFlagMatcher {
     /// Provider for realtime/behavioral cohort membership lookups.
     /// Queries the behavioral cohorts database for cohorts with CohortType::Realtime or Behavioral.
     cohort_membership_provider: Arc<dyn CohortMembershipProvider>,
+    /// Whether realtime cohort evaluation is enabled via ENABLE_REALTIME_COHORT_EVALUATION.
+    /// When false, cohorts with CohortType::Realtime/Behavioral are treated as dynamic cohorts.
+    enable_realtime_cohort_evaluation: bool,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving
@@ -312,6 +315,7 @@ impl FeatureFlagMatcher {
             rayon_dispatcher: None,
             skip_writes: false,
             filtered_out_flag_ids: HashSet::new(),
+            enable_realtime_cohort_evaluation: false,
         }
     }
 
@@ -335,6 +339,11 @@ impl FeatureFlagMatcher {
         provider: Arc<dyn CohortMembershipProvider>,
     ) -> Self {
         self.cohort_membership_provider = provider;
+        self
+    }
+
+    pub fn with_realtime_cohort_evaluation(mut self, enabled: bool) -> Self {
+        self.enable_realtime_cohort_evaluation = enabled;
         self
     }
 
@@ -625,6 +634,7 @@ impl FeatureFlagMatcher {
         target_properties: &HashMap<String, Value>,
         cohorts: Vec<Cohort>,
     ) -> Result<bool, FlagError> {
+
         // Track cohort evaluations in canonical log
         with_canonical_log(|log| log.eval.cohorts_evaluated += cohort_property_filters.len());
 
@@ -634,6 +644,7 @@ impl FeatureFlagMatcher {
             None => HashMap::new(), // Happens when targeting an anonymous user with no person record
         };
 
+
         let mut cohort_matches = cached_matches;
 
         // For any cohorts not yet evaluated (i.e., dynamic ones), evaluate them
@@ -641,6 +652,7 @@ impl FeatureFlagMatcher {
             let cohort_id = filter
                 .get_cohort_id()
                 .ok_or(FlagError::CohortFiltersParsingError)?;
+
 
             if !cohort_matches.contains_key(&cohort_id) {
                 let current_matches = cohort_matches.clone();
@@ -655,7 +667,8 @@ impl FeatureFlagMatcher {
         }
 
         // Apply cohort membership logic (IN|NOT_IN) to the cohort match results
-        apply_cohort_membership_logic(cohort_property_filters, &cohort_matches)
+        let final_result = apply_cohort_membership_logic(cohort_property_filters, &cohort_matches)?;
+        Ok(final_result)
     }
 
     /// Evaluates feature flags with property and hash key overrides.
@@ -1215,11 +1228,15 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<FeatureFlagMatch, FlagError> {
+        
         // Check if this is a group-based flag with missing group
         let hashed_id =
             self.hashed_identifier(flag, hash_key_overrides, request_hash_key_override)?;
+        
         if flag.get_group_type_index().is_some() && hashed_id.is_empty() {
             // This is a group-based flag but we don't have the group key
+            if is_debug_flag {
+            }
             return Ok(FeatureFlagMatch {
                 matches: false,
                 variant: None,
@@ -1273,6 +1290,8 @@ impl FeatureFlagMatcher {
         // group-based flags. This is because early access enrollment is a person-level concept.
         // The API validates that group-based flags cannot have early access features attached.
         if let Some(super_groups) = &flag.filters.super_groups {
+            if is_debug_flag {
+            }
             if let Some(super_condition) = super_groups.first() {
                 // Only fetch person properties if the super condition has property filters
                 // Super conditions are used for feature enrollment (aka early access features)
@@ -1282,6 +1301,8 @@ impl FeatureFlagMatcher {
                     .as_ref()
                     .is_some_and(|p| !p.is_empty())
                 {
+                    if is_debug_flag {
+                    }
                     let person_properties = self.get_person_properties(property_overrides)?;
                     let super_condition_evaluation = self.is_super_condition_match(
                         flag,
@@ -1291,6 +1312,8 @@ impl FeatureFlagMatcher {
                     )?;
 
                     if super_condition_evaluation.should_evaluate {
+                        if is_debug_flag {
+                        }
                         let payload = self.get_matching_payload(None, flag);
                         return Ok(FeatureFlagMatch {
                             matches: super_condition_evaluation.is_match,
@@ -1301,6 +1324,9 @@ impl FeatureFlagMatcher {
                         });
                     }
                     // if no match, continue to normal conditions
+                } else {
+                    if is_debug_flag {
+                    }
                 }
             }
         }
@@ -1332,8 +1358,14 @@ impl FeatureFlagMatcher {
         let conditions: Vec<(usize, &FlagPropertyGroup)> =
             flag.get_conditions().iter().enumerate().collect();
 
+        if is_debug_flag {
+        }
+
         let condition_timer = common_metrics::timing_guard(FLAG_EVALUATE_ALL_CONDITIONS_TIME, &[]);
         for (index, condition) in conditions {
+            if is_debug_flag {
+            }
+            
             // Lazily compute properties only when a condition actually needs them.
             // A condition needs properties if it has non-empty property filters that aren't
             // purely flag-value filters (which don't require person/group properties).
@@ -1357,6 +1389,9 @@ impl FeatureFlagMatcher {
                 hash_key_overrides,
                 request_hash_key_override,
             )?;
+
+            if is_debug_flag {
+            }
 
             // Update highest_match and highest_index
             let (new_highest_match, new_highest_index) = self
@@ -1397,6 +1432,8 @@ impl FeatureFlagMatcher {
                 };
                 let payload = self.get_matching_payload(variant.as_deref(), flag);
 
+                if is_debug_flag {
+                }
                 return Ok(FeatureFlagMatch {
                     matches: true,
                     variant,
@@ -1409,6 +1446,8 @@ impl FeatureFlagMatcher {
 
         condition_timer.label("outcome", "success").fin();
         // Return with the highest_match reason and index even if no conditions matched
+        if is_debug_flag {
+        }
         Ok(FeatureFlagMatch {
             matches: false,
             variant: None,
@@ -1454,10 +1493,17 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
+        let is_debug_flag = feature_flag.key == "real-users";
         let rollout_percentage = condition.rollout_percentage.unwrap_or(100.0);
+        if is_debug_flag {
+        }
 
         if let Some(flag_property_filters) = &condition.properties {
+            if is_debug_flag {
+            }
             if flag_property_filters.is_empty() {
+                if is_debug_flag {
+                }
                 return self.check_rollout(
                     feature_flag,
                     rollout_percentage,
@@ -1473,12 +1519,17 @@ impl FeatureFlagMatcher {
                     .cloned()
                     .partition(|prop| prop.depends_on_feature_flag());
 
+            if is_debug_flag {
+            }
+
             if !flag_value_filters.is_empty()
                 && !all_flag_condition_properties_match(
                     &flag_value_filters,
                     &self.flag_evaluation_state.flag_evaluation_results,
                 )
             {
+                if is_debug_flag {
+                }
                 return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
             }
 
@@ -1489,8 +1540,13 @@ impl FeatureFlagMatcher {
                     .cloned()
                     .partition(|prop| prop.is_cohort());
 
+            if is_debug_flag {
+            }
+
             // Evaluate non-cohort filters first, since they're cheaper to evaluate and we can return early if they don't match
             if !all_properties_match(&non_cohort_filters, merged_properties) {
+                if is_debug_flag {
+                }
                 return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
             }
 
@@ -1498,14 +1554,34 @@ impl FeatureFlagMatcher {
             if !cohort_filters.is_empty() {
                 let cohorts = match &self.flag_evaluation_state.cohorts {
                     Some(cohorts) => cohorts.clone(),
-                    None => return Ok((false, FeatureFlagMatchReason::NoConditionMatch)),
+                    None => {
+                        if is_debug_flag {
+                        }
+                        return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                    }
                 };
-                if !self.evaluate_cohort_filters(&cohort_filters, merged_properties, cohorts)? {
-                    return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                if is_debug_flag {
+                    for filter in &cohort_filters {
+                        if let Some(cohort_id) = filter.get_cohort_id() {
+                        }
+                    }
                 }
+                if !self.evaluate_cohort_filters(&cohort_filters, merged_properties, cohorts)? {
+                    if is_debug_flag {
+                    }
+                    return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                } else {
+                    if is_debug_flag {
+                    }
+                }
+            }
+        } else {
+            if is_debug_flag {
             }
         }
 
+        if is_debug_flag {
+        }
         self.check_rollout(
             feature_flag,
             rollout_percentage,
@@ -1814,7 +1890,13 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
+        let is_debug_flag = feature_flag.key == "real-users";
+        if is_debug_flag {
+        }
+        
         if rollout_percentage == 100.0 {
+            if is_debug_flag {
+            }
             return Ok((true, FeatureFlagMatchReason::ConditionMatch));
         }
         let hash = self.get_hash(
@@ -1823,9 +1905,17 @@ impl FeatureFlagMatcher {
             hash_key_overrides,
             request_hash_key_override,
         )?;
-        if hash <= (rollout_percentage / 100.0) {
+        let threshold = rollout_percentage / 100.0;
+        if is_debug_flag {
+        }
+        
+        if hash <= threshold {
+            if is_debug_flag {
+            }
             Ok((true, FeatureFlagMatchReason::ConditionMatch))
         } else {
+            if is_debug_flag {
+            }
             Ok((false, FeatureFlagMatchReason::OutOfRolloutBound))
         }
     }
@@ -1889,9 +1979,13 @@ impl FeatureFlagMatcher {
         // (a cohort with is_static=true should never have CohortType::Realtime/Behavioral).
         let static_cohort_ids: Vec<CohortId> = cohorts
             .iter()
-            .filter(|c| c.is_static)
+            .filter(|c| {
+                         c.id, c.name.as_deref().unwrap_or("unnamed"), c.is_static, c.cohort_type, c.uses_realtime_membership());
+                c.is_static
+            })
             .map(|c| c.id)
             .collect();
+            
 
         // Then prepare group mappings and properties
         // This should be _wicked_ fast since it's async and is just pulling from a cache that's already in memory
@@ -1928,11 +2022,22 @@ impl FeatureFlagMatcher {
         // Fetch realtime cohort memberships for Realtime/Behavioral cohorts.
         // This is a separate DB call to the behavioral cohorts database, isolated from
         // the static cohort path above which uses the persons_reader pool.
-        let realtime_cohort_ids: Vec<CohortId> = cohorts
-            .iter()
-            .filter(|c| c.uses_realtime_membership())
-            .map(|c| c.id)
-            .collect();
+        let realtime_cohort_ids: Vec<CohortId> = if self.enable_realtime_cohort_evaluation {
+            cohorts
+                .iter()
+                .filter(|c| {
+                    let uses_realtime = c.uses_realtime_membership();
+                    if uses_realtime {
+                                 c.id, c.name.as_deref().unwrap_or("unnamed"), c.cohort_type);
+                    }
+                    uses_realtime
+                })
+                .map(|c| c.id)
+                .collect()
+        } else {
+            Vec::new()
+        };
+            
 
         if !realtime_cohort_ids.is_empty() {
             with_canonical_log(|log| {

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -634,7 +634,6 @@ impl FeatureFlagMatcher {
         target_properties: &HashMap<String, Value>,
         cohorts: Vec<Cohort>,
     ) -> Result<bool, FlagError> {
-
         // Track cohort evaluations in canonical log
         with_canonical_log(|log| log.eval.cohorts_evaluated += cohort_property_filters.len());
 
@@ -644,7 +643,6 @@ impl FeatureFlagMatcher {
             None => HashMap::new(), // Happens when targeting an anonymous user with no person record
         };
 
-
         let mut cohort_matches = cached_matches;
 
         // For any cohorts not yet evaluated (i.e., dynamic ones), evaluate them
@@ -652,7 +650,6 @@ impl FeatureFlagMatcher {
             let cohort_id = filter
                 .get_cohort_id()
                 .ok_or(FlagError::CohortFiltersParsingError)?;
-
 
             if !cohort_matches.contains_key(&cohort_id) {
                 let current_matches = cohort_matches.clone();
@@ -1228,15 +1225,13 @@ impl FeatureFlagMatcher {
         hash_key_overrides: Option<&HashMap<String, String>>,
         request_hash_key_override: &Option<String>,
     ) -> Result<FeatureFlagMatch, FlagError> {
-        
         // Check if this is a group-based flag with missing group
         let hashed_id =
             self.hashed_identifier(flag, hash_key_overrides, request_hash_key_override)?;
-        
+
         if flag.get_group_type_index().is_some() && hashed_id.is_empty() {
             // This is a group-based flag but we don't have the group key
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
             return Ok(FeatureFlagMatch {
                 matches: false,
                 variant: None,
@@ -1290,8 +1285,7 @@ impl FeatureFlagMatcher {
         // group-based flags. This is because early access enrollment is a person-level concept.
         // The API validates that group-based flags cannot have early access features attached.
         if let Some(super_groups) = &flag.filters.super_groups {
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
             if let Some(super_condition) = super_groups.first() {
                 // Only fetch person properties if the super condition has property filters
                 // Super conditions are used for feature enrollment (aka early access features)
@@ -1301,8 +1295,7 @@ impl FeatureFlagMatcher {
                     .as_ref()
                     .is_some_and(|p| !p.is_empty())
                 {
-                    if is_debug_flag {
-                    }
+                    if is_debug_flag {}
                     let person_properties = self.get_person_properties(property_overrides)?;
                     let super_condition_evaluation = self.is_super_condition_match(
                         flag,
@@ -1312,8 +1305,7 @@ impl FeatureFlagMatcher {
                     )?;
 
                     if super_condition_evaluation.should_evaluate {
-                        if is_debug_flag {
-                        }
+                        if is_debug_flag {}
                         let payload = self.get_matching_payload(None, flag);
                         return Ok(FeatureFlagMatch {
                             matches: super_condition_evaluation.is_match,
@@ -1325,8 +1317,7 @@ impl FeatureFlagMatcher {
                     }
                     // if no match, continue to normal conditions
                 } else {
-                    if is_debug_flag {
-                    }
+                    if is_debug_flag {}
                 }
             }
         }
@@ -1358,14 +1349,12 @@ impl FeatureFlagMatcher {
         let conditions: Vec<(usize, &FlagPropertyGroup)> =
             flag.get_conditions().iter().enumerate().collect();
 
-        if is_debug_flag {
-        }
+        if is_debug_flag {}
 
         let condition_timer = common_metrics::timing_guard(FLAG_EVALUATE_ALL_CONDITIONS_TIME, &[]);
         for (index, condition) in conditions {
-            if is_debug_flag {
-            }
-            
+            if is_debug_flag {}
+
             // Lazily compute properties only when a condition actually needs them.
             // A condition needs properties if it has non-empty property filters that aren't
             // purely flag-value filters (which don't require person/group properties).
@@ -1390,8 +1379,7 @@ impl FeatureFlagMatcher {
                 request_hash_key_override,
             )?;
 
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
 
             // Update highest_match and highest_index
             let (new_highest_match, new_highest_index) = self
@@ -1432,8 +1420,7 @@ impl FeatureFlagMatcher {
                 };
                 let payload = self.get_matching_payload(variant.as_deref(), flag);
 
-                if is_debug_flag {
-                }
+                if is_debug_flag {}
                 return Ok(FeatureFlagMatch {
                     matches: true,
                     variant,
@@ -1446,8 +1433,7 @@ impl FeatureFlagMatcher {
 
         condition_timer.label("outcome", "success").fin();
         // Return with the highest_match reason and index even if no conditions matched
-        if is_debug_flag {
-        }
+        if is_debug_flag {}
         Ok(FeatureFlagMatch {
             matches: false,
             variant: None,
@@ -1495,15 +1481,12 @@ impl FeatureFlagMatcher {
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
         let is_debug_flag = feature_flag.key == "real-users";
         let rollout_percentage = condition.rollout_percentage.unwrap_or(100.0);
-        if is_debug_flag {
-        }
+        if is_debug_flag {}
 
         if let Some(flag_property_filters) = &condition.properties {
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
             if flag_property_filters.is_empty() {
-                if is_debug_flag {
-                }
+                if is_debug_flag {}
                 return self.check_rollout(
                     feature_flag,
                     rollout_percentage,
@@ -1519,8 +1502,7 @@ impl FeatureFlagMatcher {
                     .cloned()
                     .partition(|prop| prop.depends_on_feature_flag());
 
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
 
             if !flag_value_filters.is_empty()
                 && !all_flag_condition_properties_match(
@@ -1528,8 +1510,7 @@ impl FeatureFlagMatcher {
                     &self.flag_evaluation_state.flag_evaluation_results,
                 )
             {
-                if is_debug_flag {
-                }
+                if is_debug_flag {}
                 return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
             }
 
@@ -1540,13 +1521,11 @@ impl FeatureFlagMatcher {
                     .cloned()
                     .partition(|prop| prop.is_cohort());
 
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
 
             // Evaluate non-cohort filters first, since they're cheaper to evaluate and we can return early if they don't match
             if !all_properties_match(&non_cohort_filters, merged_properties) {
-                if is_debug_flag {
-                }
+                if is_debug_flag {}
                 return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
             }
 
@@ -1555,33 +1534,27 @@ impl FeatureFlagMatcher {
                 let cohorts = match &self.flag_evaluation_state.cohorts {
                     Some(cohorts) => cohorts.clone(),
                     None => {
-                        if is_debug_flag {
-                        }
+                        if is_debug_flag {}
                         return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
                     }
                 };
                 if is_debug_flag {
                     for filter in &cohort_filters {
-                        if let Some(cohort_id) = filter.get_cohort_id() {
-                        }
+                        if let Some(cohort_id) = filter.get_cohort_id() {}
                     }
                 }
                 if !self.evaluate_cohort_filters(&cohort_filters, merged_properties, cohorts)? {
-                    if is_debug_flag {
-                    }
+                    if is_debug_flag {}
                     return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
                 } else {
-                    if is_debug_flag {
-                    }
+                    if is_debug_flag {}
                 }
             }
         } else {
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
         }
 
-        if is_debug_flag {
-        }
+        if is_debug_flag {}
         self.check_rollout(
             feature_flag,
             rollout_percentage,
@@ -1891,12 +1864,10 @@ impl FeatureFlagMatcher {
         request_hash_key_override: &Option<String>,
     ) -> Result<(bool, FeatureFlagMatchReason), FlagError> {
         let is_debug_flag = feature_flag.key == "real-users";
-        if is_debug_flag {
-        }
-        
+        if is_debug_flag {}
+
         if rollout_percentage == 100.0 {
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
             return Ok((true, FeatureFlagMatchReason::ConditionMatch));
         }
         let hash = self.get_hash(
@@ -1906,16 +1877,13 @@ impl FeatureFlagMatcher {
             request_hash_key_override,
         )?;
         let threshold = rollout_percentage / 100.0;
-        if is_debug_flag {
-        }
-        
+        if is_debug_flag {}
+
         if hash <= threshold {
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
             Ok((true, FeatureFlagMatchReason::ConditionMatch))
         } else {
-            if is_debug_flag {
-            }
+            if is_debug_flag {}
             Ok((false, FeatureFlagMatchReason::OutOfRolloutBound))
         }
     }
@@ -1979,13 +1947,9 @@ impl FeatureFlagMatcher {
         // (a cohort with is_static=true should never have CohortType::Realtime/Behavioral).
         let static_cohort_ids: Vec<CohortId> = cohorts
             .iter()
-            .filter(|c| {
-                         c.id, c.name.as_deref().unwrap_or("unnamed"), c.is_static, c.cohort_type, c.uses_realtime_membership());
-                c.is_static
-            })
+            .filter(|c| c.is_static)
             .map(|c| c.id)
             .collect();
-            
 
         // Then prepare group mappings and properties
         // This should be _wicked_ fast since it's async and is just pulling from a cache that's already in memory
@@ -2027,9 +1991,7 @@ impl FeatureFlagMatcher {
                 .iter()
                 .filter(|c| {
                     let uses_realtime = c.uses_realtime_membership();
-                    if uses_realtime {
-                                 c.id, c.name.as_deref().unwrap_or("unnamed"), c.cohort_type);
-                    }
+                    if uses_realtime {}
                     uses_realtime
                 })
                 .map(|c| c.id)
@@ -2037,7 +1999,6 @@ impl FeatureFlagMatcher {
         } else {
             Vec::new()
         };
-            
 
         if !realtime_cohort_ids.is_empty() {
             with_canonical_log(|log| {

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -240,9 +240,6 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
     let person_query_start = Instant::now();
     let person_query_timer = common_metrics::timing_guard(FLAG_PERSON_QUERY_TIME, &query_labels);
     let person = Person::from_distinct_id(&mut conn, team_id, &distinct_id).await?;
-    let (person_id, person_props) = person
-        .map(|p| (Some(p.id), Some(p.properties)))
-        .unwrap_or((None, None));
     person_query_timer.fin();
     let person_query_duration = person_query_start.elapsed();
     with_canonical_log(|log| {
@@ -268,9 +265,10 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
         );
     }
     let person_processing_timer = common_metrics::timing_guard(FLAG_PERSON_PROCESSING_TIME, &[]);
-    if let Some(person_id) = person_id {
-        // NB: this is where we actually set our person ID in the flag evaluation state.
-        flag_evaluation_state.set_person_id(person_id);
+    if let Some(ref person) = person {
+        // NB: this is where we actually set our person ID and UUID in the flag evaluation state.
+        flag_evaluation_state.set_person_id(person.id);
+        flag_evaluation_state.set_person_uuid(person.uuid);
         // If we have static cohort IDs to check and a valid person_id, do the cohort query
         if !static_cohort_ids.is_empty() {
             let cohort_query = r#"
@@ -290,7 +288,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             let cohort_timer = common_metrics::timing_guard(FLAG_COHORT_QUERY_TIME, &query_labels);
             let cohort_rows = sqlx::query(cohort_query)
                 .bind(&static_cohort_ids)
-                .bind(person_id)
+                .bind(person.id)
                 .fetch_all(&mut *conn)
                 .await?;
             cohort_timer.fin();
@@ -303,7 +301,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             if cohort_query_duration.as_millis() > 200 {
                 warn!(
                     duration_ms = cohort_query_duration.as_millis(),
-                    person_id = person_id,
+                    person_id = person.id,
                     cohort_count = static_cohort_ids.len(),
                     sql_summary =
                         "SELECT cohort membership with LEFT JOIN from UNNEST to cohortpeople",
@@ -312,7 +310,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             } else {
                 info!(
                     duration_ms = cohort_query_duration.as_millis(),
-                    person_id = person_id,
+                    person_id = person.id,
                     cohort_count = static_cohort_ids.len(),
                     "Cohort query completed"
                 );
@@ -329,7 +327,7 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
                 })
                 .collect();
 
-            flag_evaluation_state.set_static_cohort_matches(cohort_results);
+            flag_evaluation_state.set_cohort_matches(cohort_results);
             cohort_processing_timer.fin();
         } else {
             // TRICKY: if there are no static cohorts to check, we want to return an empty map to show that
@@ -337,14 +335,14 @@ pub async fn fetch_and_locally_cache_all_relevant_properties(
             // would indicate that that we had an error doing this evaluation in the first place.
             // i.e.: if there are no static cohort ID matches, it means we checked, and if there's None, it means something
             // went wrong.  This is handled in the caller.
-            flag_evaluation_state.set_static_cohort_matches(HashMap::new());
+            flag_evaluation_state.set_cohort_matches(HashMap::new());
         }
     }
 
     // if we have person properties, set them
-    let mut all_person_properties: HashMap<String, Value> = if let Some(person_props) = person_props
-    {
-        person_props
+    let mut all_person_properties: HashMap<String, Value> = if let Some(ref person) = person {
+        person
+            .properties
             .as_object()
             .unwrap_or(&serde_json::Map::new())
             .iter()

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -210,12 +210,20 @@ pub struct FlagsCanonicalLogLine {
     pub group_queries: usize,
     /// Number of static cohort membership queries made to the database.
     pub static_cohort_queries: usize,
+    /// Number of realtime cohort membership queries made to the behavioral cohorts database.
+    pub realtime_cohort_queries: usize,
+    /// Count of realtime cohort IDs encountered during evaluation.
+    /// Incremented even for anonymous users (no person UUID), where no DB query is made.
+    /// Use `realtime_cohort_queries` to distinguish how many queries actually reached the DB.
+    pub realtime_cohorts_evaluated: usize,
     /// Time spent on person property queries in milliseconds.
     pub person_query_time_ms: u64,
     /// Time spent on group property queries in milliseconds.
     pub group_query_time_ms: u64,
     /// Time spent on static cohort membership queries in milliseconds.
     pub cohort_query_time_ms: u64,
+    /// Time spent on realtime cohort membership queries in milliseconds.
+    pub realtime_cohort_query_time_ms: u64,
     /// Number of flags whose evaluation returned an error. Not in `EvalCounters` because it is
     /// incremented in `process_flag_result`, which runs on the tokio task after rayon returns.
     pub flags_errored: usize,
@@ -276,9 +284,12 @@ impl Default for FlagsCanonicalLogLine {
             person_queries: 0,
             group_queries: 0,
             static_cohort_queries: 0,
+            realtime_cohort_queries: 0,
+            realtime_cohorts_evaluated: 0,
             person_query_time_ms: 0,
             group_query_time_ms: 0,
             cohort_query_time_ms: 0,
+            realtime_cohort_query_time_ms: 0,
             flags_errored: 0,
             dependency_graph_errors: 0,
             hash_key_override_status: None,
@@ -332,9 +343,12 @@ impl FlagsCanonicalLogLine {
             person_queries = self.person_queries,
             group_queries = self.group_queries,
             static_cohort_queries = self.static_cohort_queries,
+            realtime_cohort_queries = self.realtime_cohort_queries,
+            realtime_cohorts_evaluated = self.realtime_cohorts_evaluated,
             person_query_time_ms = self.person_query_time_ms,
             group_query_time_ms = self.group_query_time_ms,
             cohort_query_time_ms = self.cohort_query_time_ms,
+            realtime_cohort_query_time_ms = self.realtime_cohort_query_time_ms,
             property_cache_hits = self.eval.property_cache_hits,
             property_cache_misses = self.eval.property_cache_misses,
             person_properties_not_cached = self.eval.person_properties_not_cached,
@@ -396,6 +410,21 @@ impl FlagsCanonicalLogLine {
                 self.static_cohort_queries as f64,
             );
         }
+
+        // Emit realtime cohort query count
+        if self.realtime_cohort_queries > 0 {
+            common_metrics::histogram(
+                FLAG_DB_OPERATIONS_PER_REQUEST,
+                &[
+                    ("team_id".to_string(), team_id.clone()),
+                    (
+                        "operation_type".to_string(),
+                        "realtime_cohort_query".to_string(),
+                    ),
+                ],
+                self.realtime_cohort_queries as f64,
+            );
+        }
     }
 
     /// Merge evaluation counters accumulated on a rayon thread back into this log.
@@ -454,6 +483,9 @@ mod tests {
         assert_eq!(log.person_queries, 0);
         assert_eq!(log.group_queries, 0);
         assert_eq!(log.static_cohort_queries, 0);
+        assert_eq!(log.realtime_cohort_queries, 0);
+        assert_eq!(log.realtime_cohorts_evaluated, 0);
+        assert_eq!(log.realtime_cohort_query_time_ms, 0);
         assert_eq!(log.eval.property_cache_hits, 0);
         assert_eq!(log.eval.property_cache_misses, 0);
         assert!(!log.eval.person_properties_not_cached);

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -31,6 +31,7 @@ pub async fn evaluate_feature_flags(
         Some(group_type_mapping_cache),
         context.groups,
     )
+    .with_cohort_membership_provider(context.cohort_membership_provider)
     .with_parallel_eval_threshold(context.parallel_eval_threshold)
     .with_rayon_dispatcher(context.rayon_dispatcher)
     .with_skip_writes(context.skip_writes);

--- a/rust/feature-flags/src/handler/evaluation.rs
+++ b/rust/feature-flags/src/handler/evaluation.rs
@@ -34,7 +34,8 @@ pub async fn evaluate_feature_flags(
     .with_cohort_membership_provider(context.cohort_membership_provider)
     .with_parallel_eval_threshold(context.parallel_eval_threshold)
     .with_rayon_dispatcher(context.rayon_dispatcher)
-    .with_skip_writes(context.skip_writes);
+    .with_skip_writes(context.skip_writes)
+    .with_realtime_cohort_evaluation(context.enable_realtime_cohort_evaluation);
 
     matcher
         .evaluate_all_feature_flags(

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -278,6 +278,7 @@ pub async fn evaluate_for_request(
         parallel_eval_threshold: state.config.parallel_eval_threshold,
         rayon_dispatcher: state.rayon_dispatcher.clone(),
         skip_writes: *state.config.skip_writes,
+        cohort_membership_provider: state.cohort_membership_provider.clone(),
     };
 
     evaluation::evaluate_feature_flags(ctx, request_id).await

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -279,6 +279,7 @@ pub async fn evaluate_for_request(
         rayon_dispatcher: state.rayon_dispatcher.clone(),
         skip_writes: *state.config.skip_writes,
         cohort_membership_provider: state.cohort_membership_provider.clone(),
+        enable_realtime_cohort_evaluation: state.config.enable_realtime_cohort_evaluation,
     };
 
     evaluation::evaluate_feature_flags(ctx, request_id).await

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -8,6 +8,7 @@ use crate::{
         },
     },
     cohorts::cohort_cache_manager::CohortCacheManager,
+    cohorts::membership::NoOpCohortMembershipProvider,
     config::Config,
     flags::{
         flag_analytics::SURVEY_TARGETING_FLAG_PREFIX,
@@ -199,6 +200,7 @@ async fn test_evaluate_feature_flags() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
 
     let request_id = Uuid::new_v4();
@@ -299,6 +301,7 @@ async fn test_evaluate_feature_flags_with_errors() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
 
     let request_id = Uuid::new_v4();
@@ -714,6 +717,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
 
     let request_id = Uuid::new_v4();
@@ -828,6 +832,7 @@ async fn test_evaluate_feature_flags_details() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
 
     let request_id = Uuid::new_v4();
@@ -993,6 +998,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
 
     let request_id = Uuid::new_v4();
@@ -1093,6 +1099,7 @@ async fn test_long_distinct_id() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
 
     let request_id = Uuid::new_v4();
@@ -1633,6 +1640,7 @@ async fn test_parallel_path_matches_sequential_results() {
         parallel_eval_threshold: 100,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
     let sequential_result = evaluate_feature_flags(sequential_context, Uuid::new_v4())
         .await
@@ -1661,6 +1669,7 @@ async fn test_parallel_path_matches_sequential_results() {
         parallel_eval_threshold: 1,
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
+        cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
     };
     let parallel_result = evaluate_feature_flags(parallel_context, Uuid::new_v4())
         .await

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -201,6 +201,7 @@ async fn test_evaluate_feature_flags() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -302,6 +303,7 @@ async fn test_evaluate_feature_flags_with_errors() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -718,6 +720,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -833,6 +836,7 @@ async fn test_evaluate_feature_flags_details() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -999,6 +1003,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -1100,6 +1105,7 @@ async fn test_long_distinct_id() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
 
     let request_id = Uuid::new_v4();
@@ -1641,6 +1647,7 @@ async fn test_parallel_path_matches_sequential_results() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
     let sequential_result = evaluate_feature_flags(sequential_context, Uuid::new_v4())
         .await
@@ -1670,6 +1677,7 @@ async fn test_parallel_path_matches_sequential_results() {
         rayon_dispatcher: crate::rayon_dispatcher::RayonDispatcher::new(2, None),
         skip_writes: false,
         cohort_membership_provider: Arc::new(NoOpCohortMembershipProvider),
+        enable_realtime_cohort_evaluation: false,
     };
     let parallel_result = evaluate_feature_flags(parallel_context, Uuid::new_v4())
         .await

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -6,8 +6,11 @@ use std::{collections::HashMap, fmt, net::IpAddr, sync::Arc};
 use uuid::Uuid;
 
 use crate::{
-    api::types::FlagsQueryParams, cohorts::cohort_cache_manager::CohortCacheManager,
-    flags::flag_models::FeatureFlagList, rayon_dispatcher::RayonDispatcher, router,
+    api::types::FlagsQueryParams,
+    cohorts::{cohort_cache_manager::CohortCacheManager, membership::CohortMembershipProvider},
+    flags::flag_models::FeatureFlagList,
+    rayon_dispatcher::RayonDispatcher,
+    router,
     utils::user_agent::UserAgentInfo,
 };
 
@@ -67,6 +70,8 @@ pub struct FeatureFlagEvaluationContext {
     pub rayon_dispatcher: RayonDispatcher,
     /// When true, skip all writes to PostgreSQL and Redis.
     pub skip_writes: bool,
+    /// Provider for realtime/behavioral cohort membership lookups.
+    pub cohort_membership_provider: Arc<dyn CohortMembershipProvider>,
 }
 
 /// SDK type classification based on user-agent parsing.

--- a/rust/feature-flags/src/handler/types.rs
+++ b/rust/feature-flags/src/handler/types.rs
@@ -72,6 +72,8 @@ pub struct FeatureFlagEvaluationContext {
     pub skip_writes: bool,
     /// Provider for realtime/behavioral cohort membership lookups.
     pub cohort_membership_provider: Arc<dyn CohortMembershipProvider>,
+    /// Whether realtime cohort evaluation is enabled via ENABLE_REALTIME_COHORT_EVALUATION env var.
+    pub enable_realtime_cohort_evaluation: bool,
 }
 
 /// SDK type classification based on user-agent parsing.

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -39,6 +39,9 @@ pub const FLAG_DEFINITION_QUERY_TIME: &str = "flags_definition_query_time";
 pub const FLAG_PERSON_PROCESSING_TIME: &str = "flags_person_processing_time";
 pub const FLAG_COHORT_QUERY_TIME: &str = "flags_cohort_query_time";
 pub const FLAG_COHORT_PROCESSING_TIME: &str = "flags_cohort_processing_time";
+pub const FLAG_REALTIME_COHORT_QUERY_TIME: &str = "flags_realtime_cohort_query_time";
+pub const FLAG_REALTIME_COHORT_QUERY_ERROR_COUNTER: &str =
+    "flags_realtime_cohort_query_error_total";
 pub const FLAG_GROUP_QUERY_TIME: &str = "flags_group_query_time";
 pub const FLAG_GROUP_PROCESSING_TIME: &str = "flags_group_processing_time";
 pub const FLAG_DB_CONNECTION_TIME: &str = "flags_db_connection_time";

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -37,7 +37,7 @@ use crate::{
         flag_definitions_rate_limiter::FlagDefinitionsRateLimiter,
         flags_rate_limiter::{FlagsRateLimiter, IpRateLimiter},
     },
-    cohorts::cohort_cache_manager::CohortCacheManager,
+    cohorts::{cohort_cache_manager::CohortCacheManager, membership::CohortMembershipProvider},
     config::{Config, TeamIdCollection},
     metrics::{
         consts::{
@@ -87,6 +87,8 @@ pub struct State {
     /// In-memory negative cache for invalid API tokens, preventing repeated
     /// Redis/S3/PG lookups for tokens that don't correspond to any team
     pub team_negative_cache: NegativeCache,
+    /// Provider for realtime/behavioral cohort membership lookups
+    pub cohort_membership_provider: Arc<dyn CohortMembershipProvider>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -106,6 +108,7 @@ pub fn router(
     config_hypercache_reader: Arc<HyperCacheReader>,
     rayon_dispatcher: RayonDispatcher,
     team_negative_cache: NegativeCache,
+    cohort_membership_provider: Arc<dyn CohortMembershipProvider>,
     config: Config,
 ) -> Router {
     // Initialize flag definitions rate limiter with default and custom team rates
@@ -187,6 +190,7 @@ pub fn router(
         config_hypercache_reader,
         rayon_dispatcher,
         team_negative_cache,
+        cohort_membership_provider,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -5,6 +5,10 @@ use std::time::Duration;
 
 use crate::billing_limiters::{FeatureFlagsLimiter, SessionReplayLimiter};
 use crate::cohorts::cohort_cache_manager::CohortCacheManager;
+use crate::cohorts::membership::{
+    CachedCohortMembershipProvider, CohortMembershipProvider, NoOpCohortMembershipProvider,
+    RealtimeCohortMembershipProvider,
+};
 use crate::config::Config;
 use crate::database_pools::DatabasePools;
 use crate::db_monitor::DatabasePoolMonitor;
@@ -114,6 +118,26 @@ pub async fn serve<F>(
         Some(config.cohort_cache_capacity_bytes),
         Some(config.cache_ttl_seconds),
     ));
+
+    // Initialize the cohort membership provider for realtime/behavioral cohorts.
+    // Requires both the behavioral cohorts DB pool AND the explicit feature gate.
+    // When the gate is off (default), NoOp is used regardless of DB availability,
+    // so no realtime cohort queries hit the hot path until you flip the env var.
+    let cohort_membership_provider: Arc<dyn CohortMembershipProvider> =
+        if config.enable_realtime_cohort_evaluation {
+            if let Some(pool) = database_pools.behavioral_cohorts_reader.clone() {
+                let realtime = RealtimeCohortMembershipProvider::new(pool);
+                Arc::new(CachedCohortMembershipProvider::new(
+                    realtime,
+                    Some(config.cohort_membership_cache_ttl_seconds),
+                    Some(config.cohort_membership_cache_max_entries),
+                ))
+            } else {
+                Arc::new(NoOpCohortMembershipProvider)
+            }
+        } else {
+            Arc::new(NoOpCohortMembershipProvider)
+        };
 
     let health = HealthRegistry::new("liveness");
 
@@ -361,6 +385,7 @@ pub async fn serve<F>(
         config_hypercache_reader,
         rayon_dispatcher,
         team_negative_cache,
+        cohort_membership_provider,
         config,
     );
 

--- a/rust/feature-flags/tests/common/mod.rs
+++ b/rust/feature-flags/tests/common/mod.rs
@@ -13,6 +13,7 @@ use reqwest::header::CONTENT_TYPE;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 
+use feature_flags::cohorts::membership::NoOpCohortMembershipProvider;
 use feature_flags::config::Config;
 use feature_flags::rayon_dispatcher::RayonDispatcher;
 use feature_flags::server::serve;
@@ -331,6 +332,7 @@ impl ServerHandle {
                 config_hypercache_reader,
                 RayonDispatcher::new(2, None),
                 NegativeCache::new(10_000, 300),
+                Arc::new(NoOpCohortMembershipProvider),
                 config,
             );
 


### PR DESCRIPTION
## Problem

The `ENABLE_REALTIME_COHORT_EVALUATION` environment variable was not being properly enforced in the flag matching logic. Cohorts with `CohortType::Realtime/Behavioral` were still being processed and incorrectly cached with `false` results, preventing dynamic evaluation.

## Changes

- Added `enable_realtime_cohort_evaluation` field to `FeatureFlagMatcher` to track config state
- Updated context chain to pass the config value: `Config` → `FeatureFlagEvaluationContext` → `FeatureFlagMatcher`  
- Added guard in `prepare_flag_evaluation_state()` to skip realtime cohort detection when disabled
- Updated all test cases to include the new context field

## How did you test this code?

- Manually tested that flags with realtime cohorts now properly fall back to dynamic evaluation when `ENABLE_REALTIME_COHORT_EVALUATION=false` (default)
- Verified the flag evaluation works correctly for cohorts that should be treated as dynamic
- Confirmed existing tests still pass with the new context field