### PR TITLE
fix(batch-exports): handle memory errors in backfill estimation and optimize persons query

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -372,11 +372,13 @@ async def _get_backfill_info_for_persons(
     logger = LOGGER.bind()
     is_limited_export = str(team_id) in settings.BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS
 
+    lower_bound_condition = ""
     date_conditions = ""
     having_date_conditions = ""
     query_parameters: dict[str, typing.Any] = {"team_id": team_id, "log_comment": log_comment}
 
     if start_at is not None:
+        lower_bound_condition = "AND _timestamp >= %(start_at)s "
         date_conditions += "AND _timestamp >= %(start_at)s "
         having_date_conditions += "AND argMax(_timestamp, version) >= %(start_at)s "
         query_parameters["start_at"] = start_at.astimezone(dt.UTC)
@@ -441,6 +443,7 @@ async def _get_backfill_info_for_persons(
             SELECT id
             FROM person
             WHERE team_id = %(team_id)s
+            {lower_bound_condition}
             GROUP BY id
             HAVING argMax(_timestamp, version) > '2000-01-01'
                 {having_date_conditions}
@@ -451,6 +454,7 @@ async def _get_backfill_info_for_persons(
             SELECT distinct_id
             FROM person_distinct_id2
             WHERE team_id = %(team_id)s
+            {lower_bound_condition}
             GROUP BY distinct_id
             HAVING argMax(_timestamp, version) > '2000-01-01'
                 {having_date_conditions}

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -24,7 +24,7 @@ from posthog.clickhouse import query_tagging
 from posthog.clickhouse.query_tagging import Product
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.common.clickhouse import get_client
+from posthog.temporal.common.clickhouse import ClickHouseMemoryLimitExceededError, get_client
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -557,34 +557,45 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
 
     interval_seconds = batch_export.interval_time_delta.total_seconds()
 
-    if model == "events":
-        min_timestamp, record_count = await _get_backfill_info_for_events(
-            batch_export=batch_export,
-            start_at=start_at,
-            end_at=end_at,
-            include_events=include_events,
-            exclude_events=exclude_events,
-            filters_str=filters_str,
-            extra_query_parameters=extra_query_parameters,
-            log_comment=log_comment,
-        )
-    elif model == "persons":
-        min_timestamp, record_count = await _get_backfill_info_for_persons(
-            batch_export=batch_export,
-            start_at=start_at,
-            end_at=end_at,
-            log_comment=log_comment,
-        )
-    elif model == "sessions":
-        min_timestamp, record_count = await _get_backfill_info_for_sessions(
-            batch_export=batch_export,
-            start_at=start_at,
-            end_at=end_at,
-            log_comment=log_comment,
-        )
-    else:
-        logger.info(
-            "Backfill info not yet implemented for model, skipping estimation",
+    try:
+        if model == "events":
+            min_timestamp, record_count = await _get_backfill_info_for_events(
+                batch_export=batch_export,
+                start_at=start_at,
+                end_at=end_at,
+                include_events=include_events,
+                exclude_events=exclude_events,
+                filters_str=filters_str,
+                extra_query_parameters=extra_query_parameters,
+                log_comment=log_comment,
+            )
+        elif model == "persons":
+            min_timestamp, record_count = await _get_backfill_info_for_persons(
+                batch_export=batch_export,
+                start_at=start_at,
+                end_at=end_at,
+                log_comment=log_comment,
+            )
+        elif model == "sessions":
+            min_timestamp, record_count = await _get_backfill_info_for_sessions(
+                batch_export=batch_export,
+                start_at=start_at,
+                end_at=end_at,
+                log_comment=log_comment,
+            )
+        else:
+            logger.info(
+                "Backfill info not yet implemented for model, skipping estimation",
+                model=model,
+            )
+            return GetBackfillInfoOutputs(
+                adjusted_start_at=inputs.start_at,
+                total_records_count=None,
+                interval_seconds=interval_seconds,
+            )
+    except ClickHouseMemoryLimitExceededError:
+        logger.warning(
+            "Backfill estimation query exceeded memory limit, proceeding without estimate",
             model=model,
         )
         return GetBackfillInfoOutputs(


### PR DESCRIPTION
## Problem

The backfill estimation query can sometimes fail with a `ClickHouseMemoryLimitExceededError`, which causes the entire backfill workflow to fail. The backfill should still proceed even if we can't estimate the record count.

Additionally, the persons count query scans more data than necessary because it doesn't pre-filter rows by timestamp before the GROUP BY.

## Changes

- Wrap the backfill estimation calls in `get_backfill_info` with a try/except for `ClickHouseMemoryLimitExceededError`. When caught, log a warning and return `total_records_count=None` so the workflow continues without an estimate.
- Add a `lower_bound_condition` (`_timestamp >= start_at`) to the WHERE clauses in the persons count query's `new_persons` and `distinct_ids` CTEs. This pre-filters rows before the GROUP BY/HAVING, reducing memory usage. Only the lower bound is used (not the upper bound) to avoid incorrectly excluding person rows that have versions both inside and outside the backfill range.

## How did you test this code?

- Existing unit tests.
- Query performance was tested in production on a team with a lot of persons:
  - For a large backfill range, memory usage was reduced by around 15%
  - For a smaller backfill range, memory usage was reduced by around 90% (since the pre-filtering has much more of an effect)
  - Row counts in each case were identical

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code.