### PR TITLE
feat: move one-off exports from Celery to Temporal workflow with durable retry

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -319,14 +319,14 @@ jobs:
             - name: Start Docker services
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-                  COMPOSE_PROFILES: capture
+                  COMPOSE_PROFILES: capture,temporal
               run: bin/ci-wait-for-docker launch --down
 
             - name: Wait for Docker services
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-                  COMPOSE_PROFILES: capture
-              run: bin/ci-wait-for-docker wait capture
+                  COMPOSE_PROFILES: capture,temporal
+              run: bin/ci-wait-for-docker wait capture temporal
 
             - name: Build frontend
               run: |
@@ -392,9 +392,10 @@ jobs:
                     echo "POSTHOG_NODE_TAG=master" >> "$GITHUB_ENV"
                   fi
 
-            - name: Start PostHog web, Celery worker & ingestion
+            - name: Start PostHog web, Celery worker, Temporal worker & ingestion
               run: |
                   python manage.py run_autoreload_celery --type=worker &> /tmp/celery.log &
+                  python manage.py start_temporal_worker --task-queue analytics-platform-task-queue &> /tmp/temporal-worker.log &
                   # WARNING: Worker count is tuned to avoid CPU scheduling contention. Talk to #team-devex before changing.
                   python -m granian --interface asgi posthog.asgi:application --host 0.0.0.0 --port 8000 --log-level debug --workers 2 &> /tmp/server.log &
                   # Start the Node.js containers now that the database exists and migrations have run.
@@ -537,6 +538,7 @@ jobs:
                       playwright/test-results-attempt-*/
                       /tmp/celery.log
                       /tmp/server.log
+                      /tmp/temporal-worker.log
                       /tmp/playwright-output-attempt-*.log
                   retention-days: 30
                   if-no-files-found: ignore

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -1,6 +1,7 @@
 import threading
 from datetime import timedelta
 from typing import Any
+from uuid import NAMESPACE_DNS, uuid5
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -19,7 +20,7 @@ from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
-from posthog.event_usage import groups
+from posthog.event_usage import EventSource, groups
 from posthog.models import Insight, User
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, get_content_response
@@ -28,6 +29,7 @@ from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
 from posthog.tasks import exporter
 from posthog.temporal.common.client import async_connect
+from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 from posthog.temporal.exports_video.workflow import VideoExportInputs, VideoExportWorkflow
 
 VIDEO_EXPORT_SEMAPHORE = threading.Semaphore(10)  # Allow max 10 concurrent video exports
@@ -230,20 +232,9 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                         logger.exception("video_export_workflow_dispatch_failed", asset_id=instance.id, error=str(e))
                         raise
             else:
-                exporter.export_asset(instance.id)
+                self._start_export_workflow(instance, team, user)
         else:
-            task = exporter.export_asset.delay(instance.id)
-            posthoganalytics.capture(
-                distinct_id=user.distinct_id if user else str(team.uuid),
-                event="export queued",
-                properties={
-                    **instance.get_analytics_metadata(),
-                    "force_async": force_async,
-                    "reason": reason,
-                    "task_id": task.id,
-                },
-                groups=groups(team.organization, team),
-            )
+            self._start_export_workflow(instance, team, user)
 
         posthoganalytics.capture(
             distinct_id=user.distinct_id if user else str(team.uuid),
@@ -294,6 +285,43 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 )
                 pass
         return instance
+
+    def _start_export_workflow(self, instance: ExportedAsset, team: Any, user: User | None) -> None:
+        """Dispatch a Temporal ExportAssetWorkflow. Falls back to Celery on failure."""
+        posthoganalytics.capture(
+            distinct_id=str(team.id),
+            event="slo_export_started",
+            uuid=str(uuid5(NAMESPACE_DNS, f"slo-export-started-{instance.id}")),
+            properties={
+                "exported_asset_id": instance.id,
+                "team_id": team.id,
+                "source": EventSource.WEB if user else EventSource.API,
+                "format": instance.export_format,
+            },
+        )
+
+        async def _start():
+            client = await async_connect()
+            await client.start_workflow(
+                ExportAssetWorkflow.run,
+                ExportAssetWorkflowInputs(
+                    exported_asset_id=instance.id,
+                    team_id=team.id,
+                    source=EventSource.WEB if user else EventSource.API,
+                    export_format=instance.export_format,
+                ),
+                id=f"export-asset-{instance.id}",
+                task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                execution_timeout=timedelta(minutes=35),
+            )
+
+        try:
+            async_to_sync(_start)()
+            logger.info("export_workflow_dispatched", asset_id=instance.id)
+        except Exception:
+            logger.warning("export_workflow_dispatch_failed", asset_id=instance.id, exc_info=True)
+            exporter.export_asset.delay(instance.id)
 
 
 @extend_schema(tags=["core"])

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from datetime import timedelta
 from typing import Any
@@ -19,7 +20,7 @@ from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
-from posthog.event_usage import EventSource, groups
+from posthog.event_usage import EventSource, get_event_source, groups
 from posthog.models import Insight, User
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, get_content_response
@@ -28,7 +29,6 @@ from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
 from posthog.slo.events import emit_slo_started
 from posthog.slo.types import SloArea, SloOperation, SloStartedProperties
-from posthog.tasks import exporter
 from posthog.temporal.common.client import async_connect
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 from posthog.temporal.exports_video.workflow import VideoExportInputs, VideoExportWorkflow
@@ -233,9 +233,9 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                         logger.exception("video_export_workflow_dispatch_failed", asset_id=instance.id, error=str(e))
                         raise
             else:
-                self._start_export_workflow(instance, team, user, wait=True)
+                self._start_export_workflow(instance, team, user, force_async=False)
         else:
-            self._start_export_workflow(instance, team, user, wait=False)
+            self._start_export_workflow(instance, team, user, force_async=True)
 
         posthoganalytics.capture(
             distinct_id=user.distinct_id if user else str(team.uuid),
@@ -288,15 +288,9 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         return instance
 
     def _start_export_workflow(
-        self, instance: ExportedAsset, team: Any, user: User | None, wait: bool = True
+        self, instance: ExportedAsset, team: Any, user: User | None, force_async: bool = False
     ) -> None:
-        """Dispatch a Temporal ExportAssetWorkflow. Falls back to Celery on failure.
-
-        Args:
-            wait: If True, block until the workflow completes (synchronous export).
-                  If False, fire-and-forget (async export, frontend polls).
-        """
-        source = EventSource.WEB if user else EventSource.API
+        source = get_event_source(self.context["request"])
         distinct_id = str(user.distinct_id) if user else str(team.id)
 
         emit_slo_started(
@@ -318,46 +312,26 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             exported_asset_id=instance.id,
             team_id=team.id,
             distinct_id=distinct_id,
-            source=source,
             export_format=instance.export_format,
         )
 
-        if wait:
-            async def _execute():
-                client = await async_connect()
-                await client.execute_workflow(
-                    ExportAssetWorkflow.run,
-                    workflow_inputs,
-                    id=f"export-asset-{instance.id}",
-                    task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
-                    id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-                    execution_timeout=timedelta(minutes=35),
-                )
+        async def _run():
+            client = await async_connect()
+            method = client.start_workflow if force_async else client.execute_workflow
+            await method(
+                ExportAssetWorkflow.run,
+                workflow_inputs,
+                id=f"export-asset-{instance.id}",
+                task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
+                id_reuse_policy=WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
+                execution_timeout=timedelta(minutes=30),
+            )
 
-            try:
-                async_to_sync(_execute)()
-                logger.info("export_workflow_completed", asset_id=instance.id)
-            except Exception:
-                logger.warning("export_workflow_failed", asset_id=instance.id, exc_info=True)
-                exporter.export_asset(instance.id)
-        else:
-            async def _start():
-                client = await async_connect()
-                await client.start_workflow(
-                    ExportAssetWorkflow.run,
-                    workflow_inputs,
-                    id=f"export-asset-{instance.id}",
-                    task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
-                    id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-                    execution_timeout=timedelta(minutes=35),
-                )
-
-            try:
-                async_to_sync(_start)()
-                logger.info("export_workflow_dispatched", asset_id=instance.id)
-            except Exception:
-                logger.warning("export_workflow_dispatch_failed", asset_id=instance.id, exc_info=True)
-                exporter.export_asset.delay(instance.id)
+        asyncio.run(_run())
+        logger.info(
+            "export_workflow_dispatched" if force_async else "export_workflow_completed",
+            asset_id=instance.id,
+        )
 
 
 @extend_schema(tags=["core"])

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -20,7 +20,7 @@ from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
-from posthog.event_usage import EventSource, get_event_source, groups
+from posthog.event_usage import get_event_source, groups
 from posthog.models import Insight, User
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, get_content_response

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -233,9 +233,9 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                         logger.exception("video_export_workflow_dispatch_failed", asset_id=instance.id, error=str(e))
                         raise
             else:
-                self._start_export_workflow(instance, team, user)
+                self._start_export_workflow(instance, team, user, wait=True)
         else:
-            self._start_export_workflow(instance, team, user)
+            self._start_export_workflow(instance, team, user, wait=False)
 
         posthoganalytics.capture(
             distinct_id=user.distinct_id if user else str(team.uuid),
@@ -287,8 +287,15 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 pass
         return instance
 
-    def _start_export_workflow(self, instance: ExportedAsset, team: Any, user: User | None) -> None:
-        """Dispatch a Temporal ExportAssetWorkflow. Falls back to Celery on failure."""
+    def _start_export_workflow(
+        self, instance: ExportedAsset, team: Any, user: User | None, wait: bool = True
+    ) -> None:
+        """Dispatch a Temporal ExportAssetWorkflow. Falls back to Celery on failure.
+
+        Args:
+            wait: If True, block until the workflow completes (synchronous export).
+                  If False, fire-and-forget (async export, frontend polls).
+        """
         source = EventSource.WEB if user else EventSource.API
         distinct_id = str(user.distinct_id) if user else str(team.id)
 
@@ -307,29 +314,50 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             },
         )
 
-        async def _start():
-            client = await async_connect()
-            await client.start_workflow(
-                ExportAssetWorkflow.run,
-                ExportAssetWorkflowInputs(
-                    exported_asset_id=instance.id,
-                    team_id=team.id,
-                    distinct_id=distinct_id,
-                    source=source,
-                    export_format=instance.export_format,
-                ),
-                id=f"export-asset-{instance.id}",
-                task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
-                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
-                execution_timeout=timedelta(minutes=35),
-            )
+        workflow_inputs = ExportAssetWorkflowInputs(
+            exported_asset_id=instance.id,
+            team_id=team.id,
+            distinct_id=distinct_id,
+            source=source,
+            export_format=instance.export_format,
+        )
 
-        try:
-            async_to_sync(_start)()
-            logger.info("export_workflow_dispatched", asset_id=instance.id)
-        except Exception:
-            logger.warning("export_workflow_dispatch_failed", asset_id=instance.id, exc_info=True)
-            exporter.export_asset.delay(instance.id)
+        if wait:
+            async def _execute():
+                client = await async_connect()
+                await client.execute_workflow(
+                    ExportAssetWorkflow.run,
+                    workflow_inputs,
+                    id=f"export-asset-{instance.id}",
+                    task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
+                    id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                    execution_timeout=timedelta(minutes=35),
+                )
+
+            try:
+                async_to_sync(_execute)()
+                logger.info("export_workflow_completed", asset_id=instance.id)
+            except Exception:
+                logger.warning("export_workflow_failed", asset_id=instance.id, exc_info=True)
+                exporter.export_asset(instance.id)
+        else:
+            async def _start():
+                client = await async_connect()
+                await client.start_workflow(
+                    ExportAssetWorkflow.run,
+                    workflow_inputs,
+                    id=f"export-asset-{instance.id}",
+                    task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
+                    id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+                    execution_timeout=timedelta(minutes=35),
+                )
+
+            try:
+                async_to_sync(_start)()
+                logger.info("export_workflow_dispatched", asset_id=instance.id)
+            except Exception:
+                logger.warning("export_workflow_dispatch_failed", asset_id=instance.id, exc_info=True)
+                exporter.export_asset.delay(instance.id)
 
 
 @extend_schema(tags=["core"])

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -1,7 +1,6 @@
 import threading
 from datetime import timedelta
 from typing import Any
-from uuid import NAMESPACE_DNS, uuid5
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -27,6 +26,8 @@ from posthog.models.exported_asset import ExportedAsset, get_content_response
 from posthog.security.url_validation import is_url_allowed
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
+from posthog.slo.events import emit_slo_started
+from posthog.slo.types import SloArea, SloOperation, SloStartedProperties
 from posthog.tasks import exporter
 from posthog.temporal.common.client import async_connect
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
@@ -288,15 +289,21 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
 
     def _start_export_workflow(self, instance: ExportedAsset, team: Any, user: User | None) -> None:
         """Dispatch a Temporal ExportAssetWorkflow. Falls back to Celery on failure."""
-        posthoganalytics.capture(
-            distinct_id=str(team.id),
-            event="slo_export_started",
-            uuid=str(uuid5(NAMESPACE_DNS, f"slo-export-started-{instance.id}")),
-            properties={
+        source = EventSource.WEB if user else EventSource.API
+        distinct_id = str(user.distinct_id) if user else str(team.id)
+
+        emit_slo_started(
+            distinct_id=distinct_id,
+            properties=SloStartedProperties(
+                operation=SloOperation.EXPORT,
+                resource_id=str(instance.id),
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=team.id,
+            ),
+            extra_properties={
                 "exported_asset_id": instance.id,
-                "team_id": team.id,
-                "source": EventSource.WEB if user else EventSource.API,
-                "format": instance.export_format,
+                "source": source,
+                "export_format": instance.export_format,
             },
         )
 
@@ -307,7 +314,8 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 ExportAssetWorkflowInputs(
                     exported_asset_id=instance.id,
                     team_id=team.id,
-                    source=EventSource.WEB if user else EventSource.API,
+                    distinct_id=distinct_id,
+                    source=source,
                     export_format=instance.export_format,
                 ),
                 id=f"export-asset-{instance.id}",

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -302,7 +302,6 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 team_id=team.id,
             ),
             extra_properties={
-                "exported_asset_id": instance.id,
                 "source": source,
                 "export_format": instance.export_format,
             },

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -19,7 +19,7 @@ from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
-from posthog.event_usage import get_event_source, groups
+from posthog.event_usage import EventSource, get_event_source, groups
 from posthog.models import Insight, User
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, get_content_response
@@ -289,7 +289,8 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
     def _start_export_workflow(
         self, instance: ExportedAsset, team: Any, user: User | None, force_async: bool = False
     ) -> None:
-        source = get_event_source(self.context["request"])
+        request = self.context.get("request")
+        source = get_event_source(request) if request else EventSource.EXPORT
         distinct_id = str(user.distinct_id) if user else str(team.id)
 
         emit_slo_started(

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -1,4 +1,3 @@
-import asyncio
 import threading
 from datetime import timedelta
 from typing import Any
@@ -327,7 +326,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 execution_timeout=timedelta(minutes=30),
             )
 
-        asyncio.run(_run())
+        async_to_sync(_run)()
         logger.info(
             "export_workflow_dispatched" if force_async else "export_workflow_completed",
             asset_id=instance.id,

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -323,7 +323,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 id=f"export-asset-{instance.id}",
                 task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
                 id_reuse_policy=WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
-                execution_timeout=timedelta(minutes=30),
+                execution_timeout=timedelta(minutes=35),
             )
 
         async_to_sync(_run)()

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -326,7 +326,20 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 execution_timeout=timedelta(minutes=35),
             )
 
-        async_to_sync(_run)()
+        try:
+            async_to_sync(_run)()
+        except Exception as e:
+            # Swallow workflow failures so the API always returns a 201 with the
+            # ExportedAsset record. export_asset_direct populates the exception
+            # field before re-raising, so callers (frontend toast, sharing
+            # endpoint) can inspect the failure on the asset itself.
+            logger.info(
+                "export_workflow_failed_gracefully",
+                asset_id=instance.id,
+                error=str(e),
+            )
+            return
+
         logger.info(
             "export_workflow_dispatched" if force_async else "export_workflow_completed",
             asset_id=instance.id,

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -20,7 +20,7 @@ from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.event_usage import EventSource, get_event_source, groups
-from posthog.models import Insight, User
+from posthog.models import Insight, Team, User
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, get_content_response
 from posthog.security.url_validation import is_url_allowed
@@ -287,7 +287,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         return instance
 
     def _start_export_workflow(
-        self, instance: ExportedAsset, team: Any, user: User | None, force_async: bool = False
+        self, instance: ExportedAsset, team: Team, user: User | None, force_async: bool = False
     ) -> None:
         request = self.context.get("request")
         source = get_event_source(request) if request else EventSource.EXPORT

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -392,8 +392,9 @@ class TestExports(APIBaseTest):
             },
         )
 
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     @patch("posthog.tasks.exports.csv_exporter.requests.request")
-    def test_can_download_a_csv(self, patched_request) -> None:
+    def test_can_download_a_csv(self, patched_request, _mock_workflow) -> None:
         with self.settings(SITE_URL="http://testserver", OBJECT_STORAGE_ENABLED=False):
             _create_event(
                 event="event_name",
@@ -977,23 +978,26 @@ class TestExports(APIBaseTest):
         self.assertIn("reached the limit of 3 full video exports this month", error_data["detail"])
 
     @patch("posthog.tasks.exports.image_exporter.export_image")
-    def test_synchronous_export_records_failure_on_query_error(self, mock_export_direct) -> None:
-        """Test that synchronous exports record failure info when a QueryError occurs."""
+    def test_export_records_failure_on_query_error(self, mock_export_direct) -> None:
+        """Test that export_asset records failure info on the asset when a QueryError occurs.
+
+        The actual export now runs inside a Temporal workflow (tested in
+        test_export_workflow.py). This test verifies the underlying exporter
+        still records structured failure metadata on the ExportedAsset model.
+        """
         from posthog.hogql.errors import QueryError
 
         mock_export_direct.side_effect = QueryError("Unknown table 'nonexistent_table'")
 
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/exports",
-            {"export_format": "image/png", "insight": self.insight.id},
+        asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format="image/png",
+            insight=self.insight,
+            created_by=self.user,
         )
+        exporter.export_asset(asset.id)
 
-        # Should return 201 even though the export failed internally
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data = response.json()
-
-        # Reload the asset and verify failure info was recorded
-        asset = ExportedAsset.objects.get(pk=data["id"])
+        asset.refresh_from_db()
         self.assertEqual(asset.exception, "Unknown table 'nonexistent_table'")
         self.assertEqual(asset.exception_type, "QueryError")
         self.assertEqual(asset.failure_type, "user")
@@ -1047,7 +1051,10 @@ class TestExportMixin(APIBaseTest):
         Use this function to test the CSV output of exports in other tests
         """
         with self.settings(SITE_URL="http://testserver", OBJECT_STORAGE_ENABLED=False):
-            with patch("posthog.tasks.exports.csv_exporter.requests.request") as patched_request:
+            with (
+                patch("posthog.tasks.exports.csv_exporter.requests.request") as patched_request,
+                patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow"),
+            ):
 
                 def requests_side_effect(*args, **kwargs):
                     response = self.client.get(kwargs["url"], kwargs["json"], **kwargs["headers"])
@@ -1070,6 +1077,10 @@ class TestExportMixin(APIBaseTest):
                         "export_format": "text/csv",
                     },
                 )
+                # Workflow is mocked so the export content isn't generated during
+                # the POST. Run the exporter directly to produce CSV content.
+                exporter.export_asset(response.json()["id"])
+
                 download_response = self.client.get(
                     f"/api/projects/{self.team.id}/exports/{response.json()['id']}/content?download=true"
                 )

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, _create_event, flush_persons_and_events
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 from django.http import HttpResponse
 from django.utils.timezone import now
@@ -1001,6 +1001,21 @@ class TestExports(APIBaseTest):
         self.assertEqual(asset.exception, "Unknown table 'nonexistent_table'")
         self.assertEqual(asset.exception_type, "QueryError")
         self.assertEqual(asset.failure_type, "user")
+
+    @patch("posthog.api.exports.emit_slo_started")
+    @patch("posthog.api.exports.async_connect")
+    def test_workflow_failure_returns_201_with_failed_asset(self, mock_async_connect, _mock_slo) -> None:
+        mock_client = AsyncMock()
+        mock_client.execute_workflow.side_effect = Exception("workflow failed")
+        mock_async_connect.return_value = mock_client
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {"export_format": "text/csv", "insight": self.insight.id},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertFalse(response.json()["has_content"])
 
 
 class TestExportHeatmapSSRFValidation(APIBaseTest):

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -10,7 +10,6 @@ from unittest.mock import ANY, patch
 from django.http import HttpResponse
 from django.utils.timezone import now
 
-import celery
 import requests.exceptions
 from boto3 import resource
 from botocore.client import Config
@@ -94,7 +93,7 @@ class TestExports(APIBaseTest):
             team=cls.team, dashboard_id=cls.dashboard.id, export_format="image/png", created_by=cls.user
         )
 
-    @patch("posthog.api.exports.exporter")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_create_new_valid_export_dashboard(self, mock_exporter_task) -> None:
         # add filter to dashboard
         self.dashboard.filters = {"properties": [{"key": "$browser_version", "value": "1.0"}]}
@@ -124,9 +123,10 @@ class TestExports(APIBaseTest):
             .replace("+00:00", "Z"),
         }
 
-        mock_exporter_task.export_asset.assert_called_once_with(data["id"])
+        mock_exporter_task.assert_called_once()
+        assert mock_exporter_task.call_args[0][0].id == data["id"]
 
-    @patch("posthog.api.exports.exporter")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_create_export_with_ttl(self, mock_exporter_task) -> None:
         one_week_from_now = datetime.now() + timedelta(weeks=1)
         response = self.client.post(
@@ -162,13 +162,12 @@ class TestExports(APIBaseTest):
             "expires_after": expected_expiry,
         }
 
-        mock_exporter_task.export_asset.assert_called_once_with(data["id"])
+        mock_exporter_task.assert_called_once()
+        assert mock_exporter_task.call_args[0][0].id == data["id"]
 
-    @patch("posthog.api.exports.exporter")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_swallow_missing_schema_and_allow_front_end_to_poll(self, mock_exporter_task) -> None:
         # regression test see https://github.com/PostHog/posthog/issues/11204
-
-        mock_exporter_task.get.side_effect = requests.exceptions.MissingSchema("why is this raised?")
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/exports",
@@ -185,10 +184,11 @@ class TestExports(APIBaseTest):
             msg=f"was not HTTP 201 😱 - {response.json()}",
         )
         data = response.json()
-        mock_exporter_task.export_asset.assert_called_once_with(data["id"])
+        mock_exporter_task.assert_called_once()
+        assert mock_exporter_task.call_args[0][0].id == data["id"]
 
     @patch("posthog.tasks.exports.image_exporter._export_to_png")
-    @patch("posthog.api.exports.exporter")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     @freeze_time("2021-08-25T22:09:14.252Z")
     def test_can_create_new_valid_export_insight(self, mock_exporter_task, mock_export_to_png) -> None:
         response = self.client.post(
@@ -248,7 +248,8 @@ class TestExports(APIBaseTest):
             ],
         )
 
-        mock_exporter_task.export_asset.assert_called_once_with(data["id"])
+        mock_exporter_task.assert_called_once()
+        assert mock_exporter_task.call_args[0][0].id == data["id"]
 
         # look at the page the screenshot will be taken of
         exported_asset = ExportedAsset.objects.get(pk=data["id"])
@@ -292,18 +293,8 @@ class TestExports(APIBaseTest):
             },
         )
 
-    @patch("posthog.api.exports.exporter")
-    def test_will_respond_even_if_task_timesout(self, mock_exporter_task) -> None:
-        mock_exporter_task.export_asset.delay.return_value.get.side_effect = celery.exceptions.TimeoutError("timed out")
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/exports",
-            {"export_format": "image/png", "insight": self.insight.id},
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-    @patch("posthog.api.exports.exporter")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_will_error_if_export_unsupported(self, mock_exporter_task) -> None:
-        mock_exporter_task.export_asset.delay.return_value.get.side_effect = NotImplementedError("not implemented")
         response = self.client.post(
             f"/api/projects/{self.team.id}/exports",
             {"export_format": "image/jpeg", "insight": self.insight.id},
@@ -762,9 +753,8 @@ class TestExports(APIBaseTest):
     )
     @patch("posthog.api.exports.async_to_sync")
     @patch("posthog.api.exports.async_connect")
-    @patch("posthog.api.exports.exporter")
     def test_export_expiry_varies_by_format(
-        self, export_format, expected_delta, mock_exporter_task, mock_async_connect, mock_async_to_sync
+        self, export_format, expected_delta, mock_async_connect, mock_async_to_sync
     ) -> None:
         is_video_format = export_format in ("video/mp4", "video/webm", "image/gif")
 
@@ -793,9 +783,6 @@ class TestExports(APIBaseTest):
         )
 
         self.assertEqual(data["expires_after"], expected_expiry)
-
-        if not is_video_format:
-            mock_exporter_task.export_asset.assert_called_once_with(data["id"])
 
     @patch("posthog.api.exports.async_to_sync")
     @patch("posthog.api.exports.async_connect")
@@ -1036,7 +1023,7 @@ class TestExportHeatmapSSRFValidation(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    @patch("posthog.api.exports.exporter")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     @patch("posthog.security.url_validation.resolve_host_ips")
     def test_accepts_valid_external_heatmap_url(self, mock_resolve, mock_exporter_task) -> None:
         import ipaddress

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -119,7 +119,7 @@ class TestSharing(APIBaseTest):
         )
 
     @freeze_time("2022-01-01")
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_gets_sharing_config(self, patched_exporter_task: Mock):
         assert SharingConfiguration.objects.count() == 0
 
@@ -138,7 +138,7 @@ class TestSharing(APIBaseTest):
         }
 
     @freeze_time("2022-01-01")
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_does_not_change_token_when_toggling_enabled_state(self, patched_exporter_task: Mock):
         assert SharingConfiguration.objects.count() == 0
         response = self.client.patch(
@@ -170,7 +170,7 @@ class TestSharing(APIBaseTest):
             "share_passwords": [],
         }
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_edit_enabled_state(self, patched_exporter_task: Mock):
         response = self.client.patch(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing",
@@ -185,7 +185,7 @@ class TestSharing(APIBaseTest):
         assert response.json()["is_shared"]
         assert ActivityLog.objects.filter(scope="SharingConfiguration").count() == 0
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_edit_enabled_state_for_insight(self, patched_exporter_task: Mock):
         assert ActivityLog.objects.filter(scope="SharingConfiguration").count() == 0
 
@@ -212,7 +212,7 @@ class TestSharing(APIBaseTest):
             "sharing disabled",
         ]
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_exports_image_when_sharing(self, patched_exporter_task: Mock):
         assert ExportedAsset.objects.count() == 0
 
@@ -226,7 +226,7 @@ class TestSharing(APIBaseTest):
         assert asset is not None
         assert asset.export_format == "image/png"
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_should_update_to_match_existing_dashboard_sharing_token(self, patched_exporter_task: Mock):
         dashboard = Dashboard.objects.create(team=self.team, name="example dashboard", created_by=self.user)
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{dashboard.id}/sharing")
@@ -252,7 +252,7 @@ class TestSharing(APIBaseTest):
         assert data["access_token"] == "my_test_token"
         assert data["enabled"]
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_should_not_be_affected_by_collaboration_rules(self, _patched_exporter_task: Mock):
         other_user = User.objects.create_and_join(self.organization, "a@x.com", None)
         dashboard = Dashboard.objects.create(
@@ -269,7 +269,7 @@ class TestSharing(APIBaseTest):
 
         assert response.status_code == 200
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_should_not_get_deleted_item(self, _patched_exporter_task: Mock):
         dashboard = Dashboard.objects.create(
             team=self.team,
@@ -295,7 +295,7 @@ class TestSharing(APIBaseTest):
             "/shared_dashboard/something.png?token=my_test_token",
         ]
     )
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     @patch("posthog.models.exported_asset.object_storage.get_presigned_url")
     @patch("posthog.api.sharing.asset_for_token")
     def test_can_get_shared_dashboard_asset_with_no_content_but_content_location(
@@ -327,7 +327,7 @@ class TestSharing(APIBaseTest):
 
     @parameterized.expand(["insights", "dashboards"])
     @patch("posthog.models.exported_asset.object_storage.get_presigned_url")
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_shared_thing_can_generate_open_graph_image(
         self, type: str, patched_exporter_task: Mock, patched_get_presigned_url: Mock
     ) -> None:
@@ -353,7 +353,7 @@ class TestSharing(APIBaseTest):
 
     @parameterized.expand(["insights", "dashboards"])
     @patch("posthog.models.exported_asset.object_storage.get_presigned_url")
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_shared_thing_can_reuse_existing_generated_open_graph_image(
         self, type: str, patched_exporter_task: Mock, patched_get_presigned_url: Mock
     ) -> None:
@@ -393,7 +393,7 @@ class TestSharing(APIBaseTest):
 
     @parameterized.expand(["insights", "dashboards"])
     @patch("posthog.models.exported_asset.object_storage.get_presigned_url")
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_shared_insight_can_regenerate_stale_existing_generated_open_graph_image(
         self, type: str, patched_exporter_task: Mock, patched_get_presigned_url: Mock
     ) -> None:
@@ -428,7 +428,7 @@ class TestSharing(APIBaseTest):
         assert original_asset is not None
         assert final_asset.id != original_asset.id
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_refresh_sharing_access_token_for_dashboard(self, patched_exporter_task: Mock):
         # Enable sharing
         response = self.client.patch(
@@ -452,7 +452,7 @@ class TestSharing(APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{self.dashboard.id}/sharing")
         assert response.json()["access_token"] == refreshed_data["access_token"]
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_refresh_sharing_access_token_for_insight(self, patched_exporter_task: Mock):
         # First enable sharing
         response = self.client.patch(
@@ -480,7 +480,7 @@ class TestSharing(APIBaseTest):
         assert first.item_id == str(self.insight.id)
 
     @freeze_time("2025-01-01 00:00:00")
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_refresh_token_grace_period(self, patched_exporter_task: Mock):
         # Enable sharing
         response = self.client.patch(
@@ -573,7 +573,7 @@ class TestSharing(APIBaseTest):
         assert original_config.expires_at is not None
         assert original_config.expires_at > timezone.now()  # Should be in the future
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_sharing_configuration_settings_field_defaults(self, patched_exporter_task: Mock):
         """Test that settings field defaults to empty dict"""
         response = self.client.patch(
@@ -585,7 +585,7 @@ class TestSharing(APIBaseTest):
         assert "settings" in data
         assert data["settings"] is None
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_can_update_settings_field(self, patched_exporter_task: Mock):
         """Test that settings field can be updated"""
         # First enable sharing
@@ -613,7 +613,7 @@ class TestSharing(APIBaseTest):
             "whitelabel": True,
         }
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_settings_preserved_on_token_rotation(self, patched_exporter_task: Mock):
         """Test that settings are preserved when rotating access tokens"""
         # Enable sharing with comprehensive settings
@@ -643,7 +643,7 @@ class TestSharing(APIBaseTest):
         assert response.json()["settings"] == settings_data
 
     # @freeze_time("2023-12-15")  # Before ship date
-    # @patch("posthog.api.exports.exporter.export_asset.delay")
+
     # def test_all_query_params_work_for_old_configs(self, patched_exporter_task: Mock):
     #     """Test that all query params work for configurations created before ship date"""
     #     # Ensure organization has white labelling feature
@@ -673,7 +673,7 @@ class TestSharing(APIBaseTest):
     #     assert '\\"showInspector\\": true' in content
 
     # @freeze_time("2025-10-15")  # After ship date
-    # @patch("posthog.api.exports.exporter.export_asset.delay")
+
     # def test_all_query_params_ignored_for_new_configs(self, patched_exporter_task: Mock):
     #     """Test that all query params are ignored for configurations created after ship date"""
     #     # Ensure organization has white labelling feature
@@ -703,7 +703,7 @@ class TestSharing(APIBaseTest):
     #     assert '\\"detailed\\": true' not in content
 
     # @freeze_time("2025-10-15")  # After ship date
-    # @patch("posthog.api.exports.exporter.export_asset.delay")
+
     # def test_all_options_from_settings_work_for_new_configs(self, patched_exporter_task: Mock):
     #     """Test that all options from settings work for new configurations"""
     #     # Create sharing configuration with all options in settings
@@ -732,7 +732,7 @@ class TestSharing(APIBaseTest):
     #     assert '\\"showInspector\\": true' in content
 
     # @freeze_time("2025-10-15")  # After ship date
-    # @patch("posthog.api.exports.exporter.export_asset.delay")
+
     # def test_settings_override_query_params_for_new_configs(self, patched_exporter_task: Mock):
     #     """Test that settings take precedence over query params for configurations created after ship date"""
     #     # Ensure organization has white labelling feature
@@ -768,7 +768,7 @@ class TestSharing(APIBaseTest):
     #     assert '\\"detailed\\": true' not in content
 
     @parameterized.expand(["insights", "dashboards"])
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_settings_field_works_for_both_insights_and_dashboards(self, type: str, patched_exporter_task: Mock):
         """Test that settings field works for both insights and dashboards"""
         target = self.insight if type == "insights" else self.dashboard
@@ -848,7 +848,7 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
         super().setUpTestData()
         cls.dashboard = Dashboard.objects.create(team=cls.team, name="test dashboard", created_by=cls.user)
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_valid_settings_are_accepted(self, patched_exporter_task: Mock):
         """Test that valid settings are accepted and validated"""
         valid_settings = {
@@ -869,7 +869,7 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
         data = response.json()
         assert data["settings"] == valid_settings
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_partial_settings_are_filled_with_defaults(self, patched_exporter_task: Mock):
         """Test that partial settings are filled with defaults during validation"""
         partial_settings = {"whitelabel": True, "legend": True, "theme": "light"}
@@ -890,7 +890,7 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
         }
         assert data["settings"] == expected_settings
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_unknown_settings_are_filtered_out(self, patched_exporter_task: Mock):
         """Test that unknown settings fields are filtered out during validation"""
         settings_with_unknown = {
@@ -915,7 +915,7 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
         }
         assert data["settings"] == expected_settings
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_null_settings_are_accepted(self, patched_exporter_task: Mock):
         """Test that null settings are accepted"""
         response = self.client.patch(
@@ -927,7 +927,7 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
         data = response.json()
         assert data["settings"] is None
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_empty_settings_get_defaults(self, patched_exporter_task: Mock):
         """Test that empty settings dictionary gets filled with defaults"""
         response = self.client.patch(
@@ -963,7 +963,7 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
 
         valid_settings = {"whitelabel": True, "detailed": True}
 
-        with patch("posthog.api.exports.exporter.export_asset.delay"):
+        with patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow"):
             response = self.client.patch(
                 f"/api/projects/{self.team.id}/insights/{insight.id}/sharing",
                 {"enabled": True, "settings": valid_settings},
@@ -978,7 +978,7 @@ class TestSharingConfigurationSerializerValidation(APIBaseTest):
         }
         assert data["settings"] == expected_settings
 
-    @patch("posthog.api.exports.exporter.export_asset.delay")
+    @patch("posthog.api.exports.ExportedAssetSerializer._start_export_workflow")
     def test_shared_resource_blocked_when_organization_disallows_public_sharing(self, _patched_exporter_task: Mock):
         """Test that shared resources return 404 when organization.allow_publicly_shared_resources is False and feature is enabled"""
         self.organization.available_product_features = [

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -69,6 +69,10 @@ from posthog.temporal.export_recording import (
     ACTIVITIES as EXPORT_RECORDING_ACTIVITIES,
     WORKFLOWS as EXPORT_RECORDING_WORKFLOWS,
 )
+from posthog.temporal.exports import (
+    ACTIVITIES as EXPORT_ACTIVITIES,
+    WORKFLOWS as EXPORT_WORKFLOWS,
+)
 from posthog.temporal.exports_video import (
     ACTIVITIES as VIDEO_EXPORT_ACTIVITIES,
     WORKFLOWS as VIDEO_EXPORT_WORKFLOWS,
@@ -217,8 +221,8 @@ _task_queue_specs = [
     ),
     (
         settings.ANALYTICS_PLATFORM_TASK_QUEUE,
-        SUBSCRIPTION_WORKFLOWS,
-        SUBSCRIPTION_ACTIVITIES,
+        EXPORT_WORKFLOWS + SUBSCRIPTION_WORKFLOWS,
+        EXPORT_ACTIVITIES + SUBSCRIPTION_ACTIVITIES,
     ),
     (
         settings.TASKS_TASK_QUEUE,

--- a/posthog/temporal/exports/__init__.py
+++ b/posthog/temporal/exports/__init__.py
@@ -1,17 +1,31 @@
-from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
+from posthog.temporal.exports.activities import (
+    emit_delivery_outcome,
+    emit_delivery_started,
+    emit_export_outcome,
+    export_asset_activity,
+)
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAssetActivityInputs, ExportAssetResult
+from posthog.temporal.exports.types import (
+    EmitDeliveryOutcomeInput,
+    EmitExportOutcomeInput,
+    ExportAssetActivityInputs,
+    ExportAssetResult,
+)
+from posthog.temporal.exports.workflows import ExportAssetWorkflow
 
 __all__ = [
     "emit_delivery_outcome",
     "emit_delivery_started",
+    "emit_export_outcome",
     "export_asset_activity",
+    "ExportAssetWorkflow",
     "EXPORT_RETRY_POLICY",
     "EmitDeliveryOutcomeInput",
+    "EmitExportOutcomeInput",
     "ExportAssetActivityInputs",
     "ExportAssetResult",
 ]
 
-WORKFLOWS: list = []
+WORKFLOWS = [ExportAssetWorkflow]
 
-ACTIVITIES = [export_asset_activity, emit_delivery_started, emit_delivery_outcome]
+ACTIVITIES = [export_asset_activity, emit_delivery_started, emit_delivery_outcome, emit_export_outcome]

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -13,7 +13,12 @@ from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, Slo
 from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAssetActivityInputs, ExportAssetResult
+from posthog.temporal.exports.types import (
+    EmitDeliveryOutcomeInput,
+    EmitExportOutcomeInput,
+    ExportAssetActivityInputs,
+    ExportAssetResult,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -119,5 +124,33 @@ async def emit_delivery_outcome(inputs: EmitDeliveryOutcomeInput) -> None:
     logger.info(
         "emit_delivery_outcome.emitted",
         subscription_id=inputs.subscription_id,
+        outcome=inputs.outcome,
+    )
+
+
+@temporalio.activity.defn
+async def emit_export_outcome(inputs: EmitExportOutcomeInput) -> None:
+    emit_slo_completed(
+        distinct_id=inputs.distinct_id,
+        properties=SloCompletedProperties(
+            operation=SloOperation.EXPORT,
+            resource_id=str(inputs.exported_asset_id),
+            area=SloArea.ANALYTIC_PLATFORM,
+            team_id=inputs.team_id,
+            outcome=inputs.outcome,
+            duration_ms=inputs.duration_ms,
+        ),
+        extra_properties={
+            "exported_asset_id": inputs.exported_asset_id,
+            "export_format": inputs.export_format,
+            "source": inputs.source,
+            "error": {"exception_class": inputs.error.exception_class, "error_trace": inputs.error.error_trace}
+            if inputs.error
+            else None,
+        },
+    )
+    logger.info(
+        "emit_export_outcome.emitted",
+        exported_asset_id=inputs.exported_asset_id,
         outcome=inputs.outcome,
     )

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -141,9 +141,7 @@ async def emit_export_outcome(inputs: EmitExportOutcomeInput) -> None:
             duration_ms=inputs.duration_ms,
         ),
         extra_properties={
-            "exported_asset_id": inputs.exported_asset_id,
             "export_format": inputs.export_format,
-            "source": inputs.source,
             "error": {"exception_class": inputs.error.exception_class, "error_trace": inputs.error.error_trace}
             if inputs.error
             else None,

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -12,6 +12,7 @@ from posthog.slo.events import emit_slo_completed, emit_slo_started
 from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloStartedProperties
 from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
+from posthog.tasks.exports.failure_handler import SYSTEM_ERROR_NAMES
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.exports.types import (
     EmitDeliveryOutcomeInput,
@@ -60,6 +61,8 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
             )
             # Wrap in ApplicationError to propagate failure metadata as details
             # while preserving the exception class name for retry policy matching.
+            # Only known transient errors (CH/network) are worth retrying — unknown
+            # errors like Chrome crashes or programming errors should fail fast.
             # Detail order: [exception_class, duration_ms, export_format, attempt, error_trace]
             raise ApplicationError(
                 str(e),
@@ -69,6 +72,7 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
                 temporalio.activity.info().attempt,
                 error_trace,
                 type=exception_class,
+                non_retryable=exception_class not in SYSTEM_ERROR_NAMES,
             ) from e
 
         duration_ms = (time.monotonic() - start) * 1000

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -1,4 +1,3 @@
-import time
 import traceback
 
 import structlog
@@ -40,14 +39,12 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
             team_id=asset.team_id,
         )
 
-        start = time.monotonic()
         try:
             await database_sync_to_async(exporter.export_asset_direct, thread_sensitive=False)(
                 asset,
                 source=EventSource(inputs.source) if inputs.source else None,
             )
         except Exception as e:
-            duration_ms = (time.monotonic() - start) * 1000
             await database_sync_to_async(asset.refresh_from_db, thread_sensitive=False)()
             exception_class = type(e).__name__
             error_trace = "\n".join(traceback.format_exception(e)[:5])
@@ -63,28 +60,21 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
             # while preserving the exception class name for retry policy matching.
             # Only known transient errors (CH/network) are worth retrying — unknown
             # errors like Chrome crashes or programming errors should fail fast.
-            # Detail order: [exception_class, duration_ms, export_format, attempt, error_trace]
+            # Detail order: [exception_class, error_trace]
+            # See: posthog.temporal.exports.types.extract_error_details
             raise ApplicationError(
                 str(e),
                 exception_class,
-                duration_ms,
-                asset.export_format,
-                temporalio.activity.info().attempt,
                 error_trace,
                 type=exception_class,
                 non_retryable=exception_class not in SYSTEM_ERROR_NAMES,
             ) from e
 
-        duration_ms = (time.monotonic() - start) * 1000
         await database_sync_to_async(asset.refresh_from_db, thread_sensitive=False)()
 
         return ExportAssetResult(
             exported_asset_id=asset.id,
             success=asset.has_content,
-            insight_id=asset.insight_id,
-            duration_ms=duration_ms,
-            export_format=asset.export_format,
-            attempts=temporalio.activity.info().attempt,
         )
 
 

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -60,11 +60,10 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
             # while preserving the exception class name for retry policy matching.
             # Only known transient errors (CH/network) are worth retrying — unknown
             # errors like Chrome crashes or programming errors should fail fast.
-            # Detail order: [exception_class, error_trace]
+            # exception_class is on .type; details carry [error_trace]
             # See: posthog.temporal.exports.types.extract_error_details
             raise ApplicationError(
                 str(e),
-                exception_class,
                 error_trace,
                 type=exception_class,
                 non_retryable=exception_class not in SYSTEM_ERROR_NAMES,

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -37,3 +37,15 @@ class EmitDeliveryOutcomeInput:
     assets_with_content: int = 0
     total_assets: int = 0
     errors: list[ExportError] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class EmitExportOutcomeInput:
+    exported_asset_id: int
+    team_id: int
+    distinct_id: str
+    outcome: SloOutcome
+    duration_ms: Optional[float] = None
+    export_format: str = ""
+    source: str = ""
+    error: Optional[ExportError] = None

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -47,5 +47,4 @@ class EmitExportOutcomeInput:
     outcome: SloOutcome
     duration_ms: Optional[float] = None
     export_format: str = ""
-    source: str = ""
     error: Optional[ExportError] = None

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -1,7 +1,32 @@
+import typing
 import dataclasses
 from typing import Optional
 
+from temporalio.exceptions import ActivityError, ApplicationError
+
 from posthog.slo.types import SloOutcome
+
+
+class ExportErrorDetails(typing.NamedTuple):
+    exception_class: str | None = None
+    error_trace: str | None = None
+
+
+def extract_error_details(exc: BaseException) -> ExportErrorDetails:
+    """Extract failure metadata from a Temporal activity exception chain.
+
+    asyncio.gather(return_exceptions=True) yields BaseException, but Temporal
+    wraps activity failures as ActivityError -> ApplicationError. We narrow
+    through that chain to reach the structured details.
+    """
+    if not isinstance(exc, ActivityError) or not isinstance(exc.cause, ApplicationError):
+        return ExportErrorDetails()
+
+    details = exc.cause.details
+    return ExportErrorDetails(
+        exception_class=details[0] if len(details) >= 1 and isinstance(details[0], str) else None,
+        error_trace=details[1] if len(details) >= 2 and isinstance(details[1], str) else None,
+    )
 
 
 @dataclasses.dataclass
@@ -21,10 +46,6 @@ class ExportAssetResult:
     exported_asset_id: int
     success: bool
     error: Optional[ExportError] = None
-    insight_id: Optional[int] = None
-    duration_ms: Optional[float] = None
-    export_format: str = ""
-    attempts: int = 1
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -22,10 +22,10 @@ def extract_error_details(exc: BaseException) -> ExportErrorDetails:
     if not isinstance(exc, ActivityError) or not isinstance(exc.cause, ApplicationError):
         return ExportErrorDetails()
 
-    details = exc.cause.details
+    cause = exc.cause
     return ExportErrorDetails(
-        exception_class=details[0] if len(details) >= 1 and isinstance(details[0], str) else None,
-        error_trace=details[1] if len(details) >= 2 and isinstance(details[1], str) else None,
+        exception_class=cause.type,
+        error_trace=cause.details[0] if len(cause.details) >= 1 and isinstance(cause.details[0], str) else None,
     )
 
 

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -1,0 +1,62 @@
+import dataclasses
+from datetime import timedelta
+from typing import Optional
+
+import temporalio.workflow as wf
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
+from posthog.temporal.exports.types import EmitExportOutcomeInput, ExportAssetActivityInputs, ExportOutcomeAsset
+
+with wf.unsafe.imports_passed_through():
+    from posthog.temporal.exports.activities import emit_export_outcome_events, export_asset_activity
+
+
+@dataclasses.dataclass
+class ExportAssetWorkflowInputs:
+    exported_asset_id: int
+    team_id: int
+    source: Optional[str] = None
+    export_format: Optional[str] = None
+    limit: Optional[int] = None
+    max_height_pixels: Optional[int] = None
+
+
+@wf.defn(name="export-asset")
+class ExportAssetWorkflow(PostHogWorkflow):
+    """One-off export workflow: export a single asset with durable retry, then emit SLO events."""
+
+    @wf.run
+    async def run(self, inputs: ExportAssetWorkflowInputs) -> None:
+        result = await wf.execute_activity(
+            export_asset_activity,
+            ExportAssetActivityInputs(
+                exported_asset_id=inputs.exported_asset_id,
+                source=inputs.source,
+                limit=inputs.limit,
+                max_height_pixels=inputs.max_height_pixels,
+            ),
+            retry_policy=EXPORT_RETRY_POLICY,
+            start_to_close_timeout=timedelta(minutes=10),
+            schedule_to_close_timeout=timedelta(minutes=30),
+            heartbeat_timeout=timedelta(minutes=2),
+        )
+
+        await wf.execute_activity(
+            emit_export_outcome_events,
+            EmitExportOutcomeInput(
+                team_id=inputs.team_id,
+                source=inputs.source or "interactive",
+                export_format=inputs.export_format or "unknown",
+                assets=[
+                    ExportOutcomeAsset(
+                        exported_asset_id=result.exported_asset_id,
+                        success=result.success,
+                        failure_type=result.failure_type,
+                    )
+                ],
+            ),
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -11,8 +11,8 @@ from temporalio.exceptions import ActivityError, ApplicationError
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
+from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.types import EmitExportOutcomeInput, ExportAssetActivityInputs, ExportError
 
 

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -8,13 +8,12 @@ import temporalio.workflow as wf
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError
 
+from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
+from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
 from posthog.temporal.exports.types import EmitExportOutcomeInput, ExportAssetActivityInputs, ExportError
-
-with wf.unsafe.imports_passed_through():
-    from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
 
 
 @dataclasses.dataclass
@@ -22,13 +21,12 @@ class ExportAssetWorkflowInputs:
     exported_asset_id: int
     team_id: int
     distinct_id: str = ""
-    source: Optional[str] = None
     export_format: Optional[str] = None
 
 
 @wf.defn(name="export-asset")
 class ExportAssetWorkflow(PostHogWorkflow):
-    """One-off export workflow: export a single asset with durable retry, then emit SLO outcome."""
+    """One-off export workflow: export a single asset with durable retry."""
 
     @staticmethod
     def parse_inputs(inputs: list[str]) -> ExportAssetWorkflowInputs:
@@ -47,33 +45,29 @@ class ExportAssetWorkflow(PostHogWorkflow):
                 export_asset_activity,
                 ExportAssetActivityInputs(
                     exported_asset_id=inputs.exported_asset_id,
-                    source=inputs.source,
+                    source=EventSource.EXPORT,
                 ),
-                retry_policy=EXPORT_RETRY_POLICY,
-                start_to_close_timeout=timedelta(minutes=10),
-                schedule_to_close_timeout=timedelta(minutes=30),
+                start_to_close_timeout=timedelta(minutes=30),
                 heartbeat_timeout=timedelta(minutes=2),
+                retry_policy=EXPORT_RETRY_POLICY,
             )
 
-        except (ActivityError, ApplicationError) as e:
+        except Exception as e:
             outcome = SloOutcome.FAILURE
             caught_error = e
-            cause = e.cause if isinstance(e, ActivityError) and isinstance(e.cause, ApplicationError) else e
+
+            # Unwrap Temporal's ActivityError -> ApplicationError chain to get structured details
+            cause = e.cause if isinstance(e, ActivityError) and isinstance(e.cause, ApplicationError) else None
             if isinstance(cause, ApplicationError) and cause.details:
                 error = ExportError(
                     exception_class=cause.details[0] if len(cause.details) >= 1 else type(e).__name__,
                     error_trace=cause.details[4] if len(cause.details) >= 5 else "",
                 )
             else:
-                error = ExportError(exception_class=type(e).__name__, error_trace=str(e))
-
-        except Exception as e:
-            outcome = SloOutcome.FAILURE
-            caught_error = e
-            error = ExportError(
-                exception_class=type(e).__name__,
-                error_trace="\n".join(traceback.format_exception(e)[:5]),
-            )
+                error = ExportError(
+                    exception_class=type(e).__name__,
+                    error_trace="\n".join(traceback.format_exception(e)[:5]),
+                )
 
         finally:
             duration_ms = (wf.time() - start_time) * 1000
@@ -82,15 +76,18 @@ class ExportAssetWorkflow(PostHogWorkflow):
                 EmitExportOutcomeInput(
                     exported_asset_id=inputs.exported_asset_id,
                     team_id=inputs.team_id,
-                    distinct_id=inputs.distinct_id or str(inputs.team_id),
+                    distinct_id=inputs.distinct_id,
                     outcome=outcome,
                     duration_ms=duration_ms,
-                    export_format=inputs.export_format or "",
-                    source=inputs.source or "",
+                    export_format=inputs.export_format,
                     error=error,
                 ),
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RetryPolicy(maximum_attempts=3),
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=5),
+                    maximum_interval=timedelta(minutes=1),
+                    maximum_attempts=3,
+                ),
             )
 
         # Re-raise after SLO event is emitted so Temporal marks the workflow as failed

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -1,3 +1,4 @@
+import json
 import traceback
 import dataclasses
 from datetime import timedelta
@@ -28,6 +29,11 @@ class ExportAssetWorkflowInputs:
 @wf.defn(name="export-asset")
 class ExportAssetWorkflow(PostHogWorkflow):
     """One-off export workflow: export a single asset with durable retry, then emit SLO outcome."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> ExportAssetWorkflowInputs:
+        loaded = json.loads(inputs[0])
+        return ExportAssetWorkflowInputs(**loaded)
 
     @wf.run
     async def run(self, inputs: ExportAssetWorkflowInputs) -> None:

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -1,62 +1,92 @@
+import traceback
 import dataclasses
 from datetime import timedelta
 from typing import Optional
 
 import temporalio.workflow as wf
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import ActivityError, ApplicationError
 
+from posthog.slo.types import SloOutcome
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import EmitExportOutcomeInput, ExportAssetActivityInputs, ExportOutcomeAsset
+from posthog.temporal.exports.types import EmitExportOutcomeInput, ExportAssetActivityInputs, ExportError
 
 with wf.unsafe.imports_passed_through():
-    from posthog.temporal.exports.activities import emit_export_outcome_events, export_asset_activity
+    from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
 
 
 @dataclasses.dataclass
 class ExportAssetWorkflowInputs:
     exported_asset_id: int
     team_id: int
+    distinct_id: str = ""
     source: Optional[str] = None
     export_format: Optional[str] = None
-    limit: Optional[int] = None
-    max_height_pixels: Optional[int] = None
 
 
 @wf.defn(name="export-asset")
 class ExportAssetWorkflow(PostHogWorkflow):
-    """One-off export workflow: export a single asset with durable retry, then emit SLO events."""
+    """One-off export workflow: export a single asset with durable retry, then emit SLO outcome."""
 
     @wf.run
     async def run(self, inputs: ExportAssetWorkflowInputs) -> None:
-        result = await wf.execute_activity(
-            export_asset_activity,
-            ExportAssetActivityInputs(
-                exported_asset_id=inputs.exported_asset_id,
-                source=inputs.source,
-                limit=inputs.limit,
-                max_height_pixels=inputs.max_height_pixels,
-            ),
-            retry_policy=EXPORT_RETRY_POLICY,
-            start_to_close_timeout=timedelta(minutes=10),
-            schedule_to_close_timeout=timedelta(minutes=30),
-            heartbeat_timeout=timedelta(minutes=2),
-        )
+        start_time = wf.time()
+        outcome = SloOutcome.SUCCESS
+        error: Optional[ExportError] = None
+        caught_error: BaseException | None = None
 
-        await wf.execute_activity(
-            emit_export_outcome_events,
-            EmitExportOutcomeInput(
-                team_id=inputs.team_id,
-                source=inputs.source or "interactive",
-                export_format=inputs.export_format or "unknown",
-                assets=[
-                    ExportOutcomeAsset(
-                        exported_asset_id=result.exported_asset_id,
-                        success=result.success,
-                        failure_type=result.failure_type,
-                    )
-                ],
-            ),
-            start_to_close_timeout=timedelta(seconds=30),
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
+        try:
+            await wf.execute_activity(
+                export_asset_activity,
+                ExportAssetActivityInputs(
+                    exported_asset_id=inputs.exported_asset_id,
+                    source=inputs.source,
+                ),
+                retry_policy=EXPORT_RETRY_POLICY,
+                start_to_close_timeout=timedelta(minutes=10),
+                schedule_to_close_timeout=timedelta(minutes=30),
+                heartbeat_timeout=timedelta(minutes=2),
+            )
+
+        except (ActivityError, ApplicationError) as e:
+            outcome = SloOutcome.FAILURE
+            caught_error = e
+            cause = e.cause if isinstance(e, ActivityError) and isinstance(e.cause, ApplicationError) else e
+            if isinstance(cause, ApplicationError) and cause.details:
+                error = ExportError(
+                    exception_class=cause.details[0] if len(cause.details) >= 1 else type(e).__name__,
+                    error_trace=cause.details[4] if len(cause.details) >= 5 else "",
+                )
+            else:
+                error = ExportError(exception_class=type(e).__name__, error_trace=str(e))
+
+        except Exception as e:
+            outcome = SloOutcome.FAILURE
+            caught_error = e
+            error = ExportError(
+                exception_class=type(e).__name__,
+                error_trace="\n".join(traceback.format_exception(e)[:5]),
+            )
+
+        finally:
+            duration_ms = (wf.time() - start_time) * 1000
+            await wf.execute_activity(
+                emit_export_outcome,
+                EmitExportOutcomeInput(
+                    exported_asset_id=inputs.exported_asset_id,
+                    team_id=inputs.team_id,
+                    distinct_id=inputs.distinct_id or str(inputs.team_id),
+                    outcome=outcome,
+                    duration_ms=duration_ms,
+                    export_format=inputs.export_format or "",
+                    source=inputs.source or "",
+                    error=error,
+                ),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+
+        # Re-raise after SLO event is emitted so Temporal marks the workflow as failed
+        if caught_error is not None:
+            raise caught_error

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -79,7 +79,7 @@ class ExportAssetWorkflow(PostHogWorkflow):
                     distinct_id=inputs.distinct_id,
                     outcome=outcome,
                     duration_ms=duration_ms,
-                    export_format=inputs.export_format,
+                    export_format=inputs.export_format or "",
                     error=error,
                 ),
                 start_to_close_timeout=timedelta(minutes=2),

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -6,14 +6,18 @@ from typing import Optional
 
 import temporalio.workflow as wf
 from temporalio.common import RetryPolicy
-from temporalio.exceptions import ActivityError, ApplicationError
 
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import EmitExportOutcomeInput, ExportAssetActivityInputs, ExportError
+from posthog.temporal.exports.types import (
+    EmitExportOutcomeInput,
+    ExportAssetActivityInputs,
+    ExportError,
+    extract_error_details,
+)
 
 
 @dataclasses.dataclass
@@ -56,18 +60,11 @@ class ExportAssetWorkflow(PostHogWorkflow):
             outcome = SloOutcome.FAILURE
             caught_error = e
 
-            # Unwrap Temporal's ActivityError -> ApplicationError chain to get structured details
-            cause = e.cause if isinstance(e, ActivityError) and isinstance(e.cause, ApplicationError) else None
-            if isinstance(cause, ApplicationError) and cause.details:
-                error = ExportError(
-                    exception_class=cause.details[0] if len(cause.details) >= 1 else type(e).__name__,
-                    error_trace=cause.details[4] if len(cause.details) >= 5 else "",
-                )
-            else:
-                error = ExportError(
-                    exception_class=type(e).__name__,
-                    error_trace="\n".join(traceback.format_exception(e)[:5]),
-                )
+            err = extract_error_details(e)
+            error = ExportError(
+                exception_class=err.exception_class or type(e).__name__,
+                error_trace=err.error_trace or "\n".join(traceback.format_exception(e)[:5]),
+            )
 
         finally:
             duration_ms = (wf.time() - start_time) * 1000

--- a/posthog/temporal/subscriptions/__init__.py
+++ b/posthog/temporal/subscriptions/__init__.py
@@ -1,4 +1,3 @@
-from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
 from posthog.temporal.subscriptions.activities import (
     advance_next_delivery_date,
     create_export_assets,
@@ -16,9 +15,6 @@ WORKFLOWS = [ScheduleAllSubscriptionsWorkflow, HandleSubscriptionValueChangeWork
 ACTIVITIES = [
     fetch_due_subscriptions_activity,
     create_export_assets,
-    export_asset_activity,
     deliver_subscription,
-    emit_delivery_started,
-    emit_delivery_outcome,
     advance_next_delivery_date,
 ]

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -1,12 +1,11 @@
 import json
-import typing
 import asyncio
 import datetime as dt
 import traceback
 
 import temporalio.common
 import temporalio.workflow
-from temporalio.exceptions import ActivityError, ApplicationError, WorkflowAlreadyStartedError
+from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
 
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
@@ -19,6 +18,7 @@ from posthog.temporal.exports.types import (
     ExportAssetActivityInputs,
     ExportAssetResult,
     ExportError,
+    extract_error_details,
 )
 from posthog.temporal.subscriptions.activities import (
     advance_next_delivery_date,
@@ -35,40 +35,6 @@ from posthog.temporal.subscriptions.types import (
 )
 
 
-class ExportErrorDetails(typing.NamedTuple):
-    """Failure metadata extracted from a Temporal activity exception.
-
-    Fields mirror the ApplicationError details emitted by export_asset_activity:
-    [exception_class, duration_ms, export_format, attempt, error_trace].
-    """
-
-    exception_class: str | None = None
-    duration_ms: float | None = None
-    export_format: str = ""
-    attempts: int = 1
-    error_trace: str | None = None
-
-
-def _extract_error_details(exc: BaseException) -> ExportErrorDetails:
-    """Extract failure metadata from a Temporal activity exception chain.
-
-    asyncio.gather(return_exceptions=True) yields BaseException, but Temporal
-    wraps activity failures as ActivityError → ApplicationError. We narrow
-    through that chain to reach the structured details.
-    """
-    if not isinstance(exc, ActivityError) or not isinstance(exc.cause, ApplicationError):
-        return ExportErrorDetails()
-
-    details = exc.cause.details
-    return ExportErrorDetails(
-        exception_class=details[0] if len(details) >= 1 and isinstance(details[0], str) else None,
-        duration_ms=details[1] if len(details) >= 2 and isinstance(details[1], (int, float)) else None,
-        export_format=details[2] if len(details) >= 3 and isinstance(details[2], str) else "",
-        attempts=details[3] if len(details) >= 4 and isinstance(details[3], int) else 1,
-        error_trace=details[4] if len(details) >= 5 and isinstance(details[4], str) else None,
-    )
-
-
 def _build_outcome_assets(
     asset_ids: list[int],
     export_results: list[ExportAssetResult | BaseException],
@@ -83,7 +49,7 @@ def _build_outcome_assets(
     successful_asset_ids: list[int] = []
     for asset_id, result in zip(asset_ids, export_results):
         if isinstance(result, BaseException):
-            err = _extract_error_details(result)
+            err = extract_error_details(result)
             outcome_assets.append(
                 ExportAssetResult(
                     exported_asset_id=asset_id,
@@ -94,9 +60,6 @@ def _build_outcome_assets(
                     )
                     if err.exception_class
                     else None,
-                    duration_ms=err.duration_ms,
-                    export_format=err.export_format,
-                    attempts=err.attempts,
                 )
             )
         else:

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -1,0 +1,66 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+
+from asgiref.sync import sync_to_async
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog.models.exported_asset import ExportedAsset
+from posthog.temporal.exports.activities import emit_export_outcome_events, export_asset_activity
+from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
+
+
+@patch("posthog.temporal.exports.activities.posthoganalytics")
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_export_asset_workflow_end_to_end(
+    mock_exporter: MagicMock,
+    mock_analytics: MagicMock,
+    team,
+):
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        export_format="image/png",
+    )
+
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/test.png"
+        asset_obj.save(update_fields=["content_location"])
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[ExportAssetWorkflow],
+            activities=[export_asset_activity, emit_export_outcome_events],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=5),
+            debug_mode=True,
+        ):
+            await env.client.execute_workflow(
+                ExportAssetWorkflow.run,
+                ExportAssetWorkflowInputs(
+                    exported_asset_id=asset.id,
+                    team_id=team.id,
+                    source="web",
+                    export_format="image/png",
+                ),
+                id=f"export-asset-{asset.id}",
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    await sync_to_async(asset.refresh_from_db)()
+    assert asset.has_content
+    assert asset.content_location == "s3://bucket/test.png"
+
+    slo_calls = [c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_export_completed"]
+    assert len(slo_calls) == 1
+    assert slo_calls[0].kwargs["properties"]["outcome"] == "success"
+    assert slo_calls[0].kwargs["properties"]["exported_asset_id"] == asset.id

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -9,8 +9,9 @@ from asgiref.sync import sync_to_async
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from posthog.errors import CHQueryErrorS3Error
 from posthog.hogql.errors import QueryError
+
+from posthog.errors import CHQueryErrorS3Error
 from posthog.models.exported_asset import ExportedAsset
 from posthog.slo.types import SloOutcome
 from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -113,55 +113,40 @@ async def test_transient_error_retries_and_succeeds(
     assert props["error"] is None
 
 
+@pytest.mark.parametrize(
+    "error,expected_exception_class,expected_call_count",
+    [
+        (QueryError("Invalid HogQL query"), "QueryError", 1),
+        (RuntimeError("Chrome crashed"), "RuntimeError", 1),
+    ],
+    ids=["non_retryable_user_error", "generic_runtime_error"],
+)
 @patch("posthog.slo.events.posthoganalytics")
 @patch("posthog.temporal.exports.activities.exporter")
-async def test_non_retryable_user_error_fails_immediately(
+async def test_export_failure_emits_slo_failure(
     mock_exporter: MagicMock,
     mock_analytics: MagicMock,
     team,
+    error: Exception,
+    expected_exception_class: str,
+    expected_call_count: int,
 ):
-    """User query errors are non-retryable — called once, SLO reports failure with structured error details
-    extracted from Temporal's ActivityError -> ApplicationError chain."""
     asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
 
     call_count = 0
 
-    def user_error_export(asset_obj, **kwargs):
+    def failing_export(asset_obj, **kwargs):
         nonlocal call_count
         call_count += 1
-        raise QueryError("Invalid HogQL query")
+        raise error
 
     with pytest.raises(Exception):
         async with await WorkflowEnvironment.start_time_skipping() as env:
-            await _run_export_workflow(env, asset, team, mock_exporter, user_error_export)
+            await _run_export_workflow(env, asset, team, mock_exporter, failing_export)
 
-    assert call_count == 1
+    assert call_count == expected_call_count
 
     props = _get_slo_completed_props(mock_analytics)
     assert props["outcome"] == SloOutcome.FAILURE
     assert props["error"] is not None
-    assert props["error"]["exception_class"] == "QueryError"
-
-
-@patch("posthog.slo.events.posthoganalytics")
-@patch("posthog.temporal.exports.activities.exporter")
-async def test_generic_error_reports_failure_with_traceback(
-    mock_exporter: MagicMock,
-    mock_analytics: MagicMock,
-    team,
-):
-    """Non-Temporal exceptions (no ApplicationError chain) fall back to generic error extraction
-    with exception class name and traceback."""
-    asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
-
-    with pytest.raises(Exception):
-        async with await WorkflowEnvironment.start_time_skipping() as env:
-            await _run_export_workflow(
-                env, asset, team, mock_exporter, MagicMock(side_effect=RuntimeError("Chrome crashed"))
-            )
-
-    props = _get_slo_completed_props(mock_analytics)
-    assert props["outcome"] == SloOutcome.FAILURE
-    assert props["error"] is not None
-    # Generic errors use the exception class name, not the ApplicationError chain
-    assert "RuntimeError" in str(props["error"])
+    assert expected_exception_class in str(props["error"])

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -77,7 +77,7 @@ async def test_successful_export(
     props = _get_slo_completed_props(mock_analytics)
     assert props["outcome"] == SloOutcome.SUCCESS
     assert props["operation"] == "export"
-    assert props["exported_asset_id"] == asset.id
+    assert props["resource_id"] == str(asset.id)
     assert props["export_format"] == EXPORT_FORMAT
     assert props["error"] is None
 

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -10,15 +10,16 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.models.exported_asset import ExportedAsset
-from posthog.temporal.exports.activities import emit_export_outcome_events, export_asset_activity
+from posthog.slo.types import SloOutcome
+from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
 
 
-@patch("posthog.temporal.exports.activities.posthoganalytics")
+@patch("posthog.slo.events.posthoganalytics")
 @patch("posthog.temporal.exports.activities.exporter")
-async def test_export_asset_workflow_end_to_end(
+async def test_export_asset_workflow_success_emits_slo_completed(
     mock_exporter: MagicMock,
     mock_analytics: MagicMock,
     team,
@@ -39,7 +40,7 @@ async def test_export_asset_workflow_end_to_end(
             env.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
             workflows=[ExportAssetWorkflow],
-            activities=[export_asset_activity, emit_export_outcome_events],
+            activities=[export_asset_activity, emit_export_outcome],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=5),
             debug_mode=True,
@@ -58,9 +59,60 @@ async def test_export_asset_workflow_end_to_end(
 
     await sync_to_async(asset.refresh_from_db)()
     assert asset.has_content
-    assert asset.content_location == "s3://bucket/test.png"
 
-    slo_calls = [c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_export_completed"]
-    assert len(slo_calls) == 1
-    assert slo_calls[0].kwargs["properties"]["outcome"] == "success"
-    assert slo_calls[0].kwargs["properties"]["exported_asset_id"] == asset.id
+    completed_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    props = completed_calls[0].kwargs["properties"]
+    assert props["outcome"] == SloOutcome.SUCCESS
+    assert props["operation"] == "export"
+    assert props["exported_asset_id"] == asset.id
+    assert props["export_format"] == "image/png"
+    assert props["source"] == "web"
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_export_asset_workflow_failure_emits_slo_failure(
+    mock_exporter: MagicMock,
+    mock_analytics: MagicMock,
+    team,
+):
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        export_format="image/png",
+    )
+
+    mock_exporter.export_asset_direct = MagicMock(side_effect=RuntimeError("Chrome crashed"))
+
+    with pytest.raises(Exception):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+                workflows=[ExportAssetWorkflow],
+                activities=[export_asset_activity, emit_export_outcome],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+                activity_executor=ThreadPoolExecutor(max_workers=5),
+                debug_mode=True,
+            ):
+                await env.client.execute_workflow(
+                    ExportAssetWorkflow.run,
+                    ExportAssetWorkflowInputs(
+                        exported_asset_id=asset.id,
+                        team_id=team.id,
+                        source="web",
+                        export_format="image/png",
+                    ),
+                    id=f"export-asset-{asset.id}",
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                )
+
+    completed_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    props = completed_calls[0].kwargs["properties"]
+    assert props["outcome"] == SloOutcome.FAILURE
+    assert props["error"] is not None

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -9,6 +9,8 @@ from asgiref.sync import sync_to_async
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
+from posthog.errors import CHQueryErrorS3Error
+from posthog.hogql.errors import QueryError
 from posthog.models.exported_asset import ExportedAsset
 from posthog.slo.types import SloOutcome
 from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
@@ -16,103 +18,149 @@ from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetW
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
 
+EXPORT_FORMAT = ExportedAsset.ExportFormat.PNG
+
+
+async def _run_export_workflow(env, asset, team, mock_exporter, fake_export):
+    mock_exporter.export_asset_direct = fake_export
+
+    async with Worker(
+        env.client,
+        task_queue=settings.TEMPORAL_TASK_QUEUE,
+        workflows=[ExportAssetWorkflow],
+        activities=[export_asset_activity, emit_export_outcome],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        activity_executor=ThreadPoolExecutor(max_workers=5),
+        debug_mode=True,
+    ):
+        await env.client.execute_workflow(
+            ExportAssetWorkflow.run,
+            ExportAssetWorkflowInputs(
+                exported_asset_id=asset.id,
+                team_id=team.id,
+                export_format=EXPORT_FORMAT,
+            ),
+            id=f"export-asset-{asset.id}",
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+        )
+
+
+def _get_slo_completed_props(mock_analytics) -> dict:
+    completed_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    return completed_calls[0].kwargs["properties"]
+
+
+def _success_export(asset_obj, **kwargs):
+    asset_obj.content_location = "s3://bucket/test.png"
+    asset_obj.save(update_fields=["content_location"])
+
 
 @patch("posthog.slo.events.posthoganalytics")
 @patch("posthog.temporal.exports.activities.exporter")
-async def test_export_asset_workflow_success_emits_slo_completed(
+async def test_successful_export(
     mock_exporter: MagicMock,
     mock_analytics: MagicMock,
     team,
 ):
-    asset = await sync_to_async(ExportedAsset.objects.create)(
-        team=team,
-        export_format="image/png",
-    )
-
-    def fake_export(asset_obj, **kwargs):
-        asset_obj.content_location = "s3://bucket/test.png"
-        asset_obj.save(update_fields=["content_location"])
-
-    mock_exporter.export_asset_direct = fake_export
+    asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
-        async with Worker(
-            env.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ExportAssetWorkflow],
-            activities=[export_asset_activity, emit_export_outcome],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=5),
-            debug_mode=True,
-        ):
-            await env.client.execute_workflow(
-                ExportAssetWorkflow.run,
-                ExportAssetWorkflowInputs(
-                    exported_asset_id=asset.id,
-                    team_id=team.id,
-                    source="web",
-                    export_format="image/png",
-                ),
-                id=f"export-asset-{asset.id}",
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
+        await _run_export_workflow(env, asset, team, mock_exporter, _success_export)
 
     await sync_to_async(asset.refresh_from_db)()
     assert asset.has_content
 
-    completed_calls = [
-        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
-    ]
-    assert len(completed_calls) == 1
-    props = completed_calls[0].kwargs["properties"]
+    props = _get_slo_completed_props(mock_analytics)
     assert props["outcome"] == SloOutcome.SUCCESS
     assert props["operation"] == "export"
     assert props["exported_asset_id"] == asset.id
-    assert props["export_format"] == "image/png"
-    assert props["source"] == "web"
+    assert props["export_format"] == EXPORT_FORMAT
+    assert props["error"] is None
 
 
 @patch("posthog.slo.events.posthoganalytics")
 @patch("posthog.temporal.exports.activities.exporter")
-async def test_export_asset_workflow_failure_emits_slo_failure(
+async def test_transient_error_retries_and_succeeds(
     mock_exporter: MagicMock,
     mock_analytics: MagicMock,
     team,
 ):
-    asset = await sync_to_async(ExportedAsset.objects.create)(
-        team=team,
-        export_format="image/png",
-    )
+    asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
 
-    mock_exporter.export_asset_direct = MagicMock(side_effect=RuntimeError("Chrome crashed"))
+    call_count = 0
+
+    def flaky_export(asset_obj, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise CHQueryErrorS3Error("S3 error", code=499)
+        _success_export(asset_obj, **kwargs)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        await _run_export_workflow(env, asset, team, mock_exporter, flaky_export)
+
+    assert call_count == 3
+
+    await sync_to_async(asset.refresh_from_db)()
+    assert asset.has_content
+
+    props = _get_slo_completed_props(mock_analytics)
+    assert props["outcome"] == SloOutcome.SUCCESS
+    assert props["error"] is None
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_non_retryable_user_error_fails_immediately(
+    mock_exporter: MagicMock,
+    mock_analytics: MagicMock,
+    team,
+):
+    """User query errors are non-retryable — called once, SLO reports failure with structured error details
+    extracted from Temporal's ActivityError -> ApplicationError chain."""
+    asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
+
+    call_count = 0
+
+    def user_error_export(asset_obj, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise QueryError("Invalid HogQL query")
 
     with pytest.raises(Exception):
         async with await WorkflowEnvironment.start_time_skipping() as env:
-            async with Worker(
-                env.client,
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-                workflows=[ExportAssetWorkflow],
-                activities=[export_asset_activity, emit_export_outcome],
-                workflow_runner=UnsandboxedWorkflowRunner(),
-                activity_executor=ThreadPoolExecutor(max_workers=5),
-                debug_mode=True,
-            ):
-                await env.client.execute_workflow(
-                    ExportAssetWorkflow.run,
-                    ExportAssetWorkflowInputs(
-                        exported_asset_id=asset.id,
-                        team_id=team.id,
-                        source="web",
-                        export_format="image/png",
-                    ),
-                    id=f"export-asset-{asset.id}",
-                    task_queue=settings.TEMPORAL_TASK_QUEUE,
-                )
+            await _run_export_workflow(env, asset, team, mock_exporter, user_error_export)
 
-    completed_calls = [
-        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
-    ]
-    assert len(completed_calls) == 1
-    props = completed_calls[0].kwargs["properties"]
+    assert call_count == 1
+
+    props = _get_slo_completed_props(mock_analytics)
     assert props["outcome"] == SloOutcome.FAILURE
     assert props["error"] is not None
+    assert props["error"]["exception_class"] == "QueryError"
+
+
+@patch("posthog.slo.events.posthoganalytics")
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_generic_error_reports_failure_with_traceback(
+    mock_exporter: MagicMock,
+    mock_analytics: MagicMock,
+    team,
+):
+    """Non-Temporal exceptions (no ApplicationError chain) fall back to generic error extraction
+    with exception class name and traceback."""
+    asset = await sync_to_async(ExportedAsset.objects.create)(team=team, export_format=EXPORT_FORMAT)
+
+    with pytest.raises(Exception):
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            await _run_export_workflow(
+                env, asset, team, mock_exporter, MagicMock(side_effect=RuntimeError("Chrome crashed"))
+            )
+
+    props = _get_slo_completed_props(mock_analytics)
+    assert props["outcome"] == SloOutcome.FAILURE
+    assert props["error"] is not None
+    # Generic errors use the exception class name, not the ApplicationError chain
+    assert "RuntimeError" in str(props["error"])

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -114,10 +114,10 @@ async def test_transient_error_retries_and_succeeds(
 
 
 @pytest.mark.parametrize(
-    "error,expected_exception_class,expected_call_count",
+    "error_factory,expected_exception_class,expected_call_count",
     [
-        (QueryError("Invalid HogQL query"), "QueryError", 1),
-        (RuntimeError("Chrome crashed"), "RuntimeError", 1),
+        (lambda: QueryError("Invalid HogQL query"), "QueryError", 1),
+        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 1),
     ],
     ids=["non_retryable_user_error", "generic_runtime_error"],
 )
@@ -127,7 +127,7 @@ async def test_export_failure_emits_slo_failure(
     mock_exporter: MagicMock,
     mock_analytics: MagicMock,
     team,
-    error: Exception,
+    error_factory,
     expected_exception_class: str,
     expected_call_count: int,
 ):
@@ -138,7 +138,7 @@ async def test_export_failure_emits_slo_failure(
     def failing_export(asset_obj, **kwargs):
         nonlocal call_count
         call_count += 1
-        raise error
+        raise error_factory()
 
     with pytest.raises(Exception):
         async with await WorkflowEnvironment.start_time_skipping() as env:

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -5,6 +5,11 @@ locals {
   # events with matching properties.operation value (see posthog/slo/types.py).
   # ===========================================================================
   slo_operations = {
+    export = {
+      name    = "Exports"
+      slo     = 99.95 # error budget = 0.05%
+      regions = ["US", "EU"]
+    }
     subscription_delivery = {
       name    = "Subscription deliveries"
       slo     = 99.95 # error budget = 0.05%


### PR DESCRIPTION
## Problem

As it's easier to maintain a single system vs different systems, I would propose that we move the "django in-process" and "Celery" based export flows to Temporal as well. This way we can re-use the same logic as we do for the subscription flow and keep things concise / centralised in terms of resiliency and reliability improvements.

## Changes

Migrate both "old" flows to Temporal as well.

- Added new `ExportAssetWorkflow` in Temporal to handle asset exports with durable retry and SLO event emission
- Modified exports API to dispatch Temporal workflows instead of using Celery tasks
- Added SLO tracking events (start and completed)
- Integrated export workflows into the analytics platform task queue alongside subscription workflows

## How did you test this code?

Added automated tests that verify the complete export workflow execution, including asset creation, export processing, and SLO event emission. The test uses Temporal's testing framework to simulate the full workflow lifecycle.

:white_check_mark: Exports work on dashboards

![export-key-metrics-2026-03-23-151719.png](https://app.graphite.com/user-attachments/assets/6bc40eb6-168c-4999-bdff-f16cf0e0d185.png)

:white_check_mark: Exports work on insights

![export-active-user-lifecycle-2026-03-23-151655.png](https://app.graphite.com/user-attachments/assets/a0a4ab2d-d3de-4087-9bd9-859ce5d061cd.png)

[export-weekly-signups123-2026-03-23-151805.xlsx](https://github.com/user-attachments/files/26186315/export-weekly-signups123-2026-03-23-151805.xlsx)

:white_check_mark: Sharing still works (uses the async flow)

![CleanShot 2026-03-23 at 16.16.26.png](https://app.graphite.com/user-attachments/assets/00b9f0ee-86d2-4a46-8b0b-403cd3d5cccc.png)

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No - This is an internal update; Users should not notice this

## Docs update

No - This is an internal update; Users should not notice this