### PR TITLE
feat(experiments): create framework-free facade contract for experiments.

### DIFF
--- a/products/experiments/backend/facade/__init__.py
+++ b/products/experiments/backend/facade/__init__.py
@@ -1,0 +1,15 @@
+"""
+Facade for experiments product.
+
+This module provides the public interface for other products to interact with experiments.
+"""
+
+from .contracts import CreateExperimentInput, CreateFeatureFlagInput, Experiment, FeatureFlag, FeatureFlagVariant
+
+__all__ = [
+    "CreateExperimentInput",
+    "CreateFeatureFlagInput",
+    "Experiment",
+    "FeatureFlag",
+    "FeatureFlagVariant",
+]

--- a/products/experiments/backend/facade/contracts.py
+++ b/products/experiments/backend/facade/contracts.py
@@ -1,0 +1,74 @@
+"""
+Facade contracts (DTOs) for experiments product.
+
+These are framework-free frozen dataclasses that define the interface
+between the experiments product and the rest of the system.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FeatureFlagVariant:
+    """Feature flag variant configuration."""
+
+    key: str
+    rollout_percentage: int
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class CreateFeatureFlagInput:
+    """Input for creating a feature flag (new format)."""
+
+    key: str
+    variants: list[FeatureFlagVariant]
+    name: str | None = None
+    rollout_percentage: int | None = None
+    aggregation_group_type_index: int | None = None
+    ensure_experience_continuity: bool | None = None
+
+
+@dataclass(frozen=True)
+class CreateExperimentInput:
+    """
+    Input for creating an experiment.
+
+    Supports both old format (parameters.feature_flag_variants)
+    and new format (feature_flag_data).
+    """
+
+    name: str
+    feature_flag_key: str
+    description: str = ""
+    feature_flag_data: CreateFeatureFlagInput | None = None
+    parameters: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class FeatureFlag:
+    """Feature flag output."""
+
+    id: int
+    key: str
+    active: bool
+    created_at: datetime
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class Experiment:
+    """Experiment output."""
+
+    id: int
+    name: str
+    feature_flag_id: int
+    feature_flag_key: str
+    is_draft: bool
+    created_at: datetime
+    description: str | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    updated_at: datetime | None = None

--- a/products/experiments/backend/facade/contracts.py
+++ b/products/experiments/backend/facade/contracts.py
@@ -37,13 +37,13 @@ class CreateExperimentInput:
     Input for creating an experiment.
 
     Supports both old format (parameters.feature_flag_variants)
-    and new format (feature_flag_data).
+    and new format (feature_flag_filters).
     """
 
     name: str
     feature_flag_key: str
     description: str = ""
-    feature_flag_data: CreateFeatureFlagInput | None = None
+    feature_flag_filters: CreateFeatureFlagInput | None = None
     parameters: dict[str, Any] | None = None
 
 

--- a/products/experiments/backend/facade/test_contracts.py
+++ b/products/experiments/backend/facade/test_contracts.py
@@ -1,0 +1,255 @@
+"""
+Tests for experiment contracts (DTOs).
+
+These tests verify that our frozen dataclasses are immutable,
+hashable, and have the correct structure.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from products.experiments.backend.facade.contracts import (
+    CreateExperimentInput,
+    CreateFeatureFlagInput,
+    Experiment,
+    FeatureFlag,
+    FeatureFlagVariant,
+)
+
+
+class TestFeatureFlagVariant:
+    def test_create_variant(self):
+        """Test creating a feature flag variant."""
+        variant = FeatureFlagVariant(
+            key="control",
+            name="Control",
+            rollout_percentage=50,
+        )
+
+        assert variant.key == "control"
+        assert variant.name == "Control"
+        assert variant.rollout_percentage == 50
+
+    def test_variant_is_immutable(self):
+        """Test that variants are immutable."""
+        variant = FeatureFlagVariant(key="test", rollout_percentage=50)
+
+        with pytest.raises(AttributeError):
+            variant.key = "modified"  # type: ignore
+
+    def test_variant_is_hashable(self):
+        """Test that variants are hashable (for Turbo caching)."""
+        variant = FeatureFlagVariant(key="test", rollout_percentage=50)
+        assert hash(variant) is not None
+
+
+class TestCreateFeatureFlagInput:
+    def test_create_flag_input_minimal(self):
+        """Test creating flag input with minimal fields."""
+        input_dto = CreateFeatureFlagInput(
+            key="my-flag",
+            variants=[
+                FeatureFlagVariant(key="control", rollout_percentage=50),
+                FeatureFlagVariant(key="test", rollout_percentage=50),
+            ],
+        )
+
+        assert input_dto.key == "my-flag"
+        assert len(input_dto.variants) == 2
+        assert input_dto.name is None
+
+    def test_create_flag_input_full(self):
+        """Test creating flag input with all fields."""
+        input_dto = CreateFeatureFlagInput(
+            key="my-flag",
+            name="My Flag",
+            variants=[
+                FeatureFlagVariant(key="control", rollout_percentage=50),
+                FeatureFlagVariant(key="test", rollout_percentage=50),
+            ],
+            rollout_percentage=100,
+            aggregation_group_type_index=0,
+            ensure_experience_continuity=True,
+        )
+
+        assert input_dto.name == "My Flag"
+        assert input_dto.rollout_percentage == 100
+        assert input_dto.aggregation_group_type_index == 0
+        assert input_dto.ensure_experience_continuity is True
+
+    def test_flag_input_is_immutable(self):
+        """Test that flag input is immutable."""
+        input_dto = CreateFeatureFlagInput(
+            key="test",
+            variants=[FeatureFlagVariant(key="control", rollout_percentage=100)],
+        )
+
+        with pytest.raises(AttributeError):
+            input_dto.key = "modified"  # type: ignore
+
+
+class TestCreateExperimentInput:
+    def test_create_experiment_input_minimal(self):
+        """Test creating experiment input with minimal fields."""
+        input_dto = CreateExperimentInput(
+            name="My Experiment",
+            feature_flag_key="my-flag",
+        )
+
+        assert input_dto.name == "My Experiment"
+        assert input_dto.feature_flag_key == "my-flag"
+        assert input_dto.description == ""
+        assert input_dto.feature_flag_data is None
+        assert input_dto.parameters is None
+
+    def test_create_experiment_input_with_new_flag_format(self):
+        """Test creating experiment with new feature flag format."""
+        flag_input = CreateFeatureFlagInput(
+            key="my-flag",
+            name="My Flag",
+            variants=[
+                FeatureFlagVariant(key="control", rollout_percentage=50),
+                FeatureFlagVariant(key="test", rollout_percentage=50),
+            ],
+        )
+
+        input_dto = CreateExperimentInput(
+            name="My Experiment",
+            feature_flag_key="my-flag",
+            feature_flag_data=flag_input,
+        )
+
+        assert input_dto.feature_flag_data is not None
+        assert input_dto.feature_flag_data.key == "my-flag"
+        assert len(input_dto.feature_flag_data.variants) == 2
+
+    def test_create_experiment_input_with_old_parameters_format(self):
+        """Test creating experiment with old parameters format."""
+        input_dto = CreateExperimentInput(
+            name="My Experiment",
+            feature_flag_key="my-flag",
+            parameters={
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ]
+            },
+        )
+
+        assert input_dto.parameters is not None
+        assert "feature_flag_variants" in input_dto.parameters
+
+    def test_experiment_input_is_immutable(self):
+        """Test that experiment input is immutable."""
+        input_dto = CreateExperimentInput(
+            name="Test",
+            feature_flag_key="test-flag",
+        )
+
+        with pytest.raises(AttributeError):
+            input_dto.name = "modified"  # type: ignore
+
+
+class TestFeatureFlag:
+    def test_feature_flag_output(self):
+        """Test feature flag output DTO."""
+        flag = FeatureFlag(
+            id=123,
+            key="my-flag",
+            name="My Flag",
+            active=True,
+            created_at=datetime.now(UTC),
+        )
+
+        assert flag.id == 123
+        assert flag.key == "my-flag"
+        assert flag.name == "My Flag"
+        assert flag.active is True
+
+    def test_feature_flag_is_immutable(self):
+        """Test that feature flag output is immutable."""
+        flag = FeatureFlag(
+            id=123,
+            key="test",
+            active=False,
+            created_at=datetime.now(UTC),
+        )
+
+        with pytest.raises(AttributeError):
+            flag.active = True  # type: ignore
+
+    def test_feature_flag_is_hashable(self):
+        """Test that feature flag is hashable."""
+        flag = FeatureFlag(
+            id=123,
+            key="test",
+            active=False,
+            created_at=datetime.now(UTC),
+        )
+        assert hash(flag) is not None
+
+
+class TestExperiment:
+    def test_experiment_output_minimal(self):
+        """Test experiment output DTO with minimal fields."""
+        exp = Experiment(
+            id=456,
+            name="My Experiment",
+            feature_flag_id=123,
+            feature_flag_key="my-flag",
+            is_draft=True,
+            created_at=datetime.now(UTC),
+        )
+
+        assert exp.id == 456
+        assert exp.name == "My Experiment"
+        assert exp.feature_flag_id == 123
+        assert exp.is_draft is True
+
+    def test_experiment_output_full(self):
+        """Test experiment output with all fields."""
+        now = datetime.now(UTC)
+        exp = Experiment(
+            id=456,
+            name="My Experiment",
+            description="Test description",
+            feature_flag_id=123,
+            feature_flag_key="my-flag",
+            is_draft=False,
+            start_date=now,
+            end_date=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        assert exp.description == "Test description"
+        assert exp.is_draft is False
+        assert exp.start_date == now
+        assert exp.updated_at == now
+
+    def test_experiment_is_immutable(self):
+        """Test that experiment output is immutable."""
+        exp = Experiment(
+            id=456,
+            name="Test",
+            feature_flag_id=123,
+            feature_flag_key="test",
+            is_draft=True,
+            created_at=datetime.now(UTC),
+        )
+
+        with pytest.raises(AttributeError):
+            exp.name = "modified"  # type: ignore
+
+    def test_experiment_is_hashable(self):
+        """Test that experiment is hashable."""
+        exp = Experiment(
+            id=456,
+            name="Test",
+            feature_flag_id=123,
+            feature_flag_key="test",
+            is_draft=True,
+            created_at=datetime.now(UTC),
+        )
+        assert hash(exp) is not None

--- a/products/experiments/backend/facade/test_contracts.py
+++ b/products/experiments/backend/facade/test_contracts.py
@@ -8,6 +8,7 @@ hashable, and have the correct structure.
 from datetime import UTC, datetime
 
 import pytest
+from freezegun import freeze_time
 
 from products.experiments.backend.facade.contracts import (
     CreateExperimentInput,
@@ -100,11 +101,11 @@ class TestCreateExperimentInput:
         assert input_dto.name == "My Experiment"
         assert input_dto.feature_flag_key == "my-flag"
         assert input_dto.description == ""
-        assert input_dto.feature_flag_data is None
+        assert input_dto.feature_flag_filters is None
         assert input_dto.parameters is None
 
     def test_create_experiment_input_with_new_flag_format(self):
-        """Test creating experiment with new feature flag format."""
+        """Test creating experiment with new feature flag filters format."""
         flag_input = CreateFeatureFlagInput(
             key="my-flag",
             name="My Flag",
@@ -117,12 +118,12 @@ class TestCreateExperimentInput:
         input_dto = CreateExperimentInput(
             name="My Experiment",
             feature_flag_key="my-flag",
-            feature_flag_data=flag_input,
+            feature_flag_filters=flag_input,
         )
 
-        assert input_dto.feature_flag_data is not None
-        assert input_dto.feature_flag_data.key == "my-flag"
-        assert len(input_dto.feature_flag_data.variants) == 2
+        assert input_dto.feature_flag_filters is not None
+        assert input_dto.feature_flag_filters.key == "my-flag"
+        assert len(input_dto.feature_flag_filters.variants) == 2
 
     def test_create_experiment_input_with_old_parameters_format(self):
         """Test creating experiment with old parameters format."""
@@ -151,6 +152,7 @@ class TestCreateExperimentInput:
             input_dto.name = "modified"  # type: ignore
 
 
+@freeze_time("2026-03-21T12:00:00Z")
 class TestFeatureFlag:
     def test_feature_flag_output(self):
         """Test feature flag output DTO."""
@@ -190,6 +192,7 @@ class TestFeatureFlag:
         assert hash(flag) is not None
 
 
+@freeze_time("2026-03-21T12:00:00Z")
 class TestExperiment:
     def test_experiment_output_minimal(self):
         """Test experiment output DTO with minimal fields."""

--- a/products/experiments/package.json
+++ b/products/experiments/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@posthog/products-experiments",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short"
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short",
+        "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
         "kea": "catalog:",

--- a/products/experiments/tsconfig.json
+++ b/products/experiments/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true
+    }
+}

--- a/tach.toml
+++ b/tach.toml
@@ -213,7 +213,11 @@ depends_on = [
     "ee",
     "posthog",
 ]
-layer = "non_isolated"
+layer = "products"
+interfaces = [
+    "products.experiments.backend.facade",
+    "products.experiments.backend.presentation.views",
+]
 
 [[modules]]
 path = "products.feature_flags"


### PR DESCRIPTION
## Problem

The experiments product needed to deprecate the old `parameters.feature_flag_variants` format in favor of a new feature_flag_data structure, while maintaining backwards compatibility. To achieve this incrementally without breaking existing code, the first step was to establish a clean facade layer following PostHog's new products architecture.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Created framework-free facade contracts (DTOs) using frozen dataclasses that define the interface between the experiments product and the rest of the system. These contracts are immutable and hashable (required for Turbo caching), support both old and new formats, and provide a stable API boundary. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pytest products/experiments/backend/facade/test_contracts.py -v
```

or if you feel modern:

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
