### PR TITLE
fix: first seen last seen improvements

### DIFF
--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -37,6 +37,8 @@ export type TZLabelProps = Omit<LemonDropdownProps, 'overlay' | 'trigger' | 'chi
     /** Timezone to display the time in (e.g., 'UTC', 'America/New_York'). If not set, uses local timezone.
      * Note: When set, forces timestampStyle to 'absolute' to avoid broken relative date comparisons. */
     displayTimezone?: string
+    /** Custom suffix to replace "ago" in relative time display. e.g. suffix="old" renders "5 hours old" */
+    suffix?: string
 }
 
 const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
@@ -181,6 +183,7 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
         className,
         children,
         displayTimezone,
+        suffix,
         ...dropdownProps
     },
     ref
@@ -199,12 +202,16 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
     const effectiveTimestampStyle = displayTimezone ? 'absolute' : timestampStyle
 
     const format = useCallback(() => {
-        return formatDate || formatTime || effectiveTimestampStyle === 'absolute'
-            ? humanFriendlyDetailedTime(displayTime, formatDate, formatTime, {
-                  timestampStyle: effectiveTimestampStyle,
-              })
-            : displayTime.fromNow()
-    }, [formatDate, formatTime, displayTime, effectiveTimestampStyle])
+        if (formatDate || formatTime || effectiveTimestampStyle === 'absolute') {
+            return humanFriendlyDetailedTime(displayTime, formatDate, formatTime, {
+                timestampStyle: effectiveTimestampStyle,
+            })
+        }
+        if (suffix) {
+            return `${displayTime.fromNow(true)} ${suffix}`
+        }
+        return displayTime.fromNow()
+    }, [formatDate, formatTime, displayTime, effectiveTimestampStyle, suffix])
 
     const [formattedContent, setFormattedContent] = useState(format)
 

--- a/products/error_tracking/frontend/components/IssueMetadata.tsx
+++ b/products/error_tracking/frontend/components/IssueMetadata.tsx
@@ -2,7 +2,6 @@ import { useValues } from 'kea'
 import { PropsWithChildren, useState } from 'react'
 import { match } from 'ts-pattern'
 
-import { IconChevronRight } from '@posthog/icons'
 import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -72,16 +71,6 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
                             () => (
                                 <>
                                     <TimeBoundary
-                                        time={firstSeen}
-                                        loading={issueLoading}
-                                        label="First Seen"
-                                        updateDateRange={(dateRange) => {
-                                            dateRange.date_from = firstSeen?.toISOString()
-                                            return dateRange
-                                        }}
-                                    />
-                                    <IconChevronRight />
-                                    <TimeBoundary
                                         time={lastSeen}
                                         loading={summaryLoading}
                                         label="Last Seen"
@@ -90,6 +79,17 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
                                             return dateRange
                                         }}
                                     />
+                                    <span className="text-xs text-muted ml-1">(</span>
+                                    <TimeBoundary
+                                        time={firstSeen}
+                                        loading={issueLoading}
+                                        label="First Seen"
+                                        updateDateRange={(dateRange) => {
+                                            dateRange.date_from = firstSeen?.toISOString()
+                                            return dateRange
+                                        }}
+                                    />
+                                    <span className="text-xs text-muted">old)</span>
                                 </>
                             )
                         )

--- a/products/error_tracking/frontend/components/IssueMetadata.tsx
+++ b/products/error_tracking/frontend/components/IssueMetadata.tsx
@@ -2,6 +2,7 @@ import { useValues } from 'kea'
 import { PropsWithChildren, useState } from 'react'
 import { match } from 'ts-pattern'
 
+import { IconChevronRight } from '@posthog/icons'
 import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -71,16 +72,6 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
                             () => (
                                 <>
                                     <TimeBoundary
-                                        time={lastSeen}
-                                        loading={summaryLoading}
-                                        label="Last Seen"
-                                        updateDateRange={(dateRange) => {
-                                            dateRange.date_to = lastSeen?.endOf('minute').toISOString()
-                                            return dateRange
-                                        }}
-                                    />
-                                    <span className="text-xs text-muted ml-1">(</span>
-                                    <TimeBoundary
                                         time={firstSeen}
                                         loading={issueLoading}
                                         label="First Seen"
@@ -89,7 +80,16 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
                                             return dateRange
                                         }}
                                     />
-                                    <span className="text-xs text-muted">old)</span>
+                                    <IconChevronRight />
+                                    <TimeBoundary
+                                        time={lastSeen}
+                                        loading={summaryLoading}
+                                        label="Last Seen"
+                                        updateDateRange={(dateRange) => {
+                                            dateRange.date_to = lastSeen?.endOf('minute').toISOString()
+                                            return dateRange
+                                        }}
+                                    />
                                 </>
                             )
                         )

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -18,6 +18,7 @@ import { AssigneeIconDisplay, AssigneeLabelDisplay } from './Assignee/AssigneeDi
 import { AssigneeSelect } from './Assignee/AssigneeSelect'
 import { issueActionsLogic } from './IssueActions/issueActionsLogic'
 import { issueFiltersLogic, updateFilterSearchParams } from './IssueFilters/issueFiltersLogic'
+import { issueQueryOptionsLogic } from './IssueQueryOptions/issueQueryOptionsLogic'
 import { IssueStatusSelect } from './IssueStatusSelect'
 import { RuntimeIcon } from './RuntimeIcon'
 
@@ -50,6 +51,7 @@ export const IssueListTitleColumn = <T extends ErrorTrackingIssue | ErrorTrackin
     const { setSelectedIssueIds, setPreviouslyCheckedRecordIndex } = useActions(bulkSelectLogic)
     const { updateIssueAssignee, updateIssueStatus } = useActions(issueActionsLogic)
     const { dateRange, filterGroup, filterTestAccounts, searchQuery } = useValues(issueFiltersLogic)
+    const { orderBy } = useValues(issueQueryOptionsLogic)
 
     const record = props.record as ErrorTrackingIssue
     const checked = selectedIssueIds.includes(record.id)
@@ -139,12 +141,25 @@ export const IssueListTitleColumn = <T extends ErrorTrackingIssue | ErrorTrackin
                         )}
                     </AssigneeSelect>
                     <CustomSeparator />
-                    <TZLabel time={record.first_seen} className="border-dotted border-b text-xs ml-1" delayMs={750} />
-                    <IconChevronRight className="text-quaternary mx-1" />
+                    {orderBy === 'first_seen' && (
+                        <>
+                            <TZLabel
+                                time={record.first_seen}
+                                className="border-dotted border-b text-xs ml-1"
+                                suffix="old"
+                                delayMs={750}
+                            />
+                            <IconChevronRight className="text-quaternary mx-0.5" fontSize="0.75rem" />
+                        </>
+                    )}
                     {record.last_seen ? (
-                        <TZLabel time={record.last_seen} className="border-dotted border-b text-xs" delayMs={750} />
+                        <TZLabel
+                            time={record.last_seen}
+                            className="border-dotted border-b text-xs ml-1"
+                            delayMs={750}
+                        />
                     ) : (
-                        <LemonSkeleton />
+                        <LemonSkeleton className="ml-1" />
                     )}
                 </div>
             </div>

--- a/products/error_tracking/frontend/components/TimeBoundary.tsx
+++ b/products/error_tracking/frontend/components/TimeBoundary.tsx
@@ -16,9 +16,11 @@ type TimeBoundaryProps = {
     time: Dayjs | null | undefined
     loading: boolean
     updateDateRange: (dateRange: DateRange) => DateRange
+    /** Custom suffix to replace "ago" in relative time display. e.g. suffix="old" renders "5 hours old" */
+    suffix?: string
 }
 
-export function TimeBoundary({ time, loading, label, updateDateRange }: TimeBoundaryProps): JSX.Element {
+export function TimeBoundary({ time, loading, label, updateDateRange, suffix }: TimeBoundaryProps): JSX.Element {
     const { dateRange } = useValues(issueFiltersLogic)
     const { setDateRange } = useActions(issueFiltersLogic)
     const onClick = useCallback(
@@ -43,6 +45,7 @@ export function TimeBoundary({ time, loading, label, updateDateRange }: TimeBoun
                             time={time as Dayjs}
                             className="border-dotted border-b text-xs text-muted"
                             title={label}
+                            suffix={suffix}
                         />
                     </span>
                 ))


### PR DESCRIPTION
Made it so by default we only display last seen:
<img width="1034" height="350" alt="CleanShot 2026-03-17 at 15 58 15@2x" src="https://github.com/user-attachments/assets/dc390415-f01a-4820-bc5b-d3b5ad76a7fb" />

Only if user selects sorting by `first_seen` (which is very rare), we then display it like that:
<img width="1272" height="888" alt="CleanShot 2026-03-17 at 16 04 46@2x" src="https://github.com/user-attachments/assets/fc739c4a-a983-4e62-8051-66967148c75e" />



Slack thread: https://posthog.slack.com/archives/C0ACRAMJUAG/p1773761088166689?thread_ts=1773752675.422449&cid=C0ACRAMJUAG
