### PR TITLE
fix(devex): Update killProcessGroup to catch descendants

### DIFF
--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -532,6 +532,11 @@ func (p *Process) killProcessGroup() {
 	if p.cmd == nil || p.cmd.Process == nil {
 		return
 	}
+	// If the tracked command has already exited, avoid signaling based on a
+	// potentially reused PID.
+	if p.cmd.ProcessState != nil && p.cmd.ProcessState.Exited() {
+		return
+	}
 	pid := p.cmd.Process.Pid
 	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil {
 		_ = p.cmd.Process.Signal(syscall.SIGTERM)

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -314,6 +314,11 @@ func (p *Process) Start(send func(tea.Msg)) error {
 
 // Falls back to stdout/stderr pipes when PTY allocation fails
 func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
+	// pty.Start may have contaminated SysProcAttr with Setsid/Setctty
+	// before failing. For the pipe path we only need Setpgid so Stop() can
+	// kill the full process tree via Kill(-pid, SIGTERM).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		return err

--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -521,11 +521,21 @@ func collectProcessTree(ps *gops.Process) []*gops.Process {
 
 // killProcessGroup sends SIGTERM to the process group. Must be called with
 // p.mu held. Falls back to signaling the direct child if the group kill fails.
+// Also walks the process tree to terminate descendants that escaped the group
+// (e.g. pnpm/node processes spawned with a detached process group).
 func (p *Process) killProcessGroup() {
-	if p.cmd != nil && p.cmd.Process != nil {
-		pgid := p.cmd.Process.Pid
-		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
-			_ = p.cmd.Process.Signal(syscall.SIGTERM)
+	if p.cmd == nil || p.cmd.Process == nil {
+		return
+	}
+	pid := p.cmd.Process.Pid
+	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil {
+		_ = p.cmd.Process.Signal(syscall.SIGTERM)
+	}
+	// Walk the full process tree to catch any descendants that escaped the
+	// process group (e.g. pnpm spawns node as a detached child).
+	if ps, err := gops.NewProcess(int32(pid)); err == nil {
+		for _, proc := range collectProcessTree(ps) {
+			_ = proc.SendSignal(syscall.SIGTERM)
 		}
 	}
 }


### PR DESCRIPTION
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

* pty.Start may have contaminated SysProcAttr with Setsid/Setctty before failing. For the pipe path we only need Setpgid so Stop() can kill the full process tree via Kill(-pid, SIGTERM).
* killProcessGroup als walks the process tree to terminate descendants that escaped the group (e.g. pnpm/node processes spawned with a detached process group).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

skip-inkeep-docs

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
