### PR TITLE
fix(modeling): modify new temporal schedules to use new schedule spreading

### DIFF
--- a/products/data_warehouse/backend/data_load/saved_query_service.py
+++ b/products/data_warehouse/backend/data_load/saved_query_service.py
@@ -1,5 +1,3 @@
-import uuid
-import random
 from dataclasses import asdict
 from datetime import timedelta
 from typing import TYPE_CHECKING
@@ -10,10 +8,8 @@ import temporalio
 from temporalio.client import (
     Schedule,
     ScheduleActionStartWorkflow,
-    ScheduleIntervalSpec,
     ScheduleOverlapPolicy,
     SchedulePolicy,
-    ScheduleSpec,
     ScheduleState,
 )
 from temporalio.common import RetryPolicy, SearchAttributePair, TypedSearchAttributes
@@ -32,27 +28,10 @@ from posthog.temporal.common.schedule import (
 from posthog.temporal.common.search_attributes import POSTHOG_DAG_ID_KEY, POSTHOG_ORG_ID_KEY, POSTHOG_TEAM_ID_KEY
 
 from products.data_modeling.backend.models.node import Node
+from products.data_modeling.backend.schedule import build_schedule_spec
 
 if TYPE_CHECKING:
     from products.data_warehouse.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-
-
-def get_sync_frequency(saved_query: "DataWarehouseSavedQuery") -> tuple[timedelta, timedelta]:
-    interval = saved_query.sync_frequency_interval or timedelta(hours=24)
-
-    if interval <= timedelta(hours=1):
-        return (interval, timedelta(minutes=1))
-    if interval <= timedelta(hours=12):
-        return (interval, timedelta(minutes=30))
-
-    return (interval, timedelta(hours=1))
-
-
-def _get_midnight_offset(saved_query_id: uuid.UUID) -> timedelta:
-    """Deterministic offset of 0h, +1h, or -1h (as 23h) to spread 24h schedules around midnight UTC."""
-    rng = random.Random(str(saved_query_id))
-    offset_seconds = rng.choice([-3600, 0, 3600])
-    return timedelta(seconds=offset_seconds) % timedelta(hours=24)
 
 
 def get_saved_query_schedule(saved_query: "DataWarehouseSavedQuery") -> Schedule:
@@ -63,8 +42,12 @@ def get_saved_query_schedule(saved_query: "DataWarehouseSavedQuery") -> Schedule
         select=[Selector(label=saved_query.id.hex, ancestors=0, descendants=0)],
     )
 
-    sync_frequency, jitter = get_sync_frequency(saved_query)
-    offset = _get_midnight_offset(saved_query.id) if sync_frequency >= timedelta(hours=24) else timedelta()
+    interval = saved_query.sync_frequency_interval or timedelta(hours=24)
+    spec = build_schedule_spec(
+        entity_id=saved_query.id,
+        interval=interval,
+        team_timezone=saved_query.team.timezone,
+    )
 
     return Schedule(
         action=ScheduleActionStartWorkflow(
@@ -79,10 +62,7 @@ def get_saved_query_schedule(saved_query: "DataWarehouseSavedQuery") -> Schedule
                 non_retryable_error_types=["NondeterminismError", "CancelledError"],
             ),
         ),
-        spec=ScheduleSpec(
-            intervals=[ScheduleIntervalSpec(every=sync_frequency, offset=offset)],
-            jitter=jitter,
-        ),
+        spec=spec,
         state=ScheduleState(note=f"Schedule for saved query: {saved_query.pk}"),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )

--- a/products/data_warehouse/backend/test/test_saved_query_schedule.py
+++ b/products/data_warehouse/backend/test/test_saved_query_schedule.py
@@ -7,60 +7,65 @@ from django.test import TestCase
 
 from parameterized import parameterized
 
-from products.data_warehouse.backend.data_load.saved_query_service import _get_midnight_offset, get_saved_query_schedule
-
-
-class TestGetMidnightOffset(TestCase):
-    def test_deterministic_for_same_id(self):
-        id = uuid.uuid4()
-        assert _get_midnight_offset(id) == _get_midnight_offset(id)
-
-    def test_different_ids_produce_different_offsets(self):
-        offsets = {_get_midnight_offset(uuid.uuid4()) for _ in range(20)}
-        assert len(offsets) > 1
-
-    def test_offset_within_range(self):
-        for _ in range(100):
-            offset = _get_midnight_offset(uuid.uuid4())
-            offset_seconds = offset.total_seconds()
-            # offset should map to either [0, 3600] (12am - 1am) or [82800, 86400] (11pm - 12am)
-            assert 0 <= offset_seconds < 86400
-            in_window = offset_seconds <= 3600 or offset_seconds >= 82800
-            assert in_window, f"Offset {offset_seconds}s is outside the 11PM-1AM UTC window"
-
-    def test_offset_is_positive(self):
-        for _ in range(50):
-            offset = _get_midnight_offset(uuid.uuid4())
-            assert offset >= timedelta()
+from products.data_warehouse.backend.data_load.saved_query_service import get_saved_query_schedule
 
 
 class TestGetSavedQuerySchedule(TestCase):
-    def _make_saved_query(self, sync_frequency_interval: timedelta | None = None) -> MagicMock:
+    def _make_saved_query(self, sync_frequency_interval: timedelta | None = None, timezone: str = "UTC") -> MagicMock:
         sq = MagicMock()
         sq.id = uuid.uuid4()
         sq.team_id = 1
         sq.pk = sq.id
         sq.sync_frequency_interval = sync_frequency_interval
+        sq.team.timezone = timezone
         return sq
+
+    def test_uses_calendar_spec(self):
+        sq = self._make_saved_query(sync_frequency_interval=timedelta(hours=24))
+        schedule = get_saved_query_schedule(sq)
+        assert len(schedule.spec.calendars) >= 1
+
+    def test_defaults_to_24h_when_no_interval(self):
+        sq = self._make_saved_query(sync_frequency_interval=None)
+        schedule = get_saved_query_schedule(sq)
+        # 24hr -> medium tier -> 1 hour entry
+        assert len(schedule.spec.calendars) == 1
+        assert len(schedule.spec.calendars[0].hour) == 1
+
+    def test_passes_team_timezone(self):
+        sq = self._make_saved_query(sync_frequency_interval=timedelta(hours=24), timezone="America/New_York")
+        schedule = get_saved_query_schedule(sq)
+        assert schedule.spec.time_zone_name == "America/New_York"
 
     @parameterized.expand(
         [
+            ("15min", timedelta(minutes=15)),
+            ("30min", timedelta(minutes=30)),
             ("1h", timedelta(hours=1)),
             ("6h", timedelta(hours=6)),
             ("12h", timedelta(hours=12)),
+            ("24h", timedelta(hours=24)),
+            ("7d", timedelta(days=7)),
+            ("30d", timedelta(days=30)),
         ]
     )
-    def test_sub_24h_interval_has_zero_offset(self, _name, interval):
+    def test_deterministic_for_same_id(self, _name, interval):
         sq = self._make_saved_query(sync_frequency_interval=interval)
-        schedule = get_saved_query_schedule(sq)
-        offset = schedule.spec.intervals[0].offset
-        assert offset == timedelta(), f"Expected zero offset for interval={interval}"
+        schedule_a = get_saved_query_schedule(sq)
+        schedule_b = get_saved_query_schedule(sq)
+        assert schedule_a.spec.calendars == schedule_b.spec.calendars
 
-    def test_24h_offset_in_11pm_1am_window(self):
-        sq = self._make_saved_query(sync_frequency_interval=timedelta(hours=24))
+    def test_schedule_has_skip_overlap_policy(self):
+        sq = self._make_saved_query(sync_frequency_interval=timedelta(hours=6))
         schedule = get_saved_query_schedule(sq)
-        offset = schedule.spec.intervals[0].offset
-        assert offset is not None, "Expected non-None offset for 24h interval"
-        offset_seconds = offset.total_seconds()
-        in_window = offset_seconds <= 3600 or offset_seconds >= 82800
-        assert in_window, f"Offset {offset_seconds}s is outside the 11PM-1AM UTC window"
+        from temporalio.client import ScheduleOverlapPolicy
+
+        assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP
+
+    def test_schedule_action_is_data_modeling_run(self):
+        from temporalio.client import ScheduleActionStartWorkflow
+
+        sq = self._make_saved_query(sync_frequency_interval=timedelta(hours=6))
+        schedule = get_saved_query_schedule(sq)
+        assert isinstance(schedule.action, ScheduleActionStartWorkflow)
+        assert schedule.action.workflow == "data-modeling-run"

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1261,7 +1261,7 @@ class TestEndpointMaterializationTemporal:
         assert saved_query is not None
 
         # Get the schedule that should be created
-        schedule = get_saved_query_schedule(saved_query)
+        schedule = await sync_to_async(get_saved_query_schedule)(saved_query)
 
         # Verify schedule configuration
         from temporalio.client import ScheduleActionStartWorkflow, ScheduleOverlapPolicy
@@ -1270,10 +1270,9 @@ class TestEndpointMaterializationTemporal:
         assert schedule.action.id == str(saved_query.id)
         assert schedule.action.task_queue == DATA_MODELING_TASK_QUEUE
 
-        # Verify schedule interval matches sync_frequency_interval
-        intervals = schedule.spec.intervals
-        assert len(intervals) == 1
-        assert intervals[0].every == timedelta(hours=12)
+        # Verify schedule uses calendar spec (medium interval for 12h)
+        assert len(schedule.spec.calendars) == 1
+        assert schedule.spec.jitter == timedelta(hours=1)
 
         # Verify schedule policy
         assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP
@@ -1287,20 +1286,20 @@ class TestEndpointMaterializationTemporal:
 
         saved_query = await sync_to_async(get_saved_query)(version)
 
-        # Test 1-hour frequency
+        # Test 1-hour frequency (short interval: calendar with minute buckets, 1min jitter)
         saved_query.sync_frequency_interval = timedelta(hours=1)
-        schedule = get_saved_query_schedule(saved_query)
-        assert schedule.spec.intervals[0].every == timedelta(hours=1)
+        schedule = await sync_to_async(get_saved_query_schedule)(saved_query)
+        assert len(schedule.spec.calendars) == 1
         assert schedule.spec.jitter == timedelta(minutes=1)
 
-        # Test 12-hour frequency
+        # Test 12-hour frequency (medium interval: calendar with hour buckets, 1hr jitter)
         saved_query.sync_frequency_interval = timedelta(hours=12)
-        schedule = get_saved_query_schedule(saved_query)
-        assert schedule.spec.intervals[0].every == timedelta(hours=12)
-        assert schedule.spec.jitter == timedelta(minutes=30)
+        schedule = await sync_to_async(get_saved_query_schedule)(saved_query)
+        assert len(schedule.spec.calendars) == 1
+        assert schedule.spec.jitter == timedelta(hours=1)
 
-        # Test 24-hour frequency
+        # Test 24-hour frequency (medium interval: calendar with hour buckets, 1hr jitter)
         saved_query.sync_frequency_interval = timedelta(hours=24)
-        schedule = get_saved_query_schedule(saved_query)
-        assert schedule.spec.intervals[0].every == timedelta(hours=24)
+        schedule = await sync_to_async(get_saved_query_schedule)(saved_query)
+        assert len(schedule.spec.calendars) == 1
         assert schedule.spec.jitter == timedelta(hours=1)


### PR DESCRIPTION
## Problem

now we have cool load spreading for schedules models but nothing uses it

## Changes

use it for newly created schedules

## How did you test this code?

units

## Publish to changelog?

no
