### PR TITLE
chore(modeling): migrate 5min sync interval to 15min

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -11192,7 +11192,7 @@
             "type": "string"
         },
         "DataWarehouseSyncInterval": {
-            "enum": ["5min", "30min", "1hour", "6hour", "12hour", "24hour", "7day", "30day"],
+            "enum": ["5min", "15min", "30min", "1hour", "6hour", "12hour", "24hour", "7day", "30day"],
             "type": "string"
         },
         "DataWarehouseViewLink": {

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -60,8 +60,8 @@ const OPTIONS = [
         label: ' No resync',
     },
     {
-        value: '5min' as DataWarehouseSyncInterval,
-        label: ' Resync every 5 mins',
+        value: '15min' as DataWarehouseSyncInterval,
+        label: ' Resync every 15 mins',
     },
     {
         value: '30min' as DataWarehouseSyncInterval,

--- a/frontend/src/scenes/data-warehouse/external-data-sources/activityDescriptions.tsx
+++ b/frontend/src/scenes/data-warehouse/external-data-sources/activityDescriptions.tsx
@@ -12,6 +12,7 @@ import { SyncTypeLabelMap } from '../utils'
 const getSyncFrequencyLabel = (syncFrequency: string): string => {
     const syncFrequencyMap: Record<DataWarehouseSyncInterval, string> = {
         '5min': 'every 5 mins',
+        '15min': 'every 15 mins',
         '30min': 'every 30 mins',
         '1hour': 'every 1 hour',
         '6hour': 'every 6 hours',

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -301,7 +301,7 @@ export const SchemaTable = ({ schemas, isLoading, isDirectQuerySource }: SchemaT
                                             })
                                         }
                                         options={[
-                                            { value: '5min' as DataWarehouseSyncInterval, label: '5 mins' },
+                                            { value: '15min' as DataWarehouseSyncInterval, label: '15 mins' },
                                             { value: '30min' as DataWarehouseSyncInterval, label: '30 mins' },
                                             { value: '1hour' as DataWarehouseSyncInterval, label: '1 hour' },
                                             { value: '6hour' as DataWarehouseSyncInterval, label: '6 hours' },

--- a/frontend/src/scenes/data-warehouse/utils.ts
+++ b/frontend/src/scenes/data-warehouse/utils.ts
@@ -78,6 +78,8 @@ export function syncIntervalToShorthand(syncInterval: DataWarehouseSyncInterval 
     switch (syncInterval) {
         case '5min':
             return '5m'
+        case '15min':
+            return '15m'
         case '30min':
             return '30m'
         case '1hour':

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5720,7 +5720,16 @@ export type BatchExportService =
 
 export type BatchExportInterval = 'hour' | 'day' | 'week' | 'every 5 minutes' | 'every 15 minutes'
 
-export type DataWarehouseSyncInterval = '5min' | '30min' | '1hour' | '6hour' | '12hour' | '24hour' | '7day' | '30day'
+export type DataWarehouseSyncInterval =
+    | '5min'
+    | '15min'
+    | '30min'
+    | '1hour'
+    | '6hour'
+    | '12hour'
+    | '24hour'
+    | '7day'
+    | '30day'
 export type OrNever = 'never'
 
 export type BatchExportConfiguration = {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1045,6 +1045,7 @@ class DataWarehouseSavedQueryOrigin(StrEnum):
 
 class DataWarehouseSyncInterval(StrEnum):
     FIELD_5MIN = "5min"
+    FIELD_15MIN = "15min"
     FIELD_30MIN = "30min"
     FIELD_1HOUR = "1hour"
     FIELD_6HOUR = "6hour"

--- a/products/data_warehouse/backend/api/saved_query.py
+++ b/products/data_warehouse/backend/api/saved_query.py
@@ -332,6 +332,9 @@ class DataWarehouseSavedQuerySerializer(DataWarehouseSavedQuerySerializerMixin, 
                 locked_instance.sync_frequency_interval = None
                 validated_data["sync_frequency_interval"] = None
             elif sync_frequency:
+                # Clamp deprecated 5min interval to 15min for saved queries
+                if sync_frequency == "5min":
+                    sync_frequency = "15min"
                 sync_frequency_interval = sync_frequency_to_sync_frequency_interval(sync_frequency)
                 validated_data["sync_frequency_interval"] = sync_frequency_interval
                 locked_instance.sync_frequency_interval = sync_frequency_interval

--- a/products/data_warehouse/backend/migrations/0031_migrate_5min_to_15min.py
+++ b/products/data_warehouse/backend/migrations/0031_migrate_5min_to_15min.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+from django.db import migrations
+
+
+def migrate_5min_to_15min(apps, schema_editor):
+    DataWarehouseSavedQuery = apps.get_model("data_warehouse", "DataWarehouseSavedQuery")
+    DataWarehouseSavedQuery.objects.filter(sync_frequency_interval=timedelta(minutes=5)).update(
+        sync_frequency_interval=timedelta(minutes=15)
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_warehouse", "0030_externaldataschema_description"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_5min_to_15min, migrations.RunPython.noop),
+    ]

--- a/products/data_warehouse/backend/migrations/max_migration.txt
+++ b/products/data_warehouse/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0030_externaldataschema_description
+0031_migrate_5min_to_15min

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -3675,6 +3675,7 @@ export type DataWarehouseSyncIntervalApi =
 
 export const DataWarehouseSyncIntervalApi = {
     '5min': '5min',
+    '15min': '15min',
     '30min': '30min',
     '1hour': '1hour',
     '6hour': '6hour',

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11406,6 +11406,7 @@ export namespace Schemas {
 
     export const DataWarehouseSyncInterval = {
       '5min': '5min',
+      '15min': '15min',
       '30min': '30min',
       '1hour': '1hour',
       '6hour': '6hour',


### PR DESCRIPTION
## Problem

5min syncs are kinda silly

## Changes

drop them and offer 15min instead. migrate existing 5min schedules to 15min

## How did you test this code?

existing tests

## Publish to changelog?

yes. we are dropping support for 5min schedules in favor of 15min schedules for data models. this is in an effort to improve reliability and the overall user experience with posthog data modeling. we may bring back 5min schedules in the future but only after we can guarantee a good experience with them.

## Docs update

we are dropping support for 5min schedules in favor of 15min schedules for data models. this is in an effort to improve reliability and the overall user experience with posthog data modeling. we may bring back 5min schedules in the future but only after we can guarantee a good experience with them.
