### PR TITLE
fix(signals): Add larger timeout to survive bursts.

### DIFF
--- a/posthog/api/embedding_worker.py
+++ b/posthog/api/embedding_worker.py
@@ -73,7 +73,7 @@ async def async_generate_embedding(
     """Async equivalent of generate_embedding — uses httpx instead of requests to avoid blocking a thread."""
     logger.info(f"Generating ad-hoc embedding (async) for team {team.pk}")
     payload = _build_embedding_payload(team, content, model, no_truncate)
-    async with internal_httpx_async_client() as client:
+    async with internal_httpx_async_client(timeout=60) as client:
         response = await client.post(_EMBEDDING_URL, json=payload)
         response.raise_for_status()
         return _parse_embedding_response(response.json())


### PR DESCRIPTION
## Problem
- When sending 400+ embeddings to the embeddings worker at once - we hit ReadTimeouts, as the worker doesn't answer in 5s, `httpx` expects it to

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Increase the timeout to 60s to cover most of the bursts

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
