### PR TITLE
feat(subscriptions): add subscription delivery insights to dashboards

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/insights.tf
@@ -638,6 +638,47 @@ import {
   id = "2/6984945"
 }
 
+resource "posthog_insight" "subscription_delivery_success_rate" {
+  name = "Subscription delivery success rate"
+  query_json = jsonencode({
+    "kind": "InsightVizNode",
+    "source": {
+      "kind": "TrendsQuery",
+      "series": [
+        {
+          "kind": "EventsNode",
+          "math": "total",
+          "event": "subscription_delivery_started",
+          "custom_name": "Started"
+        },
+        {
+          "kind": "EventsNode",
+          "math": "total",
+          "event": "subscription_delivery_exhausted",
+          "custom_name": "Exhausted (failed)"
+        }
+      ],
+      "version": 2,
+      "interval": "day",
+      "dateRange": {
+        "date_from": "-30d"
+      },
+      "trendsFilter": {
+        "display": "ActionsLineGraph",
+        "showLegend": true,
+        "showValuesOnSeries": true,
+        "formulaNodes": [
+          { "formula": "(A-B)/A", "custom_name": "Success rate" }
+        ],
+        "aggregationAxisFormat": "percentage_scaled"
+      },
+      "filterTestAccounts": false
+    }
+  })
+  tags = ["managed-by:terraform"]
+  dashboard_ids = [posthog_dashboard.team_analytics_platform_key_metrics.id]
+}
+
 resource "posthog_insight" "alert_failures_by_exception_type_aggregated" {
   name = "Alert failures by exception type (aggregated)"
   description = "Failures grouped by exception type with alert IDs normalized, showing the core issues affecting alerts"

--- a/terraform/us/project-2/team-analytics-platform/slos/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slos/insights.tf
@@ -173,6 +173,23 @@ locals {
       SQL
     }
 
+    subscriptions = {
+      name_prefix  = "SLO: Subscription deliveries"
+      description  = "Rolling burn rate for subscription deliveries."
+      error_budget = 0.01
+      regions      = ["us"]
+      daily_sql    = <<-SQL
+        SELECT
+            toDate(timestamp) AS date,
+            countIf(event = 'subscription_delivery_started') AS total,
+            countIf(event = 'subscription_delivery_exhausted') AS failures
+        FROM events
+        WHERE event IN ('subscription_delivery_started', 'subscription_delivery_exhausted')
+            AND timestamp >= now() - INTERVAL 30 DAY
+        GROUP BY date
+      SQL
+    }
+
     # Cohorts not calculated within a day count as failures.
     cohorts = {
       name_prefix  = "SLO: Cohort calculations"


### PR DESCRIPTION
## Problem

We now emit `subscription_delivery_started`, `subscription_delivery_succeeded`, and `subscription_delivery_exhausted` events from the subscription workflow but have no dashboard visibility into delivery success rates.

## Changes

- Add a **subscription delivery success rate** insight to the key metrics dashboard, showing `(started - exhausted) / started` as a percentage
- Add a **subscriptions SLO** (99% target) to the SLOs dashboard, tracking `subscription_delivery_started` vs `subscription_delivery_exhausted` with burn rate and success rate charts

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code. The insight and SLO definitions follow existing patterns in the same Terraform files.