### PR TITLE
feat(skills): Adds a playwright test writing skill

### DIFF
--- a/.agents/skills/playwright-test/SKILL.md
+++ b/.agents/skills/playwright-test/SKILL.md
@@ -32,7 +32,9 @@ After your exploration, present the plan to me for confirmation or any changes.
 
 ### Step 3: Ensure no flaky tests
 
-After all tests pass in the file, run with --repeat-each 10 added to the command. This will ensure no tests are flaky.
+After all tests pass in the file, run with `--repeat-each 10` added to the command. This will surface any flaky tests.
+
+If any test fails across the 10 runs, treat it as a real failure: go back to Step 2, debug, fix, and re-run Step 3. Do not proceed to Step 4 until every run of every test passes.
 
 ### Step 4: Report
 

--- a/.agents/skills/playwright-test/SKILL.md
+++ b/.agents/skills/playwright-test/SKILL.md
@@ -24,7 +24,7 @@ After your exploration, present the plan to me for confirmation or any changes.
 
 ### Step 2: Implement the test plan
 
-- Write the tests, making sure to use common patters used in neighbouring files.
+- Write the tests, making sure to use common patterns used in neighbouring files.
 - Run the tests with `BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test <file name> --retries 0 --workers 3`
 - Debug any failures. Look at screen shots, if needed launch the playwright mcp skills to interact with the browser. Go back to step 1 after attempting a fix.
 - **Keep looping until all tests pass.** Do not give up or ask the user for help. You must resolve every failure yourself.

--- a/.agents/skills/playwright-test/SKILL.md
+++ b/.agents/skills/playwright-test/SKILL.md
@@ -6,11 +6,11 @@ allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, mcp__playwright__*
 
 ## Rules
 
-- Don't use any locators with css selectors, prefer getting elements via accesibilty roles or pageId's, add data-attr if required.
+- Don't use any locators with css selectors, prefer getting elements via accessibility roles or data-testids, add data-attr if required.
 - Write fewer longer tests that do multiple things, split up by test.steps into logical steps
 - Use page object models for common tasks and accessing common elements
-- After UI interactions, always assert on UI changes, do not asser on network requests resolving
-- Never put an if statment in a test
+- After UI interactions, always assert on UI changes, do not assert on network requests resolving
+- Never put an if statement in a test
 
 ## Instructions
 

--- a/.agents/skills/playwright-test/SKILL.md
+++ b/.agents/skills/playwright-test/SKILL.md
@@ -18,17 +18,16 @@ You are to plan an end to end playwright test for a feature.
 
 ### Step 1: Plan the test(s) to be done.
 
-Use the Playwright MCP tools (e.g., `mcp__playwright__browser_navigate`, `mcp__playwright__browser_click`, `mcp__playwright__browser_screenshot`) to
-interact with the browser and plan your tests.
+Use the Playwright MCP tools (e.g., `mcp__playwright__browser_navigate`, `mcp__playwright__browser_click`, `mcp__playwright__browser_screenshot`) to interact with the browser and plan your tests.
 
 After your exploration, present the plan to me for confirmation or any changes.
 
 ### Step 2: Implement the test plan
 
-1. Write the tests, making sure to use common patters used in neighbouring files.
-2. Run the tests with `BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test <file name> --retries 0 --workers 3`
-3. Debug any failures. Look at screen shots, if needed launch the playwright mcp skills to interact with the browser. Go back to step 1 after attempting a fix.
-4. **Keep looping until all tests pass.** Do not give up or ask the user for help. You must resolve every failure yourself.
+- Write the tests, making sure to use common patters used in neighbouring files.
+- Run the tests with `BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test <file name> --retries 0 --workers 3`
+- Debug any failures. Look at screen shots, if needed launch the playwright mcp skills to interact with the browser. Go back to step 1 after attempting a fix.
+- **Keep looping until all tests pass.** Do not give up or ask the user for help. You must resolve every failure yourself.
 
 ### Step 3: Ensure no flaky tests
 

--- a/.agents/skills/playwright-test/SKILL.md
+++ b/.agents/skills/playwright-test/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: playwright-test
+description: Write a playwright test, make sure it runs, and is not flaky.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, mcp__playwright__*
+---
+
+## Rules
+
+- Don't use any locators with css selectors, prefer getting elements via accesibilty roles or pageId's, add data-attr if required.
+- Write fewer longer tests that do multiple things, split up by test.steps into logical steps
+- Use page object models for common tasks and accessing common elements
+- After UI interactions, always assert on UI changes, do not asser on network requests resolving
+- Never put an if statment in a test
+
+## Instructions
+
+You are to plan an end to end playwright test for a feature.
+
+### Step 1: Plan the test(s) to be done.
+
+Use the Playwright MCP tools (e.g., `mcp__playwright__browser_navigate`, `mcp__playwright__browser_click`, `mcp__playwright__browser_screenshot`) to
+interact with the browser and plan your tests.
+
+After your exploration, present the plan to me for confirmation or any changes.
+
+### Step 2: Implement the test plan
+
+1. Write the tests, making sure to use common patters used in neighbouring files.
+2. Run the tests with `BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test <file name> --retries 0 --workers 3`
+3. Debug any failures. Look at screen shots, if needed launch the playwright mcp skills to interact with the browser. Go back to step 1 after attempting a fix.
+4. **Keep looping until all tests pass.** Do not give up or ask the user for help. You must resolve every failure yourself.
+
+### Step 3: Ensure no flaky tests
+
+After all tests pass in the file, run with --repeat-each 10 added to the command. This will ensure no tests are flaky.
+
+### Step 4: Report
+
+Once all tests pass, output a single line: **Testing Complete**

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -19,6 +19,11 @@ LOGIN_USERNAME='my@email.address' LOGIN_PASSWORD="the-password" BASE_URL='http:/
 
 You might need to install Playwright first: `pnpm --filter=@posthog/playwright exec playwright install`
 
+## Writing tests with Claude Code
+
+Use the `/playwright-test` skill to have Claude Code write and validate end-to-end tests for you.
+It will explore the UI with Playwright MCP tools, plan the tests, implement them, and run them in a loop until they pass reliably (including a flakiness check with `--repeat-each 10`).
+
 ## Writing tests
 
 ### Flaky tests are almost always due to not waiting for the right thing


### PR DESCRIPTION
## Problem

Playwright test writing is long, boring and therefore tempting to avoid. Even if you do them they are often flaky and need even more work.

## Changes

Adds a playwright skill which makes it really easy to write playwright tests. I've been using this a couple weeks and can pretty much one shot tests like these [Notebook e2e tests](https://github.com/PostHog/posthog/pull/51251/changes)

What's good about it:
- Actually uses playwright mcp to actually check the browser
- Verifies theyre not flaky by running with `--repeat-each 10`

## How did you test this code?

I've been using it to make most my playwright PRs

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
