### PR TITLE
fix(ds): handle MySQL zero dates ('0000-00-00') in data warehouse imports

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import math
+import datetime
 import collections
 from collections.abc import Callable, Iterator
 from contextlib import _GeneratorContextManager
@@ -13,6 +14,7 @@ import pyarrow as pa
 import pymysql
 import pymysql.converters
 from dlt.common.normalizers.naming.snake_case import NamingConvention
+from pymysql.constants import FIELD_TYPE
 from pymysql.cursors import Cursor, SSCursor
 from structlog.types import FilteringBoundLogger
 
@@ -30,6 +32,45 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
 from posthog.temporal.data_imports.sources.common.sql import Column, Table
 
 from products.data_warehouse.backend.types import IncrementalFieldType, PartitionSettings
+
+
+def _safe_convert_date(obj: Any) -> datetime.date | None:
+    """Convert MySQL date, returning None for invalid dates like '0000-00-00'."""
+    if isinstance(obj, (bytes, bytearray)):
+        obj = obj.decode("ascii")
+    try:
+        parts = obj.split("-", 2)
+        return datetime.date(int(parts[0]), int(parts[1]), int(parts[2]))
+    except (ValueError, IndexError, AttributeError):
+        return None
+
+
+def _safe_convert_datetime(obj: Any) -> datetime.datetime | None:
+    """Convert MySQL datetime/timestamp, returning None for invalid values like '0000-00-00 00:00:00'."""
+    if isinstance(obj, (bytes, bytearray)):
+        obj = obj.decode("ascii")
+    try:
+        date_part, time_part = obj.split(" ", 1)
+        date_values = [int(x) for x in date_part.split("-", 2)]
+        time_parts = time_part.split(":", 2)
+        hours = int(time_parts[0])
+        minutes = int(time_parts[1])
+        # Handle optional microseconds
+        sec_parts = time_parts[2].split(".", 1)
+        seconds = int(sec_parts[0])
+        microseconds = int(sec_parts[1].ljust(6, "0")) if len(sec_parts) > 1 else 0
+        return datetime.datetime(*date_values, hours, minutes, seconds, microseconds)
+    except (ValueError, IndexError, AttributeError):
+        return None
+
+
+# Custom conversions that return None for MySQL zero dates instead of raw strings
+_MYSQL_SAFE_CONVERSIONS: dict[int, Any] = {
+    **pymysql.converters.conversions,
+    FIELD_TYPE.DATE: _safe_convert_date,
+    FIELD_TYPE.DATETIME: _safe_convert_datetime,
+    FIELD_TYPE.TIMESTAMP: _safe_convert_datetime,
+}
 
 
 def filter_mysql_incremental_fields(
@@ -312,9 +353,13 @@ class MySQLColumn(Column):
             case "varchar" | "char" | "text" | "mediumtext" | "longtext":
                 arrow_type = pa.string()
             case "date":
+                # MySQL allows zero dates ('0000-00-00') which become None,
+                # so date columns must always be nullable in the Arrow schema
                 arrow_type = pa.date32()
+                return pa.field(self.name, arrow_type, nullable=True)
             case "datetime" | "timestamp":
                 arrow_type = pa.timestamp("us")
+                return pa.field(self.name, arrow_type, nullable=True)
             case "time":
                 arrow_type = pa.time64("us")
             case "boolean" | "bool":
@@ -517,6 +562,7 @@ def mysql_source(
             password=password,
             connect_timeout=5,
             ssl_ca=ssl_ca,
+            conv=_MYSQL_SAFE_CONVERSIONS,
         ) as connection:
             with connection.cursor() as cursor:
                 inner_query, inner_query_args = _build_query(
@@ -566,6 +612,7 @@ def mysql_source(
                 connect_timeout=5,
                 ssl_ca=ssl_ca,
                 init_command=init_command,
+                conv=_MYSQL_SAFE_CONVERSIONS,
             ) as connection:
                 with connection.cursor(SSCursor) as cursor:
                     query, args = _build_query(

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -37,7 +37,7 @@ from products.data_warehouse.backend.types import IncrementalFieldType, Partitio
 def _safe_convert_date(obj: Any) -> datetime.date | None:
     """Convert MySQL date, returning None for invalid dates like '0000-00-00'."""
     if isinstance(obj, (bytes, bytearray)):
-        obj = obj.decode("ascii")
+        obj = obj.decode("utf-8")
     try:
         parts = obj.split("-", 2)
         return datetime.date(int(parts[0]), int(parts[1]), int(parts[2]))
@@ -48,7 +48,7 @@ def _safe_convert_date(obj: Any) -> datetime.date | None:
 def _safe_convert_datetime(obj: Any) -> datetime.datetime | None:
     """Convert MySQL datetime/timestamp, returning None for invalid values like '0000-00-00 00:00:00'."""
     if isinstance(obj, (bytes, bytearray)):
-        obj = obj.decode("ascii")
+        obj = obj.decode("utf-8")
     try:
         date_part, time_part = obj.split(" ", 1)
         date_values = [int(x) for x in date_part.split("-", 2)]

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -65,8 +65,8 @@ def _safe_convert_datetime(obj: Any) -> datetime.datetime | None:
 
 
 # Custom conversions that return None for MySQL zero dates instead of raw strings
-_MYSQL_SAFE_CONVERSIONS: dict[int, Any] = {
-    **dict(pymysql.converters.conversions),
+_MYSQL_SAFE_CONVERSIONS: dict[type[object] | int, Any] = {
+    **pymysql.converters.conversions,
     FIELD_TYPE.DATE: _safe_convert_date,
     FIELD_TYPE.DATETIME: _safe_convert_datetime,
     FIELD_TYPE.TIMESTAMP: _safe_convert_datetime,

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -59,14 +59,14 @@ def _safe_convert_datetime(obj: Any) -> datetime.datetime | None:
         sec_parts = time_parts[2].split(".", 1)
         seconds = int(sec_parts[0])
         microseconds = int(sec_parts[1].ljust(6, "0")) if len(sec_parts) > 1 else 0
-        return datetime.datetime(*date_values, hours, minutes, seconds, microseconds)
+        return datetime.datetime(date_values[0], date_values[1], date_values[2], hours, minutes, seconds, microseconds)
     except (ValueError, IndexError, AttributeError):
         return None
 
 
 # Custom conversions that return None for MySQL zero dates instead of raw strings
 _MYSQL_SAFE_CONVERSIONS: dict[int, Any] = {
-    **pymysql.converters.conversions,
+    **dict(pymysql.converters.conversions),
     FIELD_TYPE.DATE: _safe_convert_date,
     FIELD_TYPE.DATETIME: _safe_convert_datetime,
     FIELD_TYPE.TIMESTAMP: _safe_convert_datetime,

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -53,7 +53,6 @@ class TestSafeConvertDate:
         [
             "0000-00-00",
             b"0000-00-00",
-            "0000-00-00",
             "invalid",
             "",
         ],

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1,6 +1,13 @@
+import datetime
+
 import pytest
 
-from posthog.temporal.data_imports.sources.mysql.mysql import _sanitize_identifier
+from posthog.temporal.data_imports.sources.mysql.mysql import (
+    MySQLColumn,
+    _safe_convert_date,
+    _safe_convert_datetime,
+    _sanitize_identifier,
+)
 
 
 @pytest.mark.parametrize(
@@ -26,3 +33,86 @@ def test_sanitize_identifier_valid(identifier, expected):
 def test_sanitize_identifier_invalid(identifier):
     with pytest.raises(ValueError, match="Invalid SQL identifier"):
         _sanitize_identifier(identifier)
+
+
+class TestSafeConvertDate:
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            ("2024-03-15", datetime.date(2024, 3, 15)),
+            ("1970-01-01", datetime.date(1970, 1, 1)),
+            ("9999-12-31", datetime.date(9999, 12, 31)),
+            (b"2024-03-15", datetime.date(2024, 3, 15)),
+        ],
+    )
+    def test_valid_dates(self, input_val, expected):
+        assert _safe_convert_date(input_val) == expected
+
+    @pytest.mark.parametrize(
+        "input_val",
+        [
+            "0000-00-00",
+            b"0000-00-00",
+            "0000-00-00",
+            "invalid",
+            "",
+        ],
+    )
+    def test_invalid_dates_return_none(self, input_val):
+        assert _safe_convert_date(input_val) is None
+
+
+class TestSafeConvertDatetime:
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            ("2024-03-15 10:30:45", datetime.datetime(2024, 3, 15, 10, 30, 45)),
+            ("2024-03-15 10:30:45.123456", datetime.datetime(2024, 3, 15, 10, 30, 45, 123456)),
+            ("1970-01-01 00:00:00", datetime.datetime(1970, 1, 1, 0, 0, 0)),
+            (b"2024-03-15 10:30:45", datetime.datetime(2024, 3, 15, 10, 30, 45)),
+        ],
+    )
+    def test_valid_datetimes(self, input_val, expected):
+        assert _safe_convert_datetime(input_val) == expected
+
+    @pytest.mark.parametrize(
+        "input_val",
+        [
+            "0000-00-00 00:00:00",
+            b"0000-00-00 00:00:00",
+            "invalid",
+            "",
+        ],
+    )
+    def test_invalid_datetimes_return_none(self, input_val):
+        assert _safe_convert_datetime(input_val) is None
+
+
+class TestMySQLColumnDateNullability:
+    @pytest.mark.parametrize(
+        "data_type",
+        [
+            "date",
+            "datetime",
+            "timestamp",
+        ],
+    )
+    def test_date_columns_always_nullable(self, data_type):
+        column = MySQLColumn(
+            name="test_col",
+            data_type=data_type,
+            column_type=data_type,
+            nullable=False,
+        )
+        field = column.to_arrow_field()
+        assert field.nullable is True
+
+    def test_non_date_column_respects_nullable_flag(self):
+        column = MySQLColumn(
+            name="test_col",
+            data_type="int",
+            column_type="int",
+            nullable=False,
+        )
+        field = column.to_arrow_field()
+        assert field.nullable is False


### PR DESCRIPTION
## Problem

This PR fixes ArrowInvalid: Failed to parse string: '0000-00-00' as a scalar of type date32[day] errors when importing MySQL tables that contain zero dates.

## Changes

  - Added _safe_convert_date and _safe_convert_datetime custom PyMySQL converters that return None for invalid/zero dates instead of passing raw strings through
  - Added _MYSQL_SAFE_CONVERSIONS dict overriding FIELD_TYPE.DATE, FIELD_TYPE.DATETIME, and FIELD_TYPE.TIMESTAMP
  - Applied conv=_MYSQL_SAFE_CONVERSIONS to both pymysql.connect() calls in mysql_source()
  - Forced date/datetime/timestamp columns to always be nullable in MySQLColumn.to_arrow_field(), since MySQL zero dates are semantically null
  - Added unit tests for safe converters and date column nullability

## How did you test this code?

Test pass

## Publish to changelog?
 NO
