### PR TITLE
fix(ci): fix migration safety docs link in risk analysis comments

### DIFF
--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -9,7 +9,9 @@ from posthog.management.migration_analysis.models import OperationRisk
 from posthog.management.migration_analysis.utils import VolatileFunctionDetector, check_drop_properly_staged
 
 # Base URL for migration safety documentation
-SAFE_MIGRATIONS_DOCS_URL = "https://github.com/PostHog/posthog/blob/master/docs/safe-django-migrations.md"
+SAFE_MIGRATIONS_DOCS_URL = (
+    "https://github.com/PostHog/posthog/blob/master/docs/published/handbook/engineering/safe-django-migrations.md"
+)
 
 
 def is_unmanaged_model(op, migration, unapplied_migrations=None) -> bool:


### PR DESCRIPTION
## Problem

The migration safety documentation link generated by the migration risk analysis tool points to a file that no longer exists at that path.

## Changes

Updates the `SAFE_MIGRATIONS_DOCS_URL` constant in `posthog/management/migration_analysis/operations.py` to point to the current location of the safe Django migrations guide under `docs/published/handbook/engineering/`.

## How did you test this code?

Verified the updated URL resolves to the correct documentation page.

## Publish to changelog?

no