### PR TITLE
feat(subscriptions): add US/EU subscription delivery insights and SLO

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/insights.tf
@@ -639,7 +639,9 @@ import {
 }
 
 resource "posthog_insight" "subscription_delivery_success_rate" {
-  name = "Subscription delivery success rate"
+  for_each = toset(["US", "EU"])
+
+  name = "Subscription delivery success rate (${each.key})"
   query_json = jsonencode({
     "kind": "InsightVizNode",
     "source": {
@@ -649,13 +651,29 @@ resource "posthog_insight" "subscription_delivery_success_rate" {
           "kind": "EventsNode",
           "math": "total",
           "event": "subscription_delivery_started",
-          "custom_name": "Started"
+          "custom_name": "Started",
+          "properties": [
+            {
+              "key": "$set.region",
+              "type": "event",
+              "value": [each.key],
+              "operator": "exact"
+            }
+          ]
         },
         {
           "kind": "EventsNode",
           "math": "total",
           "event": "subscription_delivery_exhausted",
-          "custom_name": "Exhausted (failed)"
+          "custom_name": "Exhausted (failed)",
+          "properties": [
+            {
+              "key": "$set.region",
+              "type": "event",
+              "value": [each.key],
+              "operator": "exact"
+            }
+          ]
         }
       ],
       "version": 2,

--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/layouts.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/layouts.tf
@@ -92,7 +92,7 @@ resource "posthog_dashboard_layout" "team_analytics_platform_key_metrics" {
       })
     },
     {
-      text_body = "## Alerts & Subscriptions 🚨"
+      text_body = "## Alerts, subscriptions & exports 🚨"
       layouts_json = jsonencode({
         "sm": {
           "h": 1,
@@ -140,6 +140,38 @@ resource "posthog_dashboard_layout" "team_analytics_platform_key_metrics" {
       })
     },
     {
+      insight_id = posthog_insight.subscription_delivery_success_rate["US"].id
+      layouts_json = jsonencode({
+        "sm": {
+          "h": 5,
+          "i": "subscription_us",
+          "w": 6,
+          "x": 0,
+          "y": 16,
+          "minH": 1,
+          "minW": 1,
+          "moved": false,
+          "static": false
+        }
+      })
+    },
+    {
+      insight_id = posthog_insight.subscription_delivery_success_rate["EU"].id
+      layouts_json = jsonencode({
+        "sm": {
+          "h": 5,
+          "i": "subscription_eu",
+          "w": 6,
+          "x": 6,
+          "y": 16,
+          "minH": 1,
+          "minW": 1,
+          "moved": false,
+          "static": false
+        }
+      })
+    },
+    {
       insight_id = posthog_insight.alert_failures_by_exception_type_aggregated.id
       layouts_json = jsonencode({
         "sm": {
@@ -147,7 +179,7 @@ resource "posthog_dashboard_layout" "team_analytics_platform_key_metrics" {
           "i": "6157400",
           "w": 12,
           "x": 0,
-          "y": 16,
+          "y": 21,
           "minH": 1,
           "minW": 1,
           "moved": false,
@@ -163,7 +195,7 @@ resource "posthog_dashboard_layout" "team_analytics_platform_key_metrics" {
           "i": "6274570",
           "w": 12,
           "x": 0,
-          "y": 21,
+          "y": 26,
           "minH": 1,
           "minW": 1,
           "moved": false,
@@ -179,7 +211,7 @@ resource "posthog_dashboard_layout" "team_analytics_platform_key_metrics" {
           "i": "4788951",
           "w": 12,
           "x": 0,
-          "y": 22,
+          "y": 27,
           "minH": 1,
           "minW": 1,
           "moved": false,
@@ -195,7 +227,7 @@ resource "posthog_dashboard_layout" "team_analytics_platform_key_metrics" {
           "i": "3202514",
           "w": 12,
           "x": 0,
-          "y": 25,
+          "y": 30,
           "minH": 1,
           "minW": 1,
           "moved": false,

--- a/terraform/us/project-2/team-analytics-platform/slos/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slos/insights.tf
@@ -185,6 +185,7 @@ locals {
             countIf(event = 'subscription_delivery_exhausted') AS failures
         FROM events
         WHERE event IN ('subscription_delivery_started', 'subscription_delivery_exhausted')
+            AND properties.$set.region = '{{REGION}}'
             AND timestamp >= now() - INTERVAL 30 DAY
         GROUP BY date
       SQL
@@ -239,9 +240,11 @@ locals {
         description  = slo.description
         error_budget = slo.error_budget
         daily_sql = replace(
-          replace(slo.daily_sql,
-            "{{EXPORTS_TABLE}}", local.region_tables[region].exports_table),
-          "{{HISTORY_TABLE}}", local.region_tables[region].history_table)
+          replace(
+            replace(slo.daily_sql,
+              "{{EXPORTS_TABLE}}", local.region_tables[region].exports_table),
+            "{{HISTORY_TABLE}}", local.region_tables[region].history_table),
+          "{{REGION}}", upper(region))
       }
     }
   ]...)

--- a/terraform/us/project-2/team-analytics-platform/slos/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slos/insights.tf
@@ -177,7 +177,7 @@ locals {
       name_prefix  = "SLO: Subscription deliveries"
       description  = "Rolling burn rate for subscription deliveries."
       error_budget = 0.01
-      regions      = ["us"]
+      regions      = ["us", "eu"]
       daily_sql    = <<-SQL
         SELECT
             toDate(timestamp) AS date,

--- a/terraform/us/project-2/team-analytics-platform/slos/layouts.tf
+++ b/terraform/us/project-2/team-analytics-platform/slos/layouts.tf
@@ -134,5 +134,37 @@ resource "posthog_dashboard_layout" "team_analytics_platform_slos" {
         }
       })
     },
+    {
+      insight_id = posthog_insight.slo["subscriptions_us"].id
+      layouts_json = jsonencode({
+        sm = {
+          h      = 5
+          i      = "subscriptions_us"
+          w      = 6
+          x      = 0
+          y      = 21
+          minH   = 1
+          minW   = 1
+          moved  = false
+          static = false
+        }
+      })
+    },
+    {
+      insight_id = posthog_insight.slo["subscriptions_eu"].id
+      layouts_json = jsonencode({
+        sm = {
+          h      = 5
+          i      = "subscriptions_eu"
+          w      = 6
+          x      = 6
+          y      = 21
+          minH   = 1
+          minW   = 1
+          moved  = false
+          static = false
+        }
+      })
+    },
   ]
 }


### PR DESCRIPTION
## Problem

The subscription delivery success rate insight added in #51335 was US-only and not positioned correctly on the key metrics dashboard. It also needs to be added to the SLOs dashboard.

## Changes

- Split subscription delivery success rate insight into **US and EU** variants, filtering by `$set.region`
- Position them **under the exports row** on the key metrics dashboard layout, shift remaining tiles down
- Update section header to "Alerts, subscriptions & exports"
- Add **subscriptions SLO** for both US and EU to the SLOs dashboard with burn rate and combined success rate tracking
- Add layout tiles for the new SLO insights (US left, EU right)

## How did you test this code?

I'm an agent — verified Terraform config consistency with existing insight/SLO patterns but did not run `terraform plan`. Verify by checking the plan output on the PR CI comment.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code. Builds on #51335 which added the initial single-region insight.