### PR TITLE
fix(ws): replace delta merge with delete+append for Google Ads daily-partitioned tables to prevent OOM

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -171,13 +171,6 @@ class DeltaTableHelper:
 
             await self._logger.adebug(f"write_to_deltalake: merging...")
 
-            # Normalize keys and check the keys actually exist in the dataset
-            py_table_column_names = data.column_names
-            normalized_primary_keys = [
-                normalize_column_name(x) for x in primary_keys if normalize_column_name(x) in py_table_column_names
-            ]
-
-            predicate_ops = [f"source.{c} = target.{c}" for c in normalized_primary_keys]
             if use_partitioning and partition_overwrite:
                 # Delete+append: avoids loading the entire partition into memory for merge.
                 # Safe when the source fetches complete data for each partition (e.g. daily
@@ -200,10 +193,18 @@ class DeltaTableHelper:
                     deltalake.write_deltalake,
                     table_or_uri=delta_table,
                     data=data,
+                    partition_by=PARTITION_KEY,
                     mode="append",
                     schema_mode="merge",
                 )
             elif use_partitioning:
+                # Normalize keys and check the keys actually exist in the dataset
+                py_table_column_names = data.column_names
+                normalized_primary_keys = [
+                    normalize_column_name(x) for x in primary_keys if normalize_column_name(x) in py_table_column_names
+                ]
+
+                predicate_ops = [f"source.{c} = target.{c}" for c in normalized_primary_keys]
                 predicate_ops.append(f"source.{PARTITION_KEY} = target.{PARTITION_KEY}")
 
                 # Group the table by the partition key and merge multiple times with streamed_exec=True for optimised merging
@@ -238,6 +239,13 @@ class DeltaTableHelper:
 
                     await self._logger.adebug(f"Delta Merge Stats: {json.dumps(merge_stats)}")
             else:
+                # Normalize keys and check the keys actually exist in the dataset
+                py_table_column_names = data.column_names
+                normalized_primary_keys = [
+                    normalize_column_name(x) for x in primary_keys if normalize_column_name(x) in py_table_column_names
+                ]
+
+                predicate_ops = [f"source.{c} = target.{c}" for c in normalized_primary_keys]
 
                 def _do_merge_unpartitioned(data: pa.Table, predicate_ops: list[str]):
                     return (

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -27,6 +27,7 @@ class DeltaTableHelper:
     _job: ExternalDataJob
     _logger: FilteringBoundLogger
     _is_first_sync: bool
+    _overwritten_partitions: set[str]
 
     def __init__(
         self, resource_name: str, job: ExternalDataJob, logger: FilteringBoundLogger, is_first_sync: bool = False
@@ -35,6 +36,7 @@ class DeltaTableHelper:
         self._job = job
         self._logger = logger
         self._is_first_sync = is_first_sync
+        self._overwritten_partitions = set()
 
     @property
     def is_first_sync(self) -> bool:
@@ -147,6 +149,7 @@ class DeltaTableHelper:
         write_type: Literal["incremental", "full_refresh", "append"],
         should_overwrite_table: bool,
         primary_keys: Sequence[Any] | None,
+        partition_overwrite: bool = False,
     ) -> deltalake.DeltaTable:
         delta_table = await self.get_delta_table()
 
@@ -175,7 +178,32 @@ class DeltaTableHelper:
             ]
 
             predicate_ops = [f"source.{c} = target.{c}" for c in normalized_primary_keys]
-            if use_partitioning:
+            if use_partitioning and partition_overwrite:
+                # Delete+append: avoids loading the entire partition into memory for merge.
+                # Safe when the source fetches complete data for each partition (e.g. daily
+                # date-filtered tables where the query returns ALL rows for each date).
+                unique_partitions = pc.unique(data[PARTITION_KEY])  # type: ignore
+
+                partitions_to_delete = [
+                    str(p.as_py()) for p in unique_partitions if str(p.as_py()) not in self._overwritten_partitions
+                ]
+
+                if partitions_to_delete:
+                    await self._logger.adebug(
+                        f"Deleting {len(partitions_to_delete)} partition(s) before append: {partitions_to_delete}"
+                    )
+                    for partition_value in partitions_to_delete:
+                        await asyncio.to_thread(delta_table.delete, predicate=f"{PARTITION_KEY} = '{partition_value}'")
+                        self._overwritten_partitions.add(partition_value)
+
+                await asyncio.to_thread(
+                    deltalake.write_deltalake,
+                    table_or_uri=delta_table,
+                    data=data,
+                    mode="append",
+                    schema_mode="merge",
+                )
+            elif use_partitioning:
                 predicate_ops.append(f"source.{PARTITION_KEY} = target.{PARTITION_KEY}")
 
                 # Group the table by the partition key and merge multiple times with streamed_exec=True for optimised merging

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -278,6 +278,7 @@ class PipelineNonDLT(Generic[ResumableData]):
             write_type,
             should_overwrite_table=should_overwrite_table,
             primary_keys=self._resource.primary_keys,
+            partition_overwrite=self._resource.partition_overwrite,
         )
 
         self._internal_schema.add_pyarrow_table(pa_table)

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -149,6 +149,12 @@ class PipelineNonDLT(Generic[ResumableData]):
         self._table = table
         self._is_incremental = schema.is_incremental
 
+        if source_response.partition_overwrite and resumable_source_manager is not None:
+            raise ValueError(
+                "partition_overwrite is incompatible with resumable sources: "
+                "a partial write after a delete would lose data"
+            )
+
         self._delta_table_helper = DeltaTableHelper(self._resource_name, self._job, self._logger)
         self._resumable_source_manager = resumable_source_manager
         self._batcher = Batcher(self._logger)

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -1,0 +1,346 @@
+import asyncio
+import tempfile
+
+import pytest
+from unittest import mock
+
+import pyarrow as pa
+import deltalake
+import structlog
+
+from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
+from posthog.temporal.data_imports.pipelines.pipeline.delta_table_helper import DeltaTableHelper
+
+
+def _make_helper(table_uri: str, is_first_sync: bool = False) -> DeltaTableHelper:
+    job = mock.MagicMock()
+    job.folder_path.return_value = "test_folder"
+    logger = structlog.get_logger()
+
+    helper = DeltaTableHelper(resource_name="test_resource", job=job, logger=logger, is_first_sync=is_first_sync)
+    # Override internals so the helper uses a local directory instead of S3
+    helper._get_delta_table_uri = mock.AsyncMock(return_value=table_uri)  # type: ignore[method-assign]
+    helper._get_credentials = mock.MagicMock(return_value={})  # type: ignore[method-assign]
+    return helper
+
+
+def _create_partitioned_table(uri: str, data: pa.Table) -> deltalake.DeltaTable:
+    deltalake.write_deltalake(uri, data, partition_by=PARTITION_KEY, mode="overwrite")
+    return deltalake.DeltaTable(uri)
+
+
+def _pa_table_with_partitions(ids: list[int], names: list[str], partitions: list[str]) -> pa.Table:
+    return pa.table(
+        {
+            "id": pa.array(ids, type=pa.int64()),
+            "name": pa.array(names),
+            PARTITION_KEY: pa.array(partitions),
+        }
+    )
+
+
+class TestPartitionOverwrite:
+    def test_partition_overwrite_deletes_and_appends(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uri = f"{tmpdir}/delta_table"
+
+            initial_data = _pa_table_with_partitions(
+                ids=[1, 2, 3],
+                names=["old_a", "old_b", "old_c"],
+                partitions=["2024-01-01", "2024-01-01", "2024-01-02"],
+            )
+            _create_partitioned_table(uri, initial_data)
+
+            helper = _make_helper(uri)
+            # Pre-populate the cache so get_delta_table returns the existing table
+            helper.get_delta_table.cache_clear()
+
+            new_data = _pa_table_with_partitions(
+                ids=[1, 2],
+                names=["new_a", "new_b"],
+                partitions=["2024-01-01", "2024-01-01"],
+            )
+
+            asyncio.get_event_loop().run_until_complete(
+                helper.write_to_deltalake(
+                    data=new_data,
+                    write_type="incremental",
+                    should_overwrite_table=False,
+                    primary_keys=["id"],
+                    partition_overwrite=True,
+                )
+            )
+
+            dt = deltalake.DeltaTable(uri)
+            result = dt.to_pyarrow_table()
+
+            # Partition 2024-01-01 should have the new data only
+            p1 = result.filter(pa.compute.equal(result[PARTITION_KEY], "2024-01-01")).sort_by("id")
+            assert p1.column("name").to_pylist() == ["new_a", "new_b"]
+            assert p1.column("id").to_pylist() == [1, 2]
+
+            # Partition 2024-01-02 should be untouched
+            p2 = result.filter(pa.compute.equal(result[PARTITION_KEY], "2024-01-02"))
+            assert p2.column("name").to_pylist() == ["old_c"]
+            assert p2.column("id").to_pylist() == [3]
+
+    def test_partition_overwrite_does_not_double_delete(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uri = f"{tmpdir}/delta_table"
+
+            initial_data = _pa_table_with_partitions(
+                ids=[1, 2],
+                names=["a", "b"],
+                partitions=["2024-01-01", "2024-01-01"],
+            )
+            _create_partitioned_table(uri, initial_data)
+
+            helper = _make_helper(uri)
+            helper.get_delta_table.cache_clear()
+
+            # First write: should delete partition then append
+            batch1 = _pa_table_with_partitions(
+                ids=[1],
+                names=["batch1"],
+                partitions=["2024-01-01"],
+            )
+            asyncio.get_event_loop().run_until_complete(
+                helper.write_to_deltalake(
+                    data=batch1,
+                    write_type="incremental",
+                    should_overwrite_table=False,
+                    primary_keys=["id"],
+                    partition_overwrite=True,
+                )
+            )
+
+            # Second write to the same partition: should NOT delete again, just append
+            batch2 = _pa_table_with_partitions(
+                ids=[2],
+                names=["batch2"],
+                partitions=["2024-01-01"],
+            )
+            asyncio.get_event_loop().run_until_complete(
+                helper.write_to_deltalake(
+                    data=batch2,
+                    write_type="incremental",
+                    should_overwrite_table=False,
+                    primary_keys=["id"],
+                    partition_overwrite=True,
+                )
+            )
+
+            dt = deltalake.DeltaTable(uri)
+            result = dt.to_pyarrow_table().sort_by("id")
+
+            # Both batch1 and batch2 rows should be present
+            assert result.column("id").to_pylist() == [1, 2]
+            assert result.column("name").to_pylist() == ["batch1", "batch2"]
+
+    def test_partition_overwrite_data_integrity_across_partitions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uri = f"{tmpdir}/delta_table"
+
+            initial_data = _pa_table_with_partitions(
+                ids=[1, 2, 3, 4],
+                names=["a", "b", "c", "d"],
+                partitions=["2024-01-01", "2024-01-01", "2024-01-02", "2024-01-03"],
+            )
+            _create_partitioned_table(uri, initial_data)
+
+            helper = _make_helper(uri)
+            helper.get_delta_table.cache_clear()
+
+            # Overwrite partitions 2024-01-01 and 2024-01-02 in one batch
+            new_data = _pa_table_with_partitions(
+                ids=[10, 20, 30],
+                names=["new_a", "new_b", "new_c"],
+                partitions=["2024-01-01", "2024-01-01", "2024-01-02"],
+            )
+
+            asyncio.get_event_loop().run_until_complete(
+                helper.write_to_deltalake(
+                    data=new_data,
+                    write_type="incremental",
+                    should_overwrite_table=False,
+                    primary_keys=["id"],
+                    partition_overwrite=True,
+                )
+            )
+
+            dt = deltalake.DeltaTable(uri)
+            result = dt.to_pyarrow_table()
+
+            # 2024-01-01: replaced
+            p1 = result.filter(pa.compute.equal(result[PARTITION_KEY], "2024-01-01")).sort_by("id")
+            assert p1.column("id").to_pylist() == [10, 20]
+            assert p1.column("name").to_pylist() == ["new_a", "new_b"]
+
+            # 2024-01-02: replaced
+            p2 = result.filter(pa.compute.equal(result[PARTITION_KEY], "2024-01-02"))
+            assert p2.column("id").to_pylist() == [30]
+            assert p2.column("name").to_pylist() == ["new_c"]
+
+            # 2024-01-03: untouched
+            p3 = result.filter(pa.compute.equal(result[PARTITION_KEY], "2024-01-03"))
+            assert p3.column("id").to_pylist() == [4]
+            assert p3.column("name").to_pylist() == ["d"]
+
+
+class TestIncrementalMergeUnaffected:
+    """Verify that the standard incremental merge paths (partition_overwrite=False)
+    are not affected by the partition_overwrite changes."""
+
+    def test_partitioned_incremental_merge_upserts_rows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uri = f"{tmpdir}/delta_table"
+
+            initial_data = _pa_table_with_partitions(
+                ids=[1, 2, 3],
+                names=["a", "b", "c"],
+                partitions=["2024-01-01", "2024-01-01", "2024-01-02"],
+            )
+            _create_partitioned_table(uri, initial_data)
+
+            helper = _make_helper(uri)
+            helper.get_delta_table.cache_clear()
+
+            # Update id=1 and insert id=4, both in partition 2024-01-01
+            update_data = _pa_table_with_partitions(
+                ids=[1, 4],
+                names=["updated_a", "new_d"],
+                partitions=["2024-01-01", "2024-01-01"],
+            )
+
+            asyncio.get_event_loop().run_until_complete(
+                helper.write_to_deltalake(
+                    data=update_data,
+                    write_type="incremental",
+                    should_overwrite_table=False,
+                    primary_keys=["id"],
+                    partition_overwrite=False,
+                )
+            )
+
+            dt = deltalake.DeltaTable(uri)
+            result = dt.to_pyarrow_table()
+
+            p1 = result.filter(pa.compute.equal(result[PARTITION_KEY], "2024-01-01")).sort_by("id")
+            # id=1 updated, id=2 untouched, id=4 inserted
+            assert p1.column("id").to_pylist() == [1, 2, 4]
+            assert p1.column("name").to_pylist() == ["updated_a", "b", "new_d"]
+
+            # Partition 2024-01-02 untouched
+            p2 = result.filter(pa.compute.equal(result[PARTITION_KEY], "2024-01-02"))
+            assert p2.column("id").to_pylist() == [3]
+            assert p2.column("name").to_pylist() == ["c"]
+
+    def test_unpartitioned_incremental_merge_upserts_rows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uri = f"{tmpdir}/delta_table"
+
+            # No partition key column — unpartitioned table
+            initial_data = pa.table(
+                {
+                    "id": pa.array([1, 2, 3], type=pa.int64()),
+                    "name": pa.array(["a", "b", "c"]),
+                }
+            )
+            deltalake.write_deltalake(uri, initial_data, mode="overwrite")
+
+            helper = _make_helper(uri)
+            helper.get_delta_table.cache_clear()
+
+            update_data = pa.table(
+                {
+                    "id": pa.array([2, 4], type=pa.int64()),
+                    "name": pa.array(["updated_b", "new_d"]),
+                }
+            )
+
+            asyncio.get_event_loop().run_until_complete(
+                helper.write_to_deltalake(
+                    data=update_data,
+                    write_type="incremental",
+                    should_overwrite_table=False,
+                    primary_keys=["id"],
+                    partition_overwrite=False,
+                )
+            )
+
+            dt = deltalake.DeltaTable(uri)
+            result = dt.to_pyarrow_table().sort_by("id")
+
+            assert result.column("id").to_pylist() == [1, 2, 3, 4]
+            assert result.column("name").to_pylist() == ["a", "updated_b", "c", "new_d"]
+
+    def test_partition_overwrite_false_does_not_delete_partition(self):
+        """Explicitly confirm that partition_overwrite=False uses merge, not delete+append."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            uri = f"{tmpdir}/delta_table"
+
+            initial_data = _pa_table_with_partitions(
+                ids=[1, 2],
+                names=["a", "b"],
+                partitions=["2024-01-01", "2024-01-01"],
+            )
+            _create_partitioned_table(uri, initial_data)
+
+            helper = _make_helper(uri)
+            helper.get_delta_table.cache_clear()
+
+            # Write only id=1 with partition_overwrite=False — id=2 must survive
+            update_data = _pa_table_with_partitions(
+                ids=[1],
+                names=["updated_a"],
+                partitions=["2024-01-01"],
+            )
+
+            asyncio.get_event_loop().run_until_complete(
+                helper.write_to_deltalake(
+                    data=update_data,
+                    write_type="incremental",
+                    should_overwrite_table=False,
+                    primary_keys=["id"],
+                    partition_overwrite=False,
+                )
+            )
+
+            dt = deltalake.DeltaTable(uri)
+            result = dt.to_pyarrow_table().sort_by("id")
+
+            # Both rows present — id=2 was NOT deleted (merge, not delete+append)
+            assert result.column("id").to_pylist() == [1, 2]
+            assert result.column("name").to_pylist() == ["updated_a", "b"]
+
+
+class TestPartitionOverwriteResumableGuard:
+    def test_partition_overwrite_with_resumable_source_raises(self):
+        from posthog.temporal.data_imports.pipelines.pipeline.pipeline import PipelineNonDLT
+        from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+
+        source_response = SourceResponse(
+            name="test",
+            items=lambda: iter([]),
+            primary_keys=["id"],
+            partition_overwrite=True,
+        )
+
+        with pytest.raises(ValueError, match="partition_overwrite is incompatible with resumable sources"):
+            PipelineNonDLT(
+                source_response=source_response,
+                logger=structlog.get_logger(),
+                job_id="test-job",
+                reset_pipeline=False,
+                shutdown_monitor=mock.MagicMock(),
+                job=mock.MagicMock(),
+                schema=mock.MagicMock(
+                    is_incremental=True,
+                    is_append=False,
+                    incremental_field_earliest_value=None,
+                    incremental_field_type=None,
+                ),
+                source=mock.MagicMock(),
+                table=None,
+                resumable_source_manager=mock.MagicMock(),  # non-None = resumable
+            )

--- a/posthog/temporal/data_imports/pipelines/pipeline/typings.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/typings.py
@@ -38,6 +38,10 @@ class SourceResponse:
     rows_to_sync: Optional[int] = None
     has_duplicate_primary_keys: Optional[bool] = None
     """Whether incremental tables have non-unique primary keys"""
+    partition_overwrite: bool = False
+    """When True, incremental syncs delete+append partitions instead of merging.
+    Only safe when partition_format='day' and the partition key matches the
+    incremental field, so the source fetches complete data for each partition."""
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -389,6 +389,7 @@ def google_ads_source(
         partition_mode="datetime" if table.requires_filter else None,
         partition_format="day" if table.requires_filter else None,
         partition_keys=["segments_date"] if table.requires_filter else None,
+        partition_overwrite=table.requires_filter,
     )
 
 

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -3500,3 +3500,165 @@ async def test_stripe_webhook_s3_charges(team, stripe_charge, mock_stripe_client
     # Verify webhook parquet file was deleted from S3 after consumption
     files = await minio_client.list_objects_v2(Bucket=BUCKET_NAME, Prefix=webhook_prefix)
     assert files.get("Contents") is None or len(files.get("Contents", [])) == 0
+
+
+def _patch_pipeline_partition_overwrite():
+    """Wrap PipelineNonDLT.__init__ so that the SourceResponse always has partition_overwrite=True."""
+    original_init = PipelineNonDLT.__init__
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self._resource.partition_overwrite = True
+
+    return mock.patch.object(PipelineNonDLT, "__init__", patched_init)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_partition_overwrite_uses_delete_and_append(team, postgres_config, postgres_connection, pipeline_mode):
+    if pipeline_mode == "v3":
+        pytest.skip("partition_overwrite path only runs in non_dlt pipeline")
+
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.test_partition_overwrite (id integer, created_at timestamp)".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_overwrite (id, created_at) VALUES (1, '2025-01-01T12:00:00.000Z')".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.commit()
+
+    # First sync: creates the delta table
+    workflow_id, inputs = await _run(
+        team=team,
+        schema_name="test_partition_overwrite",
+        table_name="postgres_test_partition_overwrite",
+        source_type="Postgres",
+        job_inputs={
+            "host": postgres_config["host"],
+            "port": postgres_config["port"],
+            "database": postgres_config["database"],
+            "user": postgres_config["user"],
+            "password": postgres_config["password"],
+            "schema": postgres_config["schema"],
+            "ssh_tunnel_enabled": "False",
+        },
+        mock_data_response=[],
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        sync_type_config={"incremental_field": "created_at", "incremental_field_type": "timestamp"},
+        ignore_assertions=True,
+    )
+
+    # Insert a new row so the second incremental sync picks it up
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_overwrite (id, created_at) VALUES (2, '2025-02-01T12:00:00.000Z')".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.commit()
+
+    with (
+        _patch_pipeline_partition_overwrite(),
+        mock.patch.object(DeltaTable, "delete") as mock_delete,
+        mock.patch.object(deltalake, "write_deltalake") as mock_write,
+        mock.patch.object(PipelineNonDLT, "_post_run_operations"),
+    ):
+        await _execute_run(str(uuid.uuid4()), inputs, [])
+
+    # partition_overwrite should use delete+append, NOT merge
+    assert mock_delete.call_count >= 1
+
+    # Every delete call should target a specific partition
+    for call in mock_delete.call_args_list:
+        predicate = call.kwargs.get("predicate") or call.args[0]
+        assert PARTITION_KEY in predicate
+
+    # write_deltalake should be called in append mode with partition_by
+    assert mock_write.call_count >= 1
+    for call in mock_write.call_args_list:
+        _, kwargs = call
+        assert kwargs["mode"] == "append"
+        assert kwargs["partition_by"] == PARTITION_KEY
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_partition_overwrite_does_not_redelete_same_partition(
+    team, postgres_config, postgres_connection, pipeline_mode
+):
+    if pipeline_mode == "v3":
+        pytest.skip("partition_overwrite path only runs in non_dlt pipeline")
+
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.test_partition_overwrite_nodelete (id integer, created_at timestamp)".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    # Two rows that will land in the same partition (same week)
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_overwrite_nodelete (id, created_at) VALUES (1, '2025-01-01T12:00:00.000Z')".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_overwrite_nodelete (id, created_at) VALUES (2, '2025-01-02T12:00:00.000Z')".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.commit()
+
+    # First sync: creates the delta table
+    workflow_id, inputs = await _run(
+        team=team,
+        schema_name="test_partition_overwrite_nodelete",
+        table_name="postgres_test_partition_overwrite_nodelete",
+        source_type="Postgres",
+        job_inputs={
+            "host": postgres_config["host"],
+            "port": postgres_config["port"],
+            "database": postgres_config["database"],
+            "user": postgres_config["user"],
+            "password": postgres_config["password"],
+            "schema": postgres_config["schema"],
+            "ssh_tunnel_enabled": "False",
+        },
+        mock_data_response=[],
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        sync_type_config={"incremental_field": "created_at", "incremental_field_type": "timestamp"},
+        ignore_assertions=True,
+    )
+
+    # Insert two more rows that will land in the same partition, with chunk_size=1
+    # so they arrive as separate batches — the second batch should NOT re-delete
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_overwrite_nodelete (id, created_at) VALUES (3, '2025-02-01T12:00:00.000Z')".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_overwrite_nodelete (id, created_at) VALUES (4, '2025-02-02T12:00:00.000Z')".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.commit()
+
+    with (
+        mock.patch("posthog.temporal.data_imports.sources.postgres.postgres.DEFAULT_CHUNK_SIZE", 1),
+        _patch_pipeline_partition_overwrite(),
+        mock.patch.object(DeltaTable, "delete") as mock_delete,
+        mock.patch.object(deltalake, "write_deltalake"),
+        mock.patch.object(PipelineNonDLT, "_post_run_operations"),
+    ):
+        await _execute_run(str(uuid.uuid4()), inputs, [])
+
+    # Two batches hit the same partition — delete should only be called once per partition
+    partition_predicates = []
+    for call in mock_delete.call_args_list:
+        predicate = call.kwargs.get("predicate") or call.args[0]
+        partition_predicates.append(predicate)
+
+    # Each unique partition value should appear at most once in the delete calls
+    assert len(partition_predicates) == len(set(partition_predicates))


### PR DESCRIPTION
## Problem

Google Ads `geographic_stats` are partitioned by day via `segments.date`. Some daily partitions contain millions of rows (due to the cross-product of geographic criteria × campaigns ×  customers), while others have only dozens. Repartitioning for this table is not a solution and we encounter tons of OOMs due to the partition size (right now is the table that causes most of the OOMs)

## Changes

  * Added `partition_overwrite` field to `SourceResponse` — opt-in flag for sources that fetch complete data per partition
  * Added `_overwritten_partitions` tracking to `DeltaTableHelper` to ensure each partition is only deleted once per sync
  * Added delete+append path in `DeltaTableHelper.write_to_deltalake` when `partition_overwrite=True`
  * Enabled `partition_overwrite` for all Google Ads date-filtered tables (`requires_filter=True`)

## How did you test this code?

Test Pass
Local Run

## Publish to changelog?

NO
