### PR TITLE
chore: Extract Redis config config, narrow test helper types

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -74,7 +74,7 @@ describe('CDP API', () => {
             SITE_URL: 'http://localhost:8000',
         })
         hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN = 'ADWORDS_TOKEN'
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         api = new CdpApi(hub, hub)
         app = setupExpressApp()

--- a/nodejs/src/cdp/cdp-e2e.test.ts
+++ b/nodejs/src/cdp/cdp-e2e.test.ts
@@ -54,7 +54,7 @@ describe.each(['postgres' as const, 'kafka' as const, 'hybrid' as const])('CDP C
 
             await resetTestDatabase()
             hub = await createHub()
-            team = await getFirstTeam(hub)
+            team = await getFirstTeam(hub.postgres)
             mockProducerObserver = new KafkaProducerObserver(hub.kafkaProducer)
             mockProducerObserver.resetKafkaProducer()
 

--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
@@ -32,7 +32,7 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         processor = new CdpBatchHogFlowRequestsConsumer(hub, hub)
 

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
@@ -68,9 +68,9 @@ describe('CdpCyclotronWorkerHogFlow', () => {
         await resetTestDatabase()
         hub = await createHub()
         personRepository = new PostgresPersonRepository(hub.postgres)
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         const team2Id = await createTeam(hub.postgres, team.organization_id)
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub.postgres, team2Id))!
 
         processor = new CdpCyclotronWorkerHogFlow(hub, hub)
 

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-plugins.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-plugins.test.ts
@@ -53,7 +53,7 @@ describe('CdpCyclotronWorkerPlugins', () => {
         await resetTestDatabase()
         hub = await createHub()
 
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         processor = new CdpCyclotronWorker(hub, hub)
 
         await processor.start()

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.test.ts
@@ -35,7 +35,7 @@ describe('CdpCyclotronWorker', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         processor = new CdpCyclotronWorker(hub, hub)
 
         fn = await insertHogFunction(

--- a/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
@@ -45,12 +45,12 @@ describe('CdpDatawarehouseEventsConsumer', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub) // This team has data_pipelines feature by default (legacy addon)
+        team = await getFirstTeam(hub.postgres) // This team has data_pipelines feature by default (legacy addon)
 
         // Create second organization without data_pipelines for testing quota limiting
         const otherOrganizationId = await createOrganization(hub.postgres)
         const team2Id = await createTeam(hub.postgres, otherOrganizationId)
-        team2 = (await getTeam(hub, team2Id))! // This team does NOT have data_pipelines
+        team2 = (await getTeam(hub.postgres, team2Id))! // This team does NOT have data_pipelines
 
         // Set up default quota limiting mock - not limited by default
         jest.spyOn(hub.quotaLimiting, 'isTeamQuotaLimited').mockResolvedValue(false)

--- a/nodejs/src/cdp/consumers/cdp-dwh-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-dwh-source-webhooks.consumer.test.ts
@@ -151,7 +151,7 @@ describe('DWH source webhooks', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub({})
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         mockFetch.mockClear()
     })
 

--- a/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -50,12 +50,12 @@ describe.each([
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub) // This team has data_pipelines feature by default (legacy addon)
+        team = await getFirstTeam(hub.postgres) // This team has data_pipelines feature by default (legacy addon)
 
         // Create second organization without data_pipelines for testing quota limiting
         const otherOrganizationId = await createOrganization(hub.postgres)
         const team2Id = await createTeam(hub.postgres, otherOrganizationId)
-        team2 = (await getTeam(hub, team2Id))! // This team does NOT have data_pipelines
+        team2 = (await getTeam(hub.postgres, team2Id))! // This team does NOT have data_pipelines
 
         // Set up default quota limiting mock - not limited by default
         jest.spyOn(hub.quotaLimiting, 'isTeamQuotaLimited').mockResolvedValue(false)
@@ -576,7 +576,7 @@ describe('hog flow processing', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         processor = new CdpEventsConsumer(hub, hub)
 
         // NOTE: We don't want to actually connect to Kafka for these tests as it is slow and we are testing the core logic only

--- a/nodejs/src/cdp/consumers/cdp-internal-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-internal-events-consumer.test.ts
@@ -25,7 +25,7 @@ describe('CDP Internal Events Consumer', () => {
         hub = await createHub({
             SITE_URL: 'http://localhost:8000',
         })
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         processor = new CdpInternalEventsConsumer(hub, hub)
         await processor.start()

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
@@ -32,7 +32,7 @@ describe('CdpLegacyEventsConsumer', () => {
         await resetTestDatabase()
         consumer = new CdpLegacyEventsConsumer(hub, hub)
         legacyPluginExecutor = new LegacyPluginExecutorService(hub.postgres, hub.geoipService)
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         const fixedTime = DateTime.fromObject({ year: 2025, month: 1, day: 1 }, { zone: 'UTC' })
         jest.spyOn(Date, 'now').mockReturnValue(fixedTime.toMillis())

--- a/nodejs/src/cdp/consumers/cdp-person-updates-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-person-updates-consumer.test.ts
@@ -33,7 +33,7 @@ describe('CDP Person Updates Consumer', () => {
         hub = await createHub({
             SITE_URL: 'http://localhost:8000',
         })
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         processor = new CdpPersonUpdatesConsumer(hub, hub)
         await processor.start()

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.test.ts
@@ -160,7 +160,7 @@ describe('CdpPrecalculatedFiltersConsumer', () => {
 
         mockProducerObserver.resetKafkaProducer()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         processor = new CdpPrecalculatedFiltersConsumer(hub, hub)
         await processor.start()

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -91,7 +91,7 @@ describe('SourceWebhooksConsumer', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub({})
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         mockFetch.mockClear()
     })

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -47,7 +47,7 @@ describe('HogTransformer', () => {
         jest.spyOn(Date, 'now').mockReturnValue(fixedTime.toMillis())
 
         // Create a team first before inserting hog functions
-        const team = await getFirstTeam(hub)
+        const team = await getFirstTeam(hub.postgres)
         teamId = team.id
 
         hogTransformer = createHogTransformerService(hub, hub)

--- a/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.test.ts
+++ b/nodejs/src/cdp/legacy-webhooks/legacy-webhook-service.test.ts
@@ -55,10 +55,10 @@ describe('LegacyWebhookService', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         const otherOrganizationId = await createOrganization(hub.postgres)
         const team2Id = await createTeam(hub.postgres, otherOrganizationId)
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub.postgres, team2Id))!
 
         service = new LegacyWebhookService(
             hub.postgres,

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
@@ -41,7 +41,7 @@ describe('BatchExportHogFunctionService', () => {
 
     beforeAll(async () => {
         hub = await createHub({ SITE_URL: 'http://localhost:8000' })
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         api = new CdpApi(hub, hub)
         app = setupExpressApp()

--- a/nodejs/src/cdp/services/hog-inputs.service.test.ts
+++ b/nodejs/src/cdp/services/hog-inputs.service.test.ts
@@ -20,7 +20,7 @@ describe('Hog Inputs', () => {
         await resetTestDatabase()
         hub = await createHub()
         hub.SITE_URL = 'http://localhost:8000'
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         const fixedTime = DateTime.fromObject({ year: 2025, month: 1, day: 1 }, { zone: 'UTC' })
         jest.spyOn(Date, 'now').mockReturnValue(fixedTime.toMillis())

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -38,7 +38,7 @@ describe('HogFunctionHandler', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         const hogInputsService = new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
         const emailService = new EmailService(

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1633,7 +1633,7 @@ describe('Hogflow Executor', () => {
         }
 
         it('should record billing metrics for both regular hog functions and email functions', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
 
             await insertIntegration(hub.postgres, team.id, {
                 id: 1,

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
@@ -26,7 +26,7 @@ describe('HogFlowManager', () => {
         await resetTestDatabase()
         manager = new HogFlowManagerService(hub.postgres, hub.pubSub)
 
-        const team = await getTeam(hub, 2)
+        const team = await getTeam(hub.postgres, 2)
 
         teamId1 = await createTeam(hub.postgres, team!.organization_id)
         teamId2 = await createTeam(hub.postgres, team!.organization_id)

--- a/nodejs/src/cdp/services/legacy-plugin-executor.service.test.ts
+++ b/nodejs/src/cdp/services/legacy-plugin-executor.service.test.ts
@@ -44,7 +44,7 @@ describe('LegacyPluginExecutorService', () => {
         hub = await createHub()
         await resetTestDatabase()
         service = new LegacyPluginExecutorService(hub.postgres, hub.geoipService)
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         fn = createHogFunction({
             name: 'Plugin test',

--- a/nodejs/src/cdp/services/managers/hog-function-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/hog-function-manager.service.test.ts
@@ -25,7 +25,7 @@ describe('HogFunctionManager', () => {
         await resetTestDatabase()
         manager = new HogFunctionManagerService(hub.postgres, hub.pubSub, hub.encryptedFields)
 
-        const team = await getTeam(hub, 2)
+        const team = await getTeam(hub.postgres, 2)
 
         teamId1 = await createTeam(hub.postgres, team!.organization_id)
         teamId2 = await createTeam(hub.postgres, team!.organization_id)
@@ -274,7 +274,7 @@ describe('Hogfunction Manager - Execution Order', () => {
         await resetTestDatabase()
         manager = new HogFunctionManagerService(hub.postgres, hub.pubSub, hub.encryptedFields)
 
-        const team = await getTeam(hub, 2)
+        const team = await getTeam(hub.postgres, 2)
         teamId = await createTeam(hub.postgres, team!.organization_id)
         teamId2 = await createTeam(hub.postgres, team!.organization_id)
 

--- a/nodejs/src/cdp/services/managers/integration-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/integration-manager.service.test.ts
@@ -19,7 +19,7 @@ describe('IntegrationManager', () => {
         await resetTestDatabase()
         manager = new IntegrationManagerService(hub.pubSub, hub.postgres, hub.encryptedFields)
 
-        const team = await getTeam(hub, 2)
+        const team = await getTeam(hub.postgres, 2)
 
         teamId1 = await createTeam(hub.postgres, team!.organization_id)
 

--- a/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/persons-manager.service.test.ts
@@ -21,9 +21,9 @@ describe('PersonsManager', () => {
         personRepository = new PostgresPersonRepository(hub.postgres)
         await resetTestDatabase()
         manager = new PersonsManagerService(hub.personRepository)
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         const team2Id = await createTeam(hub.postgres, team.organization_id)
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub.postgres, team2Id))!
 
         const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
         const result = await personRepository.createPerson(

--- a/nodejs/src/cdp/services/managers/recipients-manager.service.test.ts
+++ b/nodejs/src/cdp/services/managers/recipients-manager.service.test.ts
@@ -16,9 +16,9 @@ describe('RecipientsManager', () => {
         hub = await createHub()
         await resetTestDatabase()
         manager = new RecipientsManagerService(hub.postgres)
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         const team2Id = await createTeam(hub.postgres, team.organization_id)
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub.postgres, team2Id))!
     })
 
     afterEach(async () => {

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -24,7 +24,7 @@ describe('EmailTrackingService', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub({})
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         mockFetch.mockClear()
     })

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -47,7 +47,7 @@ describe('EmailService', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub({})
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         service = new EmailService(
             {
                 sesAccessKeyId: hub.SES_ACCESS_KEY_ID,

--- a/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/recipient-preferences.service.test.ts
@@ -26,7 +26,7 @@ describe('RecipientPreferencesService', () => {
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         mockRecipientsManager = new RecipientsManagerService(hub.postgres)
         mockRecipientsManagerGet = jest.spyOn(mockRecipientsManager, 'get')
         mockRecipientsManagerGetPreference = jest.spyOn(mockRecipientsManager, 'getPreference')

--- a/nodejs/src/common/services/quota-limiting.service.test.ts
+++ b/nodejs/src/common/services/quota-limiting.service.test.ts
@@ -27,10 +27,10 @@ describe('QuotaLimiting', () => {
         await resetTestDatabase()
         redisPool = hub.redisPool
         service = new QuotaLimiting(redisPool, hub.teamManager)
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         const otherTeamId = await createTeam(hub.postgres, team!.organization_id)
-        team2 = (await getTeam(hub, otherTeamId))!
+        team2 = (await getTeam(hub.postgres, otherTeamId))!
 
         await setupQuotaLimits('events', [])
     })

--- a/nodejs/src/config/redis-pools.ts
+++ b/nodejs/src/config/redis-pools.ts
@@ -1,0 +1,70 @@
+import { CommonConfig } from '../common/config'
+import { IngestionConsumerConfig } from '../ingestion/config'
+import { RedisConnectionConfig } from '../utils/db/redis'
+
+/**
+ * Build the connection config for the ingestion Redis pool.
+ * Fallback chain: INGESTION_REDIS_HOST → POSTHOG_REDIS_HOST → REDIS_URL
+ */
+export function createIngestionRedisConnectionConfig(
+    config: Pick<
+        CommonConfig,
+        | 'INGESTION_REDIS_HOST'
+        | 'INGESTION_REDIS_PORT'
+        | 'POSTHOG_REDIS_HOST'
+        | 'POSTHOG_REDIS_PORT'
+        | 'POSTHOG_REDIS_PASSWORD'
+        | 'REDIS_URL'
+    >
+): RedisConnectionConfig {
+    if (config.INGESTION_REDIS_HOST) {
+        return {
+            url: config.INGESTION_REDIS_HOST,
+            options: { port: config.INGESTION_REDIS_PORT },
+            name: 'ingestion-redis',
+        }
+    }
+    if (config.POSTHOG_REDIS_HOST) {
+        return {
+            url: config.POSTHOG_REDIS_HOST,
+            options: { port: config.POSTHOG_REDIS_PORT, password: config.POSTHOG_REDIS_PASSWORD },
+            name: 'ingestion-redis',
+        }
+    }
+    return { url: config.REDIS_URL, name: 'ingestion-redis' }
+}
+
+/**
+ * Build the connection config for the PostHog Redis pool.
+ * Fallback chain: POSTHOG_REDIS_HOST → REDIS_URL
+ */
+export function createPosthogRedisConnectionConfig(
+    config: Pick<CommonConfig, 'POSTHOG_REDIS_HOST' | 'POSTHOG_REDIS_PORT' | 'POSTHOG_REDIS_PASSWORD' | 'REDIS_URL'>
+): RedisConnectionConfig {
+    if (config.POSTHOG_REDIS_HOST) {
+        return {
+            url: config.POSTHOG_REDIS_HOST,
+            options: { port: config.POSTHOG_REDIS_PORT, password: config.POSTHOG_REDIS_PASSWORD },
+            name: 'posthog-redis',
+        }
+    }
+    return { url: config.REDIS_URL, name: 'posthog-redis' }
+}
+
+/**
+ * Build the connection config for the cookieless Redis pool.
+ * Fallback chain: COOKIELESS_REDIS_HOST → REDIS_URL
+ */
+export function createCookielessRedisConnectionConfig(
+    config: Pick<IngestionConsumerConfig, 'COOKIELESS_REDIS_HOST' | 'COOKIELESS_REDIS_PORT'> &
+        Pick<CommonConfig, 'REDIS_URL'>
+): RedisConnectionConfig {
+    if (config.COOKIELESS_REDIS_HOST) {
+        return {
+            url: config.COOKIELESS_REDIS_HOST,
+            options: { port: config.COOKIELESS_REDIS_PORT ?? 6379 },
+            name: 'cookieless-redis',
+        }
+    }
+    return { url: config.REDIS_URL, name: 'cookieless-redis' }
+}

--- a/nodejs/src/ingestion/cookieless/cookieless-manager.test.ts
+++ b/nodejs/src/ingestion/cookieless/cookieless-manager.test.ts
@@ -216,7 +216,7 @@ describe('CookielessManager', () => {
                 [mode, teamId],
                 'set team to cookieless'
             )
-            team = (await getTeam(hub, teamId))!
+            team = (await getTeam(hub.postgres, teamId))!
         }
 
         const clearRedis = async () => {
@@ -229,7 +229,7 @@ describe('CookielessManager', () => {
             await clearRedis()
             hub.cookielessManager.deleteAllLocalSalts()
             teamId = await createTeam(hub.postgres, organizationId)
-            team = (await getTeam(hub, teamId))!
+            team = (await getTeam(hub.postgres, teamId))!
             event = deepFreeze({
                 event: 'test event',
                 distinct_id: COOKIELESS_SENTINEL_VALUE,

--- a/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-personless-step.test.ts
@@ -57,7 +57,7 @@ describe('createProcessPersonlessStep', () => {
         hub = await createHub()
         const organizationId = await createOrganization(hub.postgres)
         teamId = await createTeam(hub.postgres, organizationId)
-        team = (await getTeam(hub, teamId))!
+        team = (await getTeam(hub.postgres, teamId))!
 
         const personRepository = new PostgresPersonRepository(hub.postgres)
         personsStore = new BatchWritingPersonsStore(personRepository, hub.kafkaProducer)

--- a/nodejs/src/ingestion/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/src/ingestion/event-processing/process-persons-step.integration.test.ts
@@ -44,7 +44,7 @@ describe('createProcessPersonsStep', () => {
         hub = await createHub()
         const organizationId = await createOrganization(hub.postgres)
         teamId = await createTeam(hub.postgres, organizationId)
-        team = (await getTeam(hub, teamId))!
+        team = (await getTeam(hub.postgres, teamId))!
 
         personRepository = new PostgresPersonRepository(hub.postgres)
         personsStore = new BatchWritingPersonsStore(personRepository, hub.kafkaProducer)
@@ -300,7 +300,7 @@ describe('createProcessPersonsStep', () => {
         const enabledTeamId = await createTeam(hub.postgres, organizationId, undefined, {
             extra_settings: JSON.stringify({ person_last_seen_at_enabled: true }),
         })
-        const enabledTeam = (await getTeam(hub, enabledTeamId))!
+        const enabledTeam = (await getTeam(hub.postgres, enabledTeamId))!
 
         await personRepository.createPerson(
             DateTime.utc(),

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -163,9 +163,9 @@ describe('IngestionConsumer', () => {
         hub = await createHub()
 
         // hub.kafkaProducer = mockProducer
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         const team2Id = await createTeam(hub.postgres, team.organization_id, 'THIS IS NOT A TOKEN FOR TEAM 3')
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub.postgres, team2Id))!
 
         jest.mocked(createPrepareEventStep).mockImplementation((...args) => {
             const original = jest.requireActual('./event-processing/prepare-event-step')

--- a/nodejs/src/ingestion/ingestion-testing-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-testing-consumer.test.ts
@@ -121,9 +121,9 @@ describe('IngestionTestingConsumer', () => {
         await resetTestDatabase()
         hub = await createHub()
 
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         const team2Id = await createTeam(hub.postgres, team.organization_id, 'THIS IS NOT A TOKEN FOR TEAM 3')
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub.postgres, team2Id))!
 
         ingester = await createIngestionTestingConsumer(hub)
     })

--- a/nodejs/src/llm-analytics/services/evaluation-manager.service.test.ts
+++ b/nodejs/src/llm-analytics/services/evaluation-manager.service.test.ts
@@ -22,7 +22,7 @@ describe('EvaluationManagerService', () => {
         await resetTestDatabase()
         manager = new EvaluationManagerService(hub.postgres, hub.pubSub)
 
-        const team = await getTeam(hub, 2)
+        const team = await getTeam(hub.postgres, 2)
 
         teamId1 = await createTeam(hub.postgres, team!.organization_id)
         teamId2 = await createTeam(hub.postgres, team!.organization_id)

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -138,9 +138,9 @@ describe('LogsIngestionConsumer', () => {
         await resetTestDatabase()
         hub = await createHub()
 
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
         const team2Id = await createTeam(hub.postgres, team.organization_id)
-        team2 = (await getTeam(hub, team2Id))!
+        team2 = (await getTeam(hub.postgres, team2Id))!
 
         consumer = await createLogsIngestionConsumer(hub)
 

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -34,6 +34,11 @@ import {
     KAFKA_EVENTS_PLUGIN_INGESTION_HISTORICAL,
     KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
 } from './config/kafka-topics'
+import {
+    createCookielessRedisConnectionConfig,
+    createIngestionRedisConnectionConfig,
+    createPosthogRedisConnectionConfig,
+} from './config/redis-pools'
 import { startEvaluationScheduler } from './evaluation-scheduler/evaluation-scheduler'
 import { CookielessManager } from './ingestion/cookieless/cookieless-manager'
 import { IngestionConsumer, IngestionConsumerDeps } from './ingestion/ingestion-consumer'
@@ -512,22 +517,7 @@ export class PluginServer {
 
         logger.info('🤔', 'Connecting to ingestion Redis...')
         this.redisPool = createRedisPoolFromConfig({
-            connection: this.config.INGESTION_REDIS_HOST
-                ? {
-                      url: this.config.INGESTION_REDIS_HOST,
-                      options: { port: this.config.INGESTION_REDIS_PORT },
-                      name: 'ingestion-redis',
-                  }
-                : this.config.POSTHOG_REDIS_HOST
-                  ? {
-                        url: this.config.POSTHOG_REDIS_HOST,
-                        options: {
-                            port: this.config.POSTHOG_REDIS_PORT,
-                            password: this.config.POSTHOG_REDIS_PASSWORD,
-                        },
-                        name: 'ingestion-redis',
-                    }
-                  : { url: this.config.REDIS_URL, name: 'ingestion-redis' },
+            connection: createIngestionRedisConnectionConfig(this.config),
             poolMinSize: this.config.REDIS_POOL_MIN_SIZE,
             poolMaxSize: this.config.REDIS_POOL_MAX_SIZE,
         })
@@ -579,13 +569,7 @@ export class PluginServer {
     } {
         logger.info('🤔', 'Connecting to cookieless Redis...')
         this.cookielessRedisPool = createRedisPoolFromConfig({
-            connection: this.config.COOKIELESS_REDIS_HOST
-                ? {
-                      url: this.config.COOKIELESS_REDIS_HOST,
-                      options: { port: this.config.COOKIELESS_REDIS_PORT ?? 6379 },
-                      name: 'cookieless-redis',
-                  }
-                : { url: this.config.REDIS_URL, name: 'cookieless-redis' },
+            connection: createCookielessRedisConnectionConfig(this.config),
             poolMinSize: this.config.REDIS_POOL_MIN_SIZE,
             poolMaxSize: this.config.REDIS_POOL_MAX_SIZE,
         })
@@ -601,16 +585,7 @@ export class PluginServer {
     private createCdpLogsServices(teamManager: TeamManager): { quotaLimiting: QuotaLimiting } {
         logger.info('🤔', 'Connecting to PostHog Redis...')
         this.posthogRedisPool = createRedisPoolFromConfig({
-            connection: this.config.POSTHOG_REDIS_HOST
-                ? {
-                      url: this.config.POSTHOG_REDIS_HOST,
-                      options: {
-                          port: this.config.POSTHOG_REDIS_PORT,
-                          password: this.config.POSTHOG_REDIS_PASSWORD,
-                      },
-                      name: 'posthog-redis',
-                  }
-                : { url: this.config.REDIS_URL, name: 'posthog-redis' },
+            connection: createPosthogRedisConnectionConfig(this.config),
             poolMinSize: this.config.REDIS_POOL_MIN_SIZE,
             poolMaxSize: this.config.REDIS_POOL_MAX_SIZE,
         })

--- a/nodejs/src/session-recording/consumer.e2e.test.ts
+++ b/nodejs/src/session-recording/consumer.e2e.test.ts
@@ -916,7 +916,7 @@ describe('Session Recording Consumer Integration', () => {
             SESSION_RECORDING_V2_REPLAY_EVENTS_KAFKA_TOPIC: KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
         })
 
-        team = await getFirstTeam(hub)
+        team = await getFirstTeam(hub.postgres)
 
         // Enable console log capture for the primary team so console log tests work
         await hub.postgres.query(

--- a/nodejs/src/utils/action-manager-cdp.test.ts
+++ b/nodejs/src/utils/action-manager-cdp.test.ts
@@ -21,7 +21,7 @@ describe('ActionManagerCDP()', () => {
 
         postgres = new PostgresRouter(defaultConfig)
         actionManager = new ActionManagerCDP(postgres)
-        const team = await getFirstTeam(hub)
+        const team = await getFirstTeam(hub.postgres)
         teamId = team.id
         fetchActionsSpy = jest.spyOn(actionManager as any, 'fetchActions')
     })

--- a/nodejs/src/utils/db/hub.ts
+++ b/nodejs/src/utils/db/hub.ts
@@ -5,6 +5,11 @@ import { QuotaLimiting } from '~/common/services/quota-limiting.service'
 
 import { EncryptedFields } from '../../cdp/utils/encryption-utils'
 import { defaultConfig } from '../../config/config'
+import {
+    createCookielessRedisConnectionConfig,
+    createIngestionRedisConnectionConfig,
+    createPosthogRedisConnectionConfig,
+} from '../../config/redis-pools'
 import { CookielessManager } from '../../ingestion/cookieless/cookieless-manager'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Hub, PluginsServerConfig } from '../../types'
@@ -55,19 +60,7 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
 
     logger.info('🤔', `Connecting to ingestion Redis...`)
     const redisPool = createRedisPoolFromConfig({
-        connection: serverConfig.INGESTION_REDIS_HOST
-            ? {
-                  url: serverConfig.INGESTION_REDIS_HOST,
-                  options: { port: serverConfig.INGESTION_REDIS_PORT },
-                  name: 'ingestion-redis',
-              }
-            : serverConfig.POSTHOG_REDIS_HOST
-              ? {
-                    url: serverConfig.POSTHOG_REDIS_HOST,
-                    options: { port: serverConfig.POSTHOG_REDIS_PORT, password: serverConfig.POSTHOG_REDIS_PASSWORD },
-                    name: 'ingestion-redis',
-                }
-              : { url: serverConfig.REDIS_URL, name: 'ingestion-redis' },
+        connection: createIngestionRedisConnectionConfig(serverConfig),
         poolMinSize: serverConfig.REDIS_POOL_MIN_SIZE,
         poolMaxSize: serverConfig.REDIS_POOL_MAX_SIZE,
     })
@@ -75,13 +68,7 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
 
     logger.info('🤔', `Connecting to cookieless Redis...`)
     const cookielessRedisPool = createRedisPoolFromConfig({
-        connection: serverConfig.COOKIELESS_REDIS_HOST
-            ? {
-                  url: serverConfig.COOKIELESS_REDIS_HOST,
-                  options: { port: serverConfig.COOKIELESS_REDIS_PORT ?? 6379 },
-                  name: 'cookieless-redis',
-              }
-            : { url: serverConfig.REDIS_URL, name: 'cookieless-redis' },
+        connection: createCookielessRedisConnectionConfig(serverConfig),
         poolMinSize: serverConfig.REDIS_POOL_MIN_SIZE,
         poolMaxSize: serverConfig.REDIS_POOL_MAX_SIZE,
     })
@@ -90,13 +77,7 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
     const teamManager = new TeamManager(postgres)
     logger.info('🤔', `Connecting to PostHog Redis...`)
     const posthogRedisPool = createRedisPoolFromConfig({
-        connection: serverConfig.POSTHOG_REDIS_HOST
-            ? {
-                  url: serverConfig.POSTHOG_REDIS_HOST,
-                  options: { port: serverConfig.POSTHOG_REDIS_PORT, password: serverConfig.POSTHOG_REDIS_PASSWORD },
-                  name: 'posthog-redis',
-              }
-            : { url: serverConfig.REDIS_URL, name: 'posthog-redis' },
+        connection: createPosthogRedisConnectionConfig(serverConfig),
         poolMinSize: serverConfig.REDIS_POOL_MIN_SIZE,
         poolMaxSize: serverConfig.REDIS_POOL_MAX_SIZE,
     })

--- a/nodejs/src/utils/event-schema-enforcement-manager.test.ts
+++ b/nodejs/src/utils/event-schema-enforcement-manager.test.ts
@@ -22,7 +22,7 @@ describe('EventSchemaEnforcementManager', () => {
 
         postgres = new PostgresRouter(defaultConfig)
         schemaManager = new EventSchemaEnforcementManager(postgres)
-        const team = await getFirstTeam(hub)
+        const team = await getFirstTeam(hub.postgres)
         teamId = team.id
         projectId = team.project_id
         fetchSchemasSpy = jest.spyOn(schemaManager as any, 'fetchSchemas')

--- a/nodejs/src/utils/realtime-supported-filter-manager-cdp.test.ts
+++ b/nodejs/src/utils/realtime-supported-filter-manager-cdp.test.ts
@@ -27,7 +27,7 @@ describe('RealtimeSupportedFilterManagerCDP()', () => {
 
         postgres = new PostgresRouter(defaultConfig)
         realtimeSupportedFilterManager = new RealtimeSupportedFilterManagerCDP(postgres)
-        const team = await getFirstTeam(hub)
+        const team = await getFirstTeam(hub.postgres)
         teamId = team.id
         fetchRealtimeSupportedFiltersSpy = jest.spyOn(
             realtimeSupportedFilterManager as any,

--- a/nodejs/src/utils/team-manager.test.ts
+++ b/nodejs/src/utils/team-manager.test.ts
@@ -30,7 +30,7 @@ describe('TeamManager()', () => {
 
         postgres = new PostgresRouter(defaultConfig)
         teamManager = new TeamManager(postgres)
-        const team = await getFirstTeam(hub)
+        const team = await getFirstTeam(hub.postgres)
         teamId = team.id
         teamToken = team.api_token
         organizationId = team.organization_id

--- a/nodejs/src/worker/ingestion/group-type-manager.test.ts
+++ b/nodejs/src/worker/ingestion/group-type-manager.test.ts
@@ -117,7 +117,7 @@ describe('GroupTypeManager()', () => {
             expect(hub.groupRepository.insertGroupType).toHaveBeenCalledTimes(1)
             expect(hub.postgres.query).toHaveBeenCalledTimes(3) // FETCH + INSERT + Team lookup
 
-            const team = await getTeam(hub, 2)
+            const team = await getTeam(hub.postgres, 2)
             expect(captureTeamEvent).toHaveBeenCalledWith(
                 expect.objectContaining({ id: team?.id }),
                 'group type ingested',

--- a/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/worker/ingestion/persons/repositories/postgres-person-repository.test.ts
@@ -54,14 +54,14 @@ describe('PostgresPersonRepository', () => {
 
     describe('fetchPerson()', () => {
         it('returns undefined if person does not exist', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await repository.fetchPerson(team.id, 'some_id')
 
             expect(person).toEqual(undefined)
         })
 
         it('returns person object if person exists', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const createdPerson = await createTestPerson(team.id, 'some_id', { foo: 'bar' })
             const person = await repository.fetchPerson(team.id, 'some_id')
 
@@ -79,7 +79,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('throws error when both forUpdate and useReadReplica are true', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
 
             await expect(
                 repository.fetchPerson(team.id, 'some_id', { forUpdate: true, useReadReplica: true })
@@ -87,7 +87,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('uses read replica when useReadReplica is true', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const createdPerson = await createTestPerson(team.id, 'some_id', { foo: 'bar' })
 
             // Mock the postgres query to verify it's called with the right parameters
@@ -124,7 +124,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('uses write connection when useReadReplica is false', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const createdPerson = await createTestPerson(team.id, 'some_id', { foo: 'bar' })
 
             // Mock the postgres query to verify it's called with the right parameters
@@ -161,7 +161,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('adds FOR UPDATE clause when forUpdate is true', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
 
             // Mock the postgres query to verify the SQL contains FOR UPDATE
             const mockQuery = jest.spyOn(postgres, 'query').mockResolvedValue({
@@ -185,7 +185,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('createPerson()', () => {
         it('creates a person with basic properties', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const uuid = new UUIDT().toString()
             const properties = { name: 'John Doe', email: 'john@example.com' }
 
@@ -217,7 +217,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('creates a person with multiple distinct IDs', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const uuid = new UUIDT().toString()
             const properties = { name: 'Jane Doe' }
 
@@ -266,7 +266,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('throws error when trying to create a person with the same distinct ID twice', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const distinctId = 'duplicate-distinct-id'
             const uuid1 = new UUIDT().toString()
             const uuid2 = new UUIDT().toString()
@@ -319,7 +319,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('addDistinctId()', () => {
         it('should add distinct ID to person', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'existing-distinct-id', { name: 'John Doe' })
             const newDistinctId = 'new-distinct-id'
             const version = 1
@@ -341,7 +341,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle adding distinct ID with different version', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'existing-distinct-id', { name: 'John Doe' })
             const newDistinctId = 'another-distinct-id'
             const version = 5
@@ -365,7 +365,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('deletePerson()', () => {
         it('should delete person from postgres', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const uuid = new UUIDT().toString()
             const result = await repository.createPerson(TIMESTAMP, {}, {}, {}, team.id, null, true, uuid, {
                 distinctId: 'delete-test-distinct',
@@ -411,7 +411,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle deleting person that does not exist', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const nonExistentPerson = {
                 id: '999999',
                 uuid: new UUIDT().toString(),
@@ -435,7 +435,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('moveDistinctIds()', () => {
         it('should move distinct IDs from source to target person', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const sourcePerson = await createTestPerson(team.id, 'source-distinct-id', { name: 'Source Person' })
             const targetPerson = await createTestPerson(team.id, 'target-distinct-id', { name: 'Target Person' })
 
@@ -466,7 +466,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it.skip('should handle target person not found', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const sourcePerson = await createTestPerson(team.id, 'source-distinct-id', { name: 'Source Person' })
             const nonExistentTargetPerson = {
                 id: '999999',
@@ -491,7 +491,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle source person not found', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const targetPerson = await createTestPerson(team.id, 'target-distinct-id', { name: 'Target Person' })
             const nonExistentSourcePerson = {
                 id: '888888',
@@ -516,7 +516,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should respect per-call move limit when provided', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const limitedRepository = new PostgresPersonRepository(postgres, {})
 
             const sourcePerson = await createTestPerson(team.id, 'source-distinct-id', { name: 'Source Person' })
@@ -562,7 +562,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should move all distinct IDs when no limit is configured', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const unlimitedRepository = new PostgresPersonRepository(postgres, {}) // No limit
 
             const sourcePerson = await createTestPerson(team.id, 'source-unlimited', { name: 'Source Person' })
@@ -593,7 +593,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should move distinct IDs in deterministic order when per-call limit is set', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const limitedRepository = new PostgresPersonRepository(postgres, {})
 
             const sourcePerson = await createTestPerson(team.id, 'source-deterministic', { name: 'Source Person' })
@@ -648,7 +648,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should move all distinct IDs when person has fewer than the per-call limit', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const limitedRepository = new PostgresPersonRepository(postgres, {})
 
             const sourcePerson = await createTestPerson(team.id, 'source-below-limit', { name: 'Source Person' })
@@ -695,7 +695,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('fetchPersonDistinctIds()', () => {
         it('should fetch all distinct IDs when no limit is specified', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct-id', { name: 'Test Person' })
 
             // Add more distinct IDs
@@ -713,7 +713,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should fetch limited distinct IDs when limit is specified', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-limit-distinct', { name: 'Test Person' })
 
             // Add more distinct IDs
@@ -729,7 +729,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should return distinct IDs in deterministic order', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'order-test-distinct', { name: 'Test Person' })
 
             // Add distinct IDs in non-alphabetical order
@@ -746,7 +746,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle limit larger than available distinct IDs', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'large-limit-distinct', { name: 'Test Person' })
 
             // Add only 2 more distinct IDs (total of 3)
@@ -762,7 +762,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should work with transactions', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'tx-distinct', { name: 'Test Person' })
 
             await repository.addDistinctId(person, 'tx-distinct-2', 1)
@@ -783,7 +783,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should fetch persons by distinct IDs from multiple teams', async () => {
-            const team1 = await getFirstTeam(hub)
+            const team1 = await getFirstTeam(hub.postgres)
             const team2Id = await createTeam(postgres, team1.organization_id)
 
             // Create persons in different teams
@@ -822,7 +822,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle non-existent distinct IDs gracefully', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'existing-distinct', { name: 'Existing Person' })
 
             const teamPersons = [
@@ -839,7 +839,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle single team person lookup', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'single-distinct', { name: 'Single Person' })
 
             const teamPersons = [{ teamId: team.id as any, distinctId: 'single-distinct' }]
@@ -854,7 +854,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle duplicate team/distinctId pairs', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'duplicate-distinct', { name: 'Duplicate Person' })
 
             const teamPersons = [
@@ -871,7 +871,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should include all required fields in InternalPersonWithDistinctId', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'fields-test', { name: 'Fields Test', age: 25 })
 
             const teamPersons = [{ teamId: team.id as any, distinctId: 'fields-test' }]
@@ -906,7 +906,7 @@ describe('PostgresPersonRepository', () => {
             ['single team', 1],
             ['multiple teams', 2],
         ])('should fetch persons by person IDs (%s)', async (_label, teamCount) => {
-            const team1 = await getFirstTeam(hub)
+            const team1 = await getFirstTeam(hub.postgres)
             const team2Id = teamCount > 1 ? await createTeam(postgres, team1.organization_id) : team1.id
 
             const person1 = await createTestPerson(team1.id, 'pid-test-1', { name: 'Person 1' })
@@ -926,7 +926,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should not return persons from a different team even if their IDs were referenced', async () => {
-            const team1 = await getFirstTeam(hub)
+            const team1 = await getFirstTeam(hub.postgres)
             const team2Id = await createTeam(postgres, team1.organization_id)
 
             const team1Person = await createTestPerson(team1.id, 'cross-team-1', { name: 'Team 1 Person' })
@@ -943,7 +943,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle non-existent person IDs gracefully', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'existing-person', { name: 'Existing' })
             const nonExistentId = new UUIDT().toString()
 
@@ -957,7 +957,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should deduplicate repeated (teamId, personId) pairs', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'dedup-person', { name: 'Dedup' })
 
             const result = await repository.fetchPersonsByPersonIds([
@@ -972,7 +972,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('addPersonlessDistinctId', () => {
         it('should insert personless distinct ID successfully', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const distinctId = 'test-distinct-new'
 
             const result = await repository.addPersonlessDistinctId(team.id, distinctId)
@@ -992,7 +992,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should return existing is_merged value when distinct ID already exists', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const distinctId = 'test-distinct-existing'
 
             // First insert
@@ -1015,7 +1015,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle different team IDs correctly', async () => {
-            const team1 = await getFirstTeam(hub)
+            const team1 = await getFirstTeam(hub.postgres)
             const team2Id = await createTeam(hub.postgres, team1.organization_id)
             const distinctId = 'shared-distinct-id'
 
@@ -1051,7 +1051,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('addPersonlessDistinctIdForMerge', () => {
         it('should insert personless distinct ID for merge successfully', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const distinctId = 'test-distinct-merge-new'
 
             const result = await repository.addPersonlessDistinctIdForMerge(team.id, distinctId)
@@ -1071,7 +1071,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should update existing record to merged when distinct ID already exists', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const distinctId = 'test-distinct-merge-existing'
 
             // First insert as regular personless distinct ID
@@ -1102,7 +1102,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle transaction parameter correctly', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const distinctId = 'test-distinct-merge-transaction'
 
             // Use a transaction
@@ -1135,7 +1135,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('addPersonlessDistinctIdsBatch', () => {
         it('should insert multiple personless distinct IDs in batch', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const entries = [
                 { teamId: team.id, distinctId: 'batch-distinct-1' },
                 { teamId: team.id, distinctId: 'batch-distinct-2' },
@@ -1161,7 +1161,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle duplicate distinct IDs in batch (deduplicates)', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const entries = [
                 { teamId: team.id, distinctId: 'dup-distinct' },
                 { teamId: team.id, distinctId: 'dup-distinct' },
@@ -1177,7 +1177,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should return is_merged=true for already merged distinct IDs', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const mergedDistinctId = 'already-merged-distinct'
 
             // First, insert and mark as merged
@@ -1202,7 +1202,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle multiple teams in same batch', async () => {
-            const team1 = await getFirstTeam(hub)
+            const team1 = await getFirstTeam(hub.postgres)
             const team2Id = await createTeam(hub.postgres, team1.organization_id)
 
             const entries = [
@@ -1220,7 +1220,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('personPropertiesSize', () => {
         it('should return properties size for existing person', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', {
                 name: 'John Doe',
                 email: 'john@example.com',
@@ -1238,7 +1238,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should return 0 for non-existent person', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const fakePersonId = '999999' // Use a numeric ID instead of UUID
             const size = await repository.personPropertiesSize(fakePersonId, team.id)
 
@@ -1246,7 +1246,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle different persons correctly', async () => {
-            const team1 = await getFirstTeam(hub)
+            const team1 = await getFirstTeam(hub.postgres)
             const team2Id = await createTeam(hub.postgres, team1.organization_id)
 
             // Create person in team 1
@@ -1265,7 +1265,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should return larger size for person with more properties', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
 
             // Create person with minimal properties
             const minimalPerson = await createTestPerson(team.id, 'minimal-person', { name: 'Minimal' })
@@ -1306,7 +1306,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('updatePerson', () => {
         it('should update person properties successfully', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', { name: 'John', age: 25 })
 
             const update = { properties: { name: 'Jane', age: 30, city: 'New York' } }
@@ -1327,7 +1327,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should update is_identified field', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', { name: 'John' })
 
             const update = { is_identified: true }
@@ -1342,7 +1342,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle version conflicts correctly', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', { name: 'John' })
 
             // First update
@@ -1366,7 +1366,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle transaction parameter correctly', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', { name: 'John' })
 
             await postgres.transaction(PostgresUse.PERSONS_WRITE, 'test-transaction', async (tx) => {
@@ -1388,7 +1388,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle tag parameter correctly', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', { name: 'John' })
 
             const update = { properties: { name: 'Jane' } }
@@ -1403,7 +1403,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should throw NoRowsUpdatedError when person does not exist', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const nonExistentPerson: InternalPerson = {
                 id: '1234567890',
                 team_id: team.id,
@@ -1425,7 +1425,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle updatePersonAssertVersion with optimistic concurrency control', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', { name: 'John' })
 
             // Create a PersonUpdate object
@@ -1463,7 +1463,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle updatePersonAssertVersion with version mismatch', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-distinct', { name: 'John' })
 
             // Create a PersonUpdate with an outdated version
@@ -1501,7 +1501,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle updatePersonAssertVersion with non-existent person', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
 
             // Create a PersonUpdate for a non-existent person
             const personUpdate = {
@@ -1533,7 +1533,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should merge properties_to_set into properties when updating', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-merge-set', { existing: 'value', to_update: 'old' })
 
             const personUpdate = {
@@ -1571,7 +1571,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should apply properties_to_unset when updating', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-unset', {
                 keep: 'value',
                 remove_me: 'will be removed',
@@ -1609,7 +1609,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle combined properties_to_set and properties_to_unset', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-combined', {
                 keep: 'value',
                 remove: 'will go',
@@ -1668,7 +1668,7 @@ describe('PostgresPersonRepository', () => {
         }
 
         beforeEach(async () => {
-            team = await getFirstTeam(hub)
+            team = await getFirstTeam(hub.postgres)
             const result = await repository.createPerson(
                 TIMESTAMP,
                 {},
@@ -1941,7 +1941,7 @@ describe('PostgresPersonRepository', () => {
 
         describe('createPerson with oversized properties', () => {
             it('should throw PersonPropertiesSizeViolationError when properties exceed size limit', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
                 const uuid = new UUIDT().toString()
                 const oversizedProperties = {
                     description: 'x'.repeat(200),
@@ -1992,7 +1992,7 @@ describe('PostgresPersonRepository', () => {
 
         describe('updatePerson with oversized properties', () => {
             it('should trim existing oversized person properties and update successfully', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
 
                 const normalPerson = await createTestPerson(team.id, 'test-oversized-update', {
                     name: 'John',
@@ -2025,7 +2025,7 @@ describe('PostgresPersonRepository', () => {
             })
 
             it('should reject update when current person is under limit but update would exceed it', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
                 const normalPerson = await createTestPerson(team.id, 'test-normal-person', { name: 'John' })
 
                 const mockPersonPropertiesSize = jest
@@ -2067,7 +2067,7 @@ describe('PostgresPersonRepository', () => {
             })
 
             it('should fail gracefully when trimming fails', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
                 const normalPerson = await createTestPerson(team.id, 'test-trim-failure', {
                     name: 'John',
                     description: 'x'.repeat(120),
@@ -2122,7 +2122,7 @@ describe('PostgresPersonRepository', () => {
             })
 
             it('should fail when protected properties alone exceed size limit and cannot be trimmed', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
 
                 const largeProtectedProperties = {
                     name: 'John Doe with a very long name that takes up significant space',
@@ -2224,7 +2224,7 @@ describe('PostgresPersonRepository', () => {
 
         describe('updatePersonAssertVersion with oversized properties', () => {
             it('should throw PersonPropertiesSizeViolationError when properties exceed size limit', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
                 const person = await createTestPerson(team.id, 'test-assert-oversized', { name: 'John' })
 
                 const originalQuery = postgres.query.bind(postgres)
@@ -2275,7 +2275,7 @@ describe('PostgresPersonRepository', () => {
 
         describe('new metrics and error handling', () => {
             it('should increment personPropertiesSizeViolationCounter with correct labels', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
                 const uuid = new UUIDT().toString()
                 const oversizedProperties = {
                     description: 'x'.repeat(200),
@@ -2320,7 +2320,7 @@ describe('PostgresPersonRepository', () => {
             })
 
             it('should increment oversizedPersonPropertiesTrimmedCounter when trimming succeeds', async () => {
-                const team = await getFirstTeam(hub)
+                const team = await getFirstTeam(hub.postgres)
                 const person = await createTestPerson(team.id, 'test-trimming-metrics', {
                     name: 'John',
                     description: 'x'.repeat(120),
@@ -2421,7 +2421,7 @@ describe('PostgresPersonRepository', () => {
 
     describe('calculate properties size feature flag', () => {
         it('should have identical output whether properties size calculation is enabled or disabled', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
 
             const person1 = await createTestPerson(team.id, 'test-distinct-1', {
                 name: 'John',
@@ -2481,7 +2481,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should have identical behavior for updatePersonAssertVersion regardless of logging configuration', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
 
             const person1 = await createTestPerson(team.id, 'test-assert-1', { name: 'John', data: 'x'.repeat(2000) })
             const person2 = await createTestPerson(team.id, 'test-assert-2', { name: 'John', data: 'x'.repeat(2000) })
@@ -2539,7 +2539,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should work with default options (no logging)', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const defaultRepository = new PostgresPersonRepository(postgres, {
                 calculatePropertiesSize: 0,
                 personPropertiesDbConstraintLimitBytes: 1024 * 1024,
@@ -2595,7 +2595,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should track JSON field sizes on createPerson', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const properties = { name: 'Alice', email: 'alice@example.com', age: 25 }
             const propertiesLastUpdatedAt = { name: '2024-01-15T10:30:00.000Z', email: '2024-01-15T10:30:00.000Z' }
             const propertiesLastOperation = { name: PropertyUpdateOperation.Set, email: PropertyUpdateOperation.Set }
@@ -2641,7 +2641,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should track JSON field sizes on updatePerson with properties', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-metrics-update', { name: 'Bob' })
 
             // Clear observe calls from createTestPerson
@@ -2684,7 +2684,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should only track metrics for fields being updated', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-metrics-partial', { name: 'Charlie' })
 
             // Clear observe calls from createTestPerson
@@ -2709,7 +2709,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should handle large properties correctly', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const largeProperties = {
                 name: 'David',
                 large_field: 'z'.repeat(100000), // 100KB of data
@@ -2755,7 +2755,7 @@ describe('PostgresPersonRepository', () => {
         })
 
         it('should not record metrics when update is empty', async () => {
-            const team = await getFirstTeam(hub)
+            const team = await getFirstTeam(hub.postgres)
             const person = await createTestPerson(team.id, 'test-metrics-empty', { name: 'Eve' })
 
             // Clear observe calls from createTestPerson
@@ -2774,8 +2774,8 @@ describe('PostgresPersonRepository', () => {
 })
 
 // Helper function from the original test file
-async function getFirstTeam(hub: Hub): Promise<Team> {
-    const teams = await hub.postgres.query(
+async function getFirstTeam(postgres: PostgresRouter): Promise<Team> {
+    const teams = await postgres.query(
         PostgresUse.COMMON_WRITE,
         'SELECT * FROM posthog_team LIMIT 1',
         [],

--- a/nodejs/tests/helpers/sql.ts
+++ b/nodejs/tests/helpers/sql.ts
@@ -1,15 +1,7 @@
 import { DateTime } from 'luxon'
 
 import { defaultConfig } from '../../src/config/config'
-import {
-    CookielessServerHashMode,
-    Hub,
-    InternalPerson,
-    ProjectId,
-    RawOrganization,
-    RawPerson,
-    Team,
-} from '../../src/types'
+import { CookielessServerHashMode, InternalPerson, ProjectId, RawOrganization, RawPerson, Team } from '../../src/types'
 import { PostgresRouter, PostgresUse } from '../../src/utils/db/postgres'
 import { UUIDT } from '../../src/utils/utils'
 
@@ -307,8 +299,8 @@ export async function createUserTeamAndOrganization(
     await insertRow(db, 'posthog_team', teamData)
 }
 
-export async function getTeams(hub: Hub): Promise<Team[]> {
-    const selectResult = await hub.postgres.query<Team>(
+export async function getTeams(postgres: PostgresRouter): Promise<Team[]> {
+    const selectResult = await postgres.query<Team>(
         PostgresUse.COMMON_READ,
         'SELECT * FROM posthog_team ORDER BY id',
         undefined,
@@ -320,13 +312,13 @@ export async function getTeams(hub: Hub): Promise<Team[]> {
     return selectResult.rows
 }
 
-export async function getTeam(hub: Hub, teamId: Team['id']): Promise<Team | null> {
-    const teams = await getTeams(hub)
+export async function getTeam(postgres: PostgresRouter, teamId: Team['id']): Promise<Team | null> {
+    const teams = await getTeams(postgres)
     return teams.find((team) => team.id === teamId) ?? null
 }
 
-export async function getFirstTeam(hub: Hub): Promise<Team> {
-    return (await getTeams(hub))[0]
+export async function getFirstTeam(postgres: PostgresRouter): Promise<Team> {
+    return (await getTeams(postgres))[0]
 }
 
 export const createOrganization = async (pg: PostgresRouter) => {

--- a/nodejs/tests/worker/ingestion/person-state-batch.test.ts
+++ b/nodejs/tests/worker/ingestion/person-state-batch.test.ts
@@ -126,7 +126,7 @@ describe('PersonState.processEvent()', () => {
 
     beforeEach(async () => {
         teamId = await createTeam(hub.postgres, organizationId)
-        mainTeam = (await getTeam(hub, teamId))!
+        mainTeam = (await getTeam(hub.postgres, teamId))!
         timestamp = DateTime.fromISO('2020-01-01T12:00:05.200Z').toUTC()
         timestamp2 = DateTime.fromISO('2020-02-02T12:00:05.200Z').toUTC()
         timestampch = '2020-01-01 12:00:05.000'
@@ -317,7 +317,7 @@ describe('PersonState.processEvent()', () => {
             }).updateProperties()
 
             const otherTeamId = await createTeam(hub.postgres, organizationId)
-            const otherTeam = (await getTeam(hub, otherTeamId))!
+            const otherTeam = (await getTeam(hub.postgres, otherTeamId))!
             teamId = otherTeamId
             const [personOtherTeam, kafkaAcksOther] = await personPropertyService(
                 {


### PR DESCRIPTION
## Problem

Redis connection config (host fallback chains) was duplicated between `createHub()` and `PluginServer`, and test helpers like `getTeam`/`getFirstTeam` unnecessarily depended on the `Hub` god object when they only needed `PostgresRouter`.

## Changes

- Extract three Redis connection config factory functions into `nodejs/src/config/redis-pools.ts`, eliminating duplicated fallback logic between `createHub()` and `PluginServer`
- Update `getTeams`, `getTeam`, and `getFirstTeam` test helpers to accept `PostgresRouter` instead of `Hub`
- Update all test files to pass `hub.postgres` to the narrowed helpers


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
