### PR TITLE
fix(session-recordings): add tier to snapshot throttle scope for prom metrics

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -529,14 +529,14 @@ def get_cached_org_tier(team_id: int) -> str:
 
 class _TierAwareSnapshotThrottle(PersonalApiKeyRateThrottle):
     def _apply_tier_rates(self, tier: str) -> None:
-        # scope is str | None in DRF's base class, but subclasses always set it
         if self.scope is None:
             raise ValueError("_TierAwareSnapshotThrottle subclasses must set scope")
+        base_scope = self.scope
         rates = _snapshot_rates()
         rates_for_tier = rates.get(tier) or rates[SNAPSHOT_DEFAULT_TIER]
-        self.rate = rates_for_tier[self.scope]
+        self.rate = rates_for_tier[base_scope]
         self.num_requests, self.duration = self.parse_rate(self.rate)
-        self.scope = f"{self.scope}_{tier}"
+        self.scope = f"{base_scope}_{tier}"
 
     def _is_personal_api_key_request(self, request) -> bool:
         return isinstance(getattr(request, "successful_authenticator", None), PersonalAPIKeyAuthentication)

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -533,10 +533,10 @@ class _TierAwareSnapshotThrottle(PersonalApiKeyRateThrottle):
             raise ValueError("_TierAwareSnapshotThrottle subclasses must set scope")
         base_scope = self.scope
         rates = _snapshot_rates()
-        rates_for_tier = rates.get(tier) or rates[SNAPSHOT_DEFAULT_TIER]
-        self.rate = rates_for_tier[base_scope]
+        resolved_tier = tier if tier in rates else SNAPSHOT_DEFAULT_TIER
+        self.rate = rates[resolved_tier][base_scope]
         self.num_requests, self.duration = self.parse_rate(self.rate)
-        self.scope = f"{base_scope}_{tier}"
+        self.scope = f"{base_scope}_{resolved_tier}"
 
     def _is_personal_api_key_request(self, request) -> bool:
         return isinstance(getattr(request, "successful_authenticator", None), PersonalAPIKeyAuthentication)

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -536,6 +536,7 @@ class _TierAwareSnapshotThrottle(PersonalApiKeyRateThrottle):
         rates_for_tier = rates.get(tier) or rates[SNAPSHOT_DEFAULT_TIER]
         self.rate = rates_for_tier[self.scope]
         self.num_requests, self.duration = self.parse_rate(self.rate)
+        self.scope = f"{self.scope}_{tier}"
 
     def _is_personal_api_key_request(self, request) -> bool:
         return isinstance(getattr(request, "successful_authenticator", None), PersonalAPIKeyAuthentication)

--- a/posthog/session_recordings/test/test_session_recording_snapshot_throttle.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshot_throttle.py
@@ -151,7 +151,7 @@ class TestSnapshotRatesConfig(BaseTest):
 
         expected_rate = SNAPSHOT_RATES[SNAPSHOT_DEFAULT_TIER]["snapshots_burst"]
         assert throttle.rate == expected_rate
-        assert throttle.scope == "snapshots_burst_mystery_tier"
+        assert throttle.scope == "snapshots_burst_free"
 
 
 class TestTierAwareSnapshotThrottle(BaseTest):

--- a/posthog/session_recordings/test/test_session_recording_snapshot_throttle.py
+++ b/posthog/session_recordings/test/test_session_recording_snapshot_throttle.py
@@ -12,6 +12,7 @@ from posthog.session_recordings.session_recording_api import (
     SNAPSHOT_RATES,
     SNAPSHOTS_TIER_CACHE_TTL_SECONDS,
     SnapshotsBurstRateThrottle,
+    SnapshotsSustainedRateThrottle,
     _org_tier_from_features,
     _snapshot_rates,
     get_cached_org_tier,
@@ -150,6 +151,7 @@ class TestSnapshotRatesConfig(BaseTest):
 
         expected_rate = SNAPSHOT_RATES[SNAPSHOT_DEFAULT_TIER]["snapshots_burst"]
         assert throttle.rate == expected_rate
+        assert throttle.scope == "snapshots_burst_mystery_tier"
 
 
 class TestTierAwareSnapshotThrottle(BaseTest):
@@ -162,6 +164,7 @@ class TestTierAwareSnapshotThrottle(BaseTest):
 
         expected_rate = SNAPSHOT_RATES[SNAPSHOT_DEFAULT_TIER]["snapshots_burst"]
         assert throttle.rate == expected_rate
+        assert throttle.scope == "snapshots_burst_free"
 
     @patch("posthog.session_recordings.session_recording_api.get_cached_org_tier")
     def test_skips_tier_lookup_for_non_personal_api_key_requests(self, mock_tier) -> None:
@@ -173,6 +176,7 @@ class TestTierAwareSnapshotThrottle(BaseTest):
 
         mock_tier.assert_not_called()
         assert throttle.rate == original_rate
+        assert throttle.scope == "snapshots_burst"
 
     @patch("posthog.session_recordings.session_recording_api.get_cached_org_tier", return_value="paid")
     def test_applies_tier_rates_for_personal_api_key_requests(self, _mock_tier) -> None:
@@ -182,6 +186,7 @@ class TestTierAwareSnapshotThrottle(BaseTest):
         throttle.allow_request(request=_fake_personal_api_key_request(), view=view)
 
         assert throttle.rate == SNAPSHOT_RATES["paid"]["snapshots_burst"]
+        assert throttle.scope == "snapshots_burst_paid"
 
     def test_missing_team_id_applies_free_tier_rates(self) -> None:
         throttle = SnapshotsBurstRateThrottle()
@@ -191,6 +196,7 @@ class TestTierAwareSnapshotThrottle(BaseTest):
 
         expected_rate = SNAPSHOT_RATES[SNAPSHOT_DEFAULT_TIER]["snapshots_burst"]
         assert throttle.rate == expected_rate
+        assert throttle.scope == "snapshots_burst_free"
 
     @override_settings(SNAPSHOT_RATE_PAID_BURST="200/minute")
     @patch("posthog.session_recordings.session_recording_api.get_cached_org_tier", return_value="paid")
@@ -201,6 +207,25 @@ class TestTierAwareSnapshotThrottle(BaseTest):
         throttle.allow_request(request=_fake_personal_api_key_request(), view=view)
 
         assert throttle.rate == "200/minute"
+
+
+class TestApplyTierRatesSetsScope(BaseTest):
+    @parameterized.expand(
+        [
+            ("burst_free", SnapshotsBurstRateThrottle, "free", "snapshots_burst_free"),
+            ("burst_paid", SnapshotsBurstRateThrottle, "paid", "snapshots_burst_paid"),
+            ("burst_enterprise", SnapshotsBurstRateThrottle, "enterprise", "snapshots_burst_enterprise"),
+            ("sustained_free", SnapshotsSustainedRateThrottle, "free", "snapshots_sustained_free"),
+            ("sustained_paid", SnapshotsSustainedRateThrottle, "paid", "snapshots_sustained_paid"),
+            ("sustained_enterprise", SnapshotsSustainedRateThrottle, "enterprise", "snapshots_sustained_enterprise"),
+        ]
+    )
+    def test_scope_includes_tier(self, _name: str, throttle_class: type, tier: str, expected_scope: str) -> None:
+        throttle = throttle_class()
+
+        throttle._apply_tier_rates(tier)
+
+        assert throttle.scope == expected_scope
 
 
 class TestSnapshotRatesFromSettings(BaseTest):


### PR DESCRIPTION
## Changes

The `rate_limit_exceeded_total` Prometheus counter's `scope` label was always `snapshots_burst` or `snapshots_sustained` regardless of org tier, making it impossible to tell from Grafana/metrics which tier was hitting rate limits.

After `_apply_tier_rates` resolves the tier, `self.scope` is updated to include it — e.g. `snapshots_burst_free`, `snapshots_sustained_paid`, `snapshots_burst_enterprise`. This flows into both the Prometheus `scope` label and the DRF throttle cache key.

The cache key becoming tier-specific is intentional: different tiers have different rates and should have separate rate limit buckets.

For non-personal-API-key requests (session auth) where tier lookup is skipped, the scope is unchanged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)