### PR TITLE
fix: Get variant from feature flag

### DIFF
--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -52,24 +52,19 @@ class RelatedActorsQuery:
     def is_aggregating_by_groups(self) -> bool:
         return self.group_type_index is not None
 
-    def _use_optimized_related_people_query(self) -> bool:
-        return posthoganalytics.feature_enabled(
+    def _is_test_variant(self) -> bool:
+        flag_result = posthoganalytics.get_feature_flag(
             "optimized-related-people-query",
             str(self.team.uuid),
-            groups={"organization": str(self.team.organization_id), "project": str(self.team.id)},
-            group_properties={
-                "organization": {"id": str(self.team.organization_id)},
-                "project": {"id": str(self.team.id)},
-            },
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
+            groups={"organization": str(self.team.organization.id), "project": str(self.team.uuid)},
         )
+        return flag_result == "test"  # type: ignore[comparison-overlap]
 
     def _query_related_people(self) -> list[SerializedPerson]:
         if not self.is_aggregating_by_groups:
             return []
 
-        if self._use_optimized_related_people_query():
+        if self._is_test_variant():
             tag_queries(name="optimized-related-people-test")
             person_ids = self._query_related_people_optimized()
         else:

--- a/ee/clickhouse/queries/test/test_related_actors_query.py
+++ b/ee/clickhouse/queries/test/test_related_actors_query.py
@@ -58,7 +58,7 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         return {r["id"] for r in results if r["type"] == "person"}
 
     @snapshot_clickhouse_queries
-    @patch(f"{PATH}.posthoganalytics.feature_enabled", return_value=False)
+    @patch(f"{PATH}.posthoganalytics.get_feature_flag", return_value="control")
     def test_query_related_people_control(self, _):
         results = self._query()
 
@@ -68,7 +68,7 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         assert str(self.another_person.uuid) in ids
 
     @snapshot_clickhouse_queries
-    @patch(f"{PATH}.posthoganalytics.feature_enabled", return_value=True)
+    @patch(f"{PATH}.posthoganalytics.get_feature_flag", return_value="test")
     def test_query_related_people_optimized(self, _):
         results = self._query()
 
@@ -77,10 +77,10 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         assert str(self.person.uuid) in ids
         assert str(self.another_person.uuid) in ids
 
-    @parameterized.expand([("control", False), ("optimized", True)])
-    @patch(f"{PATH}.posthoganalytics.feature_enabled")
-    def test_returns_related_people(self, _name, flag_value, mock_flag):
-        mock_flag.return_value = flag_value
+    @parameterized.expand(["control", "test"])
+    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
+    def test_returns_related_people(self, variant, mock_flag):
+        mock_flag.return_value = variant
 
         results = self._query()
 
@@ -91,10 +91,10 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         assert str(self.unrelated_person.uuid) not in ids
         assert str(self.old_related_person.uuid) not in ids
 
-    @parameterized.expand([("control", False), ("optimized", True)])
-    @patch(f"{PATH}.posthoganalytics.feature_enabled")
-    def test_excludes_deleted_person_mapping(self, _name, flag_value, mock_flag):
-        mock_flag.return_value = flag_value
+    @parameterized.expand(["control", "test"])
+    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
+    def test_excludes_deleted_person_mapping(self, variant, mock_flag):
+        mock_flag.return_value = variant
         self._insert_pdi2_row("user2", str(self.another_person.uuid), version=100, is_deleted=1)
 
         results = self._query()
@@ -102,10 +102,10 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         ids = self._get_person_ids(results)
         assert str(self.another_person.uuid) not in ids
 
-    @parameterized.expand([("control", False), ("optimized", True)])
-    @patch(f"{PATH}.posthoganalytics.feature_enabled")
-    def test_reassigned_distinct_id_resolves_to_new_person(self, _name, flag_value, mock_flag):
-        mock_flag.return_value = flag_value
+    @parameterized.expand(["control", "test"])
+    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
+    def test_reassigned_distinct_id_resolves_to_new_person(self, variant, mock_flag):
+        mock_flag.return_value = variant
         new_person = _create_person(distinct_ids=["new_user"], team=self.team, uuid=uuid4())
         flush_persons_and_events()
         self._insert_pdi2_row("user1", str(new_person.uuid), version=100)
@@ -116,10 +116,10 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         assert str(new_person.uuid) in ids
         assert str(self.person.uuid) not in ids
 
-    @parameterized.expand([("control", False), ("optimized", True)])
-    @patch(f"{PATH}.posthoganalytics.feature_enabled")
-    def test_multiple_distinct_ids_same_person_deduped(self, _name, flag_value, mock_flag):
-        mock_flag.return_value = flag_value
+    @parameterized.expand(["control", "test"])
+    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
+    def test_multiple_distinct_ids_same_person_deduped(self, variant, mock_flag):
+        mock_flag.return_value = variant
         self._insert_pdi2_row("user2", str(self.person.uuid), version=100)
 
         results = self._query()


### PR DESCRIPTION
## Problem
We were getting the feature flag as if it was a boolean, but it is a multivariate.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Part of https://github.com/PostHog/posthog/issues/40472
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
All unit tests passing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
