### PR TITLE
test(signals): Remove POSTHOG_PROJECT_API_KEY requirement for eval

### DIFF
--- a/products/signals/eval/conftest.py
+++ b/products/signals/eval/conftest.py
@@ -13,6 +13,8 @@ from posthoganalytics import Posthog
 from posthoganalytics.ai.gemini import genai
 from posthoganalytics.ai.openai import AsyncOpenAI
 
+from posthog.models import Organization, Team
+
 load_dotenv(Path(__file__).resolve().parents[3] / ".env")
 
 logging.getLogger("google_genai").setLevel(logging.ERROR)
@@ -60,8 +62,16 @@ def online(request):
 
 
 @pytest.fixture
-def posthog_client(no_capture):
+def posthog_client(no_capture, db):
     api_key = os.environ.get("POSTHOG_PROJECT_API_KEY", "")
+    if not api_key:
+        last_team = Team.objects.order_by("-pk").first()
+        if last_team:
+            api_key = last_team.api_token
+        elif not no_capture:
+            org = Organization.objects.create(name="Eval Org", is_ai_data_processing_approved=True)
+            team = Team.objects.create(organization=org, name="Eval Team")
+            api_key = team.api_token
     if not api_key and not no_capture:
         raise ValueError("POSTHOG_PROJECT_API_KEY needs to be set (or pass --no-capture).")
     host = os.environ.get("POSTHOG_HOST", "http://localhost:8010")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

It's just toil to have to manually configure POSTHOG_PROJECT_API_KEY to run signals evals locally, this should be automated by default.

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Proposing we just use the API token of the latest team in the local PostHog instance!

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Ran it.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->