### PR TITLE
chore(flags): separate flags fleets

### DIFF
--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -41,6 +41,28 @@ impl Deref for FlexBool {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServiceMode {
+    All,         // default — both fleets (current behavior)
+    Flags,       // /flags and /decide only
+    Definitions, // /flags/definitions only
+}
+
+impl FromStr for ServiceMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "all" => Ok(ServiceMode::All),
+            "flags" => Ok(ServiceMode::Flags),
+            "definitions" => Ok(ServiceMode::Definitions),
+            _ => Err(format!(
+                "Invalid SERVICE_MODE: '{s}'. Expected 'all', 'flags', or 'definitions'"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TeamIdCollection {
     All,
     None,
@@ -578,6 +600,9 @@ pub struct Config {
 
     #[envconfig(from = "TEAM_NEGATIVE_CACHE_TTL_SECONDS", default = "300")]
     pub team_negative_cache_ttl_seconds: u64,
+
+    #[envconfig(from = "SERVICE_MODE", default = "all")]
+    pub service_mode: ServiceMode,
 }
 
 /// Thread counts for Tokio (async I/O) and Rayon (CPU-bound parallel evaluation).
@@ -779,6 +804,7 @@ impl Config {
             thread_pool_cores: 0,
             team_negative_cache_capacity: 10_000,
             team_negative_cache_ttl_seconds: 300,
+            service_mode: ServiceMode::All,
         }
     }
 
@@ -1188,6 +1214,40 @@ mod tests {
 
         assert_eq!(zero_config.redis_response_timeout_ms, 0);
         assert_eq!(zero_config.redis_connection_timeout_ms, 0);
+    }
+}
+
+#[cfg(test)]
+mod service_mode_tests {
+    use super::*;
+
+    #[test]
+    fn test_service_mode_from_str() {
+        assert_eq!("all".parse::<ServiceMode>().unwrap(), ServiceMode::All);
+        assert_eq!("flags".parse::<ServiceMode>().unwrap(), ServiceMode::Flags);
+        assert_eq!(
+            "definitions".parse::<ServiceMode>().unwrap(),
+            ServiceMode::Definitions
+        );
+        // case insensitive
+        assert_eq!("ALL".parse::<ServiceMode>().unwrap(), ServiceMode::All);
+        assert_eq!("Flags".parse::<ServiceMode>().unwrap(), ServiceMode::Flags);
+        assert_eq!(
+            "DEFINITIONS".parse::<ServiceMode>().unwrap(),
+            ServiceMode::Definitions
+        );
+    }
+
+    #[test]
+    fn test_service_mode_invalid() {
+        assert!("invalid".parse::<ServiceMode>().is_err());
+        assert!("".parse::<ServiceMode>().is_err());
+    }
+
+    #[test]
+    fn test_service_mode_default() {
+        let config = Config::default_test_config();
+        assert_eq!(config.service_mode, ServiceMode::All);
     }
 }
 

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -38,7 +38,7 @@ use crate::{
         flags_rate_limiter::{FlagsRateLimiter, IpRateLimiter},
     },
     cohorts::cohort_cache_manager::CohortCacheManager,
-    config::{Config, TeamIdCollection},
+    config::{Config, ServiceMode, TeamIdCollection},
     metrics::{
         consts::{
             FLAG_DEFINITIONS_RATE_LIMITED_COUNTER, FLAG_DEFINITIONS_REQUESTS_COUNTER,
@@ -221,19 +221,32 @@ pub fn router(
     // 2. TimeoutLayer: cancels the entire request after request_timeout_ms,
     //    ensuring zombie tasks don't hold connections after Envoy kills the downstream.
     // 3. ConcurrencyLimitLayer (innermost): bounds in-flight requests.
-    let flags_router = Router::new()
-        .route("/flags", any(endpoint::flags))
-        .route("/flags/", any(endpoint::flags))
-        .route(
-            "/flags/definitions",
-            any(flag_definitions::flags_definitions),
-        )
-        .route(
-            "/flags/definitions/",
-            any(flag_definitions::flags_definitions),
-        )
-        .route("/decide", any(endpoint::flags))
-        .route("/decide/", any(endpoint::flags))
+    let mut flags_router = Router::new();
+
+    if matches!(config.service_mode, ServiceMode::All | ServiceMode::Flags) {
+        flags_router = flags_router
+            .route("/flags", any(endpoint::flags))
+            .route("/flags/", any(endpoint::flags))
+            .route("/decide", any(endpoint::flags))
+            .route("/decide/", any(endpoint::flags));
+    }
+
+    if matches!(
+        config.service_mode,
+        ServiceMode::All | ServiceMode::Definitions
+    ) {
+        flags_router = flags_router
+            .route(
+                "/flags/definitions",
+                any(flag_definitions::flags_definitions),
+            )
+            .route(
+                "/flags/definitions/",
+                any(flag_definitions::flags_definitions),
+            );
+    }
+
+    let flags_router = flags_router
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency))
         .layer(
             ServiceBuilder::new()

--- a/rust/feature-flags/src/server.rs
+++ b/rust/feature-flags/src/server.rs
@@ -345,6 +345,8 @@ pub async fn serve<F>(
         );
     }
 
+    let service_mode = config.service_mode.clone();
+
     let app = router::router(
         redis_client,
         dedicated_redis_client,
@@ -364,7 +366,11 @@ pub async fn serve<F>(
         config,
     );
 
-    tracing::info!("listening on {:?}", listener.local_addr().unwrap());
+    tracing::info!(
+        service_mode = ?service_mode,
+        "listening on {:?}",
+        listener.local_addr().unwrap()
+    );
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),

--- a/rust/feature-flags/tests/test_service_mode.rs
+++ b/rust/feature-flags/tests/test_service_mode.rs
@@ -6,144 +6,87 @@ use feature_flags::config::{Config, ServiceMode};
 pub mod common;
 
 #[tokio::test]
-async fn service_mode_all_serves_all_routes() {
-    let config = Config::default_test_config();
-    assert_eq!(config.service_mode, ServiceMode::All);
+async fn service_mode_route_availability() {
+    let cases: &[(ServiceMode, &[(&str, bool)])] = &[
+        (
+            ServiceMode::All,
+            &[
+                ("/flags", true),
+                ("/decide", true),
+                ("/flags/definitions", true),
+            ],
+        ),
+        (
+            ServiceMode::Flags,
+            &[
+                ("/flags", true),
+                ("/decide", true),
+                ("/flags/definitions", false),
+            ],
+        ),
+        (
+            ServiceMode::Definitions,
+            &[
+                ("/flags", false),
+                ("/decide", false),
+                ("/flags/definitions", true),
+            ],
+        ),
+    ];
 
-    let server = ServerHandle::for_config(config).await;
-    let client = reqwest::Client::new();
+    for (mode, expectations) in cases {
+        let mut config = Config::default_test_config();
+        config.service_mode = mode.clone();
+        let server = ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
 
-    // /flags should be reachable
-    let resp = client
-        .get(format!("http://{}/flags", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
-
-    // /decide should be reachable
-    let resp = client
-        .get(format!("http://{}/decide", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
-
-    // /flags/definitions should be reachable
-    let resp = client
-        .get(format!("http://{}/flags/definitions", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
-}
-
-#[tokio::test]
-async fn service_mode_flags_excludes_definitions() {
-    let mut config = Config::default_test_config();
-    config.service_mode = ServiceMode::Flags;
-
-    let server = ServerHandle::for_config(config).await;
-    let client = reqwest::Client::new();
-
-    // /flags should be reachable
-    let resp = client
-        .get(format!("http://{}/flags", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
-
-    // /decide should be reachable
-    let resp = client
-        .get(format!("http://{}/decide", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
-
-    // /flags/definitions should NOT be reachable
-    let resp = client
-        .get(format!("http://{}/flags/definitions", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-}
-
-#[tokio::test]
-async fn service_mode_definitions_excludes_flags() {
-    let mut config = Config::default_test_config();
-    config.service_mode = ServiceMode::Definitions;
-
-    let server = ServerHandle::for_config(config).await;
-    let client = reqwest::Client::new();
-
-    // /flags should NOT be reachable
-    let resp = client
-        .get(format!("http://{}/flags", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-
-    // /decide should NOT be reachable
-    let resp = client
-        .get(format!("http://{}/decide", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-
-    // /flags/definitions should be reachable
-    let resp = client
-        .get(format!("http://{}/flags/definitions", server.addr))
-        .send()
-        .await
-        .unwrap();
-    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+        for &(path, reachable) in *expectations {
+            let resp = client
+                .get(format!("http://{}{}", server.addr, path))
+                .send()
+                .await
+                .unwrap();
+            if reachable {
+                assert_ne!(
+                    resp.status(),
+                    StatusCode::NOT_FOUND,
+                    "{path} should be reachable in {mode:?} mode",
+                );
+            } else {
+                assert_eq!(
+                    resp.status(),
+                    StatusCode::NOT_FOUND,
+                    "{path} should NOT be reachable in {mode:?} mode",
+                );
+            }
+        }
+    }
 }
 
 #[tokio::test]
 async fn service_mode_health_checks_always_available() {
-    for mode in [ServiceMode::All, ServiceMode::Flags, ServiceMode::Definitions] {
+    for mode in [
+        ServiceMode::All,
+        ServiceMode::Flags,
+        ServiceMode::Definitions,
+    ] {
         let mut config = Config::default_test_config();
         config.service_mode = mode.clone();
 
         let server = ServerHandle::for_config(config).await;
         let client = reqwest::Client::new();
 
-        let resp = client
-            .get(format!("http://{}/", server.addr))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::OK,
-            "/ should be available in {mode:?} mode"
-        );
-
-        let resp = client
-            .get(format!("http://{}/_readiness", server.addr))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::OK,
-            "/_readiness should be available in {mode:?} mode"
-        );
-
-        let resp = client
-            .get(format!("http://{}/_liveness", server.addr))
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::OK,
-            "/_liveness should be available in {mode:?} mode"
-        );
+        for path in ["/", "/_readiness", "/_liveness", "/_startup"] {
+            let resp = client
+                .get(format!("http://{}{path}", server.addr))
+                .send()
+                .await
+                .unwrap();
+            assert_ne!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "{path} should be available in {mode:?} mode"
+            );
+        }
     }
 }

--- a/rust/feature-flags/tests/test_service_mode.rs
+++ b/rust/feature-flags/tests/test_service_mode.rs
@@ -1,0 +1,149 @@
+use reqwest::StatusCode;
+
+use crate::common::*;
+use feature_flags::config::{Config, ServiceMode};
+
+pub mod common;
+
+#[tokio::test]
+async fn service_mode_all_serves_all_routes() {
+    let config = Config::default_test_config();
+    assert_eq!(config.service_mode, ServiceMode::All);
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // /flags should be reachable
+    let resp = client
+        .get(format!("http://{}/flags", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+
+    // /decide should be reachable
+    let resp = client
+        .get(format!("http://{}/decide", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+
+    // /flags/definitions should be reachable
+    let resp = client
+        .get(format!("http://{}/flags/definitions", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn service_mode_flags_excludes_definitions() {
+    let mut config = Config::default_test_config();
+    config.service_mode = ServiceMode::Flags;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // /flags should be reachable
+    let resp = client
+        .get(format!("http://{}/flags", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+
+    // /decide should be reachable
+    let resp = client
+        .get(format!("http://{}/decide", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+
+    // /flags/definitions should NOT be reachable
+    let resp = client
+        .get(format!("http://{}/flags/definitions", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn service_mode_definitions_excludes_flags() {
+    let mut config = Config::default_test_config();
+    config.service_mode = ServiceMode::Definitions;
+
+    let server = ServerHandle::for_config(config).await;
+    let client = reqwest::Client::new();
+
+    // /flags should NOT be reachable
+    let resp = client
+        .get(format!("http://{}/flags", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // /decide should NOT be reachable
+    let resp = client
+        .get(format!("http://{}/decide", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // /flags/definitions should be reachable
+    let resp = client
+        .get(format!("http://{}/flags/definitions", server.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn service_mode_health_checks_always_available() {
+    for mode in [ServiceMode::All, ServiceMode::Flags, ServiceMode::Definitions] {
+        let mut config = Config::default_test_config();
+        config.service_mode = mode.clone();
+
+        let server = ServerHandle::for_config(config).await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .get(format!("http://{}/", server.addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "/ should be available in {mode:?} mode"
+        );
+
+        let resp = client
+            .get(format!("http://{}/_readiness", server.addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "/_readiness should be available in {mode:?} mode"
+        );
+
+        let resp = client
+            .get(format!("http://{}/_liveness", server.addr))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "/_liveness should be available in {mode:?} mode"
+        );
+    }
+}


### PR DESCRIPTION
Part 1 of #51087 

## Summary

Adds a `SERVICE_MODE` env var to the feature-flags Rust service to support splitting into two independent fleets: one for `/flags` + `/decide` traffic and one for `/flags/definitions` traffic.

- Adds `ServiceMode` enum (`All`, `Flags`, `Definitions`) with case-insensitive parsing to `config.rs`
- Conditionally registers routes in `router.rs` based on `service_mode` — health checks and middleware remain in all modes
- Adds unit tests for config parsing and integration tests verifying route availability per mode

**No chart changes are included in this PR.** The default is `"all"`, so this is a no-op deploy, all pods continue serving all routes, identical to current behavior.

## Changes

### `rust/feature-flags/src/config.rs`
- New `ServiceMode` enum with `FromStr` (accepts `"all"`, `"flags"`, `"definitions"`, case-insensitive)
- New `service_mode` field on `Config` (`#[envconfig(from = "SERVICE_MODE", default = "all")]`)
- Updated `default_test_config()` with `service_mode: ServiceMode::All`
- New `service_mode_tests` module (parsing, invalid input, default value)

### `rust/feature-flags/src/router.rs`
- Imported `ServiceMode`
- Split monolithic `flags_router` route registration into two conditional blocks:
  - `ServiceMode::All | ServiceMode::Flags` → `/flags`, `/decide`
  - `ServiceMode::All | ServiceMode::Definitions` → `/flags/definitions`
- Health checks (`/`, `/_readiness`, `/_liveness`, `/_startup`), `/metrics`, and all middleware layers are unchanged

### `rust/feature-flags/tests/test_service_mode.rs` (new)
- Integration tests spinning up a real server per mode:
  - `All` mode serves all routes
  - `Flags` mode returns 404 for `/flags/definitions`
  - `Definitions` mode returns 404 for `/flags` and `/decide`
  - Health checks available in all modes

## Follow-up: chart changes needed to split fleets

Once this is deployed, the fleet split can be done entirely in the [charts repo](https://github.com/PostHog/charts) with no further Rust changes:

1. **New ApplicationSet** — duplicate `argocd/posthog-rust/posthog-feature-flags.yaml` → `posthog-feature-flags-definitions.yaml`, pointing to a new values directory (`values/posthog-feature-flags-definitions/`) with:
   - `name: posthog-feature-flags-definitions`
   - `SERVICE_MODE: "definitions"` in `env`
   - Its own `autoscaling`, `resources`, `rollout` config tuned for definitions traffic

2. **Update existing fleet** — add `SERVICE_MODE: "flags"` to `env` in existing `values/posthog-feature-flags/values.yaml`

3. **Contour routing split** — in `argocd/contour-ingress/values/values.{prod-us,prod-eu,dev}.yaml`, update the `feature-flags` HTTPProxy:
   - `/flags/definitions/?` route → `posthog-feature-flags-definitions:3001`
   - `/flags/?` route stays → `posthog-feature-flags:3001`
   - `decide` proxy stays → `posthog-feature-flags:3001`