### PR TITLE
chore(devex): require `update-snapshots` label for snapshot auto-updates

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -6,6 +6,7 @@
 name: E2E CI Playwright
 on:
     pull_request:
+        types: [opened, synchronize, reopened, labeled, unlabeled]
     workflow_dispatch:
     push:
         branches:
@@ -151,7 +152,7 @@ jobs:
 
                     # Trusted bots that are allowed to run in update mode
                     # Add bot usernames here to allow snapshot auto-updates on their PRs
-                    TRUSTED_BOTS=("mendral-app[bot]")
+                    TRUSTED_BOTS=("mendral-app[bot]" "cursor[bot]")
 
                     IS_TRUSTED=false
                     for bot in "${TRUSTED_BOTS[@]}"; do
@@ -582,10 +583,10 @@ jobs:
                       // comment that may have relevant info from a previous run.
                       let extraLines = '';
                       let resultsRead = false;
+                      let failed = [];
                       try {
                           const results = JSON.parse(fs.readFileSync('playwright/results.json', 'utf8'));
                           resultsRead = true;
-                          const failed = [];
                           const flaky = [];
                           function collect(suites) {
                               for (const suite of suites || []) {

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -6,7 +6,6 @@
 name: E2E CI Playwright
 on:
     pull_request:
-        types: [opened, synchronize, reopened, labeled, unlabeled]
     workflow_dispatch:
     push:
         branches:
@@ -634,7 +633,7 @@ jobs:
                       const reportLink = reportUrl ? ` · [View test results →](${reportUrl})` : '';
                       const snapshotMode = '${{ needs.detect-snapshot-mode.outputs.mode }}';
                       const snapshotHint = (snapshotMode === 'check' && failed.length > 0)
-                          ? '\n\n---\n**If your changes intentionally update screenshots:** add the `update-snapshots` label to this PR and re-run CI. Screenshots will be auto-committed.\n**If you didn\'t change any UI:** this is likely a flaky screenshot — wait for fixes to land on master.'
+                          ? '\n\n---\n**If your changes intentionally update screenshots:** add the `update-snapshots` label, then push an empty commit or merge master to trigger a new run. Screenshots will be auto-committed.\n**If you didn\'t change any UI:** this is likely a flaky screenshot — wait for a fix to land on master.'
                           : '';
                       const footer = '\n\n\n*These issues are not necessarily caused by your changes.*\n*Annoyed by this comment? Help fix flakies and failures and it\'ll disappear!*';
                       const body = `${marker}\n🎭 Playwright report${reportLink}${extraLines}${snapshotHint}${footer}`;

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -136,10 +136,15 @@ jobs:
         steps:
             - name: Detect mode
               id: detect
+              env:
+                  HAS_UPDATE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'update-snapshots') }}
               run: |
                   if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
                     echo "mode=check" >> $GITHUB_OUTPUT
                     echo "Fork detected - running in CHECK mode (no commits allowed)"
+                  elif [ "$HAS_UPDATE_LABEL" == "true" ]; then
+                    echo "mode=update" >> $GITHUB_OUTPUT
+                    echo "::notice::🔄 Running in UPDATE mode - 'update-snapshots' label detected"
                   else
                     AUTHOR="${{ github.actor }}"
                     echo "Workflow triggered by: $AUTHOR"
@@ -159,12 +164,9 @@ jobs:
                     if [[ "$IS_TRUSTED" == "true" ]]; then
                       echo "mode=update" >> $GITHUB_OUTPUT
                       echo "::notice::🔄 Trusted bot '$AUTHOR' - running in UPDATE mode"
-                    elif [[ "$AUTHOR" == *"github-actions"* ]] || [[ "$AUTHOR" == *"[bot]"* ]] || [[ "$AUTHOR" == "posthog-bot" ]]; then
-                      echo "mode=check" >> $GITHUB_OUTPUT
-                      echo "::notice::🔍 Running in CHECK mode - snapshots must match exactly"
                     else
-                      echo "mode=update" >> $GITHUB_OUTPUT
-                      echo "::notice::🔄 Running in UPDATE mode - snapshots can be updated"
+                      echo "mode=check" >> $GITHUB_OUTPUT
+                      echo "::notice::🔍 Running in CHECK mode - add 'update-snapshots' label to enable snapshot updates"
                     fi
                   fi
 
@@ -629,8 +631,12 @@ jobs:
                       }
 
                       const reportLink = reportUrl ? ` · [View test results →](${reportUrl})` : '';
+                      const snapshotMode = '${{ needs.detect-snapshot-mode.outputs.mode }}';
+                      const snapshotHint = (snapshotMode === 'check' && failed.length > 0)
+                          ? '\n\n---\n**If your changes intentionally update screenshots:** add the `update-snapshots` label to this PR and re-run CI. Screenshots will be auto-committed.\n**If you didn\'t change any UI:** this is likely a flaky screenshot — wait for fixes to land on master.'
+                          : '';
                       const footer = '\n\n\n*These issues are not necessarily caused by your changes.*\n*Annoyed by this comment? Help fix flakies and failures and it\'ll disappear!*';
-                      const body = `${marker}\n🎭 Playwright report${reportLink}${extraLines}${footer}`;
+                      const body = `${marker}\n🎭 Playwright report${reportLink}${extraLines}${snapshotHint}${footer}`;
 
                       if (existing) {
                           await github.rest.issues.updateComment({

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -152,7 +152,7 @@ jobs:
 
                     # Trusted bots that are allowed to run in update mode
                     # Add bot usernames here to allow snapshot auto-updates on their PRs
-                    TRUSTED_BOTS=("mendral-app[bot]" "cursor[bot]")
+                    TRUSTED_BOTS=("mendral-app[bot]")
 
                     IS_TRUSTED=false
                     for bot in "${TRUSTED_BOTS[@]}"; do

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -112,10 +112,15 @@ jobs:
         steps:
             - name: Detect mode
               id: detect
+              env:
+                  HAS_UPDATE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'update-snapshots') }}
               run: |
                   if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
                     echo "mode=check" >> $GITHUB_OUTPUT
                     echo "Fork detected - running in CHECK mode (no commits allowed)"
+                  elif [ "$HAS_UPDATE_LABEL" == "true" ]; then
+                    echo "mode=update" >> $GITHUB_OUTPUT
+                    echo "::notice::🔄 Running in UPDATE mode - 'update-snapshots' label detected"
                   else
                     AUTHOR="${{ github.actor }}"
                     echo "Workflow triggered by: $AUTHOR"
@@ -135,12 +140,9 @@ jobs:
                     if [[ "$IS_TRUSTED" == "true" ]]; then
                       echo "mode=update" >> $GITHUB_OUTPUT
                       echo "::notice::🔄 Trusted bot '$AUTHOR' - running in UPDATE mode"
-                    elif [[ "$AUTHOR" == *"github-actions"* ]] || [[ "$AUTHOR" == *"[bot]"* ]] || [[ "$AUTHOR" == "posthog-bot" ]]; then
-                      echo "mode=check" >> $GITHUB_OUTPUT
-                      echo "::notice::🔍 Running in CHECK mode - snapshots must match exactly"
                     else
-                      echo "mode=update" >> $GITHUB_OUTPUT
-                      echo "::notice::🔄 Running in UPDATE mode - snapshots can be updated"
+                      echo "mode=check" >> $GITHUB_OUTPUT
+                      echo "::notice::🔍 Running in CHECK mode - add 'update-snapshots' label to enable snapshot updates"
                     fi
                   fi
 
@@ -406,6 +408,86 @@ jobs:
                   path: /tmp/patches/shard-${{ matrix.browser }}-${{ matrix.shard }}.patch
                   retention-days: 1
                   if-no-files-found: ignore
+
+    # Post a helpful comment when snapshot tests fail in check mode (no label)
+    snapshot-failure-comment:
+        name: Post snapshot failure guidance
+        runs-on: ubuntu-latest
+        needs: [visual-regression, detect-snapshot-mode]
+        if: >-
+            always()
+            && needs.visual-regression.result == 'failure'
+            && needs.detect-snapshot-mode.outputs.mode == 'check'
+            && github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const marker = '<!-- storybook-snapshot-hint -->';
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                      });
+                      const existing = comments.find(c => c.body.includes(marker));
+
+                      const body = `${marker}
+                      ### Storybook visual regression tests failed
+
+                      **If your changes intentionally update UI snapshots:** add the \`update-snapshots\` label to this PR and re-run CI. Snapshots will be auto-committed.
+
+                      **If you didn't change any UI:** this is likely a flaky snapshot. No action needed on your part — wait for fixes to land on master.`.replace(/^                      /gm, '');
+
+                      if (existing) {
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                              body,
+                          });
+                      } else {
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: context.issue.number,
+                              body,
+                          });
+                      }
+
+    # Clean up the hint comment when tests pass
+    snapshot-success-cleanup:
+        name: Clean up snapshot hint
+        runs-on: ubuntu-latest
+        needs: [visual-regression, detect-snapshot-mode]
+        if: >-
+            always()
+            && needs.visual-regression.result == 'success'
+            && github.event_name == 'pull_request'
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const marker = '<!-- storybook-snapshot-hint -->';
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                      });
+                      const existing = comments.find(c => c.body.includes(marker));
+                      if (existing) {
+                          await github.rest.issues.deleteComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                          });
+                      }
 
     # Job to collate the status of the matrix jobs for requiring passing status
     # Must depend on handle-snapshots to prevent auto-merge before commits complete

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -1,7 +1,6 @@
 name: Storybook
 on:
     pull_request:
-        types: [opened, synchronize, reopened, labeled, unlabeled]
     merge_group:
     push:
         branches:
@@ -439,9 +438,9 @@ jobs:
                       const body = `${marker}
                       ### Storybook visual regression tests failed
 
-                      **If your changes intentionally update UI snapshots:** add the \`update-snapshots\` label to this PR and re-run CI. Snapshots will be auto-committed.
+                      **If your changes intentionally update UI snapshots:** add the \`update-snapshots\` label, then push an empty commit or merge master to trigger a new run. Snapshots will be auto-committed.
 
-                      **If you didn't change any UI:** this is likely a flaky snapshot. No action needed on your part — wait for fixes to land on master.`.replace(/^                      /gm, '');
+                      **If you didn't change any UI:** this is likely a flaky snapshot — wait for a fix to land on master.`.replace(/^                      /gm, '');
 
                       if (existing) {
                           await github.rest.issues.updateComment({

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -128,7 +128,7 @@ jobs:
 
                     # Trusted bots that are allowed to run in update mode
                     # Add bot usernames here to allow snapshot auto-updates on their PRs
-                    TRUSTED_BOTS=("mendral-app[bot]" "cursor[bot]")
+                    TRUSTED_BOTS=("mendral-app[bot]")
 
                     IS_TRUSTED=false
                     for bot in "${TRUSTED_BOTS[@]}"; do

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -1,6 +1,7 @@
 name: Storybook
 on:
     pull_request:
+        types: [opened, synchronize, reopened, labeled, unlabeled]
     merge_group:
     push:
         branches:
@@ -467,6 +468,7 @@ jobs:
             always()
             && needs.visual-regression.result == 'success'
             && github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             pull-requests: write
         steps:


### PR DESCRIPTION
**Problem**
Snapshot auto-updates run on every human PR by default. When flaky snapshots update on unrelated changes, devs get confused by unexpected commits and noise in their PRs.

**Change**
Storybook and Playwright CI now default to check mode — snapshots must match or the test fails. To opt in to auto-updates, add the `update-snapshots` label and re-run CI (or just push a new commit with the label applied).

When tests fail in check mode, a PR comment explains the two options:
- Add label if the snapshot changes are intentional
- Ignore if flaky — wait for fixes on master

Only mendral-app[bot] still gets update mode automatically (fully automated, no human in the loop).

**Note:** the `update-snapshots` label needs to be created in the repo settings.