### PR TITLE
fix(workflows): Don't send empty HTML body for plaintext emails

### DIFF
--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -452,6 +452,24 @@ describe('EmailService', () => {
             ])
         })
 
+        it('should send plaintext-only email when html is empty', async () => {
+            sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+            invocation.hogFunction.metadata = { message_category_type: 'transactional' }
+            invocation.queueParameters = createEmailParams({
+                from: { integrationId: 1, email: 'test@posthog-test.com' },
+                html: '',
+                text: 'Hello, this is a plain text email.',
+            })
+            const result = await service.executeSendEmail(invocation)
+            expect(result.error).toBeUndefined()
+            const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
+            expect(sentCommand.input.Content.Simple.Body.Text).toEqual({
+                Data: 'Hello, this is a plain text email.',
+                Charset: 'UTF-8',
+            })
+            expect(sentCommand.input.Content.Simple.Body.Html).toBeUndefined()
+        })
+
         it('should not include preheader span if not in params', async () => {
             sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
             invocation.queueParameters = createEmailParams({

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -147,7 +147,7 @@ export class EmailService {
             to: params.to.name ? `"${params.to.name}" <${params.to.email}>` : params.to.email,
             subject: params.subject,
             text: params.text,
-            html: addTrackingToEmail(params.html, result.invocation),
+            ...(params.html ? { html: addTrackingToEmail(params.html, result.invocation) } : {}),
         }
 
         const ccAddresses = parseAddressList(params.cc)
@@ -177,8 +177,18 @@ export class EmailService {
             throw new Error('SES is not configured - set SES_REGION and AWS credentials')
         }
         const trackingCode = generateEmailTrackingCode(result.invocation)
-        const htmlWithTracking = addTrackingToEmail(params.html, result.invocation)
-        const htmlWithTrackingAndPreheader = maybeAddPreheaderToEmail(htmlWithTracking, params.preheader)
+
+        const htmlBody = params.html
+            ? {
+                  Html: {
+                      Data: maybeAddPreheaderToEmail(
+                          addTrackingToEmail(params.html, result.invocation),
+                          params.preheader
+                      ),
+                      Charset: 'UTF-8',
+                  },
+              }
+            : {}
 
         const sendEmailParams: SendEmailCommandInput = {
             FromEmailAddress: params.from.name ? `"${params.from.name}" <${params.from.email}>` : params.from.email,
@@ -192,14 +202,11 @@ export class EmailService {
                         Charset: 'UTF-8',
                     },
                     Body: {
-                        Html: {
-                            Data: htmlWithTrackingAndPreheader,
-                            Charset: 'UTF-8',
-                        },
                         Text: {
                             Data: params.text,
                             Charset: 'UTF-8',
                         },
+                        ...htmlBody,
                     },
                 },
             },


### PR DESCRIPTION
## Problem

Customers sending plaintext-only emails via workflows receive blank emails. When the email editor's "Plain text" tab is used (setting `html: ""`), SES still receives an empty `Body.Html` field. SES wraps this in a `multipart/alternative` MIME message and injects its own tracking pixel into the HTML part. Email clients like Gmail prefer the HTML part per RFC 2046, rendering just a hidden 1x1 pixel - a blank email.

Confirmed via Gmail "Show original" on a production email - the `text/html` MIME part contains only an AWS tracking pixel.

## Changes

- Skip `Body.Html` in the SES request when `params.html` is empty, so SES sends a single-part `text/plain` email
- Same treatment for the maildev (local dev) path
- Added test asserting `Body.Html` is undefined for plaintext-only emails

## How did you test this code?

- Verified the root cause by inspecting raw MIME source of a production email in Gmail
- Sent a plaintext-only email via SES (dev account) with Body.Html omitted — Gmail source confirms single-part Content-Type: text/plain with no HTML part
- Added a unit test (should send plaintext-only email when html is empty) that mocks the SES client and asserts Body.Html is undefined

## Publish to changelog?

No