### PR TITLE
feat(flags): add per-condition-set aggregation_group_type_index to Rust models

### DIFF
--- a/rust/feature-flags/src/flags/flag_filters.rs
+++ b/rust/feature-flags/src/flags/flag_filters.rs
@@ -146,6 +146,7 @@ mod tests {
             )]),
             variant: Some("holdout-1".to_string()),
             rollout_percentage: Some(10.0),
+            ..Default::default()
         }]);
 
         assert!(!filters.requires_cohort_filters());
@@ -211,6 +212,7 @@ mod tests {
             ]),
             variant: Some("holdout-1".to_string()),
             rollout_percentage: Some(10.0),
+            ..Default::default()
         }]);
 
         // Holdout groups don't require DB properties.

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -27,6 +27,11 @@ pub struct FlagPropertyGroup {
     pub rollout_percentage: Option<f64>,
     #[serde(default)]
     pub variant: Option<String>,
+    /// Per-condition-set aggregation group type index. When present, this condition
+    /// set uses the specified group type for hashing and property evaluation. When
+    /// absent/null, the condition set uses person-level aggregation (distinct_id).
+    #[serde(default)]
+    pub aggregation_group_type_index: Option<i32>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -299,6 +299,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -337,6 +338,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -376,6 +378,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(50.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -388,6 +391,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(50.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -437,6 +441,7 @@ mod tests {
                     ]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -504,6 +509,7 @@ mod tests {
                 }]),
                 rollout_percentage: Some(100.0),
                 variant: None,
+                ..Default::default()
             }];
 
             let deps = flag.extract_dependencies().unwrap();
@@ -1652,6 +1658,7 @@ mod tests {
                 properties: Some(vec![]),
                 variant: Some("holdout-1".to_string()),
                 rollout_percentage: Some(10.0),
+                ..Default::default()
             },
             // Ignored, but here for testing.
             FlagPropertyGroup {
@@ -1662,6 +1669,7 @@ mod tests {
                 )]),
                 rollout_percentage: Some(100.0),
                 variant: Some("holdout-2".to_string()),
+                ..Default::default()
             },
         ]);
 
@@ -1745,6 +1753,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         }];
         assert!(!flag.has_partial_rollout());
     }
@@ -1756,6 +1765,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(50.0),
             variant: None,
+            ..Default::default()
         }];
         assert!(flag.has_partial_rollout());
     }
@@ -1767,6 +1777,7 @@ mod tests {
             properties: None,
             rollout_percentage: None, // Defaults to 100%
             variant: None,
+            ..Default::default()
         }];
         assert!(!flag.has_partial_rollout());
     }
@@ -1779,11 +1790,13 @@ mod tests {
                 properties: None,
                 rollout_percentage: Some(100.0),
                 variant: None,
+                ..Default::default()
             },
             FlagPropertyGroup {
                 properties: None,
                 rollout_percentage: Some(50.0),
                 variant: None,
+                ..Default::default()
             },
         ];
         assert!(flag.has_partial_rollout());
@@ -1804,6 +1817,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(50.0),
             variant: None,
+            ..Default::default()
         }];
         // None defaults to false, so no continuity means no lookup needed
         assert!(!flag.needs_hash_key_override());
@@ -1817,6 +1831,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         }];
         // 100% rollout with no variants -> doesn't need lookup
         assert!(!flag.needs_hash_key_override());
@@ -1830,6 +1845,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(50.0),
             variant: None,
+            ..Default::default()
         }];
         // Partial rollout needs consistent bucketing
         assert!(flag.needs_hash_key_override());
@@ -1843,6 +1859,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         }];
         flag.filters.multivariate = Some(MultivariateFlagOptions {
             variants: vec![
@@ -1871,6 +1888,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(50.0),
             variant: None,
+            ..Default::default()
         }];
         // Group-based flags don't use hash key overrides
         assert!(!flag.needs_hash_key_override());
@@ -1885,6 +1903,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(50.0),
             variant: None,
+            ..Default::default()
         }];
         // Device ID bucketing doesn't use hash key overrides
         assert!(!flag.needs_hash_key_override());
@@ -1907,6 +1926,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(50.0), // Partial rollout
             variant: None,
+            ..Default::default()
         }];
         flag.filters.multivariate = Some(MultivariateFlagOptions {
             variants: vec![

--- a/rust/feature-flags/src/flags/flag_property_group.rs
+++ b/rust/feature-flags/src/flags/flag_property_group.rs
@@ -62,6 +62,7 @@ mod tests {
             properties: None,
             rollout_percentage,
             variant: None,
+            ..Default::default()
         };
         assert_eq!(group.is_rolled_out_to_some(), expected);
     }
@@ -72,6 +73,7 @@ mod tests {
             properties: None,
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         };
         assert!(!group.requires_db_properties(&HashMap::new()));
     }
@@ -89,6 +91,7 @@ mod tests {
             ]),
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         };
 
         {
@@ -126,6 +129,7 @@ mod tests {
             ]),
             rollout_percentage: Some(0.0),
             variant: None,
+            ..Default::default()
         };
 
         assert!(!group.requires_db_properties(&HashMap::new()));
@@ -141,6 +145,7 @@ mod tests {
             )]),
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         };
 
         assert!(group.has_cohort_filters());
@@ -156,6 +161,7 @@ mod tests {
             )]),
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         };
 
         assert!(!group.has_cohort_filters());
@@ -171,6 +177,7 @@ mod tests {
             )]),
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         };
 
         assert!(group.requires_cohort_filters());
@@ -186,6 +193,7 @@ mod tests {
             )]),
             rollout_percentage: Some(0.0),
             variant: None,
+            ..Default::default()
         };
 
         assert!(!group.requires_cohort_filters());

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -321,6 +321,7 @@ mod tests {
                             }]),
                             rollout_percentage: Some(50.0),
                             variant: None,
+                            ..Default::default()
                         }],
                         multivariate: None,
                         aggregation_group_type_index: None,
@@ -376,6 +377,7 @@ mod tests {
                             }]),
                             rollout_percentage: Some(100.0),
                             variant: None,
+                            ..Default::default()
                         }],
                         multivariate: None,
                         aggregation_group_type_index: None,
@@ -500,6 +502,7 @@ mod tests {
                             }]),
                             rollout_percentage: Some(50.0 + i as f64),
                             variant: None,
+                            ..Default::default()
                         }],
                         multivariate: None,
                         aggregation_group_type_index: None,

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -176,6 +176,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -252,6 +253,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -334,6 +336,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -364,6 +367,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: Some(0),
@@ -454,6 +458,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: Some(1),
@@ -686,6 +691,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: Some("control".to_string()),
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -698,11 +704,13 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: Some("test".to_string()),
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![]),
                         rollout_percentage: Some(100.0),
                         variant: Some("other".to_string()),
+                        ..Default::default()
                     },
                 ],
                 multivariate: Some(MultivariateFlagOptions {
@@ -1169,6 +1177,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: Some("control".to_string()),
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -1181,6 +1190,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: Some("test".to_string()),
+                        ..Default::default()
                     },
                 ],
                 multivariate: Some(MultivariateFlagOptions {
@@ -1392,6 +1402,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1409,6 +1420,7 @@ mod tests {
             variant: None,
             properties: Some(vec![]),
             rollout_percentage: Some(100.0),
+            ..Default::default()
         };
 
         let matcher = FeatureFlagMatcher::new(
@@ -1445,6 +1457,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1469,6 +1482,7 @@ mod tests {
                 negation: None,
             }]),
             rollout_percentage: Some(100.0),
+            ..Default::default()
         };
 
         let mut matcher = FeatureFlagMatcher::new(
@@ -1501,6 +1515,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: Some(MultivariateFlagOptions {
                     variants: vec![
@@ -1564,6 +1579,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1645,6 +1661,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1724,6 +1741,7 @@ mod tests {
                     ]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1785,6 +1803,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1833,6 +1852,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(0.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1966,6 +1986,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -2031,6 +2052,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -2078,6 +2100,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -2137,6 +2160,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -2149,6 +2173,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -2383,6 +2408,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -2460,6 +2486,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(0.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -2472,11 +2499,13 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: None,
                         rollout_percentage: Some(50.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -2493,6 +2522,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }]),
                 holdout_groups: None,
                 holdout: None,
@@ -2620,6 +2650,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(0.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -2632,11 +2663,13 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: None,
                         rollout_percentage: Some(50.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -2653,6 +2686,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }]),
                 holdout_groups: None,
                 holdout: None,
@@ -2732,6 +2766,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(0.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -2744,11 +2779,13 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: None,
                         rollout_percentage: Some(50.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -2765,6 +2802,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }]),
                 holdout_groups: None,
                 holdout: None,
@@ -2913,6 +2951,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3010,6 +3049,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3107,6 +3147,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3225,6 +3266,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3322,6 +3364,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3419,6 +3462,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3508,6 +3552,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3592,6 +3637,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3691,6 +3737,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3768,6 +3815,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3875,6 +3923,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3965,6 +4014,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -3996,6 +4046,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -4103,6 +4154,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: Some("control".to_string()), // Override to always show "control" variant
+                    ..Default::default()
                 }],
                 multivariate: Some(MultivariateFlagOptions {
                     variants: vec![
@@ -4175,6 +4227,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: Some("nonexistent_variant".to_string()), // Override with invalid variant
+                    ..Default::default()
                 }],
                 multivariate: Some(MultivariateFlagOptions {
                     variants: vec![
@@ -4283,11 +4336,13 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 holdout_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![]),
                     rollout_percentage: Some(70.0),
                     variant: Some("holdout".to_string()),
+                    ..Default::default()
                 }]),
                 holdout: None,
                 multivariate: Some(multivariate_json.clone()),
@@ -4317,11 +4372,13 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 holdout_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![]),
                     rollout_percentage: Some(70.0),
                     variant: Some("holdout".to_string()),
+                    ..Default::default()
                 }]),
                 holdout: None,
                 multivariate: Some(multivariate_json.clone()),
@@ -4351,11 +4408,13 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 holdout_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![]),
                     rollout_percentage: Some(0.0),
                     variant: Some("holdout".to_string()),
+                    ..Default::default()
                 }]),
                 holdout: None,
                 multivariate: Some(multivariate_json),
@@ -4520,6 +4579,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 holdout_groups: None,
                 holdout: Some(Holdout {
@@ -4640,11 +4700,13 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 holdout_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![]),
                     rollout_percentage: Some(70.0),
                     variant: Some("holdout".to_string()),
+                    ..Default::default()
                 }]),
                 holdout: Some(Holdout {
                     id: 42,
@@ -4718,6 +4780,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 holdout_groups: None,
                 holdout: Some(Holdout {
@@ -4820,6 +4883,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 holdout_groups: None,
                 holdout: Some(Holdout {
@@ -4895,6 +4959,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: None,
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: Some(MultivariateFlagOptions {
                     variants: vec![
@@ -5060,6 +5125,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -5124,6 +5190,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -5193,6 +5260,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: Some(1),
@@ -5340,6 +5408,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -5357,6 +5426,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
@@ -5369,6 +5439,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -5385,6 +5456,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }]),
                 holdout_groups: None,
                 holdout: None,
@@ -5588,6 +5660,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(50.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 ..FlagFilters::default()
             },
@@ -5853,6 +5926,7 @@ mod tests {
                         ]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     // Condition 2: Requires only email (100% rollout)
                     FlagPropertyGroup {
@@ -5866,6 +5940,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -6111,6 +6186,7 @@ mod tests {
                         ]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                     // Condition 2: Requires only billing_email (100% rollout)
                     FlagPropertyGroup {
@@ -6124,6 +6200,7 @@ mod tests {
                         }]),
                         rollout_percentage: Some(100.0),
                         variant: None,
+                        ..Default::default()
                     },
                 ],
                 multivariate: None,
@@ -6404,11 +6481,13 @@ mod tests {
                             negation: None,
                         }]),
                         rollout_percentage: Some(100.0),
+                        ..Default::default()
                     },
                     FlagPropertyGroup {
                         variant: Some("test".to_string()), // Has variant override
                         properties: Some(vec![]),          // Catch-all
                         rollout_percentage: Some(100.0),
+                        ..Default::default()
                     },
                 ],
                 multivariate: Some(MultivariateFlagOptions {
@@ -7223,6 +7302,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -7316,6 +7396,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(50.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -7409,6 +7490,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: Some(MultivariateFlagOptions {
                     variants: vec![
@@ -7520,6 +7602,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: Some(MultivariateFlagOptions {
                     variants: vec![
@@ -7631,6 +7714,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -7713,6 +7797,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -7737,6 +7822,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(50.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -7761,6 +7847,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -7881,6 +7968,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -7905,6 +7993,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(50.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -8019,6 +8108,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(50.0), // Partial rollout means we need consistent bucketing
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -8051,6 +8141,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0), // 100% rollout - doesn't need lookup on its own
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -8143,6 +8234,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(0.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -8158,6 +8250,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }]),
                 holdout_groups: None,
                 holdout: None,
@@ -8242,6 +8335,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(0.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -8257,6 +8351,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }]),
                 holdout_groups: None,
                 holdout: None,
@@ -8347,6 +8442,7 @@ mod tests {
                     properties: None,
                     rollout_percentage: Some(0.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -8362,6 +8458,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }]),
                 holdout_groups: None,
                 holdout: None,
@@ -8461,6 +8558,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: Some(0),
@@ -8492,6 +8590,7 @@ mod tests {
                     }]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: Some(1),

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -55,6 +55,7 @@ pub fn create_simple_flag_property_group(
         properties: Some(properties),
         rollout_percentage: Some(rollout_percentage),
         variant: None,
+        ..Default::default()
     }
 }
 

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -112,6 +112,7 @@ mod tests {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -157,6 +157,7 @@ async fn test_evaluate_feature_flags() {
                 }]),
                 rollout_percentage: Some(100.0), // Set to 100% to ensure it's always on
                 variant: None,
+                ..Default::default()
             }],
             multivariate: None,
             aggregation_group_type_index: None,
@@ -259,6 +260,7 @@ async fn test_evaluate_feature_flags_with_errors() {
                 }]),
                 rollout_percentage: Some(100.0), // Set to 100% to ensure it's always on
                 variant: None,
+                ..Default::default()
             }],
             multivariate: None,
             aggregation_group_type_index: None,
@@ -648,6 +650,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -674,6 +677,7 @@ async fn test_evaluate_feature_flags_multiple_flags() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(0.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -762,6 +766,7 @@ async fn test_evaluate_feature_flags_details() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -788,6 +793,7 @@ async fn test_evaluate_feature_flags_details() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(0.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -946,6 +952,7 @@ async fn test_evaluate_feature_flags_with_overrides() {
                 }]),
                 rollout_percentage: Some(100.0),
                 variant: None,
+                ..Default::default()
             }],
             multivariate: None,
             aggregation_group_type_index: Some(0),
@@ -1054,6 +1061,7 @@ async fn test_long_distinct_id() {
                 properties: Some(vec![]),
                 rollout_percentage: Some(100.0),
                 variant: None,
+                ..Default::default()
             }],
             multivariate: None,
             aggregation_group_type_index: None,
@@ -1513,6 +1521,7 @@ async fn test_parallel_path_matches_sequential_results() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1539,6 +1548,7 @@ async fn test_parallel_path_matches_sequential_results() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(0.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1565,6 +1575,7 @@ async fn test_parallel_path_matches_sequential_results() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,
@@ -1591,6 +1602,7 @@ async fn test_parallel_path_matches_sequential_results() {
                     properties: Some(vec![]),
                     rollout_percentage: Some(100.0),
                     variant: None,
+                    ..Default::default()
                 }],
                 multivariate: None,
                 aggregation_group_type_index: None,

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -1328,6 +1328,7 @@ fn create_flag_with_deps(
             properties: Some(vec![]),
             rollout_percentage: Some(100.0),
             variant: None,
+            ..Default::default()
         }],
         multivariate: None,
         aggregation_group_type_index: None,

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -807,6 +807,7 @@ pub fn create_test_flag(
                 properties: Some(vec![]),
                 rollout_percentage: Some(100.0),
                 variant: None,
+                ..Default::default()
             }],
             multivariate: None,
             aggregation_group_type_index: None,
@@ -878,6 +879,7 @@ pub fn create_test_flag_with_properties(
                 properties: Some(filters),
                 rollout_percentage: Some(100.0),
                 variant: None,
+                ..Default::default()
             }],
             multivariate: None,
             aggregation_group_type_index: None,


### PR DESCRIPTION
## Problem

The feature flags system needs to support per-condition-set aggregation types to enable more flexible targeting. Currently, `aggregation_group_type_index` only exists at the flag level, but we need it at the condition set level to eventually support mixed person/group targeting within a single flag.

This PR adds the field to the Rust models as the first step in a stack of changes.

## Changes

- Add `aggregation_group_type_index: Option<i32>` field to `FlagPropertyGroup` struct with `#[serde(default)]` for backward-compatible deserialization
- Update all 148 `FlagPropertyGroup` struct literals across 11 files to use `..Default::default()` pattern, which:
  - Fixes compile errors from the new required field
  - Future-proofs against additional field additions

## How did you test this code?

- Verified syntax with `rustfmt --check`
- The struct already derives `Default`, so the `..Default::default()` pattern is valid
- This is an additive change with no behavior modification — the field defaults to `None` which maintains existing behavior

## Publish to changelog?

No

## 🤖 LLM context

This PR was co-authored with Claude. Part of a 4-PR stack to add per-condition-set aggregation support to feature flags.