### PR TITLE
fix: hide side panel offramp banner for organizations created after panel removal

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelOfframpLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelOfframpLogic.ts
@@ -1,7 +1,12 @@
 import { actions, kea, listeners, path, reducers, selectors } from 'kea'
 import posthog from 'posthog-js'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { OrganizationType } from '~/types'
 
 import type { sidePanelOfframpLogicType } from './sidePanelOfframpLogicType'
+
+// Organizations created after this date never had the old right-hand side panel, removed by #48326
+const SIDE_PANEL_REMOVAL_DATE = new Date('2026-02-19')
 
 export const sidePanelOfframpLogic = kea<sidePanelOfframpLogicType>([
     path(['layout', 'navigation-3000', 'sidepanel', 'sidePanelOfframpLogic']),
@@ -31,6 +36,14 @@ export const sidePanelOfframpLogic = kea<sidePanelOfframpLogicType>([
         shouldShowOfframpModal: [
             (s) => [s.isOfframpModalVisible],
             (isOfframpModalVisible): boolean => isOfframpModalVisible,
+        ],
+        isOrganizationCreatedAfterPanelRemoval: [
+            () => [organizationLogic.selectors.currentOrganization],
+            (currentOrganization: OrganizationType | null): boolean => {
+                return currentOrganization?.created_at
+                    ? new Date(currentOrganization.created_at) > SIDE_PANEL_REMOVAL_DATE
+                    : false
+            },
         ],
     }),
     listeners({

--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -38,7 +38,7 @@ export function SceneTabs(): JSX.Element {
     const { isLayoutNavbarVisibleForMobile } = useValues(panelLayoutLogic)
     const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
     const { showOfframpModal } = useActions(sidePanelOfframpLogic)
-    const { isSceneTabsOfframpDismissed } = useValues(sidePanelOfframpLogic)
+    const { isSceneTabsOfframpDismissed, isOrganizationCreatedAfterPanelRemoval } = useValues(sidePanelOfframpLogic)
 
     const handleDragEnd = ({ active, over }: DragEndEvent): void => {
         if (!over || over.id === 'new' || active.id === over.id) {
@@ -138,7 +138,7 @@ export function SceneTabs(): JSX.Element {
                             </Link>
                         </AppShortcut>
 
-                        {!isSceneTabsOfframpDismissed && (
+                        {!isSceneTabsOfframpDismissed && !isOrganizationCreatedAfterPanelRemoval && (
                             <ButtonPrimitive
                                 onClick={() => {
                                     showOfframpModal()


### PR DESCRIPTION
## Problem

Organizations created after the side panel was removed (2026-02-18, #48326) still see the offramp banner in the scene tabs, even though they never had the old side panel. This causes confusion and means the onboarding experience is not as good as it could be

## Changes

- Added an isOrganizationCreatedAfterPanelRemoval selector to sidePanelOfframpLogic that checks the organization's created_at date against the panel removal date
- Skip rendering the offramp banner in SceneTabs for these organizations

Closes issue #51404