### PR TITLE
chore(auth): document all-access scope usage in setup_local_api_key

### DIFF
--- a/posthog/management/commands/setup_local_api_key.py
+++ b/posthog/management/commands/setup_local_api_key.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             "--scopes",
             nargs="*",
             default=None,
-            help="Scopes to grant (e.g. --scopes llm_gateway:read project:read). Omit for no scopes.",
+            help='Scopes to grant (e.g. --scopes llm_gateway:read project:read). Use --scopes "*" for all-access. Omit for no scopes.',
         )
         parser.add_argument(
             "--add-scopes",

--- a/posthog/management/commands/setup_local_api_key.py
+++ b/posthog/management/commands/setup_local_api_key.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
             elif scopes is not None and existing_key.scopes != scopes:
                 existing_key.scopes = scopes or None
                 existing_key.save(update_fields=["scopes"])
-                print(f"Updated scopes to {scopes} for user '{existing_key.user.email}'")
+                print(f"Updated scopes to {existing_key.scopes} for user '{existing_key.user.email}'")
             else:
                 print(f"API key already exists for user '{existing_key.user.email}'")
             print(f"Key: {DEV_API_KEY}")


### PR DESCRIPTION
## Problem

After #51237, `scopes=NULL` means no access for PersonalAPIKey. The `setup_local_api_key` help text doesn't document how to grant all-access via the CLI (`--scopes "*"`).

## Changes

Update the `--scopes` help text to document `--scopes "*"` for all-access.

## How did you test this code?

Help text change only. `--scopes "*"` already works with the existing argparse `nargs="*"` config — it produces `["*"]` which flows through correctly.

## Publish to changelog?

No