### PR TITLE
feat: restore billing fetch for dynamic service descriptions and clean up service IDs

### DIFF
--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -1,11 +1,71 @@
+import time
+
+from unittest.mock import MagicMock, patch
+
 from django.test import override_settings
 
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
+from ee.api.agentic_provisioning.views import SERVICES_CACHE_EXPIRES_KEY, SERVICES_CACHE_KEY
+
+MOCK_BILLING_PRODUCTS = {
+    "products": [
+        {
+            "type": "product_analytics",
+            "name": "Product analytics",
+            "headline": "Product analytics with autocapture",
+            "plans": [
+                {"plan_key": "free-20230117", "price_id": None},
+                {"plan_key": "paid-20240404", "price_id": "price_1PMG1IEuIatRXSdzht4rGlho"},
+            ],
+        },
+        {
+            "type": "session_replay",
+            "name": "Session replay",
+            "headline": "Watch how users experience your app",
+            "plans": [
+                {"plan_key": "free-20231218", "price_id": None},
+                {"plan_key": "paid-20240402-5k-free", "price_id": "price_1P1EZoEuIatRXSdzakl5PcUF"},
+            ],
+        },
+        {
+            "type": "platform_and_support",
+            "name": "Platform and support",
+            "inclusion_only": True,
+            "plans": [{"plan_key": "free-20230117", "price_id": None}],
+        },
+    ]
+}
+
+
+def _mock_billing_response():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = MOCK_BILLING_PRODUCTS
+    mock_resp.raise_for_status.return_value = None
+    return mock_resp
+
+
+def _mock_cache_empty():
+    mock = MagicMock()
+    mock.get.return_value = None
+    return mock
+
+
+def _mock_cache_fresh(services):
+    store = {
+        SERVICES_CACHE_KEY: services,
+        SERVICES_CACHE_EXPIRES_KEY: time.time() + 3600,
+    }
+    mock = MagicMock()
+    mock.get.side_effect = lambda key: store.get(key)
+    return mock
 
 
 @override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
 class TestProvisioningServices(StripeProvisioningTestBase):
-    def test_returns_three_services(self):
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_returns_three_services(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         data = res.json()
@@ -13,25 +73,40 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         assert len(services) == 3
         assert data["next_cursor"] == ""
 
-    def test_free_plan(self):
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_free_plan(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         free = res.json()["data"][0]
         assert free["id"] == "free"
         assert free["kind"] == "plan"
         assert free["pricing"]["type"] == "free"
 
-    def test_pay_as_you_go_plan(self):
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_pay_as_you_go_plan(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         paid = res.json()["data"][1]
         assert paid["id"] == "pay_as_you_go"
         assert paid["kind"] == "plan"
         assert paid["pricing"]["type"] == "paid"
 
-    def test_analytics_deployable(self):
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_analytics_deployable_description_from_billing(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         analytics = res.json()["data"][2]
         assert analytics["id"] == "analytics"
         assert analytics["kind"] == "deployable"
+        assert "product analytics" in analytics["description"]
+        assert "session replay" in analytics["description"]
+        assert "platform and support" not in analytics["description"].lower()
+
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_analytics_deployable_structure(self, mock_cache, mock_get):
+        res = self._get_signed("/api/agentic/provisioning/services")
+        analytics = res.json()["data"][2]
         assert analytics["pricing"]["type"] == "component"
         options = analytics["pricing"]["component"]["options"]
         assert len(options) == 2
@@ -40,7 +115,21 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         assert options[1]["parent_service_ids"] == ["pay_as_you_go"]
         assert options[1]["type"] == "paid"
 
-    def test_all_services_have_categories(self):
+    @patch("ee.api.agentic_provisioning.views.requests.get")
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_billing_failure_returns_fallback(self, mock_cache, mock_get):
+        mock_get.side_effect = Exception("connection error")
+        res = self._get_signed("/api/agentic/provisioning/services")
+        assert res.status_code == 200
+        data = res.json()["data"]
+        assert len(data) == 3
+        assert data[0]["id"] == "free"
+        assert data[2]["id"] == "analytics"
+        assert "PostHog" in data[2]["description"]
+
+    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
+    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
+    def test_all_services_have_categories(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         for service in res.json()["data"]:
             assert "analytics" in service["categories"]

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -112,9 +112,6 @@ ANALYTICS_DEPLOYABLE_SERVICE: dict[str, Any] = {
     "kind": "deployable",
 }
 
-# For backwards compat, POSTHOG_SERVICE_ID is the deployable that gets provisioned
-POSTHOG_SERVICE_ID = ANALYTICS_SERVICE_ID
-
 
 def _get_services() -> list[dict[str, Any]]:
     return [FREE_PLAN_SERVICE, PAY_AS_YOU_GO_PLAN_SERVICE, ANALYTICS_DEPLOYABLE_SERVICE]
@@ -593,7 +590,7 @@ def provisioning_resources_create(request: Request) -> Response:
     except Team.DoesNotExist:
         return _error_response("team_not_found", "Team not found", resource_id=str(team_id), status=404)
 
-    resolved_service_id = service_id or POSTHOG_SERVICE_ID
+    resolved_service_id = service_id or ANALYTICS_SERVICE_ID
     cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", resolved_service_id, timeout=None)
 
     region = get_instance_region() or "US"
@@ -670,7 +667,7 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
             "credential_rotation_failed", "Failed to rotate credentials", resource_id=resource_id, status=500
         )
 
-    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or POSTHOG_SERVICE_ID
+    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or ANALYTICS_SERVICE_ID
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 
@@ -732,7 +729,7 @@ def _resolve_resource_response(request: Request, resource_id: str) -> Response:
             status=404,
         )
 
-    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or POSTHOG_SERVICE_ID
+    service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or ANALYTICS_SERVICE_ID
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import time
 import secrets
 from datetime import timedelta
 from typing import Any, cast
@@ -15,6 +16,7 @@ from django.http import HttpResponseRedirect
 from django.http.response import HttpResponseBase
 from django.utils import timezone
 
+import requests
 import structlog
 import posthoganalytics
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
@@ -30,6 +32,8 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.utils import generate_random_oauth_access_token, generate_random_oauth_refresh_token
 from posthog.utils import get_instance_region
+
+from ee.settings import BILLING_SERVICE_URL
 
 from . import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX, RESOURCE_SERVICE_CACHE_PREFIX
 from .region_proxy import stripe_region_proxy
@@ -67,6 +71,14 @@ ANALYTICS_SERVICE_ID = "analytics"
 
 ALL_CATEGORIES: list[str] = ["analytics", "feature_flags", "ai"]
 
+SERVICES_CACHE_KEY = "agentic_provisioning:services"
+SERVICES_CACHE_TTL = 3600
+SERVICES_CACHE_RETRY_TTL = 300
+SERVICES_CACHE_EXPIRES_KEY = "agentic_provisioning:services:expires_at"
+SERVICES_CACHE_STORE_TTL = 86400
+
+_EXCLUDED_PRODUCT_TYPES = {"platform_and_support", "integrations"}
+
 FREE_PLAN_SERVICE: dict[str, Any] = {
     "id": FREE_PLAN_ID,
     "description": "Free — generous free tier across all PostHog products, no credit card required.",
@@ -86,35 +98,85 @@ PAY_AS_YOU_GO_PLAN_SERVICE: dict[str, Any] = {
     "kind": "plan",
 }
 
-ANALYTICS_DEPLOYABLE_SERVICE: dict[str, Any] = {
-    "id": ANALYTICS_SERVICE_ID,
-    "description": "PostHog — product analytics, session replay, feature flags, A/B testing, surveys, and more.",
-    "categories": ALL_CATEGORIES,
-    "pricing": {
-        "type": "component",
-        "component": {
-            "options": [
-                {
-                    "parent_service_ids": [FREE_PLAN_ID],
-                    "type": "free",
-                },
-                {
-                    "parent_service_ids": [PAY_AS_YOU_GO_PLAN_ID],
-                    "type": "paid",
-                    "paid": {
-                        "type": "freeform",
-                        "freeform": "Usage-based pricing",
+_FALLBACK_DESCRIPTION = "PostHog — product analytics, session replay, feature flags, A/B testing, surveys, and more."
+
+
+def _build_analytics_service(description: str) -> dict[str, Any]:
+    return {
+        "id": ANALYTICS_SERVICE_ID,
+        "description": description,
+        "categories": ALL_CATEGORIES,
+        "pricing": {
+            "type": "component",
+            "component": {
+                "options": [
+                    {
+                        "parent_service_ids": [FREE_PLAN_ID],
+                        "type": "free",
                     },
-                },
-            ]
+                    {
+                        "parent_service_ids": [PAY_AS_YOU_GO_PLAN_ID],
+                        "type": "paid",
+                        "paid": USAGE_BASED_PRICING,
+                    },
+                ]
+            },
         },
-    },
-    "kind": "deployable",
-}
+        "kind": "deployable",
+    }
+
+
+def _fetch_services_from_billing() -> list[dict[str, Any]] | None:
+    """Fetch product catalog from billing and build the service list."""
+    try:
+        res = requests.get(
+            f"{BILLING_SERVICE_URL}/api/products-v2",
+            params={"plan": "standard"},
+        )
+        res.raise_for_status()
+        products = res.json().get("products", [])
+    except Exception:
+        logger.exception("agentic_provisioning.services.billing_fetch_failed")
+        return None
+
+    product_names = [
+        p.get("name", "")
+        for p in products
+        if p.get("type", "") not in _EXCLUDED_PRODUCT_TYPES and not p.get("inclusion_only")
+    ]
+    description = f"PostHog — {', '.join(n for n in product_names if n).lower()}, and more."
+
+    return [
+        FREE_PLAN_SERVICE,
+        PAY_AS_YOU_GO_PLAN_SERVICE,
+        _build_analytics_service(description),
+    ]
 
 
 def _get_services() -> list[dict[str, Any]]:
-    return [FREE_PLAN_SERVICE, PAY_AS_YOU_GO_PLAN_SERVICE, ANALYTICS_DEPLOYABLE_SERVICE]
+    cached = cache.get(SERVICES_CACHE_KEY)
+    expires_at = cache.get(SERVICES_CACHE_EXPIRES_KEY)
+
+    now = time.time()
+    if cached is not None and expires_at is not None and now < expires_at:
+        return cached
+
+    services = _fetch_services_from_billing()
+    if services is not None:
+        cache.set(SERVICES_CACHE_KEY, services, SERVICES_CACHE_STORE_TTL)
+        cache.set(SERVICES_CACHE_EXPIRES_KEY, now + SERVICES_CACHE_TTL, SERVICES_CACHE_STORE_TTL)
+        return services
+
+    if cached is not None:
+        logger.warning("agentic_provisioning.services.serving_stale_cache")
+        cache.set(SERVICES_CACHE_EXPIRES_KEY, now + SERVICES_CACHE_RETRY_TTL, SERVICES_CACHE_STORE_TTL)
+        return cached
+
+    logger.warning("agentic_provisioning.services.no_cache_fallback")
+    fallback = [FREE_PLAN_SERVICE, PAY_AS_YOU_GO_PLAN_SERVICE, _build_analytics_service(_FALLBACK_DESCRIPTION)]
+    cache.set(SERVICES_CACHE_KEY, fallback, SERVICES_CACHE_RETRY_TTL)
+    cache.set(SERVICES_CACHE_EXPIRES_KEY, now + SERVICES_CACHE_RETRY_TTL, SERVICES_CACHE_RETRY_TTL)
+    return fallback
 
 
 VALID_SERVICE_IDS: set[str] = {FREE_PLAN_ID, PAY_AS_YOU_GO_PLAN_ID, ANALYTICS_SERVICE_ID}


### PR DESCRIPTION
## Problem

1. The services catalog used a hardcoded description for the analytics service instead of dynamically fetching product names from billing
2. `POSTHOG_SERVICE_ID` was a backwards-compat alias for `ANALYTICS_SERVICE_ID` that added confusion

## Changes

- Fetches product catalog from billing service to build a dynamic description for the analytics service (with caching and fallback)
- Removes the `POSTHOG_SERVICE_ID` alias and uses `ANALYTICS_SERVICE_ID` directly everywhere
- Uses `USAGE_BASED_PRICING` constant for freeform pricing

## How did you test this code

Services endpoint verified against production. Billing fetch tested with fallback to hardcoded description when billing is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)