### PR TITLE
fix(dwh): prevent SSL cert permission error in SQL editor postgres connections

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -456,14 +456,16 @@ class HogQLQueryExecutor:
                         "connect_timeout": DIRECT_POSTGRES_CONNECT_TIMEOUT_SECONDS,
                         "sslmode": _get_sslmode(require_ssl),
                         "options": f"-c default_transaction_read_only=on -c statement_timeout={statement_timeout_ms}",
+                        # Prevent libpq from probing ~/.postgresql/ for client certs,
+                        # which fails with "Permission denied" in containers where
+                        # $HOME is /root/ but the process runs as a non-root user.
+                        "sslcert": "/tmp/no.txt",
+                        "sslkey": "/tmp/no.txt",
+                        "sslrootcert": "/tmp/no.txt",
                     }
                     if host.endswith(".us.postwh.com"):
                         # DuckLake hosts require SSL but do not use certificate-based auth.
-                        # Override sslmode to "require" (encrypt without cert verification).
                         connection_kwargs["sslmode"] = "require"
-                        connection_kwargs["sslcert"] = "/tmp/no.txt"
-                        connection_kwargs["sslkey"] = "/tmp/no.txt"
-                        connection_kwargs["sslrootcert"] = "/tmp/no.txt"
 
                     with psycopg.connect(**connection_kwargs) as connection:
                         with connection.cursor() as cursor:


### PR DESCRIPTION
## Summary

- Fixes "could not open certificate file `/root/.postgresql/postgresql.crt`: Permission denied" when connecting to external Postgres sources via the SQL editor
- libpq automatically probes `~/.postgresql/` for client certs when `sslmode` is `prefer` or `require`. In containers where `$HOME=/root/` but the process runs as non-root, this fails with a permission error
- The data imports code (`posthog/temporal/data_imports/sources/postgres/postgres.py`) already sets `sslcert`/`sslkey`/`sslrootcert` to dummy paths on every connection, but the SQL editor's direct query path in `posthog/hogql/query.py` only did this for DuckLake hosts (`.us.postwh.com`)
- Moves the SSL cert overrides into the base connection kwargs so they apply to all connections

## Test plan

- [ ] Connect to an external Postgres source via the SQL editor and verify the connection succeeds without the certificate permission error
- [ ] Verify DuckLake connections still work (they still get `sslmode=require` override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)