### PR TITLE
fix(dwh): whitelist postwh.com hosts from internal IP check

### DIFF
--- a/posthog/temporal/data_imports/sources/common/mixins.py
+++ b/posthog/temporal/data_imports/sources/common/mixins.py
@@ -32,6 +32,11 @@ def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
         return True, None
 
     normalized = host.lower().strip().rstrip(".")
+
+    # PostHog-managed DuckLake hosts resolve to internal IPs but are safe.
+    if normalized.endswith(".postwh.com"):
+        return True, None
+
     if normalized in {"localhost"}:
         return False, "Hosts with internal IP addresses are not allowed"
 

--- a/posthog/temporal/data_imports/sources/common/test_mixins.py
+++ b/posthog/temporal/data_imports/sources/common/test_mixins.py
@@ -56,6 +56,27 @@ class TestIsHostSafe(SimpleTestCase):
         valid, _ = _is_host_safe("10.0.0.1", team_id=1)
         assert valid
 
+    @parameterized.expand(
+        [
+            ("postwh_us", "entirely-chief-wildcat.us.postwh.com"),
+            ("postwh_eu", "my-db.eu.postwh.com"),
+            ("postwh_bare", "something.postwh.com"),
+        ]
+    )
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_allows_postwh_hosts(self, _name: str, host: str):
+        valid, _ = _is_host_safe(host, team_id=999)
+        assert valid
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_blocks_fake_postwh_suffix(self):
+        with patch(
+            "posthog.temporal.data_imports.sources.common.mixins.socket.getaddrinfo",
+            return_value=[(None, None, None, None, ("10.0.0.1", 0))],
+        ):
+            valid, error = _is_host_safe("evil.postwh.com.evil.example.com", team_id=999)
+            assert not valid
+
     @override_settings(CLOUD_DEPLOYMENT="US")
     def test_dns_resolving_to_internal_ip_blocked(self):
         with patch(


### PR DESCRIPTION
## Summary

- DuckLake hosts (`*.postwh.com`) resolve to internal/private IPs but are PostHog-managed and safe to connect to
- Adding a postgres source with a `postwh.com` hostname (e.g. `entirely-chief-wildcat.us.postwh.com`) was failing with "Hosts with internal IP addresses are not allowed" because DNS resolution returned private addresses
- Adds a whitelist check in `_is_host_safe()` for hostnames ending in `.postwh.com`, which is the shared codepath used by both the SQL editor source creation (`posthog/hogql/direct_connection.py`) and the temporal data imports pipeline

## Test plan

- [x] Added parameterized tests for various `postwh.com` subdomains (US, EU, bare)
- [x] Added test confirming fake suffixes like `evil.postwh.com.evil.example.com` are still blocked
- [x] All 34 mixin tests pass
- [ ] Manually verify adding a `*.postwh.com` postgres source in the SQL editor succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)