### PR TITLE
fix: use freeform pricing type in services catalog

### DIFF
--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -77,7 +77,8 @@ PAY_AS_YOU_GO_PLAN_SERVICE: dict[str, Any] = {
     "pricing": {
         "type": "paid",
         "paid": {
-            "type": "custom",
+            "type": "freeform",
+            "freeform": "Usage-based pricing",
         },
     },
     "kind": "plan",
@@ -99,7 +100,8 @@ ANALYTICS_DEPLOYABLE_SERVICE: dict[str, Any] = {
                     "parent_service_ids": [PAY_AS_YOU_GO_PLAN_ID],
                     "type": "paid",
                     "paid": {
-                        "type": "custom",
+                        "type": "freeform",
+                        "freeform": "Usage-based pricing",
                     },
                 },
             ]

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -58,6 +58,7 @@ ACCESS_TOKEN_EXPIRY_SECONDS = 365 * 24 * 3600
 
 FREE_PLAN_ID = "free"
 PAY_AS_YOU_GO_PLAN_ID = "pay_as_you_go"
+USAGE_BASED_PRICING = {"type": "freeform", "freeform": "Usage-based pricing"}
 ANALYTICS_SERVICE_ID = "analytics"
 
 ALL_CATEGORIES: list[str] = ["analytics", "feature_flags", "ai"]
@@ -76,10 +77,7 @@ PAY_AS_YOU_GO_PLAN_SERVICE: dict[str, Any] = {
     "categories": ALL_CATEGORIES,
     "pricing": {
         "type": "paid",
-        "paid": {
-            "type": "freeform",
-            "freeform": "Usage-based pricing",
-        },
+        "paid": USAGE_BASED_PRICING,
     },
     "kind": "plan",
 }


### PR DESCRIPTION
## Problem

Stripe's services sync rejects `"type": "custom"` as a paid pricing type. The [APP spec](https://github.com/agentic-provisioning/posthog-spec/blob/master/spec.md) defines valid types as `"freeform"` or `"stripe_price"`.

Error from Stripe: `"Provider paid pricing type is invalid: custom"`

## Changes

Changed `"type": "custom"` to `"type": "freeform", "freeform": "Usage-based pricing"` in both the pay_as_you_go plan and the analytics deployable component pricing.

## How did you test this code

Verified the current services endpoint returns the updated pricing format. Stripe confirmed the sync was failing with the "custom" type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)