### PR TITLE
feat(experiments): funnel step validations

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -23,7 +23,6 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
 from posthog.approvals.mixins import ApprovalHandlingMixin
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
-from posthog.hogql_queries.experiments.funnel_validation import FunnelDWValidator
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -23,6 +23,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
 from posthog.approvals.mixins import ApprovalHandlingMixin
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
+from posthog.hogql_queries.experiments.funnel_validation import FunnelDWValidator
 from posthog.hogql_queries.experiments.utils import get_experiment_stats_method
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -285,30 +285,42 @@ class ExperimentQueryBuilder:
     def _build_funnel_query(self) -> ast.SelectQuery:
         """
         Builds query for funnel metrics.
+
+        Supports two patterns:
+        1. Events-only: Single query with boolean step columns
+        2. With DW steps: UNION ALL pattern with separate subqueries per source
         """
         assert isinstance(self.metric, ExperimentFunnelMetric)
 
         num_steps = len(self.metric.series) + 1  #  +1 as we are including exposure criteria
 
-        session_id_column = (
-            """
-                        properties.$session_id AS session_id,"""
-            if not self.funnel_steps_data_disabled
-            else ""
-        )
 
-        metric_events_cte_str = f"""
-                metric_events AS (
-                    SELECT
-                        {{entity_key}} AS entity_id,
-                        {{variant_property}} as variant,
-                        timestamp,
-                        uuid,{session_id_column}
-                        -- step_0, step_1, ... step_N columns added programmatically below
-                    FROM events
-                    WHERE ({{exposure_predicate}} OR {{funnel_steps_filter}})
-                )
-        """
+        # Determine which query pattern to use
+        has_dw_steps = self._has_datawarehouse_steps()
+
+        if has_dw_steps:
+            # UNION ALL pattern for heterogeneous sources
+            metric_events_cte_str = self._build_funnel_metric_events_cte_with_union()
+        else:
+            session_id_column = (
+                """
+                            properties.$session_id AS session_id,"""
+                if not self.funnel_steps_data_disabled
+                else ""
+            )
+
+            metric_events_cte_str = f"""
+                    metric_events AS (
+                        SELECT
+                            {{entity_key}} AS entity_id,
+                            {{variant_property}} as variant,
+                            timestamp,
+                            uuid,{session_id_column}
+                            -- step_0, step_1, ... step_N columns added programmatically below
+                        FROM events
+                        WHERE ({{exposure_predicate}} OR {{funnel_steps_filter}})
+                    )
+            """
 
         is_unordered_funnel = self.metric.funnel_order_type == StepOrderValue.UNORDERED
 
@@ -1505,6 +1517,39 @@ class ExperimentQueryBuilder:
         """
         return parse_expr(
             "mapFromArrays(groupArray(coalesce(toString(metric_events.uuid), '')), groupArray(coalesce(metric_events.timestamp, toDateTime(0))))"
+        )
+
+    def _has_datawarehouse_steps(self) -> bool:
+        """
+        Check if funnel metric has any datawarehouse steps.
+
+        Returns:
+            True if any step in the series is ExperimentDataWarehouseNode
+        """
+        assert isinstance(self.metric, ExperimentFunnelMetric)
+        return any(isinstance(step, ExperimentDataWarehouseNode) for step in self.metric.series)
+
+    def _build_funnel_metric_events_cte_with_union(self) -> str:
+        """
+        Build metric_events CTE using UNION ALL pattern for funnels with DW steps.
+
+        TODO: Full implementation requires:
+        1. Building step-specific filters for each subquery (event_or_action_to_filter for events, property filters for DW)
+        2. Building constant step columns for each subquery (using FunnelStepBuilder.build_constant_columns)
+        3. Handling timestamp filtering within conversion window
+        4. Ensuring all subqueries have compatible schema (entity_id as String, placeholder uuid/session_id for DW)
+
+        Pattern:
+        - Exposure subquery (step_0=1, others=0): SELECT FROM events WHERE exposure_predicate
+        - Each event/action step subquery (step_N=1, others=0): SELECT FROM events WHERE step_filter
+        - Each DW step subquery (step_N=1, others=0): SELECT FROM dw_table WHERE timestamp_filter AND property_filters
+
+        For now, raise NotImplementedError to prevent runtime errors.
+        """
+        raise NotImplementedError(
+            "UNION ALL pattern for datawarehouse funnel steps not yet fully implemented. "
+            "The abstractions (FunnelStepBuilder, MetricSourceInfo, FunnelDWValidator) are in place. "
+            "See experiment_query_builder.py:_build_funnel_metric_events_cte_with_union for implementation TODO."
         )
 
     def _build_retention_query(self) -> ast.SelectQuery:

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -294,7 +294,6 @@ class ExperimentQueryBuilder:
 
         num_steps = len(self.metric.series) + 1  #  +1 as we are including exposure criteria
 
-
         # Determine which query pattern to use
         has_dw_steps = self._has_datawarehouse_steps()
 

--- a/posthog/hogql_queries/experiments/funnel_validation.py
+++ b/posthog/hogql_queries/experiments/funnel_validation.py
@@ -1,0 +1,215 @@
+"""
+Datawarehouse funnel validation utilities.
+
+This module provides validation for datawarehouse funnel configurations,
+ensuring required fields are present, join keys are consistent, and
+complexity limits are enforced before query execution.
+"""
+
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import ExperimentDataWarehouseNode, ExperimentFunnelMetric
+
+
+class FunnelDWValidator:
+    """
+    Validates datawarehouse funnel configuration.
+
+    Provides clear, actionable error messages for common DW funnel
+    misconfigurations before expensive query execution.
+
+    All methods are static as validation is stateless - operates only
+    on the provided metric configuration.
+    """
+
+    # Complexity limits to prevent expensive queries
+    MAX_DW_STEPS = 3
+    MAX_DISTINCT_DW_TABLES = 2
+
+    @staticmethod
+    def validate_required_fields(node: ExperimentDataWarehouseNode, step_index: int) -> list[str]:
+        """
+        Validate DW node has all required fields.
+
+        Args:
+            node: The datawarehouse node to validate
+            step_index: Step number in funnel (1-based for error messages)
+
+        Returns:
+            List of error messages (empty if valid)
+
+        Example:
+            >>> errors = FunnelDWValidator.validate_required_fields(node, 2)
+            >>> if errors:
+            ...     raise ValidationError({"datawarehouse_configuration": errors})
+        """
+        errors = []
+
+        if not node.table_name:
+            errors.append(f"Step {step_index}: table_name is required to identify the datawarehouse table")
+
+        if not node.timestamp_field:
+            errors.append(
+                f"Step {step_index}: timestamp_field is required for time-based filtering "
+                "(e.g., 'created_at', 'purchase_date')"
+            )
+
+        if not node.data_warehouse_join_key:
+            errors.append(
+                f"Step {step_index}: data_warehouse_join_key is required to join with events "
+                "(e.g., 'user_id', 'customer_id')"
+            )
+
+        if not node.events_join_key:
+            errors.append(
+                f"Step {step_index}: events_join_key is required to specify the field in PostHog events "
+                "(e.g., 'properties.$user_id', 'distinct_id')"
+            )
+
+        return errors
+
+    @staticmethod
+    def validate_consistent_join_keys(metric: ExperimentFunnelMetric) -> dict[str, str] | None:
+        """
+        Validate all DW steps use the same events_join_key.
+
+        This is a current limitation that simplifies the UNION ALL query pattern.
+        All DW steps must join to events using the same field.
+
+        Args:
+            metric: The funnel metric to validate
+
+        Returns:
+            Dictionary with error key and message if invalid, None if valid
+
+        Example:
+            >>> error = FunnelDWValidator.validate_consistent_join_keys(metric)
+            >>> if error:
+            ...     raise ValidationError(error)
+        """
+        dw_steps = [
+            (i + 1, step) for i, step in enumerate(metric.series) if isinstance(step, ExperimentDataWarehouseNode)
+        ]
+
+        if len(dw_steps) <= 1:
+            # 0 or 1 DW steps - no consistency to check
+            return None
+
+        # Collect all unique events_join_keys
+        join_keys: dict[str, list[int]] = {}
+        for step_index, step in dw_steps:
+            join_key = step.events_join_key
+            if join_key not in join_keys:
+                join_keys[join_key] = []
+            join_keys[join_key].append(step_index)
+
+        if len(join_keys) > 1:
+            # Multiple different join keys - build helpful error message
+            error_lines = ["All datawarehouse steps must use the same join key to events.\n"]
+
+            for join_key, step_indices in join_keys.items():
+                steps_str = ", ".join(f"Step {idx}" for idx in step_indices)
+                error_lines.append(f"{steps_str} use: {join_key}")
+
+            error_lines.append("\nPlease ensure all DW steps join on the same field.")
+
+            return {"join_key_mismatch": "\n".join(error_lines)}
+
+        return None
+
+    @staticmethod
+    def validate_complexity_limits(metric: ExperimentFunnelMetric) -> dict[str, str] | None:
+        """
+        Enforce complexity limits to prevent expensive queries.
+
+        Limits:
+        - Max 3 DW steps per funnel (reduces UNION ALL query size)
+        - Max 2 distinct DW tables per funnel (limits join complexity)
+
+        Args:
+            metric: The funnel metric to validate
+
+        Returns:
+            Dictionary with error key and message if limit exceeded, None if valid
+
+        Example:
+            >>> error = FunnelDWValidator.validate_complexity_limits(metric)
+            >>> if error:
+            ...     raise ValidationError(error)
+        """
+        dw_steps = [step for step in metric.series if isinstance(step, ExperimentDataWarehouseNode)]
+
+        # Check max DW steps
+        if len(dw_steps) > FunnelDWValidator.MAX_DW_STEPS:
+            return {
+                "complexity_limit": (
+                    f"Too many datawarehouse steps: {len(dw_steps)} "
+                    f"(maximum: {FunnelDWValidator.MAX_DW_STEPS}).\n\n"
+                    "Datawarehouse steps create expensive UNION queries. "
+                    "Consider using fewer DW steps or creating a materialized view "
+                    "that combines your DW tables."
+                )
+            }
+
+        # Check max distinct tables
+        distinct_tables = {step.table_name for step in dw_steps}
+        if len(distinct_tables) > FunnelDWValidator.MAX_DISTINCT_DW_TABLES:
+            table_list = ", ".join(f"'{table}'" for table in sorted(distinct_tables))
+            return {
+                "complexity_limit": (
+                    f"Too many distinct datawarehouse tables: {len(distinct_tables)} "
+                    f"(maximum: {FunnelDWValidator.MAX_DISTINCT_DW_TABLES}).\n\n"
+                    f"Tables used: {table_list}\n\n"
+                    "Multiple DW tables increase join complexity. "
+                    "Consider using a single table or creating a view that joins them."
+                )
+            }
+
+        return None
+
+    @classmethod
+    def validate_funnel_metric(cls, metric: ExperimentFunnelMetric) -> None:
+        """
+        Run all validations on a funnel metric.
+
+        This is the main entry point - call before building queries for DW funnels.
+
+        Args:
+            metric: The funnel metric to validate
+
+        Raises:
+            ValidationError: If any validation fails, with detailed error messages
+
+        Example:
+            >>> try:
+            ...     FunnelDWValidator.validate_funnel_metric(metric)
+            ... except ValidationError as e:
+            ...     # Show error to user
+            ...     return Response(e.detail, status=400)
+        """
+        errors = {}
+
+        # 1. Validate required fields for each DW step
+        field_errors: list[str] = []
+        for i, step in enumerate(metric.series):
+            if isinstance(step, ExperimentDataWarehouseNode):
+                step_errors = cls.validate_required_fields(step, i + 1)
+                field_errors.extend(step_errors)
+
+        if field_errors:
+            errors["datawarehouse_configuration"] = field_errors
+            errors["help"] = "All DW steps need table name, timestamp field, and join keys configured."
+
+        # 2. Validate join key consistency
+        join_key_error = cls.validate_consistent_join_keys(metric)
+        if join_key_error:
+            errors.update(join_key_error)
+
+        # 3. Validate complexity limits
+        complexity_error = cls.validate_complexity_limits(metric)
+        if complexity_error:
+            errors.update(complexity_error)
+
+        # Raise if any errors found
+        if errors:
+            raise ValidationError(errors)

--- a/posthog/hogql_queries/experiments/funnel_validation.py
+++ b/posthog/hogql_queries/experiments/funnel_validation.py
@@ -204,31 +204,3 @@ class FunnelDWValidator:
             "Datawarehouse funnel steps are not yet supported. This feature is under active development."
         )
         raise ValidationError(errors)
-
-        # The code below will be re-enabled once UNION ALL query building is complete
-        # ---
-        # field_errors: list[str] = []
-        # for i, step in enumerate(metric.series):
-        #     if isinstance(step, ExperimentDataWarehouseNode):
-        #         step_errors = cls.validate_required_fields(step, i + 1)
-        #         field_errors.extend(step_errors)
-        #
-        # if field_errors:
-        #     errors["datawarehouse_configuration"] = field_errors
-        #     errors["help"] = "All DW steps need table name, timestamp field, and join keys configured."
-        #     # Early return - downstream checks are unreliable with missing fields
-        #     raise ValidationError(errors)
-        #
-        # # 2. Validate join key consistency
-        # join_key_error = cls.validate_consistent_join_keys(metric)
-        # if join_key_error:
-        #     errors.update(join_key_error)
-        #
-        # # 3. Validate complexity limits
-        # complexity_error = cls.validate_complexity_limits(metric)
-        # if complexity_error:
-        #     errors.update(complexity_error)
-        #
-        # # Raise if any errors found
-        # if errors:
-        #     raise ValidationError(errors)

--- a/posthog/hogql_queries/experiments/funnel_validation.py
+++ b/posthog/hogql_queries/experiments/funnel_validation.py
@@ -198,9 +198,29 @@ class FunnelDWValidator:
         if not has_dw_steps:
             return
 
-        # Block DW funnels entirely until implementation is complete
-        # This prevents valid DW configurations from hitting NotImplementedError at query time
-        errors["not_implemented"] = (
-            "Datawarehouse funnel steps are not yet supported. This feature is under active development."
-        )
-        raise ValidationError(errors)
+        # 1. Validate required fields for each DW step
+        field_errors: list[str] = []
+        for i, step in enumerate(metric.series):
+            if isinstance(step, ExperimentDataWarehouseNode):
+                step_errors = cls.validate_required_fields(step, i + 1)
+                field_errors.extend(step_errors)
+
+        if field_errors:
+            errors["datawarehouse_configuration"] = field_errors
+            errors["help"] = "All DW steps need table name, timestamp field, and join keys configured."
+            # Early return - downstream checks are unreliable with missing fields
+            raise ValidationError(errors)
+
+        # 2. Validate join key consistency
+        join_key_error = cls.validate_consistent_join_keys(metric)
+        if join_key_error:
+            errors.update(join_key_error)
+
+        # 3. Validate complexity limits
+        complexity_error = cls.validate_complexity_limits(metric)
+        if complexity_error:
+            errors.update(complexity_error)
+
+        # Raise if any errors found
+        if errors:
+            raise ValidationError(errors)

--- a/posthog/hogql_queries/experiments/funnel_validation.py
+++ b/posthog/hogql_queries/experiments/funnel_validation.py
@@ -191,7 +191,13 @@ class FunnelDWValidator:
         """
         errors: dict[str, Any] = {}
 
-        # 1. Validate required fields for each DW step
+        # Check if there are any DW steps
+        has_dw_steps = any(isinstance(step, ExperimentDataWarehouseNode) for step in metric.series)
+
+        # If no DW steps, no validation needed
+        if not has_dw_steps:
+            return
+
         # Block DW funnels entirely until implementation is complete
         # This prevents valid DW configurations from hitting NotImplementedError at query time
         errors["not_implemented"] = (

--- a/posthog/hogql_queries/experiments/funnel_validation.py
+++ b/posthog/hogql_queries/experiments/funnel_validation.py
@@ -192,26 +192,37 @@ class FunnelDWValidator:
         errors: dict[str, Any] = {}
 
         # 1. Validate required fields for each DW step
-        field_errors: list[str] = []
-        for i, step in enumerate(metric.series):
-            if isinstance(step, ExperimentDataWarehouseNode):
-                step_errors = cls.validate_required_fields(step, i + 1)
-                field_errors.extend(step_errors)
+        # Block DW funnels entirely until implementation is complete
+        # This prevents valid DW configurations from hitting NotImplementedError at query time
+        errors["not_implemented"] = (
+            "Datawarehouse funnel steps are not yet supported. This feature is under active development."
+        )
+        raise ValidationError(errors)
 
-        if field_errors:
-            errors["datawarehouse_configuration"] = field_errors
-            errors["help"] = "All DW steps need table name, timestamp field, and join keys configured."
-
-        # 2. Validate join key consistency
-        join_key_error = cls.validate_consistent_join_keys(metric)
-        if join_key_error:
-            errors.update(join_key_error)
-
-        # 3. Validate complexity limits
-        complexity_error = cls.validate_complexity_limits(metric)
-        if complexity_error:
-            errors.update(complexity_error)
-
-        # Raise if any errors found
-        if errors:
-            raise ValidationError(errors)
+        # The code below will be re-enabled once UNION ALL query building is complete
+        # ---
+        # field_errors: list[str] = []
+        # for i, step in enumerate(metric.series):
+        #     if isinstance(step, ExperimentDataWarehouseNode):
+        #         step_errors = cls.validate_required_fields(step, i + 1)
+        #         field_errors.extend(step_errors)
+        #
+        # if field_errors:
+        #     errors["datawarehouse_configuration"] = field_errors
+        #     errors["help"] = "All DW steps need table name, timestamp field, and join keys configured."
+        #     # Early return - downstream checks are unreliable with missing fields
+        #     raise ValidationError(errors)
+        #
+        # # 2. Validate join key consistency
+        # join_key_error = cls.validate_consistent_join_keys(metric)
+        # if join_key_error:
+        #     errors.update(join_key_error)
+        #
+        # # 3. Validate complexity limits
+        # complexity_error = cls.validate_complexity_limits(metric)
+        # if complexity_error:
+        #     errors.update(complexity_error)
+        #
+        # # Raise if any errors found
+        # if errors:
+        #     raise ValidationError(errors)

--- a/posthog/hogql_queries/experiments/funnel_validation.py
+++ b/posthog/hogql_queries/experiments/funnel_validation.py
@@ -6,6 +6,8 @@ ensuring required fields are present, join keys are consistent, and
 complexity limits are enforced before query execution.
 """
 
+from typing import Any
+
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import ExperimentDataWarehouseNode, ExperimentFunnelMetric
@@ -187,7 +189,7 @@ class FunnelDWValidator:
             ...     # Show error to user
             ...     return Response(e.detail, status=400)
         """
-        errors = {}
+        errors: dict[str, Any] = {}
 
         # 1. Validate required fields for each DW step
         field_errors: list[str] = []

--- a/posthog/hogql_queries/experiments/test/test_funnel_validation.py
+++ b/posthog/hogql_queries/experiments/test/test_funnel_validation.py
@@ -1,0 +1,513 @@
+"""
+Tests for FunnelDWValidator.
+
+Created by: Rodrigo
+Date: 2026-03-05
+
+NOTE: These tests use unittest.mock to bypass schema validation since
+ExperimentFunnelMetric.series doesn't yet support ExperimentDataWarehouseNode
+(that schema change happens in Phase 3). The validator logic is tested
+independently of schema validation.
+"""
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock
+
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import EventsNode, ExperimentDataWarehouseNode
+
+from posthog.hogql_queries.experiments.funnel_validation import FunnelDWValidator
+
+
+def create_mock_metric(series):
+    """
+    Create mock ExperimentFunnelMetric with given series.
+
+    This bypasses schema validation to allow testing with ExperimentDataWarehouseNode
+    before the schema is updated in Phase 3.
+    """
+    metric = MagicMock()
+    metric.series = series
+    return metric
+
+
+class TestFunnelDWValidator(BaseTest):
+    """Test FunnelDWValidator for DW funnel configuration validation."""
+
+    def test_validate_required_fields_all_present(self):
+        """Valid DW node with all required fields returns no errors."""
+        node = ExperimentDataWarehouseNode(
+            table_name="revenue_table",
+            timestamp_field="purchase_date",
+            data_warehouse_join_key="user_id",
+            events_join_key="properties.$user_id",
+        )
+
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=1)
+
+        assert errors == []
+
+    def test_validate_required_fields_missing_table_name(self):
+        """Missing table_name produces clear error."""
+        node = ExperimentDataWarehouseNode(
+            table_name="",  # Missing
+            timestamp_field="purchase_date",
+            data_warehouse_join_key="user_id",
+            events_join_key="properties.$user_id",
+        )
+
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=2)
+
+        assert len(errors) == 1
+        assert "Step 2" in errors[0]
+        assert "table_name is required" in errors[0]
+
+    def test_validate_required_fields_missing_timestamp_field(self):
+        """Missing timestamp_field produces clear error."""
+        node = ExperimentDataWarehouseNode(
+            table_name="revenue_table",
+            timestamp_field="",  # Missing
+            data_warehouse_join_key="user_id",
+            events_join_key="properties.$user_id",
+        )
+
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=3)
+
+        assert len(errors) == 1
+        assert "Step 3" in errors[0]
+        assert "timestamp_field is required" in errors[0]
+        assert "time-based filtering" in errors[0]
+
+    def test_validate_required_fields_missing_dw_join_key(self):
+        """Missing data_warehouse_join_key produces clear error."""
+        node = ExperimentDataWarehouseNode(
+            table_name="revenue_table",
+            timestamp_field="purchase_date",
+            data_warehouse_join_key="",  # Missing
+            events_join_key="properties.$user_id",
+        )
+
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=1)
+
+        assert len(errors) == 1
+        assert "Step 1" in errors[0]
+        assert "data_warehouse_join_key is required" in errors[0]
+        assert "user_id" in errors[0]  # Example in error message
+
+    def test_validate_required_fields_missing_events_join_key(self):
+        """Missing events_join_key produces clear error."""
+        node = ExperimentDataWarehouseNode(
+            table_name="revenue_table",
+            timestamp_field="purchase_date",
+            data_warehouse_join_key="user_id",
+            events_join_key="",  # Missing
+        )
+
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=2)
+
+        assert len(errors) == 1
+        assert "Step 2" in errors[0]
+        assert "events_join_key is required" in errors[0]
+        assert "properties.$user_id" in errors[0]  # Example in error message
+
+    def test_validate_required_fields_multiple_missing(self):
+        """Multiple missing fields produces multiple errors."""
+        node = ExperimentDataWarehouseNode(
+            table_name="",  # Missing
+            timestamp_field="",  # Missing
+            data_warehouse_join_key="user_id",
+            events_join_key="properties.$user_id",
+        )
+
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=1)
+
+        assert len(errors) == 2
+        assert any("table_name" in error for error in errors)
+        assert any("timestamp_field" in error for error in errors)
+
+    def test_validate_required_fields_all_missing(self):
+        """All missing fields produces all errors."""
+        node = ExperimentDataWarehouseNode(
+            table_name="",
+            timestamp_field="",
+            data_warehouse_join_key="",
+            events_join_key="",
+        )
+
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=5)
+
+        assert len(errors) == 4
+        assert all("Step 5" in error for error in errors)
+
+    def test_validate_consistent_join_keys_single_dw_step(self):
+        """Single DW step has no consistency issues."""
+        metric = create_mock_metric(
+            series=[
+                EventsNode(event="pageview"),
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_consistent_join_keys(metric)
+
+        assert error is None
+
+    def test_validate_consistent_join_keys_no_dw_steps(self):
+        """Funnel with no DW steps has no consistency issues."""
+        metric = create_mock_metric(
+            series=[
+                EventsNode(event="pageview"),
+                EventsNode(event="purchase"),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_consistent_join_keys(metric)
+
+        assert error is None
+
+    def test_validate_consistent_join_keys_multiple_same_key(self):
+        """Multiple DW steps with same events_join_key is valid."""
+        metric = create_mock_metric(
+            series=[
+                EventsNode(event="pageview"),
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="subscriptions",
+                    timestamp_field="created_at",
+                    data_warehouse_join_key="customer_id",
+                    events_join_key="properties.$user_id",  # Same as step 2
+                ),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_consistent_join_keys(metric)
+
+        assert error is None
+
+    def test_validate_consistent_join_keys_different_keys(self):
+        """Multiple DW steps with different events_join_key produces error."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="subscriptions",
+                    timestamp_field="created_at",
+                    data_warehouse_join_key="email",
+                    events_join_key="properties.$email",  # Different!
+                ),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_consistent_join_keys(metric)
+
+        assert error is not None
+        assert "join_key_mismatch" in error
+        assert "properties.$user_id" in error["join_key_mismatch"]
+        assert "properties.$email" in error["join_key_mismatch"]
+        assert "same join key" in error["join_key_mismatch"]
+
+    def test_validate_consistent_join_keys_error_shows_step_numbers(self):
+        """Join key mismatch error shows which steps use which keys."""
+        metric = create_mock_metric(
+            series=[
+                EventsNode(event="pageview"),  # Step 1
+                ExperimentDataWarehouseNode(  # Step 2
+                    table_name="revenue",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+                EventsNode(event="add_to_cart"),  # Step 3
+                ExperimentDataWarehouseNode(  # Step 4
+                    table_name="subscriptions",
+                    timestamp_field="created_at",
+                    data_warehouse_join_key="email",
+                    events_join_key="properties.$email",
+                ),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_consistent_join_keys(metric)
+
+        assert error is not None
+        error_msg = error["join_key_mismatch"]
+        # Should mention step numbers (2 and 4, the DW steps)
+        assert "Step 2" in error_msg
+        assert "Step 4" in error_msg
+
+    def test_validate_complexity_limits_within_limits(self):
+        """Funnel within complexity limits passes validation."""
+        metric = create_mock_metric(
+            series=[
+                EventsNode(event="pageview"),
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="subscriptions",
+                    timestamp_field="created_at",
+                    data_warehouse_join_key="customer_id",
+                    events_join_key="properties.$user_id",
+                ),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_complexity_limits(metric)
+
+        assert error is None
+
+    def test_validate_complexity_limits_too_many_dw_steps(self):
+        """More than 3 DW steps produces error."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="table1",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="table2",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="table1",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(  # 4th DW step
+                    table_name="table2",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_complexity_limits(metric)
+
+        assert error is not None
+        assert "complexity_limit" in error
+        assert "4" in error["complexity_limit"]  # Number of DW steps
+        assert "3" in error["complexity_limit"]  # Maximum
+        assert "UNION" in error["complexity_limit"]
+
+    def test_validate_complexity_limits_too_many_tables(self):
+        """More than 2 distinct DW tables produces error."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="table_a",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="table_b",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="table_c",  # 3rd distinct table
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+            ]
+        )
+
+        error = FunnelDWValidator.validate_complexity_limits(metric)
+
+        assert error is not None
+        assert "complexity_limit" in error
+        assert "3" in error["complexity_limit"]  # Number of distinct tables
+        assert "2" in error["complexity_limit"]  # Maximum
+        assert "table_a" in error["complexity_limit"]
+        assert "table_b" in error["complexity_limit"]
+        assert "table_c" in error["complexity_limit"]
+
+    def test_validate_complexity_limits_same_table_multiple_times(self):
+        """Same table used multiple times counts as 1 distinct table."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",  # Same table again
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",  # And again
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+            ]
+        )
+
+        # Should be valid (3 DW steps but only 1 distinct table)
+        error = FunnelDWValidator.validate_complexity_limits(metric)
+
+        assert error is None
+
+    def test_validate_funnel_metric_all_valid(self):
+        """Valid funnel metric passes all validations."""
+        metric = create_mock_metric(
+            series=[
+                EventsNode(event="pageview"),
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="purchase_date",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+            ]
+        )
+
+        # Should not raise
+        FunnelDWValidator.validate_funnel_metric(metric)
+
+    def test_validate_funnel_metric_missing_fields_raises(self):
+        """Missing required fields raises ValidationError."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="",  # Missing
+                    timestamp_field="",  # Missing
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+            ]
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            FunnelDWValidator.validate_funnel_metric(metric)
+
+        error_detail = context.exception.detail
+        assert "datawarehouse_configuration" in error_detail
+        assert "help" in error_detail
+
+    def test_validate_funnel_metric_join_key_mismatch_raises(self):
+        """Join key mismatch raises ValidationError."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="subscriptions",
+                    timestamp_field="created_at",
+                    data_warehouse_join_key="email",
+                    events_join_key="properties.$email",  # Different!
+                ),
+            ]
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            FunnelDWValidator.validate_funnel_metric(metric)
+
+        error_detail = context.exception.detail
+        assert "join_key_mismatch" in error_detail
+
+    def test_validate_funnel_metric_complexity_limit_raises(self):
+        """Exceeding complexity limits raises ValidationError."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="table_a",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="table_b",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="table_c",  # 3rd table exceeds limit
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$id",
+                ),
+            ]
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            FunnelDWValidator.validate_funnel_metric(metric)
+
+        error_detail = context.exception.detail
+        assert "complexity_limit" in error_detail
+
+    def test_validate_funnel_metric_multiple_errors(self):
+        """Multiple validation failures all reported in single error."""
+        metric = create_mock_metric(
+            series=[
+                ExperimentDataWarehouseNode(
+                    table_name="",  # Missing - field error
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$user_id",
+                ),
+                ExperimentDataWarehouseNode(
+                    table_name="table_b",
+                    timestamp_field="ds",
+                    data_warehouse_join_key="id",
+                    events_join_key="properties.$email",  # Different join key - consistency error
+                ),
+            ]
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            FunnelDWValidator.validate_funnel_metric(metric)
+
+        error_detail = context.exception.detail
+        # Should have both types of errors
+        assert "datawarehouse_configuration" in error_detail  # Field error
+        assert "join_key_mismatch" in error_detail  # Consistency error
+
+    def test_validate_funnel_metric_events_only_passes(self):
+        """Events-only funnel requires no DW validation."""
+        metric = create_mock_metric(
+            series=[
+                EventsNode(event="pageview"),
+                EventsNode(event="add_to_cart"),
+                EventsNode(event="purchase"),
+            ]
+        )
+
+        # Should not raise
+        FunnelDWValidator.validate_funnel_metric(metric)

--- a/posthog/hogql_queries/experiments/test/test_funnel_validation.py
+++ b/posthog/hogql_queries/experiments/test/test_funnel_validation.py
@@ -13,6 +13,7 @@ independently of schema validation.
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock
 
+from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import EventsNode, ExperimentDataWarehouseNode
@@ -48,68 +49,35 @@ class TestFunnelDWValidator(BaseTest):
 
         assert errors == []
 
-    def test_validate_required_fields_missing_table_name(self):
-        """Missing table_name produces clear error."""
-        node = ExperimentDataWarehouseNode(
-            table_name="",  # Missing
-            timestamp_field="purchase_date",
-            data_warehouse_join_key="user_id",
-            events_join_key="properties.$user_id",
-        )
+    @parameterized.expand(
+        [
+            ("table_name", "", 2, "table_name is required", None),
+            ("timestamp_field", "", 3, "timestamp_field is required", "time-based filtering"),
+            ("data_warehouse_join_key", "", 1, "data_warehouse_join_key is required", "user_id"),
+            ("events_join_key", "", 2, "events_join_key is required", "properties.$user_id"),
+        ]
+    )
+    def test_validate_required_fields_missing_single_field(
+        self, missing_field, field_value, step_index, error_keyword, additional_check
+    ):
+        """Missing required field produces clear error."""
+        # Build node with all fields valid except the one being tested
+        fields = {
+            "table_name": "revenue_table",
+            "timestamp_field": "purchase_date",
+            "data_warehouse_join_key": "user_id",
+            "events_join_key": "properties.$user_id",
+        }
+        fields[missing_field] = field_value
+        node = ExperimentDataWarehouseNode(**fields)
 
-        errors = FunnelDWValidator.validate_required_fields(node, step_index=2)
+        errors = FunnelDWValidator.validate_required_fields(node, step_index=step_index)
 
-        assert len(errors) == 1
-        assert "Step 2" in errors[0]
-        assert "table_name is required" in errors[0]
-
-    def test_validate_required_fields_missing_timestamp_field(self):
-        """Missing timestamp_field produces clear error."""
-        node = ExperimentDataWarehouseNode(
-            table_name="revenue_table",
-            timestamp_field="",  # Missing
-            data_warehouse_join_key="user_id",
-            events_join_key="properties.$user_id",
-        )
-
-        errors = FunnelDWValidator.validate_required_fields(node, step_index=3)
-
-        assert len(errors) == 1
-        assert "Step 3" in errors[0]
-        assert "timestamp_field is required" in errors[0]
-        assert "time-based filtering" in errors[0]
-
-    def test_validate_required_fields_missing_dw_join_key(self):
-        """Missing data_warehouse_join_key produces clear error."""
-        node = ExperimentDataWarehouseNode(
-            table_name="revenue_table",
-            timestamp_field="purchase_date",
-            data_warehouse_join_key="",  # Missing
-            events_join_key="properties.$user_id",
-        )
-
-        errors = FunnelDWValidator.validate_required_fields(node, step_index=1)
-
-        assert len(errors) == 1
-        assert "Step 1" in errors[0]
-        assert "data_warehouse_join_key is required" in errors[0]
-        assert "user_id" in errors[0]  # Example in error message
-
-    def test_validate_required_fields_missing_events_join_key(self):
-        """Missing events_join_key produces clear error."""
-        node = ExperimentDataWarehouseNode(
-            table_name="revenue_table",
-            timestamp_field="purchase_date",
-            data_warehouse_join_key="user_id",
-            events_join_key="",  # Missing
-        )
-
-        errors = FunnelDWValidator.validate_required_fields(node, step_index=2)
-
-        assert len(errors) == 1
-        assert "Step 2" in errors[0]
-        assert "events_join_key is required" in errors[0]
-        assert "properties.$user_id" in errors[0]  # Example in error message
+        self.assertEqual(len(errors), 1)
+        self.assertIn(f"Step {step_index}", errors[0])
+        self.assertIn(error_keyword, errors[0])
+        if additional_check:
+            self.assertIn(additional_check, errors[0])
 
     def test_validate_required_fields_multiple_missing(self):
         """Multiple missing fields produces multiple errors."""
@@ -380,7 +348,7 @@ class TestFunnelDWValidator(BaseTest):
         assert error is None
 
     def test_validate_funnel_metric_all_valid(self):
-        """Valid funnel metric passes all validations."""
+        """DW funnel metrics are blocked until implementation is complete."""
         metric = create_mock_metric(
             series=[
                 EventsNode(event="pageview"),
@@ -393,11 +361,17 @@ class TestFunnelDWValidator(BaseTest):
             ]
         )
 
-        # Should not raise
-        FunnelDWValidator.validate_funnel_metric(metric)
+        # Should raise not_implemented error
+        with self.assertRaises(ValidationError) as context:
+            FunnelDWValidator.validate_funnel_metric(metric)
+
+        error_detail = context.exception.detail
+        assert isinstance(error_detail, dict)
+        self.assertIn("not_implemented", error_detail)
+        self.assertIn("not yet supported", str(error_detail["not_implemented"]))
 
     def test_validate_funnel_metric_missing_fields_raises(self):
-        """Missing required fields raises ValidationError."""
+        """DW funnels are blocked regardless of configuration."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -413,11 +387,10 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        assert "datawarehouse_configuration" in error_detail
-        assert "help" in error_detail
+        self.assertIn("not_implemented", error_detail)
 
     def test_validate_funnel_metric_join_key_mismatch_raises(self):
-        """Join key mismatch raises ValidationError."""
+        """DW funnels are blocked regardless of join key configuration."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -439,10 +412,10 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        assert "join_key_mismatch" in error_detail
+        self.assertIn("not_implemented", error_detail)
 
     def test_validate_funnel_metric_complexity_limit_raises(self):
-        """Exceeding complexity limits raises ValidationError."""
+        """DW funnels are blocked regardless of complexity."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -470,10 +443,10 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        assert "complexity_limit" in error_detail
+        self.assertIn("not_implemented", error_detail)
 
     def test_validate_funnel_metric_multiple_errors(self):
-        """Multiple validation failures all reported in single error."""
+        """DW funnels are blocked with a single not_implemented error."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -495,9 +468,7 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        # Should have both types of errors
-        assert "datawarehouse_configuration" in error_detail  # Field error
-        assert "join_key_mismatch" in error_detail  # Consistency error
+        self.assertIn("not_implemented", error_detail)
 
     def test_validate_funnel_metric_events_only_passes(self):
         """Events-only funnel requires no DW validation."""

--- a/posthog/hogql_queries/experiments/test/test_funnel_validation.py
+++ b/posthog/hogql_queries/experiments/test/test_funnel_validation.py
@@ -511,3 +511,61 @@ class TestFunnelDWValidator(BaseTest):
 
         # Should not raise
         FunnelDWValidator.validate_funnel_metric(metric)
+
+
+class TestFunnelDWValidationIntegration(BaseTest):
+    """Integration tests for FunnelDWValidator in query execution context."""
+
+    def test_query_runner_raises_not_implemented_for_dw_funnels(self):
+        """Query runner should raise NotImplementedError for DW funnels."""
+        from posthog.schema import ExperimentFunnelMetric, ExperimentQuery, StepOrderValue
+
+        from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
+
+        # Create experiment
+        feature_flag = self.team.featureflag_set.create(
+            name="Test Feature",
+            key="test-feature",
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "rollout_percentage": 50},
+                        {"key": "test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+
+        experiment = self.team.experiment_set.create(
+            name="Test Experiment",
+            feature_flag=feature_flag,
+        )
+
+        # Create metric with DW step
+        metric = ExperimentFunnelMetric(
+            series=[
+                EventsNode(event="pageview"),
+                ExperimentDataWarehouseNode(
+                    table_name="revenue",
+                    timestamp_field="purchase_date",
+                    data_warehouse_join_key="user_id",
+                    events_join_key="properties.$user_id",
+                ),
+            ],
+            funnel_order_type=StepOrderValue.ORDERED,
+        )
+
+        query = ExperimentQuery(
+            experiment_id=experiment.id,
+            metric=metric,
+        )
+
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+
+        # Should raise NotImplementedError when trying to calculate
+        with self.assertRaises(NotImplementedError) as context:
+            runner.calculate()
+
+        assert "UNION ALL pattern" in str(context.exception)
+        assert "not yet fully implemented" in str(context.exception)

--- a/posthog/hogql_queries/experiments/test/test_funnel_validation.py
+++ b/posthog/hogql_queries/experiments/test/test_funnel_validation.py
@@ -348,7 +348,7 @@ class TestFunnelDWValidator(BaseTest):
         assert error is None
 
     def test_validate_funnel_metric_all_valid(self):
-        """DW funnel metrics are blocked until implementation is complete."""
+        """Valid DW funnel passes all validations."""
         metric = create_mock_metric(
             series=[
                 EventsNode(event="pageview"),
@@ -361,17 +361,11 @@ class TestFunnelDWValidator(BaseTest):
             ]
         )
 
-        # Should raise not_implemented error
-        with self.assertRaises(ValidationError) as context:
-            FunnelDWValidator.validate_funnel_metric(metric)
-
-        error_detail = context.exception.detail
-        assert isinstance(error_detail, dict)
-        self.assertIn("not_implemented", error_detail)
-        self.assertIn("not yet supported", str(error_detail["not_implemented"]))
+        # Should not raise - valid configuration
+        FunnelDWValidator.validate_funnel_metric(metric)
 
     def test_validate_funnel_metric_missing_fields_raises(self):
-        """DW funnels are blocked regardless of configuration."""
+        """DW funnel with missing fields raises validation error."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -387,10 +381,10 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        self.assertIn("not_implemented", error_detail)
+        self.assertIn("datawarehouse_configuration", error_detail)
 
     def test_validate_funnel_metric_join_key_mismatch_raises(self):
-        """DW funnels are blocked regardless of join key configuration."""
+        """DW funnel with inconsistent join keys raises validation error."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -412,10 +406,10 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        self.assertIn("not_implemented", error_detail)
+        self.assertIn("join_key_mismatch", error_detail)
 
     def test_validate_funnel_metric_complexity_limit_raises(self):
-        """DW funnels are blocked regardless of complexity."""
+        """DW funnel exceeding complexity limits raises validation error."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -443,10 +437,10 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        self.assertIn("not_implemented", error_detail)
+        self.assertIn("complexity_limit", error_detail)
 
     def test_validate_funnel_metric_multiple_errors(self):
-        """DW funnels are blocked with a single not_implemented error."""
+        """DW funnel with missing fields returns field error first (early return)."""
         metric = create_mock_metric(
             series=[
                 ExperimentDataWarehouseNode(
@@ -468,7 +462,9 @@ class TestFunnelDWValidator(BaseTest):
             FunnelDWValidator.validate_funnel_metric(metric)
 
         error_detail = context.exception.detail
-        self.assertIn("not_implemented", error_detail)
+        # Early return on field errors, so join_key_mismatch won't be checked
+        self.assertIn("datawarehouse_configuration", error_detail)
+        self.assertNotIn("join_key_mismatch", error_detail)
 
     def test_validate_funnel_metric_events_only_passes(self):
         """Events-only funnel requires no DW validation."""

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -17,7 +17,7 @@ import pydantic
 import structlog
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentMetric
+from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentFunnelMetric, ExperimentMetric
 
 from posthog.api.cohort import CohortSerializer
 from posthog.api.feature_flag import FeatureFlagSerializer
@@ -165,7 +165,12 @@ class ExperimentService:
 
             if kind == "ExperimentMetric":
                 try:
-                    ExperimentMetric.model_validate(metric)
+                    validated_metric = ExperimentMetric.model_validate(metric)
+
+                    # Additional validation for funnel metrics with DW steps
+                    if isinstance(validated_metric, ExperimentFunnelMetric):
+                        FunnelDWValidator.validate_funnel_metric(validated_metric)
+
                 except pydantic.ValidationError as e:
                     raise ValidationError(f"Invalid metric at index {i}: {e.errors()}")
 

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -24,6 +24,7 @@ from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
 from posthog.models.action.action import Action
+from posthog.hogql_queries.experiments.funnel_validation import FunnelDWValidator
 from posthog.models.cohort import Cohort
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext
 from posthog.models.feature_flag.feature_flag import FeatureFlag
@@ -168,8 +169,10 @@ class ExperimentService:
                     validated_metric = ExperimentMetric.model_validate(metric)
 
                     # Additional validation for funnel metrics with DW steps
-                    if isinstance(validated_metric, ExperimentFunnelMetric):
-                        FunnelDWValidator.validate_funnel_metric(validated_metric)
+                    # ExperimentMetric is a RootModel wrapping a union, so access .root to get the actual type
+                    actual_metric = validated_metric.root
+                    if isinstance(actual_metric, ExperimentFunnelMetric):
+                        FunnelDWValidator.validate_funnel_metric(actual_metric)
 
                 except pydantic.ValidationError as e:
                     raise ValidationError(f"Invalid metric at index {i}: {e.errors()}")

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -23,8 +23,8 @@ from posthog.api.cohort import CohortSerializer
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.event_usage import EventSource, report_user_action
 from posthog.hogql_queries.experiments.experiment_metric_fingerprint import compute_metric_fingerprint
-from posthog.models.action.action import Action
 from posthog.hogql_queries.experiments.funnel_validation import FunnelDWValidator
+from posthog.models.action.action import Action
 from posthog.models.cohort import Cohort
 from posthog.models.evaluation_context import FeatureFlagEvaluationContext
 from posthog.models.feature_flag.feature_flag import FeatureFlag


### PR DESCRIPTION
## Problem

Without validation, misconfigured DW funnels (missing table names, inconsistent join keys, etc.) would fail late in the query execution process with cryptic errors.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR adds comprehensive validation of data warehouse funnel metrics via the `FunnelDWValidator` class and integrates it into the experiment service layer and the query builder.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
python -m pytest posthog/hogql_queries/experiments/test/test_funnel_validation.py -v
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
