### PR TITLE
fix: strip invalid properties from insight filters before query validation

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -10,12 +10,18 @@ from posthog.schema import (
     DatabaseSchemaQuery,
     DatabaseSchemaQueryResponse,
     DataWarehouseViewLink,
+    FunnelsFilter,
     HogQLAutocomplete,
     HogQLMetadata,
     HogQLVariable,
     HogQuery,
     HogQueryResponse,
+    LifecycleFilter,
+    PathsFilter,
     QuerySchemaRoot,
+    RetentionFilter,
+    StickinessFilter,
+    TrendsFilter,
 )
 
 from posthog.hogql.autocomplete import get_hogql_autocomplete
@@ -40,6 +46,56 @@ from common.hogvm.python.debugger import color_bytecode
 
 logger = structlog.get_logger(__name__)
 
+# Mapping of insight query kinds to their filter key and Pydantic model.
+# Used to strip invalid properties that may have leaked from other insight types
+# (e.g. "display" ending up in funnelsFilter after converting a Trend to a Funnel).
+_INSIGHT_FILTER_MODELS: dict[str, tuple[str, type]] = {
+    "TrendsQuery": ("trendsFilter", TrendsFilter),
+    "FunnelsQuery": ("funnelsFilter", FunnelsFilter),
+    "RetentionQuery": ("retentionFilter", RetentionFilter),
+    "PathsQuery": ("pathsFilter", PathsFilter),
+    "StickinessQuery": ("stickinessFilter", StickinessFilter),
+    "LifecycleQuery": ("lifecycleFilter", LifecycleFilter),
+}
+
+
+def _clean_insight_filter_properties(query_json: dict) -> dict:
+    """Strip unknown properties from insight-specific filter objects.
+
+    When users convert an insight from one type to another (e.g. Trends -> Funnels),
+    properties from the old insight type can leak into the new filter object. Since
+    the Pydantic filter models use extra="forbid", these stale properties cause
+    validation errors at query time. This function defensively removes any fields
+    that aren't recognized by the target filter model.
+    """
+    # Handle InsightVizNode wrapper — the actual query is in "source"
+    source = query_json.get("source", query_json)
+    if not isinstance(source, dict):
+        return query_json
+
+    kind = source.get("kind")
+    if kind not in _INSIGHT_FILTER_MODELS:
+        return query_json
+
+    filter_key, filter_model = _INSIGHT_FILTER_MODELS[kind]
+    filter_dict = source.get(filter_key)
+    if not isinstance(filter_dict, dict):
+        return query_json
+
+    valid_fields = set(filter_model.model_fields.keys())
+    unknown_keys = [k for k in filter_dict if k not in valid_fields]
+    if unknown_keys:
+        for key in unknown_keys:
+            del filter_dict[key]
+        logger.warning(
+            "stripped_unknown_insight_filter_properties",
+            kind=kind,
+            filter_key=filter_key,
+            unknown_keys=unknown_keys,
+        )
+
+    return query_json
+
 
 def process_query_dict(
     team: Team,
@@ -58,6 +114,7 @@ def process_query_dict(
     analytics_props: Optional[AnalyticsProps] = None,
 ) -> dict | BaseModel:
     upgraded_query_json = upgrade(query_json)
+    _clean_insight_filter_properties(upgraded_query_json)
     try:
         model = QuerySchemaRoot.model_validate(upgraded_query_json)
     except pydantic_core.ValidationError as e:


### PR DESCRIPTION
## Problem

Closes #50844

When a user converts an insight from one type to another (e.g. Trends → Funnels), properties from the old insight type can leak into the new filter object. Since the Pydantic filter models use `extra="forbid"`, these stale properties cause a validation error at query time:

```
JSON parse error - 1 validation error for QueryRequest
query.FunnelsQuery.funnelsFilter.display
Extra inputs are not permitted [type=extra_forbidden, input_value='ActionsLineGraph', input_type=str]
```

This makes the funnel insight completely broken — it can't load at all — and there's no way for the user to fix it from the UI since the insight editor itself fails to render the query.

## Changes

Adds a defensive cleaning step in `process_query_dict` (the backend query processing pipeline) that strips unrecognized fields from insight-specific filter objects **before** Pydantic validation.

The implementation:
- Uses each filter model's `model_fields` as the allowlist of valid property names
- Only cleans filter objects for known insight query kinds (TrendsQuery, FunnelsQuery, etc.)
- Handles the `InsightVizNode` wrapper by looking at `source`
- Logs a warning when unknown properties are stripped, so we can track how often this happens and identify upstream leaks

This is intentionally a backend-level fix rather than trying to chase down every frontend code path that might produce a bad query — the exact reproduction path in the issue is unclear, and there are many ways query JSON can get modified (API, direct editing, cache state, etc.).

## How did you test this code?

Manually verified the logic against the exact query JSON from the issue:
- `funnelsFilter` with `display: "ActionsLineGraph"` → `display` gets stripped → query validates successfully
- Valid `funnelsFilter` properties (like `funnelVizType`, `funnelWindowInterval`) are preserved
- Non-insight queries (HogQL, etc.) pass through untouched