### PR TITLE
chore: replace (hub, hub) pattern with explicit CDP consumer deps

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -20,12 +20,14 @@ import { insertHogFunction as _insertHogFunction, createHogFunction } from './_t
 import { insertHogFlow as _insertHogFlow } from './_tests/fixtures-hogflows'
 import { deleteKeysWithPrefix } from './_tests/redis'
 import { CdpApi } from './cdp-api'
+import { CdpConsumerBaseDeps } from './consumers/cdp-base.consumer'
 import { posthogFilterOutPlugin } from './legacy-plugins/_transformations/posthog-filter-out-plugin/template'
 import { BASE_REDIS_KEY, HogWatcherState } from './services/monitoring/hog-watcher.service'
 import { HogFunctionInvocationGlobals, HogFunctionType } from './types'
 
 describe('CDP API', () => {
     let hub: Hub
+    let cdpDeps: CdpConsumerBaseDeps
     let team: Team
     let app: express.Application
     let server: Server
@@ -77,7 +79,8 @@ describe('CDP API', () => {
         hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN = 'ADWORDS_TOKEN'
         team = await getFirstTeam(hub.postgres)
 
-        api = new CdpApi(hub, createCdpConsumerDeps(hub))
+        cdpDeps = createCdpConsumerDeps(hub)
+        api = new CdpApi(hub, cdpDeps)
         app = setupExpressApp()
         app.use('/', api.router())
         server = app.listen(0, () => {})
@@ -637,7 +640,7 @@ describe('CDP API', () => {
         let originalKafkaProducer: any
 
         beforeEach(async () => {
-            originalKafkaProducer = hub.kafkaProducer
+            originalKafkaProducer = cdpDeps.kafkaProducer
             batchHogFlow = await insertHogFlow({
                 id: new UUIDT().toString(),
                 name: 'test batch hog flow',
@@ -663,7 +666,7 @@ describe('CDP API', () => {
         })
 
         afterEach(() => {
-            hub.kafkaProducer = originalKafkaProducer
+            cdpDeps.kafkaProducer = originalKafkaProducer
         })
 
         it('errors if missing team', async () => {
@@ -713,7 +716,7 @@ describe('CDP API', () => {
 
         it('queues batch job request to kafka', async () => {
             const mockProduce = jest.fn().mockResolvedValue(undefined)
-            hub.kafkaProducer = { produce: mockProduce } as any
+            cdpDeps.kafkaProducer = { produce: mockProduce } as any
 
             const res = await supertest(app)
                 .post(`/api/projects/${batchHogFlow.team_id}/hog_flows/${batchHogFlow.id}/batch_invocations/job-123`)
@@ -744,7 +747,7 @@ describe('CDP API', () => {
 
         it('queues batch job with filters from hog flow config when not provided', async () => {
             const mockProduce = jest.fn().mockResolvedValue(undefined)
-            hub.kafkaProducer = { produce: mockProduce } as any
+            cdpDeps.kafkaProducer = { produce: mockProduce } as any
 
             const res = await supertest(app)
                 .post(`/api/projects/${batchHogFlow.team_id}/hog_flows/${batchHogFlow.id}/batch_invocations/job-456`)
@@ -770,7 +773,7 @@ describe('CDP API', () => {
         })
 
         it('errors if kafka producer not available', async () => {
-            hub.kafkaProducer = undefined as any
+            cdpDeps.kafkaProducer = undefined as any
 
             const res = await supertest(app)
                 .post(`/api/projects/${batchHogFlow.team_id}/hog_flows/${batchHogFlow.id}/batch_invocations/job-123`)

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -9,6 +9,7 @@ import { setupExpressApp } from '~/api/router'
 import { createRedisV2PoolFromConfig } from '~/common/redis/redis-v2'
 import { HogFlow } from '~/schema/hogflow'
 
+import { createCdpConsumerDeps } from '../../tests/helpers/cdp'
 import { forSnapshot } from '../../tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '../../tests/helpers/sql'
 import { Hub, Team } from '../types'
@@ -76,7 +77,7 @@ describe('CDP API', () => {
         hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN = 'ADWORDS_TOKEN'
         team = await getFirstTeam(hub.postgres)
 
-        api = new CdpApi(hub, hub)
+        api = new CdpApi(hub, createCdpConsumerDeps(hub))
         app = setupExpressApp()
         app.use('/', api.router())
         server = app.listen(0, () => {})

--- a/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-batch-hogflow.consumer.test.ts
@@ -1,6 +1,7 @@
 import { HogFlow } from '~/schema/hogflow'
 import { UUIDT } from '~/utils/utils'
 
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
@@ -34,7 +35,7 @@ describe('CdpBatchHogFlowRequestsConsumer', () => {
         hub = await createHub()
         team = await getFirstTeam(hub.postgres)
 
-        processor = new CdpBatchHogFlowRequestsConsumer(hub, hub)
+        processor = new CdpBatchHogFlowRequestsConsumer(hub, createCdpConsumerDeps(hub))
 
         // NOTE: We don't want to actually connect to Kafka for these tests as it is slow and we are testing the core logic only
         processor['kafkaConsumer'] = {

--- a/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cohort-membership.consumer.test.ts
@@ -5,6 +5,7 @@ import { Message } from 'node-rdkafka'
 import { resetKafka } from '~/tests/helpers/kafka'
 import { UUIDT } from '~/utils/utils'
 
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
 import { resetBehavioralCohortsDatabase } from '../../../tests/helpers/sql'
 import { KAFKA_COHORT_MEMBERSHIP_CHANGED, KAFKA_COHORT_MEMBERSHIP_CHANGED_TRIGGER } from '../../config/kafka-topics'
 import { Hub } from '../../types'
@@ -22,7 +23,7 @@ describe('CdpCohortMembershipConsumer', () => {
     beforeEach(async () => {
         await resetKafka()
         hub = await createHub()
-        consumer = new CdpCohortMembershipConsumer(hub, hub)
+        consumer = new CdpCohortMembershipConsumer(hub, createCdpConsumerDeps(hub))
         await consumer.start()
         await resetBehavioralCohortsDatabase(hub.postgres)
     })

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
 
 import { HogFlow } from '~/schema/hogflow'
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { createTeam, getFirstTeam, getTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { PostgresUse } from '~/utils/db/postgres'
 import { UUIDT } from '~/utils/utils'
@@ -72,7 +73,7 @@ describe('CdpCyclotronWorkerHogFlow', () => {
         const team2Id = await createTeam(hub.postgres, team.organization_id)
         team2 = (await getTeam(hub.postgres, team2Id))!
 
-        processor = new CdpCyclotronWorkerHogFlow(hub, hub)
+        processor = new CdpCyclotronWorkerHogFlow(hub, createCdpConsumerDeps(hub))
 
         hogFlows = []
         hogFlows.push(

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-plugins.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-plugins.test.ts
@@ -4,6 +4,7 @@ import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 import { DateTime } from 'luxon'
 
 import { RetryError } from '~/plugin-scaffold'
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { forSnapshot } from '~/tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
@@ -54,7 +55,7 @@ describe('CdpCyclotronWorkerPlugins', () => {
         hub = await createHub()
 
         team = await getFirstTeam(hub.postgres)
-        processor = new CdpCyclotronWorker(hub, hub)
+        processor = new CdpCyclotronWorker(hub, createCdpConsumerDeps(hub))
 
         await processor.start()
 

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.test.ts
@@ -2,6 +2,7 @@ import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { DateTime } from 'luxon'
 
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { UUIDT } from '~/utils/utils'
 
@@ -36,7 +37,7 @@ describe('CdpCyclotronWorker', () => {
         await resetTestDatabase()
         hub = await createHub()
         team = await getFirstTeam(hub.postgres)
-        processor = new CdpCyclotronWorker(hub, hub)
+        processor = new CdpCyclotronWorker(hub, createCdpConsumerDeps(hub))
 
         fn = await insertHogFunction(
             hub.postgres,

--- a/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
@@ -1,5 +1,6 @@
 import { mockProducerObserver } from '../../../tests/helpers/mocks/producer.mock'
 
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
 import { createOrganization, createTeam, getFirstTeam, getTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
@@ -55,7 +56,7 @@ describe('CdpDatawarehouseEventsConsumer', () => {
         // Set up default quota limiting mock - not limited by default
         jest.spyOn(hub.quotaLimiting, 'isTeamQuotaLimited').mockResolvedValue(false)
 
-        processor = new CdpDatawarehouseEventsConsumer(hub, hub)
+        processor = new CdpDatawarehouseEventsConsumer(hub, createCdpConsumerDeps(hub))
 
         // NOTE: We don't want to actually connect to Kafka for these tests as it is slow and we are testing the core logic only
         processor['kafkaConsumer'] = {

--- a/nodejs/src/cdp/consumers/cdp-dwh-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-dwh-source-webhooks.consumer.test.ts
@@ -12,6 +12,7 @@ import { insertHogFunction, insertHogFunctionTemplate } from '~/cdp/_tests/fixtu
 import { CdpApi } from '~/cdp/cdp-api'
 import { HogFunctionType } from '~/cdp/types'
 import { KAFKA_WAREHOUSE_SOURCE_WEBHOOKS } from '~/config/kafka-topics'
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { Hub, Team } from '~/types'
 import { closeHub, createHub } from '~/utils/db/hub'
@@ -177,7 +178,7 @@ describe('DWH source webhooks', () => {
         const signingSecret = 'whsec_testsecret'
 
         beforeEach(async () => {
-            api = new CdpApi(hub, hub)
+            api = new CdpApi(hub, createCdpConsumerDeps(hub))
             app = setupExpressApp()
             app.use('/', api.router())
             server = app.listen(0, () => {})

--- a/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -2,6 +2,7 @@ import { mockProducerObserver } from '../../../tests/helpers/mocks/producer.mock
 
 import { HogFlow } from '~/schema/hogflow'
 
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
 import { createOrganization, createTeam, getFirstTeam, getTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
@@ -60,7 +61,7 @@ describe.each([
         // Set up default quota limiting mock - not limited by default
         jest.spyOn(hub.quotaLimiting, 'isTeamQuotaLimited').mockResolvedValue(false)
 
-        processor = new Consumer(hub, hub)
+        processor = new Consumer(hub, createCdpConsumerDeps(hub))
 
         // NOTE: We don't want to actually connect to Kafka for these tests as it is slow and we are testing the core logic only
         processor['kafkaConsumer'] = {
@@ -577,7 +578,7 @@ describe('hog flow processing', () => {
         await resetTestDatabase()
         hub = await createHub()
         team = await getFirstTeam(hub.postgres)
-        processor = new CdpEventsConsumer(hub, hub)
+        processor = new CdpEventsConsumer(hub, createCdpConsumerDeps(hub))
 
         // NOTE: We don't want to actually connect to Kafka for these tests as it is slow and we are testing the core logic only
         processor['kafkaConsumer'] = {

--- a/nodejs/src/cdp/consumers/cdp-internal-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-internal-events-consumer.test.ts
@@ -1,5 +1,6 @@
 import '../../../tests/helpers/mocks/producer.mock'
 
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
@@ -27,7 +28,7 @@ describe('CDP Internal Events Consumer', () => {
         })
         team = await getFirstTeam(hub.postgres)
 
-        processor = new CdpInternalEventsConsumer(hub, hub)
+        processor = new CdpInternalEventsConsumer(hub, createCdpConsumerDeps(hub))
         await processor.start()
     })
 

--- a/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-legacy-event.consumer.test.ts
@@ -2,6 +2,7 @@ import { mockFetch } from '~/tests/helpers/mocks/request.mock'
 
 import { DateTime } from 'luxon'
 
+import { createCdpLegacyEventsConsumerDeps } from '~/tests/helpers/cdp'
 import { forSnapshot } from '~/tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
@@ -30,7 +31,7 @@ describe('CdpLegacyEventsConsumer', () => {
     beforeEach(async () => {
         hub = await createHub()
         await resetTestDatabase()
-        consumer = new CdpLegacyEventsConsumer(hub, hub)
+        consumer = new CdpLegacyEventsConsumer(hub, createCdpLegacyEventsConsumerDeps(hub))
         legacyPluginExecutor = new LegacyPluginExecutorService(hub.postgres, hub.geoipService)
         team = await getFirstTeam(hub.postgres)
 

--- a/nodejs/src/cdp/consumers/cdp-person-updates-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-person-updates-consumer.test.ts
@@ -2,6 +2,7 @@ import '../../../tests/helpers/mocks/producer.mock'
 
 import { forSnapshot } from '~/tests/helpers/snapshots'
 
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
@@ -35,7 +36,7 @@ describe('CDP Person Updates Consumer', () => {
         })
         team = await getFirstTeam(hub.postgres)
 
-        processor = new CdpPersonUpdatesConsumer(hub, hub)
+        processor = new CdpPersonUpdatesConsumer(hub, createCdpConsumerDeps(hub))
         await processor.start()
 
         hogFunction = createHogFunction({

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.test.ts
@@ -2,6 +2,7 @@ import { mockProducerObserver } from '~/tests/helpers/mocks/producer.mock'
 
 import { resetKafka } from '~/tests/helpers/kafka'
 
+import { createCdpConsumerDeps } from '../../../tests/helpers/cdp'
 import { buildInlineFiltersForCohorts, createCohort, getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { KAFKA_CDP_CLICKHOUSE_PREFILTERED_EVENTS } from '../../config/kafka-topics'
 import { Hub, RawClickHouseEvent, Team } from '../../types'
@@ -162,7 +163,7 @@ describe('CdpPrecalculatedFiltersConsumer', () => {
         hub = await createHub()
         team = await getFirstTeam(hub.postgres)
 
-        processor = new CdpPrecalculatedFiltersConsumer(hub, hub)
+        processor = new CdpPrecalculatedFiltersConsumer(hub, createCdpConsumerDeps(hub))
         await processor.start()
     })
 

--- a/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-source-webhooks.consumer.test.ts
@@ -13,6 +13,7 @@ import { template as pixelTemplate } from '~/cdp/templates/_sources/pixel/pixel.
 import { template as incomingWebhookTemplate } from '~/cdp/templates/_sources/webhook/incoming_webhook.template'
 import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult, HogFunctionType } from '~/cdp/types'
 import { HogFlow } from '~/schema/hogflow'
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { forSnapshot } from '~/tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { Hub, Team } from '~/types'
@@ -113,7 +114,7 @@ describe('SourceWebhooksConsumer', () => {
 
         beforeEach(async () => {
             hub.CDP_WATCHER_OBSERVE_RESULTS_BUFFER_TIME_MS = 50
-            api = new CdpApi(hub, hub)
+            api = new CdpApi(hub, createCdpConsumerDeps(hub))
             mockExecuteSpy = jest.spyOn(api['cdpSourceWebhooksConsumer']['hogExecutor'], 'execute')
             mockQueueInvocationsSpy = jest.spyOn(
                 api['cdpSourceWebhooksConsumer']['cyclotronJobQueue'],

--- a/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
+++ b/nodejs/src/cdp/services/batch-export-hog-function.service.test.ts
@@ -11,6 +11,7 @@ import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '~/cdp/_
 import { insertHogFunction as _insertHogFunction, insertBatchExport } from '~/cdp/_tests/fixtures'
 import { CdpApi } from '~/cdp/cdp-api'
 import { HogFunctionType } from '~/cdp/types'
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase, updateOrganizationAvailableFeatures } from '~/tests/helpers/sql'
 import { Hub, Team } from '~/types'
 import { closeHub, createHub } from '~/utils/db/hub'
@@ -43,7 +44,7 @@ describe('BatchExportHogFunctionService', () => {
         hub = await createHub({ SITE_URL: 'http://localhost:8000' })
         team = await getFirstTeam(hub.postgres)
 
-        api = new CdpApi(hub, hub)
+        api = new CdpApi(hub, createCdpConsumerDeps(hub))
         app = setupExpressApp()
         app.use('/', api.router())
         server = app.listen(0, () => {})

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -10,6 +10,7 @@ import { insertHogFunction } from '~/cdp/_tests/fixtures'
 import { CdpApi } from '~/cdp/cdp-api'
 import { HogFunctionType } from '~/cdp/types'
 import { KAFKA_APP_METRICS_2 } from '~/config/kafka-topics'
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { closeHub, createHub } from '~/utils/db/hub'
 import { UUIDT } from '~/utils/utils'
@@ -42,7 +43,7 @@ describe('EmailTrackingService', () => {
         let server: Server
 
         beforeEach(async () => {
-            api = new CdpApi(hub, hub)
+            api = new CdpApi(hub, createCdpConsumerDeps(hub))
             app = setupExpressApp()
             app.use('/', api.router())
             server = app.listen(0, () => {})

--- a/nodejs/tests/helpers/cdp.ts
+++ b/nodejs/tests/helpers/cdp.ts
@@ -1,0 +1,26 @@
+import { CdpConsumerBaseDeps } from '../../src/cdp/consumers/cdp-base.consumer'
+import { CdpLegacyEventsConsumerDeps } from '../../src/cdp/consumers/cdp-legacy-event.consumer'
+import { Hub } from '../../src/types'
+
+export function createCdpConsumerDeps(hub: Hub): CdpConsumerBaseDeps {
+    return {
+        postgres: hub.postgres,
+        pubSub: hub.pubSub,
+        encryptedFields: hub.encryptedFields,
+        teamManager: hub.teamManager,
+        integrationManager: hub.integrationManager,
+        kafkaProducer: hub.kafkaProducer,
+        internalCaptureService: hub.internalCaptureService,
+        personRepository: hub.personRepository,
+        geoipService: hub.geoipService,
+        groupRepository: hub.groupRepository,
+        quotaLimiting: hub.quotaLimiting,
+    }
+}
+
+export function createCdpLegacyEventsConsumerDeps(hub: Hub): CdpLegacyEventsConsumerDeps {
+    return {
+        ...createCdpConsumerDeps(hub),
+        groupTypeManager: hub.groupTypeManager,
+    }
+}


### PR DESCRIPTION
## Problem

CDP consumer tests pass the entire `Hub` god object as both config and deps arguments (`new Consumer(hub, hub)`), hiding the actual dependencies each consumer needs and making it harder to eventually remove `Hub`.

## Changes

- Add `createCdpConsumerDeps` and `createCdpLegacyEventsConsumerDeps` test helpers that extract the explicit `CdpConsumerBaseDeps` fields from Hub, mirroring how production code in `server.ts` constructs deps
- Migrate all 16 CDP consumer/API test files from `new Consumer(hub, hub)` to `new Consumer(hub, createCdpConsumerDeps(hub))`


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
