### PR TITLE
feat(llma): add HogQL schema and framework support for ai_events

### DIFF
--- a/bin/clickhouse-ai-events-init
+++ b/bin/clickhouse-ai-events-init
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Create ai_events ClickHouse tables for local development.
+
+In production these tables live on a dedicated ai_events cluster and are
+applied manually. This script generates the DDL from the Python source of
+truth (posthog/models/ai_events/sql.py) and executes it locally.
+
+Temporary until CH migrations can target the ai_events cluster.
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+
+import django
+
+django.setup()
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models.ai_events.sql import (
+    AI_EVENTS_DATA_TABLE_SQL,
+    AI_EVENTS_MV_SQL,
+    DISTRIBUTED_AI_EVENTS_TABLE_SQL,
+    KAFKA_AI_EVENTS_TABLE_SQL,
+    TABLE_BASE_NAME,
+)
+
+# Local dev uses plain MergeTree since there's no replicated cluster.
+data_sql = re.sub(r"ReplicatedMergeTree\([^)]*\)", "MergeTree()", AI_EVENTS_DATA_TABLE_SQL())
+
+sync_execute(data_sql)
+sync_execute(DISTRIBUTED_AI_EVENTS_TABLE_SQL())
+sync_execute(KAFKA_AI_EVENTS_TABLE_SQL())
+sync_execute(AI_EVENTS_MV_SQL(TABLE_BASE_NAME))
+
+print("✅ ai_events tables created")

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -614,6 +614,9 @@ tools:
         cmd: python manage.py print_hog_stl_table
         description: Print HogSQL standard library definitions for reference
         hidden: true
+    clickhouse:ai:init:
+        bin_script: clickhouse-ai-events-init
+        description: Create ai_events ClickHouse tables for local development
     clickhouse:logs:init:
         bin_script: clickhouse-logs-init
         description: 'TODO: add description for clickhouse-logs-init'

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -683,6 +683,11 @@ class FieldType(Type):
     def get_child(self, name: str | int, context: HogQLContext) -> Type:
         database_field = self.resolve_database_field(context)
         if database_field is None:
+            # For non-BaseTableType (e.g. subquery aliases), check the constant type
+            # to determine if this field supports property access (JSON / array).
+            constant_type = self.resolve_constant_type(context)
+            if isinstance(constant_type, (StringJSONType, StringArrayType)):
+                return PropertyType(chain=[name], field_type=self)
             raise ResolutionError(f'Can not access property "{name}" on field "{self.name}".')
         if isinstance(database_field, StringJSONDatabaseField):
             return PropertyType(chain=[name], field_type=self)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -57,6 +57,7 @@ from posthog.hogql.database.models import (
 from posthog.hogql.database.postgres_table import PostgresTable
 from posthog.hogql.database.postgres_utils import add_postgres_foreign_key_lazy_joins
 from posthog.hogql.database.s3_table import S3Table
+from posthog.hogql.database.schema.ai_events import AiEventsTable
 from posthog.hogql.database.schema.app_metrics2 import AppMetrics2Table
 from posthog.hogql.database.schema.channel_type import create_initial_channel_type, create_initial_domain_type
 from posthog.hogql.database.schema.cohort_membership import CohortMembershipTable
@@ -256,6 +257,7 @@ def build_database_root_node(*, include_posthog_tables: bool = True) -> TableNod
                 children={
                     **clone_root_tables(),
                     # Add new tables here
+                    "ai_events": TableNode(name="ai_events", table=AiEventsTable()),
                     "trace_spans": TableNode(name="trace_spans", table=TraceSpansTable()),
                     "trace_attributes": TableNode(name="trace_attributes", table=TraceAttributesTable()),
                 },

--- a/posthog/hogql/database/schema/ai_events.py
+++ b/posthog/hogql/database/schema/ai_events.py
@@ -1,0 +1,100 @@
+from posthog.hogql.database.models import (
+    BooleanDatabaseField,
+    DateTimeDatabaseField,
+    FieldOrTable,
+    FieldTraverser,
+    FloatDatabaseField,
+    IntegerDatabaseField,
+    LazyJoin,
+    StringDatabaseField,
+    StringJSONDatabaseField,
+    Table,
+)
+from posthog.hogql.database.schema.person_distinct_ids import (
+    PersonDistinctIdsTable,
+    join_with_person_distinct_ids_table,
+)
+
+
+class AiEventsTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        # Core
+        "uuid": StringDatabaseField(name="uuid", nullable=False),
+        "event": StringDatabaseField(name="event", nullable=False),
+        "timestamp": DateTimeDatabaseField(name="timestamp", nullable=False),
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "distinct_id": StringDatabaseField(name="distinct_id", nullable=False),
+        "person_id": StringDatabaseField(name="person_id", nullable=False),
+        "properties": StringJSONDatabaseField(name="properties", nullable=False),
+        "retention_days": IntegerDatabaseField(name="retention_days", nullable=False),
+        # Trace structure
+        "trace_id": StringDatabaseField(name="trace_id", nullable=False),
+        "session_id": StringDatabaseField(name="session_id", nullable=True),
+        "parent_id": StringDatabaseField(name="parent_id", nullable=True),
+        "span_id": StringDatabaseField(name="span_id", nullable=True),
+        "span_type": StringDatabaseField(name="span_type", nullable=True),
+        "generation_id": StringDatabaseField(name="generation_id", nullable=True),
+        "experiment_id": StringDatabaseField(name="experiment_id", nullable=True),
+        # Names
+        "span_name": StringDatabaseField(name="span_name", nullable=True),
+        "trace_name": StringDatabaseField(name="trace_name", nullable=True),
+        "prompt_name": StringDatabaseField(name="prompt_name", nullable=True),
+        # Model info
+        "model": StringDatabaseField(name="model", nullable=True),
+        "provider": StringDatabaseField(name="provider", nullable=True),
+        "framework": StringDatabaseField(name="framework", nullable=True),
+        # Token counts
+        "total_tokens": IntegerDatabaseField(name="total_tokens", nullable=True),
+        "input_tokens": IntegerDatabaseField(name="input_tokens", nullable=True),
+        "output_tokens": IntegerDatabaseField(name="output_tokens", nullable=True),
+        "text_input_tokens": IntegerDatabaseField(name="text_input_tokens", nullable=True),
+        "text_output_tokens": IntegerDatabaseField(name="text_output_tokens", nullable=True),
+        "image_input_tokens": IntegerDatabaseField(name="image_input_tokens", nullable=True),
+        "image_output_tokens": IntegerDatabaseField(name="image_output_tokens", nullable=True),
+        "audio_input_tokens": IntegerDatabaseField(name="audio_input_tokens", nullable=True),
+        "audio_output_tokens": IntegerDatabaseField(name="audio_output_tokens", nullable=True),
+        "video_input_tokens": IntegerDatabaseField(name="video_input_tokens", nullable=True),
+        "video_output_tokens": IntegerDatabaseField(name="video_output_tokens", nullable=True),
+        "reasoning_tokens": IntegerDatabaseField(name="reasoning_tokens", nullable=True),
+        "cache_read_input_tokens": IntegerDatabaseField(name="cache_read_input_tokens", nullable=True),
+        "cache_creation_input_tokens": IntegerDatabaseField(name="cache_creation_input_tokens", nullable=True),
+        "web_search_count": IntegerDatabaseField(name="web_search_count", nullable=True),
+        # Costs
+        "input_cost_usd": FloatDatabaseField(name="input_cost_usd", nullable=True),
+        "output_cost_usd": FloatDatabaseField(name="output_cost_usd", nullable=True),
+        "total_cost_usd": FloatDatabaseField(name="total_cost_usd", nullable=True),
+        "request_cost_usd": FloatDatabaseField(name="request_cost_usd", nullable=True),
+        "web_search_cost_usd": FloatDatabaseField(name="web_search_cost_usd", nullable=True),
+        "audio_cost_usd": FloatDatabaseField(name="audio_cost_usd", nullable=True),
+        "image_cost_usd": FloatDatabaseField(name="image_cost_usd", nullable=True),
+        "video_cost_usd": FloatDatabaseField(name="video_cost_usd", nullable=True),
+        # Timing
+        "latency": FloatDatabaseField(name="latency", nullable=True),
+        "time_to_first_token": FloatDatabaseField(name="time_to_first_token", nullable=True),
+        # Errors
+        "is_error": BooleanDatabaseField(name="is_error", nullable=False),
+        "error": StringDatabaseField(name="error", nullable=True),
+        "error_type": StringDatabaseField(name="error_type", nullable=True),
+        "error_normalized": StringDatabaseField(name="error_normalized", nullable=True),
+        # Heavy columns (JSON strings — use StringJSONDatabaseField so HogQL
+        # handles array/object access via JSONExtract under the hood)
+        "input": StringJSONDatabaseField(name="input", nullable=True),
+        "output": StringJSONDatabaseField(name="output", nullable=True),
+        "output_choices": StringJSONDatabaseField(name="output_choices", nullable=True),
+        "input_state": StringJSONDatabaseField(name="input_state", nullable=True),
+        "output_state": StringJSONDatabaseField(name="output_state", nullable=True),
+        "tools": StringJSONDatabaseField(name="tools", nullable=True),
+        # Person join via person_distinct_ids
+        "pdi": LazyJoin(
+            from_field=["distinct_id"],
+            join_table=PersonDistinctIdsTable(),
+            join_function=join_with_person_distinct_ids_table,
+        ),
+        "person": FieldTraverser(chain=["pdi", "person"]),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "ai_events"
+
+    def to_printed_hogql(self):
+        return "ai_events"

--- a/posthog/hogql/filters.py
+++ b/posthog/hogql/filters.py
@@ -67,7 +67,7 @@ class ReplaceFilters(CloningVisitor):
             while last_join is not None:
                 if isinstance(last_join.table, ast.Field):
                     all_tables.append(last_join.table.chain)
-                    if last_join.table.chain == ["events"]:
+                    if last_join.table.chain == ["events"] or last_join.table.chain == ["posthog", "ai_events"]:
                         found_events = True
                     if last_join.table.chain == ["sessions"]:
                         found_sessions = True


### PR DESCRIPTION
## Problem

The `ai_events` ClickHouse table needs to be queryable via HogQL
so that query runners can target it directly with native column access.

## Changes

- Add `AiEventsTable` HogQL schema (93 fields including person joins)
- Register `ai_events` in `ROOT_TABLES` in `database.py`
- Fix `ast.py` to allow JSON/array property access on subquery-aliased fields
  (needed for heavy columns like `input`, `output`, `tools` through subqueries)
- Update `filters.py` to treat `ai_events` like `events` for `{filters}` placeholder

## How did you test this code?

- Existing HogQL test suite (`pytest posthog/hogql/test/ -x`)

## Publish to changelog?

No

## Docs update

N/A