### PR TITLE
feat(analytics-platform): Fix sessions v3 backfill preflight checks

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_raw_sessions_v3_model.ambr
@@ -91,7 +91,7 @@
             count() as parts_count,
             partition
      FROM clusterAllReplicas('posthog', system.parts)
-     WHERE database = 'posthog_test'
+     WHERE database = currentDatabase()
        AND table = 'sharded_raw_sessions_v3'
        AND partition IN ('202511')
        AND active = 99999

--- a/posthog/clickhouse/test/test_raw_sessions_v3_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_v3_model.py
@@ -11,7 +11,7 @@ from posthog.test.base import (
 from posthog.clickhouse.client import query_with_columns, sync_execute
 from posthog.models.raw_sessions.sessions_v3 import (
     DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
-    GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS,
+    GET_NUM_RAW_SESSIONS_ACTIVE_PARTS,
     RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3,
     RAW_SESSION_TABLE_BACKFILL_SQL_V3,
 )
@@ -794,7 +794,7 @@ class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
     def test_get_number_of_umerged_parts(self):
         # Just test that the query succeeds without errors and returns an int.
         # We can't really guarantee anything about the number of parts on the test DB.
-        query = GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(["202511"])
+        query = GET_NUM_RAW_SESSIONS_ACTIVE_PARTS(["202511"])
         result = sync_execute(query)
         self.assertEqual(len(result), 1)
         self.assertIsInstance(result[0][0], int)

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -32,7 +32,7 @@ from posthog.dags.common.common import JobOwners, dagster_tags
 from posthog.git import get_git_commit_short
 from posthog.models.raw_sessions.sessions_v3 import (
     DISTRIBUTED_RAW_SESSIONS_TABLE_V3,
-    GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS,
+    GET_NUM_RAW_SESSIONS_ACTIVE_PARTS,
     RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3,
     RAW_SESSION_TABLE_BACKFILL_SQL_V3,
 )
@@ -208,7 +208,7 @@ def wait_for_parts_to_merge(
 
     while True:
         # Check parts across all relevant partitions
-        query = GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(partitions, table=table, use_cluster=use_cluster)
+        query = GET_NUM_RAW_SESSIONS_ACTIVE_PARTS(partitions, table=table, use_cluster=use_cluster)
         result = sync_execute(query, sync_client=sync_client)
         (unmerged_parts_count, max_partition, max_host) = result[0]
 

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -183,11 +183,19 @@ def wait_for_parts_to_merge(
     context: AssetExecutionContext,
     config: SessionsBackfillConfig | ExperimentalSessionsBackfillConfig,
     sync_client: Optional[Client] = None,
+    *,
+    table: str | None = None,
+    use_cluster: bool = True,
 ) -> None:
     """Check for unmerged parts and wait if there are too many.
 
-    Queries system.parts using clusterAllReplicas to count active parts in the target partitions,
+    Queries system.parts to count active parts in the target partitions,
     and waits until the count drops below the threshold.
+
+    Args:
+        table: Table name to check parts for. Defaults to the sharded raw sessions table.
+        use_cluster: If True, query across all cluster replicas. If False, query
+            only the local node (useful for standalone/experimental nodes).
     """
     if config.max_unmerged_parts <= 0:
         return
@@ -200,7 +208,7 @@ def wait_for_parts_to_merge(
 
     while True:
         # Check parts across all relevant partitions
-        query = GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(partitions)
+        query = GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(partitions, table=table, use_cluster=use_cluster)
         result = sync_execute(query, sync_client=sync_client)
         (unmerged_parts_count, max_partition, max_host) = result[0]
 
@@ -445,12 +453,16 @@ def _do_experimental_backfill(
     kwargs = get_kwargs_for_client(
         workload=Workload.OFFLINE, team_id=None, readonly=False, ch_user=ClickHouseUser.DEFAULT
     )
+    # The experimental cluster uses the non-sharded table name (raw_sessions_v3),
+    # and is a standalone node not in the main ClickHouse cluster
+    target_table = DISTRIBUTED_RAW_SESSIONS_TABLE_V3()
+
     with get_http_client(**kwargs, **config.client_overrides) as client:
         tags = dagster_tags(context)
         with tags_context(kind="dagster", dagster=tags):
             # this loop is largely copied from _do_backfill, but not writing per shard
             for chunk_i in range(team_id_chunks):
-                wait_for_parts_to_merge(context, config, sync_client=client)
+                wait_for_parts_to_merge(context, config, sync_client=client, table=target_table, use_cluster=False)
 
                 if team_id_chunks > 1:
                     chunk_where_clause = f"({where_clause}) AND team_id % {team_id_chunks} = {chunk_i}"
@@ -462,7 +474,7 @@ def _do_experimental_backfill(
 
                 backfill_sql = sql_template(
                     where=chunk_where_clause,
-                    target_table=DISTRIBUTED_RAW_SESSIONS_TABLE_V3(),  # this is just what the table is called in the experimental cluster, it's not actually distributed
+                    target_table=target_table,
                     include_session_timestamp=True,
                 )
                 context.log.info(backfill_sql)

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -810,24 +810,39 @@ LIMIT 20
 """
 
 
-def GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(partitions: list[str]) -> str:
-    """Get the maximum number of active parts across specified partitions and all nodes.
+def GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(
+    partitions: list[str],
+    *,
+    table: str | None = None,
+    use_cluster: bool = True,
+) -> str:
+    """Get the maximum number of active parts across specified partitions.
+
+    ClickHouse's parts_to_throw_insert is per-partition, so this checks the max
+    active parts in any single (host, partition) combination.
 
     Args:
         partitions: List of partition names in YYYYMM format (e.g., ['202501', '202412'])
+        table: Table name to check. Defaults to the sharded raw sessions table.
+        use_cluster: If True, query across all cluster replicas. If False, query
+            only the local node's system.parts (useful for standalone/experimental nodes).
     """
     if not partitions:
         raise ValueError("partitions list cannot be empty")
     # Format partitions for SQL IN clause: ('202501', '202412')
     partitions_sql = ", ".join(f"'{p}'" for p in partitions)
+    table = table or SHARDED_RAW_SESSIONS_TABLE_V3()
+    parts_table = (
+        f"clusterAllReplicas('{settings.CLICKHOUSE_CLUSTER}', system.parts)" if use_cluster else "system.parts"
+    )
 
     return f"""
         SELECT coalesce(max(parts_count), 0), argMax(partition, parts_count), argMax(host, parts_count)
         FROM (
             SELECT hostName() as host, count() as parts_count, partition
-            FROM clusterAllReplicas('{settings.CLICKHOUSE_CLUSTER}', system.parts)
+            FROM {parts_table}
             WHERE database = '{settings.CLICKHOUSE_DATABASE}'
-              AND table = '{SHARDED_RAW_SESSIONS_TABLE_V3()}'
+              AND table = '{table}'
               AND partition IN ({partitions_sql})
               AND active = 1
             GROUP BY host, partition

--- a/posthog/models/raw_sessions/sessions_v3.py
+++ b/posthog/models/raw_sessions/sessions_v3.py
@@ -810,7 +810,7 @@ LIMIT 20
 """
 
 
-def GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(
+def GET_NUM_RAW_SESSIONS_ACTIVE_PARTS(
     partitions: list[str],
     *,
     table: str | None = None,
@@ -841,7 +841,7 @@ def GET_NUM_SHARDED_RAW_SESSIONS_ACTIVE_PARTS(
         FROM (
             SELECT hostName() as host, count() as parts_count, partition
             FROM {parts_table}
-            WHERE database = '{settings.CLICKHOUSE_DATABASE}'
+            WHERE database = currentDatabase()
               AND table = '{table}'
               AND partition IN ({partitions_sql})
               AND active = 1


### PR DESCRIPTION
## Problem
This is failing a lot right now, because the pre-flight check is testing the wrong thing

## Changes
Make the pre-flight check read the right table in the experimental backfill

## How did you test this code?

n/a

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
