### PR TITLE
refactor: optimize split person process

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -453,7 +453,6 @@ posthog/models/filters/mixins/simplify.py:0: error: Incompatible type for lookup
 posthog/models/organization.py:0: error: Couldn't resolve related manager 'oauth_applications' for relation 'posthog.models.oauth.OAuthApplication.organization'.  [django-manager-missing]
 posthog/models/organization_invite.py:0: error: Argument "level" to "join" of "User" has incompatible type "int"; expected "Level"  [arg-type]
 posthog/models/person/person.py:0: error: "_T" has no attribute "_add_distinct_ids"  [attr-defined]
-posthog/models/person/person.py:0: error: Argument "version" to "create_person" has incompatible type "int | None"; expected "int"  [arg-type]
 posthog/models/person/person.py:0: error: Argument 1 to "union" of "QuerySet" has incompatible type "QuerySet[PersonDistinctId, str]"; expected "QuerySet[Model, Model]"  [arg-type]
 posthog/models/person/person.py:0: error: Incompatible types in assignment (expression has type "list[Never]", variable has type "QuerySet[PersonDistinctId, str]")  [assignment]
 posthog/models/plugin.py:0: error: Argument 1 to "extract_plugin_code" has incompatible type "bytes | memoryview[int] | None"; expected "bytes"  [arg-type]

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -272,7 +272,7 @@ class Person(models.Model):
             self.add_distinct_id(distinct_id)
 
     def split_person(self, main_distinct_id: Optional[str], max_splits: Optional[int] = None):
-        original_person = Person.objects.get(team_id=self.team_id, pk=self.pk)
+        original_person = Person.objects.only("id", "team_id", "uuid", "version").get(team_id=self.team_id, pk=self.pk)
         distinct_ids = original_person.distinct_ids
         original_person_version = original_person.version or 0
 
@@ -297,6 +297,9 @@ class Person(models.Model):
             distinct_ids = distinct_ids[-1 * max_splits :]
 
         ids_to_split = [did for did in distinct_ids if did != main_distinct_id]
+        if not ids_to_split:
+            return
+
         logger.info(
             "split_person will split distinct_ids",
             person_id=self.pk,
@@ -305,47 +308,97 @@ class Person(models.Model):
             ids_to_split_count=len(ids_to_split),
         )
 
-        for distinct_id in ids_to_split:
-            try:
-                db_alias = router.db_for_write(PersonDistinctId) or "default"
-                with transaction.atomic(using=db_alias):
-                    pdi = PersonDistinctId.objects.select_for_update().get(person=self, distinct_id=distinct_id)
-                    person, _ = Person.objects.get_or_create(
-                        uuid=uuidFromDistinctId(self.team_id, distinct_id),
+        from posthog.models.person.util import create_person, create_person_distinct_id
+
+        db_alias = router.db_for_write(PersonDistinctId) or "default"
+        uuid_by_did = {did: uuidFromDistinctId(self.team_id, did) for did in ids_to_split}
+
+        with transaction.atomic(using=db_alias):
+            # 1. Lock all PDIs in one query — hits unique index (team_id, distinct_id)
+            pdis = {
+                pdi.distinct_id: pdi
+                for pdi in PersonDistinctId.objects.select_for_update().filter(
+                    team_id=self.team_id, person=self, distinct_id__in=ids_to_split
+                )
+            }
+
+            logger.info(
+                "split_person locked PDIs",
+                person_id=self.pk,
+                team_id=self.team_id,
+                locked_count=len(pdis),
+                expected_count=len(ids_to_split),
+            )
+
+            # 2. Batch create new persons — ignore_conflicts handles pre-existing ones
+            Person.objects.bulk_create(
+                [
+                    Person(
+                        uuid=uuid_by_did[did],
                         team_id=self.team_id,
-                        defaults={
-                            # Set version higher than delete events (which use version + 100).
-                            # Keep in sync with: posthog/models/person/util.py:222 (_delete_person)
-                            # and plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
-                            "version": original_person_version + 101,
-                        },
+                        # Set version higher than delete events (which use version + 100).
+                        # Keep in sync with: posthog/models/person/util.py:222 (_delete_person)
+                        # and plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
+                        version=original_person_version + 101,
                     )
-                    pdi.person_id = str(person.id)
-                    # Set distinct_id version higher than delete events (which use pdi.version + 100).
-                    # This ensures the split distinct_id overrides any deleted distinct_id.
-                    pdi.version = (pdi.version or 0) + 101
-                    pdi.save(update_fields=["version", "person_id"])
+                    for did in ids_to_split
+                ],
+                ignore_conflicts=True,
+            )
 
-                from posthog.models.person.util import create_person, create_person_distinct_id
+            # 3. Fetch all new persons — only columns needed for Kafka publishes
+            person_by_uuid = {
+                p.uuid: p
+                for p in Person.objects.only("id", "team_id", "uuid", "version", "created_at").filter(
+                    team_id=self.team_id, uuid__in=list(uuid_by_did.values())
+                )
+            }
 
-                create_person_distinct_id(
-                    team_id=self.team_id,
-                    distinct_id=distinct_id,
-                    person_id=str(person.uuid),
-                    is_deleted=False,
-                    version=pdi.version,
-                )
-                create_person(
-                    team_id=self.team_id, uuid=str(person.uuid), version=person.version, created_at=person.created_at
-                )
-            except Exception:
-                logger.exception(
-                    "split_person failed to split distinct_id",
-                    person_id=self.pk,
-                    team_id=self.team_id,
-                    distinct_id=distinct_id,
-                )
-                raise
+            logger.info(
+                "split_person created persons",
+                person_id=self.pk,
+                team_id=self.team_id,
+                created_count=len(person_by_uuid),
+            )
+
+            # 4. Update all PDIs to point to new persons
+            for did in ids_to_split:
+                pdi = pdis.get(did)
+                if not pdi:
+                    logger.warning(
+                        "split_person PDI not found for distinct_id",
+                        person_id=self.pk,
+                        team_id=self.team_id,
+                        distinct_id=did,
+                    )
+                    continue
+
+                person = person_by_uuid[uuid_by_did[did]]
+                pdi.person_id = str(person.id)
+                # Set distinct_id version higher than delete events (which use pdi.version + 100).
+                # This ensures the split distinct_id overrides any deleted distinct_id.
+                pdi.version = (pdi.version or 0) + 101
+
+            PersonDistinctId.objects.bulk_update(list(pdis.values()), ["person_id", "version"])
+
+        # 5. Publish Kafka messages after transaction commits — DB is source of truth,
+        # Kafka/ClickHouse catches up via versioning
+        for did in ids_to_split:
+            pdi = pdis.get(did)
+            if not pdi:
+                continue
+            person = person_by_uuid[uuid_by_did[did]]
+
+            create_person_distinct_id(
+                team_id=self.team_id,
+                distinct_id=did,
+                person_id=str(person.uuid),
+                is_deleted=False,
+                version=pdi.version,
+            )
+            create_person(
+                team_id=self.team_id, uuid=str(person.uuid), version=person.version, created_at=person.created_at
+            )
 
 
 class PersonDistinctId(models.Model):

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -289,15 +289,15 @@ class Person(models.Model):
 
         if not main_distinct_id:
             self.properties = {}
-            self.save()
+            self.save(update_fields=["properties"])
             main_distinct_id = distinct_ids[0]
 
         if max_splits is not None and len(distinct_ids) > max_splits:
             # Split the last N distinct_ids of the list
             distinct_ids = distinct_ids[-1 * max_splits :]
 
-        ids_to_split = [did for did in distinct_ids if did != main_distinct_id]
-        if not ids_to_split:
+        distinct_ids_to_split = [did for did in distinct_ids if did != main_distinct_id]
+        if not distinct_ids_to_split:
             return
 
         logger.info(
@@ -305,109 +305,119 @@ class Person(models.Model):
             person_id=self.pk,
             team_id=self.team_id,
             main_distinct_id=main_distinct_id,
-            ids_to_split_count=len(ids_to_split),
+            distinct_ids_to_split_count=len(distinct_ids_to_split),
         )
 
-        from posthog.models.person.util import create_person, create_person_distinct_id
-
         db_alias = router.db_for_write(PersonDistinctId) or "default"
-        uuid_by_did = {did: uuidFromDistinctId(self.team_id, did) for did in ids_to_split}
+        new_uuid_by_distinct_id = {
+            distinct_id: uuidFromDistinctId(self.team_id, distinct_id) for distinct_id in distinct_ids_to_split
+        }
 
         with transaction.atomic(using=db_alias):
             # 1. Lock all PDIs in one query — hits unique index (team_id, distinct_id)
-            pdis = {
-                pdi.distinct_id: pdi
-                for pdi in PersonDistinctId.objects.select_for_update().filter(
-                    team_id=self.team_id, person=self, distinct_id__in=ids_to_split
-                )
-            }
+            locked_pdis = self._lock_person_distinct_ids(distinct_ids_to_split)
 
-            logger.info(
-                "split_person locked PDIs",
-                person_id=self.pk,
-                team_id=self.team_id,
-                locked_count=len(pdis),
-                expected_count=len(ids_to_split),
-            )
+            # 2. Create or update persons for each split distinct_id
+            new_person_by_uuid = self._create_split_persons(new_uuid_by_distinct_id, original_person_version)
 
-            # 2. Batch create new persons, or update version if they already exist.
-            # update_conflicts ensures pre-existing persons (e.g., from a previous partial run)
-            # get their version bumped, so the Kafka message carries the correct version.
-            # Set version higher than delete events (which use version + 100).
-            # Keep in sync with: posthog/models/person/util.py:222 (_delete_person)
-            # and plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
-            Person.objects.bulk_create(
-                [
-                    Person(
-                        uuid=uuid_by_did[did],
-                        team_id=self.team_id,
-                        version=original_person_version + 101,
-                    )
-                    for did in ids_to_split
-                ],
-                update_conflicts=True,
-                unique_fields=["team_id", "uuid"],
-                update_fields=["version"],
-            )
+            # 3. Reassign PDIs to new persons
+            self._assign_person_distinct_ids(locked_pdis, new_person_by_uuid, new_uuid_by_distinct_id)
 
-            # 3. Fetch all new persons in a single query — bulk_create doesn't
-            # populate id/created_at on the returned objects, so we need this fetch
-            new_uuids = list(uuid_by_did.values())
-            new_persons = Person.objects.only("id", "team_id", "uuid", "version", "created_at").filter(
-                team_id=self.team_id, uuid__in=new_uuids
-            )
-            person_by_uuid = {p.uuid: p for p in new_persons}
-
-            logger.info(
-                "split_person created persons",
-                person_id=self.pk,
-                team_id=self.team_id,
-                created_count=len(person_by_uuid),
-            )
-
-            # 4. Update all PDIs to point to new persons
-            for did in ids_to_split:
-                pdi = pdis.get(did)
-                if not pdi:
-                    logger.warning(
-                        "split_person PDI not found for distinct_id",
-                        person_id=self.pk,
-                        team_id=self.team_id,
-                        distinct_id=did,
-                    )
-                    continue
-
-                expected_uuid = uuid_by_did[did]
-                person = person_by_uuid.get(expected_uuid)
-                if not person:
-                    raise ValueError(
-                        f"split_person: new person not found after bulk_create "
-                        f"(team_id={self.team_id}, distinct_id={did}, expected_uuid={expected_uuid})"
-                    )
-                pdi.person_id = str(person.id)
-                # Set distinct_id version higher than delete events (which use pdi.version + 100).
-                # This ensures the split distinct_id overrides any deleted distinct_id.
-                pdi.version = (pdi.version or 0) + 101
-
-            PersonDistinctId.objects.bulk_update(list(pdis.values()), ["person_id", "version"])
-
-        # 5. Publish Kafka messages after transaction commits — DB is source of truth,
+        # 4. Publish Kafka messages after transaction commits — DB is source of truth,
         # Kafka/ClickHouse catches up via versioning
-        for did in ids_to_split:
-            pdi = pdis.get(did)
-            if not pdi:
-                continue
-            person = person_by_uuid[uuid_by_did[did]]  # safe: validated in transaction above
+        self._publish_split_to_kafka(locked_pdis, new_person_by_uuid, new_uuid_by_distinct_id)
+
+    def _lock_person_distinct_ids(self, distinct_ids: list[str]) -> dict[str, "PersonDistinctId"]:
+        """Lock and return PDIs for the given distinct_ids. Raises if any are missing."""
+        locked = {
+            person_distinct_id.distinct_id: person_distinct_id
+            for person_distinct_id in PersonDistinctId.objects.select_for_update().filter(
+                team_id=self.team_id, person=self, distinct_id__in=distinct_ids
+            )
+        }
+
+        missing = set(distinct_ids) - set(locked.keys())
+        if missing:
+            raise ValueError(
+                f"split_person: PDIs missing for distinct_ids {missing} (team_id={self.team_id}, person_id={self.pk})"
+            )
+
+        logger.info(
+            "split_person locked PDIs",
+            person_id=self.pk,
+            team_id=self.team_id,
+            locked_count=len(locked),
+        )
+
+        return locked
+
+    def _create_split_persons(self, new_uuid_by_distinct_id: dict, original_person_version: int) -> dict:
+        """Create or update a Person for each split distinct_id.
+
+        update_or_create handles pre-existing persons (e.g., from a previous partial run)
+        by bumping their version, so the Kafka message carries the correct version.
+        Set version higher than delete events (which use version + 100).
+        Keep in sync with: posthog/models/person/util.py:222 (_delete_person)
+        and plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
+        """
+        new_person_by_uuid = {}
+        for new_uuid in new_uuid_by_distinct_id.values():
+            new_person, _created = Person.objects.update_or_create(
+                uuid=new_uuid,
+                team_id=self.team_id,
+                defaults={"version": original_person_version + 101},
+            )
+            new_person_by_uuid[new_uuid] = new_person
+
+        logger.info(
+            "split_person created persons",
+            person_id=self.pk,
+            team_id=self.team_id,
+            created_count=len(new_person_by_uuid),
+        )
+
+        return new_person_by_uuid
+
+    @staticmethod
+    def _assign_person_distinct_ids(
+        locked_pdis: dict[str, "PersonDistinctId"],
+        new_person_by_uuid: dict,
+        new_uuid_by_distinct_id: dict,
+    ) -> None:
+        """Point each locked PDI to its new person and bump its version."""
+        for distinct_id, person_distinct_id in locked_pdis.items():
+            new_person = new_person_by_uuid[new_uuid_by_distinct_id[distinct_id]]
+            person_distinct_id.person_id = str(new_person.id)
+            # Set distinct_id version higher than delete events (which use pdi.version + 100).
+            # This ensures the split distinct_id overrides any deleted distinct_id.
+            person_distinct_id.version = (person_distinct_id.version or 0) + 101
+
+        PersonDistinctId.objects.bulk_update(list(locked_pdis.values()), ["person_id", "version"])
+
+    def _publish_split_to_kafka(
+        self,
+        locked_pdis: dict[str, "PersonDistinctId"],
+        new_person_by_uuid: dict,
+        new_uuid_by_distinct_id: dict,
+    ) -> None:
+        """Publish Kafka messages for each split person and PDI reassignment."""
+        from posthog.models.person.util import create_person, create_person_distinct_id
+
+        for distinct_id, person_distinct_id in locked_pdis.items():
+            new_person = new_person_by_uuid[new_uuid_by_distinct_id[distinct_id]]
 
             create_person_distinct_id(
                 team_id=self.team_id,
-                distinct_id=did,
-                person_id=str(person.uuid),
+                distinct_id=distinct_id,
+                person_id=str(new_person.uuid),
                 is_deleted=False,
-                version=pdi.version,
+                version=person_distinct_id.version,
             )
             create_person(
-                team_id=self.team_id, uuid=str(person.uuid), version=person.version, created_at=person.created_at
+                team_id=self.team_id,
+                uuid=str(new_person.uuid),
+                version=new_person.version,
+                created_at=new_person.created_at,
             )
 
 

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -330,29 +330,33 @@ class Person(models.Model):
                 expected_count=len(ids_to_split),
             )
 
-            # 2. Batch create new persons — ignore_conflicts handles pre-existing ones
+            # 2. Batch create new persons, or update version if they already exist.
+            # update_conflicts ensures pre-existing persons (e.g., from a previous partial run)
+            # get their version bumped, so the Kafka message carries the correct version.
+            # Set version higher than delete events (which use version + 100).
+            # Keep in sync with: posthog/models/person/util.py:222 (_delete_person)
+            # and plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
             Person.objects.bulk_create(
                 [
                     Person(
                         uuid=uuid_by_did[did],
                         team_id=self.team_id,
-                        # Set version higher than delete events (which use version + 100).
-                        # Keep in sync with: posthog/models/person/util.py:222 (_delete_person)
-                        # and plugin-server/src/utils/db/utils.ts:152 (generateKafkaPersonUpdateMessage)
                         version=original_person_version + 101,
                     )
                     for did in ids_to_split
                 ],
-                ignore_conflicts=True,
+                update_conflicts=True,
+                unique_fields=["team_id", "uuid"],
+                update_fields=["version"],
             )
 
-            # 3. Fetch all new persons — only columns needed for Kafka publishes
-            person_by_uuid = {
-                p.uuid: p
-                for p in Person.objects.only("id", "team_id", "uuid", "version", "created_at").filter(
-                    team_id=self.team_id, uuid__in=list(uuid_by_did.values())
-                )
-            }
+            # 3. Fetch all new persons in a single query — bulk_create doesn't
+            # populate id/created_at on the returned objects, so we need this fetch
+            new_uuids = list(uuid_by_did.values())
+            new_persons = Person.objects.only("id", "team_id", "uuid", "version", "created_at").filter(
+                team_id=self.team_id, uuid__in=new_uuids
+            )
+            person_by_uuid = {p.uuid: p for p in new_persons}
 
             logger.info(
                 "split_person created persons",
@@ -373,7 +377,13 @@ class Person(models.Model):
                     )
                     continue
 
-                person = person_by_uuid[uuid_by_did[did]]
+                expected_uuid = uuid_by_did[did]
+                person = person_by_uuid.get(expected_uuid)
+                if not person:
+                    raise ValueError(
+                        f"split_person: new person not found after bulk_create "
+                        f"(team_id={self.team_id}, distinct_id={did}, expected_uuid={expected_uuid})"
+                    )
                 pdi.person_id = str(person.id)
                 # Set distinct_id version higher than delete events (which use pdi.version + 100).
                 # This ensures the split distinct_id overrides any deleted distinct_id.
@@ -387,7 +397,7 @@ class Person(models.Model):
             pdi = pdis.get(did)
             if not pdi:
                 continue
-            person = person_by_uuid[uuid_by_did[did]]
+            person = person_by_uuid[uuid_by_did[did]]  # safe: validated in transaction above
 
             create_person_distinct_id(
                 team_id=self.team_id,

--- a/posthog/models/person/test/test_split_person.py
+++ b/posthog/models/person/test/test_split_person.py
@@ -57,8 +57,8 @@ class TestSplitPerson(BaseTest):
         assert person.properties == {"email": "test@example.com", "name": "Test"}
 
         # New persons have empty properties
-        new_person_2 = Person.objects.get(id=pdi_id2.person_id)
-        new_person_3 = Person.objects.get(id=pdi_id3.person_id)
+        new_person_2 = Person.objects.get(team_id=self.team.id, id=pdi_id2.person_id)
+        new_person_3 = Person.objects.get(team_id=self.team.id, id=pdi_id3.person_id)
         assert new_person_2.properties == {}
         assert new_person_3.properties == {}
 
@@ -116,7 +116,7 @@ class TestSplitPerson(BaseTest):
         person.split_person(main_distinct_id="id1")
 
         pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
-        new_person = Person.objects.get(id=pdi_id2.person_id)
+        new_person = Person.objects.get(team_id=self.team.id, id=pdi_id2.person_id)
 
         assert new_person.version == 5 + 101
 
@@ -138,7 +138,7 @@ class TestSplitPerson(BaseTest):
         person.split_person(main_distinct_id="id1")
 
         pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
-        new_person = Person.objects.get(id=pdi_id2.person_id)
+        new_person = Person.objects.get(team_id=self.team.id, id=pdi_id2.person_id)
 
         expected_uuid = uuidFromDistinctId(self.team.id, "id2")
         assert new_person.uuid == expected_uuid
@@ -161,15 +161,54 @@ class TestSplitPerson(BaseTest):
         for call in mock_create_person.call_args_list:
             assert call.kwargs["team_id"] == self.team.id
 
-    def test_split_is_atomic(self, mock_create_pdi, mock_create_person):
+    def test_split_rolls_back_on_failure(self, mock_create_pdi, mock_create_person):
         person = self._create_person_with_distinct_ids(["id1", "id2", "id3"], mock_create_pdi, mock_create_person)
+
+        original_pdi_ids = {
+            did: PersonDistinctId.objects.get(team=self.team, distinct_id=did).person_id
+            for did in ["id1", "id2", "id3"]
+        }
+        original_person_count = Person.objects.filter(team_id=self.team.id).count()
+
+        with patch.object(PersonDistinctId.objects, "bulk_update", side_effect=Exception("simulated failure")):
+            with self.assertRaises(Exception, msg="simulated failure"):
+                person.split_person(main_distinct_id="id1")
+
+        # All PDIs should still point to the original person
+        for did in ["id1", "id2", "id3"]:
+            pdi = PersonDistinctId.objects.get(team=self.team, distinct_id=did)
+            assert pdi.person_id == original_pdi_ids[did]
+
+        # No new persons should have been committed
+        assert Person.objects.filter(team_id=self.team.id).count() == original_person_count
+
+    def test_split_updates_version_on_pre_existing_person(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(["id1", "id2"], mock_create_pdi, mock_create_person, version=5)
+
+        # Pre-create a person with the UUID that split would generate, simulating a previous partial run
+        expected_uuid = uuidFromDistinctId(self.team.id, "id2")
+        pre_existing = Person.objects.create(
+            team=self.team,
+            uuid=expected_uuid,
+            version=0,
+        )
+        mock_create_person.reset_mock()
+        mock_create_pdi.reset_mock()
 
         person.split_person(main_distinct_id="id1")
 
-        for did in ["id2", "id3"]:
-            pdi = PersonDistinctId.objects.get(team=self.team, distinct_id=did)
-            assert pdi.person_id != person.id
-            assert Person.objects.filter(id=pdi.person_id).exists()
+        # The pre-existing person's version should be updated to original_version + 101
+        pre_existing.refresh_from_db()
+        assert pre_existing.version == 5 + 101
+
+        # PDI should point to the pre-existing person
+        pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
+        assert pdi_id2.person_id == pre_existing.id
+
+        # Kafka message should carry the updated version
+        person_calls = [c for c in mock_create_person.call_args_list if c.kwargs.get("uuid") == str(expected_uuid)]
+        assert len(person_calls) == 1
+        assert person_calls[0].kwargs["version"] == 5 + 101
 
     def test_split_many_distinct_ids(self, mock_create_pdi, mock_create_person):
         distinct_ids = ["main"] + [f"id_{i}" for i in range(100)]

--- a/posthog/models/person/test/test_split_person.py
+++ b/posthog/models/person/test/test_split_person.py
@@ -1,0 +1,192 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from posthog.models import Person
+from posthog.models.person import PersonDistinctId
+from posthog.models.person.missing_person import uuidFromDistinctId
+
+
+@patch("posthog.models.person.util.create_person")
+@patch("posthog.models.person.util.create_person_distinct_id")
+class TestSplitPerson(BaseTest):
+    def _create_person_with_distinct_ids(
+        self,
+        distinct_ids: list[str],
+        mock_create_pdi,
+        mock_create_person,
+        properties: dict | None = None,
+        version: int = 0,
+    ) -> Person:
+        person = Person.objects.create(
+            team=self.team,
+            properties=properties or {},
+            version=version,
+        )
+        for distinct_id in distinct_ids:
+            PersonDistinctId.objects.create(
+                team=self.team,
+                person=person,
+                distinct_id=distinct_id,
+            )
+        # Reset mocks after setup so post_save signal calls from setup don't count
+        mock_create_pdi.reset_mock()
+        mock_create_person.reset_mock()
+        return person
+
+    def test_split_with_main_distinct_id(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(
+            ["id1", "id2", "id3"],
+            mock_create_pdi,
+            mock_create_person,
+            properties={"email": "test@example.com", "name": "Test"},
+        )
+
+        person.split_person(main_distinct_id="id1")
+
+        pdi_id1 = PersonDistinctId.objects.get(team=self.team, distinct_id="id1")
+        pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
+        pdi_id3 = PersonDistinctId.objects.get(team=self.team, distinct_id="id3")
+
+        assert pdi_id1.person_id == person.id
+        assert pdi_id2.person_id != person.id
+        assert pdi_id3.person_id != person.id
+        assert pdi_id2.person_id != pdi_id3.person_id
+
+        # Original person keeps its properties when main_distinct_id is provided
+        person.refresh_from_db()
+        assert person.properties == {"email": "test@example.com", "name": "Test"}
+
+        # New persons have empty properties
+        new_person_2 = Person.objects.get(id=pdi_id2.person_id)
+        new_person_3 = Person.objects.get(id=pdi_id3.person_id)
+        assert new_person_2.properties == {}
+        assert new_person_3.properties == {}
+
+        assert mock_create_pdi.call_count == 2
+        assert mock_create_person.call_count == 2
+
+    def test_split_without_main_distinct_id_clears_properties(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(
+            ["id1", "id2"],
+            mock_create_pdi,
+            mock_create_person,
+            properties={"email": "test@example.com"},
+        )
+
+        person.split_person(main_distinct_id=None)
+
+        person.refresh_from_db()
+        assert person.properties == {}
+
+        pdi_id1 = PersonDistinctId.objects.get(team=self.team, distinct_id="id1")
+        pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
+        assert pdi_id1.person_id == person.id
+        assert pdi_id2.person_id != person.id
+
+    def test_split_with_max_splits(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(
+            ["id1", "id2", "id3", "id4"], mock_create_pdi, mock_create_person
+        )
+
+        person.split_person(main_distinct_id="id1", max_splits=2)
+
+        pdi_id1 = PersonDistinctId.objects.get(team=self.team, distinct_id="id1")
+        pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
+        pdi_id3 = PersonDistinctId.objects.get(team=self.team, distinct_id="id3")
+        pdi_id4 = PersonDistinctId.objects.get(team=self.team, distinct_id="id4")
+
+        assert pdi_id1.person_id == person.id
+        assert pdi_id2.person_id == person.id
+        assert pdi_id3.person_id != person.id
+        assert pdi_id4.person_id != person.id
+
+    def test_split_single_distinct_id_is_noop(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(["only_id"], mock_create_pdi, mock_create_person)
+
+        person.split_person(main_distinct_id="only_id")
+
+        pdi = PersonDistinctId.objects.get(team=self.team, distinct_id="only_id")
+        assert pdi.person_id == person.id
+        mock_create_pdi.assert_not_called()
+        mock_create_person.assert_not_called()
+
+    def test_split_sets_correct_person_version(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(["id1", "id2"], mock_create_pdi, mock_create_person, version=5)
+
+        person.split_person(main_distinct_id="id1")
+
+        pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
+        new_person = Person.objects.get(id=pdi_id2.person_id)
+
+        assert new_person.version == 5 + 101
+
+    def test_split_sets_correct_pdi_version(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(["id1", "id2"], mock_create_pdi, mock_create_person)
+        pdi = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
+        pdi.version = 3
+        pdi.save()
+        mock_create_pdi.reset_mock()
+
+        person.split_person(main_distinct_id="id1")
+
+        pdi.refresh_from_db()
+        assert pdi.version == 3 + 101
+
+    def test_split_creates_deterministic_uuids(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(["id1", "id2"], mock_create_pdi, mock_create_person)
+
+        person.split_person(main_distinct_id="id1")
+
+        pdi_id2 = PersonDistinctId.objects.get(team=self.team, distinct_id="id2")
+        new_person = Person.objects.get(id=pdi_id2.person_id)
+
+        expected_uuid = uuidFromDistinctId(self.team.id, "id2")
+        assert new_person.uuid == expected_uuid
+
+    def test_split_publishes_correct_kafka_messages(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(["id1", "id2", "id3"], mock_create_pdi, mock_create_person)
+
+        person.split_person(main_distinct_id="id1")
+
+        assert mock_create_pdi.call_count == 2
+        assert mock_create_person.call_count == 2
+
+        kafka_pdi_distinct_ids = {call.kwargs["distinct_id"] for call in mock_create_pdi.call_args_list}
+        assert kafka_pdi_distinct_ids == {"id2", "id3"}
+
+        for call in mock_create_pdi.call_args_list:
+            assert call.kwargs["team_id"] == self.team.id
+            assert call.kwargs["is_deleted"] is False
+
+        for call in mock_create_person.call_args_list:
+            assert call.kwargs["team_id"] == self.team.id
+
+    def test_split_is_atomic(self, mock_create_pdi, mock_create_person):
+        person = self._create_person_with_distinct_ids(["id1", "id2", "id3"], mock_create_pdi, mock_create_person)
+
+        person.split_person(main_distinct_id="id1")
+
+        for did in ["id2", "id3"]:
+            pdi = PersonDistinctId.objects.get(team=self.team, distinct_id=did)
+            assert pdi.person_id != person.id
+            assert Person.objects.filter(id=pdi.person_id).exists()
+
+    def test_split_many_distinct_ids(self, mock_create_pdi, mock_create_person):
+        distinct_ids = ["main"] + [f"id_{i}" for i in range(100)]
+        person = self._create_person_with_distinct_ids(distinct_ids, mock_create_pdi, mock_create_person)
+
+        person.split_person(main_distinct_id="main")
+
+        pdi_main = PersonDistinctId.objects.get(team=self.team, distinct_id="main")
+        assert pdi_main.person_id == person.id
+
+        split_person_ids = set()
+        for i in range(100):
+            pdi = PersonDistinctId.objects.get(team=self.team, distinct_id=f"id_{i}")
+            assert pdi.person_id != person.id
+            split_person_ids.add(pdi.person_id)
+
+        assert len(split_person_ids) == 100
+
+        assert mock_create_pdi.call_count == 100
+        assert mock_create_person.call_count == 100

--- a/posthog/models/person/test/test_split_person.py
+++ b/posthog/models/person/test/test_split_person.py
@@ -1,14 +1,31 @@
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.db.models.signals import post_save
+
 from posthog.models import Person
 from posthog.models.person import PersonDistinctId
 from posthog.models.person.missing_person import uuidFromDistinctId
+from posthog.models.person.util import person_created, person_distinct_id_created
 
 
 @patch("posthog.models.person.util.create_person")
 @patch("posthog.models.person.util.create_person_distinct_id")
 class TestSplitPerson(BaseTest):
+    def setUp(self):
+        super().setUp()
+        # Disconnect test-only post_save signals (see posthog/models/person/util.py)
+        # that automatically call create_person/create_person_distinct_id on every
+        # ORM save. split_person publishes to Kafka explicitly, so these signals
+        # would double-count calls and make assertions unreliable.
+        post_save.disconnect(person_created, sender=Person)
+        post_save.disconnect(person_distinct_id_created, sender=PersonDistinctId)
+
+    def tearDown(self):
+        post_save.connect(person_created, sender=Person)
+        post_save.connect(person_distinct_id_created, sender=PersonDistinctId)
+        super().tearDown()
+
     def _create_person_with_distinct_ids(
         self,
         distinct_ids: list[str],


### PR DESCRIPTION
## Problem

Splitting person process was hanging due to a missing team_id on a query, which made the query extremely slow and leading to timeout.

## Changes

Apart from adding team_id to that query, this change also batches the split of distinct_ids into a single (longer) transaction. This means all splits will succeed or fail. Then, if it succeeds, Kafka messages will be published to get Clickhouse in sync with Postgres.

For the future, this task will also be moved to Temporal, so that if publishing to Kafka fails, we are able to resume the job from that point and ensure Clickhouse will be **eventually** consistent.

## How did you test this code?

Unit tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
