### PR TITLE
feat: Implement kafka-deduplicator catch-up mechanic

### DIFF
--- a/rust/kafka-deduplicator/src/catchup/consumer.rs
+++ b/rust/kafka-deduplicator/src/catchup/consumer.rs
@@ -1,0 +1,312 @@
+//! Catch-up consumer: reads the output topic from a given offset to the high watermark
+//! and batch-inserts dedup keys into RocksDB.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::message::Message;
+use rdkafka::{Offset, TopicPartitionList};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::config::{Config, PipelineType};
+use crate::metrics::MetricsHelper;
+use crate::metrics_const::{
+    CATCHUP_BATCH_WRITE_DURATION_HISTOGRAM, CATCHUP_DURATION_HISTOGRAM,
+    CATCHUP_KEYS_INSERTED_COUNTER, CATCHUP_MESSAGES_PROCESSED_COUNTER, CATCHUP_STATUS_COUNTER,
+};
+use crate::store::deduplication_store::{DeduplicationStore, TimestampBatchEntry};
+
+use super::extract_dedup_key_value_from_payload;
+
+/// Result of a catch-up operation for a single partition.
+#[derive(Debug)]
+pub struct CatchupResult {
+    pub messages_read: u64,
+    pub keys_inserted: u64,
+    pub parse_errors: u64,
+    pub duration: Duration,
+    pub gap_size: i64,
+}
+
+/// Run catch-up for a single partition.
+///
+/// Creates a temporary BaseConsumer, reads the output topic from `start_offset`
+/// to the current high watermark, and batch-inserts dedup keys into RocksDB.
+///
+/// This function is blocking (Kafka poll + RocksDB writes) and should be called
+/// from `spawn_blocking`.
+pub fn run_catchup(
+    config: &Arc<Config>,
+    pipeline_type: PipelineType,
+    output_topic: &str,
+    partition: i32,
+    start_offset: i64,
+    store: &DeduplicationStore,
+    cancel_token: &CancellationToken,
+) -> Result<CatchupResult> {
+    let metrics = MetricsHelper::new()
+        .with_label("topic", output_topic)
+        .with_label("partition", &partition.to_string());
+
+    let start_time = Instant::now();
+
+    // Create temporary consumer
+    let consumer_config = config.build_catchup_consumer_config();
+    let consumer: BaseConsumer = consumer_config
+        .create()
+        .context("Failed to create catch-up consumer")?;
+
+    // Query high watermark
+    let (_low, high) = consumer
+        .fetch_watermarks(output_topic, partition, Duration::from_secs(10))
+        .context("Failed to fetch watermarks for catch-up")?;
+
+    let gap_size = high - start_offset;
+
+    // No gap to fill
+    if high <= start_offset {
+        info!(
+            output_topic,
+            partition,
+            start_offset,
+            high_watermark = high,
+            "Catch-up: no gap to fill"
+        );
+        metrics
+            .counter(CATCHUP_STATUS_COUNTER)
+            .with_label("result", "success")
+            .increment(1);
+        return Ok(CatchupResult {
+            messages_read: 0,
+            keys_inserted: 0,
+            parse_errors: 0,
+            duration: start_time.elapsed(),
+            gap_size: 0,
+        });
+    }
+
+    info!(
+        output_topic,
+        partition,
+        start_offset,
+        high_watermark = high,
+        gap_size,
+        "Catch-up: starting"
+    );
+
+    // Assign partition at start_offset
+    let mut tpl = TopicPartitionList::new();
+    tpl.add_partition_offset(output_topic, partition, Offset::Offset(start_offset))
+        .context("Failed to add partition to catch-up assignment")?;
+    consumer
+        .assign(&tpl)
+        .context("Failed to assign partition for catch-up")?;
+
+    let timeout = config.catchup_timeout();
+    let batch_size = config.catchup_batch_size;
+    let poll_timeout = Duration::from_secs(1);
+
+    let mut messages_read: u64 = 0;
+    let mut keys_inserted: u64 = 0;
+    let mut parse_errors: u64 = 0;
+    let mut kv_batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(batch_size);
+
+    loop {
+        // Check cancellation
+        if cancel_token.is_cancelled() {
+            info!(
+                output_topic,
+                partition, messages_read, keys_inserted, parse_errors, "Catch-up cancelled"
+            );
+            flush_batch(&kv_batch, store, &metrics, &mut keys_inserted)?;
+            metrics
+                .counter(CATCHUP_STATUS_COUNTER)
+                .with_label("result", "cancelled")
+                .increment(1);
+            return Ok(build_result(
+                messages_read,
+                keys_inserted,
+                parse_errors,
+                start_time,
+                gap_size,
+            ));
+        }
+
+        // Check timeout
+        if start_time.elapsed() >= timeout {
+            warn!(
+                output_topic,
+                partition,
+                messages_read,
+                keys_inserted,
+                parse_errors,
+                elapsed_secs = start_time.elapsed().as_secs(),
+                "Catch-up timeout reached, proceeding with partial results"
+            );
+            flush_batch(&kv_batch, store, &metrics, &mut keys_inserted)?;
+            metrics
+                .counter(CATCHUP_STATUS_COUNTER)
+                .with_label("result", "timeout")
+                .increment(1);
+            record_duration(&metrics, start_time, "timeout");
+            return Ok(build_result(
+                messages_read,
+                keys_inserted,
+                parse_errors,
+                start_time,
+                gap_size,
+            ));
+        }
+
+        // Poll for messages
+        match consumer.poll(poll_timeout) {
+            Some(Ok(msg)) => {
+                let offset = msg.offset();
+
+                if let Some(payload) = msg.payload() {
+                    match extract_dedup_key_value_from_payload(pipeline_type, payload) {
+                        Ok((key, value)) => {
+                            kv_batch.push((key, value));
+                            messages_read += 1;
+                            metrics
+                                .counter(CATCHUP_MESSAGES_PROCESSED_COUNTER)
+                                .with_label("result", "success")
+                                .increment(1);
+                        }
+                        Err(e) => {
+                            parse_errors += 1;
+                            metrics
+                                .counter(CATCHUP_MESSAGES_PROCESSED_COUNTER)
+                                .with_label("result", "parse_error")
+                                .increment(1);
+                            debug!(
+                                output_topic,
+                                partition,
+                                offset,
+                                error = %e,
+                                "Catch-up: failed to parse message, skipping"
+                            );
+                        }
+                    }
+                } else {
+                    // No payload (tombstone or empty message)
+                    metrics
+                        .counter(CATCHUP_MESSAGES_PROCESSED_COUNTER)
+                        .with_label("result", "skipped")
+                        .increment(1);
+                }
+
+                // Flush batch when full
+                if kv_batch.len() >= batch_size {
+                    flush_batch(&kv_batch, store, &metrics, &mut keys_inserted)?;
+                    kv_batch.clear();
+                }
+
+                // Check if we've reached the high watermark
+                if high > 0 && offset >= high - 1 {
+                    break;
+                }
+            }
+            Some(Err(e)) => {
+                warn!(
+                    output_topic,
+                    partition,
+                    error = %e,
+                    "Catch-up: Kafka poll error"
+                );
+            }
+            None => {
+                // No message within poll_timeout, loop will check timeout/cancellation
+            }
+        }
+    }
+
+    // Final flush
+    flush_batch(&kv_batch, store, &metrics, &mut keys_inserted)?;
+
+    info!(
+        output_topic,
+        partition,
+        messages_read,
+        keys_inserted,
+        parse_errors,
+        duration_secs = start_time.elapsed().as_secs_f64(),
+        gap_size,
+        "Catch-up completed"
+    );
+
+    metrics
+        .counter(CATCHUP_STATUS_COUNTER)
+        .with_label("result", "success")
+        .increment(1);
+    record_duration(&metrics, start_time, "success");
+
+    Ok(build_result(
+        messages_read,
+        keys_inserted,
+        parse_errors,
+        start_time,
+        gap_size,
+    ))
+}
+
+fn flush_batch(
+    kv_batch: &[(Vec<u8>, Vec<u8>)],
+    store: &DeduplicationStore,
+    metrics: &MetricsHelper,
+    keys_inserted: &mut u64,
+) -> Result<()> {
+    if kv_batch.is_empty() {
+        return Ok(());
+    }
+
+    let entries: Vec<TimestampBatchEntry> = kv_batch
+        .iter()
+        .map(|(key, value)| TimestampBatchEntry {
+            key: key.as_slice(),
+            value: value.as_slice(),
+        })
+        .collect();
+
+    let batch_start = Instant::now();
+    let count = entries.len() as u64;
+    store
+        .put_timestamp_records_batch(entries)
+        .context("Failed to batch-write catch-up keys to RocksDB")?;
+
+    *keys_inserted += count;
+    metrics
+        .counter(CATCHUP_KEYS_INSERTED_COUNTER)
+        .increment(count);
+    metrics
+        .histogram(CATCHUP_BATCH_WRITE_DURATION_HISTOGRAM)
+        .record(batch_start.elapsed().as_secs_f64());
+
+    Ok(())
+}
+
+fn build_result(
+    messages_read: u64,
+    keys_inserted: u64,
+    parse_errors: u64,
+    start_time: Instant,
+    gap_size: i64,
+) -> CatchupResult {
+    CatchupResult {
+        messages_read,
+        keys_inserted,
+        parse_errors,
+        duration: start_time.elapsed(),
+        gap_size,
+    }
+}
+
+fn record_duration(metrics: &MetricsHelper, start_time: Instant, result: &str) {
+    metrics
+        .histogram(CATCHUP_DURATION_HISTOGRAM)
+        .with_label("result", result)
+        .record(start_time.elapsed().as_secs_f64());
+}

--- a/rust/kafka-deduplicator/src/catchup/mod.rs
+++ b/rust/kafka-deduplicator/src/catchup/mod.rs
@@ -1,0 +1,237 @@
+//! Kafka catch-up mechanism for the deduplicator.
+//!
+//! After restoring a checkpoint (from S3 or local), the RocksDB state only reflects
+//! events up to the checkpoint time. Events produced to the output topic between the
+//! checkpoint and now are missing from the store, which would cause them to be
+//! re-produced as false non-duplicates.
+//!
+//! The catch-up mechanism closes this gap by reading the output topic from the
+//! checkpoint's `producer_offset` to the current high watermark, extracting dedup
+//! keys from each message, and batch-inserting them into RocksDB.
+//!
+//! ## Configuration
+//!
+//! - `CATCHUP_ENABLED` (default: false) — master switch
+//! - `CATCHUP_BATCH_SIZE` (default: 10000) — RocksDB batch insert size
+//! - `CATCHUP_TIMEOUT_SECS` (default: 60) — max time per partition
+//! - `CATCHUP_CONSUMER_FETCH_MAX_BYTES` (default: 50MB) — Kafka fetch size
+
+pub mod consumer;
+
+use anyhow::Result;
+use common_types::{CapturedEvent, ClickHouseEvent};
+
+use crate::config::PipelineType;
+use crate::pipelines::clickhouse_events::ClickHouseEventMetadata;
+use crate::pipelines::ingestion_events::{raw_event_from_captured, TimestampMetadata};
+use crate::pipelines::traits::{DeduplicationKeyExtractor, DeduplicationMetadata};
+
+/// Extract a dedup key and metadata value from raw Kafka message payload bytes.
+///
+/// Dispatches to the appropriate parser based on pipeline type, reusing
+/// the same parsing and key extraction logic as the normal pipeline path.
+///
+/// Returns `(key_bytes, value_bytes)` on success, where `value_bytes` is serialized
+/// metadata matching the format used by the normal pipeline. This ensures the dedup
+/// path can deserialize values from caught-up keys without errors.
+pub fn extract_dedup_key_value_from_payload(
+    pipeline_type: PipelineType,
+    payload: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    match pipeline_type {
+        PipelineType::IngestionEvents => {
+            let captured: CapturedEvent = serde_json::from_slice(payload)?;
+            let raw_event = raw_event_from_captured(&captured)?;
+            let key = raw_event.extract_dedup_key();
+            let metadata = TimestampMetadata::new(&raw_event);
+            let value = metadata.to_bytes()?;
+            Ok((key, value))
+        }
+        PipelineType::ClickhouseEvents => {
+            let event: ClickHouseEvent = serde_json::from_slice(payload)?;
+            let key = event.extract_dedup_key();
+            let metadata = ClickHouseEventMetadata::new(&event);
+            let value = metadata.to_bytes()?;
+            Ok((key, value))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common_types::RawEvent;
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    fn create_captured_event_json(event_name: &str, timestamp: &str) -> Vec<u8> {
+        let uuid = Uuid::new_v4();
+        let data = serde_json::json!({
+            "event": event_name,
+            "timestamp": timestamp,
+            "properties": {},
+        });
+        let captured = serde_json::json!({
+            "uuid": uuid.to_string(),
+            "distinct_id": "user123",
+            "ip": "127.0.0.1",
+            "data": data.to_string(),
+            "now": "2024-01-01T00:00:00Z",
+            "token": "test_token",
+            "event": event_name,
+            "timestamp": "2024-01-01T00:00:00Z",
+        });
+        serde_json::to_vec(&captured).unwrap()
+    }
+
+    fn create_clickhouse_event_json(event_name: &str, timestamp: &str) -> Vec<u8> {
+        let uuid = Uuid::new_v4();
+        let event = serde_json::json!({
+            "uuid": uuid.to_string(),
+            "team_id": 123,
+            "project_id": 456,
+            "event": event_name,
+            "distinct_id": "user123",
+            "properties": "{\"foo\": \"bar\"}",
+            "person_id": "person-uuid",
+            "timestamp": timestamp,
+            "created_at": "2024-01-01 12:00:00.000000",
+            "person_mode": "full",
+        });
+        serde_json::to_vec(&event).unwrap()
+    }
+
+    #[test]
+    fn test_ingestion_key_extraction_succeeds() {
+        let payload = create_captured_event_json("page_view", "2024-01-01T00:00:00Z");
+        let result = extract_dedup_key_value_from_payload(PipelineType::IngestionEvents, &payload);
+        assert!(result.is_ok());
+        let (key, value) = result.unwrap();
+        assert!(!key.is_empty());
+        assert!(!value.is_empty());
+    }
+
+    #[test]
+    fn test_clickhouse_key_extraction_succeeds() {
+        let payload = create_clickhouse_event_json("page_view", "2024-01-01 12:00:00.000000");
+        let result = extract_dedup_key_value_from_payload(PipelineType::ClickhouseEvents, &payload);
+        assert!(result.is_ok());
+        let (key, value) = result.unwrap();
+        assert!(!key.is_empty());
+        assert!(!value.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_json_returns_error() {
+        let result =
+            extract_dedup_key_value_from_payload(PipelineType::IngestionEvents, b"not valid json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ingestion_key_consistency_with_normal_pipeline() {
+        let uuid = Uuid::new_v4();
+        let raw_event = RawEvent {
+            uuid: Some(uuid),
+            event: "page_view".to_string(),
+            distinct_id: Some(serde_json::Value::String("user123".to_string())),
+            token: Some("test_token".to_string()),
+            properties: HashMap::new(),
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            ..Default::default()
+        };
+
+        // Normal pipeline key
+        let normal_key = raw_event.extract_dedup_key();
+
+        // Catch-up path: serialize as CapturedEvent JSON, then extract
+        let captured = CapturedEvent {
+            uuid,
+            distinct_id: "user123".to_string(),
+            session_id: None,
+            ip: "127.0.0.1".to_string(),
+            data: serde_json::to_string(&raw_event).unwrap(),
+            now: "2024-01-01T00:00:00Z".to_string(),
+            sent_at: None,
+            token: "test_token".to_string(),
+            event: "page_view".to_string(),
+            timestamp: chrono::Utc::now(),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+        let payload = serde_json::to_vec(&captured).unwrap();
+        let (catchup_key, _catchup_value) =
+            extract_dedup_key_value_from_payload(PipelineType::IngestionEvents, &payload).unwrap();
+
+        assert_eq!(normal_key, catchup_key);
+    }
+
+    #[test]
+    fn test_clickhouse_key_consistency_with_normal_pipeline() {
+        use common_types::PersonMode;
+
+        let uuid = Uuid::new_v4();
+        let event = ClickHouseEvent {
+            uuid,
+            team_id: 123,
+            project_id: Some(456),
+            event: "test_event".to_string(),
+            distinct_id: "user123".to_string(),
+            properties: Some(r#"{"foo": "bar"}"#.to_string()),
+            person_id: Some("person-uuid".to_string()),
+            timestamp: "2024-01-01 12:00:00.000000".to_string(),
+            created_at: "2024-01-01 12:00:00.000000".to_string(),
+            captured_at: None,
+            elements_chain: None,
+            person_created_at: None,
+            person_properties: None,
+            group0_properties: None,
+            group1_properties: None,
+            group2_properties: None,
+            group3_properties: None,
+            group4_properties: None,
+            group0_created_at: None,
+            group1_created_at: None,
+            group2_created_at: None,
+            group3_created_at: None,
+            group4_created_at: None,
+            person_mode: PersonMode::Full,
+            historical_migration: None,
+        };
+
+        let normal_key = event.extract_dedup_key();
+
+        let payload = serde_json::to_vec(&event).unwrap();
+        let (catchup_key, _catchup_value) =
+            extract_dedup_key_value_from_payload(PipelineType::ClickhouseEvents, &payload).unwrap();
+
+        assert_eq!(normal_key, catchup_key);
+    }
+
+    #[test]
+    fn test_same_events_produce_same_keys() {
+        let payload1 = create_captured_event_json("page_view", "2024-01-01T00:00:00Z");
+        let payload2 = create_captured_event_json("page_view", "2024-01-01T00:00:00Z");
+
+        let (key1, _) =
+            extract_dedup_key_value_from_payload(PipelineType::IngestionEvents, &payload1).unwrap();
+        let (key2, _) =
+            extract_dedup_key_value_from_payload(PipelineType::IngestionEvents, &payload2).unwrap();
+
+        // Same event name + timestamp + distinct_id + token = same key
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn test_different_events_produce_different_keys() {
+        let payload1 = create_captured_event_json("page_view", "2024-01-01T00:00:00Z");
+        let payload2 = create_captured_event_json("button_click", "2024-01-01T00:00:00Z");
+
+        let (key1, _) =
+            extract_dedup_key_value_from_payload(PipelineType::IngestionEvents, &payload1).unwrap();
+        let (key2, _) =
+            extract_dedup_key_value_from_payload(PipelineType::IngestionEvents, &payload2).unwrap();
+
+        assert_ne!(key1, key2);
+    }
+}

--- a/rust/kafka-deduplicator/src/config.rs
+++ b/rust/kafka-deduplicator/src/config.rs
@@ -320,6 +320,32 @@ pub struct Config {
     pub consumer_name: Option<String>,
 
     //// End kafka-assigner mode configuration ////
+
+    //// Catch-up configuration ////
+    /// Enable catch-up from the output topic after checkpoint restore.
+    /// When enabled, the deduplicator reads the output topic from the checkpoint's
+    /// producer_offset to the current high watermark and inserts dedup keys into RocksDB,
+    /// closing the gap between checkpoint time and now.
+    #[envconfig(default = "false")]
+    pub catchup_enabled: bool,
+
+    /// Batch size for RocksDB inserts during catch-up.
+    /// Larger batches reduce RocksDB write overhead but use more memory.
+    #[envconfig(default = "10000")]
+    pub catchup_batch_size: usize,
+
+    /// Maximum time (seconds) allowed for catch-up per partition.
+    /// If exceeded, catch-up stops with partial results (better than nothing).
+    /// Must fit within max.poll.interval.ms alongside checkpoint import time.
+    #[envconfig(default = "60")]
+    pub catchup_timeout_secs: u64,
+
+    /// Maximum fetch size (bytes) for the catch-up consumer.
+    /// Larger values improve throughput for sequential reads.
+    #[envconfig(default = "52428800")] // 50MB
+    pub catchup_consumer_fetch_max_bytes: u32,
+
+    //// End catch-up configuration ////
     /// Fail-open mode: bypass all deduplication and forward events directly to output topic.
     /// When enabled, the deduplicator skips store operations, checkpoint import/export,
     /// and treats all events as unique. Use as an emergency kill switch when the
@@ -614,6 +640,36 @@ impl Config {
     /// Get max staleness for local checkpoint data as Duration
     pub fn local_checkpoint_max_staleness(&self) -> Duration {
         Duration::from_secs(self.local_checkpoint_max_staleness_secs)
+    }
+
+    /// Check if catch-up is effectively enabled (flag + output topic configured)
+    pub fn catchup_enabled(&self) -> bool {
+        self.catchup_enabled && self.output_topic.is_some()
+    }
+
+    /// Get catch-up timeout as Duration
+    pub fn catchup_timeout(&self) -> Duration {
+        Duration::from_secs(self.catchup_timeout_secs)
+    }
+
+    /// Build Kafka consumer configuration for the catch-up consumer.
+    /// Uses an assign-only consumer optimized for large sequential reads.
+    pub fn build_catchup_consumer_config(&self) -> rdkafka::ClientConfig {
+        use crate::kafka::config::ConsumerConfigBuilder;
+
+        let group_id = format!("{}-catchup", self.kafka_consumer_group);
+
+        ConsumerConfigBuilder::for_watermark_consumer(&self.kafka_hosts, &group_id)
+            .with_tls(self.kafka_tls)
+            .with_max_partition_fetch_bytes(self.catchup_consumer_fetch_max_bytes)
+            .with_topic_metadata_refresh_interval_ms(self.kafka_topic_metadata_refresh_interval_ms)
+            .with_metadata_max_age_ms(self.kafka_metadata_max_age_ms)
+            .with_fetch_min_bytes(self.kafka_consumer_fetch_min_bytes)
+            .with_fetch_max_bytes(self.catchup_consumer_fetch_max_bytes)
+            .with_fetch_wait_max_ms(self.kafka_consumer_fetch_wait_max_ms)
+            .with_queued_min_messages(self.kafka_consumer_queued_min_messages)
+            .with_queued_max_messages_kbytes(self.kafka_consumer_queued_max_messages_kbytes)
+            .build()
     }
 
     /// Build Kafka consumer configuration for the group-based batch consumer.
@@ -911,6 +967,26 @@ mod tests {
         config.s3_endpoint = None;
         config.aws_region = None;
         assert!(!config.checkpoint_import_enabled());
+    }
+
+    #[test]
+    fn test_catchup_enabled() {
+        let mut config = Config::init_with_defaults().unwrap();
+
+        // Disabled by default (flag false, no output topic)
+        assert!(!config.catchup_enabled());
+
+        // Flag true but no output topic
+        config.catchup_enabled = true;
+        assert!(!config.catchup_enabled());
+
+        // Flag true and output topic set
+        config.output_topic = Some("events_deduped".to_string());
+        assert!(config.catchup_enabled());
+
+        // Flag false with output topic set
+        config.catchup_enabled = false;
+        assert!(!config.catchup_enabled());
     }
 
     #[test]

--- a/rust/kafka-deduplicator/src/kafka/assigner/consumer.rs
+++ b/rust/kafka-deduplicator/src/kafka/assigner/consumer.rs
@@ -19,7 +19,10 @@ use tracing::{error, info, warn};
 
 use super::client::AssignerGrpcClient;
 use super::handler::{proto_to_partition, AssignerCommandHandler};
+use crate::catchup::consumer::run_catchup;
 use crate::checkpoint::import::CheckpointImporter;
+use crate::checkpoint::metadata::CheckpointMetadata;
+use crate::config::Config;
 use crate::kafka::batch_consumer::BatchConsumerProcessor;
 use crate::kafka::batch_message::{Batch, BatchError, KafkaMessage};
 use crate::kafka::error_handling;
@@ -30,9 +33,10 @@ use crate::kafka::metrics_consts::{
 use crate::kafka::offset_tracker::OffsetTracker;
 use crate::kafka::partition_router::PartitionRouter;
 use crate::kafka::types::Partition;
-use crate::metrics_const::REBALANCE_CHECKPOINT_IMPORT_COUNTER;
+use crate::metrics_const::{CATCHUP_STATUS_COUNTER, REBALANCE_CHECKPOINT_IMPORT_COUNTER};
 use crate::store_manager::StoreManager;
 use crate::utils::async_helpers::unwrap_blocking_task;
+use crate::utils::format_store_path;
 
 /// Result of a background warming (checkpoint import) task.
 struct WarmResult {
@@ -63,6 +67,7 @@ where
     // For spawning warming tasks
     store_manager: Arc<StoreManager>,
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
+    catchup_config: Option<Arc<Config>>,
 
     // Config
     commit_interval: Duration,
@@ -88,6 +93,7 @@ where
         topic: String,
         store_manager: Arc<StoreManager>,
         checkpoint_importer: Option<Arc<CheckpointImporter>>,
+        catchup_config: Option<Arc<Config>>,
         offset_tracker: Arc<OffsetTracker>,
         router: Arc<PartitionRouter<T, P>>,
         processor: Arc<RoutingProcessor<T, P>>,
@@ -121,6 +127,7 @@ where
             offset_tracker,
             store_manager,
             checkpoint_importer,
+            catchup_config,
             commit_interval,
             batch_size,
             batch_timeout,
@@ -161,6 +168,7 @@ where
                                 &mut self.handler,
                                 &self.store_manager,
                                 &self.checkpoint_importer,
+                                &self.catchup_config,
                                 &warm_done_tx,
                             ).await?;
                         }
@@ -299,6 +307,7 @@ async fn handle_command<T, P>(
     handler: &mut AssignerCommandHandler<T, P>,
     store_manager: &Arc<StoreManager>,
     checkpoint_importer: &Option<Arc<CheckpointImporter>>,
+    catchup_config: &Option<Arc<Config>>,
     warm_done_tx: &mpsc::Sender<WarmResult>,
 ) -> Result<()>
 where
@@ -336,6 +345,7 @@ where
                 cancel_token,
                 store_manager.clone(),
                 checkpoint_importer.clone(),
+                catchup_config.clone(),
                 warm_done_tx.clone(),
             );
         }
@@ -353,6 +363,7 @@ fn spawn_warming_task(
     cancel_token: CancellationToken,
     store_manager: Arc<StoreManager>,
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
+    catchup_config: Option<Arc<Config>>,
     done_tx: mpsc::Sender<WarmResult>,
 ) {
     tokio::spawn(async move {
@@ -364,8 +375,142 @@ fn spawn_warming_task(
         )
         .await;
 
+        // Run catch-up after successful import
+        if result.is_ok() {
+            run_catchup_for_assigner(&partition, &catchup_config, &store_manager, &cancel_token)
+                .await;
+        }
+
         let _ = done_tx.send(WarmResult { partition, result }).await;
     });
+}
+
+/// Run catch-up for a partition in assigner mode after checkpoint import.
+///
+/// Loads metadata from the store path, reads the output topic from `producer_offset`
+/// to the high watermark, and inserts dedup keys into RocksDB.
+async fn run_catchup_for_assigner(
+    partition: &Partition,
+    catchup_config: &Option<Arc<Config>>,
+    store_manager: &Arc<StoreManager>,
+    cancel_token: &CancellationToken,
+) {
+    let Some(config) = catchup_config else {
+        return;
+    };
+
+    let output_topic = match &config.output_topic {
+        Some(t) if !t.is_empty() => t.clone(),
+        _ => return,
+    };
+
+    if cancel_token.is_cancelled() {
+        return;
+    }
+
+    // Load metadata from disk to get producer_offset
+    let store_path = format_store_path(
+        store_manager.base_path(),
+        partition.topic(),
+        partition.partition_number(),
+    );
+    let metadata = match CheckpointMetadata::load_from_dir(&store_path).await {
+        Ok(m) => m,
+        Err(_) => {
+            metrics::counter!(
+                CATCHUP_STATUS_COUNTER,
+                "topic" => partition.topic().to_string(),
+                "partition" => partition.partition_number().to_string(),
+                "result" => "skipped_no_metadata",
+            )
+            .increment(1);
+            return;
+        }
+    };
+
+    if metadata.producer_offset <= 0 {
+        metrics::counter!(
+            CATCHUP_STATUS_COUNTER,
+            "topic" => partition.topic().to_string(),
+            "partition" => partition.partition_number().to_string(),
+            "result" => "skipped_no_producer_offset",
+        )
+        .increment(1);
+        return;
+    }
+
+    // Get the store for this partition
+    let store = match store_manager.get(partition.topic(), partition.partition_number()) {
+        Some(s) => s,
+        None => {
+            warn!(
+                topic = partition.topic(),
+                partition = partition.partition_number(),
+                "Catch-up: store not found for partition, skipping"
+            );
+            return;
+        }
+    };
+
+    let pipeline_type = config.pipeline_type;
+    let partition_number = partition.partition_number();
+    let producer_offset = metadata.producer_offset;
+    let config_clone = config.clone();
+    let cancel_clone = cancel_token.clone();
+
+    info!(
+        topic = partition.topic(),
+        partition = partition_number,
+        producer_offset,
+        output_topic,
+        "Catch-up: starting for partition (assigner mode)"
+    );
+
+    let result = unwrap_blocking_task(
+        tokio::task::spawn_blocking(move || {
+            run_catchup(
+                &config_clone,
+                pipeline_type,
+                &output_topic,
+                partition_number,
+                producer_offset,
+                &store,
+                &cancel_clone,
+            )
+        }),
+        "catch-up task panicked",
+    )
+    .await;
+
+    match result {
+        Ok(catchup_result) => {
+            info!(
+                topic = partition.topic(),
+                partition = partition.partition_number(),
+                messages_read = catchup_result.messages_read,
+                keys_inserted = catchup_result.keys_inserted,
+                parse_errors = catchup_result.parse_errors,
+                duration_secs = catchup_result.duration.as_secs_f64(),
+                gap_size = catchup_result.gap_size,
+                "Catch-up: completed for partition (assigner mode)"
+            );
+        }
+        Err(e) => {
+            warn!(
+                topic = partition.topic(),
+                partition = partition.partition_number(),
+                error = %e,
+                "Catch-up: failed for partition (assigner mode), proceeding without full catch-up"
+            );
+            metrics::counter!(
+                CATCHUP_STATUS_COUNTER,
+                "topic" => partition.topic().to_string(),
+                "partition" => partition.partition_number().to_string(),
+                "result" => "error",
+            )
+            .increment(1);
+        }
+    }
 }
 
 /// Commit processed offsets to Kafka.

--- a/rust/kafka-deduplicator/src/lib.rs
+++ b/rust/kafka-deduplicator/src/lib.rs
@@ -13,6 +13,7 @@
 //! When constructing errors, use `.context()` / `.with_context()` so the original error remains
 //! the source. Avoid `anyhow!("...{e}")` — that formats the error into a string and drops the chain.
 
+pub mod catchup;
 pub mod checkpoint;
 pub mod checkpoint_manager;
 pub mod config;

--- a/rust/kafka-deduplicator/src/metrics_const.rs
+++ b/rust/kafka-deduplicator/src/metrics_const.rs
@@ -211,6 +211,28 @@ pub const KAFKA_PRODUCER_SEND_DURATION_MS: &str = "kafka_producer_send_duration_
 /// Histogram for event parsing duration using rayon (in milliseconds)
 pub const EVENT_PARSING_DURATION_MS: &str = "event_parsing_duration_ms";
 
+// ==== Catch-up metrics ====
+
+/// Histogram for total catch-up duration per partition (seconds)
+/// Labels: topic, partition, result (success|timeout|error|cancelled)
+pub const CATCHUP_DURATION_HISTOGRAM: &str = "catchup_duration_seconds";
+
+/// Counter for messages read from the output topic during catch-up
+/// Labels: topic, partition, result (success|parse_error|skipped)
+pub const CATCHUP_MESSAGES_PROCESSED_COUNTER: &str = "catchup_messages_processed_total";
+
+/// Counter for dedup keys inserted into RocksDB during catch-up
+/// Labels: topic, partition
+pub const CATCHUP_KEYS_INSERTED_COUNTER: &str = "catchup_keys_inserted_total";
+
+/// Histogram for RocksDB batch write duration during catch-up (seconds)
+/// Labels: topic, partition
+pub const CATCHUP_BATCH_WRITE_DURATION_HISTOGRAM: &str = "catchup_batch_write_duration_seconds";
+
+/// Counter for catch-up status outcomes
+/// Labels: topic, partition, result (success|skipped_disabled|skipped_no_output_topic|skipped_no_metadata|skipped_no_offset|timeout|error|cancelled)
+pub const CATCHUP_STATUS_COUNTER: &str = "catchup_status_total";
+
 // ==== Fail-open mode metrics ====
 /// Counter for events passed through in fail-open mode (deduplication bypassed)
 pub const FAIL_OPEN_EVENTS_PASSED_THROUGH: &str = "fail_open_events_passed_through_total";

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/mod.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/mod.rs
@@ -26,7 +26,7 @@ use common_types::RawEvent;
 
 pub use duplicate_event::DuplicateEvent;
 pub use metadata::{SerializableRawEvent, TimestampMetadata};
-pub use parser::IngestionEventParser;
+pub use parser::{raw_event_from_captured, IngestionEventParser};
 pub use processor::{
     DeduplicationConfig, DuplicateEventProducerWrapper, IngestionEventsBatchProcessor,
 };

--- a/rust/kafka-deduplicator/src/pipelines/ingestion_events/parser.rs
+++ b/rust/kafka-deduplicator/src/pipelines/ingestion_events/parser.rs
@@ -1,12 +1,55 @@
 //! Event parser for ingestion events (CapturedEvent -> RawEvent).
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use common_types::{CapturedEvent, RawEvent};
 use tracing::{debug, error};
 
 use crate::kafka::batch_message::KafkaMessage;
 use crate::pipelines::traits::EventParser;
 use crate::utils::timestamp;
+
+/// Extract a RawEvent from a CapturedEvent, applying timestamp and field normalization.
+///
+/// This is the shared core logic used by both the normal pipeline
+/// (via `IngestionEventParser::parse`) and the catch-up path.
+pub fn raw_event_from_captured(captured_event: &CapturedEvent) -> Result<RawEvent> {
+    let now = captured_event.now.clone();
+    let extracted_distinct_id = captured_event.distinct_id.clone();
+    let extracted_token = captured_event.token.clone();
+    let extracted_uuid = captured_event.uuid;
+
+    let mut raw_event: RawEvent = serde_json::from_str(&captured_event.data)
+        .context("Failed to parse RawEvent from CapturedEvent data field")?;
+
+    // Validate timestamp: if it's None or unparseable, use CapturedEvent.now
+    // This ensures we always have a valid timestamp for deduplication
+    match raw_event.timestamp {
+        None => {
+            debug!("No timestamp in RawEvent, using CapturedEvent.now");
+            raw_event.timestamp = Some(now);
+        }
+        Some(ref ts) if !timestamp::is_valid_timestamp(ts) => {
+            debug!("Invalid timestamp in RawEvent, replacing with CapturedEvent.now");
+            raw_event.timestamp = Some(now);
+        }
+        _ => {}
+    }
+
+    // If RawEvent is missing any of the core values
+    // extracted by capture into the CapturedEvent
+    // wrapper, use those values for downstream analysis
+    if raw_event.uuid.is_none() {
+        raw_event.uuid = Some(extracted_uuid);
+    }
+    if raw_event.distinct_id.is_none() && !extracted_distinct_id.is_empty() {
+        raw_event.distinct_id = Some(serde_json::Value::String(extracted_distinct_id));
+    }
+    if raw_event.token.is_none() && !extracted_token.is_empty() {
+        raw_event.token = Some(extracted_token);
+    }
+
+    Ok(raw_event)
+}
 
 /// Parser for ingestion events.
 ///
@@ -35,69 +78,14 @@ impl EventParser<CapturedEvent, RawEvent> for IngestionEventParser {
             }
         };
 
-        // Extract well-validated values from the CapturedEvent that
-        // may or may not be present in the wrapped RawEvent
-        let now = captured_event.now.clone();
-        let extracted_distinct_id = captured_event.distinct_id.clone();
-        let extracted_token = captured_event.token.clone();
-        let extracted_uuid = captured_event.uuid;
-
-        // The RawEvent is serialized in the data field
-        match serde_json::from_str::<RawEvent>(&captured_event.data) {
-            Ok(mut raw_event) => {
-                // Validate timestamp: if it's None or unparseable, use CapturedEvent.now
-                // This ensures we always have a valid timestamp for deduplication
-                match raw_event.timestamp {
-                    None => {
-                        debug!("No timestamp in RawEvent, using CapturedEvent.now");
-                        raw_event.timestamp = Some(now);
-                    }
-                    Some(ref ts) if !timestamp::is_valid_timestamp(ts) => {
-                        debug!(
-                            "Invalid timestamp detected at {}:{} offset {}, replacing with CapturedEvent.now",
-                            message.get_topic_partition().topic(),
-                            message.get_topic_partition().partition_number(),
-                            message.get_offset()
-                        );
-                        raw_event.timestamp = Some(now);
-                    }
-                    _ => {
-                        // Timestamp exists and is valid, keep it
-                    }
-                }
-
-                // If RawEvent is missing any of the core values
-                // extracted by capture into the CapturedEvent
-                // wrapper, use those values for downstream analysis
-                if raw_event.uuid.is_none() {
-                    raw_event.uuid = Some(extracted_uuid);
-                }
-                if raw_event.distinct_id.is_none() && !extracted_distinct_id.is_empty() {
-                    raw_event.distinct_id = Some(serde_json::Value::String(extracted_distinct_id));
-                }
-                if raw_event.token.is_none() && !extracted_token.is_empty() {
-                    raw_event.token = Some(extracted_token);
-                }
-
-                Ok(raw_event)
-            }
-            Err(e) => {
-                error!(
-                    "Failed to parse RawEvent from data field at {}:{} offset {}: {}",
-                    message.get_topic_partition().topic(),
-                    message.get_topic_partition().partition_number(),
-                    message.get_offset(),
-                    e
-                );
-                Err(anyhow::anyhow!(
-                    "Failed to parse RawEvent from data field at {}:{} offset {}: {}",
-                    message.get_topic_partition().topic(),
-                    message.get_topic_partition().partition_number(),
-                    message.get_offset(),
-                    e
-                ))
-            }
-        }
+        raw_event_from_captured(captured_event).with_context(|| {
+            format!(
+                "at {}:{} offset {}",
+                message.get_topic_partition().topic(),
+                message.get_topic_partition().partition_number(),
+                message.get_offset(),
+            )
+        })
     }
 }
 

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -18,7 +18,7 @@ use tracing::info;
 
 use crate::checkpoint::config::DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS;
 use crate::checkpoint::import::CheckpointImporter;
-use crate::config::PipelineType;
+use crate::config::{Config, PipelineType};
 use crate::kafka::assigner::AssignerConsumer;
 use crate::kafka::batch_consumer::BatchConsumer;
 use crate::kafka::{OffsetTracker, PartitionRouter, PartitionRouterConfig, RoutingProcessor};
@@ -72,6 +72,9 @@ pub struct PipelineBuilder {
     // Fail-open mode: bypass deduplication and forward events directly
     fail_open: bool,
 
+    // Catch-up config: when set, catch-up runs after checkpoint restore
+    catchup_config: Option<Arc<Config>>,
+
     // Ingestion events specific
     dedup_config: Option<DeduplicationConfig>,
     main_producer: Option<Arc<FutureProducer<KafkaContext>>>,
@@ -109,6 +112,7 @@ impl PipelineBuilder {
                 DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS,
             ),
             fail_open,
+            catchup_config: None,
             dedup_config: None,
             main_producer: None,
             duplicate_producer: None,
@@ -122,6 +126,11 @@ impl PipelineBuilder {
 
     pub fn with_local_checkpoint_staleness(mut self, staleness: Duration) -> Self {
         self.local_checkpoint_max_staleness = staleness;
+        self
+    }
+
+    pub fn with_catchup_config(mut self, config: Option<Arc<Config>>) -> Self {
+        self.catchup_config = config;
         self
     }
 
@@ -229,6 +238,7 @@ impl PipelineBuilder {
             self.checkpoint_importer,
             self.rebalance_cleanup_parallelism,
             self.local_checkpoint_max_staleness,
+            self.catchup_config,
         ));
 
         let on_commit = Arc::new(MetadataCommitCallback::new(
@@ -291,6 +301,7 @@ impl PipelineBuilder {
             self.checkpoint_importer,
             self.rebalance_cleanup_parallelism,
             self.local_checkpoint_max_staleness,
+            self.catchup_config,
         ));
 
         let on_commit = Arc::new(MetadataCommitCallback::new(
@@ -357,6 +368,7 @@ impl PipelineBuilder {
             self.topic.clone(),
             self.store_manager,
             self.checkpoint_importer,
+            self.catchup_config,
             offset_tracker,
             router,
             routing_processor,
@@ -408,6 +420,7 @@ impl PipelineBuilder {
             self.topic.clone(),
             self.store_manager,
             self.checkpoint_importer,
+            self.catchup_config,
             offset_tracker,
             router,
             routing_processor,

--- a/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
+++ b/rust/kafka-deduplicator/src/processor_rebalance_handler.rs
@@ -11,8 +11,10 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
+use crate::catchup::consumer::run_catchup;
 use crate::checkpoint::import::CheckpointImporter;
 use crate::checkpoint::metadata::CheckpointMetadata;
+use crate::config::Config;
 use crate::kafka::batch_consumer::BatchConsumerProcessor;
 use crate::kafka::batch_context::{ConsumerCommand, ConsumerCommandSender};
 use crate::kafka::offset_tracker::OffsetTracker;
@@ -20,8 +22,8 @@ use crate::kafka::partition_router::{shutdown_workers, PartitionRouter};
 use crate::kafka::rebalance_handler::RebalanceHandler;
 use crate::kafka::types::Partition;
 use crate::metrics_const::{
-    CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER, LOCAL_STORE_RESTORE_COUNTER,
-    PARTITION_STORE_FALLBACK_EMPTY, PARTITION_STORE_SETUP_SKIPPED,
+    CATCHUP_STATUS_COUNTER, CHECKPOINT_IMPORT_CANCELLED_CLEANUP_COUNTER,
+    LOCAL_STORE_RESTORE_COUNTER, PARTITION_STORE_FALLBACK_EMPTY, PARTITION_STORE_SETUP_SKIPPED,
     REBALANCE_CHECKPOINT_IMPORT_COUNTER, REBALANCE_PARTITION_STATE_CHANGE,
     REBALANCE_RESUME_SKIPPED_NO_OWNED,
 };
@@ -71,6 +73,8 @@ where
     /// Metadata from successfully restored partitions (local or S3). Used in finalize to seed
     /// OffsetTracker and seek consumer without re-reading metadata.json from disk.
     partition_restored_metadata: Arc<DashMap<Partition, CheckpointMetadata>>,
+    /// Config for running catch-up after checkpoint restore (None = catch-up disabled).
+    catchup_config: Option<Arc<Config>>,
 }
 
 impl<T, P> ProcessorRebalanceHandler<T, P>
@@ -78,6 +82,7 @@ where
     T: Send + 'static,
     P: BatchConsumerProcessor<T> + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         store_manager: Arc<StoreManager>,
         rebalance_tracker: Arc<RebalanceTracker>,
@@ -85,6 +90,7 @@ where
         checkpoint_importer: Option<Arc<CheckpointImporter>>,
         rebalance_cleanup_parallelism: usize,
         local_checkpoint_max_staleness: Duration,
+        catchup_config: Option<Arc<Config>>,
     ) -> Self {
         Self {
             store_manager,
@@ -97,9 +103,11 @@ where
             partition_setup_tasks: DashMap::new(),
             partition_fallback_reasons: Arc::new(DashMap::new()),
             partition_restored_metadata: Arc::new(DashMap::new()),
+            catchup_config,
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn with_router(
         store_manager: Arc<StoreManager>,
         rebalance_tracker: Arc<RebalanceTracker>,
@@ -108,6 +116,7 @@ where
         checkpoint_importer: Option<Arc<CheckpointImporter>>,
         rebalance_cleanup_parallelism: usize,
         local_checkpoint_max_staleness: Duration,
+        catchup_config: Option<Arc<Config>>,
     ) -> Self {
         Self {
             store_manager,
@@ -120,6 +129,7 @@ where
             partition_setup_tasks: DashMap::new(),
             partition_fallback_reasons: Arc::new(DashMap::new()),
             partition_restored_metadata: Arc::new(DashMap::new()),
+            catchup_config,
         }
     }
 
@@ -244,6 +254,7 @@ where
         let fallback_reasons = Arc::clone(&self.partition_fallback_reasons);
         let restored_metadata = Arc::clone(&self.partition_restored_metadata);
         let local_max_staleness = self.local_checkpoint_max_staleness;
+        let catchup_config = self.catchup_config.clone();
 
         tokio::spawn(async move {
             if should_skip_setup(
@@ -256,25 +267,34 @@ where
                 return;
             }
 
-            if try_restore_from_local(
+            let restored_from_local = try_restore_from_local(
                 &partition,
                 &store_manager,
                 &restored_metadata,
                 local_max_staleness,
             )
-            .await
-            {
-                return;
+            .await;
+
+            if !restored_from_local {
+                try_import_from_s3(
+                    &partition,
+                    &cancel_token,
+                    &coordinator,
+                    &store_manager,
+                    &importer,
+                    &fallback_reasons,
+                    &restored_metadata,
+                )
+                .await;
             }
 
-            try_import_from_s3(
+            // Run catch-up after successful restore (local or S3)
+            try_run_catchup(
                 &partition,
-                &cancel_token,
-                &coordinator,
+                &catchup_config,
                 &store_manager,
-                &importer,
-                &fallback_reasons,
                 &restored_metadata,
+                &cancel_token,
             )
             .await;
         })
@@ -775,6 +795,150 @@ async fn try_import_from_s3(
     }
 }
 
+/// Run catch-up for a partition after checkpoint restore.
+///
+/// Reads the output topic from the restored `producer_offset` to the current high watermark,
+/// extracting dedup keys and inserting them into RocksDB. This closes the gap between
+/// checkpoint time and now, preventing re-production of already-produced events.
+///
+/// Catch-up is skipped when:
+/// - Config is None (catch-up disabled)
+/// - No output topic configured
+/// - No restored metadata for this partition
+/// - `producer_offset` is 0 or negative (no prior production)
+/// - Partition was cancelled during rebalance
+/// - Store is not registered for this partition
+///
+/// Catch-up failures are logged but do NOT fail the partition setup — partial catch-up
+/// is strictly better than no catch-up.
+async fn try_run_catchup(
+    partition: &Partition,
+    catchup_config: &Option<Arc<Config>>,
+    store_manager: &Arc<StoreManager>,
+    restored_metadata: &Arc<DashMap<Partition, CheckpointMetadata>>,
+    cancel_token: &CancellationToken,
+) {
+    let Some(config) = catchup_config else {
+        return;
+    };
+
+    let output_topic = match &config.output_topic {
+        Some(t) if !t.is_empty() => t.clone(),
+        _ => return,
+    };
+
+    // Get the restored metadata to find producer_offset
+    let producer_offset = match restored_metadata.get(partition) {
+        Some(m) => m.producer_offset,
+        None => {
+            metrics::counter!(
+                CATCHUP_STATUS_COUNTER,
+                "topic" => partition.topic().to_string(),
+                "partition" => partition.partition_number().to_string(),
+                "result" => "skipped_no_metadata",
+            )
+            .increment(1);
+            return;
+        }
+    };
+
+    // Skip if no prior production
+    if producer_offset <= 0 {
+        metrics::counter!(
+            CATCHUP_STATUS_COUNTER,
+            "topic" => partition.topic().to_string(),
+            "partition" => partition.partition_number().to_string(),
+            "result" => "skipped_no_producer_offset",
+        )
+        .increment(1);
+        debug!(
+            topic = partition.topic(),
+            partition = partition.partition_number(),
+            producer_offset,
+            "Catch-up: skipping, no prior production"
+        );
+        return;
+    }
+
+    if cancel_token.is_cancelled() {
+        return;
+    }
+
+    // Get the store for this partition
+    let store = match store_manager.get(partition.topic(), partition.partition_number()) {
+        Some(s) => s,
+        None => {
+            warn!(
+                topic = partition.topic(),
+                partition = partition.partition_number(),
+                "Catch-up: store not found for partition, skipping"
+            );
+            return;
+        }
+    };
+
+    let pipeline_type = config.pipeline_type;
+    let partition_number = partition.partition_number();
+    let config_clone = config.clone();
+    let cancel_clone = cancel_token.clone();
+
+    info!(
+        topic = partition.topic(),
+        partition = partition_number,
+        producer_offset,
+        output_topic,
+        "Catch-up: starting for partition"
+    );
+
+    // Run catch-up on blocking thread (Kafka poll + RocksDB writes are synchronous)
+    let result = unwrap_blocking_task(
+        tokio::task::spawn_blocking(move || {
+            run_catchup(
+                &config_clone,
+                pipeline_type,
+                &output_topic,
+                partition_number,
+                producer_offset,
+                &store,
+                &cancel_clone,
+            )
+        }),
+        "catch-up task panicked",
+    )
+    .await;
+
+    match result {
+        Ok(catchup_result) => {
+            info!(
+                topic = partition.topic(),
+                partition = partition.partition_number(),
+                messages_read = catchup_result.messages_read,
+                keys_inserted = catchup_result.keys_inserted,
+                parse_errors = catchup_result.parse_errors,
+                duration_secs = catchup_result.duration.as_secs_f64(),
+                gap_size = catchup_result.gap_size,
+                "Catch-up: completed for partition"
+            );
+        }
+        Err(e) => {
+            // Catch-up failure is non-fatal: partial catch-up is better than none
+            warn!(
+                topic = partition.topic(),
+                partition = partition.partition_number(),
+                error = %e,
+                "Catch-up: failed for partition, proceeding without full catch-up"
+            );
+            metrics::counter!(
+                CATCHUP_STATUS_COUNTER,
+                "topic" => partition.topic().to_string(),
+                "partition" => partition.partition_number().to_string(),
+                "result" => "error",
+            )
+            .increment(1);
+        }
+    }
+}
+
 #[async_trait]
 impl<T, P> RebalanceHandler for ProcessorRebalanceHandler<T, P>
 where
@@ -1076,6 +1240,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
         assert!(handler.router.is_none());
 
@@ -1094,6 +1259,7 @@ mod tests {
             None,
             16, // rebalance_cleanup_parallelism
             Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+            None,
         );
         assert!(handler_with_router.router.is_some());
     }
@@ -1124,6 +1290,7 @@ mod tests {
             None,
             16, // rebalance_cleanup_parallelism
             Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+            None,
         );
 
         // Initially no workers
@@ -1188,6 +1355,7 @@ mod tests {
             None,
             16, // rebalance_cleanup_parallelism
             Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+            None,
         );
 
         // Assign partition and create a store
@@ -1296,6 +1464,7 @@ mod tests {
             None,
             16, // rebalance_cleanup_parallelism
             Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+            None,
         );
 
         // Step 1: Initial assignment
@@ -1395,6 +1564,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         // First assignment
@@ -1443,6 +1613,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         // Create command channel
@@ -1507,6 +1678,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         // Create command channel
@@ -1598,6 +1770,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         // Create command channel
@@ -1714,6 +1887,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         // Create command channel
@@ -1762,6 +1936,7 @@ mod tests {
                 None,
                 16,
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         let mut partitions = rdkafka::TopicPartitionList::new();
@@ -1806,6 +1981,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         // Create command channel
@@ -1885,6 +2061,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1997,6 +2174,7 @@ mod tests {
                 None,
                 16, // rebalance_cleanup_parallelism
                 Duration::from_secs(DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS),
+                None,
             );
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -304,6 +304,14 @@ impl KafkaDeduplicatorService {
             self.config.checkpoint_interval(),
         );
 
+        // Build catch-up config if enabled
+        let catchup_config = if self.config.catchup_enabled() {
+            info!("Catch-up enabled: will read output topic after checkpoint restore");
+            Some(Arc::new(self.config.clone()))
+        } else {
+            None
+        };
+
         // Build pipeline consumer using the builder
         let mut builder = PipelineBuilder::new(
             self.config.pipeline_type,
@@ -319,7 +327,8 @@ impl KafkaDeduplicatorService {
             self.config.fail_open,
         )
         .with_checkpoint_importer(self.checkpoint_importer.clone())
-        .with_local_checkpoint_staleness(self.config.local_checkpoint_max_staleness());
+        .with_local_checkpoint_staleness(self.config.local_checkpoint_max_staleness())
+        .with_catchup_config(catchup_config);
 
         // Configure pipeline-specific options for ingestion events
         if self.config.pipeline_type == PipelineType::IngestionEvents {

--- a/rust/kafka-deduplicator/tests/catchup_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/catchup_integration_tests.rs
@@ -1,0 +1,315 @@
+//! Integration tests for the catch-up mechanism.
+//!
+//! These tests verify the catch-up flow: after checkpoint restore, the deduplicator
+//! reads the output topic from `producer_offset` to the high watermark, inserting
+//! dedup keys into RocksDB. This prevents re-producing events that were already
+//! produced by another instance during the gap between checkpoint time and now.
+//!
+//! Requires Kafka on localhost:9092.
+//! Run with: `cargo test --test catchup_integration_tests`
+
+use std::collections::HashMap;
+use std::env;
+use std::time::Duration;
+
+use anyhow::Result;
+use common_types::{CapturedEvent, RawEvent};
+use health::HealthRegistry;
+use kafka_deduplicator::checkpoint::metadata::CheckpointMetadata;
+use kafka_deduplicator::config::Config;
+use kafka_deduplicator::pipelines::traits::DeduplicationKeyExtractor;
+use kafka_deduplicator::rocksdb::store::RocksDbConfig;
+use kafka_deduplicator::service::KafkaDeduplicatorService;
+use kafka_deduplicator::store::{DeduplicationStore, DeduplicationStoreConfig};
+use kafka_deduplicator::utils::format_store_path;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+use rdkafka::util::Timeout;
+use rdkafka::{Offset, TopicPartitionList};
+use serde_json::Value;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+const KAFKA_BROKERS: &str = "localhost:9092";
+
+/// Create test topics with 1 partition each.
+async fn create_topics(topics: &[&str]) -> Result<()> {
+    let admin_client: AdminClient<_> = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .create()?;
+
+    let new_topics: Vec<NewTopic> = topics
+        .iter()
+        .map(|t| NewTopic::new(t, 1, TopicReplication::Fixed(1)))
+        .collect();
+
+    let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));
+    let results = admin_client.create_topics(&new_topics, &opts).await?;
+    for result in results {
+        match result {
+            Ok(_) => {}
+            Err((_, rdkafka::types::RDKafkaErrorCode::TopicAlreadyExists)) => {}
+            Err((topic, err)) => {
+                return Err(anyhow::anyhow!("Failed to create topic {topic}: {err:?}"));
+            }
+        }
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
+
+/// Create a deterministic CapturedEvent with a unique key per index.
+fn create_event(index: usize) -> (CapturedEvent, RawEvent) {
+    let uuid = Uuid::new_v4();
+    let distinct_id = format!("user_{index}");
+    let event_name = format!("event_{index}");
+    let timestamp = format!("{}", 1700000000 + index as u64);
+
+    let raw_event = RawEvent {
+        uuid: Some(uuid),
+        distinct_id: Some(serde_json::Value::String(distinct_id.clone())),
+        event: event_name.clone(),
+        timestamp: Some(timestamp.clone()),
+        token: Some("test_token".to_string()),
+        properties: HashMap::new(),
+        offset: None,
+        set: None,
+        set_once: None,
+    };
+
+    let data = serde_json::to_string(&raw_event).unwrap();
+
+    let captured = CapturedEvent {
+        uuid,
+        distinct_id,
+        session_id: None,
+        ip: "127.0.0.1".to_string(),
+        data,
+        now: format!("{timestamp}000"),
+        sent_at: None,
+        token: "test_token".to_string(),
+        event: event_name,
+        timestamp: chrono::Utc::now(),
+        is_cookieless_mode: false,
+        historical_migration: false,
+    };
+
+    (captured, raw_event)
+}
+
+/// Produce events to a topic on partition 0.
+async fn produce_events(topic: &str, events: &[CapturedEvent]) -> Result<()> {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("message.timeout.ms", "5000")
+        .create()?;
+
+    for (i, event) in events.iter().enumerate() {
+        let payload = serde_json::to_string(event)?;
+        let key = format!("key_{i}");
+        let record = FutureRecord::to(topic)
+            .key(&key)
+            .payload(&payload)
+            .partition(0);
+
+        producer
+            .send(record, Timeout::After(Duration::from_secs(5)))
+            .await
+            .map_err(|(e, _)| anyhow::anyhow!("Failed to send message: {e}"))?;
+    }
+
+    producer.flush(Timeout::After(Duration::from_secs(5)))?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    Ok(())
+}
+
+/// Read all messages from a topic partition using a BaseConsumer (no consumer group).
+fn read_all_messages(topic: &str, partition: i32) -> Result<Vec<Value>> {
+    let consumer: BaseConsumer = ClientConfig::new()
+        .set("bootstrap.servers", KAFKA_BROKERS)
+        .set("group.id", format!("verify-{}", Uuid::new_v4()))
+        .create()?;
+
+    let (_low, high) = consumer.fetch_watermarks(topic, partition, Duration::from_secs(5))?;
+    if high == 0 {
+        return Ok(vec![]);
+    }
+
+    let mut tpl = TopicPartitionList::new();
+    tpl.add_partition_offset(topic, partition, Offset::Beginning)?;
+    consumer.assign(&tpl)?;
+
+    let mut messages = Vec::new();
+    let start = std::time::Instant::now();
+    let timeout = Duration::from_secs(10);
+
+    while messages.len() < high as usize && start.elapsed() < timeout {
+        if let Some(Ok(msg)) = consumer.poll(Duration::from_secs(1)) {
+            if let Some(payload) = msg.payload() {
+                let json: Value = serde_json::from_slice(payload)?;
+                messages.push(json);
+            }
+        }
+    }
+
+    Ok(messages)
+}
+
+/// Test: Catch-up prevents re-production of events already on the output topic
+///
+/// Setup:
+/// - Input topic: 20 unique events (offsets 0-19)
+/// - Output topic: first 15 events (offsets 0-14), as if produced by a previous instance
+/// - RocksDB store: dedup keys for events 0-4 (from checkpoint)
+/// - metadata.json: consumer_offset=5, producer_offset=5
+///
+/// Expected flow:
+/// 1. Service starts, detects local store with metadata (consumer_offset=5, producer_offset=5)
+/// 2. Catch-up reads output topic from offset 5 to 15 (high watermark), inserts keys for events 5-14
+/// 3. Store now has keys for events 0-14
+/// 4. Consumer resumes from input offset 5, processes events 5-19
+/// 5. Events 5-14: already in store (from catch-up) → deduplicated, not re-produced
+/// 6. Events 15-19: not in store → produced to output topic
+///
+/// Verification:
+/// - Output topic has exactly 20 messages (15 original + 5 new)
+/// - All 20 messages match the original 20 input events
+#[tokio::test(flavor = "multi_thread")]
+async fn test_catchup_prevents_duplicate_production() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_test_writer()
+        .try_init();
+
+    let test_id = Uuid::new_v4();
+    let input_topic = format!("catchup_test_input_{test_id}");
+    let output_topic = format!("catchup_test_output_{test_id}");
+    let group_id = format!("catchup_test_group_{test_id}");
+
+    println!("Test topics: input={input_topic}, output={output_topic}, group={group_id}");
+
+    // Create topics
+    create_topics(&[&input_topic, &output_topic]).await?;
+
+    // Generate 20 unique events
+    let events: Vec<(CapturedEvent, RawEvent)> = (0..20).map(create_event).collect();
+    let captured_events: Vec<CapturedEvent> = events.iter().map(|(c, _)| c.clone()).collect();
+
+    // Step 1: Produce all 20 events to input topic
+    println!("Step 1: Producing 20 events to input topic");
+    produce_events(&input_topic, &captured_events).await?;
+
+    // Step 2: Produce first 15 events to output topic (simulating previous instance's output)
+    println!("Step 2: Producing first 15 events to output topic");
+    produce_events(&output_topic, &captured_events[..15]).await?;
+
+    // Step 3: Create RocksDB store with dedup keys for first 5 events
+    println!("Step 3: Pre-seeding RocksDB store with keys for events 0-4");
+    let store_dir = TempDir::new()?;
+    let store_path = format_store_path(store_dir.path(), &input_topic, 0);
+    std::fs::create_dir_all(&store_path)?;
+
+    let store_config = DeduplicationStoreConfig {
+        path: store_dir.path().to_path_buf(),
+        max_capacity: 1_000_000,
+        rocksdb: RocksDbConfig::default(),
+    };
+    let store = DeduplicationStore::new(store_config, input_topic.clone(), 0)?;
+
+    // Insert dedup keys for events 0-4
+    for (_captured, raw_event) in events.iter().take(5) {
+        let key_bytes = raw_event.extract_dedup_key();
+        store.put_timestamp_records_batch(vec![
+            kafka_deduplicator::store::deduplication_store::TimestampBatchEntry {
+                key: &key_bytes,
+                value: &[],
+            },
+        ])?;
+    }
+
+    // Step 4: Write metadata.json with consumer_offset=5, producer_offset=5
+    println!("Step 4: Writing metadata.json (consumer_offset=5, producer_offset=5)");
+    let mut metadata = CheckpointMetadata::new(
+        input_topic.clone(),
+        0,
+        chrono::Utc::now(),
+        1, // sequence
+        5, // consumer_offset
+        5, // producer_offset
+    );
+    metadata.write_to_dir(&store_path).await?;
+
+    // Drop the store so the service can open it
+    drop(store);
+
+    // Step 5: Configure and start the service with catch-up enabled
+    println!("Step 5: Starting service with catch-up enabled");
+    env::set_var("KAFKA_CONSUMER_TOPIC", &input_topic);
+    env::set_var("KAFKA_CONSUMER_GROUP", &group_id);
+    env::set_var("OUTPUT_TOPIC", &output_topic);
+    env::set_var("STORE_PATH", store_dir.path().to_str().unwrap());
+    env::set_var("KAFKA_CONSUMER_OFFSET_RESET", "earliest");
+    env::set_var("COMMIT_INTERVAL_SECS", "1");
+    env::set_var("SHUTDOWN_TIMEOUT_SECS", "10");
+    env::set_var("KAFKA_PRODUCER_LINGER_MS", "0");
+    env::set_var("CATCHUP_ENABLED", "true");
+    env::set_var("CATCHUP_BATCH_SIZE", "100");
+    env::set_var("CATCHUP_TIMEOUT_SECS", "30");
+
+    let config = Config::init_with_defaults()?;
+    let liveness = HealthRegistry::new("test_catchup");
+    let service = KafkaDeduplicatorService::new(config, liveness).await?;
+
+    // Run service for a bounded time (needs enough for group join + catch-up + consumption)
+    let shutdown_signal = async {
+        tokio::time::sleep(Duration::from_secs(15)).await;
+    };
+    let service_handle =
+        tokio::spawn(async move { service.run_with_shutdown(shutdown_signal).await });
+
+    let _ = tokio::time::timeout(Duration::from_secs(20), service_handle).await;
+    println!("Service stopped");
+
+    // Step 6: Verify output topic has exactly 20 messages
+    println!("Step 6: Verifying output topic contents");
+    let output_messages = read_all_messages(&output_topic, 0)?;
+
+    assert_eq!(
+        output_messages.len(),
+        20,
+        "Expected exactly 20 messages on output topic (15 pre-existing + 5 new from events 15-19), got {}",
+        output_messages.len()
+    );
+
+    // Verify all 20 output messages correspond to the 20 input events by checking UUIDs
+    let input_uuids: Vec<String> = events.iter().map(|(c, _)| c.uuid.to_string()).collect();
+
+    let output_uuids: Vec<String> = output_messages
+        .iter()
+        .filter_map(|msg| msg.get("uuid")?.as_str().map(|s| s.to_string()))
+        .collect();
+
+    assert_eq!(
+        output_uuids.len(),
+        20,
+        "Expected 20 UUIDs in output, got {}",
+        output_uuids.len()
+    );
+
+    // Every input UUID should appear exactly once in the output
+    for input_uuid in &input_uuids {
+        let count = output_uuids.iter().filter(|u| *u == input_uuid).count();
+        assert_eq!(
+            count, 1,
+            "UUID {input_uuid} should appear exactly once in output, found {count} times"
+        );
+    }
+
+    println!("All verifications passed: output topic has exactly 20 unique messages");
+
+    Ok(())
+}

--- a/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
+++ b/rust/kafka-deduplicator/tests/rebalance_e2e_integration_tests.rs
@@ -336,6 +336,7 @@ async fn test_rebalance_with_checkpoint_import() -> Result<()> {
             Some(importer),
             16, // rebalance_cleanup_parallelism
             Duration::from_secs(7200),
+            None,
         ));
 
     // Create routing processor
@@ -466,6 +467,7 @@ async fn test_messages_dropped_for_revoked_partition() -> Result<()> {
             None,
             16, // rebalance_cleanup_parallelism
             Duration::from_secs(7200),
+            None,
         );
 
     // Assign partition 0
@@ -555,6 +557,7 @@ async fn test_rapid_revoke_assign_preserves_new_store() -> Result<()> {
             None,
             16, // rebalance_cleanup_parallelism
             Duration::from_secs(7200),
+            None,
         );
 
     let mut partitions = TopicPartitionList::new();


### PR DESCRIPTION
## Problem

After restoring a checkpoint, the deduplicator's RocksDB state only reflects events up to the checkpoint time. Events produced to the output topic between the checkpoint and now are missing from the store, which causes them to be re-produced as false non-duplicates.

## Changes

- Added a catch-up mechanism that runs after checkpoint restore (local or S3), reading the output topic from the checkpoint's `producer_offset` to the current high watermark and batch-inserting dedup keys into RocksDB
- Introduced configuration options for the catch-up mechanism (`CATCHUP_ENABLED`, `CATCHUP_BATCH_SIZE`, `CATCHUP_TIMEOUT_SECS`, `CATCHUP_CONSUMER_FETCH_MAX_BYTES`), all disabled by default
- Added catch-up integration for both consumer group mode (`ProcessorRebalanceHandler::try_run_catchup`) and assigner mode (`run_catchup_for_assigner`)
- Extracted `raw_event_from_captured` as a shared public function so both the normal pipeline and the catch-up path use identical parsing and key extraction logic
- Threaded `catchup_config` through `PipelineBuilder` and `KafkaDeduplicatorService` to both rebalance handlers
- Added catch-up specific metrics (`catchup_duration_seconds`, `catchup_messages_processed_total`, `catchup_keys_inserted_total`, `catchup_batch_write_duration_seconds`, `catchup_status_total`)
- Added an end-to-end integration test validating the complete catch-up and deduplication flow with 20 input messages, 15 pre-existing on the output topic, and verifying exactly 20 unique messages at the end


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
