### PR TITLE
fix(flags): fall back to person_properties.$device_id for device_id bucketing

### DIFF
--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -225,6 +225,7 @@ mod tests {
     use bytes::Bytes;
     use common_cache::NegativeCache;
     use serde_json::json;
+    use serde_json::Value;
 
     #[test]
     fn empty_distinct_id_is_accepted() {
@@ -397,98 +398,70 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_device_id_from_top_level() {
-        let flag_request = FlagRequest {
-            device_id: Some("top-level-device".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            flag_request.extract_device_id(),
-            Some("top-level-device".to_string())
-        );
-    }
+    fn test_extract_device_id() {
+        struct Case {
+            device_id: Option<String>,
+            person_properties: Option<HashMap<String, Value>>,
+            expected: Option<String>,
+        }
 
-    #[test]
-    fn test_extract_device_id_from_person_properties() {
-        let flag_request = FlagRequest {
-            device_id: None,
-            person_properties: Some(HashMap::from([(
-                "$device_id".to_string(),
-                json!("prop-device"),
-            )])),
-            ..Default::default()
-        };
-        assert_eq!(
-            flag_request.extract_device_id(),
-            Some("prop-device".to_string())
-        );
-    }
+        let cases = vec![
+            Case {
+                device_id: Some("top-level-device".to_string()),
+                person_properties: None,
+                expected: Some("top-level-device".to_string()),
+            },
+            Case {
+                device_id: None,
+                person_properties: Some(HashMap::from([(
+                    "$device_id".to_string(),
+                    json!("prop-device"),
+                )])),
+                expected: Some("prop-device".to_string()),
+            },
+            // top-level takes precedence
+            Case {
+                device_id: Some("top-level-device".to_string()),
+                person_properties: Some(HashMap::from([(
+                    "$device_id".to_string(),
+                    json!("prop-device"),
+                )])),
+                expected: Some("top-level-device".to_string()),
+            },
+            // absent entirely
+            Case {
+                device_id: None,
+                person_properties: Some(HashMap::from([(
+                    "other_prop".to_string(),
+                    json!("value"),
+                )])),
+                expected: None,
+            },
+            // empty string in person_properties → None
+            Case {
+                device_id: None,
+                person_properties: Some(HashMap::from([("$device_id".to_string(), json!(""))])),
+                expected: None,
+            },
+            // empty string at top level → should also return None / fall through
+            Case {
+                device_id: Some("".to_string()),
+                person_properties: Some(HashMap::from([(
+                    "$device_id".to_string(),
+                    json!("prop-device"),
+                )])),
+                expected: Some("prop-device".to_string()),
+            },
+        ];
 
-    #[test]
-    fn test_extract_device_id_top_level_takes_precedence() {
-        let flag_request = FlagRequest {
-            device_id: Some("top-level-device".to_string()),
-            person_properties: Some(HashMap::from([(
-                "$device_id".to_string(),
-                json!("prop-device"),
-            )])),
-            ..Default::default()
-        };
-        assert_eq!(
-            flag_request.extract_device_id(),
-            Some("top-level-device".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_device_id_none_when_absent() {
-        let flag_request = FlagRequest {
-            device_id: None,
-            person_properties: Some(HashMap::from([(
-                "other_prop".to_string(),
-                json!("value"),
-            )])),
-            ..Default::default()
-        };
-        assert_eq!(flag_request.extract_device_id(), None);
-    }
-
-    #[test]
-    fn test_extract_device_id_ignores_empty_string_top_level() {
-        let flag_request = FlagRequest {
-            device_id: Some("".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(flag_request.extract_device_id(), None);
-    }
-
-    #[test]
-    fn test_extract_device_id_empty_top_level_falls_back_to_properties() {
-        let flag_request = FlagRequest {
-            device_id: Some("".to_string()),
-            person_properties: Some(HashMap::from([(
-                "$device_id".to_string(),
-                json!("prop-device"),
-            )])),
-            ..Default::default()
-        };
-        assert_eq!(
-            flag_request.extract_device_id(),
-            Some("prop-device".to_string())
-        );
-    }
-
-    #[test]
-    fn test_extract_device_id_ignores_empty_string_in_properties() {
-        let flag_request = FlagRequest {
-            device_id: None,
-            person_properties: Some(HashMap::from([(
-                "$device_id".to_string(),
-                json!(""),
-            )])),
-            ..Default::default()
-        };
-        assert_eq!(flag_request.extract_device_id(), None);
+        for case in cases {
+            let flag_request = FlagRequest {
+                device_id: case.device_id,
+                person_properties: case.person_properties,
+                ..Default::default()
+            };
+            assert_eq!(flag_request.extract_device_id(), case.expected);
+        }
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -185,6 +185,20 @@ impl FlagRequest {
         }
     }
 
+    /// Extracts device_id from the request.
+    /// Checks the top-level device_id field first, then falls back to
+    /// person_properties.$device_id for SDKs that only send it as a property.
+    pub fn extract_device_id(&self) -> Option<String> {
+        self.device_id.clone().or_else(|| {
+            self.person_properties
+                .as_ref()
+                .and_then(|props| props.get("$device_id"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        })
+    }
+
     /// Checks if feature flags should be disabled for this request.
     /// Returns true if disable_flags is explicitly set to true.
     pub fn is_flags_disabled(&self) -> bool {
@@ -376,6 +390,76 @@ mod tests {
 
         let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
         assert_eq!(flag_payload.distinct_id, Some("123.45".to_string()));
+    }
+
+    #[test]
+    fn test_extract_device_id_from_top_level() {
+        let flag_request = FlagRequest {
+            device_id: Some("top-level-device".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            flag_request.extract_device_id(),
+            Some("top-level-device".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_device_id_from_person_properties() {
+        let flag_request = FlagRequest {
+            device_id: None,
+            person_properties: Some(HashMap::from([(
+                "$device_id".to_string(),
+                json!("prop-device"),
+            )])),
+            ..Default::default()
+        };
+        assert_eq!(
+            flag_request.extract_device_id(),
+            Some("prop-device".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_device_id_top_level_takes_precedence() {
+        let flag_request = FlagRequest {
+            device_id: Some("top-level-device".to_string()),
+            person_properties: Some(HashMap::from([(
+                "$device_id".to_string(),
+                json!("prop-device"),
+            )])),
+            ..Default::default()
+        };
+        assert_eq!(
+            flag_request.extract_device_id(),
+            Some("top-level-device".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_device_id_none_when_absent() {
+        let flag_request = FlagRequest {
+            device_id: None,
+            person_properties: Some(HashMap::from([(
+                "other_prop".to_string(),
+                json!("value"),
+            )])),
+            ..Default::default()
+        };
+        assert_eq!(flag_request.extract_device_id(), None);
+    }
+
+    #[test]
+    fn test_extract_device_id_ignores_empty_string_in_properties() {
+        let flag_request = FlagRequest {
+            device_id: None,
+            person_properties: Some(HashMap::from([(
+                "$device_id".to_string(),
+                json!(""),
+            )])),
+            ..Default::default()
+        };
+        assert_eq!(flag_request.extract_device_id(), None);
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -189,14 +189,18 @@ impl FlagRequest {
     /// Checks the top-level device_id field first, then falls back to
     /// person_properties.$device_id for SDKs that only send it as a property.
     pub fn extract_device_id(&self) -> Option<String> {
-        self.device_id.clone().or_else(|| {
-            self.person_properties
-                .as_ref()
-                .and_then(|props| props.get("$device_id"))
-                .and_then(|v| v.as_str())
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
-        })
+        self.device_id
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                self.person_properties
+                    .as_ref()
+                    .and_then(|props| props.get("$device_id"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+            })
     }
 
     /// Checks if feature flags should be disabled for this request.
@@ -447,6 +451,31 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(flag_request.extract_device_id(), None);
+    }
+
+    #[test]
+    fn test_extract_device_id_ignores_empty_string_top_level() {
+        let flag_request = FlagRequest {
+            device_id: Some("".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(flag_request.extract_device_id(), None);
+    }
+
+    #[test]
+    fn test_extract_device_id_empty_top_level_falls_back_to_properties() {
+        let flag_request = FlagRequest {
+            device_id: Some("".to_string()),
+            person_properties: Some(HashMap::from([(
+                "$device_id".to_string(),
+                json!("prop-device"),
+            )])),
+            ..Default::default()
+        };
+        assert_eq!(
+            flag_request.extract_device_id(),
+            Some("prop-device".to_string())
+        );
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -400,6 +400,7 @@ mod tests {
     #[test]
     fn test_extract_device_id() {
         struct Case {
+            name: &'static str,
             device_id: Option<String>,
             person_properties: Option<HashMap<String, Value>>,
             expected: Option<String>,
@@ -407,11 +408,13 @@ mod tests {
 
         let cases = vec![
             Case {
+                name: "returns top-level device_id",
                 device_id: Some("top-level-device".to_string()),
                 person_properties: None,
                 expected: Some("top-level-device".to_string()),
             },
             Case {
+                name: "falls back to person_properties device_id",
                 device_id: None,
                 person_properties: Some(HashMap::from([(
                     "$device_id".to_string(),
@@ -421,6 +424,7 @@ mod tests {
             },
             // top-level takes precedence
             Case {
+                name: "prefers top-level device_id over person_properties",
                 device_id: Some("top-level-device".to_string()),
                 person_properties: Some(HashMap::from([(
                     "$device_id".to_string(),
@@ -430,6 +434,7 @@ mod tests {
             },
             // absent entirely
             Case {
+                name: "returns none when device_id is absent everywhere",
                 device_id: None,
                 person_properties: Some(HashMap::from([(
                     "other_prop".to_string(),
@@ -439,18 +444,21 @@ mod tests {
             },
             // empty string in person_properties → None
             Case {
+                name: "ignores empty string in person_properties device_id",
                 device_id: None,
                 person_properties: Some(HashMap::from([("$device_id".to_string(), json!(""))])),
                 expected: None,
             },
             // non-string device_id in person_properties is ignored
             Case {
+                name: "ignores non-string person_properties device_id",
                 device_id: None,
                 person_properties: Some(HashMap::from([("$device_id".to_string(), json!(12345))])),
                 expected: None,
             },
             // empty string at top level → should also return None / fall through
             Case {
+                name: "falls through when top-level device_id is empty",
                 device_id: Some("".to_string()),
                 person_properties: Some(HashMap::from([(
                     "$device_id".to_string(),
@@ -466,7 +474,12 @@ mod tests {
                 person_properties: case.person_properties,
                 ..Default::default()
             };
-            assert_eq!(flag_request.extract_device_id(), case.expected);
+            assert_eq!(
+                flag_request.extract_device_id(),
+                case.expected,
+                "Failed: {}",
+                case.name
+            );
         }
     }
 

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -190,9 +190,9 @@ impl FlagRequest {
     /// person_properties.$device_id for SDKs that only send it as a property.
     pub fn extract_device_id(&self) -> Option<String> {
         self.device_id
-            .as_deref()
+            .as_ref()
             .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
+            .cloned()
             .or_else(|| {
                 self.person_properties
                     .as_ref()

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -443,6 +443,12 @@ mod tests {
                 person_properties: Some(HashMap::from([("$device_id".to_string(), json!(""))])),
                 expected: None,
             },
+            // non-string device_id in person_properties is ignored
+            Case {
+                device_id: None,
+                person_properties: Some(HashMap::from([("$device_id".to_string(), json!(12345))])),
+                expected: None,
+            },
             // empty string at top level → should also return None / fall through
             Case {
                 device_id: Some("".to_string()),

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -143,9 +143,10 @@ async fn process_request_inner(
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string())
         });
+        let device_id = request.extract_device_id();
         with_canonical_log(|log| {
             log.distinct_id = Some(distinct_id_for_logging.clone());
-            log.device_id = request.device_id.clone();
+            log.device_id = device_id.clone();
             log.anon_distinct_id = anon_distinct_id_for_logging;
         });
 
@@ -203,7 +204,7 @@ async fn process_request_inner(
                 &context.state,
                 team.id,
                 distinct_id.clone(),
-                request.device_id.clone(),
+                device_id.clone(),
                 filtered_flags.clone(),
                 property_overrides.person_properties,
                 property_overrides.group_properties,


### PR DESCRIPTION
## Problem

Some SDKs only send `device_id` inside `person_properties` rather than as a top-level request field, which means `device_id` bucketing silently fails (flags evaluate to `false`).

Didn't realize this. With that in mind, I think we should standarize on sending `device_id` only through person properties. For now though, we need to check both places.

## Changes

- Added `extract_device_id()` to `FlagRequest` that checks the top-level `device_id` field first, then falls back to `person_properties.$device_id` (same pattern as `anon_distinct_id`)
- Updated both call sites in the request handler to use the new method

## Testing

- Added 5 unit tests covering: top-level extraction, property fallback, top-level precedence, absent device_id, and empty string filtering
- All existing tests pass