### PR TITLE
fix(cyclotron): respect CARGO_TARGET_DIR in build:move-lib script

### DIFF
--- a/rust/cyclotron-node/package.json
+++ b/rust/cyclotron-node/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "test": "cargo test",
         "build": "pnpm run build:cargo --release && pnpm run build:move-lib && pnpm run build:typescript",
-        "build:move-lib": "cp ../target/release/libcyclotron_node.dylib index.node 2>/dev/null || cp ../target/release/libcyclotron_node.so index.node || (echo \"No valid library file found.\" && exit 1)",
+        "build:move-lib": "TARGET_DIR=${CARGO_TARGET_DIR:-../target} && cp $TARGET_DIR/release/libcyclotron_node.dylib index.node 2>/dev/null || cp $TARGET_DIR/release/libcyclotron_node.so index.node || (echo \"No valid library file found in $TARGET_DIR/release/\" && exit 1)",
         "build:cargo": "cargo build --message-format=json > cargo.log",
         "build:cargo:debug": "pnpm run build:cargo",
         "build:cross": "cross build --message-format=json > cross.log",

--- a/rust/cyclotron-node/package.json
+++ b/rust/cyclotron-node/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "test": "cargo test",
         "build": "pnpm run build:cargo --release && pnpm run build:move-lib && pnpm run build:typescript",
-        "build:move-lib": "TARGET_DIR=${CARGO_TARGET_DIR:-../target} && cp $TARGET_DIR/release/libcyclotron_node.dylib index.node 2>/dev/null || cp $TARGET_DIR/release/libcyclotron_node.so index.node || (echo \"No valid library file found in $TARGET_DIR/release/\" && exit 1)",
+        "build:move-lib": "TARGET_DIR=${CARGO_TARGET_DIR:-../target} && cp \"$TARGET_DIR/release/libcyclotron_node.dylib\" index.node 2>/dev/null || cp \"$TARGET_DIR/release/libcyclotron_node.so\" index.node || (echo \"No valid library file found in $TARGET_DIR/release/\" && exit 1)",
         "build:cargo": "cargo build --message-format=json > cargo.log",
         "build:cargo:debug": "pnpm run build:cargo",
         "build:cross": "cross build --message-format=json > cross.log",


### PR DESCRIPTION
## Problem

The `build:move-lib` script in `rust/cyclotron-node/package.json` hardcodes `../target/release/` as the source path for the compiled library. When `CARGO_TARGET_DIR` is set (e.g. to a shared target directory), cargo outputs to a different location, causing the build to fail.

## Changes

- Use `CARGO_TARGET_DIR` env var when set, falling back to `../target` when unset