### PR TITLE
feat(node): Added api metrics

### DIFF
--- a/nodejs/src/api/middleware/http-metrics.ts
+++ b/nodejs/src/api/middleware/http-metrics.ts
@@ -11,7 +11,7 @@ const httpRequestDuration = new Histogram({
 })
 
 export function httpMetricsMiddleware(req: Request, res: Response, next: NextFunction): void {
-    if (EXCLUDED_PATHS.some((p) => req.path.startsWith(p))) {
+    if (EXCLUDED_PATHS.some((p) => req.path === p || req.path.startsWith(p + '/'))) {
         next()
         return
     }
@@ -20,7 +20,10 @@ export function httpMetricsMiddleware(req: Request, res: Response, next: NextFun
 
     res.on('finish', () => {
         const duration = (performance.now() - start) / 1000
-        const route = req.route?.path ?? 'unmatched'
+        // req.route is only set when Express matches a route handler.
+        // Requests rejected by middleware (e.g. auth 401) also have no route,
+        // so we distinguish them from genuine 404s via status code.
+        const route = req.route?.path ?? (res.statusCode === 404 ? 'unmatched' : 'middleware_rejected')
         httpRequestDuration
             .labels({
                 method: req.method,

--- a/nodejs/src/api/middleware/http-metrics.ts
+++ b/nodejs/src/api/middleware/http-metrics.ts
@@ -1,0 +1,34 @@
+import { Histogram } from 'prom-client'
+import { NextFunction, Request, Response } from 'ultimate-express'
+
+const EXCLUDED_PATHS = ['/_health', '/_ready', '/_metrics', '/metrics']
+
+const httpRequestDuration = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'route', 'status_code'],
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+})
+
+export function httpMetricsMiddleware(req: Request, res: Response, next: NextFunction): void {
+    if (EXCLUDED_PATHS.some((p) => req.path.startsWith(p))) {
+        next()
+        return
+    }
+
+    const start = performance.now()
+
+    res.on('finish', () => {
+        const duration = (performance.now() - start) / 1000
+        const route = req.route?.path ?? 'unmatched'
+        httpRequestDuration
+            .labels({
+                method: req.method,
+                route,
+                status_code: String(res.statusCode),
+            })
+            .observe(duration)
+    })
+
+    next()
+}

--- a/nodejs/src/api/router.ts
+++ b/nodejs/src/api/router.ts
@@ -2,6 +2,7 @@ import * as prometheus from 'prom-client'
 import express, { Request, Response } from 'ultimate-express'
 
 import { corsMiddleware } from '~/api/middleware/cors'
+import { httpMetricsMiddleware } from '~/api/middleware/http-metrics'
 import { createInternalApiAuthMiddleware } from '~/api/middleware/internal-api-auth'
 import { HealthCheckResultError, PluginServerService } from '~/types'
 import { logger } from '~/utils/logger'
@@ -42,6 +43,9 @@ export function setupExpressApp(options: SetupExpressAppOptions = {}): express.A
 
     // Add CORS middleware before other middleware
     app.use(corsMiddleware)
+
+    // Track HTTP request duration and status codes per route pattern
+    app.use(httpMetricsMiddleware)
 
     // Add internal API authentication middleware for defense-in-depth.
     // Primary protection comes from Contour routing at the infra level.


### PR DESCRIPTION
## Problem

We have contour level metrics but we really want service level as well so that we can show metrics for internal apis 

## Changes

* Adds route middleware for metricing out response times and codes
