### PR TITLE
fix(permissions): Respect project-level admin grants in effective_membership_level

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -790,7 +790,6 @@ posthog/test/test_survey_question_ids.py:0: error: Item "None" of "Any | None" h
 posthog/test/test_utils.py:0: error: "Request" has no attribute "_authenticator"; maybe "authenticators"?  [attr-defined]
 posthog/test/test_utils.py:0: error: Argument 5 to "post" of "_RequestFactory" has incompatible type "**dict[str, str]"; expected "Mapping[Any, Any] | None"  [arg-type]
 posthog/test/test_utils.py:0: error: Argument 5 to "post" of "_RequestFactory" has incompatible type "**dict[str, str]"; expected "Mapping[str, Any] | None"  [arg-type]
-posthog/user_permissions.py:0: error: Incompatible return value type (got "int", expected "Level | None")  [return-value]
 posthog/user_permissions.py:0: error: Incompatible return value type (got "int", expected "RestrictionLevel")  [return-value]
 posthog/utils.py:0: error: "HttpRequest" has no attribute "csp_nonce"  [attr-defined]
 posthog/utils.py:0: error: Argument 1 to "asdict" has incompatible type "DataclassInstance | type[DataclassInstance]"; expected "DataclassInstance"  [arg-type]

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -821,3 +821,113 @@ class TestGitHubIntegrationStateValidation:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Invalid or expired state token" in response.json()["detail"]
         mock_from_install.assert_not_called()
+
+
+class TestIntegrationPermissions:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        from ee.models.rbac.access_control import AccessControl
+
+        self.AccessControl = AccessControl
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        # Org-level MEMBER, not ADMIN
+        self.user = User.objects.create_and_join(
+            self.organization,
+            "member@posthog.com",
+            "test",
+            level=OrganizationMembership.Level.MEMBER,
+        )
+        self.org_membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+
+    def _email_integration_payload(self):
+        return {
+            "kind": "email",
+            "config": {
+                "email": "test@example.com",
+                "name": "Test",
+                "provider": "ses",
+                "mail_from_subdomain": "mail",
+            },
+        }
+
+    def _grant_project_admin(self):
+        self.AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=self.org_membership,
+            access_level="admin",
+        )
+
+    def test_org_member_cannot_create_integration(self, client: HttpClient):
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            self._email_integration_payload(),
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_org_member_cannot_delete_integration(self, client: HttpClient):
+        # Create an integration as org admin first
+        self.org_membership.level = OrganizationMembership.Level.ADMIN
+        self.org_membership.save()
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            config={},
+        )
+        # Demote back to member
+        self.org_membership.level = OrganizationMembership.Level.MEMBER
+        self.org_membership.save()
+
+        client.force_login(self.user)
+
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{integration.pk}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("posthog.models.integration.SESProvider")
+    def test_project_admin_can_create_integration(self, mock_ses_provider_class, client: HttpClient):
+        mock_ses_provider_class.return_value = MagicMock()
+        self._grant_project_admin()
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            self._email_integration_payload(),
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_project_admin_can_delete_integration(self, client: HttpClient):
+        self._grant_project_admin()
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            config={},
+        )
+        client.force_login(self.user)
+
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{integration.pk}")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    @patch("posthog.models.integration.SESProvider")
+    def test_org_admin_can_create_integration(self, mock_ses_provider_class, client: HttpClient):
+        mock_ses_provider_class.return_value = MagicMock()
+        self.org_membership.level = OrganizationMembership.Level.ADMIN
+        self.org_membership.save()
+        client.force_login(self.user)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            self._email_integration_payload(),
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -191,9 +191,6 @@ class UserTeamPermissions:
         if organization is None or organization_membership is None:
             return None
 
-        if not organization.is_feature_available(AvailableFeature.ADVANCED_PERMISSIONS):
-            return organization_membership.level
-
         # Use prefetched data to check team privacy and access
         access_controls = self.p._prefetched_access_controls.get(self.team.id, [])
 


### PR DESCRIPTION
## Problem

Project-level admins who are org-level members cannot create or delete integrations (e.g., email senders). They get "You don't have sufficient permissions in the project" even though the access control UI shows them as "Project: Admin".

`TeamMemberStrictManagementPermission` calls `effective_membership_level` which has an `ADVANCED_PERMISSIONS` billing feature gate (`user_permissions.py:194`). Without that billing feature, it short-circuits and returns the raw org membership level (MEMBER=1), ignoring project-level admin grants set via the RBAC system. Since creating an integration requires being an ADMIN, the request is rejected.

<img width="2322" height="1031" alt="Screenshot 2026-03-18 at 11 33 51" src="https://github.com/user-attachments/assets/f3a21c0a-c20d-4d62-a623-1d32fc752b94" />

## Changes

- Remove the `ADVANCED_PERMISSIONS` billing feature gate in `effective_membership_level_for_parent_membership`. When no access control records exist, the function falls through to `return organization_membership.level` - identical to the previous gated behavior.
- Add 5 integration permission tests covering create and delete for org members, project admins, and org admins.

## How did you test this code?

Automated tests. To test manually:

1. Log in as a user who is an org-level member (not admin) but project-level admin via access control settings
2. Go to a workflow -> Channels -> try to add an email sender
3. Before this fix: 403 "You don't have sufficient permissions in the project"
4. After this fix: email sender creation succeeds

## Publish to changelog?

No