### PR TITLE
chore(experiments): move activity signal handlers to activity_logging module

### DIFF
--- a/ee/clickhouse/views/experiment_holdouts.py
+++ b/ee/clickhouse/views/experiment_holdouts.py
@@ -1,8 +1,6 @@
 from typing import Any
 
 from django.db import transaction
-from django.db.models.signals import pre_delete
-from django.dispatch import receiver
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, viewsets
@@ -13,9 +11,7 @@ from rest_framework.response import Response
 from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.experiment import ExperimentHoldout, holdout_filters_for_flag
-from posthog.models.signals import model_activity_signal, mutable_receiver
 
 
 class ExperimentHoldoutSerializer(serializers.ModelSerializer):
@@ -132,41 +128,3 @@ class ExperimentHoldoutViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 existing_flag_serializer.save()
 
             return super().destroy(request, *args, **kwargs)
-
-
-@mutable_receiver(model_activity_signal, sender=ExperimentHoldout)
-def handle_experiment_holdout_change(
-    sender, scope, before_update, after_update, activity, user=None, was_impersonated=False, **kwargs
-):
-    # Log activity for the holdout itself
-    log_activity(
-        organization_id=after_update.team.organization_id,
-        team_id=after_update.team_id,
-        user=user or after_update.created_by,
-        was_impersonated=was_impersonated,
-        item_id=after_update.id,
-        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
-        activity=activity,
-        detail=Detail(
-            changes=changes_between(scope, previous=before_update, current=after_update),
-            name=after_update.name,
-            type="holdout",
-        ),
-    )
-
-
-@receiver(pre_delete, sender=ExperimentHoldout)
-def handle_experiment_holdout_delete(sender, instance, **kwargs):
-    from posthog.models.activity_logging.utils import activity_storage
-
-    # Log activity for the holdout itself
-    log_activity(
-        organization_id=instance.team.organization_id,
-        team_id=instance.team_id,
-        user=activity_storage.get_user() or getattr(instance, "last_modified_by", instance.created_by),
-        was_impersonated=activity_storage.get_was_impersonated(),
-        item_id=instance.id,
-        scope="Experiment",
-        activity="deleted",
-        detail=Detail(name=instance.name, type="holdout"),
-    )

--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -1,6 +1,4 @@
 from django.db.models.functions import Lower
-from django.db.models.signals import pre_delete
-from django.dispatch import receiver
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, viewsets
@@ -8,9 +6,7 @@ from rest_framework import serializers, viewsets
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin
-from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.experiment import ExperimentSavedMetric, ExperimentToSavedMetric
-from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 
 from products.experiments.backend.experiment_saved_metric_service import ExperimentSavedMetricService
@@ -102,38 +98,3 @@ class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetM
     def perform_destroy(self, instance: ExperimentSavedMetric) -> None:
         service = ExperimentSavedMetricService(team=self.team, user=self.request.user)
         service.delete_saved_metric(instance)
-
-
-@mutable_receiver(model_activity_signal, sender=ExperimentSavedMetric)
-def handle_experiment_saved_metric_change(
-    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
-):
-    log_activity(
-        organization_id=after_update.team.organization_id,
-        team_id=after_update.team_id,
-        user=user,
-        was_impersonated=was_impersonated,
-        item_id=after_update.id,
-        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
-        activity=activity,
-        detail=Detail(
-            # need to use ExperimentSavedMetric here for field exclusions..
-            changes=changes_between("ExperimentSavedMetric", previous=before_update, current=after_update),
-            name=after_update.name,
-            type="shared_metric",
-        ),
-    )
-
-
-@receiver(pre_delete, sender=ExperimentSavedMetric)
-def handle_experiment_saved_metric_delete(sender, instance, **kwargs):
-    log_activity(
-        organization_id=instance.team.organization_id,
-        team_id=instance.team_id,
-        user=getattr(instance, "last_modified_by", instance.created_by),
-        was_impersonated=False,
-        item_id=instance.id,
-        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
-        activity="deleted",
-        detail=Detail(name=instance.name, type="shared_metric"),
-    )

--- a/posthog/models/activity_logging/signal_handlers.py
+++ b/posthog/models/activity_logging/signal_handlers.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.core.signing import TimestampSigner
+from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from django.http import HttpRequest
 
@@ -24,6 +25,7 @@ from posthog.models.activity_logging.activity_log import (
     changes_between,
     log_activity,
 )
+from posthog.models.experiment import ExperimentHoldout, ExperimentSavedMetric
 from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.user import User
@@ -293,4 +295,75 @@ def handle_organization_domain_change(
             name=detail_name,
             context=context,
         ),
+    )
+
+
+@mutable_receiver(model_activity_signal, sender=ExperimentSavedMetric)
+def handle_experiment_saved_metric_change(
+    sender, scope, before_update, after_update, activity, user, was_impersonated=False, **kwargs
+):
+    log_activity(
+        organization_id=after_update.team.organization_id,
+        team_id=after_update.team_id,
+        user=user,
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
+        activity=activity,
+        detail=Detail(
+            # need to use ExperimentSavedMetric here for field exclusions..
+            changes=changes_between("ExperimentSavedMetric", previous=before_update, current=after_update),
+            name=after_update.name,
+            type="shared_metric",
+        ),
+    )
+
+
+@receiver(pre_delete, sender=ExperimentSavedMetric)
+def handle_experiment_saved_metric_delete(sender, instance, **kwargs):
+    log_activity(
+        organization_id=instance.team.organization_id,
+        team_id=instance.team_id,
+        user=getattr(instance, "last_modified_by", instance.created_by),
+        was_impersonated=False,
+        item_id=instance.id,
+        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
+        activity="deleted",
+        detail=Detail(name=instance.name, type="shared_metric"),
+    )
+
+
+@mutable_receiver(model_activity_signal, sender=ExperimentHoldout)
+def handle_experiment_holdout_change(
+    sender, scope, before_update, after_update, activity, user=None, was_impersonated=False, **kwargs
+):
+    log_activity(
+        organization_id=after_update.team.organization_id,
+        team_id=after_update.team_id,
+        user=user or after_update.created_by,
+        was_impersonated=was_impersonated,
+        item_id=after_update.id,
+        scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
+        activity=activity,
+        detail=Detail(
+            changes=changes_between(scope, previous=before_update, current=after_update),
+            name=after_update.name,
+            type="holdout",
+        ),
+    )
+
+
+@receiver(pre_delete, sender=ExperimentHoldout)
+def handle_experiment_holdout_delete(sender, instance, **kwargs):
+    from posthog.models.activity_logging.utils import activity_storage
+
+    log_activity(
+        organization_id=instance.team.organization_id,
+        team_id=instance.team_id,
+        user=activity_storage.get_user() or getattr(instance, "last_modified_by", instance.created_by),
+        was_impersonated=activity_storage.get_was_impersonated(),
+        item_id=instance.id,
+        scope="Experiment",
+        activity="deleted",
+        detail=Detail(name=instance.name, type="holdout"),
     )

--- a/posthog/models/activity_logging/signal_handlers.py
+++ b/posthog/models/activity_logging/signal_handlers.py
@@ -25,6 +25,7 @@ from posthog.models.activity_logging.activity_log import (
     changes_between,
     log_activity,
 )
+from posthog.models.activity_logging.utils import activity_storage
 from posthog.models.experiment import ExperimentHoldout, ExperimentSavedMetric
 from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.signals import model_activity_signal, mutable_receiver
@@ -355,8 +356,6 @@ def handle_experiment_holdout_change(
 
 @receiver(pre_delete, sender=ExperimentHoldout)
 def handle_experiment_holdout_delete(sender, instance, **kwargs):
-    from posthog.models.activity_logging.utils import activity_storage
-
     log_activity(
         organization_id=instance.team.organization_id,
         team_id=instance.team_id,

--- a/posthog/models/activity_logging/signal_handlers.py
+++ b/posthog/models/activity_logging/signal_handlers.py
@@ -325,8 +325,8 @@ def handle_experiment_saved_metric_delete(sender, instance, **kwargs):
     log_activity(
         organization_id=instance.team.organization_id,
         team_id=instance.team_id,
-        user=getattr(instance, "last_modified_by", instance.created_by),
-        was_impersonated=False,
+        user=activity_storage.get_user() or getattr(instance, "last_modified_by", instance.created_by),
+        was_impersonated=activity_storage.get_was_impersonated(),
         item_id=instance.id,
         scope="Experiment",  # log under Experiment scope so it appears in experiment activity log
         activity="deleted",


### PR DESCRIPTION
## Problem

Experiment activity logging signal handlers (for `ExperimentSavedMetric` and `ExperimentHoldout`) lived in the API view layer (`ee/clickhouse/views/`), but they're cross-cutting activity logging concerns with no dependency on the API.

## Changes

Move all 4 signal handlers to `posthog/models/activity_logging/signal_handlers.py`, where other activity logging signal handlers (User, OrganizationDomain) already live.

## Testing

Verified locally that activity logs are created when editing a shared metric.