### PR TITLE
fix: can't duplicate to another project

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1994,6 +1994,8 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                             "request": request,
                             "team_id": team.id,
                             "project_id": team.project_id,
+                            "get_team": lambda t=team: t,
+                            "get_organization": lambda: self.organization,
                         },
                     )
 


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/53564 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55684)
recent changes to `validate_appearance` in `SurveySerializerCreateUpdateOnly` didn't account for the `duplicate_to_projects` method in this commit https://github.com/PostHog/posthog/commit/c9c405c12e2 

## Changes

Added `get_team` and `get_organization` lambdas to the serializer in `duplicate_to_projects`,

## How did you test this code?

locally

## Publish to changelog?

no

