### PR TITLE
fix(storybook): skip UserPaths snapshots

### DIFF
--- a/frontend/src/scenes/insights/UserPaths.stories.tsx
+++ b/frontend/src/scenes/insights/UserPaths.stories.tsx
@@ -11,10 +11,11 @@ import { mswDecorator } from '~/mocks/browser'
 type Story = StoryObj<typeof App>
 const meta: Meta = {
     title: 'Scenes-App/Insights/User Paths',
+    tags: ['test-skip'],
     parameters: {
         layout: 'fullscreen',
         testOptions: {
-            snapshotBrowsers: ['chromium'],
+            snapshotBrowsers: [], // Paths canvas resize observer causes flaky width — skip snapshots
             viewport: {
                 // needs a slightly larger width to push the rendered scene away from breakpoint boundary
                 width: 1300,


### PR DESCRIPTION
Canvas resize observer makes these snapshots non-deterministic. Multiple stabilization attempts (#49657, #49989, #51347) haven't stuck. Skipping via `test-skip` tag until the underlying resize behavior is addressed.