### PR TITLE
fix: don't block org deletion retry when user already deleted

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -972,7 +972,7 @@ def _delete_teams_and_data(team_ids: list[int], user_id: int, project_id: int | 
     user = User.objects.filter(id=user_id).first()
 
     try:
-        deleted_by = user.email if user else str(user_id)
+        deleted_by = user.email if user else f"deleted_user_id:{user_id}"
         _queue_delete_team_recordings(team_ids, deleted_by=deleted_by)
     except Exception:
         logger.exception("Failed to queue recording deletion workflows", team_ids=team_ids)

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -967,12 +967,13 @@ def _delete_teams_and_data(team_ids: list[int], user_id: int, project_id: int | 
     from posthog.models.team.util import delete_batch_exports, delete_bulky_postgres_data
     from posthog.models.user import User
 
+    # User may have already deleted their account after requesting org deletion,
+    # so we must not block the cleanup on user existence.
     user = User.objects.filter(id=user_id).first()
-    if not user:
-        raise ValueError(f"Cannot delete team data: user {user_id} not found")
 
     try:
-        _queue_delete_team_recordings(team_ids, deleted_by=user.email)
+        deleted_by = user.email if user else str(user_id)
+        _queue_delete_team_recordings(team_ids, deleted_by=deleted_by)
     except Exception:
         logger.exception("Failed to queue recording deletion workflows", team_ids=team_ids)
         capture_exception()

--- a/posthog/tasks/test/test_deletion_tasks.py
+++ b/posthog/tasks/test/test_deletion_tasks.py
@@ -127,6 +127,31 @@ class TestDeleteOrganizationDataAndNotifyTask(BaseTest):
         self.assertFalse(DataWarehouseSavedQuery.objects.filter(id=saved_query.id).exists())
         self.assertFalse(Node.objects.filter(id=node.id).exists())
 
+    @patch("posthog.email.is_email_available", return_value=False)
+    def test_deletes_organization_when_user_already_deleted(self, mock_email: Any) -> None:
+        org = Organization.objects.create(name="Org to delete")
+        org.members.add(self.user)
+        team = Team.objects.create(organization=org, name="Team in org")
+        org_id = str(org.id)
+        team_id = team.id
+        project_id = team.project_id
+        user_id = self.user.id
+
+        # Simulate the user deleting their account before the async task runs
+        self.user.delete()
+
+        delete_organization_data_and_notify_task(
+            team_ids=[team_id],
+            organization_id=org_id,
+            user_id=user_id,
+            organization_name="Org to delete",
+            project_names=["Team in org"],
+        )
+
+        self.assertFalse(Organization.objects.filter(id=org_id).exists())
+        self.assertFalse(Team.objects.filter(id=team_id).exists())
+        self.assertFalse(Project.objects.filter(id=project_id).exists())
+
     @patch("posthog.tasks.email.send_organization_deleted_email")
     @patch("posthog.email.is_email_available", return_value=True)
     def test_sends_email_when_available(self, mock_email_available: Any, mock_send_email: Any) -> None:


### PR DESCRIPTION
## Problem

When a user deletes their organization and then immediately deletes their account (enabled by #50875), the async org deletion task can fail on retry. 

The task requires the initiating user to exist, but if they've already deleted their account, retries raise `ValueError("Cannot delete team data: user not found")` and never reach the org/project deletion step. 

This results in orphaned org and project records in Postgres, all the actual data (events, session replays, persons, etc.) gets deleted on the first run, but the org and project records remain.

More context [here](https://posthog.slack.com/archives/C08UM214Z50/p1773321450828089). 

## Changes
 - Don't block `_delete_teams_and_data` when the initiating user no longer exists - the user is only needed for the `deleted_by` audit string in recording deletion
 - Add test for org deletion when user is already deleted

## How did you test this code?
Tests

## Publish to changelog?
No

## Docs update
No