### PR TITLE
feat(logs): add inline notification destinations for log alerts

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -573,6 +573,9 @@ export const INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID = 'insight-alert-firing'
 export const INSIGHT_ALERT_DESTINATION_LOGIC_KEY = 'insightAlertDestination'
 export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'
 
+export const LOGS_ALERT_FIRING_SUB_TEMPLATE_ID = 'logs-alert-firing'
+export const LOGS_ALERT_FIRING_EVENT_ID = '$logs_alert_firing'
+
 export const COHORT_PERSONS_QUERY_LIMIT = 10000
 
 /** Maps SDK keys to their corresponding snippet language identifiers */

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -39,6 +39,13 @@ export const getProductEventFilterOptions = (contextId: HogFunctionConfiguration
                     value: '$insight_alert_firing',
                 },
             ]
+        case 'logs-alerting':
+            return [
+                {
+                    label: 'Log alert firing',
+                    value: '$logs_alert_firing',
+                },
+            ]
         case 'discussion-mention':
             return [
                 {

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -86,6 +86,13 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         context_id: 'experiment-alerts',
         filters: { events: [{ id: '$experiment_metric_significant', type: 'events' }] },
     },
+    'logs-alert-firing': {
+        sub_template_id: 'logs-alert-firing',
+        type: 'internal_destination',
+        context_id: 'logs-alerting',
+        filters: { events: [{ id: '$logs_alert_firing', type: 'events' }] },
+        flag: FEATURE_FLAGS.LOGS_ALERTING,
+    },
 }
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
@@ -718,6 +725,58 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             },
         },
     ],
+    'logs-alert-firing': [
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-firing'],
+            template_id: 'template-webhook',
+            name: 'HTTP Webhook on log alert firing',
+            description: 'Send a webhook when a log alert fires',
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-firing'],
+            template_id: 'template-slack',
+            name: 'Post to Slack on log alert firing',
+            description: 'Post to a Slack channel when a log alert fires',
+            inputs: {
+                blocks: {
+                    value: [
+                        {
+                            type: 'header',
+                            text: {
+                                type: 'plain_text',
+                                text: "Log alert '{event.properties.alert_name}' is firing",
+                            },
+                        },
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: '*Threshold breached:* {event.properties.threshold_count} logs in {event.properties.window_minutes}m (limit: {event.properties.threshold_operator} {event.properties.threshold_value})',
+                            },
+                        },
+                        {
+                            type: 'context',
+                            elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+                        },
+                        { type: 'divider' },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    url: '{project.url}/logs?{event.properties.logs_url_params}',
+                                    text: { text: 'View logs', type: 'plain_text' },
+                                    type: 'button',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: {
+                    value: "Log alert '{event.properties.alert_name}' is firing",
+                },
+            },
+        },
+    ],
 }
 
 export const getSubTemplate = (
@@ -741,6 +800,8 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
             return 'activity-log'
         case '$discussion_mention_created':
             return 'discussion-mention'
+        case '$logs_alert_firing':
+            return 'logs-alerting'
         default:
             return 'standard'
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6238,6 +6238,7 @@ export type HogFunctionConfigurationContextId =
     | 'discussion-mention'
     | 'insight-alerts'
     | 'experiment-alerts'
+    | 'logs-alerting'
 
 export type HogFunctionSubTemplateIdType =
     | 'early-access-feature-enrollment'
@@ -6249,6 +6250,7 @@ export type HogFunctionSubTemplateIdType =
     | 'discussion-mention'
     | 'insight-alert-firing'
     | 'experiment-significant'
+    | 'logs-alert-firing'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -21,6 +21,7 @@ import { SeverityLevelsFilter } from 'products/logs/frontend/components/LogsView
 import { ThresholdOperatorEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
 import { logsAlertFormLogic } from './logsAlertFormLogic'
+import { LogsAlertNotifications } from './LogsAlertNotifications'
 
 const WINDOW_OPTIONS = [
     { value: 5, label: '5 minutes' },
@@ -260,6 +261,11 @@ export function LogsAlertForm(): JSX.Element {
                                 </LemonField.Pure>
                             </div>
                         ),
+                    },
+                    {
+                        key: 'notifications',
+                        header: 'Notifications',
+                        content: <LogsAlertNotifications />,
                     },
                 ]}
             />

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
@@ -1,0 +1,240 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconExternal, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonSelect, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
+
+import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
+import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
+import { urls } from 'scenes/urls'
+
+import { HogFunctionType, SlackChannelType } from '~/types'
+
+import { LOGS_ALERT_NOTIFICATION_TYPE_OPTIONS, logsAlertNotificationLogic } from './logsAlertNotificationLogic'
+import {
+    LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+    LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
+    PendingLogsAlertNotification,
+} from './logsAlertUtils'
+
+function resolveSlackChannelName(channelValue: string, slackChannels: SlackChannelType[]): string | null {
+    const channelId = channelValue.split('|')[0]
+    return slackChannels.find((c) => c.id === channelId)?.name ?? null
+}
+
+function getHogFunctionDestination(
+    hf: HogFunctionType,
+    slackChannels: SlackChannelType[]
+): { type: string; detail: string | null } {
+    const channelValue = hf.inputs?.channel?.value
+    if (channelValue && typeof channelValue === 'string') {
+        const channelName = resolveSlackChannelName(channelValue, slackChannels)
+        return { type: 'Slack', detail: channelName ? `#${channelName}` : null }
+    }
+    if (channelValue) {
+        return { type: 'Slack', detail: null }
+    }
+    const urlValue = hf.inputs?.url?.value
+    if (urlValue && typeof urlValue === 'string') {
+        return { type: 'Webhook', detail: urlValue }
+    }
+    return { type: hf.name, detail: null }
+}
+
+export function LogsAlertNotifications(): JSX.Element {
+    const {
+        existingHogFunctions,
+        existingHogFunctionsLoading,
+        pendingNotifications,
+        firstSlackIntegration,
+        selectedType,
+        slackChannelValue,
+        webhookUrl,
+    } = useValues(logsAlertNotificationLogic)
+    const {
+        addPendingNotification,
+        removePendingNotification,
+        deleteExistingHogFunction,
+        setSelectedType,
+        setSlackChannelValue,
+        setWebhookUrl,
+    } = useActions(logsAlertNotificationLogic)
+
+    const slackLogic = slackIntegrationLogic({ id: firstSlackIntegration?.id ?? 0 })
+    const { slackChannels } = useValues(slackLogic)
+    const { loadAllSlackChannels } = useActions(slackLogic)
+
+    useEffect(() => {
+        if (firstSlackIntegration) {
+            loadAllSlackChannels()
+        }
+    }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
+
+    const handleAdd = (): void => {
+        if (selectedType === LOGS_ALERT_NOTIFICATION_TYPE_SLACK) {
+            if (!slackChannelValue || !firstSlackIntegration) {
+                return
+            }
+            const parts = slackChannelValue.split('|')
+            const channelId = parts[0]
+            const channelName = parts[1]?.replace('#', '') ?? channelId
+
+            const notification: PendingLogsAlertNotification = {
+                type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+                slackWorkspaceId: firstSlackIntegration.id,
+                slackChannelId: channelId,
+                slackChannelName: channelName,
+            }
+            addPendingNotification(notification)
+            setSlackChannelValue(null)
+        } else {
+            if (!webhookUrl) {
+                return
+            }
+            addPendingNotification({ type: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK, webhookUrl })
+            setWebhookUrl('')
+        }
+    }
+
+    const getNotificationLabel = (notification: PendingLogsAlertNotification): string => {
+        if (notification.type === LOGS_ALERT_NOTIFICATION_TYPE_SLACK) {
+            return `Slack: #${notification.slackChannelName ?? 'channel'}`
+        }
+        return `Webhook: ${notification.webhookUrl}`
+    }
+
+    return (
+        <div className="space-y-4">
+            {(existingHogFunctionsLoading || existingHogFunctions.length > 0) && (
+                <div>
+                    {existingHogFunctionsLoading ? (
+                        <LemonSkeleton className="h-8" repeat={2} />
+                    ) : existingHogFunctions.length > 0 ? (
+                        <div className="space-y-2">
+                            {existingHogFunctions.map((hf) => {
+                                const { type: destType, detail } = getHogFunctionDestination(hf, slackChannels)
+                                return (
+                                    <div
+                                        key={hf.id}
+                                        className="flex items-center justify-between border rounded p-2 gap-2"
+                                    >
+                                        <div className="flex-1 min-w-0">
+                                            <div className="flex items-center gap-2">
+                                                <span className="text-sm font-medium">{destType}</span>
+                                                <LemonTag type={hf.enabled ? 'success' : 'default'} size="small">
+                                                    {hf.enabled ? 'Active' : 'Paused'}
+                                                </LemonTag>
+                                            </div>
+                                            {detail && (
+                                                <span className="text-xs text-muted-alt truncate block">{detail}</span>
+                                            )}
+                                        </div>
+                                        <div className="flex items-center gap-1 shrink-0">
+                                            <LemonButton
+                                                icon={<IconExternal />}
+                                                size="xsmall"
+                                                to={urls.hogFunction(hf.id)}
+                                                targetBlank
+                                                hideExternalLinkIcon
+                                                tooltip="Open destination"
+                                            />
+                                            <LemonButton
+                                                icon={<IconTrash />}
+                                                size="xsmall"
+                                                status="danger"
+                                                onClick={() => deleteExistingHogFunction(hf)}
+                                                tooltip="Delete notification"
+                                            />
+                                        </div>
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    ) : null}
+                </div>
+            )}
+
+            {pendingNotifications.length > 0 && (
+                <div className="space-y-2">
+                    {pendingNotifications.map((notification, index) => (
+                        <div
+                            key={
+                                notification.type === LOGS_ALERT_NOTIFICATION_TYPE_SLACK
+                                    ? `slack-${notification.slackChannelId}`
+                                    : `webhook-${notification.webhookUrl}`
+                            }
+                            className="flex items-center justify-between border rounded p-2 gap-2"
+                        >
+                            <span className="text-sm min-w-0 truncate flex flex-col">
+                                {getNotificationLabel(notification)}{' '}
+                                <span className="text-muted-alt">(pending - click Save to apply)</span>
+                            </span>
+                            <LemonButton
+                                icon={<IconTrash />}
+                                size="xsmall"
+                                status="danger"
+                                onClick={() => removePendingNotification(index)}
+                                tooltip="Remove notification"
+                            />
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <div className="space-y-3 border rounded p-3">
+                <div className="flex gap-2 items-end">
+                    <div className="flex-1">
+                        <LemonSelect
+                            fullWidth
+                            options={LOGS_ALERT_NOTIFICATION_TYPE_OPTIONS}
+                            value={selectedType}
+                            onChange={(value) => setSelectedType(value)}
+                        />
+                    </div>
+                </div>
+
+                {selectedType === LOGS_ALERT_NOTIFICATION_TYPE_SLACK && (
+                    <>
+                        {!firstSlackIntegration ? (
+                            <SlackNotConfiguredBanner />
+                        ) : (
+                            <SlackChannelPicker
+                                value={slackChannelValue ?? undefined}
+                                onChange={(value) => setSlackChannelValue(value)}
+                                integration={firstSlackIntegration}
+                            />
+                        )}
+                    </>
+                )}
+
+                {selectedType === LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK && (
+                    <LemonInput
+                        placeholder="https://example.com/webhook"
+                        value={webhookUrl}
+                        onChange={setWebhookUrl}
+                        fullWidth
+                    />
+                )}
+
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    onClick={handleAdd}
+                    disabledReason={
+                        selectedType === LOGS_ALERT_NOTIFICATION_TYPE_SLACK
+                            ? !firstSlackIntegration
+                                ? 'Connect Slack first'
+                                : !slackChannelValue
+                                  ? 'Select a Slack channel'
+                                  : undefined
+                            : !webhookUrl
+                              ? 'Enter a webhook URL'
+                              : undefined
+                    }
+                >
+                    Add notification
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -11,6 +11,7 @@ import { LogsAlertForm } from './LogsAlertForm'
 import { logsAlertFormLogic } from './logsAlertFormLogic'
 import { logsAlertingLogic } from './logsAlertingLogic'
 import { LogsAlertList } from './LogsAlertList'
+import { logsAlertNotificationLogic } from './logsAlertNotificationLogic'
 
 export function LogsAlertingSection(): JSX.Element {
     return (
@@ -46,30 +47,44 @@ function LogsAlertingSectionInner(): JSX.Element {
 }
 
 function LogsAlertModalContent({ editingAlert }: { editingAlert: LogsAlertConfigurationApi | null }): JSX.Element {
+    const notifLogicProps = { alertId: editingAlert?.id }
     const formLogicProps = { alert: editingAlert }
-    const { isAlertFormSubmitting } = useValues(logsAlertFormLogic(formLogicProps))
+    const { isAlertFormSubmitting, alertFormChanged } = useValues(logsAlertFormLogic(formLogicProps))
+    const { pendingNotifications } = useValues(logsAlertNotificationLogic(notifLogicProps))
+    const hasPendingNotifications = pendingNotifications.length > 0
 
     return (
-        <Form
-            logic={logsAlertFormLogic}
-            props={formLogicProps}
-            formKey="alertForm"
-            enableFormOnSubmit
-            className="LemonModal__layout"
-        >
-            <LemonModal.Header>
-                <h3>{editingAlert ? 'Edit alert' : 'New alert'}</h3>
-                <p className="text-muted text-sm m-0">Alerts are checked every minute.</p>
-            </LemonModal.Header>
-            <LemonModal.Content>
-                <LogsAlertForm />
-            </LemonModal.Content>
-            <LemonModal.Footer>
-                <div className="flex-1" />
-                <LemonButton type="primary" htmlType="submit" loading={isAlertFormSubmitting}>
-                    {editingAlert ? 'Save' : 'Create alert'}
-                </LemonButton>
-            </LemonModal.Footer>
-        </Form>
+        <BindLogic logic={logsAlertNotificationLogic} props={notifLogicProps}>
+            <Form
+                logic={logsAlertFormLogic}
+                props={formLogicProps}
+                formKey="alertForm"
+                enableFormOnSubmit
+                className="LemonModal__layout"
+            >
+                <LemonModal.Header>
+                    <h3>{editingAlert ? 'Edit alert' : 'New alert'}</h3>
+                    <p className="text-muted text-sm m-0">Alerts are checked every minute.</p>
+                </LemonModal.Header>
+                <LemonModal.Content>
+                    <LogsAlertForm />
+                </LemonModal.Content>
+                <LemonModal.Footer>
+                    <div className="flex-1" />
+                    <LemonButton
+                        type="primary"
+                        htmlType="submit"
+                        loading={isAlertFormSubmitting}
+                        disabledReason={
+                            editingAlert && !alertFormChanged && !hasPendingNotifications
+                                ? 'No changes to save'
+                                : undefined
+                        }
+                    >
+                        {editingAlert ? 'Save' : 'Create alert'}
+                    </LemonButton>
+                </LemonModal.Footer>
+            </Form>
+        </BindLogic>
     )
 }

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertNotificationLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertNotificationLogic.test.ts
@@ -1,0 +1,233 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+
+import { initKeaTests } from '~/test/init'
+import { HogFunctionType } from '~/types'
+
+import { logsAlertNotificationLogic } from '../logsAlertNotificationLogic'
+import { buildLogsAlertFilterConfig } from '../logsAlertUtils'
+
+jest.mock('lib/api', () => ({
+    __esModule: true,
+    default: {
+        hogFunctions: {
+            list: jest.fn(),
+            create: jest.fn(),
+        },
+    },
+}))
+
+jest.mock('lib/utils/deleteWithUndo', () => ({
+    deleteWithUndo: jest.fn(),
+}))
+
+jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
+    lemonToast: {
+        success: jest.fn(),
+        error: jest.fn(),
+    },
+}))
+
+const mockApi = api as jest.Mocked<typeof api>
+const mockDeleteWithUndo = deleteWithUndo as jest.MockedFunction<typeof deleteWithUndo>
+
+const MOCK_HOG_FUNCTION = {
+    id: 'hf-1',
+    name: 'Test Notification',
+    enabled: true,
+    inputs: { channel: { value: 'C123' } },
+} as unknown as HogFunctionType
+
+describe('logsAlertNotificationLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+        jest.clearAllMocks()
+        ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({ results: [] })
+    })
+
+    describe('pending notifications', () => {
+        it('adds a pending notification', async () => {
+            const logic = logsAlertNotificationLogic({ alertId: undefined })
+            logic.mount()
+
+            logic.actions.addPendingNotification({
+                type: 'slack',
+                slackWorkspaceId: 1,
+                slackChannelId: 'C123',
+                slackChannelName: 'alerts',
+            })
+
+            expect(logic.values.pendingNotifications).toHaveLength(1)
+            expect(logic.values.pendingNotifications[0]).toMatchObject({
+                type: 'slack',
+                slackChannelId: 'C123',
+            })
+
+            logic.unmount()
+        })
+
+        it('removes a pending notification by index', () => {
+            const logic = logsAlertNotificationLogic({ alertId: undefined })
+            logic.mount()
+
+            logic.actions.addPendingNotification({
+                type: 'webhook',
+                webhookUrl: 'https://a.com',
+            })
+            logic.actions.addPendingNotification({
+                type: 'webhook',
+                webhookUrl: 'https://b.com',
+            })
+
+            logic.actions.removePendingNotification(0)
+
+            expect(logic.values.pendingNotifications).toHaveLength(1)
+            expect(logic.values.pendingNotifications[0]).toMatchObject({
+                webhookUrl: 'https://b.com',
+            })
+
+            logic.unmount()
+        })
+
+        it('clears all pending notifications', () => {
+            const logic = logsAlertNotificationLogic({ alertId: undefined })
+            logic.mount()
+
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://a.com' })
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://b.com' })
+
+            logic.actions.clearPendingNotifications()
+
+            expect(logic.values.pendingNotifications).toHaveLength(0)
+
+            logic.unmount()
+        })
+    })
+
+    describe('loadExistingHogFunctions', () => {
+        it('returns empty array when no alertId', async () => {
+            const logic = logsAlertNotificationLogic({ alertId: undefined })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.loadExistingHogFunctions()
+            }).toFinishAllListeners()
+
+            expect(logic.values.existingHogFunctions).toEqual([])
+            expect(mockApi.hogFunctions.list).not.toHaveBeenCalled()
+
+            logic.unmount()
+        })
+
+        it('loads hog functions filtered by alert id', async () => {
+            ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
+                results: [MOCK_HOG_FUNCTION],
+            })
+
+            const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
+            logic.mount()
+
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(mockApi.hogFunctions.list).toHaveBeenCalledWith({
+                types: ['internal_destination'],
+                filter_groups: [buildLogsAlertFilterConfig('alert-1')],
+                full: true,
+            })
+            expect(logic.values.existingHogFunctions).toEqual([MOCK_HOG_FUNCTION])
+
+            logic.unmount()
+        })
+    })
+
+    describe('createPendingHogFunctions', () => {
+        it('skips when no pending notifications', async () => {
+            const logic = logsAlertNotificationLogic({ alertId: undefined })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.createPendingHogFunctions('alert-1', 'My Alert')
+            }).toFinishAllListeners()
+
+            expect(mockApi.hogFunctions.create).not.toHaveBeenCalled()
+
+            logic.unmount()
+        })
+
+        it('creates hog functions for each pending notification', async () => {
+            ;(mockApi.hogFunctions.create as jest.Mock).mockResolvedValue(MOCK_HOG_FUNCTION)
+
+            const logic = logsAlertNotificationLogic({ alertId: undefined })
+            logic.mount()
+
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://a.com' })
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://b.com' })
+
+            await expectLogic(logic, () => {
+                logic.actions.createPendingHogFunctions('alert-1', 'My Alert')
+            }).toFinishAllListeners()
+
+            expect(mockApi.hogFunctions.create).toHaveBeenCalledTimes(2)
+            expect(lemonToast.success).toHaveBeenCalledWith('2 notification destination(s) created.')
+            expect(logic.values.pendingNotifications).toHaveLength(0)
+
+            logic.unmount()
+        })
+
+        it('retains failed notifications on partial failure', async () => {
+            ;(mockApi.hogFunctions.create as jest.Mock)
+                .mockResolvedValueOnce(MOCK_HOG_FUNCTION)
+                .mockRejectedValueOnce(new Error('API error'))
+
+            const logic = logsAlertNotificationLogic({ alertId: undefined })
+            logic.mount()
+
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://ok.com' })
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://fail.com' })
+
+            await expectLogic(logic, () => {
+                logic.actions.createPendingHogFunctions('alert-1', 'My Alert')
+            }).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith(expect.stringContaining('1 notification(s) failed to create'))
+            expect(logic.values.pendingNotifications).toHaveLength(1)
+            expect(logic.values.pendingNotifications[0]).toMatchObject({
+                webhookUrl: 'https://fail.com',
+            })
+
+            logic.unmount()
+        })
+    })
+
+    describe('deleteExistingHogFunction', () => {
+        it('optimistically removes from state and calls deleteWithUndo', async () => {
+            ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
+                results: [MOCK_HOG_FUNCTION],
+            })
+            ;(mockDeleteWithUndo as jest.Mock).mockResolvedValue(undefined)
+
+            const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
+            logic.mount()
+
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.existingHogFunctions).toHaveLength(1)
+
+            logic.actions.deleteExistingHogFunction(MOCK_HOG_FUNCTION)
+
+            // Optimistic removal happens immediately via reducer
+            expect(logic.values.existingHogFunctions).toHaveLength(0)
+
+            await expectLogic(logic).toFinishAllListeners()
+            expect(mockDeleteWithUndo).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    object: { id: MOCK_HOG_FUNCTION.id, name: MOCK_HOG_FUNCTION.name },
+                })
+            )
+
+            logic.unmount()
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
@@ -1,0 +1,122 @@
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import {
+    buildLogsAlertFilterConfig,
+    buildLogsAlertHogFunctionPayload,
+    LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+    LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
+    PendingLogsAlertNotification,
+} from '../logsAlertUtils'
+
+describe('logsAlertUtils', () => {
+    describe('buildLogsAlertFilterConfig', () => {
+        it('includes alert_id property filter with exact operator', () => {
+            const config = buildLogsAlertFilterConfig('alert-123')
+
+            expect(config.properties).toEqual([
+                {
+                    key: 'alert_id',
+                    value: 'alert-123',
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Event,
+                },
+            ])
+        })
+
+        it('includes $logs_alert_firing event filter', () => {
+            const config = buildLogsAlertFilterConfig('alert-123')
+
+            expect(config.events).toEqual([
+                {
+                    id: '$logs_alert_firing',
+                    type: 'events',
+                },
+            ])
+        })
+    })
+
+    describe('buildLogsAlertHogFunctionPayload', () => {
+        it('builds slack notification payload with channel and workspace', () => {
+            const notification: PendingLogsAlertNotification = {
+                type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+                slackWorkspaceId: 42,
+                slackChannelId: 'C123',
+                slackChannelName: 'alerts',
+            }
+
+            const payload = buildLogsAlertHogFunctionPayload('alert-1', 'API errors', notification)
+
+            expect(payload).toMatchObject({
+                type: 'internal_destination',
+                enabled: true,
+                masking: null,
+                name: 'API errors: Slack #alerts',
+                template_id: 'template-slack',
+            })
+            expect(payload.inputs?.slack_workspace).toEqual({ value: 42 })
+            expect(payload.inputs?.channel).toEqual({ value: 'C123' })
+            expect(payload.filters?.events?.[0].id).toBe('$logs_alert_firing')
+            expect(payload.filters?.properties?.[0].value).toBe('alert-1')
+        })
+
+        it('uses fallback name when alertName is undefined for slack', () => {
+            const notification: PendingLogsAlertNotification = {
+                type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+                slackWorkspaceId: 1,
+                slackChannelId: 'C456',
+                slackChannelName: 'general',
+            }
+
+            const payload = buildLogsAlertHogFunctionPayload('alert-2', undefined, notification)
+
+            expect(payload.name).toBe('Alert: Slack #general')
+        })
+
+        it('uses fallback channel name when slackChannelName is undefined', () => {
+            const notification: PendingLogsAlertNotification = {
+                type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+                slackWorkspaceId: 1,
+                slackChannelId: 'C789',
+            }
+
+            const payload = buildLogsAlertHogFunctionPayload('alert-3', 'My Alert', notification)
+
+            expect(payload.name).toBe('My Alert: Slack #channel')
+        })
+
+        it('builds webhook notification payload with URL', () => {
+            const notification: PendingLogsAlertNotification = {
+                type: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
+                webhookUrl: 'https://example.com/hook',
+            }
+
+            const payload = buildLogsAlertHogFunctionPayload('alert-4', 'DB errors', notification)
+
+            expect(payload).toMatchObject({
+                type: 'internal_destination',
+                enabled: true,
+                masking: null,
+                name: 'DB errors: Webhook https://example.com/hook',
+                template_id: 'template-webhook',
+            })
+            expect(payload.inputs?.url).toEqual({ value: 'https://example.com/hook' })
+            expect(payload.inputs?.body?.value).toMatchObject({
+                alert_name: '{event.properties.alert_name}',
+                threshold_count: '{event.properties.threshold_count}',
+                window_minutes: '{event.properties.window_minutes}',
+                logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
+            })
+        })
+
+        it('uses fallback name when alertName is undefined for webhook', () => {
+            const notification: PendingLogsAlertNotification = {
+                type: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
+                webhookUrl: 'https://example.com/hook',
+            }
+
+            const payload = buildLogsAlertHogFunctionPayload('alert-5', undefined, notification)
+
+            expect(payload.name).toBe('Alert: Webhook https://example.com/hook')
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
@@ -17,6 +17,7 @@ import {
 
 import type { logsAlertFormLogicType } from './logsAlertFormLogicType'
 import { logsAlertingLogic } from './logsAlertingLogic'
+import { logsAlertNotificationLogic } from './logsAlertNotificationLogic'
 
 const EMPTY_FILTER_GROUP: UniversalFiltersGroup = {
     type: FilterLogicalOperator.And,
@@ -82,10 +83,20 @@ export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
     props({} as LogsAlertFormLogicProps),
     key(({ alert }) => alert?.id ?? 'new'),
 
-    connect({
-        values: [teamLogic, ['currentTeamId']],
-        actions: [logsAlertingLogic, ['loadAlerts', 'setEditingAlert', 'setIsCreating']],
-    }),
+    connect(({ alert }: LogsAlertFormLogicProps) => ({
+        values: [
+            teamLogic,
+            ['currentTeamId'],
+            logsAlertNotificationLogic({ alertId: alert?.id }),
+            ['pendingNotifications'],
+        ],
+        actions: [
+            logsAlertingLogic,
+            ['loadAlerts', 'setEditingAlert', 'setIsCreating'],
+            logsAlertNotificationLogic({ alertId: alert?.id }),
+            ['createPendingHogFunctions'],
+        ],
+    })),
 
     selectors({
         isEditing: [() => [(_, props) => props.alert], (alert: LogsAlertConfigurationApi | null) => alert !== null],
@@ -126,14 +137,23 @@ export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
                 }
 
                 try {
+                    let savedAlertId: string
                     if (props.alert) {
                         const patch: PatchedLogsAlertConfigurationApi = { ...payload }
                         await logsAlertsPartialUpdate(projectId, props.alert.id, patch)
+                        savedAlertId = props.alert.id
                         lemonToast.success('Alert updated')
                     } else {
-                        await logsAlertsCreate(projectId, payload)
+                        const created = await logsAlertsCreate(projectId, payload)
+                        savedAlertId = created.id
                         lemonToast.success('Alert created')
                     }
+
+                    if (values.pendingNotifications.length > 0) {
+                        const notifLogic = logsAlertNotificationLogic({ alertId: props.alert?.id })
+                        await notifLogic.asyncActions.createPendingHogFunctions(savedAlertId, form.name)
+                    }
+
                     actions.setEditingAlert(null)
                     actions.setIsCreating(false)
                     actions.loadAlerts()

--- a/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
@@ -1,0 +1,173 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { HogFunctionType, IntegrationType } from '~/types'
+
+import type { logsAlertNotificationLogicType } from './logsAlertNotificationLogicType'
+import {
+    buildLogsAlertFilterConfig,
+    buildLogsAlertHogFunctionPayload,
+    LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+    LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
+    LogsAlertNotificationType,
+    PendingLogsAlertNotification,
+} from './logsAlertUtils'
+
+export const LOGS_ALERT_NOTIFICATION_TYPE_OPTIONS = [
+    { label: 'Slack', value: LOGS_ALERT_NOTIFICATION_TYPE_SLACK },
+    { label: 'Webhook', value: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK },
+]
+
+export interface LogsAlertNotificationLogicProps {
+    alertId?: string
+}
+
+export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsAlerting', 'logsAlertNotificationLogic']),
+    props({} as LogsAlertNotificationLogicProps),
+    key(({ alertId }) => alertId ?? 'new'),
+
+    connect({
+        values: [projectLogic, ['currentProjectId'], integrationsLogic, ['slackIntegrations']],
+        actions: [integrationsLogic, ['loadIntegrationsSuccess']],
+    }),
+
+    actions({
+        addPendingNotification: (notification: PendingLogsAlertNotification) => ({ notification }),
+        removePendingNotification: (index: number) => ({ index }),
+        clearPendingNotifications: true,
+        setPendingNotifications: (notifications: PendingLogsAlertNotification[]) => ({ notifications }),
+        deleteExistingHogFunction: (hogFunction: HogFunctionType) => ({ hogFunction }),
+        createPendingHogFunctions: (alertId: string, alertName?: string) => ({ alertId, alertName }),
+        setSelectedType: (selectedType: LogsAlertNotificationType) => ({ selectedType }),
+        setSlackChannelValue: (slackChannelValue: string | null) => ({ slackChannelValue }),
+        setWebhookUrl: (webhookUrl: string) => ({ webhookUrl }),
+    }),
+
+    reducers({
+        pendingNotifications: [
+            [] as PendingLogsAlertNotification[],
+            {
+                addPendingNotification: (state, { notification }) => [...state, notification],
+                removePendingNotification: (state, { index }) => state.filter((_, i) => i !== index),
+                clearPendingNotifications: () => [],
+                setPendingNotifications: (_, { notifications }) => notifications,
+            },
+        ],
+        slackChannelValue: [
+            null as string | null,
+            {
+                setSlackChannelValue: (_, { slackChannelValue }) => slackChannelValue,
+            },
+        ],
+        webhookUrl: [
+            '' as string,
+            {
+                setWebhookUrl: (_, { webhookUrl }) => webhookUrl,
+            },
+        ],
+        selectedType: [
+            LOGS_ALERT_NOTIFICATION_TYPE_SLACK as LogsAlertNotificationType,
+            {
+                setSelectedType: (_, { selectedType }) => selectedType,
+            },
+        ],
+        existingHogFunctions: [
+            [] as HogFunctionType[],
+            {
+                deleteExistingHogFunction: (state, { hogFunction }) => state.filter((hf) => hf.id !== hogFunction.id),
+            },
+        ],
+    }),
+
+    selectors({
+        firstSlackIntegration: [
+            (s) => [s.slackIntegrations],
+            (slackIntegrations: IntegrationType[] | undefined): IntegrationType | undefined => slackIntegrations?.[0],
+        ],
+    }),
+
+    loaders(({ props }) => ({
+        existingHogFunctions: [
+            [] as HogFunctionType[],
+            {
+                loadExistingHogFunctions: async (alertId?: string) => {
+                    const id = alertId ?? props.alertId
+                    if (!id) {
+                        return []
+                    }
+                    const response = await api.hogFunctions.list({
+                        types: ['internal_destination'],
+                        filter_groups: [buildLogsAlertFilterConfig(id)],
+                        full: true,
+                    })
+                    return response.results
+                },
+            },
+        ],
+    })),
+
+    listeners(({ actions, values }) => ({
+        loadIntegrationsSuccess: () => {
+            if (!values.firstSlackIntegration) {
+                actions.setSelectedType(LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK)
+            }
+        },
+        deleteExistingHogFunction: async ({ hogFunction }) => {
+            await deleteWithUndo({
+                endpoint: `projects/${values.currentProjectId}/hog_functions`,
+                object: {
+                    id: hogFunction.id,
+                    name: hogFunction.name,
+                },
+                callback: (undo) => {
+                    if (undo) {
+                        actions.loadExistingHogFunctions()
+                    }
+                },
+            })
+        },
+
+        createPendingHogFunctions: async ({ alertId, alertName }) => {
+            const pending = values.pendingNotifications
+            if (pending.length === 0) {
+                return
+            }
+
+            const results = await Promise.allSettled(
+                pending.map((notification) => {
+                    const payload = buildLogsAlertHogFunctionPayload(alertId, alertName, notification)
+                    return api.hogFunctions.create(payload)
+                })
+            )
+
+            const failedNotifications = pending.filter((_, i) => results[i].status === 'rejected')
+
+            if (failedNotifications.length > 0) {
+                lemonToast.error(
+                    `Alert saved, but ${failedNotifications.length} notification(s) failed to create. Reopen the alert to add them again.`
+                )
+                actions.setPendingNotifications(failedNotifications)
+            } else {
+                if (results.length > 0) {
+                    lemonToast.success(`${results.length} notification destination(s) created.`)
+                }
+                actions.clearPendingNotifications()
+            }
+
+            actions.loadExistingHogFunctions(alertId)
+        },
+    })),
+
+    afterMount(({ actions, props }) => {
+        if (props.alertId) {
+            actions.loadExistingHogFunctions()
+        }
+    }),
+])

--- a/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
@@ -1,0 +1,90 @@
+import { LOGS_ALERT_FIRING_EVENT_ID, LOGS_ALERT_FIRING_SUB_TEMPLATE_ID } from 'lib/constants'
+import {
+    HOG_FUNCTION_SUB_TEMPLATES,
+    HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
+} from 'scenes/hog-functions/sub-templates/sub-templates'
+
+import { CyclotronJobFiltersType, HogFunctionType, PropertyFilterType, PropertyOperator } from '~/types'
+
+export const LOGS_ALERT_NOTIFICATION_TYPE_SLACK = 'slack' as const
+export const LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK = 'webhook' as const
+export type LogsAlertNotificationType =
+    | typeof LOGS_ALERT_NOTIFICATION_TYPE_SLACK
+    | typeof LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK
+
+export type PendingLogsAlertNotification =
+    | {
+          type: typeof LOGS_ALERT_NOTIFICATION_TYPE_SLACK
+          slackWorkspaceId: number
+          slackChannelId: string
+          slackChannelName?: string
+      }
+    | {
+          type: typeof LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK
+          webhookUrl: string
+      }
+
+export const buildLogsAlertFilterConfig = (alertId: string): CyclotronJobFiltersType => ({
+    properties: [
+        {
+            key: 'alert_id',
+            value: alertId,
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        },
+    ],
+    events: [
+        {
+            id: LOGS_ALERT_FIRING_EVENT_ID,
+            type: 'events',
+        },
+    ],
+})
+
+const LOGS_ALERT_SLACK_INPUTS =
+    HOG_FUNCTION_SUB_TEMPLATES[LOGS_ALERT_FIRING_SUB_TEMPLATE_ID].find((t) => t.template_id === 'template-slack')
+        ?.inputs ?? {}
+
+export function buildLogsAlertHogFunctionPayload(
+    alertId: string,
+    alertName: string | undefined,
+    notification: PendingLogsAlertNotification
+): Partial<HogFunctionType> {
+    const commonProps = HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES[LOGS_ALERT_FIRING_SUB_TEMPLATE_ID]
+    const base = {
+        type: commonProps.type,
+        enabled: true,
+        masking: null,
+        filters: buildLogsAlertFilterConfig(alertId),
+    }
+
+    if (notification.type === 'slack') {
+        return {
+            ...base,
+            name: `${alertName ?? 'Alert'}: Slack #${notification.slackChannelName ?? 'channel'}`,
+            template_id: 'template-slack',
+            inputs: {
+                ...LOGS_ALERT_SLACK_INPUTS,
+                slack_workspace: { value: notification.slackWorkspaceId },
+                channel: { value: notification.slackChannelId },
+            },
+        }
+    }
+
+    return {
+        ...base,
+        name: `${alertName ?? 'Alert'}: Webhook ${notification.webhookUrl}`,
+        template_id: 'template-webhook',
+        inputs: {
+            url: { value: notification.webhookUrl },
+            body: {
+                value: {
+                    alert_name: '{event.properties.alert_name}',
+                    threshold_count: '{event.properties.threshold_count}',
+                    window_minutes: '{event.properties.window_minutes}',
+                    logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
+                },
+            },
+        },
+    }
+}


### PR DESCRIPTION
## Problem

Users need to be notified when log alert thresholds are breached - without notification destinations, alert rules are silent. This PR adds inline notification configuration (Slack + Webhook) to the log alert modal form, so users can set up "alert me when X happens via Y" in a single flow.

## Changes  
![image.png](https://app.graphite.com/user-attachments/assets/e720b568-dded-48a8-af53-1bd0339f9580.png)

- **Type registration:** Added `'logs-alerting'` to `HogFunctionConfigurationContextId` and `'logs-alert-firing'` to `HogFunctionSubTemplateIdType` in `types.ts`
- **Sub-templates:** Registered `logs-alert-firing` in `sub-templates.ts` with Slack and Webhook variants (pre-filled message templates, feature-flagged behind `LOGS_ALERTING`)
- **Filter options:** Added `'logs-alerting'` case in `HogFunctionFiltersInternal.tsx` for the trigger event dropdown
- **Constants:** Added `LOGS_ALERT_FIRING_SUB_TEMPLATE_ID` and `LOGS_ALERT_FIRING_EVENT_ID` to `lib/constants.tsx`
- **`logsAlertUtils.ts`:** Helper functions for building HogFunction payloads (Slack/Webhook) and filter configs, following `alertUtils.ts` pattern
- **`logsAlertNotificationLogic.ts`:** Kea logic for managing pending/existing notification destinations — accumulates pending notifications in form state, creates HogFunctions on save via `Promise.allSettled`
- **`LogsAlertNotifications.tsx`:** Inline notification UI — existing destinations with edit/delete, pending destinations with remove, add-new panel with Slack channel picker or webhook URL input
- **Updated** **`LogsAlertForm`:** Added collapsible "Notifications" section rendering `LogsAlertNotifications`
- **Updated** **`logsAlertFormLogic`:** Two-step save — create/update alert, then create pending HogFunctions
- **Updated** **`LogsAlertingSection`:** `BindLogic` for notification logic at modal root, `alertFormChanged` (kea-forms convention) for Save button disabled state

## How did you test this code?

- **`logsAlertUtils.test.ts`** — unit tests for `buildLogsAlertFilterConfig` and `buildLogsAlertHogFunctionPayload` (Slack + Webhook variants)
- **`logsAlertNotificationLogic.test.ts`** — logic tests for pending notification CRUD, `createPendingHogFunctions` success/partial-failure, and `deleteExistingHogFunction`

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

## Docs update

skip-inkeep-docs