### PR TITLE
feat(llma): add Traceloop/OpenLLMetry OTel compatibility

### DIFF
--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -71,6 +71,61 @@ describe('mapOtelAttributes', () => {
     })
 
     it.each([
+        ['chat', '$ai_generation'],
+        ['completion', '$ai_generation'],
+        ['embedding', '$ai_embedding'],
+        ['embeddings', '$ai_embedding'],
+    ])('reclassifies $ai_span to %s when llm.request.type is "%s"', (requestType, expectedEvent) => {
+        const event = createEvent('$ai_span', { 'llm.request.type': requestType })
+        mapOtelAttributes(event)
+        expect(event.event).toBe(expectedEvent)
+    })
+
+    it.each(['unknown', 'rerank', ''])('keeps $ai_span when llm.request.type is "%s"', (requestType) => {
+        const event = createEvent('$ai_span', { 'llm.request.type': requestType, $ai_parent_id: 'parent-1' })
+        mapOtelAttributes(event)
+        expect(event.event).toBe('$ai_span')
+    })
+
+    it('does not reclassify already-classified events', () => {
+        const event = createEvent('$ai_generation', { 'llm.request.type': 'embedding' })
+        mapOtelAttributes(event)
+        expect(event.event).toBe('$ai_generation')
+    })
+
+    it('does not promote reclassified root $ai_generation to $ai_trace', () => {
+        const event = createEvent('$ai_span', { 'llm.request.type': 'chat' })
+        mapOtelAttributes(event)
+        expect(event.event).toBe('$ai_generation')
+    })
+
+    it('strips llm.request.type after processing', () => {
+        const event = createEvent('$ai_span', { 'llm.request.type': 'chat' })
+        mapOtelAttributes(event)
+        expect(event.properties!['llm.request.type']).toBeUndefined()
+    })
+
+    it.each([
+        ['gen_ai.usage.prompt_tokens', '$ai_input_tokens', 150],
+        ['gen_ai.usage.completion_tokens', '$ai_output_tokens', 50],
+    ])('uses deprecated %s as fallback for %s', (otelKey, phKey, value) => {
+        const event = createEvent('$ai_generation', { [otelKey]: value })
+        mapOtelAttributes(event)
+        expect(event.properties![phKey]).toBe(value)
+        expect(event.properties![otelKey]).toBeUndefined()
+    })
+
+    it.each([
+        ['gen_ai.usage.prompt_tokens', '$ai_input_tokens', 'gen_ai.usage.input_tokens'],
+        ['gen_ai.usage.completion_tokens', '$ai_output_tokens', 'gen_ai.usage.output_tokens'],
+    ])('does not override %s when primary %s mapping exists', (fallbackKey, phKey, primaryKey) => {
+        const event = createEvent('$ai_generation', { [primaryKey]: 100, [fallbackKey]: 200 })
+        mapOtelAttributes(event)
+        expect(event.properties![phKey]).toBe(100)
+        expect(event.properties![fallbackKey]).toBeUndefined()
+    })
+
+    it.each([
         ['gen_ai.system', '$ai_provider', 'openai'],
         ['gen_ai.request.model', '$ai_model', 'gpt-4'],
     ])('uses %s as fallback for %s', (otelKey, phKey, value) => {

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
@@ -18,6 +18,8 @@ const ATTRIBUTE_MAP: Record<string, string> = {
 const FALLBACK_ATTRIBUTE_MAP: Record<string, string> = {
     'gen_ai.system': '$ai_provider',
     'gen_ai.request.model': '$ai_model',
+    'gen_ai.usage.prompt_tokens': '$ai_input_tokens',
+    'gen_ai.usage.completion_tokens': '$ai_output_tokens',
 }
 
 const STRIP_ATTRIBUTES = new Set([
@@ -26,14 +28,34 @@ const STRIP_ATTRIBUTES = new Set([
     'posthog.ai.debug',
     'user.id',
     'posthog.distinct_id',
+    'llm.request.type',
 ])
 
 const JSON_PARSE_PROPERTIES = new Set(['$ai_input', '$ai_output_choices'])
+
+const REQUEST_TYPE_TO_EVENT: Record<string, string> = {
+    chat: '$ai_generation',
+    completion: '$ai_generation',
+    embedding: '$ai_embedding',
+    embeddings: '$ai_embedding',
+}
+
+function reclassifyByRequestType(event: PluginEvent): void {
+    if (event.event !== '$ai_span') {
+        return
+    }
+    const requestType = event.properties!['llm.request.type']
+    if (typeof requestType === 'string' && requestType in REQUEST_TYPE_TO_EVENT) {
+        event.event = REQUEST_TYPE_TO_EVENT[requestType]
+    }
+}
 
 export function mapOtelAttributes(event: PluginEvent): void {
     if (!event.properties) {
         return
     }
+
+    reclassifyByRequestType(event)
 
     for (const [otelKey, phKey] of Object.entries(ATTRIBUTE_MAP)) {
         if (event.properties[otelKey] !== undefined) {

--- a/nodejs/src/ingestion/ai/otel/index.test.ts
+++ b/nodejs/src/ingestion/ai/otel/index.test.ts
@@ -73,6 +73,35 @@ describe('convertOtelEvent', () => {
         })
     })
 
+    describe('traceloop detection', () => {
+        it.each([
+            ['llm.request.type', { 'llm.request.type': 'chat' }],
+            ['traceloop.span.kind', { 'traceloop.span.kind': 'workflow' }],
+            ['traceloop.entity.name', { 'traceloop.entity.name': 'openai.chat' }],
+        ])('detects traceloop library from %s attribute', (_label, properties) => {
+            const event = createEvent('$ai_span', properties)
+            convertOtelEvent(event)
+            expect(mockedMapOtelAttributes).toHaveBeenCalledWith(event)
+            expect(mockedMiddlewareCounter.labels).toHaveBeenCalledWith({ library: 'traceloop' })
+        })
+
+        it('pydantic-ai markers take priority over traceloop markers', () => {
+            const event = createEvent('$ai_span', {
+                'logfire.msg': 'agent run',
+                'llm.request.type': 'chat',
+                'traceloop.span.kind': 'workflow',
+            })
+            convertOtelEvent(event)
+            expect(event.properties!['$ai_lib']).toBe('opentelemetry/pydantic-ai')
+        })
+
+        it('does not detect traceloop when no marker keys present', () => {
+            const event = createEvent('$ai_generation', { 'gen_ai.system': 'openai' })
+            convertOtelEvent(event)
+            expect(mockedMiddlewareCounter.labels).toHaveBeenCalledWith({ library: 'none' })
+        })
+    })
+
     describe('metrics', () => {
         it('increments middleware counter with library name when matched', () => {
             const event = createEvent('$ai_generation', { 'logfire.msg': 'test' })

--- a/nodejs/src/ingestion/ai/otel/index.ts
+++ b/nodejs/src/ingestion/ai/otel/index.ts
@@ -3,11 +3,12 @@ import { PluginEvent } from '~/plugin-scaffold'
 import { aiOtelEventTypeCounter, aiOtelMiddlewareCounter } from '../metrics'
 import { mapOtelAttributes } from './attribute-mapping'
 import { pydanticAi } from './middleware/pydantic-ai'
+import { traceloop } from './middleware/traceloop'
 import { OtelLibraryMiddleware } from './middleware/types'
 import { vercelAi } from './middleware/vercel-ai'
 
 // Middleware registry — checked in order, first match wins.
-const MIDDLEWARES: OtelLibraryMiddleware[] = [pydanticAi, vercelAi]
+const MIDDLEWARES: OtelLibraryMiddleware[] = [pydanticAi, traceloop, vercelAi]
 
 export function convertOtelEvent(event: PluginEvent): void {
     const middleware = MIDDLEWARES.find((mw) => mw.matches(event))

--- a/nodejs/src/ingestion/ai/otel/middleware/traceloop.test.ts
+++ b/nodejs/src/ingestion/ai/otel/middleware/traceloop.test.ts
@@ -1,0 +1,202 @@
+import { mapOtelAttributes } from '../attribute-mapping'
+import { createEvent } from '../test-helpers'
+import { reassembleIndexedAttributes, traceloop } from './traceloop'
+
+jest.mock('../attribute-mapping', () => ({
+    mapOtelAttributes: jest.fn(),
+}))
+
+const mockedMapOtelAttributes = jest.mocked(mapOtelAttributes)
+
+describe('traceloop middleware', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('matches', () => {
+        it.each([
+            ['llm.request.type', { 'llm.request.type': 'chat' }],
+            ['traceloop.span.kind', { 'traceloop.span.kind': 'workflow' }],
+            ['traceloop.entity.name', { 'traceloop.entity.name': 'openai.chat' }],
+        ])('detects traceloop from %s', (_label, properties) => {
+            const event = createEvent('$ai_span', properties)
+            expect(traceloop.matches(event)).toBe(true)
+        })
+
+        it.each([
+            ['no markers', {}],
+            ['only gen_ai.system', { 'gen_ai.system': 'openai' }],
+        ])('does not match when %s', (_label, properties) => {
+            const event = createEvent('$ai_generation', properties)
+            expect(traceloop.matches(event)).toBe(false)
+        })
+    })
+
+    describe('reassembleIndexedAttributes', () => {
+        it('reassembles gen_ai.prompt.* into structured messages', () => {
+            const props: Record<string, unknown> = {
+                'gen_ai.prompt.0.role': 'system',
+                'gen_ai.prompt.0.content': 'You are helpful',
+                'gen_ai.prompt.1.role': 'user',
+                'gen_ai.prompt.1.content': 'Hello',
+            }
+            const result = reassembleIndexedAttributes(
+                props,
+                'gen_ai.prompt.',
+                ['role', 'content', 'tool_call_id'],
+                ['tool_calls']
+            )
+
+            expect(result).toEqual([
+                { role: 'system', content: 'You are helpful' },
+                { role: 'user', content: 'Hello' },
+            ])
+            expect(props['gen_ai.prompt.0.role']).toBeUndefined()
+        })
+
+        it('handles nested groups like tool_calls', () => {
+            const props: Record<string, unknown> = {
+                'gen_ai.prompt.0.role': 'assistant',
+                'gen_ai.prompt.0.content': '',
+                'gen_ai.prompt.0.tool_calls.0.name': 'get_weather',
+                'gen_ai.prompt.0.tool_calls.0.arguments': '{"city":"NYC"}',
+                'gen_ai.prompt.0.tool_calls.1.name': 'get_time',
+                'gen_ai.prompt.0.tool_calls.1.arguments': '{"tz":"EST"}',
+                'gen_ai.prompt.1.role': 'tool',
+                'gen_ai.prompt.1.content': 'Sunny, 72F',
+                'gen_ai.prompt.1.tool_call_id': 'call-123',
+            }
+            const result = reassembleIndexedAttributes(
+                props,
+                'gen_ai.prompt.',
+                ['role', 'content', 'tool_call_id'],
+                ['tool_calls']
+            )
+
+            expect(result).toEqual([
+                {
+                    role: 'assistant',
+                    content: '',
+                    tool_calls: [
+                        { name: 'get_weather', arguments: '{"city":"NYC"}' },
+                        { name: 'get_time', arguments: '{"tz":"EST"}' },
+                    ],
+                },
+                { role: 'tool', content: 'Sunny, 72F', tool_call_id: 'call-123' },
+            ])
+        })
+
+        it('handles non-contiguous indices', () => {
+            const props: Record<string, unknown> = {
+                'gen_ai.prompt.0.role': 'user',
+                'gen_ai.prompt.0.content': 'First',
+                'gen_ai.prompt.5.role': 'assistant',
+                'gen_ai.prompt.5.content': 'Second',
+            }
+            const result = reassembleIndexedAttributes(props, 'gen_ai.prompt.', ['role', 'content'], [])
+
+            expect(result).toEqual([
+                { role: 'user', content: 'First' },
+                { role: 'assistant', content: 'Second' },
+            ])
+        })
+
+        it('returns undefined when no matching prefix keys exist', () => {
+            const props: Record<string, unknown> = { 'some.other.key': 'value' }
+            const result = reassembleIndexedAttributes(props, 'gen_ai.prompt.', ['role', 'content'], [])
+            expect(result).toBeUndefined()
+        })
+    })
+
+    describe('process', () => {
+        it('reassembles prompts into $ai_input', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.request.type': 'chat',
+                'gen_ai.prompt.0.role': 'user',
+                'gen_ai.prompt.0.content': 'Hello',
+            })
+            traceloop.process(event, () => mapOtelAttributes(event))
+
+            expect(event.properties!['$ai_input']).toEqual([{ role: 'user', content: 'Hello' }])
+        })
+
+        it('reassembles completions into $ai_output_choices', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.request.type': 'chat',
+                'gen_ai.completion.0.role': 'assistant',
+                'gen_ai.completion.0.content': 'Hi there!',
+            })
+            traceloop.process(event, () => mapOtelAttributes(event))
+
+            expect(event.properties!['$ai_output_choices']).toEqual([{ role: 'assistant', content: 'Hi there!' }])
+        })
+
+        it('reassembles functions into $ai_tools', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.request.type': 'chat',
+                'llm.request.functions.0.name': 'get_weather',
+                'llm.request.functions.0.description': 'Get weather for a city',
+                'llm.request.functions.0.parameters': '{"type":"object"}',
+            })
+            traceloop.process(event, () => mapOtelAttributes(event))
+
+            expect(event.properties!['$ai_tools']).toEqual([
+                { name: 'get_weather', description: 'Get weather for a city', parameters: '{"type":"object"}' },
+            ])
+        })
+
+        it('does not override $ai_input when already set by generic mapping', () => {
+            mockedMapOtelAttributes.mockImplementation((e) => {
+                if (e.properties) {
+                    e.properties['$ai_input'] = [{ role: 'user', content: 'from generic' }]
+                }
+            })
+            const event = createEvent('$ai_generation', {
+                'llm.request.type': 'chat',
+                'gen_ai.prompt.0.role': 'user',
+                'gen_ai.prompt.0.content': 'from traceloop',
+            })
+            traceloop.process(event, () => mapOtelAttributes(event))
+
+            expect(event.properties!['$ai_input']).toEqual([{ role: 'user', content: 'from generic' }])
+        })
+
+        it('sets $ai_lib to opentelemetry/traceloop', () => {
+            const event = createEvent('$ai_generation', { 'llm.request.type': 'chat' })
+            traceloop.process(event, () => mapOtelAttributes(event))
+            expect(event.properties!['$ai_lib']).toBe('opentelemetry/traceloop')
+        })
+
+        it('strips traceloop-specific keys', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.request.type': 'chat',
+                'traceloop.span.kind': 'workflow',
+                'traceloop.entity.name': 'openai.chat',
+                'traceloop.entity.path': 'app.main',
+                'traceloop.workflow.name': 'my_workflow',
+                'traceloop.entity.input': '{}',
+                'traceloop.entity.output': '{}',
+                'traceloop.association.properties.user_id': '123',
+                'traceloop.association.properties.session_id': 'abc',
+                'llm.is_streaming': false,
+                'llm.usage.total_tokens': 200,
+                'llm.response.finish_reason': 'stop',
+                'llm.response.stop_reason': 'end_turn',
+            })
+            traceloop.process(event, () => mapOtelAttributes(event))
+
+            expect(event.properties!['traceloop.span.kind']).toBeUndefined()
+            expect(event.properties!['traceloop.entity.name']).toBeUndefined()
+            expect(event.properties!['traceloop.entity.path']).toBeUndefined()
+            expect(event.properties!['traceloop.workflow.name']).toBeUndefined()
+            expect(event.properties!['traceloop.entity.input']).toBeUndefined()
+            expect(event.properties!['traceloop.entity.output']).toBeUndefined()
+            expect(event.properties!['traceloop.association.properties.user_id']).toBeUndefined()
+            expect(event.properties!['traceloop.association.properties.session_id']).toBeUndefined()
+            expect(event.properties!['llm.is_streaming']).toBeUndefined()
+            expect(event.properties!['llm.usage.total_tokens']).toBeUndefined()
+            expect(event.properties!['llm.response.finish_reason']).toBeUndefined()
+            expect(event.properties!['llm.response.stop_reason']).toBeUndefined()
+        })
+    })
+})

--- a/nodejs/src/ingestion/ai/otel/middleware/traceloop.test.ts
+++ b/nodejs/src/ingestion/ai/otel/middleware/traceloop.test.ts
@@ -106,6 +106,13 @@ describe('traceloop middleware', () => {
             const result = reassembleIndexedAttributes(props, 'gen_ai.prompt.', ['role', 'content'], [])
             expect(result).toBeUndefined()
         })
+
+        it('returns undefined when keys match prefix but no fields are recognized', () => {
+            const props: Record<string, unknown> = { 'gen_ai.prompt.0.unknown_field': 'value' }
+            const result = reassembleIndexedAttributes(props, 'gen_ai.prompt.', ['role', 'content'], [])
+            expect(result).toBeUndefined()
+            expect(props['gen_ai.prompt.0.unknown_field']).toBe('value')
+        })
     })
 
     describe('process', () => {

--- a/nodejs/src/ingestion/ai/otel/middleware/traceloop.ts
+++ b/nodejs/src/ingestion/ai/otel/middleware/traceloop.ts
@@ -105,13 +105,17 @@ export function reassembleIndexedAttributes(
     }
 
     const sorted = Array.from(entries.values()).sort((a, b) => a.index - b.index)
-    return sorted.map((entry) => {
-        const obj: Record<string, unknown> = { ...entry.fields }
-        for (const [group, nestedEntries] of Object.entries(entry.nested)) {
-            obj[group] = nestedEntries.sort((a, b) => a.index - b.index).map((e) => e.fields)
-        }
-        return obj
-    })
+    const result = sorted
+        .map((entry) => {
+            const obj: Record<string, unknown> = { ...entry.fields }
+            for (const [group, nestedEntries] of Object.entries(entry.nested)) {
+                obj[group] = nestedEntries.sort((a, b) => a.index - b.index).map((e) => e.fields)
+            }
+            return obj
+        })
+        .filter((obj) => Object.keys(obj).length > 0)
+
+    return result.length > 0 ? result : undefined
 }
 
 function process(event: PluginEvent, next: () => void): void {

--- a/nodejs/src/ingestion/ai/otel/middleware/traceloop.ts
+++ b/nodejs/src/ingestion/ai/otel/middleware/traceloop.ts
@@ -1,0 +1,174 @@
+import { PluginEvent } from '~/plugin-scaffold'
+
+import { OtelLibraryMiddleware } from './types'
+
+const STRIP_KEYS = [
+    'traceloop.span.kind',
+    'traceloop.entity.name',
+    'traceloop.entity.path',
+    'traceloop.workflow.name',
+    'traceloop.entity.input',
+    'traceloop.entity.output',
+    'llm.is_streaming',
+    'llm.usage.total_tokens',
+    'llm.response.finish_reason',
+    'llm.response.stop_reason',
+]
+
+interface IndexedEntry {
+    index: number
+    fields: Record<string, unknown>
+    nested: Record<string, IndexedEntry[]>
+}
+
+/**
+ * Reassembles OTel flattened indexed attributes back into structured arrays.
+ *
+ * Traceloop/OpenLLMetry emits messages as `gen_ai.prompt.0.role`, `gen_ai.prompt.0.content`,
+ * `gen_ai.prompt.0.tool_calls.0.name`, etc. This function collects them by index and
+ * rebuilds the structured form: `[{ role, content, tool_calls: [{ name, arguments }] }]`.
+ */
+export function reassembleIndexedAttributes(
+    props: Record<string, unknown>,
+    prefix: string,
+    topFields: string[],
+    nestedGroups: string[]
+): Record<string, unknown>[] | undefined {
+    const entries = new Map<number, IndexedEntry>()
+    const consumedKeys: string[] = []
+    const topFieldSet = new Set(topFields)
+
+    for (const key of Object.keys(props)) {
+        if (!key.startsWith(prefix)) {
+            continue
+        }
+
+        const rest = key.slice(prefix.length)
+        const firstDot = rest.indexOf('.')
+        if (firstDot === -1) {
+            continue
+        }
+
+        const index = Number(rest.slice(0, firstDot))
+        if (!Number.isInteger(index) || index < 0) {
+            continue
+        }
+
+        const afterIndex = rest.slice(firstDot + 1)
+
+        if (!entries.has(index)) {
+            entries.set(index, { index, fields: {}, nested: {} })
+        }
+        const entry = entries.get(index)!
+
+        let matched = false
+        for (const group of nestedGroups) {
+            const nestedPrefix = group + '.'
+            if (afterIndex.startsWith(nestedPrefix)) {
+                const nestedRest = afterIndex.slice(nestedPrefix.length)
+                const nestedDot = nestedRest.indexOf('.')
+                if (nestedDot === -1) {
+                    continue
+                }
+                const nestedIndex = Number(nestedRest.slice(0, nestedDot))
+                if (!Number.isInteger(nestedIndex) || nestedIndex < 0) {
+                    continue
+                }
+                const nestedField = nestedRest.slice(nestedDot + 1)
+                if (!entry.nested[group]) {
+                    entry.nested[group] = []
+                }
+                let nestedEntry = entry.nested[group].find((e) => e.index === nestedIndex)
+                if (!nestedEntry) {
+                    nestedEntry = { index: nestedIndex, fields: {}, nested: {} }
+                    entry.nested[group].push(nestedEntry)
+                }
+                nestedEntry.fields[nestedField] = props[key]
+                consumedKeys.push(key)
+                matched = true
+                break
+            }
+        }
+
+        if (!matched && topFieldSet.has(afterIndex)) {
+            entry.fields[afterIndex] = props[key]
+            consumedKeys.push(key)
+        }
+    }
+
+    if (entries.size === 0) {
+        return undefined
+    }
+
+    for (const key of consumedKeys) {
+        delete props[key]
+    }
+
+    const sorted = Array.from(entries.values()).sort((a, b) => a.index - b.index)
+    return sorted.map((entry) => {
+        const obj: Record<string, unknown> = { ...entry.fields }
+        for (const [group, nestedEntries] of Object.entries(entry.nested)) {
+            obj[group] = nestedEntries.sort((a, b) => a.index - b.index).map((e) => e.fields)
+        }
+        return obj
+    })
+}
+
+function process(event: PluginEvent, next: () => void): void {
+    if (!event.properties) {
+        return next()
+    }
+    const props = event.properties
+
+    next()
+
+    if (props['$ai_input'] === undefined) {
+        const messages = reassembleIndexedAttributes(
+            props,
+            'gen_ai.prompt.',
+            ['role', 'content', 'tool_call_id'],
+            ['tool_calls']
+        )
+        if (messages) {
+            props['$ai_input'] = messages
+        }
+    }
+
+    if (props['$ai_output_choices'] === undefined) {
+        const completions = reassembleIndexedAttributes(props, 'gen_ai.completion.', ['role', 'content'], [])
+        if (completions) {
+            props['$ai_output_choices'] = completions
+        }
+    }
+
+    if (props['$ai_tools'] === undefined) {
+        const tools = reassembleIndexedAttributes(
+            props,
+            'llm.request.functions.',
+            ['name', 'description', 'parameters'],
+            []
+        )
+        if (tools) {
+            props['$ai_tools'] = tools
+        }
+    }
+
+    props['$ai_lib'] = 'opentelemetry/traceloop'
+
+    for (const key of STRIP_KEYS) {
+        delete props[key]
+    }
+    for (const key of Object.keys(props)) {
+        if (key.startsWith('traceloop.association.properties.')) {
+            delete props[key]
+        }
+    }
+}
+
+const MARKER_KEYS = ['llm.request.type', 'traceloop.span.kind', 'traceloop.entity.name']
+
+export const traceloop: OtelLibraryMiddleware = {
+    name: 'traceloop',
+    matches: (event) => MARKER_KEYS.some((key) => event.properties?.[key] !== undefined),
+    process,
+}

--- a/rust/capture/src/otel/event_name.rs
+++ b/rust/capture/src/otel/event_name.rs
@@ -15,6 +15,14 @@ fn classify_gen_ai_operation(op: &str) -> &'static str {
     }
 }
 
+fn classify_traceloop_request_type(request_type: &str) -> &'static str {
+    match request_type {
+        "chat" | "completion" => "$ai_generation",
+        "embedding" | "embeddings" => "$ai_embedding",
+        _ => "$ai_span",
+    }
+}
+
 fn classify_vercel_ai_operation(op_id: &str) -> &'static str {
     match op_id {
         s if s.ends_with(".doGenerate") || s.ends_with(".doStream") => "$ai_generation",
@@ -27,6 +35,10 @@ const EVENT_CLASSIFIERS: &[EventClassifier] = &[
     EventClassifier {
         attr_key: "gen_ai.operation.name",
         classify: classify_gen_ai_operation,
+    },
+    EventClassifier {
+        attr_key: "llm.request.type",
+        classify: classify_traceloop_request_type,
     },
     EventClassifier {
         attr_key: "ai.operationId",
@@ -87,6 +99,24 @@ mod tests {
                 get_event_name(&attrs_with("ai.operationId", op_id)),
                 expected,
                 "ai.operationId={op_id}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_traceloop_request_type() {
+        for (request_type, expected) in [
+            ("chat", "$ai_generation"),
+            ("completion", "$ai_generation"),
+            ("embedding", "$ai_embedding"),
+            ("embeddings", "$ai_embedding"),
+            ("rerank", "$ai_span"),
+            ("unknown", "$ai_span"),
+        ] {
+            assert_eq!(
+                get_event_name(&attrs_with("llm.request.type", request_type)),
+                expected,
+                "llm.request.type={request_type}"
             );
         }
     }


### PR DESCRIPTION
## Problem

Users instrumenting LLM applications with Traceloop/OpenLLMetry (which covers LangChain, OpenAI, Anthropic, Cohere, Bedrock, VertexAI and ~20 more libraries) send OTel spans using pre-spec `llm.*` and `traceloop.*` namespaces instead of the official `gen_ai.*` conventions. These spans arrive but aren't properly classified or normalized — event types stay as `$ai_span`, messages remain flattened, and deprecated token attributes are dropped.

## Changes

- **Traceloop middleware** (`middleware/traceloop.ts`): Detects Traceloop spans via marker keys (`llm.request.type`, `traceloop.span.kind`, `traceloop.entity.name`), reassembles flattened `gen_ai.prompt.{i}.*` → `$ai_input`, `gen_ai.completion.{i}.*` → `$ai_output_choices`, `llm.request.functions.{i}.*` → `$ai_tools`, and strips Traceloop-specific noise keys.
- **Event reclassification** (`attribute-mapping.ts`): Maps `llm.request.type` (`chat`/`completion` → `$ai_generation`, `embedding`/`embeddings` → `$ai_embedding`) so Traceloop spans get correct event types.
- **Deprecated token fallbacks**: `gen_ai.usage.prompt_tokens` → `$ai_input_tokens` and `gen_ai.usage.completion_tokens` → `$ai_output_tokens` as fallbacks.
- **Rust classifier** (`event_name.rs`): Adds `llm.request.type` as event classifier at the capture layer.

## How did you test this code?

- 77 Node.js unit tests across attribute-mapping, traceloop middleware, and index integration
- 4 Rust unit tests for event name classification
- cargo fmt + clippy pass

## Publish to changelog?

no