### PR TITLE
fix: add error logging to agentic provisioning _error_response

### DIFF
--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -753,6 +753,7 @@ def deep_links(request: Request) -> Response:
 
 
 def _error_response(code: str, message: str, resource_id: str = "", status: int = 400) -> Response:
+    logger.warning("stripe_app.error_response", code=code, message=message, resource_id=resource_id, status=status)
     return Response({"status": "error", "id": resource_id, "error": {"code": code, "message": message}}, status=status)
 
 


### PR DESCRIPTION
## Problem

`_error_response` in agentic provisioning views has no logging. We're seeing 401s and 400s on `/api/agentic/provisioning/resources` in production with no application-level log to explain the cause - only Django's generic "Bad Request" message.

## Changes

One line - added `logger.warning` to `_error_response` so every error response logs the error code, message, resource ID, and status.

## How did you test this code

Production logs show 401s and 400s with no details. This will capture them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)