### PR TITLE
fix(subscriptions): use correct region property key in subscription insights

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/dashboard-key-metrics/insights.tf
@@ -654,7 +654,7 @@ resource "posthog_insight" "subscription_delivery_success_rate" {
           "custom_name": "Started",
           "properties": [
             {
-              "key": "$set.region",
+              "key": "region",
               "type": "event",
               "value": [each.key],
               "operator": "exact"
@@ -668,7 +668,7 @@ resource "posthog_insight" "subscription_delivery_success_rate" {
           "custom_name": "Exhausted (failed)",
           "properties": [
             {
-              "key": "$set.region",
+              "key": "region",
               "type": "event",
               "value": [each.key],
               "operator": "exact"

--- a/terraform/us/project-2/team-analytics-platform/slos/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slos/insights.tf
@@ -185,7 +185,7 @@ locals {
             countIf(event = 'subscription_delivery_exhausted') AS failures
         FROM events
         WHERE event IN ('subscription_delivery_started', 'subscription_delivery_exhausted')
-            AND properties.$set.region = '{{REGION}}'
+            AND properties.region = '{{REGION}}'
             AND timestamp >= now() - INTERVAL 30 DAY
         GROUP BY date
       SQL


### PR DESCRIPTION
## Problem

The subscription delivery insights merged in #51345 filter by `$set.region`, but the actual event property is `region` (a top-level super property, not nested under `$set`). This means both US and EU insights would show no data.

## Changes

- Fix property key from `$set.region` to `region` in the key metrics subscription delivery success rate insight
- Fix property path from `properties.$set.region` to `properties.region` in the SLO HogQL query

## How did you test this code?

Verified the actual event properties by querying `SELECT properties FROM events WHERE event = 'subscription_delivery_started' LIMIT 5` — confirmed `region` is a top-level property.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code. Follow-up fix to #51345.