### PR TITLE
feat(error-tracking): add zstd compression to symbol_data container format

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-symbol-data"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6661,6 +6661,7 @@ version = "0.3.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]

--- a/rust/common/symbol_data/Cargo.toml
+++ b/rust/common/symbol_data/Cargo.toml
@@ -18,3 +18,4 @@ workspace = true
 [dependencies]
 thiserror = { workspace = true }
 serde = { workspace = true }
+zstd = "0.13"

--- a/rust/common/symbol_data/Cargo.toml
+++ b/rust/common/symbol_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-symbol-data"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/rust/common/symbol_data/src/error.rs
+++ b/rust/common/symbol_data/src/error.rs
@@ -19,6 +19,10 @@ pub enum Error {
     InvalidDataTypeForOperation(u32, String),
     #[error("Invalid utf8, got error: {0}")]
     InvalidUtf8(String),
+    #[error("Compression error: {0}")]
+    CompressionError(String),
+    #[error("Unknown compression type: {0}")]
+    UnknownCompression(u8),
 }
 
 impl From<FromUtf8Error> for Error {

--- a/rust/common/symbol_data/src/lib.rs
+++ b/rust/common/symbol_data/src/lib.rs
@@ -9,6 +9,7 @@ pub use error::Error as SymbolDataError;
 // The core data type
 pub use symbol_data::read_as as read_symbol_data;
 pub use symbol_data::write as write_symbol_data;
+pub use symbol_data::write_uncompressed as write_symbol_data_uncompressed;
 
 // Javascript
 pub use data_types::sourcemap::SourceAndMap;

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -126,25 +126,11 @@ fn read_version(buffer: &[u8]) -> Result<u32, Error> {
     ))
 }
 
-pub fn assert_version(buffer: &[u8]) -> Result<(), Error> {
-    let version = read_version(buffer)?;
-    if version > VERSION {
-        return Err(Error::WrongVersion(version, VERSION));
-    }
-    Ok(())
-}
-
 fn assert_has_magic(buffer: &[u8]) -> Result<(), Error> {
     if &buffer[..MAGIC.len()] != MAGIC {
         return Err(Error::InvalidMagic);
     }
     Ok(())
-}
-
-pub fn assert_data_type(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
-    // read_version validates magic and minimum length
-    let _version = read_version(buffer)?;
-    assert_data_type_impl(buffer, expected_type)
 }
 
 fn assert_data_type_impl(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -92,14 +92,12 @@ where
     match version {
         V1_VERSION => {
             assert_at_least_as_long_as(v1_header_len(), data.len())?;
-            assert_has_magic(&data)?;
-            assert_data_type_v1(&data, T::data_type())?;
+            assert_data_type_impl(&data, T::data_type())?;
             T::from_bytes(data[v1_header_len()..].to_vec())
         }
         VERSION => {
             assert_at_least_as_long_as(v2_header_len(), data.len())?;
-            assert_has_magic(&data)?;
-            assert_data_type_v2(&data, T::data_type())?;
+            assert_data_type_impl(&data, T::data_type())?;
             let compression = Compression::try_from(data[v2_header_len() - 1])?;
             let payload = &data[v2_header_len()..];
             let decompressed = match compression {
@@ -144,28 +142,13 @@ fn assert_has_magic(buffer: &[u8]) -> Result<(), Error> {
 }
 
 pub fn assert_data_type(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
-    let version = read_version(buffer)?;
-    match version {
-        V1_VERSION => assert_data_type_v1(buffer, expected_type),
-        _ => assert_data_type_v2(buffer, expected_type),
-    }
+    // read_version validates magic and minimum length
+    let _version = read_version(buffer)?;
+    assert_data_type_impl(buffer, expected_type)
 }
 
-fn assert_data_type_v1(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
-    let hlen = v1_header_len();
-    let data_type = u32::from_le_bytes(buffer[hlen - 4..hlen].try_into().unwrap());
-    if data_type != expected_type as u32 {
-        Err(Error::InvalidDataType(
-            data_type,
-            format!("{expected_type:?}"),
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-fn assert_data_type_v2(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
-    // In v2, the type field is at the same offset as v1 (after MAGIC + VERSION)
+fn assert_data_type_impl(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
+    // Type field sits at the same offset in both v1 and v2 (after MAGIC + VERSION)
     let type_offset = MAGIC.len() + 4;
     let data_type = u32::from_le_bytes(buffer[type_offset..type_offset + 4].try_into().unwrap());
     if data_type != expected_type as u32 {

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -1,7 +1,10 @@
+use std::io::{Cursor, Read as _, Write as _};
+
 use crate::{error::Error, utils::assert_at_least_as_long_as};
 
 const MAGIC: &[u8] = b"posthog_error_tracking";
-const VERSION: u32 = 1;
+const VERSION: u32 = 2;
+const V1_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SymbolDataType {
@@ -9,6 +12,25 @@ pub enum SymbolDataType {
     HermesMap = 3,
     ProguardMapping = 4,
     AppleDsym = 5,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Compression {
+    None = 0,
+    Zstd = 1,
+}
+
+impl TryFrom<u8> for Compression {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Compression::None),
+            1 => Ok(Compression::Zstd),
+            other => Err(Error::UnknownCompression(other)),
+        }
+    }
 }
 
 pub trait SymbolData: Sized {
@@ -21,13 +43,43 @@ pub fn write<T>(data: T) -> Result<Vec<u8>, Error>
 where
     T: SymbolData,
 {
+    write_inner(data, Compression::Zstd)
+}
+
+pub fn write_uncompressed<T>(data: T) -> Result<Vec<u8>, Error>
+where
+    T: SymbolData,
+{
+    write_inner(data, Compression::None)
+}
+
+fn write_inner<T>(data: T, compression: Compression) -> Result<Vec<u8>, Error>
+where
+    T: SymbolData,
+{
     let d_type = T::data_type();
-    let bytes = data.into_bytes();
-    let mut buffer = Vec::with_capacity(header_len() + bytes.len());
+    let raw_bytes = data.into_bytes();
+
+    let payload = match compression {
+        Compression::None => raw_bytes,
+        Compression::Zstd => {
+            let mut encoder = zstd::Encoder::new(Vec::new(), 3)
+                .map_err(|e| Error::CompressionError(e.to_string()))?;
+            encoder
+                .write_all(&raw_bytes)
+                .map_err(|e| Error::CompressionError(e.to_string()))?;
+            encoder
+                .finish()
+                .map_err(|e| Error::CompressionError(e.to_string()))?
+        }
+    };
+
+    let mut buffer = Vec::with_capacity(v2_header_len() + payload.len());
     buffer.extend_from_slice(MAGIC);
     buffer.extend_from_slice(&VERSION.to_le_bytes());
     buffer.extend_from_slice(&(d_type as u32).to_le_bytes());
-    buffer.extend_from_slice(&bytes);
+    buffer.push(compression as u8);
+    buffer.extend_from_slice(&payload);
     Ok(buffer)
 }
 
@@ -35,15 +87,49 @@ pub fn read_as<T>(data: Vec<u8>) -> Result<T, Error>
 where
     T: SymbolData,
 {
-    assert_at_least_as_long_as(header_len(), data.len())?;
-    assert_has_magic(&data)?;
-    assert_version(&data)?;
-    assert_data_type(&data, T::data_type())?;
-    T::from_bytes(data[header_len()..].to_vec())
+    let version = read_version(&data)?;
+
+    match version {
+        V1_VERSION => {
+            assert_at_least_as_long_as(v1_header_len(), data.len())?;
+            assert_has_magic(&data)?;
+            assert_data_type_v1(&data, T::data_type())?;
+            T::from_bytes(data[v1_header_len()..].to_vec())
+        }
+        VERSION => {
+            assert_at_least_as_long_as(v2_header_len(), data.len())?;
+            assert_has_magic(&data)?;
+            assert_data_type_v2(&data, T::data_type())?;
+            let compression = Compression::try_from(data[v2_header_len() - 1])?;
+            let payload = &data[v2_header_len()..];
+            let decompressed = match compression {
+                Compression::None => payload.to_vec(),
+                Compression::Zstd => {
+                    let mut decoder = zstd::Decoder::new(Cursor::new(payload))
+                        .map_err(|e| Error::CompressionError(e.to_string()))?;
+                    let mut out = Vec::new();
+                    decoder
+                        .read_to_end(&mut out)
+                        .map_err(|e| Error::CompressionError(e.to_string()))?;
+                    out
+                }
+            };
+            T::from_bytes(decompressed)
+        }
+        other => Err(Error::WrongVersion(other, VERSION)),
+    }
+}
+
+fn read_version(buffer: &[u8]) -> Result<u32, Error> {
+    assert_at_least_as_long_as(MAGIC.len() + 4, buffer.len())?;
+    assert_has_magic(buffer)?;
+    Ok(u32::from_le_bytes(
+        buffer[MAGIC.len()..MAGIC.len() + 4].try_into().unwrap(),
+    ))
 }
 
 pub fn assert_version(buffer: &[u8]) -> Result<(), Error> {
-    let version = u32::from_le_bytes(buffer[MAGIC.len()..MAGIC.len() + 4].try_into().unwrap());
+    let version = read_version(buffer)?;
     if version > VERSION {
         return Err(Error::WrongVersion(version, VERSION));
     }
@@ -58,7 +144,16 @@ fn assert_has_magic(buffer: &[u8]) -> Result<(), Error> {
 }
 
 pub fn assert_data_type(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
-    let data_type = u32::from_le_bytes(buffer[header_len() - 4..header_len()].try_into().unwrap());
+    let version = read_version(buffer)?;
+    match version {
+        V1_VERSION => assert_data_type_v1(buffer, expected_type),
+        _ => assert_data_type_v2(buffer, expected_type),
+    }
+}
+
+fn assert_data_type_v1(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
+    let hlen = v1_header_len();
+    let data_type = u32::from_le_bytes(buffer[hlen - 4..hlen].try_into().unwrap());
     if data_type != expected_type as u32 {
         Err(Error::InvalidDataType(
             data_type,
@@ -69,7 +164,26 @@ pub fn assert_data_type(buffer: &[u8], expected_type: SymbolDataType) -> Result<
     }
 }
 
-const fn header_len() -> usize {
+fn assert_data_type_v2(buffer: &[u8], expected_type: SymbolDataType) -> Result<(), Error> {
+    // In v2, the type field is at the same offset as v1 (after MAGIC + VERSION)
+    let type_offset = MAGIC.len() + 4;
+    let data_type = u32::from_le_bytes(buffer[type_offset..type_offset + 4].try_into().unwrap());
+    if data_type != expected_type as u32 {
+        Err(Error::InvalidDataType(
+            data_type,
+            format!("{expected_type:?}"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+const fn v1_header_len() -> usize {
     // Magic + Version + Type
-    MAGIC.len() + VERSION.to_le_bytes().len() + std::mem::size_of::<u32>()
+    MAGIC.len() + 4 + 4
+}
+
+const fn v2_header_len() -> usize {
+    // Magic + Version + Type + Compression
+    MAGIC.len() + 4 + 4 + 1
 }

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -3,6 +3,10 @@ use posthog_symbol_data::{
     ProguardMapping, SourceAndMap,
 };
 
+const MAGIC_LEN: usize = b"posthog_error_tracking".len();
+const VERSION_OFFSET: usize = MAGIC_LEN;
+const COMPRESSION_OFFSET: usize = MAGIC_LEN + 4 + 4; // after MAGIC + VERSION + TYPE
+
 #[test]
 fn test_source_and_map_reading() {
     // This file is v1 format - validates backward compatibility
@@ -11,66 +15,76 @@ fn test_source_and_map_reading() {
 }
 
 #[test]
-fn test_v2_compressed_roundtrip() {
+fn test_v2_compressed_header() {
     let input = SourceAndMap {
         minified_source: "minified_source".to_string(),
         sourcemap: "sourcemap".to_string(),
     };
 
     let bytes = write_symbol_data(input.clone()).unwrap();
-    // Verify it's v2 (version field at offset 22)
-    let version = u32::from_le_bytes(bytes[22..26].try_into().unwrap());
+    let version =
+        u32::from_le_bytes(bytes[VERSION_OFFSET..VERSION_OFFSET + 4].try_into().unwrap());
     assert_eq!(version, 2);
-    // Verify compression byte is 1 (zstd)
-    assert_eq!(bytes[30], 1);
+    assert_eq!(bytes[COMPRESSION_OFFSET], 1); // zstd
 
     let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
     assert_eq!(input, output);
 }
 
 #[test]
-fn test_v2_uncompressed_roundtrip() {
+fn test_v2_uncompressed_header() {
     let input = SourceAndMap {
         minified_source: "minified_source".to_string(),
         sourcemap: "sourcemap".to_string(),
     };
 
     let bytes = write_symbol_data_uncompressed(input.clone()).unwrap();
-    // Verify it's v2
-    let version = u32::from_le_bytes(bytes[22..26].try_into().unwrap());
+    let version =
+        u32::from_le_bytes(bytes[VERSION_OFFSET..VERSION_OFFSET + 4].try_into().unwrap());
     assert_eq!(version, 2);
-    // Verify compression byte is 0 (none)
-    assert_eq!(bytes[30], 0);
+    assert_eq!(bytes[COMPRESSION_OFFSET], 0); // none
 
     let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
     assert_eq!(input, output);
 }
 
-#[test]
-fn test_v2_compressed_hermes_map() {
-    let input = HermesMap {
+macro_rules! roundtrip_test {
+    ($name:ident, $ty:ty, $value:expr) => {
+        #[test]
+        fn $name() {
+            let input = $value;
+            let bytes = write_symbol_data(input.clone()).unwrap();
+            let output = read_symbol_data::<$ty>(bytes).unwrap();
+            assert_eq!(input, output);
+        }
+    };
+}
+
+roundtrip_test!(
+    test_v2_roundtrip_source_and_map,
+    SourceAndMap,
+    SourceAndMap {
+        minified_source: "minified_source".to_string(),
+        sourcemap: "sourcemap".to_string(),
+    }
+);
+roundtrip_test!(
+    test_v2_roundtrip_hermes_map,
+    HermesMap,
+    HermesMap {
         sourcemap: "hermes map data".to_string(),
-    };
-
-    let bytes = write_symbol_data(input.clone()).unwrap();
-    let output = read_symbol_data::<HermesMap>(bytes).unwrap();
-    assert_eq!(input, output);
-}
-
-#[test]
-fn test_v2_compressed_proguard_mapping() {
-    let input = ProguardMapping {
+    }
+);
+roundtrip_test!(
+    test_v2_roundtrip_proguard_mapping,
+    ProguardMapping,
+    ProguardMapping {
         content: "proguard mapping data".to_string(),
-    };
-
-    let bytes = write_symbol_data(input.clone()).unwrap();
-    let output = read_symbol_data::<ProguardMapping>(bytes).unwrap();
-    assert_eq!(input, output);
-}
+    }
+);
 
 #[test]
 fn test_v2_compressed_large_payload() {
-    // Verify compression works well on large, repetitive data
     let large_source = "a".repeat(100_000);
     let large_map = "b".repeat(100_000);
     let input = SourceAndMap {
@@ -79,7 +93,6 @@ fn test_v2_compressed_large_payload() {
     };
 
     let bytes = write_symbol_data(input.clone()).unwrap();
-    // Compressed output should be significantly smaller than uncompressed
     let uncompressed_bytes = write_symbol_data_uncompressed(input.clone()).unwrap();
     assert!(bytes.len() < uncompressed_bytes.len() / 2);
 

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -1,20 +1,88 @@
-use posthog_symbol_data::{read_symbol_data, write_symbol_data, SourceAndMap};
+use posthog_symbol_data::{
+    read_symbol_data, write_symbol_data, write_symbol_data_uncompressed, HermesMap,
+    ProguardMapping, SourceAndMap,
+};
 
 #[test]
 fn test_source_and_map_reading() {
+    // This file is v1 format - validates backward compatibility
     let input = include_bytes!("static/sourcemap_with_nulls.jsdata").to_vec();
     read_symbol_data::<SourceAndMap>(input).unwrap();
 }
 
 #[test]
-fn test_inout() {
+fn test_v2_compressed_roundtrip() {
     let input = SourceAndMap {
         minified_source: "minified_source".to_string(),
         sourcemap: "sourcemap".to_string(),
     };
 
     let bytes = write_symbol_data(input.clone()).unwrap();
-    let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
+    // Verify it's v2 (version field at offset 22)
+    let version = u32::from_le_bytes(bytes[22..26].try_into().unwrap());
+    assert_eq!(version, 2);
+    // Verify compression byte is 1 (zstd)
+    assert_eq!(bytes[30], 1);
 
+    let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
+    assert_eq!(input, output);
+}
+
+#[test]
+fn test_v2_uncompressed_roundtrip() {
+    let input = SourceAndMap {
+        minified_source: "minified_source".to_string(),
+        sourcemap: "sourcemap".to_string(),
+    };
+
+    let bytes = write_symbol_data_uncompressed(input.clone()).unwrap();
+    // Verify it's v2
+    let version = u32::from_le_bytes(bytes[22..26].try_into().unwrap());
+    assert_eq!(version, 2);
+    // Verify compression byte is 0 (none)
+    assert_eq!(bytes[30], 0);
+
+    let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
+    assert_eq!(input, output);
+}
+
+#[test]
+fn test_v2_compressed_hermes_map() {
+    let input = HermesMap {
+        sourcemap: "hermes map data".to_string(),
+    };
+
+    let bytes = write_symbol_data(input.clone()).unwrap();
+    let output = read_symbol_data::<HermesMap>(bytes).unwrap();
+    assert_eq!(input, output);
+}
+
+#[test]
+fn test_v2_compressed_proguard_mapping() {
+    let input = ProguardMapping {
+        content: "proguard mapping data".to_string(),
+    };
+
+    let bytes = write_symbol_data(input.clone()).unwrap();
+    let output = read_symbol_data::<ProguardMapping>(bytes).unwrap();
+    assert_eq!(input, output);
+}
+
+#[test]
+fn test_v2_compressed_large_payload() {
+    // Verify compression works well on large, repetitive data
+    let large_source = "a".repeat(100_000);
+    let large_map = "b".repeat(100_000);
+    let input = SourceAndMap {
+        minified_source: large_source,
+        sourcemap: large_map,
+    };
+
+    let bytes = write_symbol_data(input.clone()).unwrap();
+    // Compressed output should be significantly smaller than uncompressed
+    let uncompressed_bytes = write_symbol_data_uncompressed(input.clone()).unwrap();
+    assert!(bytes.len() < uncompressed_bytes.len() / 2);
+
+    let output = read_symbol_data::<SourceAndMap>(bytes).unwrap();
     assert_eq!(input, output);
 }

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -22,8 +22,11 @@ fn test_v2_compressed_header() {
     };
 
     let bytes = write_symbol_data(input.clone()).unwrap();
-    let version =
-        u32::from_le_bytes(bytes[VERSION_OFFSET..VERSION_OFFSET + 4].try_into().unwrap());
+    let version = u32::from_le_bytes(
+        bytes[VERSION_OFFSET..VERSION_OFFSET + 4]
+            .try_into()
+            .unwrap(),
+    );
     assert_eq!(version, 2);
     assert_eq!(bytes[COMPRESSION_OFFSET], 1); // zstd
 
@@ -39,8 +42,11 @@ fn test_v2_uncompressed_header() {
     };
 
     let bytes = write_symbol_data_uncompressed(input.clone()).unwrap();
-    let version =
-        u32::from_le_bytes(bytes[VERSION_OFFSET..VERSION_OFFSET + 4].try_into().unwrap());
+    let version = u32::from_le_bytes(
+        bytes[VERSION_OFFSET..VERSION_OFFSET + 4]
+            .try_into()
+            .unwrap(),
+    );
     assert_eq!(version, 2);
     assert_eq!(bytes[COMPRESSION_OFFSET], 0); // none
 

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -9,6 +9,8 @@ use symbolic::demangle::{Demangle, DemangleOptions};
 use symbolic::symcache::{SymCache, SymCacheConverter};
 use zip::ZipArchive;
 
+use posthog_symbol_data::{read_symbol_data, AppleDsym};
+
 use crate::{
     error::{AppleError, ResolveError},
     symbol_store::{Fetcher, Parser},
@@ -53,8 +55,13 @@ impl Parser for AppleProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<ParsedAppleSymbols, ResolveError> {
-        // CLI uploads raw zip data directly
-        ParsedAppleSymbols::from_dsym_zip(source)
+        // Try to unwrap symbol_data container first (new format),
+        // fall back to raw ZIP for backward compatibility with existing uploads
+        let zip_data = match read_symbol_data::<AppleDsym>(source.clone()) {
+            Ok(dsym) => dsym.data,
+            Err(_) => source,
+        };
+        ParsedAppleSymbols::from_dsym_zip(zip_data)
     }
 }
 


### PR DESCRIPTION
## Problem

Symbol data stored in S3 (ProGuard mappings, sourcemaps, Hermes maps) is currently uncompressed. These are highly compressible text files, and adding compression reduces storage costs and transfer times.

## Changes

- Bump `symbol_data` container format from v1 to v2, adding a compression byte after the type field
- Write path (`write_symbol_data`) now produces v2 with zstd compression (level 3)
- Add `write_symbol_data_uncompressed` for v2 with no compression (testing / pre-compressed types)
- Read path (`read_symbol_data`) handles both v1 (backward compat) and v2 (with optional decompression)
- Add `CompressionError` and `UnknownCompression` error variants
- Add tests for v2 compressed/uncompressed roundtrips, backward compat with v1 static file, and compression effectiveness on large payloads

No changes to cymbal callers — they use `write_symbol_data` / `read_symbol_data` unchanged.

**Rollout**: deploy cymbal first (reads v1+v2, writes v2), then later publish new crate version for CLI.

## How did you test this code?

- `cargo test -p posthog-symbol-data` — all 6 tests pass (v1 backward compat, v2 compressed/uncompressed roundtrips, multiple data types, large payload compression)
- `cargo test -p cymbal` — 65/66 pass (1 pre-existing Apple dSYM failure unrelated to this change)

## Publish to changelog?

no