### PR TITLE
fix(personhog): metrics need buckets

### DIFF
--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -120,8 +120,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }),
             )
             .route("/_liveness", get(move || async move { liveness.check() }));
+        const BUCKETS: &[f64] = &[
+            1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
+        ];
         let recorder_handle = PrometheusBuilder::new()
             .add_global_label("service", "personhog-replica")
+            .set_buckets(BUCKETS)
+            .unwrap()
             .install_recorder()
             .expect("Failed to install metrics recorder");
 

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -74,8 +74,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(async move {
         let _guard = metrics_handle.process_scope();
 
+        const BUCKETS: &[f64] = &[
+            1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0,
+        ];
         let recorder_handle = PrometheusBuilder::new()
             .add_global_label("service", "personhog-router")
+            .set_buckets(BUCKETS)
+            .unwrap()
             .install_recorder()
             .expect("Failed to install metrics recorder");
 


### PR DESCRIPTION
## Problem

All histogram metrics in personhog-router and personhog-replica record values in **milliseconds** (e.g. `personhog_replica_db_query_duration_ms`, `personhog_router_backend_duration_ms`, `personhog_replica_db_pool_acquire_duration_ms`), but the Prometheus exporter was using the default bucket boundaries which are designed for **seconds** (`[0.005, 0.01, 0.025, ... 5.0, 10.0]`).

This means nearly every observation falls into the `+Inf` bucket (a typical 50ms query records as `50.0`, far above the max default bucket of `10.0`), making `histogram_quantile()` queries in Grafana return `+Inf` for p50/p90/p99 — rendering the latency dashboards useless.


## Changes

Configure explicit histogram buckets on the `PrometheusBuilder` for both services:

```
[1, 5, 10, 50, 100, 250, 500, 1000, 2000, 5000, 10000] ms
```

This gives meaningful resolution across the range we care about:
- **1–10ms**: fast cache hits / simple queries
- **50–250ms**: typical DB queries
- **500–2000ms**: slow queries, connection pool contention
- **5000–10000ms**: timeout-level latency

Applied identically to `personhog-replica` and `personhog-router` so all histogram metrics (`db_query_duration_ms`, `db_pool_acquire_duration_ms`, `backend_duration_ms`, `db_rows_returned`) get useful bucket distributions.


## How did you test this code?

Metrics change, will verify after deploy.

Confirmed code builds with cargo build.
