### PR TITLE
fix(test): fixes a flakey dashboard text for adding text card

### DIFF
--- a/playwright/page-models/dashboardPage.ts
+++ b/playwright/page-models/dashboardPage.ts
@@ -76,15 +76,21 @@ export class DashboardPage {
     }
 
     async addTextCard(text: string): Promise<void> {
-        await this.page.getByTestId('add-text-tile-to-dashboard').click()
+        const addTextTileButton = this.page.getByTestId('add-text-tile-to-dashboard')
+        await expect(addTextTileButton).toBeVisible()
+        await addTextTileButton.click()
 
-        const modal = this.page.locator('.LemonModal')
+        await expect(this.page).toHaveURL(/\/dashboard\/\d+\/text-tiles\/new(?:\?.*)?$/, { timeout: 5000 })
+
+        const modal = this.page.locator('.LemonModal').filter({
+            has: this.page.getByTestId('text-card-edit-area'),
+        })
         await expect(modal).toBeVisible()
 
-        const textArea = modal.locator('textarea')
+        const textArea = modal.getByTestId('text-card-edit-area')
         await expect(textArea).toBeVisible()
         await textArea.fill(text)
-        await this.page.getByTestId('save-new-text-tile').click()
+        await modal.getByTestId('save-new-text-tile').click()
 
         await expect(this.textCards.filter({ hasText: text })).toBeVisible()
     }


### PR DESCRIPTION
## Problem

A flakey playwright test with `addTextCard` for dashboard
## Changes

Change how we're testing it to prevent flakiness.


## How did you test this code?

Ran the new changed test 10 times locally to ensure we're not flakey.

## Publish to changelog?
No.
