### PR TITLE
fix(mcp): update stale error-tracking snapshot blocking master

### DIFF
--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
@@ -4,7 +4,21 @@
         "assignee": {
             "properties": {
                 "id": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "type": {
                     "type": "string"


### PR DESCRIPTION
## Summary

- Regenerates the stale `error-tracking-issues-partial-update.json` MCP tool-schema snapshot that was blocking master CI
- The snapshot drifted when #51469 added `@extend_schema_field` annotations to `ErrorTrackingIssueAssignmentSerializer.get_id()`, changing `assignee.id` from `string` to `number | string | null`

## Test plan

- [x] `vitest --run tests/unit/tool-schema-snapshots.test.ts` passes