### PR TITLE
fix(endpoints): massive queries prevent saving columns to DB

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -568,7 +568,10 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 derived_from_insight=data.derived_from_insight,
             )
 
-            columns = EndpointVersion.extract_columns(query_dict, team_id=self.team.pk)
+            try:
+                columns: list[dict] | None = EndpointVersion.extract_columns(query_dict, team_id=self.team.pk)
+            except Exception:
+                columns = None
             EndpointVersion.objects.create(
                 endpoint=endpoint,
                 version=1,
@@ -1785,13 +1788,6 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
 
         # Check if we should use materialization for this version
         use_materialized = self._should_use_materialized_table(endpoint, data, version_obj)
-
-        logger.info(
-            "Endpoint run decision",
-            endpoint_name=endpoint.name,
-            use_materialized=use_materialized,
-            version=version_obj.version if version_obj else None,
-        )
 
         debug = data.debug or False
 

--- a/products/endpoints/backend/models.py
+++ b/products/endpoints/backend/models.py
@@ -156,12 +156,19 @@ class EndpointVersion(models.Model):
     def get_columns(self) -> list[dict]:
         """Return columns, lazily populating from ClickHouse if not yet computed."""
         if self.columns is None:
-            columns = EndpointVersion.extract_columns(self.query, self.endpoint.team_id)
-            # Refresh from DB to check if another request already populated it
+            columns: list[dict] = []
+            exc: Exception | None = None
+            try:
+                columns = EndpointVersion.extract_columns(self.query, self.endpoint.team_id)
+            except Exception as e:
+                exc = e
+            # Save before capture_exception (which can hang serializing large AST objects)
             self.refresh_from_db(fields=["columns"])
             if self.columns is None:
                 self.columns = columns
                 self.save(update_fields=["columns"])
+            if exc is not None:
+                capture_exception(exc)
         return self.columns
 
     def disable_materialization(self) -> None:
@@ -230,33 +237,29 @@ class EndpointVersion(models.Model):
         hogql_string = query.get("query", "")
         if not hogql_string:
             return []
-        try:
-            from posthog.hogql.query import HogQLQueryExecutor
+        from posthog.hogql.query import HogQLQueryExecutor
 
-            from posthog.clickhouse.client import sync_execute
+        from posthog.clickhouse.client import sync_execute
 
-            parsed = parse_select(hogql_string)
-            cleaned = _PLACEHOLDER_REPLACER.visit(parsed)
+        parsed = parse_select(hogql_string)
+        cleaned = _PLACEHOLDER_REPLACER.visit(parsed)
 
-            team = Team.objects.get(pk=team_id)
-            executor = HogQLQueryExecutor(query=cleaned, team=team, limit_context=None)
-            clickhouse_sql, clickhouse_context = executor.generate_clickhouse_sql()
+        team = Team.objects.get(pk=team_id)
+        executor = HogQLQueryExecutor(query=cleaned, team=team, limit_context=None)
+        clickhouse_sql, clickhouse_context = executor.generate_clickhouse_sql()
 
-            if not clickhouse_sql:
-                return []
-
-            # nosemgrep: clickhouse-fstring-param-audit (clickhouse_sql is compiler output from HogQLQueryExecutor, not user input)
-            rows = sync_execute(
-                f"DESCRIBE TABLE ({clickhouse_sql})",
-                clickhouse_context.values,
-                team_id=team_id,
-                readonly=True,
-            )
-
-            return [{"name": row[0], "type": _clickhouse_type_to_serialized_type(row[1])} for row in rows]
-        except Exception as e:
-            capture_exception(e)
+        if not clickhouse_sql:
             return []
+
+        # nosemgrep: clickhouse-fstring-param-audit (clickhouse_sql is compiler output from HogQLQueryExecutor, not user input)
+        rows = sync_execute(
+            f"DESCRIBE TABLE ({clickhouse_sql})",
+            clickhouse_context.values,
+            team_id=team_id,
+            readonly=True,
+        )
+
+        return [{"name": row[0], "type": _clickhouse_type_to_serialized_type(row[1])} for row in rows]
 
 
 class Endpoint(CreatedMetaFields, UpdatedMetaFields, DeletedMetaFields, UUIDTModel):
@@ -343,7 +346,10 @@ class Endpoint(CreatedMetaFields, UpdatedMetaFields, DeletedMetaFields, UUIDTMod
         self.save(update_fields=["current_version", "updated_at"])
 
         # Create new version, inheriting settings from previous version
-        columns = EndpointVersion.extract_columns(query, team_id=self.team_id)
+        try:
+            columns: list[dict] | None = EndpointVersion.extract_columns(query, team_id=self.team_id)
+        except Exception:
+            columns = None
         version = EndpointVersion.objects.create(
             endpoint=self,
             version=self.current_version,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
@@ -4,7 +4,21 @@
         "assignee": {
             "properties": {
                 "id": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "type": {
                     "type": "string"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
some weird queries can't get their columns saved, so the GET /endpoints request hangs, and shows no endpoints in the frontend

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- keep the exception, save the row to DB even if it's empty, then capture exception
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- it runs
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
