### PR TITLE
feat(llma): add error trend chart buttons to errors tab

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -315,6 +315,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_CLUSTERS_TAB: 'llm-analytics-clusters-tab', // owner: #team-llm-analytics
     LLM_ANALYTICS_TOOLS_TAB: 'llm-analytics-tools-tab', // owner: #team-llm-analytics
     LLM_ANALYTICS_TOOLS_CHARTS: 'llm-analytics-tools-charts', // owner: #team-llm-analytics
+    LLM_ANALYTICS_ERRORS_CHARTS: 'llm-analytics-errors-charts', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERING_ADMIN: 'llm-analytics-clustering-admin', // owner: #team-llm-analytics
     LLM_ANALYTICS_SESSIONS_VIEW: 'llm-analytics-sessions-view', // owner: #team-llm-analytics
     LLM_ANALYTICS_SUMMARIZATION: 'llm-analytics-summarization', // owner: #team-llm-analytics

--- a/products/llm_analytics/frontend/LLMAnalyticsErrors.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsErrors.tsx
@@ -1,15 +1,18 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconCopy } from '@posthog/icons'
+import { IconCopy, IconTrends } from '@posthog/icons'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
+import { type InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
@@ -21,8 +24,11 @@ export function LLMAnalyticsErrors(): JSX.Element {
     const sharedLogic = useMountedLogic(llmAnalyticsSharedLogic)
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
     const { setErrorsSort } = useActions(llmAnalyticsErrorsLogic)
-    const { errorsQuery, errorsSort } = useValues(llmAnalyticsErrorsLogic)
+    const { errorsQuery, errorsSort, buildAllErrorsTrendQuery, buildErrorTrendQuery } =
+        useValues(llmAnalyticsErrorsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
+    const showErrorsCharts = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_ERRORS_CHARTS]
 
     const { renderSortableColumnTitle } = useSortableColumns(errorsSort, setErrorsSort)
 
@@ -45,6 +51,22 @@ export function LLMAnalyticsErrors(): JSX.Element {
                 setPropertyFilters(filters.properties || [])
             }}
             context={{
+                customActions: showErrorsCharts
+                    ? [
+                          <Tooltip title="View error trends over time" key="trends">
+                              <LemonButton
+                                  icon={<IconTrends />}
+                                  size="small"
+                                  type="secondary"
+                                  to={urls.insightNew({ query: buildAllErrorsTrendQuery })}
+                                  targetBlank
+                                  data-attr="llma-errors-all-trends-click"
+                              >
+                                  Error trends
+                              </LemonButton>
+                          </Tooltip>,
+                      ]
+                    : undefined,
                 columns: {
                     error: {
                         renderTitle: () => (
@@ -94,6 +116,22 @@ export function LLMAnalyticsErrors(): JSX.Element {
                                             {displayValue}
                                         </Link>
                                     </Tooltip>
+                                    {showErrorsCharts && (
+                                        <Tooltip title="View trend for this error over time">
+                                            <LemonButton
+                                                icon={<IconTrends />}
+                                                size="xsmall"
+                                                to={urls.insightNew({
+                                                    query: {
+                                                        kind: NodeKind.InsightVizNode,
+                                                        source: buildErrorTrendQuery(errorString),
+                                                    } as InsightVizNode,
+                                                })}
+                                                targetBlank
+                                                data-attr="llma-errors-trend-click"
+                                            />
+                                        </Tooltip>
+                                    )}
                                     <LemonButton
                                         size="xsmall"
                                         noPadding

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsErrorsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsErrorsLogic.ts
@@ -3,8 +3,8 @@ import { actions, connect, kea, key, path, props, reducers, selectors } from 'ke
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { groupsModel } from '~/models/groupsModel'
-import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter } from '~/types'
+import { DataTableNode, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
 import errorsQueryTemplate from '../../backend/queries/errors.sql?raw'
 import { SortDirection, SortState, llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
@@ -50,8 +50,6 @@ export const llmAnalyticsErrorsLogic = kea<llmAnalyticsErrorsLogicType>([
                 errorsSort: SortState,
                 groupsTaxonomicTypes: TaxonomicFilterGroupType[]
             ): DataTableNode => {
-                // Use the shared query template
-                // Simple placeholder replacement - no escaping needed
                 const query = errorsQueryTemplate
                     .replace('__ORDER_BY__', errorsSort.column)
                     .replace('__ORDER_DIRECTION__', errorsSort.direction)
@@ -97,6 +95,106 @@ export const llmAnalyticsErrorsLogic = kea<llmAnalyticsErrorsLogicType>([
                     showColumnConfigurator: true,
                     allowSorting: true,
                 }
+            },
+        ],
+        buildAllErrorsTrendQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): InsightVizNode => ({
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: [
+                        ...propertyFilters,
+                        {
+                            key: '$ai_is_error',
+                            operator: PropertyOperator.Exact,
+                            value: 'true',
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_generation',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_span',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_trace',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_embedding',
+                        },
+                    ],
+                    breakdownFilter: {
+                        breakdown: '$ai_error_normalized',
+                        breakdown_type: 'event',
+                        breakdown_limit: 10,
+                    },
+                },
+            }),
+        ],
+        buildErrorTrendQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): ((errorName: string) => TrendsQuery) => {
+                return (errorName: string): TrendsQuery => ({
+                    kind: NodeKind.TrendsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: [
+                        ...propertyFilters,
+                        {
+                            key: '$ai_is_error',
+                            operator: PropertyOperator.Exact,
+                            value: 'true',
+                            type: PropertyFilterType.Event,
+                        },
+                        {
+                            key: '$ai_error_normalized',
+                            operator: PropertyOperator.Exact,
+                            value: errorName,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_generation',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_span',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_trace',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_embedding',
+                        },
+                    ],
+                })
             },
         ],
     }),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-issues-partial-update.json
@@ -4,7 +4,21 @@
         "assignee": {
             "properties": {
                 "id": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "type": {
                     "type": "string"


### PR DESCRIPTION
## Problem

The LLM analytics errors tab lacks the ability to quickly visualize error trends over time, unlike the tools tab which already has chart buttons for exploring tool usage patterns.

## Changes

- Add "Error trends" headline button that opens a time series insight showing all normalized errors broken down over time (across all AI event types)
- Add per-row trend icon button next to each error message to view that specific error's trend over time
- Add `LLM_ANALYTICS_ERRORS_CHARTS` feature flag to gate the new buttons
- Add `buildAllErrorsTrendQuery` and `buildErrorTrendQuery` selectors to `llmAnalyticsErrorsLogic`

Follows the same pattern used on the tools tab (`LLM_ANALYTICS_TOOLS_CHARTS` flag, `customActions` + row-level buttons).

## How did you test this code?

This was authored by an agent. No manual testing was performed. The implementation mirrors the existing tools tab chart buttons pattern exactly.