### PR TITLE
feat(cloud-agents): add no-repo flow and improve follow-up relay for Slack integration

### DIFF
--- a/posthog/temporal/ai/__init__.py
+++ b/posthog/temporal/ai/__init__.py
@@ -10,6 +10,7 @@ from posthog.temporal.ai.posthog_code_slack_interactivity import (
 )
 from posthog.temporal.ai.posthog_code_slack_mention import (
     PostHogCodeSlackMentionWorkflow,
+    classify_posthog_code_task_needs_repo_activity,
     collect_posthog_code_thread_messages_activity,
     create_posthog_code_routing_rule_activity,
     create_posthog_code_task_for_repo_activity,
@@ -116,6 +117,7 @@ AI_ACTIVITIES = [
     collect_posthog_code_thread_messages_activity,
     create_posthog_code_routing_rule_activity,
     select_posthog_code_repository_activity,
+    classify_posthog_code_task_needs_repo_activity,
     post_posthog_code_no_repos_activity,
     post_posthog_code_repo_picker_activity,
     create_posthog_code_task_for_repo_activity,

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -162,10 +162,40 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
 
             if decision.mode == "picker":
                 if decision.reason == "no_repos":
+                    # Layer 1: No GH integration, launch without repo immediately.
                     await _execute_posthog_code_activity(
-                        post_posthog_code_no_repos_activity, inputs, channel, thread_ts
+                        create_posthog_code_task_for_repo_activity,
+                        inputs,
+                        channel,
+                        thread_ts,
+                        slack_user_id,
+                        user_id,
+                        event,
+                        thread_messages,
+                        None,
                     )
                     return
+
+                if decision.reason == "no_rule_match":
+                    # Layer 2: Has repos but no rule match, let's classify if task needs a repo.
+                    needs_repo = await _execute_posthog_code_activity(
+                        classify_posthog_code_task_needs_repo_activity,
+                        event.get("text", ""),
+                        thread_messages,
+                    )
+                    if not needs_repo:
+                        await _execute_posthog_code_activity(
+                            create_posthog_code_task_for_repo_activity,
+                            inputs,
+                            channel,
+                            thread_ts,
+                            slack_user_id,
+                            user_id,
+                            event,
+                            thread_messages,
+                            None,
+                        )
+                        return
 
                 await _execute_posthog_code_activity(
                     post_posthog_code_repo_picker_activity,
@@ -290,7 +320,7 @@ def handle_posthog_code_rules_command_activity(
             return PostHogCodeRulesCommandResult(status="needs_picker", pending_rule_text=command.rule_text)
         _handle_rules_add(slack, integration, channel, thread_ts, user_id, command.rule_text or "", command.repository)
     elif command.action == "remove":
-        _handle_rules_remove(slack, integration, channel, thread_ts, command.rule_number)
+        _handle_rules_remove(slack, integration, channel, thread_ts, command.rule_numbers)
     elif command.action == "default_set":
         _handle_default_repo_set(slack, integration, channel, thread_ts, user_id, command.repository or "")
     elif command.action == "default_show":
@@ -311,7 +341,7 @@ def _handle_help(slack: Any, channel: str, thread_ts: str) -> None:
             "`@PostHog Code rules list` — Show all routing rules\n"
             '`@PostHog Code rules add "description" org/repo` — Add a routing rule\n'
             '`@PostHog Code rules add "description"` — Add a routing rule (pick repo from list)\n'
-            "`@PostHog Code rules remove <number>` — Remove a routing rule by number\n"
+            "`@PostHog Code rules remove <number(s)>` — Remove routing rules by number (e.g. `remove 1` or `remove 1,2`)\n"
             "`@PostHog Code default repo set org/repo` — Set your default repository for this channel\n"
             "`@PostHog Code default repo show` — Show your default repository for this channel\n"
             "`@PostHog Code default repo clear` — Clear your default repository for this channel\n"
@@ -398,34 +428,41 @@ def _handle_rules_remove(
     integration: Any,
     channel: str,
     thread_ts: str,
-    rule_number: int | None,
+    rule_numbers: list[int] | None,
 ) -> None:
     from posthog.models.repo_routing_rule import RepoRoutingRule
 
-    if rule_number is None or rule_number < 1:
+    if not rule_numbers or any(n < 1 for n in rule_numbers):
         slack.client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,
-            text="Please provide a valid rule number. Use `@PostHog Code rules list` to see current rules.",
+            text="Please provide valid rule number(s). Use `@PostHog Code rules list` to see current rules.",
         )
         return
 
     rules = list(RepoRoutingRule.objects.filter(team_id=integration.team_id).order_by("priority", "id"))
-    if rule_number > len(rules):
+    invalid = [n for n in rule_numbers if n > len(rules)]
+    if invalid:
         slack.client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,
-            text=f"Rule #{rule_number} does not exist. There are {len(rules)} rule(s). Use `@PostHog Code rules list` to see them.",
+            text=f"Rule {'number' if len(invalid) == 1 else 'numbers'} {', '.join(f'#{n}' for n in invalid)} {'does' if len(invalid) == 1 else 'do'} not exist. There are {len(rules)} rule(s). Use `@PostHog Code rules list` to see them.",
         )
         return
 
-    rule = rules[rule_number - 1]
-    rule_text = rule.rule_text
-    rule.delete()
+    # Collect rules to delete (use sorted unique numbers, delete in reverse to keep indices stable)
+    to_delete = sorted(set(rule_numbers), reverse=True)
+    removed: list[str] = []
+    for n in to_delete:
+        rule = rules[n - 1]
+        removed.append(f"#{n}: {rule.rule_text}")
+        rule.delete()
+
+    removed.reverse()
     slack.client.chat_postMessage(
         channel=channel,
         thread_ts=thread_ts,
-        text=f"Removed rule #{rule_number}: {rule_text}",
+        text=f"Removed rule{'s' if len(removed) > 1 else ''} {', '.join(removed)}",
     )
 
 
@@ -579,6 +616,16 @@ def select_posthog_code_repository_activity(
 
 
 @activity.defn
+def classify_posthog_code_task_needs_repo_activity(
+    event_text: str,
+    thread_messages: list[dict[str, str]],
+) -> bool:
+    from products.slack_app.backend.api import classify_task_needs_repo
+
+    return classify_task_needs_repo(event_text, thread_messages)
+
+
+@activity.defn
 def post_posthog_code_no_repos_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs, channel: str, thread_ts: str
 ) -> None:
@@ -644,7 +691,7 @@ def create_posthog_code_task_for_repo_activity(
     user_id: int,
     event: dict[str, Any],
     thread_messages: list[dict[str, str]],
-    repository: str,
+    repository: str | None,
 ) -> None:
     import structlog
 
@@ -696,6 +743,8 @@ def create_posthog_code_task_for_repo_activity(
             origin_product=Task.OriginProduct.SLACK,
             user_id=user_id,
             repository=repository,
+            create_pr=repository is not None,
+            mode="interactive",
             slack_thread_context=slack_thread_context,
             slack_thread_url=slack_thread_url,
             start_workflow=False,
@@ -752,7 +801,9 @@ def create_posthog_code_task_for_repo_activity(
             run_id=str(task_run.id),
             team_id=task.team.id,
             user_id=user_id,
+            create_pr=repository is not None,
             slack_thread_context=slack_thread_context,
+            posthog_mcp_scopes="full",
         )
 
 
@@ -827,6 +878,11 @@ def forward_posthog_code_followup_activity(
     Returns True if the message was handled (forwarded or rejected), False if
     no mapping exists and the caller should continue with the normal new-task flow.
     """
+    from products.slack_app.backend.api import _parse_rules_command
+
+    if _parse_rules_command(event_text):
+        return False
+
     import structlog
 
     from posthog.models.integration import Integration, SlackIntegration
@@ -920,32 +976,15 @@ def forward_posthog_code_followup_activity(
             status_code=result.status_code,
         )
         if result.retryable and result.status_code == 504:
-            timeout_reply_text = _extract_recent_assistant_text_from_logs(task_run)
-            if timeout_reply_text:
-                _set_followup_done_reaction(slack, channel, user_message_ts, "white_check_mark")
-                mention_prefix = f"<@{slack_user_id}> " if slack_user_id else ""
-                slack.client.chat_postMessage(
-                    channel=channel,
-                    thread_ts=thread_ts,
-                    text=f"{mention_prefix}{timeout_reply_text}",
-                )
-                _delete_followup_progress(
-                    integration_id=inputs.integration_id,
-                    channel=channel,
-                    thread_ts=thread_ts,
-                    user_message_ts=user_message_ts,
-                    mentioning_slack_user_id=mapping.mentioning_slack_user_id,
-                )
-                return True
-
-            _set_followup_done_reaction(slack, channel, user_message_ts, "x")
-            slack.client.chat_postMessage(
+            # Agent is still processing. relayAgentResponse fires when it
+            # finishes, delivering the correct response to Slack.
+            _set_followup_done_reaction(slack, channel, user_message_ts, "white_check_mark")
+            _delete_followup_progress(
+                integration_id=inputs.integration_id,
                 channel=channel,
                 thread_ts=thread_ts,
-                text=(
-                    "Message delivery to the sandbox timed out. "
-                    "It may still be processing - check agent logs and retry once if needed."
-                ),
+                user_message_ts=user_message_ts,
+                mentioning_slack_user_id=mapping.mentioning_slack_user_id,
             )
             return True
 
@@ -958,17 +997,6 @@ def forward_posthog_code_followup_activity(
         return True
 
     _set_followup_done_reaction(slack, channel, user_message_ts, "white_check_mark")
-
-    reply_text = _resolve_followup_reply_text(task_run, getattr(result, "data", None))
-    if not reply_text:
-        reply_text = "I processed your message but couldn't fetch the reply text. Check logs."
-
-    mention_prefix = f"<@{slack_user_id}> " if slack_user_id else ""
-    slack.client.chat_postMessage(
-        channel=channel,
-        thread_ts=thread_ts,
-        text=f"{mention_prefix}{reply_text}",
-    )
 
     _delete_followup_progress(
         integration_id=inputs.integration_id,
@@ -1023,6 +1051,11 @@ def _resume_task_with_new_run(
     if previous_state.get("slack_thread_url"):
         extra_state["slack_thread_url"] = previous_state["slack_thread_url"]
 
+    snapshot_ext_id = previous_state.get("snapshot_external_id")
+    if snapshot_ext_id:
+        extra_state["snapshot_external_id"] = snapshot_ext_id
+    extra_state["resume_from_run_id"] = str(previous_run.id)
+
     previous_pr_url = (previous_run.output or {}).get("pr_url")
     initial_prompt_override = user_text
     if previous_pr_url:
@@ -1036,8 +1069,11 @@ def _resume_task_with_new_run(
         extra_state["slack_notified_pr_url"] = previous_pr_url
 
     extra_state["initial_prompt_override"] = initial_prompt_override
+    extra_state["pending_user_message"] = initial_prompt_override
+    if user_message_ts:
+        extra_state["pending_user_message_ts"] = user_message_ts
 
-    new_run = mapping.task.create_run(extra_state=extra_state)
+    new_run = mapping.task.create_run(mode="interactive", extra_state=extra_state)
 
     slack_thread_context = SlackThreadContext(
         integration_id=inputs.integration_id,
@@ -1053,7 +1089,9 @@ def _resume_task_with_new_run(
             run_id=str(new_run.id),
             team_id=mapping.task.team_id,
             user_id=created_by.id,
+            create_pr=mapping.task.repository is not None,
             slack_thread_context=slack_thread_context,
+            posthog_mcp_scopes="full",
         )
     except Exception:
         log.exception(
@@ -1075,12 +1113,6 @@ def _resume_task_with_new_run(
 
     if user_message_ts:
         _safe_react(slack.client, channel, user_message_ts, "eyes")
-
-    slack.client.chat_postMessage(
-        channel=channel,
-        thread_ts=thread_ts,
-        text="Got it — restarting the agent to work on this.",
-    )
 
     log.info(
         "posthog_code_task_resumed",

--- a/posthog/temporal/tests/ai/test_module_integrity.py
+++ b/posthog/temporal/tests/ai/test_module_integrity.py
@@ -67,6 +67,7 @@ class TestAITemporalModuleIntegrity:
             "collect_posthog_code_thread_messages_activity",
             "create_posthog_code_routing_rule_activity",
             "select_posthog_code_repository_activity",
+            "classify_posthog_code_task_needs_repo_activity",
             "post_posthog_code_no_repos_activity",
             "post_posthog_code_repo_picker_activity",
             "create_posthog_code_task_for_repo_activity",

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -20,6 +20,7 @@ import requests
 import structlog
 from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
 
+from posthog.llm.gateway_client import get_llm_client
 from posthog.models.integration import (
     GitHubIntegration,
     Integration,
@@ -93,7 +94,7 @@ class RulesCommand:
     action: Literal["list", "add", "remove", "help", "default_set", "default_show", "default_clear"]
     rule_text: str | None = None
     repository: str | None = None
-    rule_number: int | None = None
+    rule_numbers: list[int] | None = None
 
 
 def _slack_user_info_cache_key(integration_id: int, slack_user_id: str) -> str:
@@ -694,9 +695,11 @@ def _parse_rules_command(text: str) -> RulesCommand | None:
     if add_no_repo_match:
         return RulesCommand(action="add", rule_text=add_no_repo_match.group(1))
 
-    remove_match = re.fullmatch(r"rules\s+remove\s+(\d+)", cleaned, flags=re.IGNORECASE)
+    remove_match = re.fullmatch(r"rules\s+remove\s+([\d,\s]+)", cleaned, flags=re.IGNORECASE)
     if remove_match:
-        return RulesCommand(action="remove", rule_number=int(remove_match.group(1)))
+        numbers = [int(n.strip()) for n in remove_match.group(1).split(",") if n.strip().isdigit()]
+        if numbers:
+            return RulesCommand(action="remove", rule_numbers=numbers)
 
     default_set_match = re.fullmatch(
         r"default\s+repo\s+set\s+([\w.-]+/[\w.-]+)",
@@ -960,8 +963,6 @@ def _match_repo_rule(
     )
 
     try:
-        from posthog.llm.gateway_client import get_llm_client
-
         client = get_llm_client("slack-posthog-code")
         response = client.chat.completions.create(
             model="claude-haiku-4-5-20251001",
@@ -993,6 +994,44 @@ def _match_repo_rule(
     except Exception:
         logger.exception("posthog_code_rule_match_failed", team_id=team_id)
         return None
+
+
+def classify_task_needs_repo(
+    event_text: str,
+    thread_messages: list[dict[str, str]],
+) -> bool:
+    """Classify whether a Slack conversation requires code repository access.
+
+    Returns True if the task likely needs a repo (writing code, fixing bugs, PRs),
+    False if it does not (analytics, data queries, PostHog config).
+    Defaults to True on error (conservative — falls back to picker).
+    """
+    conversation = "\n".join(f"{msg['user']}: {msg['text']}" for msg in thread_messages)
+    prompt = (
+        "You are a task classifier. Given a Slack conversation, determine whether the task "
+        "requires access to a code repository (e.g. writing code, fixing bugs, creating PRs, "
+        "reviewing code, modifying files) or NOT (e.g. answering questions about analytics, "
+        "querying data, PostHog configuration, general knowledge questions, planning).\n\n"
+        f"Conversation:\n{conversation}\n\n"
+        f"Latest message: {event_text}\n\n"
+        'Respond with ONLY a JSON object: {{"needs_repo": true}} or {{"needs_repo": false}}'
+    )
+    try:
+        client = get_llm_client("slack-posthog-code")
+        response = client.chat.completions.create(
+            model="claude-haiku-4-5-20251001",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=64,
+            temperature=0,
+        )
+        content = (response.choices[0].message.content or "").strip()
+        if content.startswith("```"):
+            content = content.strip("`").removeprefix("json").strip()
+        parsed = json.loads(content)
+        return bool(parsed.get("needs_repo", True))
+    except Exception:
+        logger.exception("classify_task_needs_repo_failed")
+        return True
 
 
 def route_posthog_code_event_to_relevant_region(

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -192,6 +192,8 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         call_kwargs = mock_execute_workflow.call_args.kwargs
         assert call_kwargs["task_id"] == str(self.task.id)
         assert call_kwargs["user_id"] == self.user.id
+        assert call_kwargs["create_pr"] is True
+        assert call_kwargs["posthog_mcp_scopes"] == "full"
 
         new_run_id = call_kwargs["run_id"]
         assert new_run_id != str(self.task_run.id)
@@ -203,13 +205,14 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         assert mapping.task_id == self.task.id
 
         new_run = self.TaskRun.objects.get(id=new_run_id)
-        assert "pending_user_message" not in new_run.state
+        assert new_run.state.get("pending_user_message") == "do something"
+        assert new_run.state.get("pending_user_message_ts") == "1234.5679"
         assert new_run.state.get("initial_prompt_override") == "do something"
 
         mock_slack_instance.client.reactions_add.assert_called_once_with(
             channel="C123", timestamp="1234.5679", name="eyes"
         )
-        assert any("restarting" in str(call) for call in mock_slack_instance.client.chat_postMessage.call_args_list)
+        mock_slack_instance.client.chat_postMessage.assert_not_called()
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("posthog.models.integration.SlackIntegration")
@@ -230,6 +233,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         assert new_run.state.get("slack_pr_opened_notified") is True
         assert new_run.state.get("slack_notified_pr_url") == "https://github.com/org/repo/pull/1"
         assert "gh pr checkout https://github.com/org/repo/pull/1" in new_run.state.get("initial_prompt_override", "")
+        assert "gh pr checkout https://github.com/org/repo/pull/1" in new_run.state.get("pending_user_message", "")
 
     @patch("posthog.models.integration.SlackIntegration")
     def test_terminal_run_unauthorized_user_returns_true_with_error(self, mock_slack_cls):
@@ -347,63 +351,8 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance.client.reactions_remove.assert_any_call(
             channel="C123", timestamp="1234.5679", name="seedling"
         )
-        mock_slack_instance.client.chat_postMessage.assert_called_once()
-        assert "thanks" in mock_slack_instance.client.chat_postMessage.call_args.kwargs["text"]
-
-    @patch("posthog.temporal.ai.posthog_code_slack_mention._resolve_followup_reply_text", return_value=None)
-    @patch("products.tasks.backend.services.connection_token.create_sandbox_connection_token", return_value="jwt-token")
-    @patch("products.tasks.backend.services.agent_command.send_user_message")
-    @patch("posthog.models.integration.SlackIntegration")
-    def test_successful_forwarding_without_reply_posts_fallback(
-        self,
-        mock_slack_cls,
-        mock_send,
-        mock_token,
-        _mock_resolve_reply,
-    ):
-        self._create_mapping()
-        mock_slack_instance = MagicMock()
-        mock_slack_cls.return_value = mock_slack_instance
-        mock_send.return_value = _command_result(success=True, status_code=200)
-
-        inputs = _make_inputs(self.integration.id)
-        result = forward_posthog_code_followup_activity(
-            inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> do something", "1234.5679"
-        )
-
-        assert result is True
-        mock_slack_instance.client.chat_postMessage.assert_called_once()
-        assert "couldn't fetch the reply text" in mock_slack_instance.client.chat_postMessage.call_args.kwargs["text"]
-
-    @patch(
-        "posthog.temporal.ai.posthog_code_slack_mention._extract_recent_assistant_text_from_logs",
-        return_value="Which license would you like to add?",
-    )
-    @patch("products.tasks.backend.services.connection_token.create_sandbox_connection_token", return_value="jwt-token")
-    @patch("products.tasks.backend.services.agent_command.send_user_message")
-    @patch("posthog.models.integration.SlackIntegration")
-    def test_successful_forwarding_uses_log_reply_when_command_has_no_reply(
-        self,
-        mock_slack_cls,
-        mock_send,
-        mock_token,
-        _mock_extract_reply,
-    ):
-        self._create_mapping()
-        mock_slack_instance = MagicMock()
-        mock_slack_cls.return_value = mock_slack_instance
-        mock_send.return_value = _command_result(
-            success=True, status_code=200, data={"result": {"stopReason": "end_turn"}}
-        )
-
-        inputs = _make_inputs(self.integration.id)
-        result = forward_posthog_code_followup_activity(
-            inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> add a license file", "1234.5679"
-        )
-
-        assert result is True
-        call_kwargs = mock_slack_instance.client.chat_postMessage.call_args.kwargs
-        assert "Which license would you like to add?" in call_kwargs["text"]
+        # Response is delivered by relayAgentResponse from the agent-server, not by this activity.
+        mock_slack_instance.client.chat_postMessage.assert_not_called()
 
     @patch("products.tasks.backend.services.connection_token.create_sandbox_connection_token", return_value="jwt-token")
     @patch("products.tasks.backend.services.agent_command.send_user_message")
@@ -425,7 +374,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
     @patch("products.tasks.backend.services.connection_token.create_sandbox_connection_token", return_value="jwt-token")
     @patch("products.tasks.backend.services.agent_command.send_user_message")
     @patch("posthog.models.integration.SlackIntegration")
-    def test_timeout_skips_retry_to_avoid_duplicate_delivery(self, mock_slack_cls, mock_send, mock_token):
+    def test_timeout_delegates_to_relay_without_posting(self, mock_slack_cls, mock_send, mock_token):
         self._create_mapping()
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
@@ -440,42 +389,12 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
 
         assert result is True
         mock_send.assert_called_once()
-        call_kwargs = mock_slack_instance.client.chat_postMessage.call_args.kwargs
-        assert "timed out" in call_kwargs["text"]
-        assert "may still be processing" in call_kwargs["text"]
-
-    @patch(
-        "posthog.temporal.ai.posthog_code_slack_mention._extract_recent_assistant_text_from_logs",
-        return_value="Which license would you like to add?",
-    )
-    @patch("products.tasks.backend.services.connection_token.create_sandbox_connection_token", return_value="jwt-token")
-    @patch("products.tasks.backend.services.agent_command.send_user_message")
-    @patch("posthog.models.integration.SlackIntegration")
-    def test_retryable_timeout_posts_log_reply_when_available(
-        self,
-        mock_slack_cls,
-        mock_send,
-        mock_token,
-        _mock_extract_reply,
-    ):
-        self._create_mapping()
-        mock_slack_instance = MagicMock()
-        mock_slack_cls.return_value = mock_slack_instance
-        mock_send.return_value = _command_result(
-            success=False,
-            status_code=504,
-            error="Sandbox request timed out",
-            retryable=True,
+        # Agent is still processing — relayAgentResponse delivers the response.
+        mock_slack_instance.client.chat_postMessage.assert_not_called()
+        mock_slack_instance.client.reactions_remove.assert_any_call(channel="C123", timestamp="1234.5679", name="eyes")
+        mock_slack_instance.client.reactions_remove.assert_any_call(
+            channel="C123", timestamp="1234.5679", name="seedling"
         )
-
-        inputs = _make_inputs(self.integration.id)
-        result = forward_posthog_code_followup_activity(
-            inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> add a license file", "1234.5679"
-        )
-
-        assert result is True
-        call_kwargs = mock_slack_instance.client.chat_postMessage.call_args.kwargs
-        assert "Which license would you like to add?" in call_kwargs["text"]
 
     @patch("products.tasks.backend.services.connection_token.create_sandbox_connection_token", return_value="jwt-token")
     @patch("products.tasks.backend.services.agent_command.send_user_message")
@@ -500,8 +419,8 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_slack_instance.client.reactions_remove.assert_any_call(
             channel="C123", timestamp="1234.5679", name="seedling"
         )
-        mock_slack_instance.client.chat_postMessage.assert_called_once()
-        assert "couldn't fetch the reply text" in mock_slack_instance.client.chat_postMessage.call_args.kwargs["text"]
+        # Response is delivered by relayAgentResponse, not by this activity.
+        mock_slack_instance.client.chat_postMessage.assert_not_called()
 
 
 class TestEventLevelDedupe(TestCase):

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -571,7 +571,7 @@ class TestMatchRepoRule:
         result = _match_repo_rule("fix bug", [{"user": "Dev", "text": "fix bug"}], self.team.id, ["org/repo"])
         assert result is None
 
-    @patch("posthog.llm.gateway_client.get_llm_client")
+    @patch("products.slack_app.backend.api.get_llm_client")
     def test_llm_returns_valid_index(self, mock_get_client):
         RepoRoutingRule.objects.create(
             team=self.team,
@@ -590,7 +590,7 @@ class TestMatchRepoRule:
         )
         assert result == "org/js-sdk"
 
-    @patch("posthog.llm.gateway_client.get_llm_client")
+    @patch("products.slack_app.backend.api.get_llm_client")
     def test_llm_returns_null_index(self, mock_get_client):
         RepoRoutingRule.objects.create(
             team=self.team,
@@ -609,7 +609,7 @@ class TestMatchRepoRule:
         )
         assert result is None
 
-    @patch("posthog.llm.gateway_client.get_llm_client")
+    @patch("products.slack_app.backend.api.get_llm_client")
     def test_llm_returns_invalid_index(self, mock_get_client):
         RepoRoutingRule.objects.create(
             team=self.team,
@@ -626,7 +626,7 @@ class TestMatchRepoRule:
         result = _match_repo_rule("fix bug", [{"user": "Dev", "text": "fix bug"}], self.team.id, ["org/js-sdk"])
         assert result is None
 
-    @patch("posthog.llm.gateway_client.get_llm_client")
+    @patch("products.slack_app.backend.api.get_llm_client")
     def test_llm_failure_returns_none(self, mock_get_client):
         RepoRoutingRule.objects.create(
             team=self.team,
@@ -640,7 +640,7 @@ class TestMatchRepoRule:
         result = _match_repo_rule("fix bug", [{"user": "Dev", "text": "fix bug"}], self.team.id, ["org/js-sdk"])
         assert result is None
 
-    @patch("posthog.llm.gateway_client.get_llm_client")
+    @patch("products.slack_app.backend.api.get_llm_client")
     def test_llm_invalid_json_returns_none(self, mock_get_client):
         RepoRoutingRule.objects.create(
             team=self.team,
@@ -673,7 +673,9 @@ class TestParseRulesCommand:
                 'rules add "fix frontend" my-org/my.repo',
                 RulesCommand(action="add", rule_text="fix frontend", repository="my-org/my.repo"),
             ),
-            ("remove", "rules remove 3", RulesCommand(action="remove", rule_number=3)),
+            ("remove", "rules remove 3", RulesCommand(action="remove", rule_numbers=[3])),
+            ("remove_multiple", "rules remove 1,2", RulesCommand(action="remove", rule_numbers=[1, 2])),
+            ("remove_multiple_spaces", "rules remove 1, 3", RulesCommand(action="remove", rule_numbers=[1, 3])),
             (
                 "bot_mention_list",
                 "<@U123BOT> rules list",
@@ -697,7 +699,7 @@ class TestParseRulesCommand:
             (
                 "bot_mention_remove",
                 "<@U123BOT> rules remove 1",
-                RulesCommand(action="remove", rule_number=1),
+                RulesCommand(action="remove", rule_numbers=[1]),
             ),
             ("help", "help", RulesCommand(action="help")),
             ("help_case_insensitive", "Help", RulesCommand(action="help")),

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -157,7 +157,7 @@ class Task(DeletedMetaFields, models.Model):
         description: str,
         origin_product: "Task.OriginProduct",
         user_id: int,  # Will be used to validate the tasks feature flag and create a personal api key for interacting with PostHog.
-        repository: str,  # Format: "organization/repository", e.g. "posthog/posthog-js"
+        repository: str | None = None,  # Format: "organization/repository", e.g. "posthog/posthog-js"
         create_pr: bool = True,
         mode: str = "background",
         slack_thread_context: Optional["SlackThreadContext"] = None,
@@ -170,10 +170,11 @@ class Task(DeletedMetaFields, models.Model):
 
         created_by = User.objects.get(id=user_id)
 
-        github_integration = Integration.objects.filter(team=team, kind="github").first()
-
-        if not github_integration:
-            raise ValueError(f"Team {team.id} does not have a GitHub integration")
+        github_integration = None
+        if repository:
+            github_integration = Integration.objects.filter(team=team, kind="github").first()
+            if not github_integration:
+                raise ValueError(f"Team {team.id} does not have a GitHub integration")
 
         task = Task.objects.create(
             team=team,
@@ -294,9 +295,6 @@ class TaskRun(models.Model):
         return self.get_workflow_id(self.task_id, self.id)
 
     def heartbeat_workflow(self) -> None:
-        if self.mode != "background":
-            return
-
         from django.core.cache import cache
 
         cache_key = f"tasks:task_run:heartbeat:{self.id}"

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -534,7 +534,9 @@ class DockerSandbox:
 
         return is_clean, result.stdout
 
-    def execute_task(self, task_id: str, run_id: str, repository: str, create_pr: bool = True) -> ExecutionResult:
+    def execute_task(
+        self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
+    ) -> ExecutionResult:
         """No-op: Task execution is now handled by agent-server."""
         return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
 
@@ -556,7 +558,7 @@ class DockerSandbox:
 
     def _build_agent_server_command(
         self,
-        repo_path: str,
+        repo_path: str | None,
         task_id: str,
         run_id: str,
         mode: str,
@@ -568,9 +570,10 @@ class DockerSandbox:
             f"env POSTHOG_CODE_INTERACTION_ORIGIN={shlex.quote(interaction_origin)} " if interaction_origin else ""
         )
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
+        repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
         return (
             f"cd /scripts && "
-            f"nohup {env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT} --repositoryPath {shlex.quote(repo_path)} "
+            f"nohup {env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
             f"{branch_flag}{mcp_servers_arg} "
             f"> /tmp/agent-server.log 2>&1 &"
@@ -589,7 +592,7 @@ class DockerSandbox:
 
     def start_agent_server(
         self,
-        repository: str,
+        repository: str | None,
         task_id: str,
         run_id: str,
         mode: str = "background",
@@ -608,8 +611,10 @@ class DockerSandbox:
         if self._host_port is None:
             raise RuntimeError("Sandbox was not created with port exposure.")
 
-        org, repo = repository.lower().split("/")
-        repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+        repo_path: str | None = None
+        if repository:
+            org, repo = repository.lower().split("/")
+            repo_path = f"/tmp/workspace/repos/{org}/{repo}"
 
         mcp_servers_arg = ""
         if mcp_configs:
@@ -620,7 +625,7 @@ class DockerSandbox:
             repo_path, task_id, run_id, mode, interaction_origin, branch, mcp_servers_arg
         )
 
-        logger.info(f"Starting agent-server in sandbox {self.id} for {repository}")
+        logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")
 
         if self._launch_and_check(command):
             logger.info(f"Agent-server started on port {self._host_port}")

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -417,7 +417,9 @@ class ModalSandbox:
 
         return is_clean, result.stdout
 
-    def execute_task(self, task_id: str, run_id: str, repository: str, create_pr: bool = True) -> ExecutionResult:
+    def execute_task(
+        self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
+    ) -> ExecutionResult:
         """No-op: Task execution is now handled by agent-server."""
         return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
 
@@ -438,7 +440,7 @@ class ModalSandbox:
 
     def start_agent_server(
         self,
-        repository: str,
+        repository: str | None,
         task_id: str,
         run_id: str,
         mode: str = "background",
@@ -455,8 +457,11 @@ class ModalSandbox:
         if not self.is_running():
             raise RuntimeError("Sandbox not in running state.")
 
-        org, repo = repository.lower().split("/")
-        repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+        repo_flag = ""
+        if repository:
+            org, repo = repository.lower().split("/")
+            repo_path = f"/tmp/workspace/repos/{org}/{repo}"
+            repo_flag = f" --repositoryPath {shlex.quote(repo_path)}"
 
         mcp_servers_arg = ""
         if mcp_configs:
@@ -469,13 +474,13 @@ class ModalSandbox:
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         command = (
             f"cd /scripts && "
-            f"nohup {env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT} --repositoryPath {shlex.quote(repo_path)} "
+            f"nohup {env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
             f"{branch_flag}{mcp_servers_arg} "
             f"> /tmp/agent-server.log 2>&1 &"
         )
 
-        logger.info(f"Starting agent-server in sandbox {self.id} for {repository}")
+        logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")
         result = self.execute(command, timeout_seconds=30)
 
         if result.exit_code != 0:

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -106,7 +106,9 @@ class SandboxProtocol(Protocol):
 
     def is_git_clean(self, repository: str) -> tuple[bool, str]: ...
 
-    def execute_task(self, task_id: str, run_id: str, repository: str, create_pr: bool = True) -> ExecutionResult: ...
+    def execute_task(
+        self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
+    ) -> ExecutionResult: ...
 
     def get_connect_credentials(self) -> AgentServerResult:
         """Get connect credentials (URL and token) for this sandbox.
@@ -118,7 +120,7 @@ class SandboxProtocol(Protocol):
 
     def start_agent_server(
         self,
-        repository: str,
+        repository: str | None,
         task_id: str,
         run_id: str,
         mode: str = "background",

--- a/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
@@ -67,19 +67,21 @@ def create_sandbox_from_snapshot(input: CreateSandboxFromSnapshotInput) -> Creat
         except Task.DoesNotExist as e:
             raise TaskNotFoundError(f"Task {ctx.task_id} not found", {"task_id": ctx.task_id}, cause=e)
 
-        try:
-            github_token = get_github_token(ctx.github_integration_id) or ""
-        except Exception as e:
-            raise GitHubAuthenticationError(
-                f"Failed to get GitHub token for integration {ctx.github_integration_id}",
-                {
-                    "github_integration_id": ctx.github_integration_id,
-                    "task_id": ctx.task_id,
-                    "team_id": ctx.team_id,
-                    "error": str(e),
-                },
-                cause=e,
-            )
+        github_token = ""
+        if ctx.github_integration_id is not None:
+            try:
+                github_token = get_github_token(ctx.github_integration_id) or ""
+            except Exception as e:
+                raise GitHubAuthenticationError(
+                    f"Failed to get GitHub token for integration {ctx.github_integration_id}",
+                    {
+                        "github_integration_id": ctx.github_integration_id,
+                        "task_id": ctx.task_id,
+                        "team_id": ctx.team_id,
+                        "error": str(e),
+                    },
+                    cause=e,
+                )
 
         try:
             access_token = create_oauth_access_token(task)

--- a/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
@@ -168,10 +168,12 @@ def _extract_recent_assistant_text_from_logs(task_run: Any) -> str | None:
     if not log_content.strip():
         return None
 
-    latest_text: str | None = None
-    latest_agent_timestamp: datetime | None = None
-    latest_user_timestamp: datetime | None = None
+    _AGENT_MSG_TYPES = {"agent_message", "agent_message_chunk"}
     cutoff = datetime.utcnow() - timedelta(minutes=5)
+    latest_user_timestamp: datetime | None = None
+    latest_agent_timestamp: datetime | None = None
+
+    parsed_updates: list[tuple[dict, datetime | None]] = []
 
     for line in log_content.strip().split("\n"):
         line = line.strip()
@@ -202,24 +204,31 @@ def _extract_recent_assistant_text_from_logs(task_run: Any) -> str | None:
                 latest_user_timestamp = timestamp
             continue
 
-        if session_update not in {"agent_message", "agent_message_chunk"}:
-            continue
+        parsed_updates.append((update, timestamp))
 
-        content = update.get("content")
-        text: str | None = None
-        if isinstance(content, dict) and content.get("type") == "text" and isinstance(content.get("text"), str):
-            candidate = content["text"].strip()
-            text = candidate or None
-        elif isinstance(update.get("message"), str):
-            candidate = update["message"].strip()
-            text = candidate or None
+        if session_update in _AGENT_MSG_TYPES and timestamp:
+            if latest_agent_timestamp is None or timestamp >= latest_agent_timestamp:
+                latest_agent_timestamp = timestamp
 
-        if not text:
-            continue
+    # Walk backwards: find last agent_message, then collect all consecutive agent messages
+    # TODO: improve this, fine for now but not efficient
+    trailing_parts: list[str] = []
+    found_agent_msg = False
+    for update, _ in reversed(parsed_updates):
+        is_agent_msg = update.get("sessionUpdate") in _AGENT_MSG_TYPES
+        if not found_agent_msg:
+            if is_agent_msg:
+                found_agent_msg = True
+            else:
+                continue
+        if found_agent_msg and not is_agent_msg:
+            break
+        text = _extract_text_from_update(update)
+        if text:
+            trailing_parts.append(text)
 
-        if latest_agent_timestamp is None or (timestamp and timestamp >= latest_agent_timestamp):
-            latest_agent_timestamp = timestamp
-            latest_text = text
+    trailing_parts.reverse()
+    latest_text = "".join(trailing_parts) if trailing_parts else None
 
     if not latest_text:
         return None
@@ -228,6 +237,18 @@ def _extract_recent_assistant_text_from_logs(task_run: Any) -> str | None:
         return None
 
     return latest_text
+
+
+def _extract_text_from_update(update: dict[str, Any]) -> str | None:
+    content = update.get("content")
+    if isinstance(content, dict) and content.get("type") == "text" and isinstance(content.get("text"), str):
+        candidate = content["text"].strip()
+        if candidate:
+            return candidate
+    message = update.get("message")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+    return None
 
 
 def _has_recent_question_tool_failure(task_run: Any) -> bool:

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -49,25 +49,39 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         "get_sandbox_for_repository",
         **ctx.to_log_context(),
     ):
-        with StepTimer("snapshot_lookup") as snapshot_lookup_timer:
-            snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(ctx.github_integration_id, [ctx.repository])
-            used_snapshot = snapshot is not None
-            snapshot_lookup_timer.set_used_snapshot(used_snapshot)
-        increment_snapshot_usage(used_snapshot)
+        has_repo = ctx.repository is not None and ctx.github_integration_id is not None
+        repository: str | None = ctx.repository
+        github_integration_id: int | None = ctx.github_integration_id
+
+        snapshot = None
+        used_snapshot = False
+        if has_repo:
+            assert repository is not None
+            assert github_integration_id is not None
+            with StepTimer("snapshot_lookup") as snapshot_lookup_timer:
+                snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(github_integration_id, [repository])
+                used_snapshot = snapshot is not None
+                snapshot_lookup_timer.set_used_snapshot(used_snapshot)
+            increment_snapshot_usage(used_snapshot)
+        else:
+            emit_agent_log(ctx.run_id, "info", "Creating environment without repository")
 
         try:
             task = Task.objects.select_related("created_by").get(id=ctx.task_id)
         except Task.DoesNotExist as e:
             raise TaskNotFoundError(f"Task {ctx.task_id} not found", {"task_id": ctx.task_id}, cause=e)
 
-        try:
-            github_token = get_github_token(ctx.github_integration_id) or ""
-        except Exception as e:
-            raise GitHubAuthenticationError(
-                f"Failed to get GitHub token for integration {ctx.github_integration_id}",
-                {"github_integration_id": ctx.github_integration_id, "task_id": ctx.task_id, "error": str(e)},
-                cause=e,
-            )
+        github_token = ""
+        if has_repo:
+            assert github_integration_id is not None
+            try:
+                github_token = get_github_token(github_integration_id) or ""
+            except Exception as e:
+                raise GitHubAuthenticationError(
+                    f"Failed to get GitHub token for integration {github_integration_id}",
+                    {"github_integration_id": github_integration_id, "task_id": ctx.task_id, "error": str(e)},
+                    cause=e,
+                )
 
         try:
             access_token = create_oauth_access_token(task)
@@ -79,30 +93,35 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
             )
 
         environment_variables = {
-            "GITHUB_TOKEN": github_token,
             "POSTHOG_PERSONAL_API_KEY": access_token,
             "POSTHOG_API_URL": get_sandbox_api_url(),
             "POSTHOG_PROJECT_ID": str(ctx.team_id),
             "JWT_PUBLIC_KEY": get_sandbox_jwt_public_key(),
         }
 
+        if github_token:
+            environment_variables["GITHUB_TOKEN"] = github_token
+
         if settings.SANDBOX_LLM_GATEWAY_URL:
             environment_variables["LLM_GATEWAY_URL"] = settings.SANDBOX_LLM_GATEWAY_URL
+
+        # Set resume run ID independently of snapshot so conversation history
+        # can be rebuilt from logs even when the filesystem snapshot has expired.
+        resume_from_run_id = (ctx.state or {}).get("resume_from_run_id", "")
+        if resume_from_run_id:
+            environment_variables["POSTHOG_RESUME_RUN_ID"] = resume_from_run_id
 
         # Check for resume snapshot (takes priority over integration-level snapshots)
         resume_snapshot_ext_id = (ctx.state or {}).get("snapshot_external_id")
         if resume_snapshot_ext_id:
             used_snapshot = True
-            resume_from_run_id = (ctx.state or {}).get("resume_from_run_id", "")
-            if resume_from_run_id:
-                environment_variables["POSTHOG_RESUME_RUN_ID"] = resume_from_run_id
 
         if resume_snapshot_ext_id:
-            emit_agent_log(ctx.run_id, "info", f"Resuming environment from snapshot for {ctx.repository}")
-        elif used_snapshot:
-            emit_agent_log(ctx.run_id, "info", f"Found existing environment for {ctx.repository}")
-        else:
-            emit_agent_log(ctx.run_id, "debug", f"Creating environment from base image for {ctx.repository}")
+            emit_agent_log(ctx.run_id, "info", f"Resuming environment from snapshot for {repository}")
+        elif has_repo and used_snapshot:
+            emit_agent_log(ctx.run_id, "info", f"Found existing environment for {repository}")
+        elif has_repo:
+            emit_agent_log(ctx.run_id, "debug", f"Creating environment from base image for {repository}")
 
         config = SandboxConfig(
             name=get_sandbox_name_for_task(ctx.task_id),
@@ -116,17 +135,19 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         with StepTimer("sandbox_creation", used_snapshot=used_snapshot):
             sandbox = Sandbox.create(config)
 
-        if not used_snapshot:
-            emit_agent_log(ctx.run_id, "info", f"Cloning {ctx.repository} into sandbox")
+        if has_repo and not used_snapshot:
+            assert repository is not None
+            emit_agent_log(ctx.run_id, "info", f"Cloning {repository} into sandbox")
             with StepTimer("repository_clone", used_snapshot=used_snapshot):
-                clone_result = sandbox.clone_repository(ctx.repository, github_token=github_token)
+                clone_result = sandbox.clone_repository(repository, github_token=github_token)
             if clone_result.exit_code != 0:
                 sandbox.destroy()
-                raise RuntimeError(f"Failed to clone repository {ctx.repository}: {clone_result.stderr}")
+                raise RuntimeError(f"Failed to clone repository {repository}: {clone_result.stderr}")
 
-        if ctx.branch:
+        if has_repo and ctx.branch:
+            assert repository is not None
             emit_agent_log(ctx.run_id, "info", f"Checking out branch {ctx.branch}")
-            org, repo = ctx.repository.lower().split("/")
+            org, repo = repository.lower().split("/")
             repo_path = f"/tmp/workspace/repos/{org}/{repo}"
 
             # For snapshot-based sandboxes, update the remote URL with the fresh token
@@ -134,7 +155,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
             if used_snapshot and github_token:
                 update_remote = (
                     f"cd {shlex.quote(repo_path)} && "
-                    f"git remote set-url origin https://x-access-token:{shlex.quote(github_token)}@github.com/{shlex.quote(ctx.repository)}.git"
+                    f"git remote set-url origin https://x-access-token:{shlex.quote(github_token)}@github.com/{shlex.quote(repository)}.git"
                 )
                 update_result = sandbox.execute(update_remote, timeout_seconds=30)
                 if update_result.exit_code != 0:

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -27,8 +27,8 @@ class TaskProcessingContext:
     task_id: str
     run_id: str
     team_id: int
-    github_integration_id: int
-    repository: str
+    github_integration_id: int | None
+    repository: str | None
     distinct_id: str
     create_pr: bool = True
     state: dict | None = None
@@ -79,28 +79,6 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
 
     task = task_run.task
 
-    if not task.github_integration_id:
-        raise TaskInvalidStateError(
-            f"Task {task.id} has no GitHub integration",
-            {"task_id": str(task.id), "run_id": run_id},
-            cause=RuntimeError(f"Task {task.id} missing github_integration_id"),
-        )
-
-    if not task.repository:
-        raise TaskInvalidStateError(
-            f"Task {task.id} has no repository configured",
-            {"task_id": str(task.id), "run_id": run_id},
-            cause=RuntimeError(f"Task {task.id} missing repository"),
-        )
-
-    repository_full_name = task.repository
-    if not repository_full_name:
-        raise TaskInvalidStateError(
-            f"Task {task.id} repository missing value",
-            {"task_id": str(task.id), "run_id": run_id},
-            cause=RuntimeError(f"Task {task.id} repository field is empty"),
-        )
-
     if not task.created_by:
         raise TaskInvalidStateError(
             f"Task {task.id} has no created_by user",
@@ -117,7 +95,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         task_id=str(task.id),
         run_id=run_id,
         team_id=task.team_id,
-        repository=repository_full_name,
+        repository=task.repository,
         distinct_id=distinct_id,
     )
 
@@ -126,7 +104,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         run_id=run_id,
         team_id=task.team_id,
         github_integration_id=task.github_integration_id,
-        repository=repository_full_name,
+        repository=task.repository,
         distinct_id=distinct_id,
         create_pr=input.create_pr,
         state=task_run.state,

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import time
 import asyncio
 from dataclasses import dataclass
 
 import httpx
 import httpx_sse
 import structlog
+import temporalio.client
 from temporalio import activity
 
 from products.tasks.backend.models import TaskRun as TaskRunModel
@@ -79,6 +81,7 @@ async def relay_sandbox_events(input: RelaySandboxEventsInput) -> None:
             params=params,
             redis_stream=redis_stream,
             run_id=input.run_id,
+            task_id=input.task_id,
         )
     except asyncio.CancelledError:
         logger.info("relay_sandbox_events_cancelled", run_id=input.run_id)
@@ -90,14 +93,41 @@ async def relay_sandbox_events(input: RelaySandboxEventsInput) -> None:
         raise
 
 
-async def _background_heartbeat(stop_event: asyncio.Event) -> None:
-    """Heartbeat to Temporal periodically, independent of event flow."""
+async def _background_heartbeat(
+    stop_event: asyncio.Event,
+    workflow_handle: temporalio.client.WorkflowHandle | None = None,
+    last_event_time: list[float] | None = None,
+    last_workflow_signal: list[float] | None = None,
+) -> None:
+    """Heartbeat to Temporal periodically, independent of event flow.
+
+    Also signals the workflow heartbeat when events have been received
+    recently and the inline mechanism hasn't signaled recently, preventing
+    the inactivity timeout from firing while the agent is actively working.
+    """
     while not stop_event.is_set():
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=HEARTBEAT_INTERVAL_SECONDS)
             return  # stop_event was set
         except TimeoutError:
             activity.heartbeat()
+            # Lazy import to avoid circular dependency (workflow imports this module)
+            from products.tasks.backend.temporal.process_task.workflow import INACTIVITY_TIMEOUT_MINUTES
+
+            now = time.monotonic()
+            if (
+                workflow_handle is not None
+                and last_event_time is not None
+                and last_event_time[0] > 0
+                and (now - last_event_time[0]) < INACTIVITY_TIMEOUT_MINUTES * 60
+                and (last_workflow_signal is None or (now - last_workflow_signal[0]) >= HEARTBEAT_INTERVAL_SECONDS)
+            ):
+                if last_workflow_signal is not None:
+                    last_workflow_signal[0] = now
+                try:
+                    await workflow_handle.signal("heartbeat")
+                except Exception as e:
+                    logger.warning("relay_workflow_heartbeat_signal_failed", error=str(e))
 
 
 async def _relay_loop(
@@ -107,12 +137,32 @@ async def _relay_loop(
     params: dict[str, str],
     redis_stream: TaskRunRedisStream,
     run_id: str,
+    task_id: str,
 ) -> None:
     """Connect to sandbox SSE and relay events to Redis. Reconnects on transient failures."""
     reconnect_count = 0
 
+    # Get a workflow handle so we can signal the workflow's heartbeat handler,
+    # keeping its inactivity timeout from firing while the relay is active.
+    workflow_handle: temporalio.client.WorkflowHandle | None = None
+    try:
+        from posthog.temporal.common.client import async_connect
+
+        temporal_client = await async_connect()
+        workflow_id = TaskRunModel.get_workflow_id(task_id, run_id)
+        workflow_handle = temporal_client.get_workflow_handle(workflow_id)
+    except Exception as e:
+        logger.warning("relay_workflow_handle_init_failed", run_id=run_id, error=str(e))
+
+    # Shared mutable state: last time we received an SSE event (monotonic clock).
+    # The background heartbeat reads this to decide whether the agent is active.
+    last_event_time: list[float] = [0.0]  # list used as mutable container
+    last_workflow_signal: list[float] = [0.0]  # shared with background heartbeat
+
     stop_heartbeat = asyncio.Event()
-    heartbeat_task = asyncio.create_task(_background_heartbeat(stop_heartbeat))
+    heartbeat_task = asyncio.create_task(
+        _background_heartbeat(stop_heartbeat, workflow_handle, last_event_time, last_workflow_signal)
+    )
 
     try:
         while reconnect_count <= MAX_RECONNECT_ATTEMPTS:
@@ -134,6 +184,7 @@ async def _relay_loop(
                     ) as event_source:
                         event_source.response.raise_for_status()
                         reconnect_count = 0  # Reset on successful connection
+                        last_event_time[0] = time.monotonic()
 
                         async for sse_event in event_source.aiter_sse():
                             if not sse_event.data:
@@ -150,6 +201,20 @@ async def _relay_loop(
                                 continue
 
                             await redis_stream.write_event(event_data)
+                            last_event_time[0] = time.monotonic()
+
+                            now = time.monotonic()
+                            if (
+                                workflow_handle is not None
+                                and (now - last_workflow_signal[0]) >= HEARTBEAT_INTERVAL_SECONDS
+                            ):
+                                last_workflow_signal[0] = now
+                                try:
+                                    await workflow_handle.signal("heartbeat")
+                                except Exception as e:
+                                    logger.warning(
+                                        "relay_workflow_heartbeat_signal_failed", run_id=run_id, error=str(e)
+                                    )
 
                             if _is_terminal_event(event_data):
                                 await redis_stream.mark_complete()

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -116,7 +116,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             sandbox_id = sandbox_output.sandbox_id
 
             # TODO(tasks): Re-enable snapshot creation
-            # if sandbox_output.should_create_snapshot:
+            # if sandbox_output.should_create_snapshot and self.context.repository and self.context.github_integration_id:
             #     await self._trigger_snapshot_workflow()
 
             await self._post_slack_update()
@@ -374,16 +374,19 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             workflow.logger.warning(f"Resume snapshot failed (non-fatal): {e}")
 
     async def _trigger_snapshot_workflow(self) -> None:
-        workflow_id = (
-            f"create-snapshot-for-repository-{self.context.github_integration_id}-"
-            f"{self.context.repository.replace('/', '-')}"
-        )
+        github_integration_id = self.context.github_integration_id
+        repository = self.context.repository
+        if github_integration_id is None or repository is None:
+            workflow.logger.info("Skipping snapshot workflow — no repository configured")
+            return
+
+        workflow_id = f"create-snapshot-for-repository-{github_integration_id}-{repository.replace('/', '-')}"
 
         await workflow.start_child_workflow(
             workflow="create-snapshot-for-repository",
             arg=CreateSnapshotForRepositoryInput(
-                github_integration_id=self.context.github_integration_id,
-                repository=self.context.repository,
+                github_integration_id=github_integration_id,
+                repository=repository,
                 team_id=self.context.team_id,
             ),
             id=workflow_id,

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -551,7 +551,7 @@ class TestTaskRun(TestCase):
         [
             ("background_mode", {"mode": "background"}, True),
             ("default_mode_is_background", {}, True),
-            ("interactive_mode_skips", {"mode": "interactive"}, False),
+            ("interactive_mode", {"mode": "interactive"}, True),
         ]
     )
     @patch("posthog.temporal.common.client.sync_connect")


### PR DESCRIPTION
## Problem

When a Slack user mentions our bot in a workspace without a GH integration (or when the task doesn't need a repository), the agent fails because it cannot find a repo to clone. Additionally, follow-up replies from the agent were being extracted client-side by polling logs, which was unreliable and produced  (also) timeout errors.

## Changes

- "no-repo flow" for Slack mentions
- removes the fragile log-polling path and timeout error messages
- support bulk rule removal (`rules remove 1,2`) and exclude rule commands from being misdetected as follow-up messages
- add workflow heartbeat signaling in `relay_sandbox_events` to prevent inactivity timeout during long-running tasks.