### PR TITLE
feat(replay): add triggers v2 to config

### DIFF
--- a/frontend/src/lib/components/IngestionControls/types.ts
+++ b/frontend/src/lib/components/IngestionControls/types.ts
@@ -73,3 +73,24 @@ export interface ErrorTrackingAutoCaptureControls {
     url_triggers: UrlTriggerConfig[]
     url_blocklist: UrlTriggerConfig[]
 }
+
+// V2: Session Recording Trigger Groups
+export interface SessionRecordingTriggerGroup {
+    id: string
+    name: string
+    sampleRate: number // 0-1
+    minDurationMs?: number // 0-30000
+    conditions: SessionRecordingTriggerConditions
+}
+
+export interface SessionRecordingTriggerConditions {
+    matchType: 'any' | 'all'
+    events?: string[]
+    urls?: UrlTriggerConfig[]
+    flag?: string | LinkedFeatureFlag | null
+}
+
+export interface SessionRecordingTriggerGroupsConfig {
+    version: 2
+    groups: SessionRecordingTriggerGroup[]
+}

--- a/frontend/src/lib/components/IngestionControls/types.ts
+++ b/frontend/src/lib/components/IngestionControls/types.ts
@@ -77,7 +77,7 @@ export interface ErrorTrackingAutoCaptureControls {
 // V2: Session Recording Trigger Groups
 export interface SessionRecordingTriggerGroup {
     id: string
-    name: string
+    name?: string
     sampleRate: number // 0-1
     minDurationMs?: number // 0-30000
     conditions: SessionRecordingTriggerConditions

--- a/posthog/api/test/__snapshots__/test_remote_config.ambr
+++ b/posthog/api/test/__snapshots__/test_remote_config.ambr
@@ -1,6 +1,6 @@
 # serializer version: 1
 # name: TestRemoteConfig.test_valid_array_js
-  b'[MOCKED_ARRAY_JS_CONTENT]\n\n(function() {\n  window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};\n  window._POSTHOG_REMOTE_CONFIG[\'token123\'] = {\n    config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "token123"},\n    siteApps: []\n  }\n})();'
+  b'[MOCKED_ARRAY_JS_CONTENT]\n\n(function() {\n  window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};\n  window._POSTHOG_REMOTE_CONFIG[\'token123\'] = {\n    config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "token123"},\n    siteApps: []\n  }\n})();'
 # ---
 # name: TestRemoteConfig.test_valid_config
   dict({
@@ -30,6 +30,8 @@
     }),
     'productTours': False,
     'sessionRecording': dict({
+      'canvasFps': None,
+      'canvasQuality': None,
       'consoleLogRecordingEnabled': True,
       'endpoint': '/s/',
       'eventTriggers': list([
@@ -38,6 +40,7 @@
       'masking': None,
       'minimumDurationMilliseconds': None,
       'networkPayloadCapture': None,
+      'recordCanvas': False,
       'recorderVersion': 'v2',
       'sampleRate': None,
       'scriptConfig': dict({
@@ -48,6 +51,7 @@
       ]),
       'urlTriggers': list([
       ]),
+      'version': 1,
     }),
     'siteApps': list([
     ]),
@@ -60,5 +64,5 @@
   })
 # ---
 # name: TestRemoteConfig.test_valid_config_js
-  b'(function() {\n  window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};\n  window._POSTHOG_REMOTE_CONFIG[\'token123\'] = {\n    config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "token123"},\n    siteApps: []\n  }\n})();'
+  b'(function() {\n  window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};\n  window._POSTHOG_REMOTE_CONFIG[\'token123\'] = {\n    config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "token123"},\n    siteApps: []\n  }\n})();'
 # ---

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -138,3 +138,132 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
                 f"/array/{self.team.api_token}/array.js", headers={"origin": "https://foo.example.com"}
             )
         assert response.status_code == status.HTTP_200_OK
+
+    def test_session_recording_v1_config(self):
+        """Test that legacy session recording config returns v1 format"""
+        self.team.session_recording_sample_rate = 0.5
+        self.team.session_recording_event_trigger_config = ["pageview", "click"]
+        self.team.session_recording_url_trigger_config = [{"url": "/checkout", "matching": "regex"}]
+        self.team.session_recording_trigger_match_type_config = "any"
+        self.team.session_recording_trigger_groups = None  # No v2 config
+        self.team.save()
+
+        from posthog.models.remote_config import RemoteConfig
+        from posthog.tasks.remote_config import update_team_remote_config
+
+        update_team_remote_config(self.team.id)
+        RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
+
+        response = self.client.get(f"/array/{self.team.api_token}/config")
+        assert response.status_code == status.HTTP_200_OK
+
+        config = response.json()
+        assert config["sessionRecording"]["version"] == 1
+        assert config["sessionRecording"]["sampleRate"] == "0.5"
+        assert config["sessionRecording"]["eventTriggers"] == ["pageview", "click"]
+        assert config["sessionRecording"]["urlTriggers"] == [{"url": "/checkout", "matching": "regex"}]
+        assert config["sessionRecording"]["triggerMatchType"] == "any"
+        # V1 fields should be present
+        assert "sampleRate" in config["sessionRecording"]
+        assert "eventTriggers" in config["sessionRecording"]
+        # V2 fields should NOT be present
+        assert "triggerGroups" not in config["sessionRecording"]
+        assert "groupEvaluationMode" not in config["sessionRecording"]
+
+    def test_session_recording_v2_config(self):
+        """Test that trigger groups config returns v2 format"""
+        self.team.session_recording_trigger_groups = {
+            "version": 2,
+            "groups": [
+                {
+                    "id": "errors",
+                    "name": "Error Tracking",
+                    "sampleRate": 1.0,
+                    "order": 0,
+                    "conditions": {
+                        "matchType": "any",
+                        "events": ["error", "crash"],
+                        "urls": [{"url": "/checkout.*", "matching": "regex"}],
+                    },
+                },
+                {
+                    "id": "feature-test",
+                    "sampleRate": 0.5,
+                    "order": 1,
+                    "conditions": {
+                        "matchType": "all",
+                        "flags": ["new-feature"],
+                    },
+                },
+            ],
+            "groupEvaluationMode": "first_match",
+            "fallbackSampleRate": 0.01,
+        }
+        # Clear legacy fields to ensure v2 is used
+        self.team.session_recording_sample_rate = None
+        self.team.session_recording_event_trigger_config = []
+        self.team.save()
+
+        from posthog.models.remote_config import RemoteConfig
+        from posthog.tasks.remote_config import update_team_remote_config
+
+        update_team_remote_config(self.team.id)
+        RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
+
+        response = self.client.get(f"/array/{self.team.api_token}/config")
+        assert response.status_code == status.HTTP_200_OK
+
+        config = response.json()
+        assert config["sessionRecording"]["version"] == 2
+        assert len(config["sessionRecording"]["triggerGroups"]) == 2
+        assert config["sessionRecording"]["triggerGroups"][0]["id"] == "errors"
+        assert config["sessionRecording"]["triggerGroups"][0]["sampleRate"] == 1.0
+        assert config["sessionRecording"]["triggerGroups"][1]["id"] == "feature-test"
+        assert config["sessionRecording"]["groupEvaluationMode"] == "first_match"
+        assert config["sessionRecording"]["fallbackSampleRate"] == 0.01
+        # V2 fields should be present
+        assert "triggerGroups" in config["sessionRecording"]
+        assert "groupEvaluationMode" in config["sessionRecording"]
+        # V1 fields should NOT be present
+        assert "sampleRate" not in config["sessionRecording"]
+        assert "eventTriggers" not in config["sessionRecording"]
+        assert "linkedFlag" not in config["sessionRecording"]
+        assert "triggerMatchType" not in config["sessionRecording"]
+
+    def test_session_recording_url_blocklist_in_both_versions(self):
+        """Test that URL blocklist is included in both v1 and v2 configs"""
+        url_blocklist = [{"url": "/admin.*", "matching": "regex"}, {"url": "/internal.*", "matching": "regex"}]
+        self.team.session_recording_url_blocklist_config = url_blocklist
+
+        # Test V1 (legacy)
+        self.team.session_recording_sample_rate = 0.5
+        self.team.session_recording_trigger_groups = None
+        self.team.save()
+
+        from posthog.models.remote_config import RemoteConfig
+        from posthog.tasks.remote_config import update_team_remote_config
+
+        update_team_remote_config(self.team.id)
+        RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
+
+        response = self.client.get(f"/array/{self.team.api_token}/config")
+        assert response.status_code == status.HTTP_200_OK
+        config_v1 = response.json()
+        assert config_v1["sessionRecording"]["version"] == 1
+        assert config_v1["sessionRecording"]["urlBlocklist"] == url_blocklist
+
+        # Test V2 (trigger groups)
+        self.team.session_recording_trigger_groups = {
+            "version": 2,
+            "groups": [{"id": "test", "sampleRate": 0.5, "order": 0, "conditions": {"matchType": "any"}}],
+        }
+        self.team.save()
+
+        update_team_remote_config(self.team.id)
+        RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
+
+        response = self.client.get(f"/array/{self.team.api_token}/config")
+        assert response.status_code == status.HTTP_200_OK
+        config_v2 = response.json()
+        assert config_v2["sessionRecording"]["version"] == 2
+        assert config_v2["sessionRecording"]["urlBlocklist"] == url_blocklist

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -179,7 +179,7 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
                     "id": "errors",
                     "name": "Error Tracking",
                     "sampleRate": 1.0,
-                    "order": 0,
+                    "minDurationMs": 0,
                     "conditions": {
                         "matchType": "any",
                         "events": ["error", "crash"],
@@ -189,15 +189,13 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
                 {
                     "id": "feature-test",
                     "sampleRate": 0.5,
-                    "order": 1,
+                    "minDurationMs": 10000,
                     "conditions": {
                         "matchType": "all",
-                        "flags": ["new-feature"],
+                        "flag": "new-feature",
                     },
                 },
             ],
-            "groupEvaluationMode": "first_match",
-            "fallbackSampleRate": 0.01,
         }
         # Clear legacy fields to ensure v2 is used
         self.team.session_recording_sample_rate = None
@@ -218,12 +216,14 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         assert len(config["sessionRecording"]["triggerGroups"]) == 2
         assert config["sessionRecording"]["triggerGroups"][0]["id"] == "errors"
         assert config["sessionRecording"]["triggerGroups"][0]["sampleRate"] == 1.0
+        assert config["sessionRecording"]["triggerGroups"][0]["minDurationMs"] == 0
         assert config["sessionRecording"]["triggerGroups"][1]["id"] == "feature-test"
-        assert config["sessionRecording"]["groupEvaluationMode"] == "first_match"
-        assert config["sessionRecording"]["fallbackSampleRate"] == 0.01
+        assert config["sessionRecording"]["triggerGroups"][1]["minDurationMs"] == 10000
         # V2 fields should be present
         assert "triggerGroups" in config["sessionRecording"]
-        assert "groupEvaluationMode" in config["sessionRecording"]
+        # Removed fields should NOT be present
+        assert "groupEvaluationMode" not in config["sessionRecording"]
+        assert "fallbackSampleRate" not in config["sessionRecording"]
         # V1 fields should NOT be present
         assert "sampleRate" not in config["sessionRecording"]
         assert "eventTriggers" not in config["sessionRecording"]

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -1,6 +1,9 @@
+from decimal import Decimal
+
 from posthog.test.base import APIBaseTest, FuzzyInt, QueryMatchingTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 # The remote config stuff plus plugin and hog function queries
@@ -142,7 +145,7 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
     def test_session_recording_v1_config(self):
         """Test that legacy session recording config returns v1 format"""
         self.team.session_recording_opt_in = True
-        self.team.session_recording_sample_rate = 0.5
+        self.team.session_recording_sample_rate = Decimal("0.5")
         self.team.session_recording_event_trigger_config = ["pageview", "click"]
         self.team.session_recording_url_trigger_config = [{"url": "/checkout", "matching": "regex"}]
         self.team.session_recording_trigger_match_type_config = "any"
@@ -155,7 +158,9 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         update_team_remote_config(self.team.id)
         RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
 
-        response = self.client.get(f"/array/{self.team.api_token}/config")
+        response = self.client.get(
+            f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+        )
         assert response.status_code == status.HTTP_200_OK
 
         config = response.json()
@@ -200,7 +205,7 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
             ],
         }
         # Set V1 fields for backward compatibility fallback
-        self.team.session_recording_sample_rate = 0.1
+        self.team.session_recording_sample_rate = Decimal("0.1")
         self.team.session_recording_event_trigger_config = []
         self.team.session_recording_url_trigger_config = []
         self.team.session_recording_trigger_match_type_config = None
@@ -212,7 +217,9 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         update_team_remote_config(self.team.id)
         RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
 
-        response = self.client.get(f"/array/{self.team.api_token}/config")
+        response = self.client.get(
+            f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+        )
         assert response.status_code == status.HTTP_200_OK
 
         config = response.json()
@@ -235,15 +242,24 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         assert config["sessionRecording"]["urlTriggers"] == []
         assert config["sessionRecording"]["triggerMatchType"] is None
 
-    def test_session_recording_url_blocklist_in_both_versions(self):
+    @parameterized.expand(
+        [
+            ("v1_no_trigger_groups", None, 1),
+            (
+                "v2_with_trigger_groups",
+                {"version": 2, "groups": [{"id": "test", "sampleRate": 0.5, "conditions": {"matchType": "any"}}]},
+                2,
+            ),
+        ],
+    )
+    def test_session_recording_url_blocklist_in_both_versions(self, _name, trigger_groups_config, expected_version):
         """Test that URL blocklist is included in both v1 and v2 configs"""
         url_blocklist = [{"url": "/admin.*", "matching": "regex"}, {"url": "/internal.*", "matching": "regex"}]
-        self.team.session_recording_url_blocklist_config = url_blocklist
 
-        # Test V1 (legacy)
         self.team.session_recording_opt_in = True
-        self.team.session_recording_sample_rate = 0.5
-        self.team.session_recording_trigger_groups = None
+        self.team.session_recording_sample_rate = Decimal("0.5")
+        self.team.session_recording_url_blocklist_config = url_blocklist
+        self.team.session_recording_trigger_groups = trigger_groups_config
         self.team.save()
 
         from posthog.models.remote_config import RemoteConfig
@@ -252,24 +268,11 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         update_team_remote_config(self.team.id)
         RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
 
-        response = self.client.get(f"/array/{self.team.api_token}/config")
+        response = self.client.get(
+            f"/array/{self.team.api_token}/config", headers={"origin": "https://foo.example.com"}
+        )
         assert response.status_code == status.HTTP_200_OK
-        config_v1 = response.json()
-        assert config_v1["sessionRecording"]["version"] == 1
-        assert config_v1["sessionRecording"]["urlBlocklist"] == url_blocklist
 
-        # Test V2 (trigger groups)
-        self.team.session_recording_trigger_groups = {
-            "version": 2,
-            "groups": [{"id": "test", "sampleRate": 0.5, "conditions": {"matchType": "any"}}],
-        }
-        self.team.save()
-
-        update_team_remote_config(self.team.id)
-        RemoteConfig.get_hypercache().clear_cache(self.team.api_token)
-
-        response = self.client.get(f"/array/{self.team.api_token}/config")
-        assert response.status_code == status.HTTP_200_OK
-        config_v2 = response.json()
-        assert config_v2["sessionRecording"]["version"] == 2
-        assert config_v2["sessionRecording"]["urlBlocklist"] == url_blocklist
+        config = response.json()
+        assert config["sessionRecording"]["version"] == expected_version
+        assert config["sessionRecording"]["urlBlocklist"] == url_blocklist

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -141,6 +141,7 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
 
     def test_session_recording_v1_config(self):
         """Test that legacy session recording config returns v1 format"""
+        self.team.session_recording_opt_in = True
         self.team.session_recording_sample_rate = 0.5
         self.team.session_recording_event_trigger_config = ["pageview", "click"]
         self.team.session_recording_url_trigger_config = [{"url": "/checkout", "matching": "regex"}]
@@ -172,6 +173,7 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
 
     def test_session_recording_v2_config(self):
         """Test that trigger groups config returns v2 format"""
+        self.team.session_recording_opt_in = True
         self.team.session_recording_trigger_groups = {
             "version": 2,
             "groups": [
@@ -197,9 +199,11 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
                 },
             ],
         }
-        # Clear legacy fields to ensure v2 is used
-        self.team.session_recording_sample_rate = None
+        # Set V1 fields for backward compatibility fallback
+        self.team.session_recording_sample_rate = 0.1
         self.team.session_recording_event_trigger_config = []
+        self.team.session_recording_url_trigger_config = []
+        self.team.session_recording_trigger_match_type_config = None
         self.team.save()
 
         from posthog.models.remote_config import RemoteConfig
@@ -224,11 +228,12 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         # Removed fields should NOT be present
         assert "groupEvaluationMode" not in config["sessionRecording"]
         assert "fallbackSampleRate" not in config["sessionRecording"]
-        # V1 fields should NOT be present
-        assert "sampleRate" not in config["sessionRecording"]
-        assert "eventTriggers" not in config["sessionRecording"]
-        assert "linkedFlag" not in config["sessionRecording"]
-        assert "triggerMatchType" not in config["sessionRecording"]
+        # V1 fields SHOULD be present for backward compatibility with old SDKs
+        assert config["sessionRecording"]["sampleRate"] == "0.1"
+        assert config["sessionRecording"]["eventTriggers"] == []
+        assert config["sessionRecording"]["linkedFlag"] is None
+        assert config["sessionRecording"]["urlTriggers"] == []
+        assert config["sessionRecording"]["triggerMatchType"] is None
 
     def test_session_recording_url_blocklist_in_both_versions(self):
         """Test that URL blocklist is included in both v1 and v2 configs"""
@@ -236,6 +241,7 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         self.team.session_recording_url_blocklist_config = url_blocklist
 
         # Test V1 (legacy)
+        self.team.session_recording_opt_in = True
         self.team.session_recording_sample_rate = 0.5
         self.team.session_recording_trigger_groups = None
         self.team.save()
@@ -255,7 +261,7 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
         # Test V2 (trigger groups)
         self.team.session_recording_trigger_groups = {
             "version": 2,
-            "groups": [{"id": "test", "sampleRate": 0.5, "order": 0, "conditions": {"matchType": "any"}}],
+            "groups": [{"id": "test", "sampleRate": 0.5, "conditions": {"matchType": "any"}}],
         }
         self.team.save()
 

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -169,8 +169,6 @@ class RemoteConfig(UUIDTModel):
                 **base_config,
                 "version": 2,
                 "triggerGroups": trigger_groups_config.get("groups", []),
-                "groupEvaluationMode": trigger_groups_config.get("groupEvaluationMode", "first_match"),
-                "fallbackSampleRate": trigger_groups_config.get("fallbackSampleRate"),
             }
 
         # V1: Use legacy trigger fields (backward compatible)

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -164,9 +164,11 @@ class RemoteConfig(UUIDTModel):
 
         # Build V1 fields (for backward compatibility with old SDKs)
         sample_rate = (
-            str(team.session_recording_sample_rate) if team.session_recording_sample_rate is not None else None
+            str(team.session_recording_sample_rate.normalize())
+            if team.session_recording_sample_rate is not None
+            else None
         )
-        if sample_rate == "1.00":
+        if sample_rate == "1":
             sample_rate = None
 
         linked_flag = None

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -162,16 +162,7 @@ class RemoteConfig(UUIDTModel):
             "canvasQuality": canvas_quality,
         }
 
-        # V2: Check for trigger groups configuration
-        if team.session_recording_trigger_groups:
-            trigger_groups_config = team.session_recording_trigger_groups
-            return {
-                **base_config,
-                "version": 2,
-                "triggerGroups": trigger_groups_config.get("groups", []),
-            }
-
-        # V1: Use legacy trigger fields (backward compatible)
+        # Build V1 fields (for backward compatibility with old SDKs)
         sample_rate = (
             str(team.session_recording_sample_rate) if team.session_recording_sample_rate is not None else None
         )
@@ -188,14 +179,30 @@ class RemoteConfig(UUIDTModel):
             else:
                 linked_flag = linked_flag_key
 
-        return {
-            **base_config,
-            "version": 1,
+        v1_fields = {
             "sampleRate": sample_rate,
             "linkedFlag": linked_flag,
             "urlTriggers": team.session_recording_url_trigger_config,
             "eventTriggers": team.session_recording_event_trigger_config,
             "triggerMatchType": team.session_recording_trigger_match_type_config,
+        }
+
+        # V2: If trigger groups configured, send V2 + V1 fallback fields
+        if team.session_recording_trigger_groups:
+            trigger_groups_config = team.session_recording_trigger_groups
+            return {
+                **base_config,
+                "version": 2,
+                "triggerGroups": trigger_groups_config.get("groups", []),
+                # Include V1 fields for backward compatibility with old SDKs
+                **v1_fields,
+            }
+
+        # V1 only: Use legacy trigger fields
+        return {
+            **base_config,
+            "version": 1,
+            **v1_fields,
         }
 
     @tracer.start_as_current_span("RemoteConfig.build_config")

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -120,6 +120,86 @@ class RemoteConfig(UUIDTModel):
             load_fn=load_config,
         )
 
+    def _build_session_recording_config(self, team: Team) -> dict:
+        """
+        Build session recording configuration with V1/V2 support.
+
+        V2: If team.session_recording_trigger_groups is set, use new trigger groups format
+        V1: Otherwise, use legacy trigger fields for backward compatibility
+        """
+        # Build base config (common to both V1 and V2)
+        capture_console_logs = True if team.capture_console_log_opt_in else False
+        minimum_duration = team.session_recording_minimum_duration_milliseconds or None
+
+        rrweb_script_config = None
+        recorder_script = team.extra_settings.get("recorder_script") if team.extra_settings else None
+        if not recorder_script and settings.DEBUG:
+            recorder_script = "posthog-recorder"
+        if recorder_script:
+            rrweb_script_config = {"script": recorder_script}
+
+        record_canvas = False
+        canvas_fps = None
+        canvas_quality = None
+        if isinstance(team.session_replay_config, dict):
+            record_canvas = team.session_replay_config.get("record_canvas", False)
+            if record_canvas:
+                canvas_fps = 3
+                canvas_quality = "0.4"
+
+        base_config = {
+            "endpoint": "/s/",
+            "consoleLogRecordingEnabled": capture_console_logs,
+            "recorderVersion": "v2",
+            "minimumDurationMilliseconds": minimum_duration,
+            "networkPayloadCapture": team.session_recording_network_payload_capture_config or None,
+            "masking": team.session_recording_masking_config or None,
+            "urlBlocklist": team.session_recording_url_blocklist_config,
+            "scriptConfig": rrweb_script_config,
+            "domains": team.recording_domains or [],
+            "recordCanvas": record_canvas,
+            "canvasFps": canvas_fps,
+            "canvasQuality": canvas_quality,
+        }
+
+        # V2: Check for trigger groups configuration
+        if team.session_recording_trigger_groups:
+            trigger_groups_config = team.session_recording_trigger_groups
+            return {
+                **base_config,
+                "version": 2,
+                "triggerGroups": trigger_groups_config.get("groups", []),
+                "groupEvaluationMode": trigger_groups_config.get("groupEvaluationMode", "first_match"),
+                "fallbackSampleRate": trigger_groups_config.get("fallbackSampleRate"),
+            }
+
+        # V1: Use legacy trigger fields (backward compatible)
+        sample_rate = (
+            str(team.session_recording_sample_rate) if team.session_recording_sample_rate is not None else None
+        )
+        if sample_rate == "1.00":
+            sample_rate = None
+
+        linked_flag = None
+        linked_flag_config = team.session_recording_linked_flag or None
+        if isinstance(linked_flag_config, dict):
+            linked_flag_key = linked_flag_config.get("key", None)
+            linked_flag_variant = linked_flag_config.get("variant", None)
+            if linked_flag_variant is not None:
+                linked_flag = {"flag": linked_flag_key, "variant": linked_flag_variant}
+            else:
+                linked_flag = linked_flag_key
+
+        return {
+            **base_config,
+            "version": 1,
+            "sampleRate": sample_rate,
+            "linkedFlag": linked_flag,
+            "urlTriggers": team.session_recording_url_trigger_config,
+            "eventTriggers": team.session_recording_event_trigger_config,
+            "triggerMatchType": team.session_recording_trigger_match_type_config,
+        }
+
     @tracer.start_as_current_span("RemoteConfig.build_config")
     def build_config(self):
         from posthog.models.feature_flag import FeatureFlag
@@ -174,64 +254,7 @@ class RemoteConfig(UUIDTModel):
 
         # TODO: Support the domain based check for recordings (maybe do it client side)?
         if team.session_recording_opt_in:
-            capture_console_logs = True if team.capture_console_log_opt_in else False
-            sample_rate = (
-                str(team.session_recording_sample_rate) if team.session_recording_sample_rate is not None else None
-            )
-
-            if sample_rate == "1.00":
-                sample_rate = None
-
-            minimum_duration = team.session_recording_minimum_duration_milliseconds or None
-
-            linked_flag = None
-            linked_flag_config = team.session_recording_linked_flag or None
-            if isinstance(linked_flag_config, dict):
-                linked_flag_key = linked_flag_config.get("key", None)
-                linked_flag_variant = linked_flag_config.get("variant", None)
-                if linked_flag_variant is not None:
-                    linked_flag = {"flag": linked_flag_key, "variant": linked_flag_variant}
-                else:
-                    linked_flag = linked_flag_key
-
-            rrweb_script_config = None
-
-            recorder_script = team.extra_settings.get("recorder_script") if team.extra_settings else None
-            if not recorder_script and settings.DEBUG:
-                recorder_script = "posthog-recorder"
-            if recorder_script:
-                rrweb_script_config = {
-                    "script": recorder_script,
-                }
-
-            session_recording_config_response = {
-                "endpoint": "/s/",
-                "consoleLogRecordingEnabled": capture_console_logs,
-                "recorderVersion": "v2",
-                "sampleRate": sample_rate,
-                "minimumDurationMilliseconds": minimum_duration,
-                "linkedFlag": linked_flag,
-                "networkPayloadCapture": team.session_recording_network_payload_capture_config or None,
-                "masking": team.session_recording_masking_config or None,
-                "urlTriggers": team.session_recording_url_trigger_config,
-                "urlBlocklist": team.session_recording_url_blocklist_config,
-                "eventTriggers": team.session_recording_event_trigger_config,
-                "triggerMatchType": team.session_recording_trigger_match_type_config,
-                "scriptConfig": rrweb_script_config,
-                # NOTE: This is cached but stripped out at the api level depending on the caller
-                "domains": team.recording_domains or [],
-            }
-
-            if isinstance(team.session_replay_config, dict):
-                record_canvas = team.session_replay_config.get("record_canvas", False)
-                session_recording_config_response.update(
-                    {
-                        "recordCanvas": record_canvas,
-                        # hard coded during beta while we decide on sensible values
-                        "canvasFps": 3 if record_canvas else None,
-                        "canvasQuality": "0.4" if record_canvas else None,
-                    }
-                )
+            session_recording_config_response = self._build_session_recording_config(team)
 
         config["sessionRecording"] = session_recording_config_response
 

--- a/posthog/models/test/__snapshots__/test_remote_config.ambr
+++ b/posthog/models/test/__snapshots__/test_remote_config.ambr
@@ -27,6 +27,8 @@
     }),
     'productTours': False,
     'sessionRecording': dict({
+      'canvasFps': None,
+      'canvasQuality': None,
       'consoleLogRecordingEnabled': True,
       'domains': list([
         'https://*.example.com',
@@ -38,6 +40,7 @@
       'masking': None,
       'minimumDurationMilliseconds': None,
       'networkPayloadCapture': None,
+      'recordCanvas': False,
       'recorderVersion': 'v2',
       'sampleRate': None,
       'scriptConfig': dict({
@@ -48,6 +51,7 @@
       ]),
       'urlTriggers': list([
       ]),
+      'version': 1,
     }),
     'siteApps': list([
     ]),

--- a/posthog/models/test/__snapshots__/test_remote_config.ambr
+++ b/posthog/models/test/__snapshots__/test_remote_config.ambr
@@ -72,7 +72,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"token": "phc_12345", "supportedCompression": ["gzip", "gzip-js"], "hasFeatureFlags": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "autocapture_opt_out": false, "autocaptureExceptions": false, "analytics": {"endpoint": "/i/v0/e/"}, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "logs": {"captureConsoleLogs": false}, "sessionRecording": {"endpoint": "/s/", "consoleLogRecordingEnabled": true, "recorderVersion": "v2", "sampleRate": null, "minimumDurationMilliseconds": null, "linkedFlag": null, "networkPayloadCapture": null, "masking": null, "urlTriggers": [], "urlBlocklist": [], "eventTriggers": [], "triggerMatchType": null, "scriptConfig": {"script": "posthog-recorder"}}, "heatmaps": false, "conversations": false, "surveys": false, "productTours": false, "defaultIdentifiedOnly": true},
+      config: {"token": "phc_12345", "supportedCompression": ["gzip", "gzip-js"], "hasFeatureFlags": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "autocapture_opt_out": false, "autocaptureExceptions": false, "analytics": {"endpoint": "/i/v0/e/"}, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "logs": {"captureConsoleLogs": false}, "sessionRecording": {"endpoint": "/s/", "consoleLogRecordingEnabled": true, "recorderVersion": "v2", "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "masking": null, "urlBlocklist": [], "scriptConfig": {"script": "posthog-recorder"}, "recordCanvas": false, "canvasFps": null, "canvasQuality": null, "version": 1, "sampleRate": null, "linkedFlag": null, "urlTriggers": [], "eventTriggers": [], "triggerMatchType": null}, "heatmaps": false, "conversations": false, "surveys": false, "productTours": false, "defaultIdentifiedOnly": true},
       siteApps: []
     }
   })();
@@ -85,7 +85,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
+      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
       siteApps: []
     }
   })();
@@ -96,7 +96,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
+      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
       siteApps: []
     }
   })();
@@ -107,7 +107,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"token": "phc_12345", "supportedCompression": ["gzip", "gzip-js"], "hasFeatureFlags": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "autocapture_opt_out": false, "autocaptureExceptions": false, "analytics": {"endpoint": "/i/v0/e/"}, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "logs": {"captureConsoleLogs": false}, "sessionRecording": {"endpoint": "/s/", "consoleLogRecordingEnabled": true, "recorderVersion": "v2", "sampleRate": null, "minimumDurationMilliseconds": null, "linkedFlag": null, "networkPayloadCapture": null, "masking": null, "urlTriggers": [], "urlBlocklist": [], "eventTriggers": [], "triggerMatchType": null, "scriptConfig": {"script": "posthog-recorder"}}, "heatmaps": false, "conversations": false, "surveys": false, "productTours": false, "defaultIdentifiedOnly": true},
+      config: {"token": "phc_12345", "supportedCompression": ["gzip", "gzip-js"], "hasFeatureFlags": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "autocapture_opt_out": false, "autocaptureExceptions": false, "analytics": {"endpoint": "/i/v0/e/"}, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "logs": {"captureConsoleLogs": false}, "sessionRecording": {"endpoint": "/s/", "consoleLogRecordingEnabled": true, "recorderVersion": "v2", "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "masking": null, "urlBlocklist": [], "scriptConfig": {"script": "posthog-recorder"}, "recordCanvas": false, "canvasFps": null, "canvasQuality": null, "version": 1, "sampleRate": null, "linkedFlag": null, "urlTriggers": [], "eventTriggers": [], "triggerMatchType": null}, "heatmaps": false, "conversations": false, "surveys": false, "productTours": false, "defaultIdentifiedOnly": true},
       siteApps: []
     }
   })();
@@ -118,7 +118,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
+      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
       siteApps: []
     }
   })();
@@ -152,6 +152,8 @@
     }),
     'productTours': False,
     'sessionRecording': dict({
+      'canvasFps': None,
+      'canvasQuality': None,
       'consoleLogRecordingEnabled': True,
       'endpoint': '/s/',
       'eventTriggers': list([
@@ -160,6 +162,7 @@
       'masking': None,
       'minimumDurationMilliseconds': None,
       'networkPayloadCapture': None,
+      'recordCanvas': False,
       'recorderVersion': 'v2',
       'sampleRate': None,
       'scriptConfig': dict({
@@ -170,6 +173,7 @@
       ]),
       'urlTriggers': list([
       ]),
+      'version': 1,
     }),
     'siteApps': list([
     ]),
@@ -209,6 +213,8 @@
     }),
     'productTours': False,
     'sessionRecording': dict({
+      'canvasFps': None,
+      'canvasQuality': None,
       'consoleLogRecordingEnabled': True,
       'endpoint': '/s/',
       'eventTriggers': list([
@@ -217,6 +223,7 @@
       'masking': None,
       'minimumDurationMilliseconds': None,
       'networkPayloadCapture': None,
+      'recordCanvas': False,
       'recorderVersion': 'v2',
       'sampleRate': None,
       'scriptConfig': dict({
@@ -227,6 +234,7 @@
       ]),
       'urlTriggers': list([
       ]),
+      'version': 1,
     }),
     'siteApps': list([
     ]),
@@ -243,7 +251,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
+      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
       siteApps: []
     }
   })();
@@ -254,7 +262,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
+      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
       siteApps: []
     }
   })();
@@ -265,7 +273,7 @@
   (function() {
     window._POSTHOG_REMOTE_CONFIG = window._POSTHOG_REMOTE_CONFIG || {};
     window._POSTHOG_REMOTE_CONFIG['phc_12345'] = {
-      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": []}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
+      config: {"analytics": {"endpoint": "/i/v0/e/"}, "autocaptureExceptions": false, "autocapture_opt_out": false, "captureDeadClicks": false, "capturePerformance": {"network_timing": true, "web_vitals": false, "web_vitals_allowed_metrics": null}, "conversations": false, "defaultIdentifiedOnly": true, "elementsChainAsString": true, "errorTracking": {"autocaptureExceptions": false, "suppressionRules": []}, "hasFeatureFlags": false, "heatmaps": false, "logs": {"captureConsoleLogs": false}, "productTours": false, "sessionRecording": {"canvasFps": null, "canvasQuality": null, "consoleLogRecordingEnabled": true, "endpoint": "/s/", "eventTriggers": [], "linkedFlag": null, "masking": null, "minimumDurationMilliseconds": null, "networkPayloadCapture": null, "recordCanvas": false, "recorderVersion": "v2", "sampleRate": null, "scriptConfig": {"script": "posthog-recorder"}, "triggerMatchType": null, "urlBlocklist": [], "urlTriggers": [], "version": 1}, "supportedCompression": ["gzip", "gzip-js"], "surveys": false, "token": "phc_12345"},
       siteApps: [    
       {
         id: 'SITE_DESTINATION_ID',

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -529,6 +529,10 @@ class TestRemoteConfigCaching(_RemoteConfigBase):
                 "urlBlocklist": [],
                 "eventTriggers": [],
                 "triggerMatchType": None,
+                "canvasFps": None,
+                "canvasQuality": None,
+                "recordCanvas": False,
+                "version": 1,
                 "scriptConfig": {"script": "posthog-recorder"},
             },
             "errorTracking": {

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -204,7 +204,7 @@ class TestRemoteConfig(_RemoteConfigBase):
         self.sync_remote_config()
         assert self.remote_config.config["conversations"] is False
 
-    @parameterized.expand([["1.00", None], ["0.95", "0.95"], ["0.50", "0.50"], ["0.00", "0.00"], [None, None]])
+    @parameterized.expand([["1.00", None], ["0.95", "0.95"], ["0.50", "0.5"], ["0.00", "0"], [None, None]])
     def test_session_recording_sample_rate(self, value: str | None, expected: str | None) -> None:
         self.team.session_recording_opt_in = True
         self.team.session_recording_sample_rate = Decimal(value) if value else None


### PR DESCRIPTION
## Problem

Add V2 trigger type and add to remote config

## Changes

V2 Schema:

- version: 2
- groups: array of trigger groups
- Each group: id, name (optional), sampleRate, minDurationMs (optional), conditions
- Conditions: matchType, events[] (optional), urls[] (optional), flag (optional, single)

Backend:

- Add session_recording_trigger_groups field to remote config response
- Return version: 1 for legacy config
- Return version: 2 when trigger groups configured
- Include V1 fallback fields in V2 responses for backward compatibility (older SDK versions)

Types:

- Add TypeScript types for V2 trigger groups schema
- Define SessionRecordingTriggerGroupsConfig interface
- Define SessionRecordingTriggerGroup and SessionRecordingTriggerConditions interfaces

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

new tests

- GET /array/:token/config with no trigger groups returns V1 format (version: 1)
- V1 response includes: sampleRate, eventTriggers, urlTriggers, triggerMatchType
- GET with session_recording_trigger_groups set returns V2 format (version: 2)
- V2 response includes triggerGroups array
- V2 response excludes V1 fields (sampleRate, eventTriggers, linkedFlag, triggerMatchType)
- urlBlocklist works in both V1 and V2 configs

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->