### PR TITLE
fix(ci): add apt-get retry flag to prevent transient mirror failures

### DIFF
--- a/.github/workflows/build-hogql-parser-npm.yml
+++ b/.github/workflows/build-hogql-parser-npm.yml
@@ -68,7 +68,7 @@ jobs:
               uses: ./.github/actions/setup-emsdk
 
             - name: Install Ninja
-              run: sudo apt-get install -y ninja-build
+              run: sudo apt-get install -y -o Acquire::Retries=2 ninja-build
 
             - name: Build WASM package
               run: cd common/hogql_parser && npm run build

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -332,7 +332,7 @@ jobs:
 
             - name: Install SAML dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
-              run: sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+              run: sudo apt-get update -o Acquire::Retries=2 && sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install Rust
               uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e
@@ -507,8 +507,8 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
             - name: Install Rust
               uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e
               with:
@@ -1059,7 +1059,7 @@ jobs:
               if: ${{ needs.changes.outputs.backend == 'true' && steps.setup-uv-tests.outputs.cache-hit != 'true' }}
               shell: bash
               run: |
-                  sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2 && sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install Rust
               if: needs.changes.outputs.backend == 'true'
@@ -1112,7 +1112,7 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
-                  sudo apt-get install unzip cmake curl uuid pkg-config
+                  sudo apt-get install -y -o Acquire::Retries=2 unzip cmake curl uuid pkg-config
                   curl https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure
                   anltr_known_md5sum="c875c148991aacd043f733827644a76f"
@@ -1591,8 +1591,8 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv-async.outputs.cache-hit != 'true'
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install Rust
               uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -131,8 +131,8 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
               shell: bash

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -243,7 +243,7 @@ jobs:
               if: steps.setup-uv.outputs.cache-hit != 'true'
               shell: bash
               run: |
-                  sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2 && sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install pnpm
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -283,7 +283,7 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
-                  sudo apt-get install unzip cmake curl uuid pkg-config
+                  sudo apt-get install -y -o Acquire::Retries=2 unzip cmake curl uuid pkg-config
                   curl https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure
                   anltr_known_md5sum="c875c148991aacd043f733827644a76f"

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -83,8 +83,8 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install Python dependencies
               run: |
@@ -105,7 +105,7 @@ jobs:
             - name: Check if ANTLR definitions are up to date
               run: |
                   cd ..
-                  sudo apt-get update && sudo apt-get install default-jre
+                  sudo apt-get update -o Acquire::Retries=2 && sudo apt-get install -y -o Acquire::Retries=2 default-jre
                   mkdir antlr
                   cd antlr
                   curl -o antlr.jar https://www.antlr.org/download/antlr-$ANTLR_VERSION-complete.jar
@@ -187,8 +187,8 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv-hogql-python.outputs.cache-hit != 'true'
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
             - name: Install Python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -246,7 +246,7 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               shell: bash
               run: |
-                  sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2 && sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Setup pnpm
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -221,8 +221,8 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
               run: |

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -97,8 +97,8 @@ jobs:
               if: steps.setup-uv.outputs.cache-hit != 'true'
               shell: bash
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install Python dependencies
               shell: bash

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -151,8 +151,8 @@ jobs:
 
             - name: Install system OpenSSL
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y libssl-dev pkg-config
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libssl-dev pkg-config
 
             - name: Install protoc
               uses: ./.github/actions/setup-protoc
@@ -243,8 +243,8 @@ jobs:
             - name: Install SAML (python3-saml) dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: |
-                  sudo apt-get update
-                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl postgresql-client
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1-dev libxmlsec1-openssl postgresql-client
 
             - name: Install python dependencies
               run: |
@@ -316,8 +316,8 @@ jobs:
 
             - name: Install system OpenSSL
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y libssl-dev pkg-config
+                  sudo apt-get update -o Acquire::Retries=2
+                  sudo apt-get install -y -o Acquire::Retries=2 libssl-dev pkg-config
 
             - name: Install protoc
               uses: ./.github/actions/setup-protoc

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -77,8 +77,8 @@ jobs:
                   (
                     if [ "$UV_CACHE_HIT" != "true" ]; then
                       echo ">>> [Python] Installing SAML (python3-saml) dependencies..."
-                      sudo apt-get update
-                      sudo apt-get install -y libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+                      sudo apt-get update -o Acquire::Retries=2
+                      sudo apt-get install -y -o Acquire::Retries=2 libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
                     fi
 
                     echo ">>> [Python] Installing dependencies..."


### PR DESCRIPTION
## Summary

- Adds `-o Acquire::Retries=2` to every `apt-get update` and `apt-get install` call across all CI workflow files
- This is apt's native HTTP-level retry mechanism -- it retries individual package fetches (not the entire command), which is the correct granularity for transient 503s from EC2 Ubuntu mirrors
- Also adds missing `-y` flags to several `apt-get install` calls that lacked them (prevents interactive prompts from hanging CI)

## Context

CI workflows fail intermittently with `503 Service Unavailable` from EC2 Ubuntu mirrors during `apt-get install`. This is a well-known problem on GitHub Actions runners. Example failure: https://github.com/PostHog/posthog/actions/runs/23251309261/job/67593823658?pr=51322

The `Acquire::Retries` approach is used by Google's Docker base images, RPi-Distro, QubesOS, and others.

## Files changed

All 10 workflow files with `apt-get` calls: `ci-backend`, `ci-mcp`, `ci-nodejs`, `ci-hog`, `ci-e2e-playwright`, `ci-rust`, `ci-dagster`, `ci-python`, `ci-turbo`, `build-hogql-parser-npm`.

## Test plan

- [ ] Grep confirms no bare `apt-get update` or `apt-get install` remains without the flag
- [ ] CI passes on this PR (the flag is a no-op when mirrors respond normally)