### PR TITLE
chore(rust): remove tower "default" feature from workspace dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -125,7 +125,7 @@ time = { version = "0.3.36", features = [
 thiserror = { version = "2.0" }
 tokio = { version = "1.34.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["time"] }
-tower = { version = "0.4.13", features = ["default", "limit", "timeout", "util"] }
+tower = { version = "0.4.13", features = ["limit", "timeout", "util"] }
 tower-http = { version = "0.5.2", features = ["cors", "decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd", "limit", "trace"] }
 tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"


### PR DESCRIPTION
## Problem

Tower 0.5 (required by axum 0.8) has no `"default"` feature. The workspace currently enables `"default"` on tower 0.4, which only activates `"log"` (tracing's log bridge) — redundant since the workspace already depends on `tracing` directly. This must be removed before upgrading.

## Changes

- Remove the `"default"` feature from the tower workspace dependency in `rust/Cargo.toml`

## How did you test this code?

- `cargo check --workspace` passes with no errors

## Publish to changelog?

No

## Docs update

N/A