### PR TITLE
feat(flags): use prebuilt dependency metadata from Django hypercache

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,7 +1,7 @@
 use crate::api::errors::{simplify_serde_error, FlagError};
 use crate::database::get_connection_with_metrics;
 use crate::flags::flag_models::{
-    FeatureFlag, FeatureFlagList, FeatureFlagRow, HypercacheFlagsWrapper,
+    EvaluationMetadata, FeatureFlag, FeatureFlagList, FeatureFlagRow, HypercacheFlagsWrapper,
 };
 use crate::metrics::consts::TOMBSTONE_COUNTER;
 use common_database::PostgresReader;
@@ -17,53 +17,49 @@ impl FeatureFlagList {
         }
     }
 
-    /// Parses a JSON Value from hypercache into a list of feature flags.
+    /// Parses a JSON Value from hypercache into flags and optional evaluation metadata.
     ///
     /// Handles:
     /// - Null values (returns empty vec)
     /// - Sentinel "__missing__" value (returns empty vec)
-    /// - Standard hypercache format `{"flags": [...]}`
+    /// - Standard hypercache format `{"flags": [...], "evaluation_metadata": {...}}`
     pub fn parse_hypercache_value(
         data: serde_json::Value,
         team_id: TeamId,
-    ) -> Result<Vec<FeatureFlag>, FlagError> {
+    ) -> Result<(Vec<FeatureFlag>, Option<EvaluationMetadata>), FlagError> {
         // Handle null (can happen when hypercache returns empty)
         if data.is_null() {
-            return Ok(vec![]);
+            return Ok((vec![], None));
         }
 
         // Check for the sentinel value indicating no flags for this team
         if data.as_str() == Some(HYPER_CACHE_EMPTY_VALUE) {
             tracing::debug!("Hypercache sentinel (no flags) for team {}", team_id);
-            return Ok(vec![]);
+            return Ok((vec![], None));
         }
 
-        // Parse the hypercache format: {"flags": [...]}
-        let wrapper: HypercacheFlagsWrapper =
-            serde_json::from_value(data.clone()).map_err(|e| {
-                let data_str = data.to_string();
-                let data_preview = &data_str[..data_str.len().min(200)];
-                tracing::error!(
-                    "Failed to parse hypercache data for team {}: {}. Data: {}",
-                    team_id,
-                    e,
-                    data_preview
-                );
-                counter!(
-                    TOMBSTONE_COUNTER,
-                    "failure_type" => "hypercache_parse_error",
-                    "team_id" => team_id.to_string(),
-                )
-                .increment(1);
-                FlagError::DataParsingErrorWithContext(format!(
-                    "Failed to parse feature flags for team {team_id}: {}",
-                    simplify_serde_error(&e.to_string())
-                ))
-            })?;
+        // Parse the hypercache format: {"flags": [...], "evaluation_metadata": {...}}
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(data).map_err(|e| {
+            tracing::error!(
+                "Failed to parse hypercache data for team {}: {}",
+                team_id,
+                e
+            );
+            counter!(
+                TOMBSTONE_COUNTER,
+                "failure_type" => "hypercache_parse_error",
+                "team_id" => team_id.to_string(),
+            )
+            .increment(1);
+            FlagError::DataParsingErrorWithContext(format!(
+                "Failed to parse feature flags for team {team_id}: {}",
+                simplify_serde_error(&e.to_string())
+            ))
+        })?;
 
         tracing::debug!("Parsed {} flags for team {}", wrapper.flags.len(), team_id);
 
-        Ok(wrapper.flags)
+        Ok((wrapper.flags, wrapper.evaluation_metadata))
     }
 
     /// Returns feature flags from postgres given a team_id
@@ -648,7 +644,8 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let flags = result.unwrap();
+        let (flags, metadata) = result.unwrap();
+        assert!(metadata.is_none());
         assert_eq!(flags.len(), 2);
         assert_eq!(flags[0].key, "test_flag");
         assert!(flags[0].active);
@@ -657,11 +654,186 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_hypercache_value_with_evaluation_context_valid_flags() {
+        let data = json!({
+            "evaluation_metadata": {
+                "dependency_stages": [
+                    [766, 768, 769],
+                    [765]
+                ],
+                "flags_with_missing_deps": [768],
+                "transitive_deps": {
+                    "765": [766],
+                    "766": [],
+                    "768": [],
+                    "769": []
+                }
+            },
+            "flags": [
+                {
+                    "active": true,
+                    "bucketing_identifier": null,
+                    "deleted": false,
+                    "ensure_experience_continuity": false,
+                    "evaluation_contexts": [],
+                    "evaluation_runtime": "all",
+                    "evaluation_tags": [],
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    {
+                                        "key": "766",
+                                        "label": "client-only-flag",
+                                        "operator": "flag_evaluates_to",
+                                        "type": "flag",
+                                        "value": true
+                                    }
+                                ],
+                                "rollout_percentage": 100,
+                                "variant": null
+                            }
+                        ],
+                        "multivariate": null,
+                        "payloads": {}
+                    },
+                    "has_encrypted_payloads": false,
+                    "id": 765,
+                    "key": "all-flag-with-flag-dependency",
+                    "name": "",
+                    "team_id": 15,
+                    "version": 3
+                },
+                {
+                    "active": true,
+                    "bucketing_identifier": null,
+                    "deleted": false,
+                    "ensure_experience_continuity": false,
+                    "evaluation_contexts": [],
+                    "evaluation_runtime": "client",
+                    "evaluation_tags": [],
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [],
+                                "rollout_percentage": 100,
+                                "variant": null
+                            }
+                        ],
+                        "multivariate": null,
+                        "payloads": {}
+                    },
+                    "has_encrypted_payloads": false,
+                    "id": 766,
+                    "key": "client-only-flag",
+                    "name": "",
+                    "team_id": 15,
+                    "version": 2
+                },
+                {
+                    "active": true,
+                    "bucketing_identifier": null,
+                    "deleted": false,
+                    "ensure_experience_continuity": false,
+                    "evaluation_contexts": [],
+                    "evaluation_runtime": "all",
+                    "evaluation_tags": [],
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    {
+                                        "key": "9999",
+                                        "label": "boolean-flag",
+                                        "operator": "flag_evaluates_to",
+                                        "type": "flag",
+                                        "value": true
+                                    }
+                                ],
+                                "rollout_percentage": 100,
+                                "variant": null
+                            }
+                        ],
+                        "multivariate": null,
+                        "payloads": {}
+                    },
+                    "has_encrypted_payloads": false,
+                    "id": 768,
+                    "key": "flag-with-truly-missing-dependency",
+                    "name": "",
+                    "team_id": 15,
+                    "version": 2
+                },
+                {
+                    "active": true,
+                    "bucketing_identifier": null,
+                    "deleted": false,
+                    "ensure_experience_continuity": false,
+                    "evaluation_contexts": [],
+                    "evaluation_runtime": "all",
+                    "evaluation_tags": [],
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    {
+                                        "cohort_name": "[Test] Dependent Cohort",
+                                        "key": "id",
+                                        "operator": "in",
+                                        "type": "cohort",
+                                        "value": 5
+                                    }
+                                ],
+                                "rollout_percentage": 100,
+                                "variant": null
+                            }
+                        ],
+                        "multivariate": null,
+                        "payloads": {}
+                    },
+                    "has_encrypted_payloads": false,
+                    "id": 769,
+                    "key": "cohort-dependency-flag",
+                    "name": "",
+                    "team_id": 15,
+                    "version": 1
+                }
+            ]
+        });
+
+        let result = FeatureFlagList::parse_hypercache_value(data, 123);
+        assert!(result.is_ok());
+        let (flags, evaluation_metadata) = result.unwrap();
+        let meta = evaluation_metadata.unwrap();
+        assert_eq!(meta.dependency_stages.len(), 2);
+        assert_eq!(meta.dependency_stages[0], vec![766, 768, 769]);
+        assert_eq!(meta.dependency_stages[1], vec![765]);
+        assert_eq!(meta.flags_with_missing_deps, vec![768]);
+        assert_eq!(meta.transitive_deps.len(), 4);
+        assert_eq!(meta.transitive_deps[&765].len(), 1);
+        assert!(meta.transitive_deps[&765].contains(&766));
+        assert!(meta.transitive_deps[&766].is_empty());
+        assert!(meta.transitive_deps[&768].is_empty());
+        assert!(meta.transitive_deps[&769].is_empty());
+        assert_eq!(flags.len(), 4);
+        assert_eq!(flags[0].key, "all-flag-with-flag-dependency");
+        assert!(flags[0].active);
+        assert_eq!(flags[1].key, "client-only-flag");
+        assert!(flags[1].active);
+        assert_eq!(flags[2].key, "flag-with-truly-missing-dependency");
+        assert!(flags[2].active);
+        assert_eq!(flags[3].key, "cohort-dependency-flag");
+        assert!(flags[3].active);
+    }
+
+    #[test]
     fn test_parse_hypercache_value_null_returns_empty() {
         let data = serde_json::Value::Null;
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        let (flags, metadata) = result.unwrap();
+        assert!(flags.is_empty());
+        assert!(metadata.is_none());
     }
 
     #[test]
@@ -669,7 +841,9 @@ mod tests {
         let data = json!("__missing__");
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        let (flags, metadata) = result.unwrap();
+        assert!(flags.is_empty());
+        assert!(metadata.is_none());
     }
 
     #[test]
@@ -677,7 +851,9 @@ mod tests {
         let data = json!({"flags": []});
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        let (flags, metadata) = result.unwrap();
+        assert!(flags.is_empty());
+        assert!(metadata.is_none());
     }
 
     #[test]
@@ -751,7 +927,8 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let flags = result.unwrap();
+        let (flags, metadata) = result.unwrap();
+        assert!(metadata.is_none());
         assert_eq!(flags.len(), 1);
         let flag = &flags[0];
         assert_eq!(flag.id, 42);

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -29,10 +29,7 @@ use crate::metrics::consts::{
 };
 use crate::properties::property_models::PropertyFilter;
 use crate::rayon_dispatcher::RayonDispatcher;
-use crate::utils::graph_utils::{
-    build_dependency_graph, filter_graph_by_keys, log_dependency_graph_operation_error,
-    DependencyGraph, DependencyGraphResult, FilteredGraphResult,
-};
+use crate::utils::graph_utils::PrecomputedDependencyGraph;
 use anyhow::Result;
 use common_metrics::{histogram, inc, timing_guard};
 use common_types::collections::HashMapExt;
@@ -330,39 +327,39 @@ impl FeatureFlagMatcher {
     ) -> Result<FlagsResponse, FlagError> {
         let eval_timer = common_metrics::timing_guard(FLAG_EVALUATION_TIME, &[]);
 
-        // Build dependency graph once - reused for both optimization check and evaluation
-        let DependencyGraphResult {
-            graph: global_dependency_graph,
-            errors: graph_errors,
-            flags_with_missing_deps: global_flags_with_missing_deps,
-        } = match build_dependency_graph(&feature_flags, self.team_id) {
+        // Build precomputed dependency graph with evaluation stages and transitive dependency map.
+        // On the precomputed path, flag_keys filtering happens during build (only needed flags
+        // are cloned). On the fallback path, we filter after build via filter_stages_by_keys.
+        let precomputed = match PrecomputedDependencyGraph::build(
+            &feature_flags,
+            self.team_id,
+            flag_keys.as_deref(),
+        ) {
             Some(result) => result,
             None => return Ok(FlagsResponse::new(true, HashMap::new(), None, request_id)),
         };
 
-        // Move the filter set onto the matcher now that the borrow from graph construction has ended.
-        // This is the single source of truth for "should this flag be skipped" during evaluation.
         self.filtered_out_flag_ids = feature_flags.filtered_out_flag_ids;
 
-        // Filter graph by flag_keys if specified (includes transitive dependencies)
-        let (dependency_graph, flags_with_missing_deps) = if let Some(ref keys) = flag_keys {
-            match filter_graph_by_keys(
-                &global_dependency_graph,
-                keys,
-                &global_flags_with_missing_deps,
-            ) {
-                Some(FilteredGraphResult {
-                    graph,
-                    flags_with_missing_deps,
-                }) => (graph, flags_with_missing_deps),
-                None => return Ok(FlagsResponse::new(true, HashMap::new(), None, request_id)),
-            }
-        } else {
-            (global_dependency_graph, global_flags_with_missing_deps)
-        };
+        // Extract global stats before potential consuming filter call
+        let error_count = precomputed.error_count;
+        let has_cycle_errors = precomputed.has_cycle_errors;
 
-        if !graph_errors.is_empty() {
-            with_canonical_log(|log| log.dependency_graph_errors = graph_errors.len());
+        // Only the fallback (graph) path needs post-build filtering — the precomputed
+        // path already filtered during build when flag_keys was provided.
+        let (evaluation_stages, flags_with_missing_deps) =
+            if precomputed.is_graph_fallback && flag_keys.is_some() {
+                let filtered = precomputed.filter_stages_by_keys(flag_keys.as_ref().unwrap());
+                (filtered.evaluation_stages, filtered.flags_with_missing_deps)
+            } else {
+                (
+                    precomputed.evaluation_stages,
+                    precomputed.flags_with_missing_deps,
+                )
+            };
+
+        if error_count > 0 {
+            with_canonical_log(|log| log.dependency_graph_errors = error_count);
         }
 
         // Compute experience continuity stats from the filtered graph.
@@ -371,7 +368,7 @@ impl FeatureFlagMatcher {
             let mut continuity_count = 0;
             let mut needs_override = false;
 
-            for flag in dependency_graph.iter_nodes() {
+            for flag in evaluation_stages.iter().flatten() {
                 if !self.filtered_out_flag_ids.contains(&flag.id)
                     && flag.has_experience_continuity()
                 {
@@ -442,17 +439,15 @@ impl FeatureFlagMatcher {
             request_hash_key_override,
         };
 
-        // Pass the pre-built graph to avoid redundant graph construction
         let flags_response = self
             .evaluate_flags_with_overrides(
                 overrides,
                 request_id,
-                dependency_graph,
+                evaluation_stages,
                 flags_with_missing_deps,
             )
             .await?;
 
-        let has_cycle_errors = graph_errors.iter().any(|e| e.is_cycle());
         let has_errors = flag_hash_key_override_error
             || flags_response.errors_while_computing_flags
             || has_cycle_errors;
@@ -628,20 +623,20 @@ impl FeatureFlagMatcher {
 
     /// Evaluates feature flags with property and hash key overrides.
     ///
-    /// Takes a pre-built dependency graph which should already be filtered by flag_keys if needed.
-    /// The graph determines which flags are evaluated and in what order.
+    /// Takes pre-computed evaluation stages which should already be filtered by flag_keys if needed.
+    /// The stages determine which flags are evaluated and in what order.
     pub async fn evaluate_flags_with_overrides(
         &mut self,
         overrides: FlagEvaluationOverrides,
         request_id: Uuid,
-        dependency_graph: DependencyGraph<FeatureFlag>,
+        evaluation_stages: Vec<Vec<FeatureFlag>>,
         flags_with_missing_deps: HashSet<i32>,
     ) -> Result<FlagsResponse, FlagError> {
         let mut errors_while_computing_flags = overrides.hash_key_override_error;
         let mut evaluated_flags_map = HashMap::new();
 
-        // Collect flags from the graph for preparation steps
-        let flags: Vec<&FeatureFlag> = dependency_graph.iter_nodes().collect();
+        // Collect flags from evaluation stages for preparation steps
+        let flags: Vec<&FeatureFlag> = evaluation_stages.iter().flatten().collect();
 
         // Handle hash key override errors by creating error responses for flags that need experience continuity
         if overrides.hash_key_override_error && overrides.hash_key_overrides.is_none() {
@@ -677,19 +672,22 @@ impl FeatureFlagMatcher {
                 .add_flag_evaluation_result(flag_id, FlagValue::Boolean(false));
         }
 
-        // Step 3: Evaluate flags using the dependency graph
-        let graph_evaluation_errors = self
-            .evaluate_flags_with_dependency_graph(
-                dependency_graph,
-                &overrides.person_property_overrides,
-                &overrides.group_property_overrides,
-                &overrides.hash_key_overrides,
-                &overrides.request_hash_key_override,
-                &mut evaluated_flags_map,
-                &flags_with_missing_deps,
-            )
-            .await?;
-        errors_while_computing_flags |= graph_evaluation_errors;
+        // Step 3: Evaluate flags stage by stage in dependency order
+        for stage in evaluation_stages {
+            let (level_evaluated_flags_map, level_errors) = self
+                .evaluate_flags_in_level(
+                    stage,
+                    &mut evaluated_flags_map,
+                    &overrides.person_property_overrides,
+                    &overrides.group_property_overrides,
+                    &overrides.hash_key_overrides,
+                    &overrides.request_hash_key_override,
+                    &flags_with_missing_deps,
+                )
+                .await?;
+            errors_while_computing_flags |= level_errors;
+            evaluated_flags_map.extend(level_evaluated_flags_map);
+        }
 
         Ok(FlagsResponse::new(
             errors_while_computing_flags,
@@ -697,49 +695,6 @@ impl FeatureFlagMatcher {
             None,
             request_id,
         ))
-    }
-
-    /// Evaluates flags using the provided dependency graph.
-    /// Returns true if there were errors during evaluation.
-    #[allow(clippy::too_many_arguments)]
-    async fn evaluate_flags_with_dependency_graph(
-        &mut self,
-        flag_dependency_graph: DependencyGraph<FeatureFlag>,
-        person_property_overrides: &Option<HashMap<String, Value>>,
-        group_property_overrides: &Option<HashMap<String, HashMap<String, Value>>>,
-        hash_key_overrides: &Option<HashMap<String, String>>,
-        request_hash_key_override: &Option<String>,
-        evaluated_flags_map: &mut HashMap<String, FlagDetails>,
-        flags_with_missing_deps: &HashSet<i32>,
-    ) -> Result<bool, FlagError> {
-        // Consume the graph to get owned flags in evaluation order
-        let evaluation_stages = match flag_dependency_graph.into_evaluation_stages() {
-            Ok(stages) => stages,
-            Err(e) => {
-                log_dependency_graph_operation_error("get evaluation stages", &e, self.team_id);
-                return Ok(true);
-            }
-        };
-
-        // Evaluate flags in dependency order
-        let mut errors_while_computing_flags = false;
-        for stage in evaluation_stages {
-            let (level_evaluated_flags_map, level_errors) = self
-                .evaluate_flags_in_level(
-                    stage,
-                    evaluated_flags_map,
-                    person_property_overrides,
-                    group_property_overrides,
-                    hash_key_overrides,
-                    request_hash_key_override,
-                    flags_with_missing_deps,
-                )
-                .await?;
-            errors_while_computing_flags |= level_errors;
-            evaluated_flags_map.extend(level_evaluated_flags_map);
-        }
-
-        Ok(errors_while_computing_flags)
     }
 
     /// Prepares evaluation state for flags that require database properties.

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -1,12 +1,72 @@
+use serde::de::{self, Deserializer};
+use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::properties::property_models::PropertyFilter;
+
+/// Deserializes a JSON object with string keys into `HashMap<i32, HashSet<i32>>`.
+/// JSON only supports string keys, so Python serializes `{1: [2, 3]}` as `{"1": [2, 3]}`.
+fn deserialize_string_keyed_i32_map<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<i32, HashSet<i32>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw: HashMap<String, Vec<i32>> = HashMap::deserialize(deserializer)?;
+    raw.into_iter()
+        .map(|(k, v)| {
+            let id = k.parse::<i32>().map_err(de::Error::custom)?;
+            Ok((id, v.into_iter().collect()))
+        })
+        .collect()
+}
+
+/// Serializes `HashMap<i32, HashSet<i32>>` back to JSON with string keys.
+fn serialize_string_keyed_i32_map<S>(
+    map: &HashMap<i32, HashSet<i32>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut ser_map = serializer.serialize_map(Some(map.len()))?;
+    let mut keys: Vec<&i32> = map.keys().collect();
+    keys.sort_unstable();
+    for k in keys {
+        let v = &map[k];
+        let sorted: Vec<i32> = {
+            let mut s: Vec<i32> = v.iter().copied().collect();
+            s.sort_unstable();
+            s
+        };
+        ser_map.serialize_entry(&k.to_string(), &sorted)?;
+    }
+    ser_map.end()
+}
+
+/// Pre-computed dependency metadata, built by Django at cache-write time.
+/// Shipped as a top-level field alongside the flags array in the hypercache.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EvaluationMetadata {
+    /// Flag IDs grouped by evaluation stage. Stage 0 (no deps) first.
+    pub dependency_stages: Vec<Vec<i32>>,
+    /// Flag IDs with missing, cyclic, or transitively broken dependencies.
+    pub flags_with_missing_deps: Vec<i32>,
+    /// Flag ID → transitive dependency flag IDs.
+    #[serde(
+        deserialize_with = "deserialize_string_keyed_i32_map",
+        serialize_with = "serialize_string_keyed_i32_map"
+    )]
+    pub transitive_deps: HashMap<i32, HashSet<i32>>,
+}
 
 /// Wrapper struct for deserializing hypercache format: {"flags": [...]}
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HypercacheFlagsWrapper {
     pub flags: Vec<FeatureFlag>,
+    #[serde(default)]
+    pub evaluation_metadata: Option<EvaluationMetadata>,
 }
 
 /// New holdout format: `{"id": 42, "exclusion_percentage": 10}`.
@@ -171,4 +231,9 @@ pub struct FeatureFlagList {
     /// Not serialized — this is a request-scoped concern, not a cache concern.
     #[serde(skip)]
     pub filtered_out_flag_ids: HashSet<i32>,
+    /// Pre-computed dependency metadata from Django's hypercache.
+    /// Present when the cache was written by new Django code; absent for PG fallback
+    /// or old cache entries.
+    #[serde(skip)]
+    pub evaluation_metadata: Option<EvaluationMetadata>,
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -160,7 +160,10 @@ impl FlagService {
             .get_with_source_or_fallback(&key, || async move {
                 // Fallback: load from PostgreSQL and convert to JSON Value
                 let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
-                let wrapper = crate::flags::flag_models::HypercacheFlagsWrapper { flags };
+                let wrapper = crate::flags::flag_models::HypercacheFlagsWrapper {
+                    flags,
+                    evaluation_metadata: None,
+                };
                 let value = serde_json::to_value(&wrapper).map_err(|e| {
                     tracing::error!(
                         "Failed to serialize flags from PG for team {}: {}",
@@ -174,11 +177,12 @@ impl FlagService {
             .await?;
 
         // Parse the result (from cache or fallback)
-        let flags = FeatureFlagList::parse_hypercache_value(data, team_id)?;
+        let (flags, evaluation_metadata) = FeatureFlagList::parse_hypercache_value(data, team_id)?;
 
         Ok(FlagResult {
             flag_list: FeatureFlagList {
                 flags,
+                evaluation_metadata,
                 ..Default::default()
             },
             cache_source: source,
@@ -524,6 +528,7 @@ mod tests {
         // Serialize exactly like Django does for large payloads: JSON -> Pickle -> Zstd
         let wrapper = HypercacheFlagsWrapper {
             flags: large_flags.flags.clone(),
+            evaluation_metadata: None,
         };
         let json_string = serde_json::to_string(&wrapper).expect("Failed to serialize to JSON");
 

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -2,7 +2,7 @@
 mod tests {
     use common_types::TeamId;
     use serde_json::json;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use uuid::Uuid;
 
@@ -18,14 +18,14 @@ mod tests {
                 reset_hash_key_override_lookup_count, set_feature_flag_hash_key_overrides,
             },
             flag_models::{
-                FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup, Holdout,
-                MultivariateFlagOptions, MultivariateFlagVariant,
+                EvaluationMetadata, FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup,
+                Holdout, MultivariateFlagOptions, MultivariateFlagVariant,
             },
         },
         properties::property_models::{OperatorType, PropertyFilter, PropertyType},
         utils::{
-            graph_utils::build_dependency_graph,
-            test_utils::{create_test_flag, TestContext},
+            graph_utils::PrecomputedDependencyGraph,
+            test_utils::{create_test_flag, create_test_flag_that_depends_on_flag, TestContext},
         },
     };
 
@@ -529,8 +529,7 @@ mod tests {
 
     // Use the shared test utility functions from test_utils.rs
     use crate::utils::test_utils::{
-        create_test_flag_that_depends_on_flag, create_test_flag_with_properties,
-        create_test_flag_with_property,
+        create_test_flag_with_properties, create_test_flag_with_property,
     };
 
     #[tokio::test]
@@ -6636,8 +6635,8 @@ mod tests {
         };
 
         // Build dependency graph for the flags
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build dependency graph");
 
         // Test the scenario where hash key override reading fails
         // This simulates the case where we have experience continuity flags but hash override reads fail
@@ -6653,8 +6652,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 overrides,
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -6740,10 +6739,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![filtered_continuity_flag, active_normal_flag],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_metadata: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build dependency graph");
 
         // Simulate a hash-key-override read failure
         let overrides = crate::flags::flag_matching::FlagEvaluationOverrides {
@@ -6760,8 +6760,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 overrides,
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -6834,8 +6834,8 @@ mod tests {
         };
 
         // Build dependency graph for the flags
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -6855,8 +6855,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -6933,10 +6933,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_metadata: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -6954,8 +6955,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -7029,10 +7030,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_metadata: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -7050,8 +7052,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -7132,8 +7134,8 @@ mod tests {
             ..Default::default()
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -7153,8 +7155,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -7223,10 +7225,11 @@ mod tests {
         let flags = FeatureFlagList {
             flags: vec![flag_a, flag_b, flag_c],
             filtered_out_flag_ids: filtered_out.clone(),
+            evaluation_metadata: None,
         };
 
-        let graph_result =
-            build_dependency_graph(&flags, team.id).expect("Should build dependency graph");
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build dependency graph");
 
         let router = context.create_postgres_router();
         let mut matcher = FeatureFlagMatcher::new(
@@ -7244,8 +7247,8 @@ mod tests {
             .evaluate_flags_with_overrides(
                 Default::default(),
                 Uuid::new_v4(),
-                graph_result.graph,
-                graph_result.flags_with_missing_deps,
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
             )
             .await
             .unwrap();
@@ -8682,5 +8685,211 @@ mod tests {
             .get(&1)
             .expect("organization group properties should be loaded");
         assert_eq!(org_props.get("tier"), Some(&json!("enterprise")));
+    }
+
+    #[tokio::test]
+    async fn test_end_to_end_evaluation_via_precomputed_path() {
+        // Exercises flag evaluation through the precomputed (EvaluationMetadata) path.
+        // A(1)->B(2)->C(3) dependency chain where C has 100% rollout, B depends on C,
+        // and A depends on B. All should evaluate to true.
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        // C: no deps, 100% rollout
+        let flag_c = create_test_flag(
+            Some(3),
+            Some(team.id),
+            None,
+            Some("flag_c".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // B: depends on C evaluating to true
+        let flag_b = create_test_flag_that_depends_on_flag(
+            2,
+            team.id,
+            "flag_b",
+            3,
+            FlagValue::Boolean(true),
+        );
+
+        // A: depends on B evaluating to true
+        let flag_a = create_test_flag_that_depends_on_flag(
+            1,
+            team.id,
+            "flag_a",
+            2,
+            FlagValue::Boolean(true),
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_a, flag_b, flag_c],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![3], vec![2], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3])),
+                    (2, HashSet::from([3])),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build from precomputed metadata");
+
+        assert!(
+            !precomputed.is_graph_fallback,
+            "Should use the precomputed path"
+        );
+
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache,
+            None,
+            None,
+        );
+
+        let result = matcher
+            .evaluate_flags_with_overrides(
+                Default::default(),
+                Uuid::new_v4(),
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
+            )
+            .await
+            .unwrap();
+
+        // All three flags should evaluate to true via the dependency chain
+        let flag_c_result = result
+            .flags
+            .get("flag_c")
+            .expect("flag_c should be present");
+        assert!(flag_c_result.enabled, "flag_c (no deps) should be enabled");
+
+        let flag_b_result = result
+            .flags
+            .get("flag_b")
+            .expect("flag_b should be present");
+        assert!(
+            flag_b_result.enabled,
+            "flag_b (depends on flag_c=true) should be enabled"
+        );
+
+        let flag_a_result = result
+            .flags
+            .get("flag_a")
+            .expect("flag_a should be present");
+        assert!(
+            flag_a_result.enabled,
+            "flag_a (depends on flag_b=true) should be enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_precomputed_path_missing_dep_evaluates_to_false() {
+        // Flag with a missing dependency should evaluate to false (fail closed)
+        // when stages come from precomputed metadata.
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in pg");
+
+        // flag_a depends on a non-existent flag (id=999)
+        let flag_a = create_test_flag_that_depends_on_flag(
+            1,
+            team.id,
+            "flag_a",
+            999,
+            FlagValue::Boolean(true),
+        );
+
+        // flag_b has no deps, 100% rollout
+        let flag_b = create_test_flag(
+            Some(2),
+            Some(team.id),
+            None,
+            Some("flag_b".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let flags = FeatureFlagList {
+            flags: vec![flag_a, flag_b],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![1, 2]],
+                flags_with_missing_deps: vec![1],
+                transitive_deps: HashMap::from([(1, HashSet::new()), (2, HashSet::new())]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
+            .expect("Should build from precomputed metadata");
+
+        assert!(!precomputed.is_graph_fallback);
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+
+        let router = context.create_postgres_router();
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            team.id,
+            router,
+            cohort_cache,
+            None,
+            None,
+        );
+
+        let result = matcher
+            .evaluate_flags_with_overrides(
+                Default::default(),
+                Uuid::new_v4(),
+                precomputed.evaluation_stages,
+                precomputed.flags_with_missing_deps,
+            )
+            .await
+            .unwrap();
+
+        // flag_a has a missing dep and should evaluate to false (fail closed)
+        let flag_a_result = result
+            .flags
+            .get("flag_a")
+            .expect("flag_a should be present");
+        assert!(
+            !flag_a_result.enabled,
+            "Flag with missing dependency should evaluate to false"
+        );
+
+        // flag_b should still evaluate normally
+        let flag_b_result = result
+            .flags
+            .get("flag_b")
+            .expect("flag_b should be present");
+        assert!(flag_b_result.enabled, "flag_b (no deps) should be enabled");
     }
 }

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -153,6 +153,7 @@ pub async fn update_flags_in_hypercache(
 ) -> Result<(), FlagError> {
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.flags.clone(),
+        evaluation_metadata: flags.evaluation_metadata.clone(),
     };
 
     // Match Django's format: JSON string -> Pickle

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -210,6 +210,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage when only filtered-out flags are present
@@ -224,6 +225,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone(), active_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
+            evaluation_metadata: None,
         };
 
         // Should record usage when at least one non-filtered, non-survey flag is present
@@ -238,6 +240,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_survey_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_survey_flag.id]),
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage for filtered-out survey flags
@@ -252,6 +255,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_flag.clone(), survey_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage when only filtered-out and survey flags are present
@@ -294,6 +298,7 @@ mod tests {
         let flag_list = FeatureFlagList {
             flags: vec![disabled_tour_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_tour_flag.id]),
+            evaluation_metadata: None,
         };
 
         // Should NOT record usage for filtered-out product tour flags

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -144,6 +144,7 @@ pub async fn fetch_and_filter(
     with_canonical_log(|log| log.flags_cache_source = Some(flag_result.cache_source.as_log_str()));
 
     let flags = flag_result.flag_list.flags;
+    let evaluation_metadata = flag_result.flag_list.evaluation_metadata;
 
     // Build the filtered-out set: user-disabled, deleted, survey filter, runtime/tag mismatches.
     // This is the single source of truth for "should this flag be skipped during evaluation."
@@ -180,6 +181,7 @@ pub async fn fetch_and_filter(
     Ok(FeatureFlagList {
         flags,
         filtered_out_flag_ids,
+        evaluation_metadata,
     })
 }
 

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -11,7 +11,10 @@ use crate::{
     config::Config,
     flags::{
         flag_analytics::SURVEY_TARGETING_FLAG_PREFIX,
-        flag_models::{FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup},
+        flag_models::{
+            EvaluationMetadata, FeatureFlag, FeatureFlagList, FlagFilters, FlagPropertyGroup,
+            HypercacheFlagsWrapper,
+        },
         flag_service::FlagService,
     },
     handler::{
@@ -1399,6 +1402,94 @@ async fn test_fetch_and_filter_flags() {
         .all(|f| f.key.starts_with(SURVEY_TARGETING_FLAG_PREFIX)));
 }
 
+#[tokio::test]
+async fn test_fetch_and_filter_preserves_evaluation_metadata() {
+    let redis_client = setup_redis_client(None).await;
+    let reader: Arc<dyn Client + Send + Sync> = setup_pg_reader_client(None);
+    let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
+    let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
+    let flag_service = FlagService::new(
+        redis_client.clone(),
+        reader.clone(),
+        team_hypercache_reader,
+        hypercache_reader,
+        NegativeCache::new(100, 300),
+    );
+    let context = TestContext::new(None).await;
+    let team = context.insert_new_team(None).await.unwrap();
+
+    let flags = vec![
+        FeatureFlag {
+            id: 1,
+            key: "flag_a".to_string(),
+            name: Some("Flag A".to_string()),
+            active: true,
+            deleted: false,
+            team_id: team.id,
+            filters: FlagFilters::default(),
+            ensure_experience_continuity: Some(false),
+            version: Some(1),
+            evaluation_runtime: Some("all".to_string()),
+            evaluation_tags: None,
+            bucketing_identifier: None,
+        },
+        FeatureFlag {
+            id: 2,
+            key: "flag_b".to_string(),
+            name: Some("Flag B".to_string()),
+            active: true,
+            deleted: false,
+            team_id: team.id,
+            filters: FlagFilters::default(),
+            ensure_experience_continuity: Some(false),
+            version: Some(1),
+            evaluation_runtime: Some("all".to_string()),
+            evaluation_tags: None,
+            bucketing_identifier: None,
+        },
+    ];
+
+    // Write to cache WITH evaluation_metadata
+    let eval_metadata = EvaluationMetadata {
+        dependency_stages: vec![vec![1], vec![2]],
+        flags_with_missing_deps: vec![],
+        transitive_deps: HashMap::from([(2, std::collections::HashSet::from([1]))]),
+    };
+    let wrapper = HypercacheFlagsWrapper {
+        flags: flags.clone(),
+        evaluation_metadata: Some(eval_metadata),
+    };
+    let json_string = serde_json::to_string(&wrapper).unwrap();
+    let pickled_bytes = serde_pickle::to_vec(&json_string, Default::default()).unwrap();
+    let cache_key = format!("posthog:1:cache/teams/{}/feature_flags/flags.json", team.id);
+    redis_client
+        .set_bytes(cache_key, pickled_bytes, None)
+        .await
+        .unwrap();
+
+    let query_params = FlagsQueryParams::default();
+    let result = fetch_and_filter(
+        &flag_service,
+        team.id,
+        &query_params,
+        &axum::http::HeaderMap::new(),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.flags.len(), 2);
+    assert!(
+        result.evaluation_metadata.is_some(),
+        "evaluation_metadata should be preserved by fetch_and_filter, not dropped"
+    );
+    let ctx = result.evaluation_metadata.unwrap();
+    assert_eq!(ctx.dependency_stages, vec![vec![1], vec![2]]);
+    assert!(ctx.flags_with_missing_deps.is_empty());
+    assert!(ctx.transitive_deps.contains_key(&2));
+}
+
 #[test]
 fn test_disable_flags_request_parsing() {
     // Test that disable_flags=true is properly parsed and detected
@@ -1630,6 +1721,7 @@ async fn test_parallel_path_matches_sequential_results() {
         feature_flags: FeatureFlagList {
             flags: flags.clone(),
             filtered_out_flag_ids: filtered_out_flag_ids.clone(),
+            evaluation_metadata: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),
@@ -1658,6 +1750,7 @@ async fn test_parallel_path_matches_sequential_results() {
         feature_flags: FeatureFlagList {
             flags,
             filtered_out_flag_ids,
+            evaluation_metadata: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -91,6 +91,14 @@ pub const FLAG_ACQUIRE_TIMEOUT_COUNTER: &str = "flags_acquire_timeout_total";
 // Error classification
 pub const FLAG_DATABASE_ERROR_COUNTER: &str = "flags_database_error_total";
 
+// Dependency graph build path
+// Labels: path (FLAG_DEPENDENCY_GRAPH_PATH_PRECOMPUTED or FLAG_DEPENDENCY_GRAPH_PATH_GRAPH)
+pub const FLAG_DEPENDENCY_GRAPH_BUILD_COUNTER: &str = "flags_dependency_graph_build_total";
+pub const FLAG_DEPENDENCY_GRAPH_BUILD_TIME: &str = "flags_dependency_graph_build_ms";
+pub const FLAG_DEPENDENCY_GRAPH_PATH_PRECOMPUTED: &str = "precomputed";
+pub const FLAG_DEPENDENCY_GRAPH_PATH_GRAPH: &str = "graph";
+pub const FLAG_MISSING_REQUESTED_FLAG_KEY: &str = "missing_requested_flag_key";
+
 // Tombstone metric for tracking "impossible" failures that should never happen in production
 // Different failure types are tracked via the "failure_type" label
 pub const TOMBSTONE_COUNTER: &str = "posthog_tombstone_total";

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -1,7 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-#[cfg(test)]
-use petgraph::visit::EdgeRef;
 use petgraph::{
     algo::toposort,
     graph::{DiGraph, NodeIndex},

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -619,6 +619,7 @@ pub fn filter_graph_by_keys(
     requested_keys: &[String],
     flags_with_missing_deps: &HashSet<i32>,
 ) -> Option<FilteredGraphResult> {
+    use petgraph::visit::EdgeRef;
     let mut nodes_to_include = HashSet::new();
 
     // Build an index from flag keys to node indices for O(1) lookups
@@ -835,7 +836,7 @@ impl PrecomputedDependencyGraph {
         });
 
         // When flag_keys is None, all non-filtered-out flags are needed.
-        let is_needed = |id: &i32| needed_ids.as_ref().map_or(true, |ids| ids.contains(id));
+        let is_needed = |id: &i32| needed_ids.as_ref().is_none_or(|ids| ids.contains(id));
 
         // Count non-filtered-out IDs across all stages for the cycle count computation.
         let global_flags_in_stages_count: usize = evaluation_metadata

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -1,16 +1,39 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+#[cfg(test)]
+use petgraph::visit::EdgeRef;
 use petgraph::{
     algo::toposort,
     graph::{DiGraph, NodeIndex},
-    visit::EdgeRef,
 };
 
 use crate::api::errors::FlagError;
 use crate::flags::flag_models::FeatureFlag;
-use crate::metrics::consts::{FLAG_EVALUATION_ERROR_COUNTER, TOMBSTONE_COUNTER};
-use common_metrics::inc;
+use crate::metrics::consts::{
+    FLAG_DEPENDENCY_GRAPH_BUILD_COUNTER, FLAG_DEPENDENCY_GRAPH_BUILD_TIME,
+    FLAG_DEPENDENCY_GRAPH_PATH_GRAPH, FLAG_DEPENDENCY_GRAPH_PATH_PRECOMPUTED,
+    FLAG_EVALUATION_ERROR_COUNTER, FLAG_MISSING_REQUESTED_FLAG_KEY, TOMBSTONE_COUNTER,
+};
+use common_metrics::{inc, timing_guard};
 use tracing::warn;
+
+/// Logs a warning and increments the error counter when a requested flag key is not found.
+fn warn_missing_flag_key(key: &str) {
+    warn!("Requested flag key not found: {}", key);
+    inc(
+        FLAG_EVALUATION_ERROR_COUNTER,
+        &[(
+            "reason".to_string(),
+            FLAG_MISSING_REQUESTED_FLAG_KEY.to_string(),
+        )],
+        1,
+    );
+}
+
+/// Builds a HashMap from flag key to flag ID for efficient key-based lookups.
+fn build_key_to_id(flags: &[FeatureFlag]) -> HashMap<String, i32> {
+    flags.iter().map(|f| (f.key.clone(), f.id)).collect()
+}
 
 /// Increments the tombstone counter for a graph_utils operation.
 fn inc_graph_tombstone(operation: &str) {
@@ -457,6 +480,10 @@ where
     }
 }
 
+// TODO: Remove these #[cfg(test)] items (DependencyGraphResult, build_dependency_graph,
+// FilteredGraphResult, filter_graph_by_keys) and the petgraph dependency once the
+// precomputed path is validated in production and the fallback path is removed.
+#[cfg(test)]
 /// Result of building a dependency graph, including the graph, errors, and flags with missing dependencies.
 pub struct DependencyGraphResult {
     /// The dependency graph (may include nodes with missing dependencies)
@@ -467,6 +494,7 @@ pub struct DependencyGraphResult {
     pub flags_with_missing_deps: HashSet<i32>,
 }
 
+#[cfg(test)]
 /// Builds a dependency graph for flag evaluation.
 /// Returns None only for fatal errors. Partial errors (cycles, missing dependencies)
 /// are returned in the result and nodes with missing dependencies are kept in the graph.
@@ -573,6 +601,7 @@ pub fn build_dependency_graph(
     })
 }
 
+#[cfg(test)]
 /// Result of filtering a dependency graph.
 pub struct FilteredGraphResult {
     /// The filtered dependency graph
@@ -581,6 +610,7 @@ pub struct FilteredGraphResult {
     pub flags_with_missing_deps: HashSet<i32>,
 }
 
+#[cfg(test)]
 /// Filters a dependency graph to include only the requested flags and their dependencies.
 /// Also filters the flags_with_missing_deps set to only include flags in the filtered graph.
 /// Returns None if:
@@ -633,16 +663,7 @@ pub fn filter_graph_by_keys(
                 }
             }
         } else {
-            // Log warning for missing flag key
-            warn!("Requested flag key not found: {}", key);
-            inc(
-                FLAG_EVALUATION_ERROR_COUNTER,
-                &[(
-                    "reason".to_string(),
-                    "missing_requested_flag_key".to_string(),
-                )],
-                1,
-            );
+            warn_missing_flag_key(key);
         }
     }
 
@@ -681,6 +702,380 @@ pub fn filter_graph_by_keys(
         },
         flags_with_missing_deps: filtered_missing_deps,
     })
+}
+
+/// Pre-computed dependency graph data, built once when flags are loaded from cache.
+/// All fields are derived deterministically from the flag list.
+#[derive(Debug)]
+pub struct PrecomputedDependencyGraph {
+    /// Topologically sorted evaluation stages. Each inner Vec contains flags
+    /// that can be evaluated in parallel (all their dependencies appear in
+    /// earlier stages).
+    pub evaluation_stages: Vec<Vec<FeatureFlag>>,
+
+    /// Flag IDs whose dependencies are missing or transitively broken.
+    /// On the precomputed path, this includes cycle participants (Django merges
+    /// them). On the graph fallback path, cycle participants are removed from
+    /// stages separately. Both paths evaluate these flags as false (fail closed).
+    pub flags_with_missing_deps: HashSet<i32>,
+
+    /// For each flag ID, the set of all transitive dependency flag IDs.
+    /// Only populated on the graph fallback path for use by `filter_stages_by_keys`.
+    pub(crate) transitive_deps: HashMap<i32, HashSet<i32>>,
+
+    /// Mapping from flag key to flag ID, for efficient key-based lookups.
+    /// Only populated on the graph fallback path for use by `filter_stages_by_keys`.
+    pub(crate) key_to_id: HashMap<String, i32>,
+
+    /// Number of flags affected by dependency errors (missing deps + cycles).
+    pub error_count: usize,
+
+    /// Whether any graph construction errors were dependency cycles.
+    pub has_cycle_errors: bool,
+
+    /// True when built via the graph fallback path (no precomputed metadata).
+    /// The caller uses this to decide whether post-build filtering via
+    /// `filter_stages_by_keys` is needed.
+    pub is_graph_fallback: bool,
+}
+
+/// Result of filtering pre-computed stages by requested flag keys.
+#[derive(Debug)]
+pub struct FilteredStagesResult {
+    /// Filtered evaluation stages containing only the requested flags and their dependencies.
+    pub evaluation_stages: Vec<Vec<FeatureFlag>>,
+    /// Subset of flags_with_missing_deps that are relevant to the filtered stages.
+    pub flags_with_missing_deps: HashSet<i32>,
+}
+
+impl PrecomputedDependencyGraph {
+    /// Builds a `PrecomputedDependencyGraph` from a flag list.
+    /// Uses the fast path when Django-precomputed `evaluation_metadata` is present,
+    /// falls back to full graph construction otherwise.
+    ///
+    /// When `flag_keys` is provided on the precomputed path, only the requested flags
+    /// and their transitive dependencies are cloned into stages, avoiding allocation
+    /// of unneeded `FeatureFlag` structs. On the fallback (graph) path, `flag_keys` is
+    /// ignored — the caller must use `filter_stages_by_keys` after build.
+    ///
+    /// Returns `None` only for fatal errors (same semantics as `build_dependency_graph`).
+    pub fn build(
+        feature_flags: &crate::flags::flag_models::FeatureFlagList,
+        team_id: common_types::TeamId,
+        flag_keys: Option<&[String]>,
+    ) -> Option<Self> {
+        let (path, result) =
+            if let Some(ref evaluation_metadata) = feature_flags.evaluation_metadata {
+                let labels = [(
+                    "path".to_string(),
+                    FLAG_DEPENDENCY_GRAPH_PATH_PRECOMPUTED.to_string(),
+                )];
+                let _timer = timing_guard(FLAG_DEPENDENCY_GRAPH_BUILD_TIME, &labels);
+                (
+                    FLAG_DEPENDENCY_GRAPH_PATH_PRECOMPUTED,
+                    Self::build_from_precomputed(
+                        &feature_flags.flags,
+                        evaluation_metadata,
+                        &feature_flags.filtered_out_flag_ids,
+                        flag_keys,
+                    ),
+                )
+            } else {
+                let labels = [(
+                    "path".to_string(),
+                    FLAG_DEPENDENCY_GRAPH_PATH_GRAPH.to_string(),
+                )];
+                let _timer = timing_guard(FLAG_DEPENDENCY_GRAPH_BUILD_TIME, &labels);
+                (
+                    FLAG_DEPENDENCY_GRAPH_PATH_GRAPH,
+                    Self::build_from_graph(
+                        &feature_flags.flags,
+                        &feature_flags.filtered_out_flag_ids,
+                        team_id,
+                    ),
+                )
+            };
+        inc(
+            FLAG_DEPENDENCY_GRAPH_BUILD_COUNTER,
+            &[("path".to_string(), path.to_string())],
+            1,
+        );
+        result
+    }
+
+    /// Fast path: consumes the top-level `EvaluationMetadata` directly.
+    /// No Kahn's algorithm, no per-flag scanning, no ID→key conversion loops.
+    ///
+    /// When `flag_keys` is provided, only the requested flags and their transitive
+    /// dependencies are cloned into stages, avoiding allocation of unneeded structs.
+    /// Global stats (`error_count`, `has_cycle_errors`) always reflect the full flag set.
+    fn build_from_precomputed(
+        flags: &[FeatureFlag],
+        evaluation_metadata: &crate::flags::flag_models::EvaluationMetadata,
+        filtered_out_flag_ids: &HashSet<i32>,
+        flag_keys: Option<&[String]>,
+    ) -> Option<Self> {
+        let id_to_flag: HashMap<i32, &FeatureFlag> = flags.iter().map(|f| (f.id, f)).collect();
+
+        // When flag_keys is specified, compute the set of needed flag IDs upfront
+        // so we only clone flags that will actually be evaluated.
+        let needed_ids: Option<HashSet<i32>> = flag_keys.map(|keys| {
+            let key_to_id: HashMap<&str, i32> =
+                flags.iter().map(|f| (f.key.as_str(), f.id)).collect();
+            let mut ids = HashSet::new();
+            for key in keys {
+                if let Some(&id) = key_to_id.get(key.as_str()) {
+                    ids.insert(id);
+                    if let Some(dep_ids) = evaluation_metadata.transitive_deps.get(&id) {
+                        ids.extend(dep_ids);
+                    }
+                } else {
+                    warn_missing_flag_key(key);
+                }
+            }
+            ids
+        });
+
+        // When flag_keys is None, all non-filtered-out flags are needed.
+        let is_needed = |id: &i32| needed_ids.as_ref().map_or(true, |ids| ids.contains(id));
+
+        // Count non-filtered-out IDs across all stages for the cycle count computation.
+        let global_flags_in_stages_count: usize = evaluation_metadata
+            .dependency_stages
+            .iter()
+            .flat_map(|stage| stage.iter())
+            .filter(|id| !filtered_out_flag_ids.contains(id))
+            .count();
+
+        // Assemble stages from pre-grouped IDs, excluding runtime-filtered flags
+        // and (when flag_keys is specified) flags not in the needed set.
+        let evaluation_stages: Vec<Vec<FeatureFlag>> = evaluation_metadata
+            .dependency_stages
+            .iter()
+            .filter_map(|stage_ids| {
+                let stage: Vec<FeatureFlag> = stage_ids
+                    .iter()
+                    .filter(|id| !filtered_out_flag_ids.contains(id))
+                    .filter(|id| is_needed(id))
+                    .filter_map(|id| id_to_flag.get(id).map(|f| (*f).clone()))
+                    .collect();
+                (!stage.is_empty()).then_some(stage)
+            })
+            .collect();
+
+        let flags_with_missing_deps: HashSet<i32> = evaluation_metadata
+            .flags_with_missing_deps
+            .iter()
+            .copied()
+            .filter(|id| !filtered_out_flag_ids.contains(id))
+            .filter(|id| is_needed(id))
+            .collect();
+
+        // Django's Kahn's algorithm guarantees: a flag appears in dependency_stages
+        // iff it reaches zero in-degree (i.e., is not a cycle participant).
+        // Therefore: total flags - filtered out - staged = cycle participants.
+        // saturating_sub guards against filtered_out_flag_ids containing IDs
+        // not present in the flags slice.
+        let cycle_count = flags
+            .len()
+            .saturating_sub(filtered_out_flag_ids.len())
+            .saturating_sub(global_flags_in_stages_count);
+
+        // When flag_keys was provided, filtering already happened during construction
+        // so transitive_deps and key_to_id are not needed on the struct.
+        // When flag_keys is None, populate them for cross-validation tests that
+        // compare precomputed and fallback paths.
+        let (transitive_deps, key_to_id) = if flag_keys.is_some() {
+            (HashMap::new(), HashMap::new())
+        } else {
+            (
+                evaluation_metadata.transitive_deps.clone(),
+                build_key_to_id(flags),
+            )
+        };
+
+        // Django's flags_with_missing_deps already includes cycle participants
+        // (in_degree > 0 after Kahn's), so don't add cycle_count separately.
+        Some(Self {
+            evaluation_stages,
+            error_count: flags_with_missing_deps.len(),
+            has_cycle_errors: cycle_count > 0,
+            flags_with_missing_deps,
+            transitive_deps,
+            key_to_id,
+            is_graph_fallback: false,
+        })
+    }
+
+    /// Fallback path: builds a full petgraph-based dependency graph when
+    /// precomputed data is absent (old cache format or PG fallback).
+    fn build_from_graph(
+        flags: &[FeatureFlag],
+        filtered_out_flag_ids: &HashSet<i32>,
+        team_id: common_types::TeamId,
+    ) -> Option<Self> {
+        // Extract edges from each flag's property filters.
+        // Filtered-out flags (runtime mismatch, tag filter, etc.) get empty
+        // edges so their dependencies aren't followed, preventing false cycles.
+        // Note: unlike the old BFS-based build_dependency_graph, this includes
+        // all filtered-out flags as isolated nodes rather than only reachable
+        // ones. This is safe — unreachable nodes end up in stage 0 and are
+        // skipped during evaluation.
+        let mut edges: HashMap<i32, HashSet<i32>> = HashMap::with_capacity(flags.len());
+        for flag in flags {
+            if filtered_out_flag_ids.contains(&flag.id) {
+                edges.insert(flag.id, HashSet::new());
+                continue;
+            }
+            match flag.extract_dependencies() {
+                Ok(deps) => {
+                    edges.insert(flag.id, deps);
+                }
+                Err(e) => {
+                    log_dependency_graph_operation_error(
+                        "extract dependencies for graph fallback",
+                        &e,
+                        team_id,
+                    );
+                    return None;
+                }
+            }
+        }
+
+        let (graph, errors, flags_with_missing_deps) =
+            match DependencyGraph::from_nodes(flags.to_vec(), &edges) {
+                Ok(result) => result,
+                Err(e) => {
+                    log_dependency_graph_operation_error(
+                        "build global dependency graph",
+                        &e,
+                        team_id,
+                    );
+                    return None;
+                }
+            };
+
+        if !errors.is_empty() {
+            log_dependency_graph_construction_errors(&errors, team_id);
+        }
+
+        let cycle_count = errors.iter().filter(|e| e.is_cycle()).count();
+        let has_cycle_errors = cycle_count > 0;
+        let error_count = flags_with_missing_deps.len() + cycle_count;
+        let transitive_deps = Self::build_transitive_deps_map_from_graph(&graph);
+        let key_to_id = build_key_to_id(flags);
+
+        let evaluation_stages = match graph.into_evaluation_stages() {
+            Ok(stages) => stages,
+            Err(e) => {
+                log_dependency_graph_operation_error("get evaluation stages", &e, team_id);
+                return None;
+            }
+        };
+
+        Some(Self {
+            evaluation_stages,
+            flags_with_missing_deps,
+            transitive_deps,
+            key_to_id,
+            error_count,
+            has_cycle_errors,
+            is_graph_fallback: true,
+        })
+    }
+
+    /// Filters evaluation stages to only include the requested flags and their
+    /// transitive dependencies. Consumes `self` to move (not clone) flags into
+    /// the result. Uses ID-based filtering for speed.
+    ///
+    /// Used by the fallback (graph) path where flag_keys filtering cannot happen
+    /// during construction. The precomputed path filters during build instead.
+    pub fn filter_stages_by_keys(self, requested_keys: &[String]) -> FilteredStagesResult {
+        debug_assert!(
+            self.is_graph_fallback,
+            "filter_stages_by_keys should only be called on graph fallback path"
+        );
+        let mut needed_ids: HashSet<i32> = HashSet::new();
+        for key in requested_keys {
+            if let Some(&id) = self.key_to_id.get(key.as_str()) {
+                needed_ids.insert(id);
+                if let Some(dep_ids) = self.transitive_deps.get(&id) {
+                    needed_ids.extend(dep_ids);
+                }
+            } else {
+                warn_missing_flag_key(key);
+            }
+        }
+
+        // Filter stages by flag ID, dropping empty stages.
+        // Uses into_iter to move flags rather than cloning them.
+        let evaluation_stages: Vec<Vec<FeatureFlag>> = self
+            .evaluation_stages
+            .into_iter()
+            .filter_map(|stage| {
+                let filtered: Vec<FeatureFlag> = stage
+                    .into_iter()
+                    .filter(|flag| needed_ids.contains(&flag.id))
+                    .collect();
+                (!filtered.is_empty()).then_some(filtered)
+            })
+            .collect();
+
+        // needed_ids is the exact set of flags that could appear in filtered stages,
+        // so intersecting with it avoids a second pass over the stages.
+        let flags_with_missing_deps: HashSet<i32> = self
+            .flags_with_missing_deps
+            .intersection(&needed_ids)
+            .copied()
+            .collect();
+
+        FilteredStagesResult {
+            evaluation_stages,
+            flags_with_missing_deps,
+        }
+    }
+
+    /// Builds a map from each flag ID to the set of all its transitive dependency IDs.
+    /// Used by the fallback (petgraph) path. Uses memoization to avoid redundant
+    /// graph traversals, though set copying makes worst case O(V^2) for chains.
+    fn build_transitive_deps_map_from_graph(
+        graph: &DependencyGraph<FeatureFlag>,
+    ) -> HashMap<i32, HashSet<i32>> {
+        use petgraph::algo::toposort;
+        use petgraph::Direction::Outgoing;
+        let inner = &graph.graph;
+
+        let mut memo: HashMap<NodeIndex, HashSet<i32>> = HashMap::new();
+
+        // Process in reverse topological order so dependencies are computed
+        // before the nodes that depend on them. If toposort fails (cycle),
+        // fall back to natural node order — cycles were already removed from
+        // the graph by this point, so this is just a safety net.
+        let order: Vec<NodeIndex> = match toposort(inner, None) {
+            Ok(mut sorted) => {
+                sorted.reverse();
+                sorted
+            }
+            Err(_) => inner.node_indices().collect(),
+        };
+
+        for node_idx in order {
+            let mut deps = HashSet::new();
+            for neighbor in inner.neighbors_directed(node_idx, Outgoing) {
+                let dep_id = inner[neighbor].id;
+                deps.insert(dep_id);
+                // Reuse already-computed transitive deps for this neighbor
+                if let Some(transitive) = memo.get(&neighbor) {
+                    deps.extend(transitive);
+                }
+            }
+            memo.insert(node_idx, deps);
+        }
+
+        memo.into_iter()
+            .map(|(idx, deps)| (inner[idx].id, deps))
+            .collect()
+    }
 }
 
 /// Handles errors during dependency graph operations.

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -3169,13 +3169,15 @@ mod precomputed_dependency_graph_tests {
                 (5, HashSet::new()),
             ]),
         };
-        let make_flags = || vec![
-            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
-            create_flag(2, "flag_b", HashSet::from([4]), true),
-            create_flag(3, "flag_c", HashSet::from([4]), true),
-            create_flag(4, "flag_d", HashSet::new(), true),
-            create_flag(5, "flag_e", HashSet::new(), true),
-        ];
+        let make_flags = || {
+            vec![
+                create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+                create_flag(2, "flag_b", HashSet::from([4]), true),
+                create_flag(3, "flag_c", HashSet::from([4]), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+                create_flag(5, "flag_e", HashSet::new(), true),
+            ]
+        };
         let requested_keys = vec!["flag_a".to_string()];
 
         // Path 1: graph fallback (no evaluation_metadata), then filter_stages_by_keys
@@ -3193,7 +3195,8 @@ mod precomputed_dependency_graph_tests {
             ..Default::default()
         };
         let direct =
-            PrecomputedDependencyGraph::build(&precomputed_flags, 1, Some(&requested_keys)).unwrap();
+            PrecomputedDependencyGraph::build(&precomputed_flags, 1, Some(&requested_keys))
+                .unwrap();
 
         assert_eq!(
             stage_keys(&direct.evaluation_stages),

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -2754,47 +2754,6 @@ mod precomputed_dependency_graph_tests {
     }
 
     #[test]
-    fn test_precomputed_filter_stages_works() {
-        // A(1)->B(2)->C(3), D(4) independent
-        let feature_flags = FeatureFlagList {
-            flags: vec![
-                create_flag(1, "flag_a", HashSet::from([2]), true),
-                create_flag(2, "flag_b", HashSet::from([3]), true),
-                create_flag(3, "flag_c", HashSet::new(), true),
-                create_flag(4, "flag_d", HashSet::new(), true),
-            ],
-            evaluation_metadata: Some(EvaluationMetadata {
-                dependency_stages: vec![vec![3, 4], vec![2], vec![1]],
-                flags_with_missing_deps: vec![],
-                transitive_deps: HashMap::from([
-                    (1, HashSet::from([2, 3])),
-                    (2, HashSet::from([3])),
-                    (3, HashSet::new()),
-                    (4, HashSet::new()),
-                ]),
-            }),
-            ..Default::default()
-        };
-
-        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
-        let result = precomputed.filter_stages_by_keys(&["flag_a".to_string()]);
-
-        let all_keys: HashSet<String> = result
-            .evaluation_stages
-            .iter()
-            .flat_map(|s| s.iter().map(|f| f.key.clone()))
-            .collect();
-
-        assert!(all_keys.contains("flag_a"));
-        assert!(all_keys.contains("flag_b"));
-        assert!(all_keys.contains("flag_c"));
-        assert!(
-            !all_keys.contains("flag_d"),
-            "flag_d is independent, should be excluded"
-        );
-    }
-
-    #[test]
     fn test_precomputed_path_handles_cycles_via_missing_deps() {
         // Simulate Django output for A(1)->B(2)->A(1) cycle plus independent C(3)
         let feature_flags = FeatureFlagList {
@@ -3210,26 +3169,31 @@ mod precomputed_dependency_graph_tests {
                 (5, HashSet::new()),
             ]),
         };
-        let make_flags = || FeatureFlagList {
-            flags: vec![
-                create_flag(1, "flag_a", HashSet::from([2, 3]), true),
-                create_flag(2, "flag_b", HashSet::from([4]), true),
-                create_flag(3, "flag_c", HashSet::from([4]), true),
-                create_flag(4, "flag_d", HashSet::new(), true),
-                create_flag(5, "flag_e", HashSet::new(), true),
-            ],
+        let make_flags = || vec![
+            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+            create_flag(2, "flag_b", HashSet::from([4]), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+            create_flag(5, "flag_e", HashSet::new(), true),
+        ];
+        let requested_keys = vec!["flag_a".to_string()];
+
+        // Path 1: graph fallback (no evaluation_metadata), then filter_stages_by_keys
+        let fallback_flags = FeatureFlagList {
+            flags: make_flags(),
+            ..Default::default()
+        };
+        let full = PrecomputedDependencyGraph::build(&fallback_flags, 1, None).unwrap();
+        let filtered = full.filter_stages_by_keys(&requested_keys);
+
+        // Path 2: precomputed path with flag_keys=Some directly
+        let precomputed_flags = FeatureFlagList {
+            flags: make_flags(),
             evaluation_metadata: Some(deps.clone()),
             ..Default::default()
         };
-        let requested_keys = vec!["flag_a".to_string()];
-
-        // Path 1: build with flag_keys=None, then filter_stages_by_keys
-        let full = PrecomputedDependencyGraph::build(&make_flags(), 1, None).unwrap();
-        let filtered = full.filter_stages_by_keys(&requested_keys);
-
-        // Path 2: build with flag_keys=Some directly
         let direct =
-            PrecomputedDependencyGraph::build(&make_flags(), 1, Some(&requested_keys)).unwrap();
+            PrecomputedDependencyGraph::build(&precomputed_flags, 1, Some(&requested_keys)).unwrap();
 
         assert_eq!(
             stage_keys(&direct.evaluation_stages),

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -1294,6 +1294,82 @@ mod filter_graph_by_keys_tests {
     }
 }
 
+#[cfg(test)]
+mod evaluation_metadata_serde_tests {
+    use crate::flags::flag_models::EvaluationMetadata;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn test_round_trip_serialization() {
+        let original = EvaluationMetadata {
+            dependency_stages: vec![vec![3, 4], vec![2], vec![1]],
+            flags_with_missing_deps: vec![4],
+            transitive_deps: HashMap::from([
+                (1, HashSet::from([2, 3])),
+                (2, HashSet::from([3])),
+                (3, HashSet::new()),
+                (4, HashSet::new()),
+            ]),
+        };
+
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: EvaluationMetadata =
+            serde_json::from_str(&json).expect("deserialize round-trip");
+
+        assert_eq!(deserialized.dependency_stages, original.dependency_stages);
+        assert_eq!(
+            deserialized.flags_with_missing_deps,
+            original.flags_with_missing_deps
+        );
+        assert_eq!(deserialized.transitive_deps, original.transitive_deps);
+    }
+
+    #[test]
+    fn test_empty_transitive_deps_round_trip() {
+        let original = EvaluationMetadata {
+            dependency_stages: vec![vec![1]],
+            flags_with_missing_deps: vec![],
+            transitive_deps: HashMap::new(),
+        };
+
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: EvaluationMetadata = serde_json::from_str(&json).expect("deserialize");
+
+        assert!(deserialized.transitive_deps.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_string_keyed_map_from_python_format() {
+        // Python serializes int keys as strings in JSON
+        let json = r#"{
+            "dependency_stages": [[1]],
+            "flags_with_missing_deps": [],
+            "transitive_deps": {"1": [2, 3], "2": [3], "3": []}
+        }"#;
+
+        let meta: EvaluationMetadata = serde_json::from_str(json).expect("deserialize");
+
+        assert_eq!(meta.transitive_deps[&1], HashSet::from([2, 3]));
+        assert_eq!(meta.transitive_deps[&2], HashSet::from([3]));
+        assert!(meta.transitive_deps[&3].is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_non_numeric_string_key_fails() {
+        let json = r#"{
+            "dependency_stages": [[1]],
+            "flags_with_missing_deps": [],
+            "transitive_deps": {"abc": [1, 2]}
+        }"#;
+
+        let result = serde_json::from_str::<EvaluationMetadata>(json);
+        assert!(
+            result.is_err(),
+            "Non-numeric string key should fail deserialization"
+        );
+    }
+}
+
 /// Creates a test flag with the given dependencies, active state, and deleted state.
 /// Builds a `FeatureFlagList` with `filtered_out_flag_ids` pre-populated
 /// from inactive/deleted flags, matching production behavior.
@@ -1309,6 +1385,7 @@ fn make_flag_list(
     crate::flags::flag_models::FeatureFlagList {
         flags,
         filtered_out_flag_ids,
+        evaluation_metadata: None,
     }
 }
 
@@ -1754,5 +1831,1539 @@ mod seed_set_closure_tests {
             "Expected a CycleDetected error, got: {:?}",
             result.errors
         );
+    }
+}
+
+#[cfg(test)]
+mod precomputed_dependency_graph_tests {
+    use crate::flags::flag_models::{EvaluationMetadata, FeatureFlag, FeatureFlagList};
+    use crate::utils::graph_utils::{
+        build_dependency_graph, filter_graph_by_keys, PrecomputedDependencyGraph,
+    };
+    use std::collections::{HashMap, HashSet};
+
+    fn create_flag(id: i32, key: &str, dependencies: HashSet<i32>, active: bool) -> FeatureFlag {
+        super::create_flag_with_deps(id, key, dependencies, active, false)
+    }
+
+    /// Extracts sorted flag keys from evaluation stages for deterministic comparison.
+    fn stage_keys(stages: &[Vec<FeatureFlag>]) -> Vec<Vec<String>> {
+        stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_build_no_dependencies() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // All flags are independent, so they should be in a single stage
+        assert_eq!(precomputed.evaluation_stages.len(), 1);
+        assert_eq!(stage_keys(&precomputed.evaluation_stages)[0].len(), 3);
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert_eq!(precomputed.error_count, 0);
+        assert!(!precomputed.has_cycle_errors);
+
+        // Each flag should have no transitive dependencies
+        for id in [1, 2, 3] {
+            assert!(
+                precomputed.transitive_deps[&id].is_empty(),
+                "Flag {} should have no transitive dependencies",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_linear_chain() {
+        // flag_a -> flag_b -> flag_c (flag_a depends on flag_b, which depends on flag_c)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Three stages: flag_c, then flag_b, then flag_a
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+
+        // Transitive deps
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3]));
+        assert_eq!(precomputed.transitive_deps[&2], HashSet::from([3]));
+        assert!(precomputed.transitive_deps[&3].is_empty());
+    }
+
+    #[test]
+    fn test_build_diamond_dependency() {
+        //   flag_a
+        //   /    \
+        // flag_b  flag_c
+        //   \    /
+        //   flag_d
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+            create_flag(2, "flag_b", HashSet::from([4]), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Three stages: flag_d, then flag_b+flag_c, then flag_a
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_d"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b", "flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+
+        // flag_a transitively depends on all others
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3, 4]));
+        assert_eq!(precomputed.transitive_deps[&2], HashSet::from([4]));
+        assert_eq!(precomputed.transitive_deps[&3], HashSet::from([4]));
+        assert!(precomputed.transitive_deps[&4].is_empty());
+    }
+
+    #[test]
+    fn test_build_missing_dependency() {
+        // flag_a depends on flag_b (id=2), but flag_b doesn't exist
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+        assert!(!precomputed.flags_with_missing_deps.contains(&3));
+        assert!(precomputed.error_count > 0);
+    }
+
+    #[test]
+    fn test_build_transitive_missing_dependency() {
+        // flag_a -> flag_b -> (missing flag_c)
+        // flag_a should also be marked as having missing deps
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert!(
+            precomputed.flags_with_missing_deps.contains(&1),
+            "flag_a should be transitively marked as missing deps"
+        );
+        assert!(
+            precomputed.flags_with_missing_deps.contains(&2),
+            "flag_b should be directly marked as missing deps"
+        );
+    }
+
+    #[test]
+    fn test_build_empty_flag_list() {
+        let feature_flags = FeatureFlagList {
+            flags: vec![],
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert!(precomputed.evaluation_stages.is_empty());
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert!(precomputed.transitive_deps.is_empty());
+        assert_eq!(precomputed.error_count, 0);
+    }
+
+    #[test]
+    fn test_build_single_flag_no_dependencies() {
+        let flags = vec![create_flag(1, "solo_flag", HashSet::new(), true)];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert_eq!(precomputed.evaluation_stages.len(), 1);
+        assert_eq!(precomputed.evaluation_stages[0].len(), 1);
+        assert_eq!(precomputed.evaluation_stages[0][0].key, "solo_flag");
+        assert!(precomputed.transitive_deps[&1].is_empty());
+    }
+
+    #[test]
+    fn test_build_inactive_flag_skips_dependencies() {
+        // Inactive flag references non-existent dependency — should not produce errors
+        let flags = vec![
+            create_flag(1, "inactive_flag", HashSet::from([999]), false),
+            create_flag(2, "active_flag", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert_eq!(precomputed.error_count, 0);
+    }
+
+    // --- Equivalence tests: PrecomputedDependencyGraph produces the same results
+    // as the current build_dependency_graph + into_evaluation_stages path ---
+
+    #[test]
+    fn test_equivalence_linear_chain() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        // Old path
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            old_stage_keys,
+            "Pre-computed stages should match the old path"
+        );
+        assert_eq!(
+            precomputed.flags_with_missing_deps, old_result.flags_with_missing_deps,
+            "Missing deps should match the old path"
+        );
+        assert_eq!(
+            precomputed.error_count,
+            old_result.flags_with_missing_deps.len()
+                + old_result.errors.iter().filter(|e| e.is_cycle()).count(),
+            "error_count counts affected flags, not error edges"
+        );
+    }
+
+    #[test]
+    fn test_equivalence_diamond() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+            create_flag(2, "flag_b", HashSet::from([4]), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert_eq!(stage_keys(&precomputed.evaluation_stages), old_stage_keys);
+        assert_eq!(
+            precomputed.flags_with_missing_deps,
+            old_result.flags_with_missing_deps
+        );
+    }
+
+    #[test]
+    fn test_equivalence_missing_deps() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert_eq!(
+            precomputed.flags_with_missing_deps, old_result.flags_with_missing_deps,
+            "Missing deps should match between old and new paths"
+        );
+        assert_eq!(
+            precomputed.error_count,
+            old_result.flags_with_missing_deps.len()
+                + old_result.errors.iter().filter(|e| e.is_cycle()).count(),
+            "error_count counts affected flags, not error edges"
+        );
+    }
+
+    #[test]
+    fn test_equivalence_multi_root_no_deps() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Both should produce a single stage with all flags
+        assert_eq!(precomputed.evaluation_stages.len(), old_stages.len());
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            old_stages
+                .iter()
+                .map(|stage| {
+                    let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                    keys.sort();
+                    keys
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // --- filter_stages_by_keys tests ---
+
+    #[test]
+    fn test_filter_stages_no_keys_returns_empty() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let result = precomputed.filter_stages_by_keys(&[]);
+
+        assert!(result.evaluation_stages.is_empty());
+    }
+
+    #[test]
+    fn test_filter_stages_single_flag_no_deps() {
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::new(), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["flag_b".to_string()]);
+
+        assert_eq!(result.evaluation_stages.len(), 1);
+        assert_eq!(result.evaluation_stages[0].len(), 1);
+        assert_eq!(result.evaluation_stages[0][0].key, "flag_b");
+    }
+
+    #[test]
+    fn test_filter_stages_includes_transitive_deps() {
+        // flag_a -> flag_b -> flag_c
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Requesting flag_a should include flag_b and flag_c but not flag_d
+        let result = precomputed.filter_stages_by_keys(&["flag_a".to_string()]);
+
+        let all_keys: HashSet<String> = result
+            .evaluation_stages
+            .iter()
+            .flat_map(|stage| stage.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(all_keys.contains("flag_c"));
+        assert!(!all_keys.contains("flag_d"));
+
+        // Stages should preserve topological order
+        assert_eq!(result.evaluation_stages.len(), 3);
+        assert_eq!(result.evaluation_stages[0][0].key, "flag_c");
+        assert_eq!(result.evaluation_stages[1][0].key, "flag_b");
+        assert_eq!(result.evaluation_stages[2][0].key, "flag_a");
+    }
+
+    #[test]
+    fn test_filter_stages_missing_key_ignored() {
+        let flags = vec![create_flag(1, "flag_a", HashSet::new(), true)];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["nonexistent".to_string()]);
+
+        assert!(result.evaluation_stages.is_empty());
+    }
+
+    #[test]
+    fn test_filter_stages_preserves_missing_deps() {
+        // flag_a -> flag_b -> (missing)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["flag_a".to_string()]);
+
+        assert!(
+            result.flags_with_missing_deps.contains(&1),
+            "flag_a should retain missing dep status after filtering"
+        );
+        assert!(
+            result.flags_with_missing_deps.contains(&2),
+            "flag_b should retain missing dep status after filtering"
+        );
+        // flag_c was not requested and should not appear
+        assert!(!result.flags_with_missing_deps.contains(&3));
+    }
+
+    #[test]
+    fn test_filter_stages_equivalence_with_filter_graph_by_keys() {
+        // Diamond: flag_a -> flag_b, flag_c -> flag_d; also flag_e (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+            create_flag(2, "flag_b", HashSet::from([4]), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+            create_flag(5, "flag_e", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+        let requested_keys = vec!["flag_a".to_string()];
+
+        // Old path: build graph, filter, then get stages
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_filtered = filter_graph_by_keys(
+            &old_result.graph,
+            &requested_keys,
+            &old_result.flags_with_missing_deps,
+        )
+        .unwrap();
+        let old_stages = old_filtered.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let new_result = precomputed.filter_stages_by_keys(&requested_keys);
+
+        assert_eq!(
+            stage_keys(&new_result.evaluation_stages),
+            old_stage_keys,
+            "Filtered stages should match between old and new paths"
+        );
+        assert_eq!(
+            new_result.flags_with_missing_deps, old_filtered.flags_with_missing_deps,
+            "Filtered missing deps should match"
+        );
+    }
+
+    #[test]
+    fn test_build_with_cycle() {
+        // flag_a -> flag_b -> flag_a (cycle), flag_c is independent
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([1]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert!(precomputed.has_cycle_errors);
+        assert!(precomputed.error_count > 0);
+
+        // Cyclic flags are removed; only flag_c should remain
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|stage| stage.iter().map(|f| f.key.clone()))
+            .collect();
+        assert!(all_keys.contains("flag_c"));
+        assert!(
+            !all_keys.contains("flag_a"),
+            "Cyclic flag should be removed"
+        );
+        assert!(
+            !all_keys.contains("flag_b"),
+            "Cyclic flag should be removed"
+        );
+    }
+
+    #[test]
+    fn test_equivalence_with_cycle() {
+        // flag_a -> flag_b -> flag_a (cycle), flag_c independent
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([1]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_has_cycles = old_result.errors.iter().any(|e| e.is_cycle());
+        let old_stages = old_result.graph.into_evaluation_stages().unwrap();
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert_eq!(precomputed.has_cycle_errors, old_has_cycles);
+        assert_eq!(
+            precomputed.error_count,
+            old_result.flags_with_missing_deps.len()
+                + old_result.errors.iter().filter(|e| e.is_cycle()).count()
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            old_stages
+                .iter()
+                .map(|stage| {
+                    let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                    keys.sort();
+                    keys
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_filter_stages_multiple_requested_keys_shared_deps() {
+        // flag_a -> flag_c, flag_b -> flag_c, flag_d (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([3]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags,
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let result =
+            precomputed.filter_stages_by_keys(&["flag_a".to_string(), "flag_b".to_string()]);
+
+        let all_keys: HashSet<String> = result
+            .evaluation_stages
+            .iter()
+            .flat_map(|stage| stage.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(
+            all_keys.contains("flag_c"),
+            "Shared dependency should be included"
+        );
+        assert!(
+            !all_keys.contains("flag_d"),
+            "Unrelated flag should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_filter_stages_equivalence_with_missing_deps() {
+        // flag_a -> flag_b -> (missing 999), flag_c (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([999]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+        let requested_keys = vec!["flag_a".to_string()];
+
+        // Old path
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_filtered = filter_graph_by_keys(
+            &old_result.graph,
+            &requested_keys,
+            &old_result.flags_with_missing_deps,
+        )
+        .unwrap();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let new_result = precomputed.filter_stages_by_keys(&requested_keys);
+
+        assert_eq!(
+            new_result.flags_with_missing_deps, old_filtered.flags_with_missing_deps,
+            "Filtered missing deps should match between old and new paths"
+        );
+    }
+
+    #[test]
+    fn test_filter_stages_equivalence_multiple_keys() {
+        // flag_a -> flag_b, flag_c -> flag_d, flag_e (independent)
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::new(), true),
+            create_flag(3, "flag_c", HashSet::from([4]), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+            create_flag(5, "flag_e", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            ..Default::default()
+        };
+        let requested_keys = vec!["flag_a".to_string(), "flag_c".to_string()];
+
+        // Old path
+        let old_result = build_dependency_graph(&feature_flags, 1).unwrap();
+        let old_filtered = filter_graph_by_keys(
+            &old_result.graph,
+            &requested_keys,
+            &old_result.flags_with_missing_deps,
+        )
+        .unwrap();
+        let old_stages = old_filtered.graph.into_evaluation_stages().unwrap();
+        let old_stage_keys: Vec<Vec<String>> = old_stages
+            .iter()
+            .map(|stage| {
+                let mut keys: Vec<String> = stage.iter().map(|f| f.key.clone()).collect();
+                keys.sort();
+                keys
+            })
+            .collect();
+
+        // New path
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let new_result = precomputed.filter_stages_by_keys(&requested_keys);
+
+        assert_eq!(
+            stage_keys(&new_result.evaluation_stages),
+            old_stage_keys,
+            "Filtered stages should match between old and new paths for multiple keys"
+        );
+    }
+
+    // --- Precomputed data tests: verify build_from_precomputed path ---
+
+    #[test]
+    fn test_deserialization_without_new_fields() {
+        let json = r#"{
+            "id": 1, "team_id": 1, "key": "test", "name": "Test",
+            "filters": {"groups": []}, "deleted": false, "active": true
+        }"#;
+        let flag: FeatureFlag = serde_json::from_str(json).unwrap();
+        assert_eq!(flag.id, 1);
+        assert_eq!(flag.key, "test");
+        assert!(flag.active);
+    }
+
+    #[test]
+    fn test_deserialization_with_evaluation_metadata() {
+        use crate::flags::flag_models::HypercacheFlagsWrapper;
+
+        let json = r#"{
+            "flags": [
+                {"id": 1, "team_id": 1, "key": "test", "name": "Test",
+                 "filters": {"groups": []}, "deleted": false, "active": true}
+            ],
+            "evaluation_metadata": {
+                "dependency_stages": [[1]],
+                "flags_with_missing_deps": [],
+                "transitive_deps": {"1": []}
+            }
+        }"#;
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_str(json).unwrap();
+        assert_eq!(wrapper.flags.len(), 1);
+        assert_eq!(wrapper.flags[0].key, "test");
+        let ctx = wrapper.evaluation_metadata.unwrap();
+        assert_eq!(ctx.dependency_stages, vec![vec![1]]);
+        assert!(ctx.flags_with_missing_deps.is_empty());
+        assert_eq!(ctx.transitive_deps[&1], HashSet::<i32>::new());
+    }
+
+    #[test]
+    fn test_precomputed_path_selected_when_fields_present() {
+        // Flags with precomputed data: A(1) -> B(2) -> C(3)
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![3], vec![2], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3])),
+                    (2, HashSet::from([3])),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Verify fast path outputs (error_count=0, no cycles from precomputed)
+        assert_eq!(precomputed.error_count, 0);
+        assert!(!precomputed.has_cycle_errors);
+
+        // Verify transitive deps were built from precomputed IDs
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3]));
+        assert_eq!(precomputed.transitive_deps[&2], HashSet::from([3]));
+        assert!(precomputed.transitive_deps[&3].is_empty());
+
+        // Verify stages: flag_c first, then flag_b, then flag_a
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+    }
+
+    #[test]
+    fn test_precomputed_missing_deps_collected() {
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![2, 3], vec![1]],
+                flags_with_missing_deps: vec![1, 2],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2])),
+                    (2, HashSet::new()),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+        assert!(precomputed.flags_with_missing_deps.contains(&2));
+        assert!(!precomputed.flags_with_missing_deps.contains(&3));
+    }
+
+    #[test]
+    fn test_fallback_path_used_without_precomputed_fields() {
+        // Flags WITHOUT evaluation_metadata: A -> B -> C (fallback path)
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Fallback should produce the same results
+        assert_eq!(precomputed.evaluation_stages.len(), 3);
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[0],
+            vec!["flag_c"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[1],
+            vec!["flag_b"]
+        );
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages)[2],
+            vec!["flag_a"]
+        );
+        assert_eq!(precomputed.transitive_deps[&1], HashSet::from([2, 3]));
+    }
+
+    #[test]
+    fn test_precomputed_equivalence_diamond() {
+        // Build with precomputed data and without, compare results
+        let deps_a = HashSet::from([2, 3]);
+        let deps_b = HashSet::from([4]);
+        let deps_c = HashSet::from([4]);
+
+        // Without precomputed (fallback path)
+        let flags_no_precomputed = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", deps_a.clone(), true),
+                create_flag(2, "flag_b", deps_b.clone(), true),
+                create_flag(3, "flag_c", deps_c.clone(), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            ..Default::default()
+        };
+        let fallback = PrecomputedDependencyGraph::build(&flags_no_precomputed, 1, None).unwrap();
+
+        // With precomputed (evaluation_metadata on the list)
+        let flags_precomputed = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", deps_a, true),
+                create_flag(2, "flag_b", deps_b, true),
+                create_flag(3, "flag_c", deps_c, true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![4], vec![2, 3], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3, 4])),
+                    (2, HashSet::from([4])),
+                    (3, HashSet::from([4])),
+                    (4, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+        let precomputed = PrecomputedDependencyGraph::build(&flags_precomputed, 1, None).unwrap();
+
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            stage_keys(&fallback.evaluation_stages),
+            "Precomputed and fallback should produce identical stages"
+        );
+        assert_eq!(
+            precomputed.transitive_deps, fallback.transitive_deps,
+            "Transitive deps should match"
+        );
+        assert_eq!(
+            precomputed.flags_with_missing_deps,
+            fallback.flags_with_missing_deps,
+        );
+    }
+
+    #[test]
+    fn test_precomputed_filter_stages_works() {
+        // A(1)->B(2)->C(3), D(4) independent
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![3, 4], vec![2], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3])),
+                    (2, HashSet::from([3])),
+                    (3, HashSet::new()),
+                    (4, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        let result = precomputed.filter_stages_by_keys(&["flag_a".to_string()]);
+
+        let all_keys: HashSet<String> = result
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(all_keys.contains("flag_c"));
+        assert!(
+            !all_keys.contains("flag_d"),
+            "flag_d is independent, should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_precomputed_path_handles_cycles_via_missing_deps() {
+        // Simulate Django output for A(1)->B(2)->A(1) cycle plus independent C(3)
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([1]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![3]], // only C, cycled flags excluded
+                flags_with_missing_deps: vec![1, 2],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2])),
+                    (2, HashSet::from([1])),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Cyclic flags should be excluded from stages
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+        assert!(
+            !all_keys.contains("flag_a"),
+            "Cyclic flag should be excluded from stages"
+        );
+        assert!(
+            !all_keys.contains("flag_b"),
+            "Cyclic flag should be excluded from stages"
+        );
+        assert!(all_keys.contains("flag_c"));
+
+        // Both cyclic flags should be in missing deps
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+        assert!(precomputed.flags_with_missing_deps.contains(&2));
+        assert!(!precomputed.flags_with_missing_deps.contains(&3));
+
+        // Error count = flags_with_missing_deps (A and B are cycle participants)
+        assert_eq!(precomputed.error_count, 2);
+        assert!(precomputed.has_cycle_errors);
+    }
+
+    #[test]
+    fn test_fallback_path_used_when_evaluation_metadata_absent() {
+        // Without evaluation_metadata, fallback path is used
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+            ],
+            ..Default::default() // no evaluation_metadata
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+
+        // Both flags should be present
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+
+        // flag_b should be evaluated before flag_a (flag_a depends on flag_b)
+        let stages = stage_keys(&precomputed.evaluation_stages);
+        assert_eq!(stages.len(), 2);
+        assert_eq!(stages[0], vec!["flag_b"]);
+        assert_eq!(stages[1], vec!["flag_a"]);
+    }
+
+    #[test]
+    fn test_filtered_out_flags_do_not_inflate_cycle_count() {
+        // Three flags total: flag_a(1) active, flag_b(2) active, flag_c(3) inactive.
+        // flag_c is in filtered_out_flag_ids and excluded from dependency_stages.
+        // Without the fix, cycle_count = flags.len(3) - flags_in_stages.len(2) = 1,
+        // falsely reporting a cycle.
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::new(), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+                create_flag(3, "flag_c", HashSet::new(), false),
+            ],
+            filtered_out_flag_ids: HashSet::from([3]),
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![1, 2]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([(1, HashSet::new()), (2, HashSet::new())]),
+            }),
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        assert!(!precomputed.has_cycle_errors);
+        assert_eq!(precomputed.error_count, 0);
+    }
+
+    #[test]
+    fn test_runtime_filtered_active_flag_excluded_from_precomputed_stages() {
+        // Django includes all 3 active flags in dependency_stages.
+        // At request time, flag_b(2) is runtime-filtered (e.g., tag mismatch).
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            filtered_out_flag_ids: HashSet::from([2]),
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![2, 3], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2])),
+                    (2, HashSet::new()),
+                    (3, HashSet::new()),
+                ]),
+            }),
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        let all_ids: HashSet<i32> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.id))
+            .collect();
+        assert!(all_ids.contains(&1));
+        assert!(
+            !all_ids.contains(&2),
+            "Runtime-filtered flag should be excluded"
+        );
+        assert!(all_ids.contains(&3));
+
+        assert!(!precomputed.has_cycle_errors);
+        assert_eq!(precomputed.error_count, 0);
+    }
+
+    #[test]
+    fn test_fallback_with_filtered_out_independent_flag() {
+        // flag_a(1) -> flag_b(2) -> flag_c(3), flag_d(4) independent but filtered out.
+        // The fallback path includes ALL flags as nodes (unlike old BFS which only
+        // includes reachable ones), so flag_d appears in stage 0 as an isolated node.
+        // This is safe — filtered-out flags are skipped during evaluation.
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+            create_flag(4, "flag_d", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            filtered_out_flag_ids: HashSet::from([4]),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // flag_d lands in stage 0 alongside flag_c (both have zero in-degree)
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            vec![vec!["flag_c", "flag_d"], vec!["flag_b"], vec!["flag_a"],],
+        );
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert!(!precomputed.has_cycle_errors);
+    }
+
+    #[test]
+    fn test_fallback_filtered_flag_breaks_dependency_chain() {
+        // flag_a(1) -> flag_b(2) -> flag_c(3), flag_b is filtered out.
+        // Filtered-out flag_b gets empty edges, so it becomes an isolated node
+        // in stage 0 alongside flag_c. flag_a still depends on flag_b, so it
+        // goes to stage 1.
+        let flags = vec![
+            create_flag(1, "flag_a", HashSet::from([2]), true),
+            create_flag(2, "flag_b", HashSet::from([3]), true),
+            create_flag(3, "flag_c", HashSet::new(), true),
+        ];
+        let feature_flags = FeatureFlagList {
+            flags: flags.clone(),
+            filtered_out_flag_ids: HashSet::from([2]),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // flag_b's edges are cleared (filtered), so it and flag_c are both stage 0.
+        // flag_a depends on flag_b, so it's stage 1.
+        assert_eq!(
+            stage_keys(&precomputed.evaluation_stages),
+            vec![vec!["flag_b", "flag_c"], vec!["flag_a"],],
+        );
+        assert!(precomputed.flags_with_missing_deps.is_empty());
+        assert!(!precomputed.has_cycle_errors);
+    }
+
+    // --- is_graph_fallback flag tests ---
+
+    #[test]
+    fn test_is_graph_fallback_false_when_evaluation_metadata_present() {
+        let feature_flags = FeatureFlagList {
+            flags: vec![create_flag(1, "flag_a", HashSet::new(), true)],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([(1, HashSet::new())]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        assert!(
+            !precomputed.is_graph_fallback,
+            "Precomputed path should set is_graph_fallback=false"
+        );
+    }
+
+    #[test]
+    fn test_is_graph_fallback_true_when_evaluation_metadata_absent() {
+        let feature_flags = FeatureFlagList {
+            flags: vec![create_flag(1, "flag_a", HashSet::new(), true)],
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+        assert!(
+            precomputed.is_graph_fallback,
+            "Fallback path should set is_graph_fallback=true"
+        );
+    }
+
+    // --- build with flag_keys=Some tests ---
+
+    #[test]
+    fn test_build_with_flag_keys_precomputed_filters_to_requested() {
+        // A(1)->B(2)->C(3), D(4) independent
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![3, 4], vec![2], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2, 3])),
+                    (2, HashSet::from([3])),
+                    (3, HashSet::new()),
+                    (4, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed =
+            PrecomputedDependencyGraph::build(&feature_flags, 1, Some(&["flag_a".to_string()]))
+                .unwrap();
+
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(all_keys.contains("flag_c"));
+        assert!(
+            !all_keys.contains("flag_d"),
+            "Unrequested independent flag should be excluded"
+        );
+        assert!(!precomputed.is_graph_fallback);
+    }
+
+    #[test]
+    fn test_build_with_flag_keys_precomputed_single_no_deps() {
+        // Three independent flags, request only one
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::new(), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![1, 2, 3]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::new()),
+                    (2, HashSet::new()),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed =
+            PrecomputedDependencyGraph::build(&feature_flags, 1, Some(&["flag_b".to_string()]))
+                .unwrap();
+
+        assert_eq!(precomputed.evaluation_stages.len(), 1);
+        assert_eq!(precomputed.evaluation_stages[0].len(), 1);
+        assert_eq!(precomputed.evaluation_stages[0][0].key, "flag_b");
+    }
+
+    #[test]
+    fn test_build_with_flag_keys_precomputed_nonexistent_key() {
+        let feature_flags = FeatureFlagList {
+            flags: vec![create_flag(1, "flag_a", HashSet::new(), true)],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([(1, HashSet::new())]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(
+            &feature_flags,
+            1,
+            Some(&["nonexistent".to_string()]),
+        )
+        .unwrap();
+
+        assert!(
+            precomputed.evaluation_stages.is_empty(),
+            "Nonexistent key should result in empty stages"
+        );
+    }
+
+    #[test]
+    fn test_build_with_flag_keys_precomputed_clears_transitive_deps_and_key_to_id() {
+        // When flag_keys is provided on the precomputed path, transitive_deps
+        // and key_to_id should be empty (filtering already happened at build time)
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![2], vec![1]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([(1, HashSet::from([2])), (2, HashSet::new())]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed =
+            PrecomputedDependencyGraph::build(&feature_flags, 1, Some(&["flag_a".to_string()]))
+                .unwrap();
+
+        assert!(
+            precomputed.transitive_deps.is_empty(),
+            "transitive_deps should be empty when flag_keys is provided"
+        );
+        assert!(
+            precomputed.key_to_id.is_empty(),
+            "key_to_id should be empty when flag_keys is provided"
+        );
+    }
+
+    #[test]
+    fn test_build_with_flag_keys_precomputed_preserves_missing_deps() {
+        // flag_a(1) -> flag_b(2) -> (missing 999), flag_c(3) independent
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::from([999]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![2, 3], vec![1]],
+                flags_with_missing_deps: vec![1, 2],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([2])),
+                    (2, HashSet::new()),
+                    (3, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed =
+            PrecomputedDependencyGraph::build(&feature_flags, 1, Some(&["flag_a".to_string()]))
+                .unwrap();
+
+        assert!(precomputed.flags_with_missing_deps.contains(&1));
+        assert!(precomputed.flags_with_missing_deps.contains(&2));
+        assert!(
+            !precomputed.flags_with_missing_deps.contains(&3),
+            "Unrequested flag_c should not appear in missing deps"
+        );
+    }
+
+    #[test]
+    fn test_build_with_flag_keys_precomputed_equivalence_with_filter_stages() {
+        // Diamond: A(1)->B(2),C(3)->D(4), E(5) independent
+        let deps = EvaluationMetadata {
+            dependency_stages: vec![vec![4, 5], vec![2, 3], vec![1]],
+            flags_with_missing_deps: vec![],
+            transitive_deps: HashMap::from([
+                (1, HashSet::from([2, 3, 4])),
+                (2, HashSet::from([4])),
+                (3, HashSet::from([4])),
+                (4, HashSet::new()),
+                (5, HashSet::new()),
+            ]),
+        };
+        let make_flags = || FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2, 3]), true),
+                create_flag(2, "flag_b", HashSet::from([4]), true),
+                create_flag(3, "flag_c", HashSet::from([4]), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+                create_flag(5, "flag_e", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(deps.clone()),
+            ..Default::default()
+        };
+        let requested_keys = vec!["flag_a".to_string()];
+
+        // Path 1: build with flag_keys=None, then filter_stages_by_keys
+        let full = PrecomputedDependencyGraph::build(&make_flags(), 1, None).unwrap();
+        let filtered = full.filter_stages_by_keys(&requested_keys);
+
+        // Path 2: build with flag_keys=Some directly
+        let direct =
+            PrecomputedDependencyGraph::build(&make_flags(), 1, Some(&requested_keys)).unwrap();
+
+        assert_eq!(
+            stage_keys(&direct.evaluation_stages),
+            stage_keys(&filtered.evaluation_stages),
+            "build(flag_keys=Some) should produce the same stages as build(None)+filter"
+        );
+        assert_eq!(
+            direct.flags_with_missing_deps, filtered.flags_with_missing_deps,
+            "Missing deps should match"
+        );
+    }
+
+    #[test]
+    fn test_build_with_flag_keys_precomputed_multiple_keys_shared_deps() {
+        // flag_a(1)->flag_c(3), flag_b(2)->flag_c(3), flag_d(4) independent
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([3]), true),
+                create_flag(2, "flag_b", HashSet::from([3]), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+                create_flag(4, "flag_d", HashSet::new(), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![vec![3, 4], vec![1, 2]],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::from([3])),
+                    (2, HashSet::from([3])),
+                    (3, HashSet::new()),
+                    (4, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(
+            &feature_flags,
+            1,
+            Some(&["flag_a".to_string(), "flag_b".to_string()]),
+        )
+        .unwrap();
+
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(
+            all_keys.contains("flag_c"),
+            "Shared dependency should be included"
+        );
+        assert!(
+            !all_keys.contains("flag_d"),
+            "Unrelated flag should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_build_with_flag_keys_fallback_ignores_flag_keys() {
+        // On the fallback path (no evaluation_metadata), flag_keys is ignored
+        // during build — the caller must use filter_stages_by_keys after.
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::from([2]), true),
+                create_flag(2, "flag_b", HashSet::new(), true),
+                create_flag(3, "flag_c", HashSet::new(), true),
+            ],
+            ..Default::default()
+        };
+
+        let precomputed =
+            PrecomputedDependencyGraph::build(&feature_flags, 1, Some(&["flag_a".to_string()]))
+                .unwrap();
+
+        // All flags should be present (fallback doesn't filter during build)
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+        assert!(
+            all_keys.contains("flag_c"),
+            "Fallback path should include all flags regardless of flag_keys"
+        );
+        assert!(precomputed.is_graph_fallback);
+    }
+
+    #[test]
+    fn test_precomputed_path_handles_phantom_ids_in_stages() {
+        // dependency_stages references flag ID 999 which doesn't exist in flags vec.
+        // This simulates stale metadata from Django where a flag was deleted after
+        // the dependency stages were computed.
+        let feature_flags = FeatureFlagList {
+            flags: vec![
+                create_flag(1, "flag_a", HashSet::new(), true),
+                create_flag(2, "flag_b", HashSet::from([1]), true),
+            ],
+            evaluation_metadata: Some(EvaluationMetadata {
+                dependency_stages: vec![
+                    vec![1, 999], // 999 is a phantom ID
+                    vec![2],
+                ],
+                flags_with_missing_deps: vec![],
+                transitive_deps: HashMap::from([
+                    (1, HashSet::new()),
+                    (2, HashSet::from([1])),
+                    (999, HashSet::new()),
+                ]),
+            }),
+            ..Default::default()
+        };
+
+        let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
+
+        // Phantom ID 999 should be silently skipped — only real flags appear in stages
+        let all_keys: HashSet<String> = precomputed
+            .evaluation_stages
+            .iter()
+            .flat_map(|s| s.iter().map(|f| f.key.clone()))
+            .collect();
+        assert_eq!(all_keys.len(), 2);
+        assert!(all_keys.contains("flag_a"));
+        assert!(all_keys.contains("flag_b"));
+
+        // Phantom ID still counts as "staged" for cycle detection math:
+        // global_flags_in_stages_count = 3 (IDs 1, 999, 2 — all non-filtered-out)
+        // cycle_count = flags.len() (2) - filtered_out (0) - staged (3) = 0 (saturating)
+        assert_eq!(precomputed.error_count, 0);
+        assert!(!precomputed.has_cycle_errors);
     }
 }


### PR DESCRIPTION
## Problem

As of https://github.com/PostHog/posthog/pull/51083, the Rust feature-flags service currently rebuilds the entire dependency graph from scratch on every request using petgraph's Kahn's algorithm. Django already computes this metadata at cache-write time, so duplicating the work in Rust is unnecessary CPU and latency overhead.

## Changes

Makes use of the pre-computed dependencies to make evaluation more efficient. Falls back to old method if the `evaluation_metadata` is not available. However, I did warm all flags caches (US + EU) so it should all be there.

```json
{
  "flags": [ ... ],
  "evaluation_metadata": {
    "dependency_stages": [[3, 4], [2], [1]],
    "flags_with_missing_deps": [],
    "transitive_deps": {
      "1": [2, 3],
      "2": [3],
      "3": [],
      "4": []
    }
  }
}
```

Once this goes live and we validate it, we could remove the old path from `/flags` if we're ready to rely on Redis cache availability 100%.

- Parse `evaluation_metadata` (dependency stages, transitive deps, flags with missing deps) from the
  hypercache JSON payload alongside the flags array
- Add `build_from_precomputed` path in `PrecomputedDependencyGraph` that assembles evaluation stages
  directly from the pre-grouped IDs — no graph construction, no topological sort
- Fall back to the existing petgraph path when `evaluation_metadata` is absent (gradual rollout)
- Add `flag_keys` filtering support to the precomputed path so only requested flags and their
  transitive dependencies are cloned into stages
- Emit metrics (`posthog_flags_dependency_graph_build_*`) to compare precomputed vs graph paths
- Custom serde deserializer for string-keyed `HashMap<i32, HashSet<i32>>` (JSON only supports string keys)
- Add `debug_assert` guard on `filter_stages_by_keys` to catch misuse on the precomputed path
- Comprehensive tests: precomputed/fallback equivalence, cycle detection, phantom IDs, round-trip
  serialization, flag_keys filtering, missing deps propagation

## How did you test this code?

- 13 new unit tests covering the precomputed path, cycle handling, phantom/stale IDs,
  serialization round-trips, and flag_keys filtering
- Cross-validation tests that compare precomputed and fallback (petgraph) paths produce identical
  results for diamond dependencies, independent flags, and mixed scenarios
- Existing test suite passes (1000+ tests in the feature-flags crate)
- Manual test of `/flags` endpoint (aka `curl`).

## Publish to changelog?

no

## Docs update

no