### PR TITLE
fix(sql editor): add error handling to HogQL

### DIFF
--- a/frontend/src/lib/monaco/hogQLAutocompleteProvider.ts
+++ b/frontend/src/lib/monaco/hogQLAutocompleteProvider.ts
@@ -14,6 +14,12 @@ import { setLatestVersionsOnQuery } from '~/queries/utils'
 
 import { getContextSourceQuery } from './sourceQueryUtils'
 
+const EMPTY_RESULT: languages.CompletionList = { suggestions: [], incomplete: false }
+
+// Cooldown period after a failed autocomplete request to avoid hammering the backend
+const FAILURE_COOLDOWN_MS = 5_000
+let lastFailure: { queryText: string; startOffset: number; timestamp: number } | null = null
+
 const convertCompletionItemKind = (kind: AutocompleteCompletionItemKind): languages.CompletionItemKind => {
     switch (kind) {
         case 'Method':
@@ -92,10 +98,7 @@ export const hogQLAutocompleteProvider = (type: HogLanguage): languages.Completi
     provideCompletionItems: async (model, position) => {
         const logic: BuiltLogic<codeEditorLogicType> | undefined = (model as any).codeEditorLogic
         if (!logic || !logic.isMounted()) {
-            return {
-                suggestions: [],
-                incomplete: false,
-            }
+            return EMPTY_RESULT
         }
         const word = model.getWordUntilPosition(position)
         const startOffset = model.getOffsetAt({
@@ -106,11 +109,23 @@ export const hogQLAutocompleteProvider = (type: HogLanguage): languages.Completi
             lineNumber: position.lineNumber,
             column: word.endColumn,
         })
+
+        const queryText = model.getValue()
+
+        // Skip if the same query+position recently failed — avoids hammering the backend
+        if (
+            lastFailure &&
+            lastFailure.queryText === queryText &&
+            lastFailure.startOffset === startOffset &&
+            Date.now() - lastFailure.timestamp < FAILURE_COOLDOWN_MS
+        ) {
+            return EMPTY_RESULT
+        }
+
         const connectionId =
             logic.isMounted() && logic.props.sourceQuery?.kind === NodeKind.HogQLQuery
                 ? (logic.props.sourceQuery.connectionId ?? undefined)
                 : undefined
-        const queryText = model.getValue()
         const sourceQuery = logic.isMounted() ? getContextSourceQuery(logic.props.sourceQuery, queryText) : undefined
 
         const query: HogQLAutocomplete = setLatestVersionsOnQuery(
@@ -128,7 +143,18 @@ export const hogQLAutocompleteProvider = (type: HogLanguage): languages.Completi
             },
             { recursion: false }
         )
-        const response = await performQuery<HogQLAutocomplete>(query)
+
+        let response
+        try {
+            response = await performQuery<HogQLAutocomplete>(query)
+        } catch {
+            lastFailure = { queryText, startOffset, timestamp: Date.now() }
+            return EMPTY_RESULT
+        }
+
+        // Clear failure state on success
+        lastFailure = null
+
         const completionItems = response.suggestions
         const suggestions = completionItems.map<languages.CompletionItem>((item) => {
             const kind = convertCompletionItemKind(item.kind)

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -1198,7 +1198,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                 actions.loadNewData()
                 cache.disposables.add(() => {
                     const timerId = window.setInterval(() => {
-                        if (!values.responseLoading) {
+                        if (!values.newDataLoading) {
                             actions.loadNewData()
                         }
                     }, AUTOLOAD_INTERVAL)


### PR DESCRIPTION
## Problem

When a user opens a SQL editor link with a malformed query (e.g. trailing `,dddddddd`), the HogQL autocomplete provider fires hundreds of requests per minute to `/query/` — all returning 400 errors — because `performQuery` errors were unhandled, causing Monaco to re-trigger the completion provider in a loop.


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
