### PR TITLE
chore(ci): add timeout and partial clone to bundle size job

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -116,8 +116,11 @@ jobs:
         needs: [changes]
         if: needs.changes.outputs.frontend == 'true' && github.event_name != 'merge_group'
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v6
+              with:
+                  filter: blob:none
             - name: Install pnpm
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 


### PR DESCRIPTION
## Problem

The frontend bundle size CI job can hang indefinitely (observed 35+ min) when `compressed-size-action` runs `git fetch -n origin master:master` on a degraded runner. The job has no timeout, so it burns runner minutes for up to 6 hours (GitHub Actions default).

## Changes

- Add `timeout-minutes: 10` to the `frontend-bundle-size` job (normal runtime is ~4 min)
- Add `filter: blob:none` to the checkout step so the action's internal `git fetch` only pulls commit/tree objects, not blobs — blobs are lazy-fetched on demand during `git reset --hard`, and most are already local from the PR checkout