### PR TITLE
chore(personhog_client): more gRPC client metrics

### DIFF
--- a/posthog/personhog_client/client.py
+++ b/posthog/personhog_client/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import threading
 from typing import Optional
 
@@ -7,6 +8,7 @@ from django.conf import settings
 
 import grpc
 import structlog
+from prometheus_client import Counter, Enum, Histogram
 
 from posthog.personhog_client.interceptor import ClientNameInterceptor, MetricsInterceptor
 from posthog.personhog_client.proto import (
@@ -42,6 +44,70 @@ from posthog.personhog_client.proto import (
 
 logger = structlog.get_logger(__name__)
 
+# -- Channel-level metrics --
+
+PERSONHOG_DJANGO_CHANNEL_STATE = Enum(
+    "personhog_django_grpc_channel_state",
+    "Current gRPC channel connectivity state",
+    labelnames=["client_name"],
+    states=["IDLE", "CONNECTING", "READY", "TRANSIENT_FAILURE", "SHUTDOWN"],
+)
+
+PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL = Counter(
+    "personhog_django_grpc_channel_state_transitions_total",
+    "gRPC channel connectivity state transitions",
+    labelnames=["from_state", "to_state", "client_name"],
+)
+
+PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS = Histogram(
+    "personhog_django_grpc_connection_establishment_seconds",
+    "Time to establish a gRPC connection (CONNECTING to READY)",
+    labelnames=["client_name"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
+
+
+class _ChannelStateMonitor:
+    """Subscribes to gRPC channel connectivity changes and emits Prometheus metrics."""
+
+    def __init__(self, channel: grpc.Channel, client_name: str) -> None:
+        self._channel = channel
+        self._client_name = client_name
+        self._previous_state: grpc.ChannelConnectivity | None = None
+        self._connecting_since: float | None = None
+        channel.subscribe(self._on_state_change)
+
+    def _on_state_change(self, new_state: grpc.ChannelConnectivity) -> None:
+        prev = self._previous_state
+        self._previous_state = new_state
+
+        PERSONHOG_DJANGO_CHANNEL_STATE.labels(client_name=self._client_name).state(new_state.name)
+        PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL.labels(
+            from_state=prev.name if prev else "NONE",
+            to_state=new_state.name,
+            client_name=self._client_name,
+        ).inc()
+
+        if new_state == grpc.ChannelConnectivity.CONNECTING:
+            self._connecting_since = time.monotonic()
+        elif new_state == grpc.ChannelConnectivity.READY and self._connecting_since is not None:
+            PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS.labels(
+                client_name=self._client_name,
+            ).observe(time.monotonic() - self._connecting_since)
+            self._connecting_since = None
+        elif new_state in (
+            grpc.ChannelConnectivity.TRANSIENT_FAILURE,
+            grpc.ChannelConnectivity.SHUTDOWN,
+            grpc.ChannelConnectivity.IDLE,
+        ):
+            self._connecting_since = None
+
+    def close(self) -> None:
+        try:
+            self._channel.unsubscribe(self._on_state_change)
+        except Exception:
+            pass
+
 
 class PersonHogClient:
     def __init__(
@@ -66,16 +132,17 @@ class PersonHogClient:
             ("grpc.initial_reconnect_backoff_ms", initial_reconnect_backoff_ms),
             ("grpc.max_send_message_length", max_send_message_length),
             ("grpc.max_receive_message_length", max_recv_message_length),
-            ("grpc.enable_retries", 1),
         ]
         channel = grpc.insecure_channel(addr, options=options)
         self._channel = grpc.intercept_channel(
             channel, ClientNameInterceptor(client_name), MetricsInterceptor(client_name)
         )
+        self._state_monitor = _ChannelStateMonitor(channel, client_name)
         self._stub = PersonHogServiceStub(self._channel)
         self._timeout = timeout_ms / 1000.0
 
     def close(self) -> None:
+        self._state_monitor.close()
         self._channel.close()
 
     # -- Person lookups --

--- a/posthog/personhog_client/interceptor.py
+++ b/posthog/personhog_client/interceptor.py
@@ -31,6 +31,12 @@ PERSONHOG_DJANGO_REQUEST_COUNT = Counter(
     labelnames=["method", "status", "client_name"],
 )
 
+PERSONHOG_DJANGO_TIMEOUT_TOTAL = Counter(
+    "personhog_django_grpc_timeouts_total",
+    "gRPC requests that exceeded their deadline (DEADLINE_EXCEEDED)",
+    labelnames=["method", "client_name"],
+)
+
 
 def _method_name(client_call_details: grpc.ClientCallDetails) -> str:
     # client_call_details.method is like "/personhog.service.v1.PersonHogService/GetPerson"
@@ -85,10 +91,15 @@ class MetricsInterceptor(grpc.UnaryUnaryClientInterceptor):
             code = response.code()
             status = code.name if code else "OK"
             PERSONHOG_DJANGO_REQUEST_COUNT.labels(method=method, status=status, client_name=self._client_name).inc()
+            if code == grpc.StatusCode.DEADLINE_EXCEEDED:
+                PERSONHOG_DJANGO_TIMEOUT_TOTAL.labels(method=method, client_name=self._client_name).inc()
             return response
         except grpc.RpcError as exc:
-            status = exc.code().name if exc.code() else "UNKNOWN"
+            code = exc.code()
+            status = code.name if code else "UNKNOWN"
             PERSONHOG_DJANGO_REQUEST_COUNT.labels(method=method, status=status, client_name=self._client_name).inc()
+            if code == grpc.StatusCode.DEADLINE_EXCEEDED:
+                PERSONHOG_DJANGO_TIMEOUT_TOTAL.labels(method=method, client_name=self._client_name).inc()
             raise
         finally:
             PERSONHOG_DJANGO_REQUEST_DURATION.labels(method=method, client_name=self._client_name).observe(

--- a/posthog/personhog_client/test_channel_state_monitor.py
+++ b/posthog/personhog_client/test_channel_state_monitor.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import grpc
+
+
+class TestChannelStateMonitor:
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
+    def test_tracks_state_transition(self, mock_conn_hist, mock_transitions, mock_state_enum):
+        from posthog.personhog_client.client import _ChannelStateMonitor
+
+        channel = MagicMock()
+        _ChannelStateMonitor(channel, "test-client")
+
+        channel.subscribe.assert_called_once()
+        callback = channel.subscribe.call_args[0][0]
+
+        callback(grpc.ChannelConnectivity.IDLE)
+
+        mock_state_enum.labels.assert_called_with(client_name="test-client")
+        mock_state_enum.labels.return_value.state.assert_called_with("IDLE")
+        mock_transitions.labels.assert_called_with(from_state="NONE", to_state="IDLE", client_name="test-client")
+
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
+    def test_tracks_connection_establishment_latency(self, mock_conn_hist, mock_transitions, mock_state_enum):
+        from posthog.personhog_client.client import _ChannelStateMonitor
+
+        channel = MagicMock()
+        _ChannelStateMonitor(channel, "test-client")
+        callback = channel.subscribe.call_args[0][0]
+
+        callback(grpc.ChannelConnectivity.CONNECTING)
+        mock_conn_hist.labels.return_value.observe.assert_not_called()
+
+        callback(grpc.ChannelConnectivity.READY)
+        mock_conn_hist.labels.assert_called_with(client_name="test-client")
+        mock_conn_hist.labels.return_value.observe.assert_called_once()
+        latency = mock_conn_hist.labels.return_value.observe.call_args[0][0]
+        assert latency >= 0
+
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
+    def test_does_not_record_latency_on_transient_failure(self, mock_conn_hist, mock_transitions, mock_state_enum):
+        from posthog.personhog_client.client import _ChannelStateMonitor
+
+        channel = MagicMock()
+        _ChannelStateMonitor(channel, "test-client")
+        callback = channel.subscribe.call_args[0][0]
+
+        callback(grpc.ChannelConnectivity.CONNECTING)
+        callback(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
+
+        mock_conn_hist.labels.return_value.observe.assert_not_called()
+
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
+    def test_does_not_record_latency_for_ready_without_connecting(
+        self, mock_conn_hist, mock_transitions, mock_state_enum
+    ):
+        from posthog.personhog_client.client import _ChannelStateMonitor
+
+        channel = MagicMock()
+        _ChannelStateMonitor(channel, "test-client")
+        callback = channel.subscribe.call_args[0][0]
+
+        callback(grpc.ChannelConnectivity.READY)
+
+        mock_conn_hist.labels.return_value.observe.assert_not_called()
+
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
+    def test_tracks_reconnection_latency(self, mock_conn_hist, mock_transitions, mock_state_enum):
+        from posthog.personhog_client.client import _ChannelStateMonitor
+
+        channel = MagicMock()
+        _ChannelStateMonitor(channel, "test-client")
+        callback = channel.subscribe.call_args[0][0]
+
+        # First connection
+        callback(grpc.ChannelConnectivity.CONNECTING)
+        callback(grpc.ChannelConnectivity.READY)
+        assert mock_conn_hist.labels.return_value.observe.call_count == 1
+
+        # Disconnect and reconnect
+        callback(grpc.ChannelConnectivity.IDLE)
+        callback(grpc.ChannelConnectivity.CONNECTING)
+        callback(grpc.ChannelConnectivity.READY)
+        assert mock_conn_hist.labels.return_value.observe.call_count == 2
+
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
+    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
+    def test_close_unsubscribes(self, mock_conn_hist, mock_transitions, mock_state_enum):
+        from posthog.personhog_client.client import _ChannelStateMonitor
+
+        channel = MagicMock()
+        monitor = _ChannelStateMonitor(channel, "test-client")
+        monitor.close()
+
+        channel.unsubscribe.assert_called_once()

--- a/posthog/personhog_client/test_channel_state_monitor.py
+++ b/posthog/personhog_client/test_channel_state_monitor.py
@@ -5,34 +5,30 @@ from unittest.mock import MagicMock, patch
 import grpc
 
 
+@patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
+@patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
+@patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
 class TestChannelStateMonitor:
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
-    def test_tracks_state_transition(self, mock_conn_hist, mock_transitions, mock_state_enum):
+    def _make_monitor(self):
         from posthog.personhog_client.client import _ChannelStateMonitor
 
         channel = MagicMock()
-        _ChannelStateMonitor(channel, "test-client")
+        monitor = _ChannelStateMonitor(channel, "test-client")
+        callback = channel.subscribe.call_args[0][0]
+        return channel, monitor, callback
+
+    def test_tracks_state_transition(self, mock_conn_hist, mock_transitions, mock_state_enum):
+        channel, _, callback = self._make_monitor()
 
         channel.subscribe.assert_called_once()
-        callback = channel.subscribe.call_args[0][0]
-
         callback(grpc.ChannelConnectivity.IDLE)
 
         mock_state_enum.labels.assert_called_with(client_name="test-client")
         mock_state_enum.labels.return_value.state.assert_called_with("IDLE")
         mock_transitions.labels.assert_called_with(from_state="NONE", to_state="IDLE", client_name="test-client")
 
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
     def test_tracks_connection_establishment_latency(self, mock_conn_hist, mock_transitions, mock_state_enum):
-        from posthog.personhog_client.client import _ChannelStateMonitor
-
-        channel = MagicMock()
-        _ChannelStateMonitor(channel, "test-client")
-        callback = channel.subscribe.call_args[0][0]
+        _, _, callback = self._make_monitor()
 
         callback(grpc.ChannelConnectivity.CONNECTING)
         mock_conn_hist.labels.return_value.observe.assert_not_called()
@@ -43,66 +39,37 @@ class TestChannelStateMonitor:
         latency = mock_conn_hist.labels.return_value.observe.call_args[0][0]
         assert latency >= 0
 
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
     def test_does_not_record_latency_on_transient_failure(self, mock_conn_hist, mock_transitions, mock_state_enum):
-        from posthog.personhog_client.client import _ChannelStateMonitor
-
-        channel = MagicMock()
-        _ChannelStateMonitor(channel, "test-client")
-        callback = channel.subscribe.call_args[0][0]
+        _, _, callback = self._make_monitor()
 
         callback(grpc.ChannelConnectivity.CONNECTING)
         callback(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
 
         mock_conn_hist.labels.return_value.observe.assert_not_called()
 
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
     def test_does_not_record_latency_for_ready_without_connecting(
         self, mock_conn_hist, mock_transitions, mock_state_enum
     ):
-        from posthog.personhog_client.client import _ChannelStateMonitor
-
-        channel = MagicMock()
-        _ChannelStateMonitor(channel, "test-client")
-        callback = channel.subscribe.call_args[0][0]
+        _, _, callback = self._make_monitor()
 
         callback(grpc.ChannelConnectivity.READY)
 
         mock_conn_hist.labels.return_value.observe.assert_not_called()
 
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
     def test_tracks_reconnection_latency(self, mock_conn_hist, mock_transitions, mock_state_enum):
-        from posthog.personhog_client.client import _ChannelStateMonitor
+        _, _, callback = self._make_monitor()
 
-        channel = MagicMock()
-        _ChannelStateMonitor(channel, "test-client")
-        callback = channel.subscribe.call_args[0][0]
-
-        # First connection
         callback(grpc.ChannelConnectivity.CONNECTING)
         callback(grpc.ChannelConnectivity.READY)
         assert mock_conn_hist.labels.return_value.observe.call_count == 1
 
-        # Disconnect and reconnect
         callback(grpc.ChannelConnectivity.IDLE)
         callback(grpc.ChannelConnectivity.CONNECTING)
         callback(grpc.ChannelConnectivity.READY)
         assert mock_conn_hist.labels.return_value.observe.call_count == 2
 
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CHANNEL_STATE_TRANSITIONS_TOTAL")
-    @patch("posthog.personhog_client.client.PERSONHOG_DJANGO_CONNECTION_ESTABLISHMENT_SECONDS")
     def test_close_unsubscribes(self, mock_conn_hist, mock_transitions, mock_state_enum):
-        from posthog.personhog_client.client import _ChannelStateMonitor
-
-        channel = MagicMock()
-        monitor = _ChannelStateMonitor(channel, "test-client")
+        channel, monitor, _ = self._make_monitor()
         monitor.close()
 
         channel.unsubscribe.assert_called_once()

--- a/posthog/personhog_client/test_metrics_interceptor.py
+++ b/posthog/personhog_client/test_metrics_interceptor.py
@@ -101,14 +101,12 @@ class TestMetricsInterceptorTimeoutTracking:
         interceptor = MetricsInterceptor("test-client")
         details = _make_call_details()
 
-        try:
+        with pytest.raises(grpc.RpcError):
             interceptor.intercept_unary_unary(
                 _make_raising_continuation(grpc.StatusCode.DEADLINE_EXCEEDED),
                 details,
                 request=b"",
             )
-        except grpc.RpcError:
-            pass
 
         mock_timeout_counter.labels.assert_called_with(method="GetPerson", client_name="test-client")
         mock_timeout_counter.labels.return_value.inc.assert_called_once()

--- a/posthog/personhog_client/test_metrics_interceptor.py
+++ b/posthog/personhog_client/test_metrics_interceptor.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import grpc
+from parameterized import parameterized
+
+from posthog.personhog_client.interceptor import MetricsInterceptor, _MutableClientCallDetails
+
+
+def _make_call_details(
+    method: str = "/personhog.service.v1.PersonHogService/GetPerson",
+    timeout: float = 5.0,
+) -> grpc.ClientCallDetails:
+    return _MutableClientCallDetails(
+        method=method,
+        timeout=timeout,
+        metadata=None,
+        credentials=None,
+        wait_for_ready=None,
+        compression=None,
+    )
+
+
+def _make_ok_response() -> MagicMock:
+    resp = MagicMock()
+    resp.code.return_value = None
+    return resp
+
+
+def _make_error_response(status_code: grpc.StatusCode) -> MagicMock:
+    resp = MagicMock()
+    resp.code.return_value = status_code
+    return resp
+
+
+def _make_raising_continuation(status_code: grpc.StatusCode):
+    def continuation(details, request):
+        error = grpc.RpcError()
+        error.code = MagicMock(return_value=status_code)
+        raise error
+
+    return continuation
+
+
+class TestMetricsInterceptorReturnsBehavior:
+    def test_returns_successful_response(self):
+        interceptor = MetricsInterceptor("test-client")
+        details = _make_call_details()
+        ok_response = _make_ok_response()
+
+        result = interceptor.intercept_unary_unary(lambda d, r: ok_response, details, request=b"")
+
+        assert result is ok_response
+
+    @parameterized.expand(
+        [
+            ("unavailable", grpc.StatusCode.UNAVAILABLE),
+            ("internal", grpc.StatusCode.INTERNAL),
+            ("not_found", grpc.StatusCode.NOT_FOUND),
+        ]
+    )
+    def test_returns_non_ok_response(self, _name: str, status_code: grpc.StatusCode):
+        interceptor = MetricsInterceptor("test-client")
+        details = _make_call_details()
+        error_response = _make_error_response(status_code)
+
+        result = interceptor.intercept_unary_unary(lambda d, r: error_response, details, request=b"")
+
+        assert result is error_response
+
+    @parameterized.expand(
+        [
+            ("unavailable", grpc.StatusCode.UNAVAILABLE),
+            ("internal", grpc.StatusCode.INTERNAL),
+        ]
+    )
+    def test_propagates_rpc_error_exceptions(self, _name: str, status_code: grpc.StatusCode):
+        interceptor = MetricsInterceptor("test-client")
+        details = _make_call_details()
+
+        with pytest.raises(grpc.RpcError):
+            interceptor.intercept_unary_unary(_make_raising_continuation(status_code), details, request=b"")
+
+
+class TestMetricsInterceptorTimeoutTracking:
+    @patch("posthog.personhog_client.interceptor.PERSONHOG_DJANGO_TIMEOUT_TOTAL")
+    def test_increments_timeout_counter_on_deadline_exceeded_response(self, mock_timeout_counter):
+        interceptor = MetricsInterceptor("test-client")
+        details = _make_call_details()
+        response = _make_error_response(grpc.StatusCode.DEADLINE_EXCEEDED)
+
+        interceptor.intercept_unary_unary(lambda d, r: response, details, request=b"")
+
+        mock_timeout_counter.labels.assert_called_with(method="GetPerson", client_name="test-client")
+        mock_timeout_counter.labels.return_value.inc.assert_called_once()
+
+    @patch("posthog.personhog_client.interceptor.PERSONHOG_DJANGO_TIMEOUT_TOTAL")
+    def test_increments_timeout_counter_on_deadline_exceeded_exception(self, mock_timeout_counter):
+        interceptor = MetricsInterceptor("test-client")
+        details = _make_call_details()
+
+        try:
+            interceptor.intercept_unary_unary(
+                _make_raising_continuation(grpc.StatusCode.DEADLINE_EXCEEDED),
+                details,
+                request=b"",
+            )
+        except grpc.RpcError:
+            pass
+
+        mock_timeout_counter.labels.assert_called_with(method="GetPerson", client_name="test-client")
+        mock_timeout_counter.labels.return_value.inc.assert_called_once()
+
+    @patch("posthog.personhog_client.interceptor.PERSONHOG_DJANGO_TIMEOUT_TOTAL")
+    def test_does_not_increment_timeout_counter_on_other_errors(self, mock_timeout_counter):
+        interceptor = MetricsInterceptor("test-client")
+        details = _make_call_details()
+        response = _make_error_response(grpc.StatusCode.UNAVAILABLE)
+
+        interceptor.intercept_unary_unary(lambda d, r: response, details, request=b"")
+
+        mock_timeout_counter.labels.return_value.inc.assert_not_called()
+
+    @patch("posthog.personhog_client.interceptor.PERSONHOG_DJANGO_TIMEOUT_TOTAL")
+    def test_does_not_increment_timeout_counter_on_success(self, mock_timeout_counter):
+        interceptor = MetricsInterceptor("test-client")
+        details = _make_call_details()
+
+        interceptor.intercept_unary_unary(lambda d, r: _make_ok_response(), details, request=b"")
+
+        mock_timeout_counter.labels.return_value.inc.assert_not_called()


### PR DESCRIPTION
## Problem

The Django gRPC personhog client had limited observability — only request duration and a status-labeled request counter. When latency spikes occurred, we couldn't easily distinguish between:

- Timeout/deadline exceeded errors vs other failures
- Connection establishment problems (slow DNS, network issues between Django and the router)
- Channel instability (frequent reconnects, prolonged TRANSIENT_FAILURE states)

The existing `grpc.enable_retries` channel option was also a no-op (requires a service config to activate), so it was removed to avoid confusion.

## Changes

**Timeout tracking** (`interceptor.py`):
- Added `personhog_django_grpc_timeouts_total` counter that fires specifically on `DEADLINE_EXCEEDED`, in both the response-code and exception paths of `MetricsInterceptor`. This is a subset of the existing `requests_total{status="DEADLINE_EXCEEDED"}` but makes alerting and dashboard queries simpler.

**Channel connectivity monitoring** (`client.py`):
- Added `_ChannelStateMonitor` that subscribes to the raw gRPC channel's connectivity callbacks and emits:
  - `personhog_django_grpc_channel_state` — Enum gauge showing current state (IDLE, CONNECTING, READY, TRANSIENT_FAILURE, SHUTDOWN)
  - `personhog_django_grpc_channel_state_transitions_total` — Counter with `from_state`/`to_state` labels for every transition
  - `personhog_django_grpc_connection_establishment_seconds` — Histogram measuring CONNECTING→READY latency (TCP + HTTP/2 handshake time)
- The monitor subscribes to the raw channel (not the intercepted one) since interceptors don't affect connectivity state.
- Removed the no-op `grpc.enable_retries` channel option (retries are handled by the personhog-router, not this client).


## How did you test this code?

- Added `test_metrics_interceptor.py` (10 tests): verifies `MetricsInterceptor` returns/raises correctly for success, non-OK, and exception paths; verifies the timeout counter fires only on `DEADLINE_EXCEEDED` and not on other statuses or success.
- Added `test_channel_state_monitor.py` (6 tests): verifies state transitions are tracked, connection establishment latency is measured for CONNECTING→READY, latency is not recorded for TRANSIENT_FAILURE or READY-without-CONNECTING, reconnection cycles produce separate latency observations, and `close()` unsubscribes.
- All 16 new tests pass (`uv run pytest posthog/personhog_client/test_metrics_interceptor.py posthog/personhog_client/test_channel_state_monitor.py`).
- Existing interceptor tests (`test_interceptor.py`) are unaffected — they test `_with_metadata` and `ClientNameInterceptor`, neither of which changed.
