### PR TITLE
fix(llma): improve sentiment card text display and dedup grouping

### DIFF
--- a/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
+++ b/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
@@ -19,15 +19,20 @@ import { normalizeMessages } from '../utils'
 import type { GroupedSentimentCard, SentimentCard, SentimentFeedbackLabel } from './llmAnalyticsSentimentLogic'
 import { llmAnalyticsSentimentLogic, SentimentFilterLabel } from './llmAnalyticsSentimentLogic'
 
+/** Max chars the backend sentiment classifier processes (last N chars of each message). */
+const CLASSIFIER_WINDOW = 2000
+
 /**
- * Truncates text to show the tail (last `displayChars` characters), mirroring the backend
- * sentiment classifier which uses the last 2000 chars of each message.
+ * Truncates long text to show start + end with an ellipsis in the middle.
+ * Shows the head and tail so users can identify the message at a glance.
  */
-function truncateToClassifierWindow(text: string, displayChars: number = 200): string {
-    if (text.length <= displayChars) {
+function truncateMiddle(text: string, maxChars: number = 500): string {
+    if (text.length <= maxChars) {
         return text
     }
-    return '…' + text.slice(-displayChars)
+    const headChars = Math.floor(maxChars / 2)
+    const tailChars = headChars
+    return text.slice(0, headChars) + ' … ' + text.slice(-tailChars)
 }
 
 /**
@@ -75,7 +80,7 @@ function ContextMessage({ aiInput, index }: { aiInput: unknown; index: number })
     }
     const role = message.role === 'user' ? 'User' : message.role === 'assistant' ? 'Assistant' : message.role
     const fullText = getTextContent(message)
-    const displayText = truncateToClassifierWindow(fullText, 150)
+    const displayText = truncateMiddle(fullText, 150)
     return (
         <div className="flex gap-2 text-xs text-muted py-1.5">
             <span className="shrink-0 font-medium w-16">{role}</span>
@@ -159,7 +164,9 @@ function SentimentCardRow({
 
     const targetMessage = getMessageAtIndex(aiInput, messageIndex)
     const fullText = targetMessage ? getTextContent(targetMessage) : ''
-    const messageText = truncateToClassifierWindow(fullText)
+    // The classifier only sees the last CLASSIFIER_WINDOW chars — show that slice
+    const classifierText = fullText.slice(-CLASSIFIER_WINDOW)
+    const collapsedText = truncateMiddle(classifierText)
     const accentColor = SENTIMENT_BAR_COLOR[sentiment.label as SentimentLabel] ?? 'bg-border'
 
     return (
@@ -177,12 +184,10 @@ function SentimentCardRow({
                     </div>
                 )}
 
-                <div className="flex items-center gap-2">
-                    <Tooltip title={fullText}>
-                        <p className="flex-1 min-w-0 text-sm text-default m-0 break-words leading-relaxed">
-                            {messageText}
-                        </p>
-                    </Tooltip>
+                <div className="flex items-start gap-2">
+                    <p className="flex-1 min-w-0 text-sm text-default m-0 break-words leading-relaxed">
+                        {expanded ? classifierText : collapsedText}
+                    </p>
                     <div className="shrink-0 flex items-center gap-1">
                         {traceCount > 1 && (
                             <Tooltip title={`${traceCount} traces contain this same message`}>

--- a/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
+++ b/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
@@ -17,10 +17,7 @@ import type { SentimentLabel } from '../sentimentUtils'
 import type { CompatMessage } from '../types'
 import { normalizeMessages } from '../utils'
 import type { GroupedSentimentCard, SentimentCard, SentimentFeedbackLabel } from './llmAnalyticsSentimentLogic'
-import { llmAnalyticsSentimentLogic, SentimentFilterLabel } from './llmAnalyticsSentimentLogic'
-
-/** Max chars the backend sentiment classifier processes (last N chars of each message). */
-const CLASSIFIER_WINDOW = 2000
+import { CLASSIFIER_WINDOW, llmAnalyticsSentimentLogic, SentimentFilterLabel } from './llmAnalyticsSentimentLogic'
 
 /**
  * Truncates long text to show start + end with an ellipsis in the middle.
@@ -30,9 +27,8 @@ function truncateMiddle(text: string, maxChars: number = 500): string {
     if (text.length <= maxChars) {
         return text
     }
-    const headChars = Math.floor(maxChars / 2)
-    const tailChars = headChars
-    return text.slice(0, headChars) + ' … ' + text.slice(-tailChars)
+    const half = Math.floor(maxChars / 2)
+    return text.slice(0, half) + ' … ' + text.slice(-half)
 }
 
 /**

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
@@ -66,7 +66,11 @@ function getRawMessageText(aiInput: unknown, messageIndex: number): string {
 }
 
 function getCardMessageText(card: SentimentCard): string {
-    return getRawMessageText(card.generation.aiInput, card.messageIndex).trim()
+    const text = getRawMessageText(card.generation.aiInput, card.messageIndex).trim()
+    // Group by the same trailing window the classifier processes so messages
+    // that differ only in a prefix (e.g. varying system prompt headers) are
+    // correctly treated as duplicates.
+    return text.slice(-SNIPPET_MAX_LENGTH)
 }
 
 function getSnippetFromCard(card: SentimentCard): string {

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
@@ -50,7 +50,7 @@ export interface LLMAnalyticsSentimentLogicProps {
 
 const GENERATIONS_PAGE_SIZE = 200
 // Match backend MAX_MESSAGE_CHARS (2000) so training data captures the same text window the model classified
-const SNIPPET_MAX_LENGTH = 2000
+export const CLASSIFIER_WINDOW = 2000
 
 /** Parse aiInput and return the raw content text for the message at the given index, or '' on failure */
 function getRawMessageText(aiInput: unknown, messageIndex: number): string {
@@ -70,11 +70,11 @@ function getCardMessageText(card: SentimentCard): string {
     // Group by the same trailing window the classifier processes so messages
     // that differ only in a prefix (e.g. varying system prompt headers) are
     // correctly treated as duplicates.
-    return text.slice(-SNIPPET_MAX_LENGTH)
+    return text.slice(-CLASSIFIER_WINDOW)
 }
 
 function getSnippetFromCard(card: SentimentCard): string {
-    return getRawMessageText(card.generation.aiInput, card.messageIndex).slice(-SNIPPET_MAX_LENGTH)
+    return getRawMessageText(card.generation.aiInput, card.messageIndex).slice(-CLASSIFIER_WINDOW)
 }
 
 interface GenerationsQueryValues {


### PR DESCRIPTION
## Problem

Sentiment cards were showing only the last 200 characters of message text, making many distinct messages appear identical. This caused confusion about why "duplicate" cards weren't being grouped, when they were actually different messages that shared the same tail.

## Changes

- **Display**: Replaced tail-only truncation (last 200 chars) with start...end truncation (first 250 + last 250 chars) so users can identify messages at a glance
- **Expand**: Clicking a card now shows the full 2000-char classifier window (the actual text the sentiment model evaluated)
- **Dedup grouping**: Changed the grouping key from full raw text to the 2000-char classifier window, so messages that differ only in a prefix (e.g. varying system prompt headers) are correctly deduplicated

## How did you test this code?

Verified the truncation logic produces correct start...end output for texts of varying lengths. Confirmed the grouping key change aligns with the backend classifier window.

## Publish to changelog?

No