### PR TITLE
fix(product-tours): persist event property filter collapse state

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -1,7 +1,8 @@
 import './PropertyFilters.scss'
 
 import { BindLogic, useActions, useValues } from 'kea'
-import React, { useEffect, useState } from 'react'
+import isEqual from 'lodash.isequal'
+import React, { useEffect, useRef, useState } from 'react'
 
 import { TaxonomicPropertyFilter } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
 import {
@@ -98,10 +99,26 @@ export function PropertyFilters({
     const { filters, filtersWithNew, filterIds, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
     const { remove, setFilters, setFilter } = useActions(propertyFilterLogic(logicProps))
     const [allowOpenOnInsert, setAllowOpenOnInsert] = useState<boolean>(false)
+    const lastSyncedFiltersProp = useRef<AnyPropertyFilter[] | null>(null)
+    const prevPageKeyRef = useRef(pageKey)
 
     useEffect(() => {
-        setFilters(propertyFilters ?? [])
-    }, [propertyFilters, setFilters])
+        const incoming = propertyFilters ?? []
+        const pageKeyChanged = prevPageKeyRef.current !== pageKey
+        if (pageKeyChanged) {
+            prevPageKeyRef.current = pageKey
+            lastSyncedFiltersProp.current = null
+        }
+        if (
+            !pageKeyChanged &&
+            lastSyncedFiltersProp.current !== null &&
+            isEqual(incoming, lastSyncedFiltersProp.current)
+        ) {
+            return
+        }
+        lastSyncedFiltersProp.current = incoming
+        setFilters(incoming)
+    }, [propertyFilters, setFilters, pageKey])
 
     const displayedFilters = allowNew && editable ? filtersWithNew : filters
     const displayedFilterIds = allowNew && editable ? filterIdsWithNew : filterIds

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -592,7 +592,21 @@ export const productTourLogic = kea<productTourLogicType>([
                     values.isEditingProductTour &&
                     isEqual(incomingPayload, cache.lastSentDraftPayload ?? cache.lastDraftPayload)
 
-                if (!isOwnEcho && !hasUnsavedLocalChanges) {
+                // While editing, draft polling must not overwrite the form with a stale GET response
+                // (e.g. right after autosave), or in-progress UI like event property filters disappears.
+                let shouldApplyForm = false
+                if (!hasUnsavedLocalChanges) {
+                    if (!values.isEditingProductTour) {
+                        shouldApplyForm = !isOwnEcho
+                    } else if (!cache.formHydratedWhileEditing) {
+                        shouldApplyForm = true
+                        cache.formHydratedWhileEditing = true
+                    } else {
+                        shouldApplyForm = isOwnEcho
+                    }
+                }
+
+                if (shouldApplyForm) {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     ;(actions.setProductTourFormValues as any)(formValues)
                     cache.lastDraftPayload = incomingPayload
@@ -608,6 +622,9 @@ export const productTourLogic = kea<productTourLogicType>([
             }
         },
         editingProductTour: ({ editing }) => {
+            if (!editing) {
+                cache.formHydratedWhileEditing = false
+            }
             if (editing && props.id !== 'new') {
                 cache.disposables.add(() => {
                     const canFetch = (): boolean =>

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -601,9 +601,16 @@ export const productTourLogic = kea<productTourLogicType>([
                     } else if (!cache.formHydratedWhileEditing) {
                         shouldApplyForm = true
                         cache.formHydratedWhileEditing = true
-                    } else {
-                        shouldApplyForm = isOwnEcho
-                    }
+                } else {
+                    // Only re-apply when the server echoes back exactly what we last sent/saved.
+                    // This is safe because PropertyFilters skips its internal setFilters when
+                    // the incoming propertyFilters prop matches what was last synced, so any
+                    // in-progress filter row (property chosen but operator/value not yet set)
+                    // is preserved even though setProductTourFormValues is dispatched here.
+                    // If the server normalises the payload differently, isOwnEcho is false and
+                    // the form is left untouched until the user finishes the current edit session.
+                    shouldApplyForm = isOwnEcho
+                }
                 }
 
                 if (shouldApplyForm) {

--- a/frontend/src/scenes/product-tours/productTourLogic.ts
+++ b/frontend/src/scenes/product-tours/productTourLogic.ts
@@ -170,6 +170,27 @@ function buildDraftPayload(formValues: ProductTourForm): Record<string, any> {
     }
 }
 
+/** Avoid overwriting the form from draft polls while editing; pairs with PropertyFilters prop-sync behavior. */
+function shouldApplyProductTourFormFromServer(options: {
+    hasUnsavedLocalChanges: boolean
+    isEditing: boolean
+    isOwnEcho: boolean
+    cache: { formHydratedWhileEditing?: boolean }
+}): boolean {
+    const { hasUnsavedLocalChanges, isEditing, isOwnEcho, cache } = options
+    if (hasUnsavedLocalChanges) {
+        return false
+    }
+    if (!isEditing) {
+        return !isOwnEcho
+    }
+    if (!cache.formHydratedWhileEditing) {
+        cache.formHydratedWhileEditing = true
+        return true
+    }
+    return isOwnEcho
+}
+
 export const productTourLogic = kea<productTourLogicType>([
     path(['scenes', 'product-tours', 'productTourLogic']),
     props({} as ProductTourLogicProps),
@@ -592,26 +613,12 @@ export const productTourLogic = kea<productTourLogicType>([
                     values.isEditingProductTour &&
                     isEqual(incomingPayload, cache.lastSentDraftPayload ?? cache.lastDraftPayload)
 
-                // While editing, draft polling must not overwrite the form with a stale GET response
-                // (e.g. right after autosave), or in-progress UI like event property filters disappears.
-                let shouldApplyForm = false
-                if (!hasUnsavedLocalChanges) {
-                    if (!values.isEditingProductTour) {
-                        shouldApplyForm = !isOwnEcho
-                    } else if (!cache.formHydratedWhileEditing) {
-                        shouldApplyForm = true
-                        cache.formHydratedWhileEditing = true
-                } else {
-                    // Only re-apply when the server echoes back exactly what we last sent/saved.
-                    // This is safe because PropertyFilters skips its internal setFilters when
-                    // the incoming propertyFilters prop matches what was last synced, so any
-                    // in-progress filter row (property chosen but operator/value not yet set)
-                    // is preserved even though setProductTourFormValues is dispatched here.
-                    // If the server normalises the payload differently, isOwnEcho is false and
-                    // the form is left untouched until the user finishes the current edit session.
-                    shouldApplyForm = isOwnEcho
-                }
-                }
+                const shouldApplyForm = shouldApplyProductTourFormFromServer({
+                    hasUnsavedLocalChanges,
+                    isEditing: values.isEditingProductTour,
+                    isOwnEcho,
+                    cache,
+                })
 
                 if (shouldApplyForm) {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Problem

When editing product tours, the event property filter row appears after you pick a property (or start adding a filter), then disappears within a second. That made it impossible to finish configuring event property filters on tour triggers.

Root causes (not collapse state):

PropertyFilters synced from props in a useEffect that depended on propertyFilters. Call sites often pass [] as a new array every render (e.g. convertPropertyFiltersToArray(...)). The parent does not get an onChange until a value is set (or similar), so after choosing only a property the parent still has no filters. Every re-render looked like a “new” empty prop → setFilters([]) → in-progress row wiped.

Draft polling while editing: loadProductTour runs on an interval. After autosave, draftSaveStatus is 'saved', so the UI treated the form as “clean” and replaced it with the fetched draft. If that GET didn’t match what had just been saved (timing/normalization), in-progress edits disappeared.

An earlier attempt used controlled LemonCollapse so panels stayed open; that helps UX but did not fix the filter row vanishing.

Changes

PropertyFilters — Only call setFilters from props when the filter list actually changes (deep compare + pageKey reset), not when the parent passes another empty []. In-progress filters stay until the parent truly updates or the user completes the row.

productTourLogic — While editing, apply server data from loadProductTour on the first load into the editor, or when the response matches the last saved draft (isOwnEcho). Otherwise do not overwrite the form, so polling doesn’t stomp local state.

(If still in this branch) AutoShowSection — Controlled collapse for event rows (activeKeys / onChange + expand when event count changes) so panels don’t reset oddly on re-renders.

How did you test this code?

Tested locally:

Edit a product tour → Configure targeting → When user sends an event.
Add an event (e.g. $autocapture).
Add property filter → choose a property → confirm the filter row stays and you can set operator/value.
Save/wait for autosave → confirm filters don’t disappear from polling.
Smoke-check PropertyFilters elsewhere if reviewers want (same component, shared behavior).

Publish to changelog?
no

