### PR TITLE
fix(signals): Storage timestamps precision.

### DIFF
--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -980,8 +980,13 @@ async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) 
 
     signal_ids = [s.signal_id for s in input.signals]
     timestamps = [s.timestamp for s in input.signals]
-    min_timestamp = min(timestamps)
-    max_timestamp = max(timestamps)
+    # Truncate to milliseconds to match ClickHouse DateTime64(3) storage precision.
+    # Without this, microsecond-precision timestamps from Python can miss rows because
+    # e.g. 22:11:18.627688 > 22:11:18.627000 (the stored value after truncation).
+    min_timestamp = min(timestamps).replace(microsecond=min(timestamps).microsecond // 1000 * 1000)
+    max_timestamp = max(timestamps).replace(microsecond=max(timestamps).microsecond // 1000 * 1000) + timedelta(
+        milliseconds=1
+    )
 
     query = """
         SELECT count(DISTINCT document_id)

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -980,13 +980,9 @@ async def wait_for_signal_in_clickhouse_activity(input: WaitForClickHouseInput) 
 
     signal_ids = [s.signal_id for s in input.signals]
     timestamps = [s.timestamp for s in input.signals]
-    # Truncate to milliseconds to match ClickHouse DateTime64(3) storage precision.
-    # Without this, microsecond-precision timestamps from Python can miss rows because
-    # e.g. 22:11:18.627688 > 22:11:18.627000 (the stored value after truncation).
-    min_timestamp = min(timestamps).replace(microsecond=min(timestamps).microsecond // 1000 * 1000)
-    max_timestamp = max(timestamps).replace(microsecond=max(timestamps).microsecond // 1000 * 1000) + timedelta(
-        milliseconds=1
-    )
+    # Widen the timestamp range to account for precision loss (Python microseconds vs ClickHouse DateTime64(3) milliseconds)
+    min_timestamp = min(timestamps) - timedelta(minutes=2)
+    max_timestamp = max(timestamps) + timedelta(minutes=2)
 
     query = """
         SELECT count(DISTINCT document_id)


### PR DESCRIPTION
## Problem
A timestamp precision mismatch between Python and ClickHouse -> leads to reports never being promoted/generated properly -> tons of timeouts and failed workflows.                                                                                                                                   
  
1. Python generates the signal's timestamp with microsecond precision: 22:11:18.627688                                                                                                                         
2. The embedding worker writes it to ClickHouse, which stores DateTime64(3) — that's millisecond precision — so it gets truncated to: 22:11:18.627000
3. The wait activity queries CH with WHERE timestamp >= 22:11:18.627688 — the exact Python value                                                                                                               
4. 627000 < 627688, so the >= check fails and the row is invisible to the query      

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Truncate min_timestamp down to the millisecond boundary and bump max_timestamp up by 1ms before querying. This way, the range always covers the stored value regardless of sub-millisecond truncation.   

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
