### PR TITLE
chore(capture): measure throughput production to kafka

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -473,7 +473,7 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             headers,
         };
 
-        counter!("capture_kafka_produce_bytes_total", "topic" => record.topic.clone())
+        counter!("capture_kafka_produce_bytes_total", "topic" => topic.to_string())
             .increment(payload_bytes);
 
         self.producer.send(record)

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -464,12 +464,17 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             }
         };
 
+        let payload_bytes = payload.len() as u64;
+
         let record = ProduceRecord {
             topic: topic.to_string(),
             key: partition_key.map(|s| s.to_string()),
             payload,
             headers,
         };
+
+        counter!("capture_kafka_produce_bytes_total", "topic" => record.topic.clone())
+            .increment(payload_bytes);
 
         self.producer.send(record)
     }


### PR DESCRIPTION
## Problem

We recently had an incident where we exceeded the throughput of disk writes to Kafka. We currently have metrics for events/s being produced, but no visibility into bytes/s. These are meaningfully different — a customer with disproportionately large events can spike byte throughput without a corresponding spike in event count, making it hard to diagnose or anticipate capacity issues.

## Changes


Added a `capture_kafka_produce_bytes_total` counter in the Kafka sink, incremented by the serialized payload size (in bytes) on every event produced. The counter is labeled by `topic`, so throughput can be broken down per Kafka topic (e.g., `events_plugin_ingestion`, `session_recording_snapshot_item_overflow`).

In Grafana, `rate(capture_kafka_produce_bytes_total[5m])` gives bytes/s produced, complementing the existing `capture_events_ingested_total` (events/s).

## How did you test this code?


- Verified the crate compiles cleanly with `cargo check -p capture`
- The metric is a straightforward counter increment on an already-serialized payload — the `payload.len()` call is the exact byte count sent to Kafka
- Existing tests continue to pass; no behavioral changes to event routing or production logic