### PR TITLE
feat(rust): GitHub Action to automate Docker Image build + push for feature branches

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -1,0 +1,64 @@
+# Rust service images built by CI.
+#
+# This is the single source of truth for which images get built.
+# Both production (rust-docker-build.yml) and smoke-test
+# (rust-smoke-test-build.yml) workflows read this file via the
+# shared build workflow (_rust-build-images.yml).
+#
+# To add a new service: append an entry here. The deploy matrix in
+# rust-docker-build.yml must also be updated for production deploys.
+- image: capture
+  dockerfile: ./rust/Dockerfile
+  project: kshskj225r
+
+- image: sqlx-migrate
+  dockerfile: ./rust/Dockerfile.sqlx-migrate
+  project: jmsz6gms8g
+
+- image: cyclotron-janitor
+  dockerfile: ./rust/Dockerfile
+  project: r4zm8vtlbw
+
+- image: property-defs-rs
+  dockerfile: ./rust/Dockerfile
+  project: vznmbshh6q
+
+- image: cymbal
+  dockerfile: ./rust/Dockerfile
+  project: 8dq0xkk0ck
+
+- image: embedding-worker
+  dockerfile: ./rust/Dockerfile
+  project: 8dq0xkk0ck
+
+- image: feature-flags
+  dockerfile: ./rust/Dockerfile
+  project: vglf58qgzw
+
+- image: batch-import-worker
+  dockerfile: ./rust/Dockerfile
+  project: 4ppc15q4bv
+
+- image: capture-logs
+  dockerfile: ./rust/Dockerfile
+  project: c1bwj4j4qg
+
+- image: kafka-deduplicator
+  dockerfile: ./rust/Dockerfile
+  project: vznmbshh6q
+
+- image: personhog-leader
+  dockerfile: ./rust/Dockerfile
+  project: g0kjbvxgqx
+
+- image: personhog-replica
+  dockerfile: ./rust/Dockerfile
+  project: vq4lxdfdv2
+
+- image: personhog-router
+  dockerfile: ./rust/Dockerfile
+  project: wqvvpmzgbk
+
+- image: kafka-assigner
+  dockerfile: ./rust/Dockerfile
+  project: 6kjc85bwm7

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -28,6 +28,10 @@ on:
                 description: 'Additional JSON properties for failure reporting (without outer braces)'
                 type: string
                 default: ''
+            image-filter:
+                description: 'Comma-separated list of images to build (empty = all)'
+                type: string
+                default: ''
         outputs:
             digests:
                 description: 'JSON object mapping image name to digest'
@@ -49,9 +53,23 @@ jobs:
                   sparse-checkout: .github/rust-images.yml
                   sparse-checkout-cone-mode: false
 
-            - name: Read matrix
+            - name: Read and filter matrix
               id: set
-              run: echo "matrix=$(yq -o=json -I=0 '.' .github/rust-images.yml)" >> "$GITHUB_OUTPUT"
+              env:
+                  IMAGE_FILTER: ${{ inputs.image-filter }}
+              run: |
+                  full=$(yq -o=json -I=0 '.' .github/rust-images.yml)
+                  if [ -n "$IMAGE_FILTER" ]; then
+                      matrix=$(echo "$full" | jq -c --arg f "$IMAGE_FILTER" \
+                        '[.[] | select(.image as $img | ($f | split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | index($img)) != null)]')
+                  else
+                      matrix="$full"
+                  fi
+                  if [ "$matrix" = "[]" ]; then
+                      echo "::error::image-filter '$IMAGE_FILTER' matched no images in rust-images.yml"
+                      exit 1
+                  fi
+                  echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
     build:
         name: build ${{ matrix.image }}

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -179,7 +179,9 @@ jobs:
                   properties: ${{ steps.failure-props.outputs.json }}
 
             - name: Container image digest
-              run: echo "${{ steps.docker_build.outputs.digest }}" > /tmp/digest.txt
+              env:
+                  DIGEST: ${{ steps.docker_build.outputs.digest }}
+              run: echo "$DIGEST" > /tmp/digest.txt
 
             - name: Upload digest
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -1,0 +1,198 @@
+name: Build rust container images
+
+# Reusable workflow — not triggered directly.
+# Called by rust-docker-build.yml (production) and
+# rust-smoke-test-build.yml (smoke tests).
+# Image list lives in .github/rust-images.yml.
+
+on:
+    workflow_call:
+        inputs:
+            tag-rules:
+                description: 'Docker metadata tag rules (newline-separated)'
+                required: true
+                type: string
+            checkout-ref:
+                description: 'Git ref for checkout (leave empty for default)'
+                type: string
+                default: ''
+            timeout-minutes:
+                description: 'Per-image build timeout'
+                type: number
+                default: 30
+            event-name:
+                description: 'PostHog event name for failure reporting'
+                type: string
+                default: 'posthog-rust-image-build'
+            extra-failure-props:
+                description: 'Additional JSON properties for failure reporting (without outer braces)'
+                type: string
+                default: ''
+        outputs:
+            digests:
+                description: 'JSON object mapping image name to digest'
+                value: ${{ jobs.collect.outputs.digests }}
+
+jobs:
+    load-matrix:
+        name: load image matrix
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        permissions:
+            contents: read
+        outputs:
+            matrix: ${{ steps.set.outputs.matrix }}
+        steps:
+            - name: Check out rust-images.yml
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  sparse-checkout: .github/rust-images.yml
+                  sparse-checkout-cone-mode: false
+
+            - name: Read matrix
+              id: set
+              run: echo "matrix=$(yq -o=json -I=0 '.' .github/rust-images.yml)" >> "$GITHUB_OUTPUT"
+
+    build:
+        name: build ${{ matrix.image }}
+        needs: load-matrix
+        strategy:
+            matrix:
+                include: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
+        runs-on: depot-ubuntu-22.04
+        timeout-minutes: ${{ inputs.timeout-minutes }}
+        permissions:
+            id-token: write
+            contents: read
+            packages: write
+
+        defaults:
+            run:
+                working-directory: rust
+
+        steps:
+            - name: Check Out Repo
+              # Use sparse checkout to only select files in rust directory
+              # Turning off cone mode ensures that files in the project root are not included during checkout
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  ref: ${{ inputs.checkout-ref || '' }}
+                  sparse-checkout: |
+                      rust/
+                      proto/
+                  sparse-checkout-cone-mode: false
+
+            - name: Copy proto files into rust build context
+              working-directory: .
+              run: cp -r proto rust/proto
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+              with:
+                  image: tonistiigi/binfmt:qemu-v10.2.1@sha256:7c76af7ed8714b80e3fc6d6d1c748ebcac867ad6b631167d0a6d3d92952151ea
+                  platforms: all
+
+            - name: Login to ghcr.io
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+                  logout: false
+
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+              with:
+                  images: ghcr.io/posthog/posthog/${{ matrix.image }}
+                  tags: ${{ inputs.tag-rules }}
+
+            - name: Set up Docker Buildx
+              id: buildx
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+            - name: Retrieve sccache configuration
+              id: sccache
+              run: |
+                  echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
+                  echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
+                  echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
+
+            - name: Build and push image
+              id: docker_build
+              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+              with:
+                  project: ${{ matrix.project }}
+                  context: ./rust/
+                  file: ${{ matrix.dockerfile }}
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  platforms: linux/arm64,linux/amd64
+                  build-args: |
+                      SCCACHE_LOG=debug
+                      SCCACHE_NO_DAEMON=1
+                      BIN=${{ matrix.image }}
+                  secrets: |
+                      SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
+                      SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
+
+            - name: Build failure properties
+              if: failure()
+              id: failure-props
+              env:
+                  EXTRA: ${{ inputs.extra-failure-props }}
+              run: |
+                  props='{"status": "failure", "commit_hash": "${{ github.sha }}", "image": "${{ matrix.image }}"'
+                  if [ -n "$EXTRA" ]; then
+                      props="$props, $EXTRA"
+                  fi
+                  echo "json=${props}}" >> "$GITHUB_OUTPUT"
+
+            - name: Report failure
+              if: failure()
+              uses: PostHog/posthog-github-action@8c42e50f2c52e002eabb9bee3f69b152ee8fc1dd # v1.0.1
+              with:
+                  posthog-token: ${{ secrets.POSTHOG_API_TOKEN }}
+                  event: ${{ inputs.event-name }}
+                  properties: ${{ steps.failure-props.outputs.json }}
+
+            - name: Container image digest
+              run: echo "${{ steps.docker_build.outputs.digest }}" > /tmp/digest.txt
+
+            - name: Upload digest
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: digest-${{ matrix.image }}
+                  path: /tmp/digest.txt
+                  retention-days: 1
+
+    collect:
+        name: collect digests
+        needs: [load-matrix, build]
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        permissions:
+            contents: read
+        outputs:
+            digests: ${{ steps.aggregate.outputs.digests }}
+        steps:
+            - name: Download all digest artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  pattern: digest-*
+                  path: /tmp/digests
+
+            - name: Aggregate digests
+              id: aggregate
+              run: |
+                  digests='{}'
+                  for dir in /tmp/digests/digest-*; do
+                      name="${dir##*/digest-}"
+                      digest=$(cat "$dir/digest.txt")
+                      digests=$(echo "$digests" | jq -c --arg k "$name" --arg v "$digest" '. + {($k): $v}')
+                  done
+                  echo "digests=$digests" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -1,250 +1,93 @@
 name: Build and deploy rust container images
 
+# Production build + deploy for Rust services on master.
+#
+# Image list: .github/rust-images.yml
+# Build steps: .github/workflows/_rust-build-images.yml
+# Deploy matrix below must be updated when adding new services.
+
 on:
     workflow_dispatch:
     push:
         paths:
             - 'rust/**'
             - '.github/workflows/rust-docker-build.yml'
+            - '.github/workflows/_rust-build-images.yml'
+            - '.github/rust-images.yml'
         branches:
             - 'master'
 
 jobs:
-    build:
-        name: build ${{ matrix.image }}
-        strategy:
-            matrix:
-                include:
-                    - image: capture
-                      dockerfile: ./rust/Dockerfile
-                      project: kshskj225r
-                    - image: sqlx-migrate
-                      dockerfile: ./rust/Dockerfile.sqlx-migrate
-                      project: jmsz6gms8g
-                    - image: cyclotron-janitor
-                      dockerfile: ./rust/Dockerfile
-                      project: r4zm8vtlbw
-                    - image: property-defs-rs
-                      dockerfile: ./rust/Dockerfile
-                      project: vznmbshh6q
-                    - image: cymbal
-                      dockerfile: ./rust/Dockerfile
-                      project: 8dq0xkk0ck
-                    - image: embedding-worker
-                      dockerfile: ./rust/Dockerfile
-                      project: 8dq0xkk0ck
-                    - image: feature-flags
-                      dockerfile: ./rust/Dockerfile
-                      project: vglf58qgzw
-                    - image: batch-import-worker
-                      dockerfile: ./rust/Dockerfile
-                      project: 4ppc15q4bv
-                    - image: capture-logs
-                      dockerfile: ./rust/Dockerfile
-                      project: c1bwj4j4qg
-                    - image: kafka-deduplicator
-                      dockerfile: ./rust/Dockerfile
-                      project: vznmbshh6q
-                    - image: personhog-leader
-                      dockerfile: ./rust/Dockerfile
-                      project: g0kjbvxgqx
-                    - image: personhog-replica
-                      dockerfile: ./rust/Dockerfile
-                      project: vq4lxdfdv2
-                    - image: personhog-router
-                      dockerfile: ./rust/Dockerfile
-                      project: wqvvpmzgbk
-                    - image: kafka-assigner
-                      dockerfile: ./rust/Dockerfile
-                      project: 6kjc85bwm7
-        runs-on: depot-ubuntu-22.04
-        timeout-minutes: 15
+    build-images:
+        uses: ./.github/workflows/_rust-build-images.yml
+        with:
+            tag-rules: |
+                type=ref,event=pr
+                type=ref,event=branch
+                type=semver,pattern={{version}}
+                type=semver,pattern={{major}}.{{minor}}
+                type=sha
+            timeout-minutes: 15
+        secrets: inherit
         permissions:
-            id-token: write # allow issuing OIDC tokens for this workflow run
-            contents: read # allow reading the repo contents
-            packages: write # allow push to ghcr.io
-
-        outputs:
-            capture_digest: ${{ steps.digest.outputs.capture_digest }}
-            cyclotron-janitor_digest: ${{ steps.digest.outputs.cyclotron-janitor_digest }}
-            property-defs-rs_digest: ${{ steps.digest.outputs.property-defs-rs_digest }}
-            batch-import-worker_digest: ${{ steps.digest.outputs.batch-import-worker_digest }}
-            sqlx-migrate_digest: ${{ steps.digest.outputs.sqlx-migrate_digest }}
-            cymbal_digest: ${{ steps.digest.outputs.cymbal_digest }}
-            embedding-worker_digest: ${{ steps.digest.outputs.embedding-worker_digest }}
-            feature-flags_digest: ${{ steps.digest.outputs.feature-flags_digest }}
-            capture-logs_digest: ${{ steps.digest.outputs.capture-logs_digest }}
-            kafka-deduplicator_digest: ${{ steps.digest.outputs.kafka-deduplicator_digest }}
-            personhog-leader_digest: ${{ steps.digest.outputs.personhog-leader_digest }}
-            personhog-replica_digest: ${{ steps.digest.outputs.personhog-replica_digest }}
-            personhog-router_digest: ${{ steps.digest.outputs.personhog-router_digest }}
-            kafka-assigner_digest: ${{ steps.digest.outputs.kafka-assigner_digest }}
-        defaults:
-            run:
-                working-directory: rust
-
-        steps:
-            - name: Check Out Repo
-              # Checkout project code
-              # Use sparse checkout to only select files in rust directory
-              # Turning off cone mode ensures that files in the project root are not included during checkout
-              uses: actions/checkout@v6
-              with:
-                  sparse-checkout: |
-                      rust/
-                      proto/
-                  sparse-checkout-cone-mode: false
-
-            - name: Copy proto files into rust build context
-              working-directory: .
-              run: cp -r proto rust/proto
-
-            - name: Set up Depot CLI
-              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-              with:
-                  image: tonistiigi/binfmt:qemu-v10.2.1@sha256:7c76af7ed8714b80e3fc6d6d1c748ebcac867ad6b631167d0a6d3d92952151ea
-                  platforms: all
-
-            - name: Login to ghcr.io
-              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-                  logout: false
-
-            - name: Docker meta
-              id: meta
-              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
-              with:
-                  images: ghcr.io/posthog/posthog/${{ matrix.image }}
-                  tags: |
-                      type=ref,event=pr
-                      type=ref,event=branch
-                      type=semver,pattern={{version}}
-                      type=semver,pattern={{major}}.{{minor}}
-                      type=sha
-
-            - name: Set up Docker Buildx
-              id: buildx
-              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-            - name: Retrieve sccache configuration
-              id: sccache
-              run: |
-                  echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
-                  echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
-                  echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
-
-            - name: Build and push image
-              id: docker_build
-              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
-              with:
-                  project: ${{ matrix.project }}
-                  context: ./rust/
-                  file: ${{ matrix.dockerfile }}
-                  push: true
-                  tags: ${{ steps.meta.outputs.tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  platforms: linux/arm64,linux/amd64
-                  build-args: |
-                      SCCACHE_LOG=debug
-                      SCCACHE_NO_DAEMON=1
-                      BIN=${{ matrix.image }}
-                  secrets: |
-                      SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
-                      SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
-
-            - name: report failure
-              if: failure()
-              uses: PostHog/posthog-github-action@8c42e50f2c52e002eabb9bee3f69b152ee8fc1dd # v1.0.1
-              with:
-                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
-                  event: 'posthog-rust-image-build'
-                  properties: '{"status": "failure", "commit_hash": "${{ github.sha }}", "image": "${{ matrix.image }}"}'
-
-            - name: Container image digest
-              id: digest
-              env:
-                  IMAGE_DIGEST: ${{ steps.docker_build.outputs.digest }}
-                  IMAGE_NAME: ${{ matrix.image }}
-              run: |
-                  echo "$IMAGE_DIGEST"
-                  echo "${IMAGE_NAME}_digest=$IMAGE_DIGEST" >> $GITHUB_OUTPUT
-                  cat $GITHUB_OUTPUT
+            id-token: write
+            contents: read
+            packages: write
 
     deploy:
         name: deploy ${{ matrix.release }}
         runs-on: ubuntu-24.04
         timeout-minutes: 5
-        needs: build
+        needs: build-images
         if: github.ref == 'refs/heads/master'
         strategy:
             matrix:
                 include:
                     - release: capture
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.capture_digest }}'
+                      digest_key: capture
+                      values_key: image
                     - release: capture-replay
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.capture_digest }}'
+                      digest_key: capture
+                      values_key: image
                     - release: cyclotron
-                      values:
-                          janitor_image:
-                              sha: '${{ needs.build.outputs.cyclotron-janitor_digest }}'
+                      digest_key: cyclotron-janitor
+                      values_key: janitor_image
                     - release: property-defs-rs
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.property-defs-rs_digest }}'
+                      digest_key: property-defs-rs
+                      values_key: image
                     - release: feature-flags
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.feature-flags_digest }}'
+                      digest_key: feature-flags
+                      values_key: image
                     - release: batch-import-worker
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.batch-import-worker_digest }}'
+                      digest_key: batch-import-worker
+                      values_key: image
                     - release: cymbal
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.cymbal_digest }}'
+                      digest_key: cymbal
+                      values_key: image
                     - release: embedding-worker
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.embedding-worker_digest }}'
+                      digest_key: embedding-worker
+                      values_key: image
                     - release: capture-logs
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.capture-logs_digest }}'
+                      digest_key: capture-logs
+                      values_key: image
                     - release: kafka-deduplicator
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.kafka-deduplicator_digest }}'
+                      digest_key: kafka-deduplicator
+                      values_key: image
                     - release: sqlx-migrate
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.sqlx-migrate_digest }}'
+                      digest_key: sqlx-migrate
+                      values_key: image
                     - release: personhog-leader
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.personhog-leader_digest }}'
+                      digest_key: personhog-leader
+                      values_key: image
                     - release: personhog-replica
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.personhog-replica_digest }}'
+                      digest_key: personhog-replica
+                      values_key: image
                     - release: personhog-router
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.personhog-router_digest }}'
+                      digest_key: personhog-router
+                      values_key: image
                     - release: kafka-assigner
-                      values:
-                          image:
-                              sha: '${{ needs.build.outputs.kafka-assigner_digest }}'
+                      digest_key: kafka-assigner
+                      values_key: image
         steps:
             - name: get deployer token
               id: deployer
@@ -261,7 +104,7 @@ jobs:
                   event-type: commit_state_update
                   client-payload: |
                       {
-                        "values": ${{ toJson(matrix.values) }},
+                        "values": {"${{ matrix.values_key }}": {"sha": "${{ fromJson(needs.build-images.outputs.digests)[matrix.digest_key] }}"}},
                         "release": "${{ matrix.release }}",
                         "commit": ${{ toJson(github.event.head_commit) }},
                         "repository": ${{ toJson(github.repository) }},

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -105,7 +105,7 @@ jobs:
             - name: Set up QEMU
               uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
               with:
-                  image: tonistiigi/binfmt:latest
+                  image: tonistiigi/binfmt:qemu-v10.2.1@sha256:7c76af7ed8714b80e3fc6d6d1c748ebcac867ad6b631167d0a6d3d92952151ea
                   platforms: all
 
             - name: Login to ghcr.io

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
     build-images:
+        timeout-minutes: 20
         uses: ./.github/workflows/_rust-build-images.yml
         with:
             tag-rules: |

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -9,7 +9,7 @@ name: Build rust smoke test images
 
 on:
     pull_request:
-        types: [labeled, synchronize, opened, reopened]
+        types: [labeled, synchronize]
         paths:
             - 'rust/**'
             - '.github/workflows/rust-smoke-test-build.yml'
@@ -25,9 +25,10 @@ jobs:
             - name: Verify PostHog org membership
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  ACTOR: ${{ github.actor }}
               run: |
-                  if ! gh api orgs/PostHog/members/${{ github.actor }} --silent 2>/dev/null; then
-                      echo "::error::${{ github.actor }} is not a PostHog org member — smoke test builds are restricted to employees"
+                  if ! gh api "orgs/PostHog/members/$ACTOR" --silent 2>/dev/null; then
+                      echo "::error::$ACTOR is not a PostHog org member — smoke test builds are restricted to employees"
                       exit 1
                   fi
 

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -6,6 +6,9 @@ name: Build rust smoke test images
 #
 # Usage: add the 'smoke_test' label to your PR. Images rebuild on every push
 # while the label is present. Remove the label to stop builds.
+#
+# Image list: .github/rust-images.yml
+# Build steps: .github/workflows/_rust-build-images.yml
 
 on:
     pull_request:
@@ -14,6 +17,8 @@ on:
             - 'rust/**'
             - 'proto/**'
             - '.github/workflows/rust-smoke-test-build.yml'
+            - '.github/workflows/_rust-build-images.yml'
+            - '.github/rust-images.yml'
 
 concurrency:
     group: rust-smoke-test-${{ github.event.pull_request.number }}
@@ -23,6 +28,7 @@ jobs:
     authorize:
         name: authorize smoke test
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         if: |
             contains(github.event.pull_request.labels.*.name, 'smoke_test') &&
             github.event.pull_request.head.repo.full_name == github.repository
@@ -39,159 +45,20 @@ jobs:
                       exit 1
                   fi
 
-    build:
-        name: build ${{ matrix.image }}
+    build-images:
         needs: authorize
-        strategy:
-            matrix:
-                include:
-                    - image: capture
-                      dockerfile: ./rust/Dockerfile
-                      project: kshskj225r
-                    - image: hook-api
-                      dockerfile: ./rust/Dockerfile
-                      project: c1bwj4j4qg
-                    - image: hook-janitor
-                      dockerfile: ./rust/Dockerfile
-                      project: c1bwj4j4qg
-                    - image: hook-worker
-                      dockerfile: ./rust/Dockerfile
-                      project: c1bwj4j4qg
-                    - image: hook-migrator
-                      dockerfile: ./rust/Dockerfile.migrate-hooks
-                      project: c1bwj4j4qg
-                    - image: sqlx-migrate
-                      dockerfile: ./rust/Dockerfile.sqlx-migrate
-                      project: jmsz6gms8g
-                    - image: cyclotron-janitor
-                      dockerfile: ./rust/Dockerfile
-                      project: r4zm8vtlbw
-                    - image: property-defs-rs
-                      dockerfile: ./rust/Dockerfile
-                      project: vznmbshh6q
-                    - image: cymbal
-                      dockerfile: ./rust/Dockerfile
-                      project: 8dq0xkk0ck
-                    - image: embedding-worker
-                      dockerfile: ./rust/Dockerfile
-                      project: 8dq0xkk0ck
-                    - image: feature-flags
-                      dockerfile: ./rust/Dockerfile
-                      project: vglf58qgzw
-                    - image: batch-import-worker
-                      dockerfile: ./rust/Dockerfile
-                      project: 4ppc15q4bv
-                    - image: capture-logs
-                      dockerfile: ./rust/Dockerfile
-                      project: c1bwj4j4qg
-                    - image: kafka-deduplicator
-                      dockerfile: ./rust/Dockerfile
-                      project: vznmbshh6q
-                    - image: personhog-replica
-                      dockerfile: ./rust/Dockerfile
-                      project: vq4lxdfdv2
-                    - image: personhog-router
-                      dockerfile: ./rust/Dockerfile
-                      project: wqvvpmzgbk
-                    - image: kafka-assigner
-                      dockerfile: ./rust/Dockerfile
-                      project: 6kjc85bwm7
-        runs-on: depot-ubuntu-22.04
+        uses: ./.github/workflows/_rust-build-images.yml
+        with:
+            tag-rules: |
+                type=ref,event=pr
+                type=sha
+                type=raw,value=${{ github.head_ref }}
+            checkout-ref: ${{ github.event.pull_request.head.sha }}
+            timeout-minutes: 30
+            event-name: posthog-rust-smoke-test-image-build
+            extra-failure-props: '"pr": "${{ github.event.pull_request.number }}"'
+        secrets: inherit
         permissions:
-            id-token: write # allow issuing OIDC tokens for this workflow run
-            contents: read # allow reading the repo contents
-            packages: write # allow push to ghcr.io
-
-        defaults:
-            run:
-                working-directory: rust
-
-        steps:
-            - name: Check Out Repo
-              # Use sparse checkout to only select files in rust directory
-              # Turning off cone mode ensures that files in the project root are not included during checkout
-              uses: actions/checkout@v6
-              with:
-                  ref: ${{ github.event.pull_request.head.sha }}
-                  sparse-checkout: |
-                      rust/
-                      proto/
-                  sparse-checkout-cone-mode: false
-
-            - name: Copy proto files into rust build context
-              working-directory: .
-              run: cp -r proto rust/proto
-
-            - name: Set up Depot CLI
-              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-              with:
-                  image: tonistiigi/binfmt:qemu-v10.2.1@sha256:7c76af7ed8714b80e3fc6d6d1c748ebcac867ad6b631167d0a6d3d92952151ea
-                  platforms: all
-
-            - name: Login to ghcr.io
-              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-                  logout: false
-
-            - name: Docker meta
-              id: meta
-              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
-              with:
-                  images: ghcr.io/posthog/posthog/${{ matrix.image }}
-                  tags: |
-                      type=ref,event=pr
-                      type=sha
-                      type=raw,value=${{ github.head_ref }}
-
-            - name: Set up Docker Buildx
-              id: buildx
-              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-            - name: Retrieve sccache configuration
-              id: sccache
-              run: |
-                  echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
-                  echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
-                  echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
-
-            - name: Build and push image
-              id: docker_build
-              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
-              with:
-                  project: ${{ matrix.project }}
-                  context: ./rust/
-                  file: ${{ matrix.dockerfile }}
-                  push: true
-                  tags: ${{ steps.meta.outputs.tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  platforms: linux/arm64,linux/amd64
-                  build-args: |
-                      SCCACHE_LOG=debug
-                      SCCACHE_NO_DAEMON=1
-                      BIN=${{ matrix.image }}
-                  secrets: |
-                      SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
-                      SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
-
-            - name: report failure
-              if: failure()
-              uses: PostHog/posthog-github-action@8c42e50f2c52e002eabb9bee3f69b152ee8fc1dd # v1.0.1
-              with:
-                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
-                  event: 'posthog-rust-smoke-test-image-build'
-                  properties: '{"status": "failure", "commit_hash": "${{ github.sha }}", "image": "${{ matrix.image }}", "pr": "${{ github.event.pull_request.number }}"}'
-
-            - name: Container image digest
-              id: digest
-              env:
-                  IMAGE_DIGEST: ${{ steps.docker_build.outputs.digest }}
-                  IMAGE_NAME: ${{ matrix.image }}
-              run: |
-                  echo "$IMAGE_DIGEST"
-                  echo "${IMAGE_NAME}_digest=$IMAGE_DIGEST" >> $GITHUB_OUTPUT
+            id-token: write
+            contents: read
+            packages: write

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -128,7 +128,7 @@ jobs:
             - name: Set up QEMU
               uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
               with:
-                  image: tonistiigi/binfmt:latest
+                  image: tonistiigi/binfmt:qemu-v10.2.1@sha256:7c76af7ed8714b80e3fc6d6d1c748ebcac867ad6b631167d0a6d3d92952151ea
                   platforms: all
 
             - name: Login to ghcr.io

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -12,23 +12,30 @@ on:
         types: [labeled, synchronize]
         paths:
             - 'rust/**'
+            - 'proto/**'
             - '.github/workflows/rust-smoke-test-build.yml'
+
+concurrency:
+    group: rust-smoke-test-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
 
 jobs:
     authorize:
         name: authorize smoke test
         runs-on: ubuntu-latest
-        if: contains(github.event.pull_request.labels.*.name, 'smoke_test')
+        if: |
+            contains(github.event.pull_request.labels.*.name, 'smoke_test') &&
+            github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             contents: read
         steps:
             - name: Verify PostHog org membership
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  ACTOR: ${{ github.actor }}
+                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
               run: |
-                  if ! gh api "orgs/PostHog/members/$ACTOR" --silent 2>/dev/null; then
-                      echo "::error::$ACTOR is not a PostHog org member — smoke test builds are restricted to employees"
+                  if ! gh api "orgs/PostHog/members/$PR_AUTHOR" --silent 2>/dev/null; then
+                      echo "::error::$PR_AUTHOR is not a PostHog org member — smoke test builds are restricted to employees"
                       exit 1
                   fi
 

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -1,0 +1,187 @@
+name: Build rust smoke test images
+
+# Builds Docker images for Rust services from PR branches labeled 'smoke_test'.
+# This is a build-only workflow — no deployment. Use it to get feature branch
+# images into ghcr.io for pre-merge smoke testing in staging/production.
+#
+# Usage: add the 'smoke_test' label to your PR. Images rebuild on every push
+# while the label is present. Remove the label to stop builds.
+
+on:
+    pull_request:
+        types: [labeled, synchronize, opened, reopened]
+        paths:
+            - 'rust/**'
+            - '.github/workflows/rust-smoke-test-build.yml'
+
+jobs:
+    authorize:
+        name: authorize smoke test
+        runs-on: ubuntu-latest
+        if: contains(github.event.pull_request.labels.*.name, 'smoke_test')
+        steps:
+            - name: Verify PostHog org membership
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  if ! gh api orgs/PostHog/members/${{ github.actor }} --silent 2>/dev/null; then
+                      echo "::error::${{ github.actor }} is not a PostHog org member — smoke test builds are restricted to employees"
+                      exit 1
+                  fi
+
+    build:
+        name: build ${{ matrix.image }}
+        needs: authorize
+        strategy:
+            matrix:
+                include:
+                    - image: capture
+                      dockerfile: ./rust/Dockerfile
+                      project: kshskj225r
+                    - image: hook-api
+                      dockerfile: ./rust/Dockerfile
+                      project: c1bwj4j4qg
+                    - image: hook-janitor
+                      dockerfile: ./rust/Dockerfile
+                      project: c1bwj4j4qg
+                    - image: hook-worker
+                      dockerfile: ./rust/Dockerfile
+                      project: c1bwj4j4qg
+                    - image: hook-migrator
+                      dockerfile: ./rust/Dockerfile.migrate-hooks
+                      project: c1bwj4j4qg
+                    - image: sqlx-migrate
+                      dockerfile: ./rust/Dockerfile.sqlx-migrate
+                      project: jmsz6gms8g
+                    - image: cyclotron-janitor
+                      dockerfile: ./rust/Dockerfile
+                      project: r4zm8vtlbw
+                    - image: property-defs-rs
+                      dockerfile: ./rust/Dockerfile
+                      project: vznmbshh6q
+                    - image: cymbal
+                      dockerfile: ./rust/Dockerfile
+                      project: 8dq0xkk0ck
+                    - image: embedding-worker
+                      dockerfile: ./rust/Dockerfile
+                      project: 8dq0xkk0ck
+                    - image: feature-flags
+                      dockerfile: ./rust/Dockerfile
+                      project: vglf58qgzw
+                    - image: batch-import-worker
+                      dockerfile: ./rust/Dockerfile
+                      project: 4ppc15q4bv
+                    - image: capture-logs
+                      dockerfile: ./rust/Dockerfile
+                      project: c1bwj4j4qg
+                    - image: kafka-deduplicator
+                      dockerfile: ./rust/Dockerfile
+                      project: vznmbshh6q
+                    - image: personhog-replica
+                      dockerfile: ./rust/Dockerfile
+                      project: vq4lxdfdv2
+                    - image: personhog-router
+                      dockerfile: ./rust/Dockerfile
+                      project: wqvvpmzgbk
+                    - image: kafka-assigner
+                      dockerfile: ./rust/Dockerfile
+                      project: 6kjc85bwm7
+        runs-on: depot-ubuntu-22.04
+        permissions:
+            id-token: write # allow issuing OIDC tokens for this workflow run
+            contents: read # allow reading the repo contents
+            packages: write # allow push to ghcr.io
+
+        defaults:
+            run:
+                working-directory: rust
+
+        steps:
+            - name: Check Out Repo
+              # Use sparse checkout to only select files in rust directory
+              # Turning off cone mode ensures that files in the project root are not included during checkout
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  sparse-checkout: |
+                      rust/
+                      proto/
+                  sparse-checkout-cone-mode: false
+
+            - name: Copy proto files into rust build context
+              working-directory: .
+              run: cp -r proto rust/proto
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1.6.0
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+              with:
+                  image: tonistiigi/binfmt:latest
+                  platforms: all
+
+            - name: Login to ghcr.io
+              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+                  logout: false
+
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+              with:
+                  images: ghcr.io/posthog/posthog/${{ matrix.image }}
+                  tags: |
+                      type=ref,event=pr
+                      type=sha
+                      type=raw,value=${{ github.head_ref }}
+
+            - name: Set up Docker Buildx
+              id: buildx
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+            - name: Retrieve sccache configuration
+              id: sccache
+              run: |
+                  echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
+                  echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
+                  echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
+
+            - name: Build and push image
+              id: docker_build
+              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+              with:
+                  project: ${{ matrix.project }}
+                  context: ./rust/
+                  file: ${{ matrix.dockerfile }}
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  platforms: linux/arm64,linux/amd64
+                  build-args: |
+                      SCCACHE_LOG=debug
+                      SCCACHE_NO_DAEMON=1
+                      BIN=${{ matrix.image }}
+                  secrets: |
+                      SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
+                      SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
+
+            - name: report failure
+              if: failure()
+              uses: PostHog/posthog-github-action@8c42e50f2c52e002eabb9bee3f69b152ee8fc1dd # v1.0.1
+              with:
+                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
+                  event: 'posthog-rust-smoke-test-image-build'
+                  properties: '{"status": "failure", "commit_hash": "${{ github.sha }}", "image": "${{ matrix.image }}", "pr": "${{ github.event.pull_request.number }}"}'
+
+            - name: Container image digest
+              id: digest
+              env:
+                  IMAGE_DIGEST: ${{ steps.docker_build.outputs.digest }}
+                  IMAGE_NAME: ${{ matrix.image }}
+              run: |
+                  echo "$IMAGE_DIGEST"
+                  echo "${IMAGE_NAME}_digest=$IMAGE_DIGEST" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -4,13 +4,21 @@ name: Build rust smoke test images
 # This is a build-only workflow — no deployment. Use it to get feature branch
 # images into ghcr.io for pre-merge smoke testing in staging/production.
 #
-# Usage: add the 'smoke_test' label to your PR. Images rebuild on every push
-# while the label is present. Remove the label to stop builds.
+# Usage:
+#   Build all images: add the 'smoke_test' label to your PR
+#   Build specific images: add 'smoke_test:capture', 'smoke_test:cymbal', etc.
+#   Manual trigger: Actions tab -> workflow_dispatch -> enter image names
 #
 # Image list: .github/rust-images.yml
 # Build steps: .github/workflows/_rust-build-images.yml
 
 on:
+    workflow_dispatch:
+        inputs:
+            images:
+                description: 'Comma-separated image names to build (empty = all)'
+                type: string
+                default: ''
     pull_request:
         types: [labeled, synchronize]
         paths:
@@ -21,7 +29,7 @@ on:
             - '.github/rust-images.yml'
 
 concurrency:
-    group: rust-smoke-test-${{ github.event.pull_request.number }}
+    group: rust-smoke-test-${{ github.event.pull_request.number || github.run_id }}
     cancel-in-progress: true
 
 jobs:
@@ -30,30 +38,65 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         if: |
-            contains(github.event.pull_request.labels.*.name, 'smoke_test') &&
-            github.event.pull_request.head.repo.full_name == github.repository
+            github.event_name == 'workflow_dispatch' ||
+            (contains(github.event.pull_request.labels.*.name, 'smoke_test') &&
+             github.event.pull_request.head.repo.full_name == github.repository) ||
+            contains(toJson(github.event.pull_request.labels.*.name), 'smoke_test:')
         permissions:
             contents: read
         steps:
-            - name: Verify PostHog org membership
+            - name: Verify PR author is a PostHog org member
+              if: |
+                  github.event_name != 'workflow_dispatch' &&
+                  github.event.pull_request.author_association != 'OWNER' &&
+                  github.event.pull_request.author_association != 'MEMBER'
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+                  AUTHOR: ${{ github.event.pull_request.user.login }}
+                  ASSOCIATION: ${{ github.event.pull_request.author_association }}
               run: |
-                  if ! gh api "orgs/PostHog/members/$PR_AUTHOR" --silent 2>/dev/null; then
-                      echo "::error::$PR_AUTHOR is not a PostHog org member — smoke test builds are restricted to employees"
-                      exit 1
+                  echo "::error::PR author ($AUTHOR) has association '$ASSOCIATION' — smoke test builds are restricted to org members"
+                  exit 1
+
+    resolve-filter:
+        name: resolve image filter
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        outputs:
+            filter: ${{ steps.parse.outputs.filter }}
+        steps:
+            - name: Parse image filter
+              id: parse
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
+                  DISPATCH_IMAGES: ${{ github.event.inputs.images }}
+                  PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+              run: |
+                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                      echo "filter=$DISPATCH_IMAGES" >> "$GITHUB_OUTPUT"
+                      exit 0
                   fi
 
+                  filter=""
+                  for label in $(echo "$PR_LABELS" | jq -r '.[]'); do
+                      case "$label" in
+                          smoke_test:*)
+                              img="${label#smoke_test:}"
+                              filter="${filter:+$filter,}$img"
+                              ;;
+                      esac
+                  done
+                  echo "filter=$filter" >> "$GITHUB_OUTPUT"
+
     build-images:
-        needs: authorize
+        needs: [authorize, resolve-filter]
         uses: ./.github/workflows/_rust-build-images.yml
         with:
+            image-filter: ${{ needs.resolve-filter.outputs.filter }}
             tag-rules: |
                 type=ref,event=pr
                 type=sha
-                type=raw,value=${{ github.head_ref }}
-            checkout-ref: ${{ github.event.pull_request.head.sha }}
+                type=raw,value=${{ github.head_ref || github.ref_name }}
+            checkout-ref: ${{ github.event.pull_request.head.sha || github.sha }}
             timeout-minutes: 30
             event-name: posthog-rust-smoke-test-image-build
             extra-failure-props: '"pr": "${{ github.event.pull_request.number }}"'

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -90,6 +90,7 @@ jobs:
 
     build-images:
         needs: [authorize, resolve-filter]
+        timeout-minutes: 35
         uses: ./.github/workflows/_rust-build-images.yml
         with:
             image-filter: ${{ needs.resolve-filter.outputs.filter }}

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -19,6 +19,8 @@ jobs:
         name: authorize smoke test
         runs-on: ubuntu-latest
         if: contains(github.event.pull_request.labels.*.name, 'smoke_test')
+        permissions:
+            contents: read
         steps:
             - name: Verify PostHog org membership
               env:

--- a/.github/workflows/rust-smoke-test-build.yml
+++ b/.github/workflows/rust-smoke-test-build.yml
@@ -61,6 +61,7 @@ jobs:
         name: resolve image filter
         runs-on: ubuntu-latest
         timeout-minutes: 2
+        permissions: {}
         outputs:
             filter: ${{ steps.parse.outputs.filter }}
         steps:


### PR DESCRIPTION
## Problem
Smoke testing critical path Rust services (risky `capture` changes etc.) often requires hot patching a Docker image of the feature branch (PR) change into a live deploy spec, where we can quickly revert without CI/CD delays.

Let's make this easier! But of course, feel free to slap me if this is insecure in a way I didn't account for 👍 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* New GitHub Action similar to `rust-docker-build.yml`
* Builds Docker Image from PR and ships to ghcr.io with gating:
    * Must be a Rust workspace PR
    * PR is tagged with `smoke_test`
    * PR authored by a PostHog GitHub org member (i.e. an employee)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
