### PR TITLE
fix(warehouse): backfill HubSpot properties to preserve columns

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/hubspot.py
+++ b/posthog/temporal/data_imports/sources/hubspot/hubspot.py
@@ -123,6 +123,11 @@ def get_rows(
         logger=logger,
     )
 
+    # Track expected properties so we can backfill missing ones with None.
+    # HubSpot omits properties from the response when they have no value for a record,
+    # which causes PyArrow to drop those columns entirely during schema inference.
+    expected_properties = props_str.split(",") if props_str else []
+
     headers = _get_headers(api_key)
     batcher = Batcher(logger=logger, chunk_size=2000, chunk_size_bytes=100 * 1024 * 1024)
 
@@ -177,7 +182,11 @@ def get_rows(
         next_url = next_page.get("link") if next_page else None
 
         for result in results:
-            batcher.batch(_flatten_result(result))
+            row = _flatten_result(result)
+            for prop in expected_properties:
+                if prop not in row:
+                    row[prop] = None
+            batcher.batch(row)
 
             if batcher.should_yield():
                 py_table = batcher.get_table()

--- a/posthog/temporal/data_imports/sources/hubspot/hubspot.py
+++ b/posthog/temporal/data_imports/sources/hubspot/hubspot.py
@@ -77,6 +77,13 @@ def _build_initial_url(path: str, associations: list[str], properties: str, limi
     return f"{BASE_URL.rstrip('/')}{path}?{'&'.join(parts)}"
 
 
+def _backfill_missing_properties(row: dict[str, Any], expected_properties: list[str]) -> None:
+    """Ensure all expected properties exist in the row, defaulting missing ones to None."""
+    for prop in expected_properties:
+        if prop not in row:
+            row[prop] = None
+
+
 def _flatten_result(result: dict[str, Any]) -> dict[str, Any]:
     """Flatten a HubSpot CRM API result into a flat dict.
 
@@ -183,9 +190,7 @@ def get_rows(
 
         for result in results:
             row = _flatten_result(result)
-            for prop in expected_properties:
-                if prop not in row:
-                    row[prop] = None
+            _backfill_missing_properties(row, expected_properties)
             batcher.batch(row)
 
             if batcher.should_yield():

--- a/posthog/temporal/data_imports/sources/hubspot/hubspot.py
+++ b/posthog/temporal/data_imports/sources/hubspot/hubspot.py
@@ -78,10 +78,9 @@ def _build_initial_url(path: str, associations: list[str], properties: str, limi
 
 
 def _backfill_missing_properties(row: dict[str, Any], expected_properties: list[str]) -> None:
-    """Ensure all expected properties exist in the row, defaulting missing ones to None."""
+    """HubSpot omits properties with null values; PyArrow drops absent columns during schema inference."""
     for prop in expected_properties:
-        if prop not in row:
-            row[prop] = None
+        row.setdefault(prop, None)
 
 
 def _flatten_result(result: dict[str, Any]) -> dict[str, Any]:

--- a/posthog/temporal/tests/data_imports/test_hubspot_source.py
+++ b/posthog/temporal/tests/data_imports/test_hubspot_source.py
@@ -30,7 +30,7 @@ from unittest.mock import patch
 
 import structlog
 
-from posthog.temporal.data_imports.sources.hubspot.hubspot import PROPERTY_LENGTH_LIMIT, _get_properties_str
+from posthog.temporal.data_imports.sources.hubspot.hubspot import PROPERTY_LENGTH_LIMIT, _flatten_result, _get_properties_str, get_rows
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 
 from products.data_warehouse.backend.models import ExternalDataSchema, ExternalDataSource
@@ -204,3 +204,138 @@ def test_hubspot_get_properties_url_length_limit():
             # check that the warning was logged
             mock_warning.assert_called_once()
             assert "Your request to Hubspot is too long to process" in mock_warning.call_args[0][0]
+
+
+def test_flatten_result_backfills_missing_properties():
+    """HubSpot omits properties with null values from the response.
+
+    get_rows() should backfill missing properties with None so that PyArrow
+    preserves all expected columns during schema inference.
+    """
+    # Simulate HubSpot API responses where some records are missing properties
+    hubspot_api_results = [
+        {
+            "id": "1",
+            "properties": {
+                "name": "Acme Corp",
+                "domain": "acme.com",
+                "stripe_subscription_status": "active",
+                "hubspot_owner_id": "123",
+            },
+        },
+        {
+            "id": "2",
+            "properties": {
+                "name": "Beta Inc",
+                "domain": "beta.com",
+                # stripe_subscription_status and hubspot_owner_id omitted (null in HubSpot)
+            },
+        },
+        {
+            "id": "3",
+            "properties": {
+                "name": "Gamma LLC",
+                # domain, stripe_subscription_status, hubspot_owner_id all omitted
+            },
+        },
+    ]
+
+    expected_properties = ["name", "domain", "stripe_subscription_status", "hubspot_owner_id"]
+
+    for result in hubspot_api_results:
+        row = _flatten_result(result)
+        for prop in expected_properties:
+            if prop not in row:
+                row[prop] = None
+
+        # Every row should have all expected properties after backfilling
+        for prop in expected_properties:
+            assert prop in row, f"Property '{prop}' missing from row with id={row.get('id')}"
+
+    # Specifically check that the second row (missing props) got backfilled
+    row2 = _flatten_result(hubspot_api_results[1])
+    for prop in expected_properties:
+        if prop not in row2:
+            row2[prop] = None
+    assert row2["stripe_subscription_status"] is None
+    assert row2["hubspot_owner_id"] is None
+
+    # Check that the third row got domain backfilled too
+    row3 = _flatten_result(hubspot_api_results[2])
+    for prop in expected_properties:
+        if prop not in row3:
+            row3[prop] = None
+    assert row3["domain"] is None
+    assert row3["stripe_subscription_status"] is None
+    assert row3["hubspot_owner_id"] is None
+
+
+def test_get_rows_backfills_missing_properties():
+    """Integration test: get_rows() should produce rows with consistent columns
+    even when HubSpot omits null-valued properties from responses.
+    """
+    from unittest.mock import MagicMock
+
+    mock_resumable_manager = MagicMock()
+    mock_resumable_manager.can_resume.return_value = False
+
+    # Mock the HubSpot API to return results with inconsistent properties
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "results": [
+            {
+                "id": "1",
+                "properties": {
+                    "createdate": "2024-01-01",
+                    "domain": "acme.com",
+                    "name": "Acme",
+                    "custom_field": "value1",
+                },
+            },
+            {
+                "id": "2",
+                "properties": {
+                    "createdate": "2024-02-01",
+                    "name": "Beta",
+                    # domain and custom_field omitted by HubSpot (null values)
+                },
+            },
+        ],
+        "paging": {},
+    }
+
+    with (
+        patch("posthog.temporal.data_imports.sources.hubspot.hubspot._get_property_names") as mock_props,
+        patch("posthog.temporal.data_imports.sources.hubspot.hubspot.requests.get") as mock_get,
+    ):
+        mock_props.return_value = ["createdate", "domain", "name", "custom_field"]
+        mock_get.return_value = mock_response
+
+        tables = list(
+            get_rows(
+                api_key="dummy",
+                refresh_token="dummy",
+                endpoint="companies",
+                logger=logger,
+                resumable_source_manager=mock_resumable_manager,
+                include_custom_props=True,
+            )
+        )
+
+        assert len(tables) == 1
+        table = tables[0]
+
+        # Both rows should have all columns, including ones HubSpot omitted
+        assert "domain" in table.column_names
+        assert "custom_field" in table.column_names
+        assert table.num_rows == 2
+
+        # Second row should have None for omitted properties
+        rows = table.to_pylist()
+        assert rows[1]["domain"] is None
+        assert rows[1]["custom_field"] is None
+        # First row should still have its values
+        assert rows[0]["domain"] == "acme.com"
+        assert rows[0]["custom_field"] == "value1"

--- a/posthog/temporal/tests/data_imports/test_hubspot_source.py
+++ b/posthog/temporal/tests/data_imports/test_hubspot_source.py
@@ -26,11 +26,11 @@ import uuid
 import urllib.parse
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import structlog
 
-from posthog.temporal.data_imports.sources.hubspot.hubspot import PROPERTY_LENGTH_LIMIT, _flatten_result, _get_properties_str, get_rows
+from posthog.temporal.data_imports.sources.hubspot.hubspot import PROPERTY_LENGTH_LIMIT, _backfill_missing_properties, _flatten_result, _get_properties_str, get_rows
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 
 from products.data_warehouse.backend.models import ExternalDataSchema, ExternalDataSource
@@ -206,76 +206,52 @@ def test_hubspot_get_properties_url_length_limit():
             assert "Your request to Hubspot is too long to process" in mock_warning.call_args[0][0]
 
 
-def test_flatten_result_backfills_missing_properties():
-    """HubSpot omits properties with null values from the response.
+@pytest.mark.parametrize(
+    "row, expected_properties, expected_none_keys",
+    [
+        pytest.param(
+            {"name": "Acme", "domain": "acme.com"},
+            ["name", "domain", "status"],
+            ["status"],
+            id="single_missing_prop",
+        ),
+        pytest.param(
+            {"name": "Beta"},
+            ["name", "domain", "status", "owner_id"],
+            ["domain", "status", "owner_id"],
+            id="multiple_missing_props",
+        ),
+        pytest.param(
+            {"name": "Gamma", "domain": "gamma.com", "status": "active"},
+            ["name", "domain", "status"],
+            [],
+            id="no_missing_props",
+        ),
+        pytest.param(
+            {},
+            ["name", "domain"],
+            ["name", "domain"],
+            id="all_props_missing",
+        ),
+        pytest.param(
+            {"name": "Delta"},
+            [],
+            [],
+            id="empty_expected_properties",
+        ),
+    ],
+)
+def test_backfill_missing_properties(row, expected_properties, expected_none_keys):
+    _backfill_missing_properties(row, expected_properties)
 
-    get_rows() should backfill missing properties with None so that PyArrow
-    preserves all expected columns during schema inference.
-    """
-    # Simulate HubSpot API responses where some records are missing properties
-    hubspot_api_results = [
-        {
-            "id": "1",
-            "properties": {
-                "name": "Acme Corp",
-                "domain": "acme.com",
-                "stripe_subscription_status": "active",
-                "hubspot_owner_id": "123",
-            },
-        },
-        {
-            "id": "2",
-            "properties": {
-                "name": "Beta Inc",
-                "domain": "beta.com",
-                # stripe_subscription_status and hubspot_owner_id omitted (null in HubSpot)
-            },
-        },
-        {
-            "id": "3",
-            "properties": {
-                "name": "Gamma LLC",
-                # domain, stripe_subscription_status, hubspot_owner_id all omitted
-            },
-        },
-    ]
-
-    expected_properties = ["name", "domain", "stripe_subscription_status", "hubspot_owner_id"]
-
-    for result in hubspot_api_results:
-        row = _flatten_result(result)
-        for prop in expected_properties:
-            if prop not in row:
-                row[prop] = None
-
-        # Every row should have all expected properties after backfilling
-        for prop in expected_properties:
-            assert prop in row, f"Property '{prop}' missing from row with id={row.get('id')}"
-
-    # Specifically check that the second row (missing props) got backfilled
-    row2 = _flatten_result(hubspot_api_results[1])
     for prop in expected_properties:
-        if prop not in row2:
-            row2[prop] = None
-    assert row2["stripe_subscription_status"] is None
-    assert row2["hubspot_owner_id"] is None
+        assert prop in row, f"Property '{prop}' missing after backfill"
 
-    # Check that the third row got domain backfilled too
-    row3 = _flatten_result(hubspot_api_results[2])
-    for prop in expected_properties:
-        if prop not in row3:
-            row3[prop] = None
-    assert row3["domain"] is None
-    assert row3["stripe_subscription_status"] is None
-    assert row3["hubspot_owner_id"] is None
+    for key in expected_none_keys:
+        assert row[key] is None, f"Expected None for '{key}', got {row[key]}"
 
 
 def test_get_rows_backfills_missing_properties():
-    """Integration test: get_rows() should produce rows with consistent columns
-    even when HubSpot omits null-valued properties from responses.
-    """
-    from unittest.mock import MagicMock
-
     mock_resumable_manager = MagicMock()
     mock_resumable_manager.can_resume.return_value = False
 

--- a/posthog/temporal/tests/data_imports/test_hubspot_source.py
+++ b/posthog/temporal/tests/data_imports/test_hubspot_source.py
@@ -30,7 +30,7 @@ from unittest.mock import MagicMock, patch
 
 import structlog
 
-from posthog.temporal.data_imports.sources.hubspot.hubspot import PROPERTY_LENGTH_LIMIT, _backfill_missing_properties, _flatten_result, _get_properties_str, get_rows
+from posthog.temporal.data_imports.sources.hubspot.hubspot import PROPERTY_LENGTH_LIMIT, _backfill_missing_properties, _get_properties_str, get_rows
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 
 from products.data_warehouse.backend.models import ExternalDataSchema, ExternalDataSource
@@ -304,6 +304,7 @@ def test_get_rows_backfills_missing_properties():
         table = tables[0]
 
         # Both rows should have all columns, including ones HubSpot omitted
+        assert "id" in table.column_names
         assert "domain" in table.column_names
         assert "custom_field" in table.column_names
         assert table.num_rows == 2

--- a/posthog/temporal/tests/data_imports/test_hubspot_source.py
+++ b/posthog/temporal/tests/data_imports/test_hubspot_source.py
@@ -30,7 +30,12 @@ from unittest.mock import MagicMock, patch
 
 import structlog
 
-from posthog.temporal.data_imports.sources.hubspot.hubspot import PROPERTY_LENGTH_LIMIT, _backfill_missing_properties, _get_properties_str, get_rows
+from posthog.temporal.data_imports.sources.hubspot.hubspot import (
+    PROPERTY_LENGTH_LIMIT,
+    _backfill_missing_properties,
+    _get_properties_str,
+    get_rows,
+)
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 
 from products.data_warehouse.backend.models import ExternalDataSchema, ExternalDataSource


### PR DESCRIPTION
## Problem

Support Ticket: https://posthoghelp.zendesk.com/agent/tickets/53570 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55015)

PR #51114 replaced the DLT-based HubSpot sync with resumable source, some HubSpot fields (`stripe_subscription_status`, `hubspot_owner_id`, etc.) stopped appearing in warehouse tables and could no longer be referenced by insights.

HubSpot omits properties with null values from API responses. The old dlt pipeline handled this through dlt's schema management, but the new resumable source passes raw dicts to PyArrow which drops columns that are absent across all rows in a batch.

## Changes

- Track the list of expected properties from the HubSpot API request string
- After flattening each result, backfill any missing expected properties with `None`
- This ensures PyArrow always sees all columns regardless of HubSpot's null-omission behavior

## How did you test this code?

Added some unit tests.

**Note**: Affected users will need a re-sync after deployment for the columns to reappear.

