### PR TITLE
fix(experiments): Clear stale results on reset analysis

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1533,6 +1533,10 @@ export const experimentLogic = kea<experimentLogicType>([
             values.experiment && actions.reportExperimentReset(values.experiment)
             actions.setLegacyPrimaryMetricsResults([])
             actions.setLegacySecondaryMetricsResults([])
+            actions.setPrimaryMetricsResults([])
+            actions.setPrimaryMetricsResultsErrors([])
+            actions.setSecondaryMetricsResults([])
+            actions.setSecondaryMetricsResultsErrors([])
         },
         updateExperimentSuccess: async ({ experiment, payload }) => {
             actions.updateExperiments(experiment)


### PR DESCRIPTION
## Problem
"Reset analysis" only cleared legacy metrics results, leaving the new results in state. The UI showed stale data until a full page reload.

## Changes
Clear `primaryMetricsResults`, `secondaryMetricsResults`, and their error arrays in `resetRunningExperiment`.

|Before|After|
|----|----|
|<img width="1289" height="1050" alt="image" src="https://github.com/user-attachments/assets/11b7ca3e-ceb8-4d36-b4a6-12f1fbd95079" />|<img width="1290" height="1036" alt="image" src="https://github.com/user-attachments/assets/ebe391be-2636-43e8-8dc6-538539350a1a" />|