### PR TITLE
feat(event_definitions): pt2 - add ingestion pipeline stamping for schema validation

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -261,19 +261,17 @@ jobs:
             - name: Wait for Clickhouse, Redis, Kafka, Localstack
               run: docker compose -f docker-compose.dev.yml up kafka redis7 clickhouse maildev localstack -d --wait
 
-            - name: Fetch base branch for diff
+            - name: Fetch master for migration diff
               if: github.event_name == 'pull_request'
-              env:
-                  BASE_REF: ${{ github.base_ref }}
-              run: git fetch origin "$BASE_REF" --depth=1
+              run: git fetch origin master --depth=1
 
             - name: Check for migrations in this PR
               id: check_migrations
               if: github.event_name == 'pull_request'
-              env:
-                  BASE_REF: ${{ github.base_ref }}
               run: |
-                  if git diff --name-only "origin/$BASE_REF..HEAD" | grep -E '(migrations/|rust/.*migrate)'; then
+                  # Compare against master (not the PR base) so stacked PRs that
+                  # depend on migrations in a parent branch take the slow path.
+                  if git diff --name-only "origin/master..HEAD" | grep -E '(migrations/|rust/.*migrate)'; then
                     echo "has_migrations=true" >> $GITHUB_OUTPUT
                   else
                     echo "has_migrations=false" >> $GITHUB_OUTPUT

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-schema.test.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-schema.test.ts
@@ -1,7 +1,22 @@
-import { EventSchemaEnforcement, Team } from '../../types'
+import { EventSchemaEnforcement, PipelineEvent, Team } from '../../types'
 import { EventSchemaEnforcementManager } from '../../utils/event-schema-enforcement-manager'
 import { PipelineResultType, drop, ok } from '../pipelines/results'
 import { createValidateEventSchemaStep, validateEventAgainstSchema } from './validate-event-schema'
+
+/** Helper to create an EventSchemaEnforcement with sensible defaults */
+function schema(
+    eventName: string,
+    requiredProperties: [string, string[]][],
+    enforcementMode: 'reject' | 'enforce' = 'reject',
+    schemaVersion: number = 1
+): EventSchemaEnforcement {
+    return {
+        event_name: eventName,
+        enforcement_mode: enforcementMode,
+        schema_version: schemaVersion,
+        required_properties: new Map(requiredProperties),
+    }
+}
 
 /** Creates a mock EventSchemaEnforcementManager that returns the provided schemas for any team */
 function createMockSchemaManager(schemas: EventSchemaEnforcement[]): EventSchemaEnforcementManager {
@@ -14,20 +29,14 @@ function createMockSchemaManager(schemas: EventSchemaEnforcement[]): EventSchema
 }
 
 describe('validateEventAgainstSchema', () => {
-    // Note: The schema only includes required_properties since optional properties
-    // are filtered out at the database query level for performance.
-
     describe('missing required fields', () => {
         it.each([
             ['undefined', undefined],
             ['null', null],
         ])('should reject when required property is %s', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['required_prop', ['String']]]),
-            }
+            const s = schema('test_event', [['required_prop', ['String']]])
 
-            const result = validateEventAgainstSchema({ required_prop: value }, schema)
+            const result = validateEventAgainstSchema({ required_prop: value }, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors).toHaveLength(1)
@@ -38,40 +47,31 @@ describe('validateEventAgainstSchema', () => {
         })
 
         it('should reject when required property is missing from properties object', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['required_prop', ['String']]]),
-            }
+            const s = schema('test_event', [['required_prop', ['String']]])
 
-            const result = validateEventAgainstSchema({}, schema)
+            const result = validateEventAgainstSchema({}, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors[0].reason).toBe('missing_required')
         })
 
         it('should reject when properties object is undefined', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['required_prop', ['String']]]),
-            }
+            const s = schema('test_event', [['required_prop', ['String']]])
 
-            const result = validateEventAgainstSchema(undefined, schema)
+            const result = validateEventAgainstSchema(undefined, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors[0].reason).toBe('missing_required')
         })
 
         it('should report multiple missing required fields', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([
-                    ['field1', ['String']],
-                    ['field2', ['Numeric']],
-                    ['field3', ['Boolean']],
-                ]),
-            }
+            const s = schema('test_event', [
+                ['field1', ['String']],
+                ['field2', ['Numeric']],
+                ['field3', ['Boolean']],
+            ])
 
-            const result = validateEventAgainstSchema({}, schema)
+            const result = validateEventAgainstSchema({}, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors).toHaveLength(3)
@@ -86,12 +86,9 @@ describe('validateEventAgainstSchema', () => {
             ['object', { foo: 'bar' }],
             ['array', [1, 2, 3]],
         ])('should accept %s as String', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['String']]]),
-            }
+            const s = schema('test_event', [['prop', ['String']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(true)
         })
@@ -107,12 +104,9 @@ describe('validateEventAgainstSchema', () => {
             ['negative numeric string', '-10'],
             ['float string', '3.14'],
         ])('should accept %s as Numeric', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Numeric']]]),
-            }
+            const s = schema('test_event', [['prop', ['Numeric']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(true)
         })
@@ -132,12 +126,9 @@ describe('validateEventAgainstSchema', () => {
             ['string "-Infinity"', '-Infinity'],
             ['string "NaN"', 'NaN'],
         ])('should reject %s as Numeric', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Numeric']]]),
-            }
+            const s = schema('test_event', [['prop', ['Numeric']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors[0].reason).toBe('type_mismatch')
@@ -151,12 +142,9 @@ describe('validateEventAgainstSchema', () => {
             ['string "true"', 'true'],
             ['string "false"', 'false'],
         ])('should accept %s as Boolean', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Boolean']]]),
-            }
+            const s = schema('test_event', [['prop', ['Boolean']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(true)
         })
@@ -173,12 +161,9 @@ describe('validateEventAgainstSchema', () => {
             ['object', {}],
             ['array', []],
         ])('should reject %s as Boolean', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Boolean']]]),
-            }
+            const s = schema('test_event', [['prop', ['Boolean']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors[0].reason).toBe('type_mismatch')
@@ -192,12 +177,9 @@ describe('validateEventAgainstSchema', () => {
             ['ISO string with offset', '2021-01-01T00:00:00+00:00'],
             ['date string', '2021-01-01'],
         ])('should accept %s as DateTime', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['DateTime']]]),
-            }
+            const s = schema('test_event', [['prop', ['DateTime']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(true)
         })
@@ -208,12 +190,9 @@ describe('validateEventAgainstSchema', () => {
             ['array', []],
             ['boolean', true],
         ])('should reject %s as DateTime', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['DateTime']]]),
-            }
+            const s = schema('test_event', [['prop', ['DateTime']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors[0].reason).toBe('type_mismatch')
@@ -227,12 +206,9 @@ describe('validateEventAgainstSchema', () => {
             ['array', [1, 2, 3]],
             ['empty array', []],
         ])('should accept %s as Object', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Object']]]),
-            }
+            const s = schema('test_event', [['prop', ['Object']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(true)
         })
@@ -242,12 +218,9 @@ describe('validateEventAgainstSchema', () => {
             ['number', 42],
             ['boolean', true],
         ])('should reject %s as Object', (_, value) => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Object']]]),
-            }
+            const s = schema('test_event', [['prop', ['Object']]])
 
-            const result = validateEventAgainstSchema({ prop: value }, schema)
+            const result = validateEventAgainstSchema({ prop: value }, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors[0].reason).toBe('type_mismatch')
@@ -256,29 +229,23 @@ describe('validateEventAgainstSchema', () => {
 
     describe('multiple required properties', () => {
         it('should accept when all required properties pass validation', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([
-                    ['name', ['String']],
-                    ['age', ['Numeric']],
-                ]),
-            }
+            const s = schema('test_event', [
+                ['name', ['String']],
+                ['age', ['Numeric']],
+            ])
 
-            const result = validateEventAgainstSchema({ name: 'alice', age: 30 }, schema)
+            const result = validateEventAgainstSchema({ name: 'alice', age: 30 }, s)
 
             expect(result.valid).toBe(true)
         })
 
         it('should reject when one of multiple required properties fails', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([
-                    ['name', ['String']],
-                    ['age', ['Numeric']],
-                ]),
-            }
+            const s = schema('test_event', [
+                ['name', ['String']],
+                ['age', ['Numeric']],
+            ])
 
-            const result = validateEventAgainstSchema({ name: 'alice', age: 'not-a-number' }, schema)
+            const result = validateEventAgainstSchema({ name: 'alice', age: 'not-a-number' }, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors).toHaveLength(1)
@@ -288,22 +255,16 @@ describe('validateEventAgainstSchema', () => {
 
     describe('multi-type properties', () => {
         it('should accept value matching any of the listed types', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['String', 'Numeric']]]),
-            }
+            const s = schema('test_event', [['prop', ['String', 'Numeric']]])
 
-            expect(validateEventAgainstSchema({ prop: 'hello' }, schema).valid).toBe(true)
-            expect(validateEventAgainstSchema({ prop: 42 }, schema).valid).toBe(true)
+            expect(validateEventAgainstSchema({ prop: 'hello' }, s).valid).toBe(true)
+            expect(validateEventAgainstSchema({ prop: 42 }, s).valid).toBe(true)
         })
 
         it('should reject value matching none of the listed types', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Numeric', 'Boolean']]]),
-            }
+            const s = schema('test_event', [['prop', ['Numeric', 'Boolean']]])
 
-            const result = validateEventAgainstSchema({ prop: { nested: true } }, schema)
+            const result = validateEventAgainstSchema({ prop: { nested: true } }, s)
 
             expect(result.valid).toBe(false)
             expect(result.errors[0].expectedTypes).toEqual(['Numeric', 'Boolean'])
@@ -312,12 +273,9 @@ describe('validateEventAgainstSchema', () => {
 
     describe('unknown types', () => {
         it('should allow values for unknown property types', () => {
-            const schema: EventSchemaEnforcement = {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['UnknownType']]]),
-            }
+            const s = schema('test_event', [['prop', ['UnknownType']]])
 
-            const result = validateEventAgainstSchema({ prop: 'anything' }, schema)
+            const result = validateEventAgainstSchema({ prop: 'anything' }, s)
 
             expect(result.valid).toBe(true)
         })
@@ -325,7 +283,11 @@ describe('validateEventAgainstSchema', () => {
 })
 
 describe('createValidateEventSchemaStep', () => {
-    const createInput = (eventName: string, properties: Record<string, unknown> | undefined) => ({
+    const createInput = (
+        eventName: string,
+        properties: Record<string, unknown> | undefined,
+        teamOverrides?: Partial<Team>
+    ) => ({
         event: {
             event: eventName,
             distinct_id: 'user123',
@@ -335,10 +297,12 @@ describe('createValidateEventSchemaStep', () => {
             site_url: 'https://example.com',
             now: '2021-01-01T00:00:00Z',
             properties,
-        },
+        } as PipelineEvent,
         team: {
             id: 1,
             name: 'Test Team',
+            schema_validation_disabled: null,
+            ...teamOverrides,
         } as unknown as Team,
     })
 
@@ -353,13 +317,7 @@ describe('createValidateEventSchemaStep', () => {
     })
 
     it('should pass events that have no matching schema', async () => {
-        const schemas: EventSchemaEnforcement[] = [
-            {
-                event_name: 'other_event',
-                required_properties: new Map([['required_prop', ['String']]]),
-            },
-        ]
-        const mockManager = createMockSchemaManager(schemas)
+        const mockManager = createMockSchemaManager([schema('other_event', [['required_prop', ['String']]])])
         const step = createValidateEventSchemaStep(mockManager)
         const input = createInput('test_event', {})
 
@@ -369,13 +327,7 @@ describe('createValidateEventSchemaStep', () => {
     })
 
     it('should pass events that match schema requirements', async () => {
-        const schemas: EventSchemaEnforcement[] = [
-            {
-                event_name: 'test_event',
-                required_properties: new Map([['required_prop', ['String']]]),
-            },
-        ]
-        const mockManager = createMockSchemaManager(schemas)
+        const mockManager = createMockSchemaManager([schema('test_event', [['required_prop', ['String']]])])
         const step = createValidateEventSchemaStep(mockManager)
         const input = createInput('test_event', { required_prop: 'hello' })
 
@@ -385,13 +337,7 @@ describe('createValidateEventSchemaStep', () => {
     })
 
     it('should drop events missing required properties', async () => {
-        const schemas: EventSchemaEnforcement[] = [
-            {
-                event_name: 'test_event',
-                required_properties: new Map([['required_prop', ['String']]]),
-            },
-        ]
-        const mockManager = createMockSchemaManager(schemas)
+        const mockManager = createMockSchemaManager([schema('test_event', [['required_prop', ['String']]])])
         const step = createValidateEventSchemaStep(mockManager)
         const input = createInput('test_event', {})
 
@@ -424,13 +370,7 @@ describe('createValidateEventSchemaStep', () => {
     })
 
     it('should drop events with type mismatch on required properties', async () => {
-        const schemas: EventSchemaEnforcement[] = [
-            {
-                event_name: 'test_event',
-                required_properties: new Map([['numeric_prop', ['Numeric']]]),
-            },
-        ]
-        const mockManager = createMockSchemaManager(schemas)
+        const mockManager = createMockSchemaManager([schema('test_event', [['numeric_prop', ['Numeric']]])])
         const step = createValidateEventSchemaStep(mockManager)
         const input = createInput('test_event', { numeric_prop: 'not-a-number' })
 
@@ -463,16 +403,12 @@ describe('createValidateEventSchemaStep', () => {
     })
 
     it('should include multiple errors in warning details', async () => {
-        const schemas: EventSchemaEnforcement[] = [
-            {
-                event_name: 'test_event',
-                required_properties: new Map([
-                    ['field1', ['String']],
-                    ['field2', ['Numeric']],
-                ]),
-            },
-        ]
-        const mockManager = createMockSchemaManager(schemas)
+        const mockManager = createMockSchemaManager([
+            schema('test_event', [
+                ['field1', ['String']],
+                ['field2', ['Numeric']],
+            ]),
+        ])
         const step = createValidateEventSchemaStep(mockManager)
         const input = createInput('test_event', { field2: 'not-numeric' })
 
@@ -485,13 +421,7 @@ describe('createValidateEventSchemaStep', () => {
     })
 
     it('should stringify object values in error details', async () => {
-        const schemas: EventSchemaEnforcement[] = [
-            {
-                event_name: 'test_event',
-                required_properties: new Map([['prop', ['Boolean']]]),
-            },
-        ]
-        const mockManager = createMockSchemaManager(schemas)
+        const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['Boolean']]])])
         const step = createValidateEventSchemaStep(mockManager)
         const input = createInput('test_event', { prop: { nested: 'object' } })
 
@@ -501,5 +431,96 @@ describe('createValidateEventSchemaStep', () => {
         if (result.type === PipelineResultType.DROP) {
             expect(result.warnings[0].details.errors[0].actualValue).toBe('{"nested":"object"}')
         }
+    })
+
+    describe('version stamping', () => {
+        it('should stamp +version on successful reject mode validation', async () => {
+            const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['String']]], 'reject', 3)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', { prop: 'hello' })
+
+            await step(input)
+
+            expect(input.event.validated_schema_version).toBe(3)
+        })
+
+        it('should stamp +version on successful enforce mode validation', async () => {
+            const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['String']]], 'enforce', 5)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', { prop: 'hello' })
+
+            await step(input)
+
+            expect(input.event.validated_schema_version).toBe(5)
+        })
+
+        it('should stamp -version on failed enforce mode validation', async () => {
+            const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['Numeric']]], 'enforce', 7)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', { prop: 'not-a-number' })
+
+            const result = await step(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(input.event.validated_schema_version).toBe(-7)
+        })
+
+        it('should include warnings on failed enforce mode validation', async () => {
+            const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['Numeric']]], 'enforce', 1)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', { prop: 'not-a-number' })
+
+            const result = await step(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.warnings).toHaveLength(1)
+                expect(result.warnings[0].type).toBe('schema_validation_failed')
+            }
+        })
+
+        it('should not stamp version when no schema matches', async () => {
+            const mockManager = createMockSchemaManager([schema('other_event', [['prop', ['String']]], 'enforce', 1)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', { prop: 'hello' })
+
+            await step(input)
+
+            expect(input.event.validated_schema_version).toBeUndefined()
+        })
+    })
+
+    describe('kill switch', () => {
+        it('should skip validation when schema_validation_disabled is true', async () => {
+            const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['String']]], 'reject', 1)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', {}, { schema_validation_disabled: true })
+
+            const result = await step(input)
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            expect(input.event.validated_schema_version).toBeUndefined()
+            expect(mockManager.getSchemas).not.toHaveBeenCalled()
+        })
+
+        it('should validate normally when schema_validation_disabled is false', async () => {
+            const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['String']]], 'reject', 1)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', {})
+
+            const result = await step(input)
+
+            expect(result.type).toBe(PipelineResultType.DROP)
+        })
+
+        it('should validate normally when schema_validation_disabled is null', async () => {
+            const mockManager = createMockSchemaManager([schema('test_event', [['prop', ['String']]], 'reject', 1)])
+            const step = createValidateEventSchemaStep(mockManager)
+            const input = createInput('test_event', {}, { schema_validation_disabled: null })
+
+            const result = await step(input)
+
+            expect(result.type).toBe(PipelineResultType.DROP)
+        })
     })
 })

--- a/nodejs/src/ingestion/event-preprocessing/validate-event-schema.ts
+++ b/nodejs/src/ingestion/event-preprocessing/validate-event-schema.ts
@@ -1,5 +1,6 @@
 import { EventSchemaEnforcement, PipelineEvent, Team } from '../../types'
 import { EventSchemaEnforcementManager } from '../../utils/event-schema-enforcement-manager'
+import { PipelineWarning } from '../pipelines/pipeline.interface'
 import { drop, ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 import { isValidClickHouseDateTime } from './clickhouse-datetime-parser'
@@ -102,9 +103,36 @@ export function validateEventAgainstSchema(
     }
 }
 
+function buildSchemaValidationWarning(event: PipelineEvent, validationResult: SchemaValidationResult): PipelineWarning {
+    return {
+        type: 'schema_validation_failed',
+        details: {
+            eventUuid: event.uuid,
+            eventName: event.event,
+            distinctId: event.distinct_id,
+            errors: validationResult.errors.map((err) => ({
+                property: err.propertyName,
+                reason: err.reason,
+                expectedTypes: err.expectedTypes,
+                actualValue:
+                    err.actualValue !== undefined
+                        ? typeof err.actualValue === 'object'
+                            ? JSON.stringify(err.actualValue)
+                            : String(err.actualValue)
+                        : undefined,
+            })),
+        },
+    }
+}
+
 /**
  * Creates a processing step that validates events against enforced schemas.
- * Events that fail validation are dropped and an ingestion warning is emitted.
+ *
+ * Behavior depends on the enforcement mode:
+ * - `reject`: events that fail validation are dropped with an ingestion warning
+ * - `enforce`: events are always passed through, but stamped with +version (pass) or -version (fail)
+ *
+ * The kill switch `team.schema_validation_disabled` bypasses all validation.
  *
  * @param schemaManager - Manager for fetching enforced schemas (uses caching internally)
  */
@@ -113,6 +141,10 @@ export function createValidateEventSchemaStep<T extends { event: PipelineEvent; 
 ): ProcessingStep<T, T> {
     return async function validateEventSchemaStep(input) {
         const { event, team } = input
+
+        if (team.schema_validation_disabled) {
+            return ok(input)
+        }
 
         const enforcedSchemas = await schemaManager.getSchemas(team.id)
         if (enforcedSchemas.size === 0) {
@@ -126,34 +158,23 @@ export function createValidateEventSchemaStep<T extends { event: PipelineEvent; 
 
         const validationResult = validateEventAgainstSchema(event.properties, schema)
 
-        if (!validationResult.valid) {
-            return drop(
-                'schema_validation_failed',
-                [],
-                [
-                    {
-                        type: 'schema_validation_failed',
-                        details: {
-                            eventUuid: event.uuid,
-                            eventName: event.event,
-                            distinctId: event.distinct_id,
-                            errors: validationResult.errors.map((err) => ({
-                                property: err.propertyName,
-                                reason: err.reason,
-                                expectedTypes: err.expectedTypes,
-                                actualValue:
-                                    err.actualValue !== undefined
-                                        ? typeof err.actualValue === 'object'
-                                            ? JSON.stringify(err.actualValue)
-                                            : String(err.actualValue)
-                                        : undefined,
-                            })),
-                        },
-                    },
-                ]
-            )
+        if (schema.enforcement_mode === 'enforce') {
+            // Enforce mode: stamp version and always pass through
+            if (validationResult.valid) {
+                event.validated_schema_version = schema.schema_version
+            } else {
+                event.validated_schema_version = -schema.schema_version
+            }
+            const warnings = validationResult.valid ? [] : [buildSchemaValidationWarning(event, validationResult)]
+            return ok(input, [], warnings)
         }
 
+        // Reject mode: drop on failure, stamp on success
+        if (!validationResult.valid) {
+            return drop('schema_validation_failed', [], [buildSchemaValidationWarning(event, validationResult)])
+        }
+
+        event.validated_schema_version = schema.schema_version
         return ok(input)
     }
 }

--- a/nodejs/src/ingestion/event-processing/emit-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.ts
@@ -104,6 +104,9 @@ export function serializeEvent(event: ProcessedEvent): RawKafkaEvent {
         person_created_at: castTimestampOrNow(event.person_created_at, TimestampFormat.ClickHouseSecondPrecision),
         person_mode: event.person_mode,
         ...(event.historical_migration ? { historical_migration: true } : {}),
+        ...(event.validated_schema_version !== undefined
+            ? { validated_schema_version: event.validated_schema_version }
+            : {}),
     }
 }
 

--- a/nodejs/src/ingestion/event-processing/prepare-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/prepare-event-step.ts
@@ -9,7 +9,7 @@ import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
 export type PrepareEventStepInput = {
-    normalizedEvent: PluginEvent
+    normalizedEvent: PluginEvent & { validated_schema_version?: number }
     team: Team
     processPerson: boolean
     headers: EventHeaders
@@ -50,6 +50,9 @@ export function createPrepareEventStep<TInput extends PrepareEventStepInput>(): 
             timestamp: timestamp.toISO() as ISOTimestamp,
             teamId: input.team.id,
             projectId: input.team.project_id,
+            ...(normalizedEvent.validated_schema_version !== undefined
+                ? { validated_schema_version: normalizedEvent.validated_schema_version }
+                : {}),
         }
 
         const historicalMigration = input.headers.historical_migration ?? false

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -262,6 +262,8 @@ export type OrganizationAvailableFeature = 'group_analytics' | 'data_pipelines' 
 /** Event schema with enforcement enabled. Only includes required properties since optional properties are not validated. */
 export interface EventSchemaEnforcement {
     event_name: string
+    enforcement_mode: 'reject' | 'enforce'
+    schema_version: number
     /** Map from property name to accepted types (multiple types when property groups disagree) */
     required_properties: Map<string, string[]>
 }
@@ -299,6 +301,7 @@ export interface Team {
     drop_events_older_than_seconds: number | null
     logs_settings?: LogsSettings | null
     extra_settings: Record<string, string | number | boolean> | null
+    schema_validation_disabled?: boolean | null
 }
 
 /** Properties shared by RawEventMessage and EventMessage. */
@@ -396,6 +399,7 @@ export interface ProcessedEvent {
     person_created_at: DateTime | null
     person_mode: PersonMode
     historical_migration?: boolean
+    validated_schema_version?: number
 }
 
 /** Parsed event row from ClickHouse. */
@@ -431,6 +435,7 @@ export interface PreIngestionEvent {
     distinctId: string
     properties: Properties
     timestamp: ISOTimestamp
+    validated_schema_version?: number
 }
 
 /** Parsed event structure after initial ingestion.
@@ -865,6 +870,7 @@ export enum OrganizationMembershipLevel {
 
 export interface PipelineEvent extends Omit<PluginEvent, 'team_id'> {
     team_id?: number | null
+    validated_schema_version?: number
 }
 
 export interface EventHeaders {

--- a/nodejs/src/utils/event-schema-enforcement-manager.test.ts
+++ b/nodejs/src/utils/event-schema-enforcement-manager.test.ts
@@ -36,14 +36,14 @@ describe('EventSchemaEnforcementManager', () => {
     const createEventDefinition = async (
         teamId: number,
         eventName: string,
-        enforcementMode: 'allow' | 'reject' = 'allow'
+        enforcementMode: 'allow' | 'reject' | 'enforce' = 'allow'
     ): Promise<string> => {
         const result = await postgres.query<{ id: string }>(
             PostgresUse.COMMON_WRITE,
             `INSERT INTO posthog_eventdefinition
-                (id, team_id, name, enforcement_mode, created_at, last_seen_at)
+                (id, team_id, name, enforcement_mode, schema_version, created_at, last_seen_at)
              VALUES
-                (gen_random_uuid(), $1, $2, $3, NOW(), NOW())
+                (gen_random_uuid(), $1, $2, $3, 1, NOW(), NOW())
              RETURNING id`,
             [teamId, eventName, enforcementMode],
             'create-test-event-definition'
@@ -257,6 +257,37 @@ describe('EventSchemaEnforcementManager', () => {
             const result2 = await schemaManager.getSchemas(99999)
             expect(result2.size).toBe(0)
             expect(fetchSchemasSpy).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('enforce mode', () => {
+        it('returns schemas for events with enforcement_mode=enforce', async () => {
+            const eventDefId = await createEventDefinition(teamId, 'test_event', 'enforce')
+            const propGroupId = await createPropertyGroup(teamId)
+            await createEventSchema(eventDefId, propGroupId)
+            await createProperty(propGroupId, 'user_id', 'String', true)
+
+            const result = await schemaManager.getSchemas(teamId)
+
+            expect(result.size).toBe(1)
+            const schema = result.get('test_event')
+            expect(schema).toBeDefined()
+            expect(schema!.enforcement_mode).toBe('enforce')
+            expect(schema!.schema_version).toBe(1)
+        })
+
+        it('returns both reject and enforce schemas for the same team', async () => {
+            await createEnforcedSchema(teamId, 'reject_event', [{ name: 'prop', type: 'String', required: true }])
+            const enforceDefId = await createEventDefinition(teamId, 'enforce_event', 'enforce')
+            const propGroupId = await createPropertyGroup(teamId)
+            await createEventSchema(enforceDefId, propGroupId)
+            await createProperty(propGroupId, 'prop', 'String', true)
+
+            const result = await schemaManager.getSchemas(teamId)
+
+            expect(result.size).toBe(2)
+            expect(result.get('reject_event')!.enforcement_mode).toBe('reject')
+            expect(result.get('enforce_event')!.enforcement_mode).toBe('enforce')
         })
     })
 })

--- a/nodejs/src/utils/event-schema-enforcement-manager.ts
+++ b/nodejs/src/utils/event-schema-enforcement-manager.ts
@@ -16,7 +16,7 @@ interface RawSchemaPropertyRow {
 /**
  * Manages event schema enforcement configuration for teams.
  *
- * Fetches schemas for events that have enforcement_mode='reject' on their EventDefinition,
+ * Fetches schemas for events that have enforcement_mode='reject' or 'enforce' on their EventDefinition,
  * which are validated at ingestion time.
  */
 /** Map from event_name to schema for O(1) lookups */
@@ -81,7 +81,7 @@ export class EventSchemaEnforcementManager {
             JOIN posthog_eventschema es ON es.event_definition_id = ed.id
             JOIN posthog_schemapropertygroupproperty p ON p.property_group_id = es.property_group_id
             WHERE ed.team_id = ANY($1)
-              AND ed.enforcement_mode = 'reject'
+              AND ed.enforcement_mode IN ('reject', 'enforce')
               AND p.is_required = true
             GROUP BY ed.team_id, ed.name, p.name
             ORDER BY ed.team_id, ed.name, p.name`,

--- a/nodejs/src/utils/event-schema-enforcement-manager.ts
+++ b/nodejs/src/utils/event-schema-enforcement-manager.ts
@@ -9,6 +9,8 @@ import { LazyLoader } from './lazy-loader'
 interface RawSchemaPropertyRow {
     team_id: number
     event_name: string
+    enforcement_mode: 'reject' | 'enforce'
+    schema_version: number
     property_name: string
     property_types: string[]
 }
@@ -75,6 +77,8 @@ export class EventSchemaEnforcementManager {
             `SELECT
                 ed.team_id,
                 ed.name as event_name,
+                ed.enforcement_mode,
+                es.version as schema_version,
                 p.name as property_name,
                 array_agg(DISTINCT p.property_type ORDER BY p.property_type) as property_types
             FROM posthog_eventdefinition ed
@@ -83,7 +87,7 @@ export class EventSchemaEnforcementManager {
             WHERE ed.team_id = ANY($1)
               AND ed.enforcement_mode IN ('reject', 'enforce')
               AND p.is_required = true
-            GROUP BY ed.team_id, ed.name, p.name
+            GROUP BY ed.team_id, ed.name, ed.enforcement_mode, es.version, p.name
             ORDER BY ed.team_id, ed.name, p.name`,
             [numericTeamIds],
             'fetch-enforced-event-schemas'
@@ -112,7 +116,12 @@ export class EventSchemaEnforcementManager {
 
             let schema = result[teamId].get(row.event_name)
             if (!schema) {
-                schema = { event_name: row.event_name, required_properties: new Map() }
+                schema = {
+                    event_name: row.event_name,
+                    enforcement_mode: row.enforcement_mode,
+                    schema_version: row.schema_version,
+                    required_properties: new Map(),
+                }
                 result[teamId].set(row.event_name, schema)
             }
 

--- a/nodejs/src/utils/event-schema-enforcement-manager.ts
+++ b/nodejs/src/utils/event-schema-enforcement-manager.ts
@@ -78,7 +78,7 @@ export class EventSchemaEnforcementManager {
                 ed.team_id,
                 ed.name as event_name,
                 ed.enforcement_mode,
-                es.version as schema_version,
+                ed.schema_version as schema_version,
                 p.name as property_name,
                 array_agg(DISTINCT p.property_type ORDER BY p.property_type) as property_types
             FROM posthog_eventdefinition ed
@@ -87,7 +87,7 @@ export class EventSchemaEnforcementManager {
             WHERE ed.team_id = ANY($1)
               AND ed.enforcement_mode IN ('reject', 'enforce')
               AND p.is_required = true
-            GROUP BY ed.team_id, ed.name, ed.enforcement_mode, es.version, p.name
+            GROUP BY ed.team_id, ed.name, ed.enforcement_mode, ed.schema_version, p.name
             ORDER BY ed.team_id, ed.name, p.name`,
             [numericTeamIds],
             'fetch-enforced-event-schemas'

--- a/nodejs/src/utils/team-manager.test.ts
+++ b/nodejs/src/utils/team-manager.test.ts
@@ -64,6 +64,7 @@ describe('TeamManager()', () => {
                   "person_display_name_properties": [],
                   "person_processing_opt_out": null,
                   "project_id": 2,
+                  "schema_validation_disabled": null,
                   "secret_api_token": null,
                   "session_recording_opt_in": true,
                   "slack_incoming_webhook": null,

--- a/nodejs/src/utils/team-manager.ts
+++ b/nodejs/src/utils/team-manager.ts
@@ -120,6 +120,7 @@ export class TeamManager {
                 t.timezone,
                 t.logs_settings,
                 t.extra_settings,
+                t.schema_validation_disabled,
                 extract('epoch' from t.drop_events_older_than) as drop_events_older_than_seconds,
                 o.available_product_features
             FROM posthog_team t

--- a/nodejs/src/worker/ingestion/create-event.ts
+++ b/nodejs/src/worker/ingestion/create-event.ts
@@ -107,6 +107,9 @@ export function createEvent(
         person_mode: personMode,
         // Only include historical_migration when true to avoid bloating messages
         ...(historicalMigration ? { historical_migration: true } : {}),
+        ...(preIngestionEvent.validated_schema_version !== undefined
+            ? { validated_schema_version: preIngestionEvent.validated_schema_version }
+            : {}),
     }
 
     return processedEvent


### PR DESCRIPTION
  ## Problem

  Stacked on #51566 (PR1: Django models + ClickHouse column).

  Events need to carry their schema validation result through the ingestion pipeline so downstream consumers and queries can filter by validation status. PR1 added the `validated_schema_version`
  ClickHouse column and the `enforce` mode to Django models. This PR wires up the Node.js ingestion pipeline to actually stamp events.

  ## Changes

  - **Validation step**: Add `enforce` mode behavior (stamp `+version` on pass, `-version` on fail, always pass through) alongside existing `reject` mode (drop on fail). Add kill switch check
  (`team.schema_validation_disabled`).
  - **Enforcement manager**: Query both `reject` and `enforce` schemas, include `enforcement_mode` and `schema_version` in cached schema data.
  - **Pipeline plumbing**: Pass `validated_schema_version` through `PipelineEvent` -> `PreIngestionEvent` -> `ProcessedEvent` -> `RawKafkaEvent` (prepare-event-step, create-event, emit-event-step,
   team-manager).
  - **Types**: Add `validated_schema_version` to event types, `enforcement_mode`/`schema_version` to `EventSchemaEnforcement`, `schema_validation_disabled` to `Team`.

  ## How did you test this code?

  - Unit tests for validation step: enforce mode stamping, reject mode stamping, kill switch bypass, version propagation (79 tests passing)
  - Integration tests for enforcement manager: enforce mode queries, both reject+enforce schemas, caching
  - TypeScript type-check passes with zero errors
