### PR TITLE
fix(insights): Fix cohort breakdown type mismatch in funnels

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel.py
+++ b/posthog/hogql_queries/insights/funnels/funnel.py
@@ -137,6 +137,8 @@ class FunnelUDF(FunnelUDFMixin, FunnelBase):
 
         if not self.context.breakdown:
             prop_selector = self._default_breakdown_selector()
+        elif self.context.breakdownType == BreakdownType.COHORT:
+            prop_selector = "prop_basic"
         elif self._query_has_array_breakdown():
             prop_selector = "arrayMap(x -> ifNull(x, ''), prop_basic)"
         else:

--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -134,6 +134,8 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
 
         if not self.context.breakdown:
             prop_selector = self._default_breakdown_selector()
+        elif self.context.breakdownType == BreakdownType.COHORT:
+            prop_selector = "prop_basic"
         elif self._query_has_array_breakdown():
             prop_selector = "arrayMap(x -> ifNull(x, ''), prop_basic)"
         else:

--- a/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
+++ b/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
@@ -1558,6 +1558,71 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             not_in_cohort_actors = self._get_actor_ids_at_step(filters, 1, NOT_IN_COHORT_ID)
             assert not_in_cohort_actors == [person_outside_cohort.uuid]
 
+        def test_funnel_single_cohort_breakdown_first_touch(self):
+            _create_person(
+                distinct_ids=["person_in_cohort"],
+                team_id=self.team.pk,
+                properties={"key": "value"},
+            )
+            _create_person(
+                distinct_ids=["person_outside_cohort"],
+                team_id=self.team.pk,
+                properties={"key": "other"},
+            )
+            journeys_for(
+                {
+                    "person_in_cohort": [
+                        {"event": "sign up", "timestamp": datetime(2020, 1, 2, 12)},
+                        {"event": "play movie", "timestamp": datetime(2020, 1, 2, 13)},
+                    ],
+                    "person_outside_cohort": [
+                        {"event": "sign up", "timestamp": datetime(2020, 1, 3, 12)},
+                        {"event": "play movie", "timestamp": datetime(2020, 1, 3, 13)},
+                    ],
+                },
+                self.team,
+                create_people=False,
+            )
+
+            cohort = Cohort.objects.create(
+                team=self.team,
+                name="test_cohort",
+                groups=[{"properties": [{"key": "key", "value": "value", "type": "person"}]}],
+            )
+            cohort.calculate_people_ch(pending_version=0)
+
+            query = FunnelsQuery(
+                series=[
+                    EventsNode(event="sign up"),
+                    EventsNode(event="play movie"),
+                ],
+                dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-08"),
+                funnelsFilter=FunnelsFilter(
+                    funnelWindowInterval=7,
+                    breakdownAttributionType="first_touch",
+                ),
+                breakdownFilter=BreakdownFilter(
+                    breakdown=[cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+            )
+
+            results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+            assert len(results) == 2
+
+            breakdown_labels = {r[0]["breakdown"] for r in results}
+            assert "test_cohort" in breakdown_labels
+            assert "Not in test_cohort" in breakdown_labels
+
+            cohort_results = next(r for r in results if r[0]["breakdown"] == "test_cohort")
+            assert cohort_results[0]["count"] == 1
+            assert cohort_results[1]["count"] == 1
+
+            not_in_cohort_results = next(r for r in results if r[0]["breakdown"] == "Not in test_cohort")
+            assert not_in_cohort_results[0]["count"] == 1
+            assert not_in_cohort_results[1]["count"] == 1
+
         def test_basic_funnel_default_funnel_days_breakdown_event(self):
             events_by_person = {
                 "user_1": [


### PR DESCRIPTION
## Problem

I spotted an error around a type mismatch.

> Funnel queries with a single cohort breakdown and `first_touch` attribution fail with a ClickHouse type error.
> The `aggregate_funnel_cohort` UDF expects `UInt64` for cohort IDs, but `ifNull(prop_basic, '')` produces  `UInt64`/`String` type mismatch that ClickHouse can't resolve.                     

                                                                                                                                                                                                    
## Changes                                                
Use prop_basic directly instead of ifNull(prop_basic, '') for cohort breakdowns in funnels, since cohort IDs are UInt64 and ifNull with a String fallback causes a ClickHouse type error.
                       
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
