### PR TITLE
fix(devex): add missing generated dir to OpenAPI auto-commit

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -884,6 +884,7 @@ jobs:
                   git add products/*/mcp/*.yaml 2>/dev/null || true
                   git add services/mcp/definitions/*.yaml 2>/dev/null || true
                   git add services/mcp/src/api/generated.ts 2>/dev/null || true
+                  git add services/mcp/src/generated/ 2>/dev/null || true
                   git add services/mcp/schema/generated-tool-definitions.json 2>/dev/null || true
                   git add services/mcp/schema/tool-definitions-all.json 2>/dev/null || true
                   git add services/mcp/src/tools/generated/ 2>/dev/null || true


### PR DESCRIPTION
The auto-commit step in CI was missing `services/mcp/src/generated/` from its `git add` list. This directory holds per-product API clients generated by orval, so changes there were silently left unstaged — causing the commit to bail with "No staged files found" and the job to fail.

Noticed on [#50850 run](https://github.com/PostHog/posthog/actions/runs/23257450077/job/67620003435).