### PR TITLE
fix(search): align Autocomplete.Root items order with DOM render order

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -447,12 +447,17 @@ function SearchRoot({
         return groups
     }, [filteredItems, allCategories, searchValue])
 
+    // Derive a flat item list from groupedItems so the order passed to Autocomplete.Root
+    // exactly matches the DOM render order. Without this, Base UI's keyboard navigation
+    // breaks at group boundaries where the two orderings diverge.
+    const orderedItems = useMemo(() => groupedItems.flatMap((g) => g.items), [groupedItems])
+
     const contextValue: SearchContextValue = useMemo(
         () => ({
             logicKey,
             searchValue,
             setSearchValue,
-            filteredItems,
+            filteredItems: orderedItems,
             groupedItems,
             isSearching,
             isActive,
@@ -465,7 +470,7 @@ function SearchRoot({
         [
             logicKey,
             searchValue,
-            filteredItems,
+            orderedItems,
             groupedItems,
             isSearching,
             isActive,
@@ -481,7 +486,7 @@ function SearchRoot({
                 className={`flex flex-col overflow-hidden ${className} group/colorful-product-icons colorful-product-icons-true`}
             >
                 <Autocomplete.Root
-                    items={filteredItems}
+                    items={orderedItems}
                     filter={null}
                     itemToStringValue={(item) => item?.name ?? ''}
                     actionsRef={actionsRef}


### PR DESCRIPTION
## Problem

Arrow key navigation in the command search (`Search.tsx`) breaks partway through the list — the keyboard cursor gets "lost" and stops moving at certain group boundaries.

![2026-03-19 10 11 56](https://github.com/user-attachments/assets/7281d328-b826-4be9-89e8-b265c00088e1)


## Changes

The root cause is an ordering mismatch between the `items` array passed to Base UI's `Autocomplete.Root` and the actual DOM render order.

- `filteredItems` (passed to Root) had items in `allCategories` order: recents, apps, data-management, health, misc, settings, create, insight, dashboard, ...
- `groupedItems` (determines DOM order) reorders to: suggested, recents, apps, create, then remaining categories

Base UI uses the `items` array to determine keyboard navigation order. When the DOM order diverges, arrow keys jump to the wrong position at group boundaries.

**Fix:** Derive a flat `orderedItems` list from `groupedItems` so the items passed to `Autocomplete.Root` exactly match the DOM render order.

## Test plan

- [ ] Open command search (Cmd+K)
- [ ] Type a search query that returns results across multiple categories
- [ ] Arrow down through all results — should navigate smoothly through every item without getting stuck or jumping

🤖 Generated with [Claude Code](https://claude.com/claude-code)