### PR TITLE
chore: set team-logs as owners of the logs backups

### DIFF
--- a/posthog/dags/backups.py
+++ b/posthog/dags/backups.py
@@ -605,7 +605,10 @@ def prepare_run_config(config: BackupConfig) -> dagster.RunConfig:
 
 
 def run_backup_request(
-    table: str, incremental: bool, context: dagster.ScheduleEvaluationContext
+    table: str,
+    incremental: bool,
+    context: dagster.ScheduleEvaluationContext,
+    owner: JobOwners = JobOwners.TEAM_CLICKHOUSE,
 ) -> Optional[dagster.RunRequest]:
     skip_reason = check_for_concurrent_runs(
         context,
@@ -630,7 +633,7 @@ def run_backup_request(
         tags={
             "backup_type": "incremental" if incremental else "full",
             "table": table,
-            "owner": JobOwners.TEAM_CLICKHOUSE.value,
+            "owner": owner.value,
         },
     )
 
@@ -698,7 +701,7 @@ def incremental_non_sharded_backup_schedule(context: dagster.ScheduleEvaluationC
 def full_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
     """Launch a full backup for logs tables"""
     for table in LOGS_TABLES:
-        request = run_backup_request(table, incremental=False, context=context)
+        request = run_backup_request(table, incremental=False, context=context, owner=JobOwners.TEAM_LOGS)
         if request:
             yield request
 
@@ -711,6 +714,6 @@ def full_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
 def incremental_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
     """Launch an incremental backup for logs tables"""
     for table in LOGS_TABLES:
-        request = run_backup_request(table, incremental=True, context=context)
+        request = run_backup_request(table, incremental=True, context=context, owner=JobOwners.TEAM_LOGS)
         if request:
             yield request

--- a/posthog/dags/common/owners.py
+++ b/posthog/dags/common/owners.py
@@ -10,6 +10,7 @@ class JobOwners(str, Enum):
 
     TEAM_GROWTH = "team-growth"
     TEAM_INGESTION = "team-ingestion"
+    TEAM_LOGS = "team-logs"
     TEAM_LLM_ANALYTICS = "team-llm-analytics"
     TEAM_POSTHOG_AI = "team-posthog-ai"
     TEAM_REVENUE_ANALYTICS = "team-revenue-analytics"

--- a/posthog/dags/slack_alerts.py
+++ b/posthog/dags/slack_alerts.py
@@ -17,6 +17,7 @@ notification_channel_per_team = {
     JobOwners.TEAM_GROWTH.value: "#alerts-growth",
     JobOwners.TEAM_LLM_ANALYTICS.value: "#alerts-llm-analytics",
     JobOwners.TEAM_INGESTION.value: "#alerts-ingestion",
+    JobOwners.TEAM_LOGS.value: "#alerts-logs-prod",
     JobOwners.TEAM_POSTHOG_AI.value: "#alerts-max-ai",
     JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-growth",
     JobOwners.TEAM_WEB_ANALYTICS.value: "#alerts-web-analytics",


### PR DESCRIPTION
## Problem

We need the team to be aware of when the logs backups fail for whatever reason.

## Changes

Set the backup owner depending on the backup being run.
