### PR TITLE
perf(signals): Concurrent Haiku matching in signals pipeline

### DIFF
--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -1248,7 +1248,8 @@ async def _process_signal_batch(
     # All match calls fire concurrently against the same search snapshot.
 
     # Step 6: Concurrent match LLM calls
-    match_results: list[MatchResult] = list(
+    # return_exceptions=True so one failed match doesn't kill the whole batch
+    match_results_raw: list[MatchResult | BaseException] = list(
         await asyncio.gather(
             *[
                 workflow.execute_activity(
@@ -1265,12 +1266,32 @@ async def _process_signal_batch(
                     retry_policy=RetryPolicy(maximum_attempts=5),
                 )
                 for i, signal in enumerate(batch)
-            ]
+            ],
+            return_exceptions=True,
         )
     )
 
+    # Log and mark failed matches so we skip them in later steps
+    failed_match_indices: set[int] = set()
+    match_results: list[MatchResult | None] = []
+    for i, result in enumerate(match_results_raw):
+        if isinstance(result, BaseException):
+            failed_match_indices.add(i)
+            match_results.append(None)
+            dropped += 1
+            workflow.logger.exception(
+                "Match LLM call failed for signal in batch",
+                exc_info=result,
+                team_id=team_id,
+                source_product=batch[i].source_product,
+                source_type=batch[i].source_type,
+                source_id=batch[i].source_id,
+            )
+        else:
+            match_results.append(result)
+
     # Step 7: Concurrent specificity checks for existing matches
-    existing_indices = [i for i, r in enumerate(match_results) if isinstance(r, ExistingReportMatch)]
+    existing_indices = [i for i, r in enumerate(match_results) if r is not None and isinstance(r, ExistingReportMatch)]
 
     # Fetch group signals concurrently (deduplicated by report_id)
     group_signals_by_idx: dict[int, FetchSignalsForReportOutput] = {}
@@ -1289,16 +1310,29 @@ async def _process_signal_batch(
             )
             for rid in unique_report_ids
         }
-        fetch_results = await asyncio.gather(*fetch_tasks.values())
-        rid_to_signals = dict(zip(fetch_tasks.keys(), fetch_results))
-        for rid, indices in unique_report_ids.items():
-            for i in indices:
-                group_signals_by_idx[i] = rid_to_signals[rid]
+        fetch_results = await asyncio.gather(*fetch_tasks.values(), return_exceptions=True)
+        for rid, fetch_result in zip(fetch_tasks.keys(), fetch_results):
+            if isinstance(fetch_result, BaseException):
+                workflow.logger.exception(
+                    "Failed to fetch group signals for report",
+                    exc_info=fetch_result,
+                    team_id=team_id,
+                    report_id=rid,
+                )
+                # Mark all signals targeting this report as failed
+                for i in unique_report_ids[rid]:
+                    failed_match_indices.add(i)
+                    dropped += 1
+            else:
+                for i in unique_report_ids[rid]:
+                    group_signals_by_idx[i] = fetch_result
 
+    # Only run specificity for indices that still have valid group signals
+    specificity_indices = [i for i in existing_indices if i not in failed_match_indices]
     specificity_by_idx: dict[int, VerifyMatchSpecificityOutput] = {}
-    if existing_indices:
+    if specificity_indices:
         specificity_tasks = []
-        for i in existing_indices:
+        for i in specificity_indices:
             match_result = cast(ExistingReportMatch, match_results[i])
             signal = batch[i]
             group_signals_result = group_signals_by_idx[i]
@@ -1319,18 +1353,34 @@ async def _process_signal_batch(
                     retry_policy=RetryPolicy(maximum_attempts=5),
                 )
             )
-        specificity_results = await asyncio.gather(*specificity_tasks)
-        for idx, i in enumerate(existing_indices):
-            specificity_by_idx[i] = specificity_results[idx]
+        specificity_results = await asyncio.gather(*specificity_tasks, return_exceptions=True)
+        for idx, i in enumerate(specificity_indices):
+            result = specificity_results[idx]
+            if isinstance(result, BaseException):
+                workflow.logger.exception(
+                    "Specificity check failed for signal in batch",
+                    exc_info=result,
+                    team_id=team_id,
+                    source_product=batch[i].source_product,
+                    source_type=batch[i].source_type,
+                    source_id=batch[i].source_id,
+                )
+                failed_match_indices.add(i)
+                dropped += 1
+            else:
+                specificity_by_idx[i] = result
 
     # Apply specificity + sequential assign+emit
     promoted_reports: dict[str, SignalReportSummaryWorkflowInputs] = {}
     emitted_signals: list[tuple[str, AssignAndEmitSignalOutput]] = []
 
     for i, signal in enumerate(batch):
+        if i in failed_match_indices:
+            continue
         signal_id = str(uuid.uuid4())
         try:
             match_result = match_results[i]
+            assert match_result is not None  # Guaranteed by failed_match_indices skip above
             updated_title: Optional[str] = None
 
             if i in specificity_by_idx and isinstance(match_result, ExistingReportMatch):

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -1123,11 +1123,14 @@ async def _process_signal_batch(
 ) -> tuple[int, FetchSignalTypeExamplesOutput]:
     """
     Process a batch of signals with parallel preparation (steps 1-5) and concurrent
-    matching (step 6). Returns (dropped_count, type_examples) — the caller can
+    matching (steps 6-7). Returns (dropped_count, type_examples) — the caller can
     cache the type_examples for subsequent batches.
 
     All match + specificity LLM calls within the batch run concurrently against
-    the same search snapshot from ClickHouse.
+    the same search snapshot from ClickHouse. This trades a small risk of
+    undergrouping (two concurrent signals for the same issue might not see each
+    other) for much lower latency — important for onboarding experience.
+    In practice, concurrent signals on the same issue are rare in the wild.
     """
     team_id = batch[0].team_id
     # Purely defensive

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -1114,13 +1114,12 @@ async def _process_signal_batch(
     cached_type_examples: Optional[FetchSignalTypeExamplesOutput] = None,
 ) -> tuple[int, FetchSignalTypeExamplesOutput]:
     """
-    Process a batch of signals with parallel preparation (steps 1-4) and sequential
-    matching/assignment (steps 5-7). Returns (dropped_count, type_examples) — the
-    caller can cache the type_examples for subsequent batches.
+    Process a batch of signals with parallel preparation (steps 1-5) and concurrent
+    matching (step 6). Returns (dropped_count, type_examples) — the caller can
+    cache the type_examples for subsequent batches.
 
-    Earlier signals in the batch are injected into later signals' candidate sets via
-    local cosine distance comparison, eliminating the need for per-signal CH waits
-    within a batch.
+    All match + specificity LLM calls within the batch run concurrently against
+    the same search snapshot from ClickHouse.
     """
     team_id = batch[0].team_id
     # Purely defensive
@@ -1128,9 +1127,9 @@ async def _process_signal_batch(
         raise ValueError("All signals in a batch must belong to the same team")
     dropped = 0
 
-    # === PARALLEL PHASE (steps 1-4) ===
+    # PARALLEL PHASE (steps 1-5)
 
-    # Step 1a: Fetch type examples if not cached (needed by query gen)
+    # Step 1: Fetch type examples if not cached (needed by query gen)
     if cached_type_examples is not None:
         type_examples_result = cached_type_examples
     else:
@@ -1141,8 +1140,7 @@ async def _process_signal_batch(
             retry_policy=RetryPolicy(maximum_attempts=3),
         )
 
-    # Step 1b: Embed all signals + generate search queries in parallel
-    # (query gen needs type examples but NOT the signal embeddings)
+    # Step 2a: Embed all signals, 2b: generate search queries (parallel)
     step1b_results = await asyncio.gather(
         *[
             workflow.execute_activity(
@@ -1171,7 +1169,7 @@ async def _process_signal_batch(
     signal_embeddings = cast(list[GenerateEmbeddingOutput], step1b_results[: len(batch)])
     query_gen_results = cast(list[GenerateSearchQueriesOutput], step1b_results[len(batch) :])
 
-    # Step 3: Embed all queries across all signals (flatten → parallel embed)
+    # Step 3: Embed all queries across all signals (parallel)
     all_queries_flat: list[tuple[int, str]] = []
     for sig_idx, qr in enumerate(query_gen_results):
         for q in qr.queries:
@@ -1191,7 +1189,7 @@ async def _process_signal_batch(
         )
     )
 
-    # Step 4: Semantic search for all queries (all parallel)
+    # Step 4: Semantic search for all queries (parallel)
     all_search_results: list[RunSignalSemanticSearchOutput] = list(
         await asyncio.gather(
             *[
@@ -1225,7 +1223,7 @@ async def _process_signal_batch(
         per_signal_query_embeddings[sig_idx].append(all_query_embeddings[flat_idx].embedding)
         per_signal_ch_results[sig_idx].append(all_search_results[flat_idx].candidates)
 
-    # Step 4.5: Fetch report contexts for all CH candidates (group-aware matching)
+    # Step 5: Fetch report contexts for all CH candidates
     all_candidate_report_ids = list({c.report_id for results in all_search_results for c in results.candidates})
     report_contexts_result: FetchReportContextsOutput = await workflow.execute_activity(
         fetch_report_contexts_activity,
@@ -1235,86 +1233,116 @@ async def _process_signal_batch(
     )
     report_contexts: dict[str, ReportContext] = report_contexts_result.contexts
 
-    # === SEQUENTIAL PHASE (steps 5-7) ===
-    processed_batch_signals: list[_ProcessedBatchSignal] = []
+    # CONCURRENT MATCHING + SPECIFICITY (step 6)
+    # All match calls fire concurrently against the same search snapshot.
+
+    # Step 6a: Concurrent match LLM calls
+    match_results: list[MatchResult] = list(
+        await asyncio.gather(
+            *[
+                workflow.execute_activity(
+                    match_signal_to_report_activity,
+                    MatchSignalToReportInput(
+                        description=signal.description,
+                        source_product=signal.source_product,
+                        source_type=signal.source_type,
+                        queries=per_signal_queries[i],
+                        query_results=per_signal_ch_results[i],
+                        report_contexts=report_contexts,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=10),
+                    retry_policy=RetryPolicy(maximum_attempts=5),
+                )
+                for i, signal in enumerate(batch)
+            ]
+        )
+    )
+
+    # Step 6b: Concurrent specificity checks for existing matches
+    existing_indices = [i for i, r in enumerate(match_results) if isinstance(r, ExistingReportMatch)]
+
+    # Fetch group signals concurrently (deduplicated by report_id)
+    group_signals_by_idx: dict[int, FetchSignalsForReportOutput] = {}
+    if existing_indices:
+        unique_report_ids: dict[str, list[int]] = defaultdict(list)
+        for i in existing_indices:
+            mr = cast(ExistingReportMatch, match_results[i])
+            unique_report_ids[mr.report_id].append(i)
+
+        fetch_tasks = {
+            rid: workflow.execute_activity(
+                fetch_signals_for_report_activity,
+                FetchSignalsForReportInput(team_id=team_id, report_id=rid),
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            for rid in unique_report_ids
+        }
+        fetch_results = await asyncio.gather(*fetch_tasks.values())
+        rid_to_signals = dict(zip(fetch_tasks.keys(), fetch_results))
+        for rid, indices in unique_report_ids.items():
+            for i in indices:
+                group_signals_by_idx[i] = rid_to_signals[rid]
+
+    specificity_by_idx: dict[int, VerifyMatchSpecificityOutput] = {}
+    if existing_indices:
+        specificity_tasks = []
+        for i in existing_indices:
+            mr = cast(ExistingReportMatch, match_results[i])
+            report_ctx = report_contexts.get(mr.report_id)
+            specificity_tasks.append(
+                workflow.execute_activity(
+                    verify_match_specificity_activity,
+                    VerifyMatchSpecificityInput(
+                        team_id=team_id,
+                        report_id=mr.report_id,
+                        report_title=report_ctx.title if report_ctx else "",
+                        new_signal_description=batch[i].description,
+                        new_signal_source_product=batch[i].source_product,
+                        new_signal_source_type=batch[i].source_type,
+                        group_signals=group_signals_by_idx[i].signals,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=10),
+                    retry_policy=RetryPolicy(maximum_attempts=5),
+                )
+            )
+        specificity_results = await asyncio.gather(*specificity_tasks)
+        for idx, i in enumerate(existing_indices):
+            specificity_by_idx[i] = specificity_results[idx]
+
+    # Apply specificity + sequential assign+emit
     promoted_reports: dict[str, SignalReportSummaryWorkflowInputs] = {}
     emitted_signals: list[tuple[str, AssignAndEmitSignalOutput]] = []
 
     for i, signal in enumerate(batch):
         signal_id = str(uuid.uuid4())
         try:
-            # Augment CH candidates with earlier-in-batch signals
-            augmented_results = _augment_candidates_with_batch(
-                per_signal_query_embeddings[i],
-                per_signal_ch_results[i],
-                processed_batch_signals,
-                limit=10,
-            )
-
-            # Step 5: Group-aware LLM match
-            match_result = await workflow.execute_activity(
-                match_signal_to_report_activity,
-                MatchSignalToReportInput(
-                    description=signal.description,
-                    source_product=signal.source_product,
-                    source_type=signal.source_type,
-                    queries=per_signal_queries[i],
-                    query_results=augmented_results,
-                    report_contexts=report_contexts,
-                ),
-                start_to_close_timeout=timedelta(minutes=10),
-                retry_policy=RetryPolicy(maximum_attempts=5),
-            )
-
-            # Step 5.5: PR-specificity verification for existing matches
+            match_result = match_results[i]
             updated_title: Optional[str] = None
 
-            if isinstance(match_result, ExistingReportMatch):
+            if i in specificity_by_idx and isinstance(match_result, ExistingReportMatch):
+                sr = specificity_by_idx[i]
                 report_ctx = report_contexts.get(match_result.report_id)
-                report_title = report_ctx.title if report_ctx else ""
-
-                group_signals_result: FetchSignalsForReportOutput = await workflow.execute_activity(
-                    fetch_signals_for_report_activity,
-                    FetchSignalsForReportInput(team_id=team_id, report_id=match_result.report_id),
-                    start_to_close_timeout=timedelta(minutes=5),
-                    retry_policy=RetryPolicy(maximum_attempts=3),
-                )
-
-                specificity_result: VerifyMatchSpecificityOutput = await workflow.execute_activity(
-                    verify_match_specificity_activity,
-                    VerifyMatchSpecificityInput(
-                        team_id=team_id,
-                        report_id=match_result.report_id,
-                        report_title=report_title,
-                        new_signal_description=signal.description,
-                        new_signal_source_product=signal.source_product,
-                        new_signal_source_type=signal.source_type,
-                        group_signals=group_signals_result.signals,
-                    ),
-                    start_to_close_timeout=timedelta(minutes=10),
-                    retry_policy=RetryPolicy(maximum_attempts=5),
-                )
 
                 specificity_meta = SpecificityMetadata(
-                    pr_title=specificity_result.pr_title,
-                    specific_enough=specificity_result.specific_enough,
-                    reason=specificity_result.reason,
+                    pr_title=sr.pr_title,
+                    specific_enough=sr.specific_enough,
+                    reason=sr.reason,
                 )
 
-                if specificity_result.specific_enough:
-                    updated_title = specificity_result.pr_title
+                if sr.specific_enough:
+                    updated_title = sr.pr_title
                     match_result.match_metadata.specificity = specificity_meta
                 else:
                     match_result = NewReportMatch(
                         title=signal.description.split("\n")[0],
-                        summary=f"Split from group: {report_title}",
+                        summary=f"Split from group: {report_ctx.title if report_ctx else ''}",
                         match_metadata=NoMatchMetadata(
-                            reason=f'PR-specificity rejected: "{specificity_result.pr_title}" — {specificity_result.reason}',
+                            reason=f'PR-specificity rejected: "{sr.pr_title}" — {sr.reason}',
                             specificity_rejection=specificity_meta,
                         ),
                     )
 
-            # Step 6: Assign + emit
             assign_result: AssignAndEmitSignalOutput = await workflow.execute_activity(
                 assign_and_emit_signal_activity,
                 AssignAndEmitSignalInput(
@@ -1334,33 +1362,7 @@ async def _process_signal_batch(
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
 
-            # Track for augmenting later signals in the batch
-            processed_batch_signals.append(
-                _ProcessedBatchSignal(
-                    signal_id=signal_id,
-                    report_id=assign_result.report_id,
-                    content=signal.description,
-                    source_product=signal.source_product,
-                    source_type=signal.source_type,
-                    embedding=signal_embeddings[i].embedding,
-                )
-            )
             emitted_signals.append((signal_id, assign_result))
-
-            # Update local report_contexts so later signals in the batch see this report
-            if isinstance(match_result, ExistingReportMatch):
-                old_ctx = report_contexts.get(assign_result.report_id)
-                report_contexts[assign_result.report_id] = ReportContext(
-                    report_id=assign_result.report_id,
-                    title=updated_title or (old_ctx.title if old_ctx else ""),
-                    signal_count=(old_ctx.signal_count if old_ctx else 0) + 1,
-                )
-            else:
-                report_contexts[assign_result.report_id] = ReportContext(
-                    report_id=assign_result.report_id,
-                    title=match_result.title,
-                    signal_count=1,
-                )
 
             if assign_result.promoted:
                 promoted_reports[assign_result.report_id] = SignalReportSummaryWorkflowInputs(
@@ -1376,8 +1378,7 @@ async def _process_signal_batch(
                 source_type=signal.source_type,
                 source_id=signal.source_id,
             )
-
-    # Step 7: Wait for all emitted signals to land in CH so the next batch can find them
+    # Step 7: Wait for all emitted signals to land in ClickHouse
     if emitted_signals:
         await workflow.execute_activity(
             wait_for_signal_in_clickhouse_activity,

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -29,7 +29,12 @@ from posthog.sync import database_sync_to_async
 
 from products.signals.backend.models import SignalReport
 from products.signals.backend.temporal.clickhouse import execute_hogql_query_with_retry
-from products.signals.backend.temporal.llm import MAX_QUERY_TOKENS, call_llm, truncate_query_to_token_limit
+from products.signals.backend.temporal.llm import (
+    GROUPING_MODEL,
+    MAX_QUERY_TOKENS,
+    call_llm,
+    truncate_query_to_token_limit,
+)
 from products.signals.backend.temporal.summary import (
     FetchSignalsForReportInput,
     FetchSignalsForReportOutput,
@@ -245,6 +250,7 @@ async def generate_search_queries(
         user_prompt=user_prompt,
         validate=validate,
         temperature=0.7,
+        model=GROUPING_MODEL,
     )
 
 
@@ -619,6 +625,7 @@ async def match_signal_to_report(
         user_prompt=user_prompt,
         validate=validate,
         temperature=0.2,
+        model=GROUPING_MODEL,
     )
 
 
@@ -739,6 +746,7 @@ async def verify_match_specificity(
         user_prompt=specificity_prompt,
         validate=lambda text: SpecificityResult.model_validate_json(text),
         temperature=0.2,
+        model=GROUPING_MODEL,
     )
 
     return VerifyMatchSpecificityOutput(

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -1244,7 +1244,7 @@ async def _process_signal_batch(
     # CONCURRENT MATCHING + SPECIFICITY (step 6)
     # All match calls fire concurrently against the same search snapshot.
 
-    # Step 6a: Concurrent match LLM calls
+    # Step 6: Concurrent match LLM calls
     match_results: list[MatchResult] = list(
         await asyncio.gather(
             *[
@@ -1266,7 +1266,7 @@ async def _process_signal_batch(
         )
     )
 
-    # Step 6b: Concurrent specificity checks for existing matches
+    # Step 7: Concurrent specificity checks for existing matches
     existing_indices = [i for i, r in enumerate(match_results) if isinstance(r, ExistingReportMatch)]
 
     # Fetch group signals concurrently (deduplicated by report_id)
@@ -1274,8 +1274,8 @@ async def _process_signal_batch(
     if existing_indices:
         unique_report_ids: dict[str, list[int]] = defaultdict(list)
         for i in existing_indices:
-            mr = cast(ExistingReportMatch, match_results[i])
-            unique_report_ids[mr.report_id].append(i)
+            match_result = cast(ExistingReportMatch, match_results[i])
+            unique_report_ids[match_result.report_id].append(i)
 
         fetch_tasks = {
             rid: workflow.execute_activity(
@@ -1296,19 +1296,21 @@ async def _process_signal_batch(
     if existing_indices:
         specificity_tasks = []
         for i in existing_indices:
-            mr = cast(ExistingReportMatch, match_results[i])
-            report_ctx = report_contexts.get(mr.report_id)
+            match_result = cast(ExistingReportMatch, match_results[i])
+            signal = batch[i]
+            group_signals_result = group_signals_by_idx[i]
+            report_ctx = report_contexts.get(match_result.report_id)
             specificity_tasks.append(
                 workflow.execute_activity(
                     verify_match_specificity_activity,
                     VerifyMatchSpecificityInput(
                         team_id=team_id,
-                        report_id=mr.report_id,
+                        report_id=match_result.report_id,
                         report_title=report_ctx.title if report_ctx else "",
-                        new_signal_description=batch[i].description,
-                        new_signal_source_product=batch[i].source_product,
-                        new_signal_source_type=batch[i].source_type,
-                        group_signals=group_signals_by_idx[i].signals,
+                        new_signal_description=signal.description,
+                        new_signal_source_product=signal.source_product,
+                        new_signal_source_type=signal.source_type,
+                        group_signals=group_signals_result.signals,
                     ),
                     start_to_close_timeout=timedelta(minutes=10),
                     retry_policy=RetryPolicy(maximum_attempts=5),
@@ -1386,7 +1388,7 @@ async def _process_signal_batch(
                 source_type=signal.source_type,
                 source_id=signal.source_id,
             )
-    # Step 7: Wait for all emitted signals to land in ClickHouse
+    # Step 8: Wait for all emitted signals to land in ClickHouse
     if emitted_signals:
         await workflow.execute_activity(
             wait_for_signal_in_clickhouse_activity,

--- a/products/signals/backend/temporal/llm.py
+++ b/products/signals/backend/temporal/llm.py
@@ -12,13 +12,16 @@ from posthoganalytics.ai.anthropic import AsyncAnthropic
 
 logger = structlog.get_logger(__name__)
 
-MATCHING_MODEL = os.getenv("SIGNAL_MATCHING_LLM_MODEL", "claude-sonnet-4-5")
+JUDGING_MODEL = os.getenv("SIGNAL_JUDGING_LLM_MODEL", "claude-sonnet-4-6")
+GROUPING_MODEL = os.getenv("SIGNAL_GROUPING_LLM_MODEL", "claude-haiku-4-5")
 
 # Models that support Anthropic extended thinking. Keep in sync with the models we actually use.
 ANTHROPIC_THINKING_MODELS = {
     "claude-haiku-4-5",
     "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
     "claude-opus-4-5",
+    "claude-opus-4-6",
     "claude-opus-4-1",
     "claude-sonnet-4-0",
     "claude-opus-4-0",
@@ -99,10 +102,12 @@ async def call_llm(
     thinking: bool = False,
     temperature: Optional[float] = 0.2,
     retries: int = MAX_RETRIES,
+    model: Optional[str] = None,
 ) -> T:
     # Worth noting a lot of this code only really works for the Anthropic API, I think (prefilling and thinking in particular). Haven't
     # looked into the OpenAI SDK yet - that'll be for the switch to the LLM gateway.
-    thinking = thinking and MATCHING_MODEL in ANTHROPIC_THINKING_MODELS
+    effective_model = model or JUDGING_MODEL
+    thinking = thinking and effective_model in ANTHROPIC_THINKING_MODELS
     client = get_async_anthropic_client()
 
     messages: list[MessageParam] = [
@@ -115,7 +120,7 @@ async def call_llm(
         messages.append({"role": "assistant", "content": "{"})
 
     create_kwargs: dict = {
-        "model": MATCHING_MODEL,
+        "model": effective_model,
         "system": system_prompt,
         "messages": messages,
         "max_tokens": MAX_RESPONSE_TOKENS,

--- a/products/signals/backend/temporal/llm.py
+++ b/products/signals/backend/temporal/llm.py
@@ -12,7 +12,11 @@ from posthoganalytics.ai.anthropic import AsyncAnthropic
 
 logger = structlog.get_logger(__name__)
 
+# Haiku for grouping tasks (query gen, matching, specificity, safety filter) -
+# these are structured classification/generation that Haiku handles well at higher speed (and lower cost)
 JUDGING_MODEL = os.getenv("SIGNAL_JUDGING_LLM_MODEL", "claude-sonnet-4-6")
+# Sonnet for judging tasks (safety judge, actionability judge, summarization) -
+# these need deeper reasoning
 GROUPING_MODEL = os.getenv("SIGNAL_GROUPING_LLM_MODEL", "claude-haiku-4-5")
 
 # Models that support Anthropic extended thinking. Keep in sync with the models we actually use.

--- a/products/signals/backend/temporal/safety_filter.py
+++ b/products/signals/backend/temporal/safety_filter.py
@@ -6,7 +6,7 @@ import structlog
 from pydantic import BaseModel, Field, model_validator
 from temporalio import activity
 
-from products.signals.backend.temporal.llm import EmptyLLMResponseError, call_llm
+from products.signals.backend.temporal.llm import GROUPING_MODEL, EmptyLLMResponseError, call_llm
 
 logger = structlog.get_logger(__name__)
 
@@ -119,6 +119,7 @@ async def safety_filter(description: str) -> SafetyFilterJudgeResponse:
             system_prompt=SAFETY_FILTER_PROMPT,
             user_prompt=description,
             validate=validate,
+            model=GROUPING_MODEL,
         )
     except EmptyLLMResponseError:
         return SafetyFilterJudgeResponse(

--- a/products/signals/eval/eval_grouping_e2e.py
+++ b/products/signals/eval/eval_grouping_e2e.py
@@ -50,6 +50,7 @@ from posthog.temporal.data_imports.workflow_activities.emit_signals import (
 
 from products.signals.backend.temporal.actionability_judge import ActionabilityChoice, judge_report_actionability
 from products.signals.backend.temporal.grouping import (
+    BATCH_SIZE,
     generate_search_queries,
     match_signal_to_report,
     verify_match_specificity,
@@ -80,32 +81,21 @@ class EvalProgress:
     def __init__(self, n_signals: int, n_groups: int):
         self.n_signals = n_signals
         self.n_groups = n_groups
-        self.active = 0
         self.dropped = 0
         self._bar = tqdm(total=n_signals, desc="Matching", unit="sig", file=sys.stderr)
 
-    def signal_started(self):
-        self.active += 1
-        self._update_postfix()
-
     def signal_done(self):
-        self.active -= 1
         self._bar.update(1)
         self._update_postfix()
 
     def signal_dropped(self):
-        self.active -= 1
         self.dropped += 1
         self._bar.update(1)
         self._update_postfix()
 
     def _update_postfix(self):
-        parts: dict[str, int] = {}
-        if self.active:
-            parts["processing"] = self.active
         if self.dropped:
-            parts["filtered"] = self.dropped
-        self._bar.set_postfix(parts)
+            self._bar.set_postfix(filtered=self.dropped)
 
     def start_judging(self, n_reports: int):
         self._bar.close()
@@ -172,7 +162,6 @@ class TestGroupingPipeline:
         self.limit = limit
         self.no_capture = no_capture
         self.online = online
-        self._match_lock = asyncio.Lock()
         self.start_time = time()
 
         # Suppress structlog noise from downstream modules during the eval
@@ -192,62 +181,79 @@ class TestGroupingPipeline:
         n_groups = len({case.group_index for case in stream})
         self.progress = EvalProgress(n_signals=len(stream), n_groups=n_groups)
 
+        # Phase 1 (concurrent): pre-emit + safety filter
         sem = asyncio.Semaphore(MAX_CONCURRENT_RUNS)
-        await asyncio.gather(
-            *[self.run_signal_pipeline_concurrently(sem, record_id=i, case=case) for i, case in enumerate(stream)]
+        pre_match_results: list[tuple[int, EvalSignalCase, str] | None] = list(
+            await asyncio.gather(*[self._pre_match(sem, record_id=i, case=case) for i, case in enumerate(stream)])
         )
+        ready = [r for r in pre_match_results if r is not None]
 
+        # Phase 2 (concurrent matching in BATCH_SIZE sub-batches + pipelined judging)
+        # Within each sub-batch, `_match()` calls fire concurrently. Between sub-batches,
+        # results are persisted so later signals can find earlier ones' reports.
+        judging_tasks: list[asyncio.Task] = []
+        judged_report_ids: set[str] = set()
+
+        for batch_start in range(0, len(ready), BATCH_SIZE):
+            batch = ready[batch_start : batch_start + BATCH_SIZE]
+            results = await asyncio.gather(
+                *[self._match(description, case) for _record_id, case, description in batch],
+                return_exceptions=True,
+            )
+            for (record_id, case, description), result in zip(batch, results):
+                if isinstance(result, BaseException):
+                    self.progress.signal_dropped()
+                    continue
+                match_result, specificity_result, queries, query_embeddings, candidates = result
+                self._capture_match_quality(
+                    case, match_result, specificity_result, queries, query_embeddings, candidates
+                )
+                await self._persist_signal(record_id, description, case, specificity_result)
+                self.progress.signal_done()
+
+            # Pipeline judging: fire tasks for new reports while next batch runs
+            for report in self.report_store.all_reports():
+                rid = report.context.report_id
+                if rid not in judged_report_ids:
+                    judged_report_ids.add(rid)
+                    judging_tasks.append(asyncio.create_task(self._judge_single_report(report)))
+
+        # ── Wait for remaining judging ──
         reports = self.report_store.all_reports()
         self.progress.start_judging(len(reports))
-        await self._judge_reports()
+        if judging_tasks:
+            await asyncio.gather(*judging_tasks, return_exceptions=True)
         self.progress.done()
 
         self._capture_grouping_quality()
         self._capture_aggregate_metrics(stream)
 
-    async def run_signal_pipeline_concurrently(self, sem: asyncio.Semaphore, record_id: int, case: EvalSignalCase):
+    async def _pre_match(
+        self, sem: asyncio.Semaphore, record_id: int, case: EvalSignalCase
+    ) -> tuple[int, EvalSignalCase, str] | None:
+        """Run pre-emit + safety filter concurrently. Returns (record_id, case, description) or None if dropped."""
         async with sem:
-            await self.run_signal_pipeline(record_id, case)
+            try:
+                description = await self.pre_emit(case)
+                if not description:
+                    self.progress.signal_dropped()
+                    return None
 
-    async def run_signal_pipeline(self, record_id: int, case: EvalSignalCase):
-        """Run a single signal through the pre-emit pipeline."""
+                safety_result = await safety_filter(description)
+                await self._capture_safety_filter(case, safety_result)
+                if not safety_result.safe:
+                    self.progress.signal_dropped()
+                    return None
 
-        self.progress.signal_started()
-        try:
-            description = await self.pre_emit(record_id, case)
-
-            if not description:
+                return record_id, case, description
+            except Exception:
                 self.progress.signal_dropped()
-                return
+                return None
 
-            safety_result = await safety_filter(description)
-            await self._capture_safety_filter(case, safety_result)
-
-            if not safety_result.safe:
-                self.progress.signal_dropped()
-                return
-
-            # Prepare queries and embeddings outside the lock — these are
-            # store-independent and can run concurrently across signals.
-            queries, query_embeddings, signal_embedding = await self._prepare(description, case)
-
-            async with self._match_lock:
-                match_result, specificity_result, candidates = await self._match(
-                    description, case, queries, query_embeddings
-                )
-                self._capture_match_quality(
-                    case, match_result, specificity_result, queries, query_embeddings, candidates
-                )
-                self._persist_signal(record_id, description, case, specificity_result, signal_embedding)
-
-            self.progress.signal_done()
-        except Exception:
-            self.progress.signal_dropped()
-
-    async def _prepare(
+    async def _match(
         self, description: str, case: EvalSignalCase
-    ) -> tuple[list[str], list[list[float]], list[float]]:
-        """Generate search queries and compute all embeddings. No store mutations."""
+    ) -> tuple[MatchResult, MatchResult, list[str], list[list[float]], list[list[SignalCandidate]]]:
+        """Generate queries, embed, search, LLM-match, and verify specificity. No side effects."""
 
         queries = await generate_search_queries(
             description=description,
@@ -256,24 +262,7 @@ class TestGroupingPipeline:
             signal_type_examples=self.store.get_type_examples(),
         )
 
-        all_embeddings = await asyncio.gather(
-            *[self.store.embed(q) for q in queries],
-            self.store.embed(description),
-        )
-        query_embeddings = list(all_embeddings[: len(queries)])
-        signal_embedding = all_embeddings[-1]
-
-        return queries, query_embeddings, signal_embedding
-
-    async def _match(
-        self,
-        description: str,
-        case: EvalSignalCase,
-        queries: list[str],
-        query_embeddings: list[list[float]],
-    ) -> tuple[MatchResult, MatchResult, list[list[SignalCandidate]]]:
-        """Search, LLM-match, and verify specificity. Must run under _match_lock."""
-
+        query_embeddings = list(await asyncio.gather(*[self.store.embed(q) for q in queries]))
         candidates = [self.store.search(emb) for emb in query_embeddings]
 
         match_result = await match_signal_to_report(
@@ -317,22 +306,22 @@ class TestGroupingPipeline:
                     ),
                 )
 
-        return match_result, specificity_match_result, candidates
+        return match_result, specificity_match_result, queries, query_embeddings, candidates
 
-    def _persist_signal(
+    async def _persist_signal(
         self,
         record_id: int,
         description: str,
         case: EvalSignalCase,
         match_result: MatchResult,
-        signal_embedding: list[float],
     ) -> str:
-        """Write match result to both stores. Must run under _match_lock."""
+        """Write match result to both stores."""
 
         report_id = match_result.report_id if isinstance(match_result, ExistingReportMatch) else str(uuid.uuid4())
 
         self.report_store.insert(report_id, match_result, case.group_index)
 
+        signal_embedding = await self.store.embed(description)
         self.store.store(
             signal_id=f"sig-{record_id}",
             content=description,
@@ -346,7 +335,7 @@ class TestGroupingPipeline:
 
         return report_id
 
-    async def pre_emit(self, record_id: int, case: EvalSignalCase) -> str | None:
+    async def pre_emit(self, case: EvalSignalCase) -> str | None:
         output = case.signal.content
         config = case.signal.config
 

--- a/products/signals/eval/eval_grouping_e2e.py
+++ b/products/signals/eval/eval_grouping_e2e.py
@@ -28,6 +28,7 @@ Run:
 """
 
 import sys
+import json
 import uuid
 import random
 import asyncio
@@ -190,8 +191,10 @@ class TestGroupingPipeline:
         ready = [r for r in pre_match_results if r is not None]
 
         # Phase 2 (concurrent matching in BATCH_SIZE sub-batches + pipelined judging)
-        # Within each sub-batch, `_match()` calls fire concurrently. Between sub-batches,
-        # results are persisted so later signals can find earlier ones' reports.
+        # Mirrors production's concurrent matching: within each sub-batch, `_match()` calls fire concurrently.
+        # Between sub-batches, results are persisted so later signals can find earlier ones' reports.
+        # Sub-batching is needed here because the eval processes all signals in one test run,
+        # which is NOT reflective of real-world batch behavior.
         judging_tasks: list[asyncio.Task] = []
         judged_report_ids: set[str] = set()
 
@@ -219,7 +222,7 @@ class TestGroupingPipeline:
                     judged_report_ids.add(rid)
                     judging_tasks.append(asyncio.create_task(self._judge_single_report(report)))
 
-        # ── Wait for remaining judging ──
+        # Wait for remaining judging
         reports = self.report_store.all_reports()
         self.progress.start_judging(len(reports))
         if judging_tasks:
@@ -748,14 +751,10 @@ class TestGroupingPipeline:
         """Write match failures to a JSON file for debugging by a human or coding agent.
         This is context to diagnose results.
         """
-        if not self._match_failures:
-            return
-        import json as json_mod
-
-        path = "/tmp/signals_eval_match_failures.json"
-        with open(path, "w") as f:
-            json_mod.dump(self._match_failures, f, indent=2)
-        tqdm.write(f"\n{len(self._match_failures)} match failures written to {path}", file=sys.stderr)
+        failures_path = "/tmp/signals_eval_match_failures.json"
+        with open(failures_path, "w") as f:
+            json.dump(self._match_failures, f, indent=2)
+        tqdm.write(f"\nMatch failures ({len(self._match_failures)}) written to {failures_path}", file=sys.stderr)
 
     def _capture(
         self,

--- a/products/signals/eval/eval_grouping_e2e.py
+++ b/products/signals/eval/eval_grouping_e2e.py
@@ -163,6 +163,7 @@ class TestGroupingPipeline:
         self.no_capture = no_capture
         self.online = online
         self.start_time = time()
+        self._match_failures: list[dict] = []
 
         # Suppress structlog noise from downstream modules during the eval
         root_logger = logging.getLogger()
@@ -227,6 +228,7 @@ class TestGroupingPipeline:
 
         self._capture_grouping_quality()
         self._capture_aggregate_metrics(stream)
+        self._dump_match_failures()
 
     async def _pre_match(
         self, sem: asyncio.Semaphore, record_id: int, case: EvalSignalCase
@@ -477,6 +479,34 @@ class TestGroupingPipeline:
             else None,
         }
 
+        if not correct:
+            self._match_failures.append(
+                {
+                    "group_index": case.group_index,
+                    "signal_index": case.signal_index,
+                    "scenario": GROUP_DATA[case.group_index].scenario,
+                    "signal_description": case.signal.content.description,
+                    "failure_mode": specificity_failure_mode.value,
+                    "pre_specificity_failure_mode": match_failure_mode.value,
+                    "match_decision": "EXISTING_REPORT" if is_existing else "NEW_REPORT",
+                    "expected": expected,
+                    "match_reason": specificity_match_result.match_metadata.reason
+                    if hasattr(specificity_match_result.match_metadata, "reason")
+                    else "",
+                    "queries": queries,
+                    "top_candidates": [
+                        {
+                            "signal_id": c.signal_id,
+                            "distance": round(c.distance, 4),
+                            "content": c.content,
+                            "report_id": c.report_id,
+                        }
+                        for cands in candidates
+                        for c in cands[:3]
+                    ],
+                }
+            )
+
         self._capture(
             eval_name="match-quality",
             item_name=f"match-{case.group_index}-{case.signal_index}",
@@ -713,6 +743,19 @@ class TestGroupingPipeline:
                 ),
             ],
         )
+
+    def _dump_match_failures(self):
+        """Write match failures to a JSON file for debugging by a human or coding agent.
+        This is context to diagnose results.
+        """
+        if not self._match_failures:
+            return
+        import json as json_mod
+
+        path = "/tmp/signals_eval_match_failures.json"
+        with open(path, "w") as f:
+            json_mod.dump(self._match_failures, f, indent=2)
+        tqdm.write(f"\n{len(self._match_failures)} match failures written to {path}", file=sys.stderr)
 
     def _capture(
         self,


### PR DESCRIPTION
## Problem

We need the signals pipeline fast for throughput, but really more importantly, fast for an excellent onboarding experience showcasing the power of signals. See this thread with @adboio: [Slack](https://posthog.slack.com/archives/C09G8Q32R6F/p1773854371796329)

Grouping is the biggest bottleneck right now. Currently, signal matching in `_process_signal_batch` runs match + specificity LLM calls sequentially – one signal at a time.

The current setup brings the most integrity, but at large latency - and it doesn't seem like concurrent signals on the same issue are truly common in the wild. (In the worst case, it's still okay to undergroup very slightly.)

## Changes

**Model split (`llm.py`, `safety_filter.py`, `grouping.py`):** Using Haiku 4.5 for grouping tasks (query gen, matching, specificity, safety filter) and Sonnet 4.6 for judging tasks (safety judge, actionability judge, summarization). Grouping tasks are structured classification/generation that Haiku handles well at multiple times the speed. Judging tasks need deeper reasoning and stay on Sonnet.

**Production pipeline (`grouping.py`):** Replacing the sequential matching loop with fully concurrent execution - the LLM calls for matching fire concurrently per-batch (up to 20 signals in a batch). This means there's a risk of undergrouping, but bringing major speed gains. Specificity checks for existing matches fire concurrently too.

**Eval pipeline (`eval_grouping_e2e.py`):** Mirrors the same structure using the same production functions 1:1, with `BATCH_SIZE` sub-batching (needed because the eval processes all 91 signals in one test run, which is _not_ reflective of the real world). Also adds match failure diagnostics dump to `/tmp/signals_eval_match_failures.json` for debugging.

## How did you test this code?

Ran the full grouping e2e eval on master and this branch with different model configs:

| Metric | master (Sonnet 4.5 everywhere) | Branch (Sonnet 4.5) | Branch (Haiku 4.5 grouping + Sonnet 4.6 judging) |
|---|---|---|---|
| ARI | 0.77 | 0.79 | 0.72-0.77 |
| Homogeneity | 0.99 | 0.99 | 0.99 |
| Completeness | 0.92 | 0.92 | 0.90 |
| Mean purity | 0.99 | 0.99 | 0.99 |
| Mean recall | 0.71 | 0.73 | 0.66 |
| Malicious leaked | 0/24 | 0/24 | 0/24 |
| Reports | 40 | 39 | 41-43 |
| Time | 342s | 329s | **191s** |

With the model split, throughput roughly doubles (191s vs 342s) with just a little bit of a quality dropoff. From the results, in equal part the difference is in Haiku being less precise, part in in batch concurrency, and part in Sonnet rejecting borderline groups aggressively (which shouldn't be new, but did come up in the couple of repeated runs i did).

## Publish to changelog?

No