### PR TITLE
fix: improve validation for group property delete endpoint

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -207,16 +207,28 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
     def get_serializer_class(self):
         return self.serializer_classes.get(self.action, self.serializer_classes["default"])
 
+    def _safely_get_query_params(self, require_group_key: bool = False) -> tuple[str, str | None]:
+        group_type_index = self.request.GET.get("group_type_index")
+        if not group_type_index:
+            raise ValidationError({"group_type_index": ["This query parameter is required."]})
+        group_key = self.request.GET.get("group_key")
+        if require_group_key and not group_key:
+            raise ValidationError({"group_key": ["This query parameter is required."]})
+        return group_type_index, group_key
+
     def safely_get_queryset(self, queryset):
+        group_type_index, _ = self._safely_get_query_params()
         return queryset.filter(
-            group_type_index=self.request.GET["group_type_index"],
+            group_type_index=group_type_index,
             group_key__icontains=self.request.GET.get("group_key", ""),
         )
 
     def safely_get_object(self, queryset):
+        group_type_index, group_key = self._safely_get_query_params(require_group_key=True)
+
         queryset = queryset.filter(
-            group_type_index=self.request.GET["group_type_index"],
-            group_key=self.request.GET.get("group_key", ""),
+            group_type_index=group_type_index,
+            group_key=group_key,
         )
 
         return get_object_or_404(queryset)
@@ -546,20 +558,16 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
     def delete_property(self, request: request.Request, **_kw) -> response.Response:
         try:
             group = self.get_object()
-            for key in ["$unset"]:
-                if request.data.get(key) is None:
-                    return response.Response(
-                        {
-                            "attr": key,
-                            "code": "This field is required.",
-                            "detail": "required",
-                            "type": "validation_error",
-                        },
-                        status=400,
-                    )
+            property_key = request.data.get("$unset")
+            if not isinstance(property_key, str):
+                raise ValidationError(
+                    {"$unset": ["This field is required and must be a string (the property name to delete)."]}
+                )
+            if property_key not in group.group_properties:
+                raise ValidationError({"$unset": [f"Property '{property_key}' does not exist on this group."]})
             group_type_mapping = self.get_group_type_mapping_or_404(cast(GroupTypeIndex, group.group_type_index))
-            original_value = group.group_properties[request.data["$unset"]]
-            del group.group_properties[request.data["$unset"]]
+            original_value = group.group_properties[property_key]
+            del group.group_properties[property_key]
             group.save()
 
             # Need to update ClickHouse too
@@ -579,7 +587,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
             properties = {
                 "$group_type": group_type_mapping.group_type,
                 "$group_key": group.group_key,
-                "$group_unset": [request.data["$unset"]],
+                "$group_unset": [property_key],
             }
 
             try:
@@ -597,7 +605,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
             except HTTPError as e:
                 return response.Response(
                     {
-                        "attr": key,
+                        "attr": "$unset",
                         "code": "Failed to submit group property deletion event.",
                         "detail": "capture_http_error",
                         "type": "capture_http_error",
@@ -607,7 +615,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
             except Exception:
                 return response.Response(
                     {
-                        "attr": key,
+                        "attr": "$unset",
                         "code": "Failed to submit group property deletion event.",
                         "detail": "capture_error",
                         "type": "capture_error",
@@ -624,7 +632,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
                 scope="Group",
                 activity="update_property",
                 detail=Detail(
-                    name=str(request.data["$unset"]),
+                    name=str(property_key),
                     changes=[Change(type="Group", action="deleted", before=original_value)],
                 ),
             )

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -830,6 +830,65 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_delete_property_missing_group_type_index(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups/delete_property?group_key=org:5",
+            {"$unset": "industry"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_delete_property_missing_group_key(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups/delete_property?group_type_index=0",
+            {"$unset": "industry"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @freeze_time("2021-05-02")
+    @patch("ee.clickhouse.views.groups.capture_internal")
+    def test_delete_property_nonexistent_property(self, mock_capture):
+        mock_capture.return_value = mock.MagicMock(status_code=200)
+        create_group_type_mapping_without_created_at(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:5",
+            properties={"industry": "finance"},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups/delete_property?group_key=org:5&group_type_index=0",
+            {"$unset": "nonexistent"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @freeze_time("2021-05-02")
+    def test_delete_property_non_string_unset(self):
+        create_group_type_mapping_without_created_at(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org:5",
+            properties={"industry": "finance"},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/groups/delete_property?group_key=org:5&group_type_index=0",
+            {"$unset": ["industry"]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
     @freeze_time("2021-05-02")
     @patch("ee.clickhouse.views.groups.capture_internal")
     def test_get_group_activities_success(self, mock_capture):


### PR DESCRIPTION
## Problem

A customer had some trouble with the delete group properties endpoint.

## Changes

Improve validation on the request.

## How did you test this code?

Unit tests passing