### PR TITLE
feat(replay): improve video session summary prompts

### DIFF
--- a/posthog/temporal/ai/session_summary/activities/a3_analyze_video_segment.py
+++ b/posthog/temporal/ai/session_summary/activities/a3_analyze_video_segment.py
@@ -277,32 +277,24 @@ Analyze this video segment from a session recording of a user using {team_name}.
 This segment starts at {start_timestamp} in the full recording and runs for approximately {segment_duration:.0f} seconds.
 {events_section}
 Your task:
-- Describe what's happening in the video as a list of salient moments
-- Highlight what features were used, and what the user was doing with them
-- Note any problems, errors, confusion, or friction the user experienced
-- If tracked events show exceptions ($exception_types, $exception_values), validate if they happened in the video
-- Red lines indicate mouse movements, and should be ignored
-- If nothing is happening, return "Static" for the timestamp range
+- Describe what the user did and how it went. Group related actions together — not every click is a separate entry.
+- Cover what went smoothly and what didn't — don't only report problems.
+- Mention errors only when they visibly affected the user (error on screen, page failed to load, action didn't complete). Ignore background console errors with no visible impact.
+- Note confusion (backtracking, repeated attempts, rage clicking) only when clearly present.
+- Red lines indicate mouse movements — ignore them.
+- If nothing is happening, return "Static" for the timestamp range.
 
 Output format (use timestamps relative to the FULL recording, starting at {start_timestamp}):
-* MM:SS - MM:SS: <detailed description>
-* MM:SS - MM:SS: <detailed description>
-* etc.
+* MM:SS - MM:SS: <what happened and the outcome>
 
-Be specific and detailed about:
-- What the user clicked on
-- What pages or sections they navigated to
-- What they typed or entered
-- Any errors or loading states (correlate with exception events if available)
-- Signs of confusion or hesitation
-- What outcomes occurred
+Include:
+- Which features, pages, or sections were involved (use names visible on screen)
+- Whether the user finished what they were doing or left
+- Specific error messages only when visible on screen
 
 Example output:
-* 0:16 - 0:18: User clicked on the dashboard navigation item in the sidebar
-* 0:18 - 0:24: User scrolled through the dashboard page viewing multiple analytics widgets
-* 0:24 - 0:25: User clicked "Create new project" button in the top toolbar
-* 0:25 - 0:32: User filled out the project creation form, entering name and description
-* 0:32 - 0:33: User attempted to submit the form but received validation error "Name is required"
+* 0:16 - 0:24: Opened the analytics dashboard, scrolled through pageview and conversion trend widgets
+* 0:24 - 0:33: Went to project creation — filled out the form, clicked submit, but got a "Name is required" error. Tried again with the same result and left the page
 
 IMPORTANT: Use timestamps relative to the full recording (starting at {start_timestamp}), not relative to this segment.
 """
@@ -310,11 +302,11 @@ IMPORTANT: Use timestamps relative to the full recording (starting at {start_tim
 VIDEO_SEGMENT_ANALYSIS_PROMPT_EVENTS_SECTION = """
 <tracked_events>
 The following events were tracked during this segment. Use them to understand what actions the user took
-and correlate them with what you see in the video. Pay special attention to:
-- $exception_types and $exception_values: These indicate errors or exceptions that occurred
+and correlate them with what you see in the video:
 - elements_chain_texts: Text content the user interacted with
 - $event_type: The type of interaction (click, submit, etc.)
 - $current_url: The page URL where the action occurred
+- $exception_types and $exception_values: These indicate errors logged in the console. IMPORTANT: Only mention an exception if it visibly affected what the user was doing (e.g., an error message appeared on screen, a page failed to load, an action didn't complete). Many console errors are background noise — do not attribute them to the user's actions unless there is a clear visual connection.
 
 Events data (in chronological order):
 {events_context}

--- a/posthog/temporal/ai/session_summary/activities/a4_consolidate_video_segments.py
+++ b/posthog/temporal/ai/session_summary/activities/a4_consolidate_video_segments.py
@@ -147,38 +147,51 @@ async def _call_llm_to_consolidate_segments(
 
 
 CONSOLIDATION_PROMPT = """
-You are analyzing a session recording from a web analytics product. Below are timestamped descriptions of what the user did during the session.
+You are summarizing a user's journey through a product session for PMs, developers, and analysts who want to understand what the user did and whether anything needs attention.
 
-Your task is to consolidate these into meaningful semantic segments and provide an overall analysis. For each segment:
-1. Have a **descriptive title** that captures the user's goal or activity (e.g., "Setting up integration", "Exploring analytics dashboard", "Debugging API errors")
-2. Span a coherent period of related activity (combine adjacent segments that are part of the same task)
-3. Have a **combined description** that synthesizes the details from the original segments
-4. Detect if the user experienced **exceptions** (errors, things not working - classify as "blocking" if it stopped their progress, "non-blocking" if they could continue), **confusion** (backtracking, hesitation, repeated attempts), or **abandonment** (starting something but not finishing)
-5. Determine if the segment was **successful** (user achieved their apparent goal)
+Below are timestamped observations. Produce a short narrative summary + key moments.
+
+Session outcome:
+- 1-2 sentence TLDR: where the user went, what they did, and how it ended. Scannable — a PM should know whether to watch this session in 5 seconds.
+- Good: "Explored analytics dashboard, created a funnel, and shared results. Hit a validation error during project setup but moved on."
+- Bad: "Encountered persistent loading failures that prevented effective analysis."
+
+Each segment is a key moment in the session:
+- **Title**: What happened in this moment (e.g., "Opened funnel creation", "Hit validation error on project setup", "Completed onboarding"). Sentence-cased. Specific, not generic.
+- **Description**: 1 sentence — the key action and its result. Keep it tight. Describe what happened at face value — don't amplify or dramatize severity.
+  - Good: "Filled out the project form and hit a 'Name is required' error."
+  - Bad: "The user proceeded to fill out the project creation form, entering various fields including the name and description, and then clicked the submit button, which resulted in a validation error message appearing on screen."
+- **Success**: Did the user finish what they were doing?
+- **Flags**: exception="blocking" only if it visibly stopped the user. confusion/abandonment only when clearly observed.
+
+Segmentation:
+- Each segment is a meaningful chunk of activity, not a single action. A chunk covers the full flow: navigating to a feature, using it, and the outcome. Example: "Went to Feature Flags, created a new flag, got blocked by unresponsive dropdown" is ONE segment, not three.
+- Short sessions: 1-3 segments. Long sessions: 3-6. If you have more than 6, you are fragmenting too much — merge harder.
+- Merge all activity in the same area/feature into one segment, even if some actions succeeded and others failed. Example: browsing recordings, trying to load summaries, checking event details — if it all happened on the same page within a few minutes, that's ONE segment.
+- Merge repeated attempts at the same thing into one segment. If the user spent most of the session hitting the same issue, keep segments minimal and let fix_suggestions carry the detail.
+- Segments are chronological. Users often pivot between goals within a session — group related actions into arcs, but don't force unrelated activity into one narrative. Example: "Dashboard exploration" → "Feature flag creation" can be two separate arcs if the user switched context.
+- Stick to what you can observe; do not infer motivation or intent.
+
+fix_suggestions:
+- Error details belong here, not in segment descriptions. Do not repeat error messages or specific failure details in both places.
+- Segment descriptions should mention that something failed; fix_suggestions should say exactly what error appeared and what to do about it.
+- Each needs: issue, evidence (exact error or observed behavior), suggestion.
+- Only include when grounded in something specific. Empty list is fine.
 
 Raw segments:
 {segments_text}
 
-Output format (JSON object matching this schema):
+Output a JSON object matching this schema, no other text:
 ```json
 {json_schema}
 ```
 
-Rules:
-- Create as many segments as needed depending on session complexity (fewer for short simple sessions, more for long complex ones)
-- Titles should be specific (avoid generic titles like "User activity" or "Browsing")
-- Titles must be sentence-cased (capitalize only the first letter and proper nouns)
-- Time ranges must not overlap and should cover the full session
-- Preserve error messages, specific UI elements clicked, and outcomes mentioned in original segments
-- Keep descriptions concise but complete
-- Set exception="blocking" if errors prevented the user from completing their intended action
-- Set exception="non-blocking" if errors occurred but the user could continue or work around them
-- Set exception=null if no errors or failures were observed
-- Set confusion_detected=true if the user backtracks, hesitates, or makes repeated attempts at the same thing
-- Set abandonment_detected=true if the user starts a flow but doesn't complete it
-- Set success=false for segments where the user's apparent goal wasn't achieved
-- session_outcome.success should be true if the user accomplished their main goals, false if they left frustrated or unsuccessful
-- segment_outcomes should have one entry per segment with a brief summary of what happened
+Style:
+- Be direct. No filler ("The user proceeded to", "It was observed that").
+- Vary phrasing — don't start every sentence with "The user".
+- Preserve specific feature names, page names, and error messages.
 
-Output ONLY the JSON object, no other text.
+Rules:
+- Time ranges must not overlap and should cover the full session.
+- One segment_outcome per segment with a brief narrative summary.
 """

--- a/posthog/temporal/ai/session_summary/types/video.py
+++ b/posthog/temporal/ai/session_summary/types/video.py
@@ -124,6 +124,17 @@ class VideoSegmentOutcome(BaseModel):
     summary: str
 
 
+class VideoFixSuggestion(BaseModel):
+    """An actionable fix suggestion grounded in observed session behavior."""
+
+    model_config = ConfigDict(frozen=True)
+
+    segment_index: int = Field(description="Index of the segment where the issue was observed")
+    issue: str = Field(description="What went wrong — specific error, failure, or friction point")
+    evidence: str = Field(description="What was observed: exact error message, failed action, or user behavior")
+    suggestion: str = Field(description="Actionable fix or improvement")
+
+
 class ConsolidatedVideoAnalysis(BaseModel):
     """Complete output from video segment consolidation including segments, outcomes, and session-level analysis."""
 
@@ -132,3 +143,7 @@ class ConsolidatedVideoAnalysis(BaseModel):
     segments: list[ConsolidatedVideoSegment]
     session_outcome: VideoSessionOutcome
     segment_outcomes: list[VideoSegmentOutcome]
+    fix_suggestions: list[VideoFixSuggestion] = Field(
+        default_factory=list,
+        description="Actionable fix suggestions grounded in observed issues — only include if there is clear evidence",
+    )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
We wanted the prompts to be a bit more human friendly and showing more clear user journey

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Updated the summarization prompts in a3 and a4
- Added a new serializer specific for fix suggestions
Example output with heavier session
<img width="939" height="1123" alt="Screenshot 2026-03-19 at 11 29 42" src="https://github.com/user-attachments/assets/9f4f3317-2c0e-45f4-a8e2-972eaca24297" />
Example output with light session
<img width="948" height="517" alt="Screenshot 2026-03-19 at 14 22 30" src="https://github.com/user-attachments/assets/ff373983-f241-4596-a286-d6539d7c424b" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
