### PR TITLE
feat(logs): refactor VirtualizedLogsList components to use column definitions

### DIFF
--- a/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRow.tsx
@@ -1,58 +1,29 @@
-import { IconChevronRight } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, Tooltip } from '@posthog/lemon-ui'
+import React from 'react'
 
-import { TZLabel, TZLabelProps } from 'lib/components/TZLabel'
 import { cn } from 'lib/utils/css-classes'
-
-import { LogMessage } from '~/queries/schema/schema-general'
 
 import { ExpandedLogContent } from 'products/logs/frontend/components/LogsViewer/ExpandedLogContent'
 import { LogRowFAB } from 'products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB'
-import { AttributeCell } from 'products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell'
-import { MessageCell } from 'products/logs/frontend/components/VirtualizedLogsList/cells/MessageCell'
-import {
-    CHECKBOX_WIDTH,
-    EXPAND_WIDTH,
-    RESIZER_HANDLE_WIDTH,
-    ROW_GAP,
-    SEVERITY_WIDTH,
-    TIMESTAMP_WIDTH,
-    getAttributeColumnWidth,
-    getFixedColumnsWidth,
-    getMessageStyle,
-} from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
+import { ROW_GAP } from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
+import { VirtualizedTableColumn } from 'products/logs/frontend/components/VirtualizedLogsList/types'
 import { ParsedLogMessage } from 'products/logs/frontend/types'
-
-const SEVERITY_BAR_COLORS: Record<LogMessage['severity_text'], string> = {
-    trace: 'bg-muted-alt',
-    debug: 'bg-muted',
-    info: 'bg-brand-blue',
-    warn: 'bg-warning',
-    error: 'bg-danger',
-    fatal: 'bg-danger-dark',
-}
 
 export interface LogRowProps {
     log: ParsedLogMessage
     logIndex: number
+    columns: VirtualizedTableColumn<ParsedLogMessage>[]
     isAtCursor: boolean
     isExpanded: boolean
     pinned: boolean
     showPinnedWithOpacity: boolean
     wrapBody: boolean
-    prettifyJson: boolean
-    tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
     onTogglePin: (log: ParsedLogMessage) => void
-    onToggleExpand: () => void
     onClick?: () => void
     rowWidth?: number
-    attributeColumns?: string[]
-    attributeColumnWidths?: Record<string, number>
     // Selection
-    isSelected?: boolean
-    onToggleSelect?: () => void
     onShiftClick?: (logIndex: number) => void
-    // Per-row prettify
+    isSelected?: boolean
+    // Per-row prettify (for FAB)
     isPrettified?: boolean
     onTogglePrettify?: (log: ParsedLogMessage) => void
     minHeight?: number
@@ -61,34 +32,22 @@ export interface LogRowProps {
 export function LogRow({
     log,
     logIndex,
+    columns,
     isAtCursor,
     isExpanded,
     pinned,
     showPinnedWithOpacity,
     wrapBody,
-    prettifyJson,
-    tzLabelFormat,
     onTogglePin,
-    onToggleExpand,
     onClick,
     rowWidth,
-    attributeColumns = [],
-    attributeColumnWidths = {},
-    isSelected = false,
-    onToggleSelect,
     onShiftClick,
+    isSelected = false,
     isPrettified = false,
     onTogglePrettify,
     minHeight = 32,
 }: LogRowProps): JSX.Element {
     const isNew = 'new' in log && log.new
-    const flexWidth = rowWidth
-        ? rowWidth -
-          getFixedColumnsWidth(attributeColumns, attributeColumnWidths) -
-          attributeColumns.length * RESIZER_HANDLE_WIDTH
-        : undefined
-
-    const severityColor = SEVERITY_BAR_COLORS[log.severity_text] ?? 'bg-muted-3000'
 
     const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>): void => {
         // Only handle shift+click here to prevent text selection during range select
@@ -129,69 +88,11 @@ export function LogRow({
                 onMouseDown={handleMouseDown}
                 onClick={handleClick}
             >
-                <div className="flex items-center self-stretch">
-                    <Tooltip title={log.severity_text.toUpperCase()}>
-                        <div
-                            className="flex items-stretch self-stretch"
-                            style={{ width: SEVERITY_WIDTH, flexShrink: 0 }}
-                        >
-                            <div className={cn('w-1 rounded-full', severityColor)} />
-                        </div>
-                    </Tooltip>
-                    <div className="flex items-center justify-center shrink-0" style={{ width: CHECKBOX_WIDTH }}>
-                        <LemonCheckbox
-                            checked={isSelected}
-                            onChange={() => onToggleSelect?.()}
-                            stopPropagation
-                            size="small"
-                        />
-                    </div>
-                    <div
-                        className="flex items-stretch self-stretch justify-center"
-                        style={{ width: EXPAND_WIDTH, flexShrink: 0 }}
-                    >
-                        <LemonButton
-                            size="xsmall"
-                            icon={
-                                <IconChevronRight className={cn('transition-transform', isExpanded && 'rotate-90')} />
-                            }
-                            onMouseDown={(e) => {
-                                e.stopPropagation()
-                                onToggleExpand()
-                            }}
-                            onClick={(e) => e.stopPropagation()}
-                        />
-                    </div>
-                </div>
-
-                {/* Timestamp */}
-                <div className="flex items-center shrink-0" style={{ width: TIMESTAMP_WIDTH }}>
-                    <span className="text-xs text-muted font-mono">
-                        <TZLabel time={log.timestamp} {...tzLabelFormat} timestampStyle="absolute" />
-                    </span>
-                </div>
-
-                {/* Attribute columns */}
-                {attributeColumns.map((attributeKey) => {
-                    const attrValue = log.attributes[attributeKey] ?? log.resource_attributes[attributeKey]
-                    return (
-                        <AttributeCell
-                            key={attributeKey}
-                            attributeKey={attributeKey}
-                            value={attrValue != null ? String(attrValue) : ''}
-                            width={getAttributeColumnWidth(attributeKey, attributeColumnWidths) + RESIZER_HANDLE_WIDTH}
-                        />
-                    )
-                })}
-
-                {/* Message */}
-                <MessageCell
-                    message={log.cleanBody}
-                    wrapBody={isPrettified || wrapBody}
-                    prettifyJson={isPrettified || prettifyJson}
-                    parsedBody={log.parsedBody}
-                    style={getMessageStyle(flexWidth)}
-                />
+                {columns
+                    .filter((col) => !col.isHidden)
+                    .map((col) => (
+                        <React.Fragment key={col.key}>{col.render(log, logIndex)}</React.Fragment>
+                    ))}
 
                 {/* Actions FAB */}
                 <LogRowFAB

--- a/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/LogRowHeader.tsx
@@ -1,170 +1,24 @@
-import { IconArrowLeft, IconArrowRight, IconEllipsis, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonMenu } from '@posthog/lemon-ui'
+import React from 'react'
 
-import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
-import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
-
-import {
-    CHECKBOX_WIDTH,
-    EXPAND_WIDTH,
-    MIN_ATTRIBUTE_COLUMN_WIDTH,
-    RESIZER_HANDLE_WIDTH,
-    ROW_GAP,
-    SEVERITY_WIDTH,
-    TIMESTAMP_WIDTH,
-    getAttributeColumnWidth,
-    getFixedColumnsWidth,
-    getMessageStyle,
-} from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
-import { LogsOrderBy } from 'products/logs/frontend/types'
+import { ROW_GAP } from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
+import { VirtualizedTableColumn } from 'products/logs/frontend/components/VirtualizedLogsList/types'
+import { ParsedLogMessage } from 'products/logs/frontend/types'
 
 export interface LogRowHeaderProps {
+    columns: VirtualizedTableColumn<ParsedLogMessage>[]
     rowWidth: number
-    attributeColumns?: string[]
-    attributeColumnWidths?: Record<string, number>
-    onRemoveAttributeColumn?: (attributeKey: string) => void
-    onResizeAttributeColumn?: (attributeKey: string, width: number) => void
-    onMoveAttributeColumn?: (attributeKey: string, direction: 'left' | 'right') => void
-    // Selection
-    selectedCount?: number
-    totalCount?: number
-    onSelectAll?: () => void
-    onClearSelection?: () => void
-    // Sorting
-    orderBy?: LogsOrderBy
-    onChangeOrderBy?: (orderBy: LogsOrderBy) => void
 }
 
-export function LogRowHeader({
-    rowWidth,
-    attributeColumns = [],
-    attributeColumnWidths = {},
-    onRemoveAttributeColumn,
-    onResizeAttributeColumn,
-    onMoveAttributeColumn,
-    selectedCount = 0,
-    totalCount = 0,
-    onSelectAll,
-    onClearSelection,
-    orderBy,
-    onChangeOrderBy,
-}: LogRowHeaderProps): JSX.Element {
-    const flexWidth =
-        rowWidth -
-        getFixedColumnsWidth(attributeColumns, attributeColumnWidths) -
-        attributeColumns.length * RESIZER_HANDLE_WIDTH
-
-    const allSelected = totalCount > 0 && selectedCount === totalCount
-    const someSelected = selectedCount > 0 && selectedCount < totalCount
-
+export function LogRowHeader({ columns, rowWidth }: LogRowHeaderProps): JSX.Element {
+    const visibleColumns = columns.filter((col) => !col.isHidden)
     return (
         <div
             style={{ width: rowWidth, gap: ROW_GAP }}
             className="flex items-center h-8 border-b border-border bg-bg-3000 text-xs font-semibold text-muted sticky top-0 z-10"
         >
-            {/* Severity + Checkbox + Expand header space */}
-            <div className="flex items-center self-stretch">
-                <div style={{ width: SEVERITY_WIDTH, flexShrink: 0 }} />
-                <div className="flex items-center justify-center shrink-0" style={{ width: CHECKBOX_WIDTH }}>
-                    <LemonCheckbox
-                        checked={someSelected ? 'indeterminate' : allSelected}
-                        onChange={() => (allSelected ? onClearSelection?.() : onSelectAll?.())}
-                        size="small"
-                    />
-                </div>
-                <div style={{ width: EXPAND_WIDTH, flexShrink: 0 }} />
-            </div>
-
-            {/* Timestamp */}
-            <div
-                className="flex items-center justify-between pr-3 gap-1 h-full border-r"
-                style={{ width: TIMESTAMP_WIDTH, flexShrink: 0 }}
-            >
-                Timestamp
-                <LemonButton
-                    size="xsmall"
-                    className="h-full"
-                    icon={orderBy === 'latest' ? <IconArrowDown /> : <IconArrowUp />}
-                    tooltip={
-                        orderBy === 'latest'
-                            ? 'Showing latest first. Click to show earliest first (reloads).'
-                            : 'Showing earliest first. Click to show latest first (reloads).'
-                    }
-                    onClick={() => {
-                        const newOrderBy = orderBy === 'latest' ? 'earliest' : 'latest'
-                        onChangeOrderBy?.(newOrderBy)
-                    }}
-                    disabled={!orderBy || !onChangeOrderBy}
-                />
-            </div>
-
-            {/* Attribute columns */}
-            {attributeColumns.map((attributeKey, index) => {
-                const width = getAttributeColumnWidth(attributeKey, attributeColumnWidths)
-                const isFirst = index === 0
-                const isLast = index === attributeColumns.length - 1
-                return (
-                    <ResizableElement
-                        key={`attr-${attributeKey}`}
-                        defaultWidth={width + RESIZER_HANDLE_WIDTH}
-                        minWidth={MIN_ATTRIBUTE_COLUMN_WIDTH + RESIZER_HANDLE_WIDTH}
-                        maxWidth={Infinity}
-                        onResize={(newWidth) =>
-                            onResizeAttributeColumn?.(attributeKey, newWidth - RESIZER_HANDLE_WIDTH)
-                        }
-                        className="flex items-center h-full shrink-0 group/header"
-                        innerClassName="h-full"
-                    >
-                        <div className="flex items-center pr-3 gap-1 h-full w-full">
-                            <span className="truncate flex-1" title={attributeKey}>
-                                {attributeKey}
-                            </span>
-                            {(onRemoveAttributeColumn || onMoveAttributeColumn) && (
-                                <LemonMenu
-                                    items={[
-                                        onMoveAttributeColumn
-                                            ? {
-                                                  label: 'Move left',
-                                                  icon: <IconArrowLeft />,
-                                                  disabledReason: isFirst ? 'Already at the start' : undefined,
-                                                  onClick: () => onMoveAttributeColumn(attributeKey, 'left'),
-                                              }
-                                            : null,
-                                        onMoveAttributeColumn
-                                            ? {
-                                                  label: 'Move right',
-                                                  icon: <IconArrowRight />,
-                                                  disabledReason: isLast ? 'Already at the end' : undefined,
-                                                  onClick: () => onMoveAttributeColumn(attributeKey, 'right'),
-                                              }
-                                            : null,
-                                        onRemoveAttributeColumn
-                                            ? {
-                                                  label: 'Remove column',
-                                                  icon: <IconTrash />,
-                                                  status: 'danger',
-                                                  onClick: () => onRemoveAttributeColumn(attributeKey),
-                                              }
-                                            : null,
-                                    ]}
-                                >
-                                    <LemonButton
-                                        size="xsmall"
-                                        noPadding
-                                        icon={<IconEllipsis className="text-muted" />}
-                                        className="shrink-0"
-                                    />
-                                </LemonMenu>
-                            )}
-                        </div>
-                    </ResizableElement>
-                )
-            })}
-
-            {/* Message */}
-            <div className="flex items-center px-1" style={getMessageStyle(flexWidth)}>
-                Message
-            </div>
+            {visibleColumns.map((col) => (
+                <React.Fragment key={col.key}>{col.renderHeader ? col.renderHeader() : col.title}</React.Fragment>
+            ))}
         </div>
     )
 }

--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -14,12 +14,20 @@ import { TZLabelProps } from 'lib/components/TZLabel'
 import { logDetailsModalLogic } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/logDetailsModalLogic'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 import {
+    createAttributeColumn,
+    createControlsColumn,
+    createMessageColumn,
+    createTimestampColumn,
+} from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
+import {
     LOG_ROW_HEADER_HEIGHT,
-    RESIZER_HANDLE_WIDTH,
-    getMinRowWidth,
+    getAttributeColumnWidth,
+    getColumnsFixedWidth,
+    getColumnsMinRowWidth,
 } from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
 import { LogRow } from 'products/logs/frontend/components/VirtualizedLogsList/LogRow'
 import { LogRowHeader } from 'products/logs/frontend/components/VirtualizedLogsList/LogRowHeader'
+import { VirtualizedTableColumn } from 'products/logs/frontend/components/VirtualizedLogsList/types'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
 import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
 
@@ -44,22 +52,17 @@ interface VirtualizedLogsListProps {
 
 interface LogsListRowProps {
     dataSource: ParsedLogMessage[]
+    columns: VirtualizedTableColumn<ParsedLogMessage>[]
     cursorIndex: number | null
     expandedLogIds: Record<string, boolean>
     pinnedLogs: Record<string, ParsedLogMessage>
     showPinnedWithOpacity: boolean
     disableCursor: boolean
     wrapBody: boolean
-    prettifyJson: boolean
-    tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
     togglePinLog: (log: ParsedLogMessage) => void
-    toggleExpandLog: (logId: string) => void
     handleLogRowClick: (log: ParsedLogMessage, index: number) => void
     rowWidth?: number
-    attributeColumns: string[]
-    attributeColumnWidths: Record<string, number>
     selectedLogIds: Record<string, boolean>
-    toggleSelectLog: (logId: string) => void
     selectLogRange: (anchorIndex: number, clickedIndex: number) => void
     userSetCursorIndex: (index: number) => void
     prettifiedLogIds: Set<string>
@@ -71,22 +74,17 @@ function LogsListRow({
     index,
     style,
     dataSource,
+    columns,
     cursorIndex,
     expandedLogIds,
     pinnedLogs,
     showPinnedWithOpacity,
     disableCursor,
     wrapBody,
-    prettifyJson,
-    tzLabelFormat,
     togglePinLog,
-    toggleExpandLog,
     handleLogRowClick,
     rowWidth,
-    attributeColumns,
-    attributeColumnWidths,
     selectedLogIds,
-    toggleSelectLog,
     selectLogRange,
     userSetCursorIndex,
     prettifiedLogIds,
@@ -111,21 +109,16 @@ function LogsListRow({
             <LogRow
                 log={log}
                 logIndex={index}
+                columns={columns}
                 isAtCursor={!disableCursor && index === cursorIndex}
                 isExpanded={!!expandedLogIds[log.uuid]}
                 pinned={!!pinnedLogs[log.uuid]}
                 showPinnedWithOpacity={showPinnedWithOpacity}
                 wrapBody={wrapBody}
-                prettifyJson={prettifyJson}
-                tzLabelFormat={tzLabelFormat}
                 onTogglePin={togglePinLog}
-                onToggleExpand={() => toggleExpandLog(log.uuid)}
                 onClick={() => handleLogRowClick(log, index)}
                 rowWidth={rowWidth}
-                attributeColumns={attributeColumns}
-                attributeColumnWidths={attributeColumnWidths}
                 isSelected={!!selectedLogIds[log.uuid]}
-                onToggleSelect={() => toggleSelectLog(log.uuid)}
                 onShiftClick={(clickedIndex) => {
                     const anchorIndex = cursorIndex ?? 0
                     selectLogRange(anchorIndex, clickedIndex)
@@ -163,21 +156,16 @@ export function VirtualizedLogsList({
         attributeColumns,
         attributeColumnWidths,
         selectedLogIds,
-        selectedCount,
         prettifiedLogIds,
         linkToLogId,
         logsCount,
     } = useValues(logsViewerLogic)
     const {
         togglePinLog,
-        toggleExpandLog,
         userSetCursorIndex,
         removeAttributeColumn,
         setAttributeColumnWidth,
         moveAttributeColumn,
-        toggleSelectLog,
-        selectAll,
-        clearSelection,
         selectLogRange,
         togglePrettifyLog,
         setFocused,
@@ -194,10 +182,57 @@ export function VirtualizedLogsList({
 
     const dynamicRowHeight = useDynamicRowHeight({ defaultRowHeight: DEFAULT_ROW_HEIGHT })
 
-    const minRowWidth = useMemo(
-        () => getMinRowWidth(attributeColumns, attributeColumnWidths) + attributeColumns.length * RESIZER_HANDLE_WIDTH,
-        [attributeColumns, attributeColumnWidths]
+    // Ref for flexWidth — updated in AutoSizer callback, read by message column
+    // render function. Avoids rebuilding columns on every resize.
+    const flexWidthRef = useRef<number | undefined>(undefined)
+
+    // Ref for dataSource — read by ControlsHeader for select-all so it
+    // operates on the correct list (main logs vs pinned logs).
+    const dataSourceRef = useRef<ParsedLogMessage[]>(dataSource)
+    dataSourceRef.current = dataSource
+
+    // Columns memoized on structural deps only — per-row state (selection,
+    // expansion, prettify) is read from kea inside cell components.
+    const columns = useMemo(
+        () => [
+            createControlsColumn({ dataSourceRef }),
+            createTimestampColumn({
+                tzLabelFormat,
+                orderBy,
+                onChangeOrderBy,
+            }),
+            ...attributeColumns.map((attributeKey, index) =>
+                createAttributeColumn({
+                    attributeKey,
+                    width: getAttributeColumnWidth(attributeKey, attributeColumnWidths),
+                    onResize: setAttributeColumnWidth,
+                    onRemove: removeAttributeColumn,
+                    onMove: moveAttributeColumn,
+                    isFirst: index === 0,
+                    isLast: index === attributeColumns.length - 1,
+                })
+            ),
+            createMessageColumn({
+                wrapBody,
+                prettifyJson,
+                flexWidthRef,
+            }),
+        ],
+        [
+            tzLabelFormat,
+            orderBy,
+            onChangeOrderBy,
+            attributeColumns,
+            attributeColumnWidths,
+            setAttributeColumnWidth,
+            removeAttributeColumn,
+            moveAttributeColumn,
+            wrapBody,
+            prettifyJson,
+        ]
     )
+
+    const minRowWidth = useMemo(() => getColumnsMinRowWidth(columns), [columns])
 
     // Position cursor at linked log when deep linking (URL -> cursor)
     useEffect(() => {
@@ -247,22 +282,17 @@ export function VirtualizedLogsList({
     const createRowProps = useCallback(
         (rowWidth?: number): LogsListRowProps => ({
             dataSource,
+            columns,
             cursorIndex,
             expandedLogIds,
             pinnedLogs,
             showPinnedWithOpacity,
             disableCursor,
             wrapBody,
-            prettifyJson,
-            tzLabelFormat,
             togglePinLog,
-            toggleExpandLog,
             handleLogRowClick,
             rowWidth,
-            attributeColumns,
-            attributeColumnWidths,
             selectedLogIds,
-            toggleSelectLog,
             selectLogRange,
             userSetCursorIndex,
             prettifiedLogIds,
@@ -271,21 +301,16 @@ export function VirtualizedLogsList({
         }),
         [
             dataSource,
+            columns,
             cursorIndex,
             expandedLogIds,
             pinnedLogs,
             showPinnedWithOpacity,
             disableCursor,
             wrapBody,
-            prettifyJson,
-            tzLabelFormat,
             togglePinLog,
-            toggleExpandLog,
             handleLogRowClick,
-            attributeColumns,
-            attributeColumnWidths,
             selectedLogIds,
-            toggleSelectLog,
             selectLogRange,
             userSetCursorIndex,
             prettifiedLogIds,
@@ -328,29 +353,19 @@ export function VirtualizedLogsList({
                             requestAnimationFrame(() => setContainerWidth(width))
                         }
                         const rowWidth = Math.max(width ?? 0, minRowWidth)
+                        const adjustedRowWidth = rowWidth - getScrollbarSize()
+                        flexWidthRef.current = adjustedRowWidth - getColumnsFixedWidth(columns)
+
                         return (
                             <div className="overflow-y-hidden overflow-x-auto" style={{ width, height: fixedHeight }}>
-                                <LogRowHeader
-                                    rowWidth={rowWidth - getScrollbarSize()}
-                                    attributeColumns={attributeColumns}
-                                    attributeColumnWidths={attributeColumnWidths}
-                                    onRemoveAttributeColumn={removeAttributeColumn}
-                                    onResizeAttributeColumn={setAttributeColumnWidth}
-                                    onMoveAttributeColumn={moveAttributeColumn}
-                                    selectedCount={selectedCount}
-                                    totalCount={dataSource.length}
-                                    onSelectAll={() => selectAll(dataSource)}
-                                    onClearSelection={clearSelection}
-                                    orderBy={orderBy}
-                                    onChangeOrderBy={onChangeOrderBy}
-                                />
+                                <LogRowHeader columns={columns} rowWidth={adjustedRowWidth} />
                                 <List<LogsListRowProps>
                                     style={{ height: fixedHeight - LOG_ROW_HEADER_HEIGHT, width: rowWidth }}
                                     overscanCount={5}
                                     rowCount={dataSource.length}
                                     rowHeight={dynamicRowHeight}
                                     rowComponent={LogsListRow}
-                                    rowProps={createRowProps(rowWidth - getScrollbarSize())}
+                                    rowProps={createRowProps(adjustedRowWidth)}
                                     listRef={listRef}
                                 />
                             </div>
@@ -377,30 +392,19 @@ export function VirtualizedLogsList({
                         requestAnimationFrame(() => setContainerWidth(width))
                     }
                     const rowWidth = Math.max(width ?? 0, minRowWidth)
+                    const adjustedRowWidth = rowWidth - getScrollbarSize()
+                    flexWidthRef.current = adjustedRowWidth - getColumnsFixedWidth(columns)
 
                     return height && width ? (
                         <div className="overflow-y-hidden overflow-x-auto" style={{ width, height }}>
-                            <LogRowHeader
-                                rowWidth={rowWidth - getScrollbarSize()}
-                                attributeColumns={attributeColumns}
-                                attributeColumnWidths={attributeColumnWidths}
-                                onRemoveAttributeColumn={removeAttributeColumn}
-                                onResizeAttributeColumn={setAttributeColumnWidth}
-                                onMoveAttributeColumn={moveAttributeColumn}
-                                selectedCount={selectedCount}
-                                totalCount={dataSource.length}
-                                onSelectAll={() => selectAll(dataSource)}
-                                onClearSelection={clearSelection}
-                                orderBy={orderBy}
-                                onChangeOrderBy={onChangeOrderBy}
-                            />
+                            <LogRowHeader columns={columns} rowWidth={adjustedRowWidth} />
                             <List<LogsListRowProps>
                                 style={{ height: height - LOG_ROW_HEADER_HEIGHT, width: rowWidth }}
                                 overscanCount={10}
                                 rowCount={dataSource.length}
                                 rowHeight={dynamicRowHeight}
                                 rowComponent={LogsListRow}
-                                rowProps={createRowProps(rowWidth - getScrollbarSize())}
+                                rowProps={createRowProps(adjustedRowWidth)}
                                 listRef={listRef}
                                 onRowsRendered={handleRowsRendered}
                             />

--- a/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/columnDefinitions.tsx
@@ -1,0 +1,290 @@
+import { useActions, useValues } from 'kea'
+import type { RefObject } from 'react'
+
+import { IconArrowLeft, IconArrowRight, IconChevronRight, IconEllipsis, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonMenu, Tooltip } from '@posthog/lemon-ui'
+
+import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
+import { TZLabel, TZLabelProps } from 'lib/components/TZLabel'
+import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
+import { cn } from 'lib/utils/css-classes'
+
+import { LogMessage } from '~/queries/schema/schema-general'
+
+import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
+import { AttributeCell } from 'products/logs/frontend/components/VirtualizedLogsList/cells/AttributeCell'
+import { MessageCell } from 'products/logs/frontend/components/VirtualizedLogsList/cells/MessageCell'
+import {
+    CHECKBOX_WIDTH,
+    EXPAND_WIDTH,
+    MESSAGE_MIN_WIDTH,
+    MIN_ATTRIBUTE_COLUMN_WIDTH,
+    RESIZER_HANDLE_WIDTH,
+    SEVERITY_WIDTH,
+    TIMESTAMP_WIDTH,
+    getMessageStyle,
+} from 'products/logs/frontend/components/VirtualizedLogsList/layoutUtils'
+import { VirtualizedTableColumn } from 'products/logs/frontend/components/VirtualizedLogsList/types'
+import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
+
+const SEVERITY_BAR_COLORS: Record<LogMessage['severity_text'], string> = {
+    trace: 'bg-muted-alt',
+    debug: 'bg-muted',
+    info: 'bg-brand-blue',
+    warn: 'bg-warning',
+    error: 'bg-danger',
+    fatal: 'bg-danger-dark',
+}
+
+// Cell components that read per-row state from kea — avoids baking
+// frequently-changing state into column closures.
+
+function ControlsCell({ log }: { log: ParsedLogMessage }): JSX.Element {
+    const { selectedLogIds, expandedLogIds } = useValues(logsViewerLogic)
+    const { toggleSelectLog, toggleExpandLog } = useActions(logsViewerLogic)
+
+    const severityColor = SEVERITY_BAR_COLORS[log.severity_text] ?? 'bg-muted-3000'
+    const isSelected = !!selectedLogIds[log.uuid]
+    const isExpanded = !!expandedLogIds[log.uuid]
+
+    return (
+        <div className="flex items-center self-stretch">
+            <Tooltip title={log.severity_text.toUpperCase()}>
+                <div className="flex items-stretch self-stretch" style={{ width: SEVERITY_WIDTH, flexShrink: 0 }}>
+                    <div className={cn('w-1 rounded-full', severityColor)} />
+                </div>
+            </Tooltip>
+            <div className="flex items-center justify-center shrink-0" style={{ width: CHECKBOX_WIDTH }}>
+                <LemonCheckbox
+                    checked={isSelected}
+                    onChange={() => toggleSelectLog(log.uuid)}
+                    stopPropagation
+                    size="small"
+                />
+            </div>
+            <div
+                className="flex items-stretch self-stretch justify-center"
+                style={{ width: EXPAND_WIDTH, flexShrink: 0 }}
+            >
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconChevronRight className={cn('transition-transform', isExpanded && 'rotate-90')} />}
+                    onMouseDown={(e) => {
+                        e.stopPropagation()
+                        toggleExpandLog(log.uuid)
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                />
+            </div>
+        </div>
+    )
+}
+
+function ControlsHeader({ dataSourceRef }: { dataSourceRef: RefObject<ParsedLogMessage[]> }): JSX.Element {
+    const { selectedCount } = useValues(logsViewerLogic)
+    const { selectAll, clearSelection } = useActions(logsViewerLogic)
+
+    const totalCount = dataSourceRef.current?.length ?? 0
+    const allSelected = totalCount > 0 && selectedCount === totalCount
+    const someSelected = selectedCount > 0 && selectedCount < totalCount
+
+    return (
+        <div className="flex items-center self-stretch">
+            <div style={{ width: SEVERITY_WIDTH, flexShrink: 0 }} />
+            <div className="flex items-center justify-center shrink-0" style={{ width: CHECKBOX_WIDTH }}>
+                <LemonCheckbox
+                    checked={someSelected ? 'indeterminate' : allSelected}
+                    onChange={() => (allSelected ? clearSelection() : selectAll(dataSourceRef.current ?? undefined))}
+                    size="small"
+                />
+            </div>
+            <div style={{ width: EXPAND_WIDTH, flexShrink: 0 }} />
+        </div>
+    )
+}
+
+function MessageColumnCell({
+    log,
+    wrapBody,
+    prettifyJson,
+    flexWidthRef,
+}: {
+    log: ParsedLogMessage
+    wrapBody: boolean
+    prettifyJson: boolean
+    flexWidthRef: RefObject<number | undefined | null>
+}): JSX.Element {
+    const { prettifiedLogIds } = useValues(logsViewerLogic)
+    const isPrettified = prettifiedLogIds.has(log.uuid)
+
+    return (
+        <MessageCell
+            message={log.cleanBody}
+            wrapBody={isPrettified || wrapBody}
+            prettifyJson={isPrettified || prettifyJson}
+            parsedBody={log.parsedBody}
+            style={getMessageStyle(flexWidthRef.current ?? undefined)}
+        />
+    )
+}
+
+// Column factory functions — only structural/settings params, no per-row state.
+
+export function createControlsColumn(params: {
+    dataSourceRef: RefObject<ParsedLogMessage[]>
+}): VirtualizedTableColumn<ParsedLogMessage> {
+    return {
+        key: 'controls',
+        sizing: { type: 'fixed', width: SEVERITY_WIDTH + CHECKBOX_WIDTH + EXPAND_WIDTH },
+        render: (log) => <ControlsCell log={log} />,
+        renderHeader: () => <ControlsHeader dataSourceRef={params.dataSourceRef} />,
+    }
+}
+
+export function createTimestampColumn(params: {
+    tzLabelFormat: Pick<TZLabelProps, 'formatDate' | 'formatTime' | 'displayTimezone'>
+    orderBy?: LogsOrderBy
+    onChangeOrderBy?: (orderBy: LogsOrderBy) => void
+}): VirtualizedTableColumn<ParsedLogMessage> {
+    const { tzLabelFormat, orderBy, onChangeOrderBy } = params
+
+    return {
+        key: 'timestamp',
+        title: 'Timestamp',
+        sizing: { type: 'fixed', width: TIMESTAMP_WIDTH },
+        render: (log) => (
+            <div className="flex items-center shrink-0" style={{ width: TIMESTAMP_WIDTH }}>
+                <span className="text-xs text-muted font-mono">
+                    <TZLabel time={log.timestamp} {...tzLabelFormat} timestampStyle="absolute" />
+                </span>
+            </div>
+        ),
+        renderHeader: () => (
+            <div
+                className="flex items-center justify-between pr-3 gap-1 h-full border-r"
+                style={{ width: TIMESTAMP_WIDTH, flexShrink: 0 }}
+            >
+                Timestamp
+                <LemonButton
+                    size="xsmall"
+                    className="h-full"
+                    icon={orderBy === 'latest' ? <IconArrowDown /> : <IconArrowUp />}
+                    tooltip={
+                        orderBy === 'latest'
+                            ? 'Showing latest first. Click to show earliest first (reloads).'
+                            : 'Showing earliest first. Click to show latest first (reloads).'
+                    }
+                    onClick={() => {
+                        const newOrderBy = orderBy === 'latest' ? 'earliest' : 'latest'
+                        onChangeOrderBy?.(newOrderBy)
+                    }}
+                    disabled={!orderBy || !onChangeOrderBy}
+                />
+            </div>
+        ),
+    }
+}
+
+export function createAttributeColumn(params: {
+    attributeKey: string
+    width: number
+    onResize?: (attributeKey: string, width: number) => void
+    onRemove?: (attributeKey: string) => void
+    onMove?: (attributeKey: string, direction: 'left' | 'right') => void
+    isFirst: boolean
+    isLast: boolean
+}): VirtualizedTableColumn<ParsedLogMessage> {
+    const { attributeKey, width, onResize, onRemove, onMove, isFirst, isLast } = params
+    const totalWidth = width + RESIZER_HANDLE_WIDTH
+
+    return {
+        key: `attr:${attributeKey}`,
+        title: attributeKey,
+        sizing: { type: 'resizable', width, minWidth: MIN_ATTRIBUTE_COLUMN_WIDTH },
+        render: (log) => {
+            const attrValue = log.attributes[attributeKey] ?? log.resource_attributes[attributeKey]
+            return (
+                <AttributeCell
+                    attributeKey={attributeKey}
+                    value={attrValue != null ? String(attrValue) : ''}
+                    width={totalWidth}
+                />
+            )
+        },
+        renderHeader: () => (
+            <ResizableElement
+                defaultWidth={totalWidth}
+                minWidth={MIN_ATTRIBUTE_COLUMN_WIDTH + RESIZER_HANDLE_WIDTH}
+                maxWidth={Infinity}
+                onResize={(newWidth) => onResize?.(attributeKey, newWidth - RESIZER_HANDLE_WIDTH)}
+                className="flex items-center h-full shrink-0 group/header"
+                innerClassName="h-full"
+            >
+                <div className="flex items-center pr-3 gap-1 h-full w-full">
+                    <span className="truncate flex-1" title={attributeKey}>
+                        {attributeKey}
+                    </span>
+                    {(onRemove || onMove) && (
+                        <LemonMenu
+                            items={[
+                                onMove
+                                    ? {
+                                          label: 'Move left',
+                                          icon: <IconArrowLeft />,
+                                          disabledReason: isFirst ? 'Already at the start' : undefined,
+                                          onClick: () => onMove(attributeKey, 'left'),
+                                      }
+                                    : null,
+                                onMove
+                                    ? {
+                                          label: 'Move right',
+                                          icon: <IconArrowRight />,
+                                          disabledReason: isLast ? 'Already at the end' : undefined,
+                                          onClick: () => onMove(attributeKey, 'right'),
+                                      }
+                                    : null,
+                                onRemove
+                                    ? {
+                                          label: 'Remove column',
+                                          icon: <IconTrash />,
+                                          status: 'danger' as const,
+                                          onClick: () => onRemove(attributeKey),
+                                      }
+                                    : null,
+                            ]}
+                        >
+                            <LemonButton
+                                size="xsmall"
+                                noPadding
+                                icon={<IconEllipsis className="text-muted" />}
+                                className="shrink-0"
+                            />
+                        </LemonMenu>
+                    )}
+                </div>
+            </ResizableElement>
+        ),
+    }
+}
+
+export function createMessageColumn(params: {
+    wrapBody: boolean
+    prettifyJson: boolean
+    flexWidthRef: RefObject<number | undefined | null>
+}): VirtualizedTableColumn<ParsedLogMessage> {
+    const { wrapBody, prettifyJson, flexWidthRef } = params
+
+    return {
+        key: 'message',
+        title: 'Message',
+        sizing: { type: 'flex', minWidth: MESSAGE_MIN_WIDTH },
+        render: (log) => (
+            <MessageColumnCell log={log} wrapBody={wrapBody} prettifyJson={prettifyJson} flexWidthRef={flexWidthRef} />
+        ),
+        renderHeader: () => (
+            <div className="flex items-center px-1" style={getMessageStyle(flexWidthRef.current ?? undefined)}>
+                Message
+            </div>
+        ),
+    }
+}

--- a/products/logs/frontend/components/VirtualizedLogsList/layoutUtils.ts
+++ b/products/logs/frontend/components/VirtualizedLogsList/layoutUtils.ts
@@ -1,5 +1,7 @@
 import type { CSSProperties } from 'react'
 
+import { VirtualizedTableColumn } from 'products/logs/frontend/components/VirtualizedLogsList/types'
+
 // Layout constants for log rows
 export const DEFAULT_ATTRIBUTE_COLUMN_WIDTH = 150
 export const MIN_ATTRIBUTE_COLUMN_WIDTH = 80
@@ -43,3 +45,51 @@ export const getMessageStyle = (flexWidth?: number): CSSProperties => ({
     flexBasis: flexWidth ? Math.max(flexWidth, MESSAGE_MIN_WIDTH) : MESSAGE_MIN_WIDTH,
     minWidth: MESSAGE_MIN_WIDTH,
 })
+
+// Column-aware layout helpers (used with VirtualizedTableColumn)
+
+/** Sum column widths. When includeFlex is false, flex columns contribute 0. */
+function sumColumnWidths<T extends Record<string, any>>(
+    columns: VirtualizedTableColumn<T>[],
+    includeFlex: boolean
+): number {
+    let totalWidth = 0
+    let resizerCount = 0
+    let gapCount = 0
+
+    for (const col of columns) {
+        if (col.isHidden) {
+            continue
+        }
+        switch (col.sizing.type) {
+            case 'fixed':
+                totalWidth += col.sizing.width
+                gapCount++
+                break
+            case 'resizable':
+                totalWidth += col.sizing.width
+                resizerCount++
+                gapCount++
+                break
+            case 'flex':
+                if (includeFlex) {
+                    totalWidth += col.sizing.minWidth
+                }
+                gapCount++
+                break
+        }
+    }
+
+    const gaps = Math.max(0, gapCount - 1) * ROW_GAP
+    return totalWidth + resizerCount * RESIZER_HANDLE_WIDTH + gaps
+}
+
+/** Total width of all non-flex columns including gaps and resizer handles */
+export function getColumnsFixedWidth<T extends Record<string, any>>(columns: VirtualizedTableColumn<T>[]): number {
+    return sumColumnWidths(columns, false)
+}
+
+/** Minimum row width (flex columns contribute their minWidth) */
+export function getColumnsMinRowWidth<T extends Record<string, any>>(columns: VirtualizedTableColumn<T>[]): number {
+    return sumColumnWidths(columns, true)
+}

--- a/products/logs/frontend/components/VirtualizedLogsList/types.ts
+++ b/products/logs/frontend/components/VirtualizedLogsList/types.ts
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react'
+
+import { LemonTableColumn } from 'lib/lemon-ui/LemonTable/types'
+
+export type VirtualizedColumnSizing =
+    | { type: 'fixed'; width: number }
+    | { type: 'resizable'; width: number; minWidth: number; maxWidth?: number }
+    | { type: 'flex'; minWidth: number }
+
+export interface VirtualizedTableColumn<T extends Record<string, any>> extends Pick<
+    LemonTableColumn<T, keyof T | undefined>,
+    'key' | 'title' | 'align' | 'tooltip' | 'isHidden'
+> {
+    /** How the column width is determined */
+    sizing: VirtualizedColumnSizing
+    /** Render cell content */
+    render: (record: T, recordIndex: number) => ReactNode
+    /** Render header content (defaults to `title` if omitted) */
+    renderHeader?: () => ReactNode
+    /** Per-cell className */
+    className?: string
+}


### PR DESCRIPTION
## Problem

The logs viewer virtualized table has its column layout hardcoded as inline JSX across `LogRow.tsx`, `LogRowHeader.tsx`, and `layoutUtils.ts`. Adding, removing, or reordering columns requires editing multiple files. This blocks future work on user-configurable columns and persisting column layouts to the database.

## Changes

- Introduce `VirtualizedTableColumn<T>` type extending `LemonTableColumn` via `Pick` (shared base with LemonTable)
- Create column factory functions (`createControlsColumn`, `createTimestampColumn`, `createAttributeColumn`, `createMessageColumn`) that encapsulate all cell and header rendering
- Refactor `LogRow` and `LogRowHeader` to render from a columns array instead of hardcoded JSX
- Per-row state (selection, expansion, prettify) read from kea inside cell components — columns are memoized on structural deps only
- `flexWidth` accessed via ref to avoid column rebuilds on resize
- Deduplicate `getColumnsFixedWidth`/`getColumnsMinRowWidth` into shared `sumColumnWidths` helper

No visual changes — pixel-identical output.

## How did you test this code?

TypeScript check passes with zero errors in changed files. This is a pure refactor with no visual or behavioral changes — the column factories produce the exact same JSX that was previously hardcoded.

## Publish to changelog?

no