### PR TITLE
chore(ph-ai): persist AI consent popover dismissal to localStorage

### DIFF
--- a/frontend/src/scenes/max/maxGlobalLogic.tsx
+++ b/frontend/src/scenes/max/maxGlobalLogic.tsx
@@ -21,6 +21,7 @@ import { maxLogic, mergeConversationHistory } from './maxLogic'
 
 // Keep this stored across all projects, only display this once per device
 const AI_LIABILITY_NOTICE_STORAGE_KEY = 'posthog_ai_liability_notice_dismissed'
+const AI_DATA_PROCESSING_DISMISSED_STORAGE_KEY = 'posthog_ai_data_processing_dismissed'
 
 /** Tools available everywhere. These CAN be shadowed by contextual tools for scene-specific handling (e.g. to intercept insight creation). */
 export const STATIC_TOOLS: ToolRegistration[] = [
@@ -158,6 +159,7 @@ export const maxGlobalLogic = kea<maxGlobalLogicType>([
         ],
         dataProcessingDismissed: [
             false,
+            { persist: true, storageKey: AI_DATA_PROCESSING_DISMISSED_STORAGE_KEY },
             {
                 dismissDataProcessing: () => true,
             },


### PR DESCRIPTION
## Problem

Customer sees the AI consent popover on every page load. Clicking "Cancel" only dismisses it in-memory, so it reappears on every reload, annoying.

## Changes

- persist the `dataProcessingDismissed` reducer to `localStorage`