### PR TITLE
fix(insights): Split funnel breakdown by cohort queries

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -172,11 +172,11 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
 
         return sub_query
 
-    def _run_sub_query(self, sub_query: FunnelsQuery) -> FunnelsQueryResponse:
+    def _run_sub_query(self, sub_query: FunnelsQuery, series_index: int = 0) -> FunnelsQueryResponse:
         runner = FunnelsQueryRunner(
             query=sub_query,
             team=self.team,
-            timings=self.timings,
+            timings=self.timings.clone_for_subquery(series_index),
             modifiers=self.modifiers,
             limit_context=self.limit_context,
             just_summarize=self.just_summarize,
@@ -209,12 +209,12 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
 
         if connection.in_atomic_block:
             # Inside a transaction (e.g. tests) — threads can't see uncommitted data
-            in_response = self._run_sub_query(in_query)
-            not_in_response = self._run_sub_query(not_in_query)
+            in_response = self._run_sub_query(in_query, series_index=0)
+            not_in_response = self._run_sub_query(not_in_query, series_index=1)
         else:
             with ThreadPoolExecutor(max_workers=2) as executor:
-                in_future = executor.submit(self._run_sub_query, in_query)
-                not_in_future = executor.submit(self._run_sub_query, not_in_query)
+                in_future = executor.submit(self._run_sub_query, in_query, 0)
+                not_in_future = executor.submit(self._run_sub_query, not_in_query, 1)
                 in_response = in_future.result()
                 not_in_response = not_in_future.result()
 

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -223,6 +223,7 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
 
         funnelVizType = self.context.funnelsFilter.funnelVizType
 
+        results: list[dict[str, Any]] | list[list[dict[str, Any]]]
         if funnelVizType == FunnelVizType.TRENDS:
             results = self._merge_trends_results(in_response.results, not_in_response.results, cohort_id, cohort_name)
         else:

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -1,3 +1,4 @@
+import threading
 from datetime import datetime, timedelta
 from math import ceil
 from typing import Any, Optional
@@ -175,21 +176,29 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
 
         return sub_query
 
-    def _run_sub_query(self, sub_query: FunnelsQuery, series_index: int = 0) -> FunnelsQueryResponse:
-        runner = FunnelsQueryRunner(
-            query=sub_query,
-            team=self.team,
-            timings=self.timings.clone_for_subquery(series_index),
-            modifiers=self.modifiers,
-            limit_context=self.limit_context,
-            just_summarize=self.just_summarize,
-        )
-        return runner._calculate_single_query()
+    def _run_sub_query(
+        self, sub_query: FunnelsQuery, series_index: int, is_parallel: bool, results: list, errors: list
+    ) -> None:
+        try:
+            runner = FunnelsQueryRunner(
+                query=sub_query,
+                team=self.team,
+                timings=self.timings.clone_for_subquery(series_index),
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+                just_summarize=self.just_summarize,
+            )
+            results[series_index] = runner._calculate_single_query()
+        except Exception as e:
+            errors.append(e)
+        finally:
+            if is_parallel:
+                from django.db import connection
+
+                connection.close()
 
     def _calculate_single_cohort_breakdown(self) -> FunnelsQueryResponse:
-        from concurrent.futures import ThreadPoolExecutor
-
-        from django.db import connection
+        from django.conf import settings
 
         cohort_id = self._single_cohort_id
         assert cohort_id is not None
@@ -210,16 +219,29 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         in_query = self._create_cohort_sub_query(cohort_id, negate=False)
         not_in_query = self._create_cohort_sub_query(cohort_id, negate=True)
 
-        if connection.in_atomic_block:
-            # Inside a transaction (e.g. tests) — threads can't see uncommitted data
-            in_response = self._run_sub_query(in_query, series_index=0)
-            not_in_response = self._run_sub_query(not_in_query, series_index=1)
+        results: list[FunnelsQueryResponse | None] = [None, None]
+        errors: list[Exception] = []
+        is_parallel = not settings.IN_UNIT_TESTING
+
+        if is_parallel:
+            jobs = [
+                threading.Thread(target=self._run_sub_query, args=(in_query, 0, True, results, errors)),
+                threading.Thread(target=self._run_sub_query, args=(not_in_query, 1, True, results, errors)),
+            ]
+            for j in jobs:
+                j.start()
+            for j in jobs:
+                j.join()
         else:
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                in_future = executor.submit(self._run_sub_query, in_query, 0)
-                not_in_future = executor.submit(self._run_sub_query, not_in_query, 1)
-                in_response = in_future.result()
-                not_in_response = not_in_future.result()
+            self._run_sub_query(in_query, 0, False, results, errors)
+            self._run_sub_query(not_in_query, 1, False, results, errors)
+
+        if errors:
+            raise errors[0]
+
+        in_response = results[0]
+        not_in_response = results[1]
+        assert in_response is not None and not_in_response is not None
 
         timings = [*(in_response.timings or []), *(not_in_response.timings or [])]
         hogql = in_response.hogql or ""

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -27,6 +27,8 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
+from posthog.clickhouse import query_tagging
+from posthog.clickhouse.query_tagging import QueryTags
 from posthog.hogql_queries.insights.funnels import FunnelTrendsUDF, FunnelUDF
 from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
 from posthog.hogql_queries.insights.funnels.funnel_time_to_convert import FunnelTimeToConvertUDF
@@ -101,8 +103,8 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         return None
 
     def _calculate(self):
-        funnelVizType = self.context.funnelsFilter.funnelVizType
-        if self._single_cohort_id is not None and funnelVizType != FunnelVizType.TIME_TO_CONVERT:
+        funnel_viz_type = self.context.funnelsFilter.funnelVizType
+        if self._single_cohort_id is not None and funnel_viz_type != FunnelVizType.TIME_TO_CONVERT:
             return self._calculate_single_cohort_breakdown()
 
         return self._calculate_single_query()
@@ -177,9 +179,18 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         return sub_query
 
     def _run_sub_query(
-        self, sub_query: FunnelsQuery, series_index: int, is_parallel: bool, results: list, errors: list
+        self,
+        sub_query: FunnelsQuery,
+        series_index: int,
+        is_parallel: bool,
+        responses: list,
+        errors: list,
+        query_tags: QueryTags | None = None,
     ) -> None:
         try:
+            if query_tags:
+                query_tagging.update_tags(query_tags)
+
             runner = FunnelsQueryRunner(
                 query=sub_query,
                 team=self.team,
@@ -188,7 +199,7 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
                 limit_context=self.limit_context,
                 just_summarize=self.just_summarize,
             )
-            results[series_index] = runner._calculate_single_query()
+            responses[series_index] = runner._calculate_single_query()
         except Exception as e:
             errors.append(e)
         finally:
@@ -219,37 +230,38 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         in_query = self._create_cohort_sub_query(cohort_id, negate=False)
         not_in_query = self._create_cohort_sub_query(cohort_id, negate=True)
 
-        results: list[FunnelsQueryResponse | None] = [None, None]
+        responses: list[FunnelsQueryResponse | None] = [None, None]
         errors: list[Exception] = []
         is_parallel = not settings.IN_UNIT_TESTING
 
         if is_parallel:
+            tags = query_tagging.get_query_tags().model_copy(deep=True)
             jobs = [
-                threading.Thread(target=self._run_sub_query, args=(in_query, 0, True, results, errors)),
-                threading.Thread(target=self._run_sub_query, args=(not_in_query, 1, True, results, errors)),
+                threading.Thread(target=self._run_sub_query, args=(in_query, 0, True, responses, errors, tags)),
+                threading.Thread(target=self._run_sub_query, args=(not_in_query, 1, True, responses, errors, tags)),
             ]
             for j in jobs:
                 j.start()
             for j in jobs:
                 j.join()
         else:
-            self._run_sub_query(in_query, 0, False, results, errors)
-            self._run_sub_query(not_in_query, 1, False, results, errors)
+            self._run_sub_query(in_query, 0, False, responses, errors)
+            self._run_sub_query(not_in_query, 1, False, responses, errors)
 
         if errors:
             raise errors[0]
 
-        in_response = results[0]
-        not_in_response = results[1]
+        in_response = responses[0]
+        not_in_response = responses[1]
         assert in_response is not None and not_in_response is not None
 
         timings = [*(in_response.timings or []), *(not_in_response.timings or [])]
         hogql = in_response.hogql or ""
 
-        funnelVizType = self.context.funnelsFilter.funnelVizType
+        funnel_viz_type = self.context.funnelsFilter.funnelVizType
 
         results: list[dict[str, Any]] | list[list[dict[str, Any]]]
-        if funnelVizType == FunnelVizType.TRENDS:
+        if funnel_viz_type == FunnelVizType.TRENDS:
             results = self._merge_trends_results(in_response.results, not_in_response.results, cohort_id, cohort_name)
         else:
             results = self._merge_steps_results(in_response.results, not_in_response.results, cohort_id, cohort_name)

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -1,4 +1,3 @@
-import threading
 from datetime import datetime, timedelta
 from math import ceil
 from typing import Any, Optional
@@ -27,8 +26,6 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
-from posthog.clickhouse import query_tagging
-from posthog.clickhouse.query_tagging import QueryTags
 from posthog.hogql_queries.insights.funnels import FunnelTrendsUDF, FunnelUDF
 from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQueryContext
 from posthog.hogql_queries.insights.funnels.funnel_time_to_convert import FunnelTimeToConvertUDF
@@ -178,39 +175,18 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
 
         return sub_query
 
-    def _run_sub_query(
-        self,
-        sub_query: FunnelsQuery,
-        series_index: int,
-        is_parallel: bool,
-        responses: list,
-        errors: list,
-        query_tags: QueryTags | None = None,
-    ) -> None:
-        try:
-            if query_tags:
-                query_tagging.update_tags(query_tags)
-
-            runner = FunnelsQueryRunner(
-                query=sub_query,
-                team=self.team,
-                timings=self.timings.clone_for_subquery(series_index),
-                modifiers=self.modifiers,
-                limit_context=self.limit_context,
-                just_summarize=self.just_summarize,
-            )
-            responses[series_index] = runner._calculate_single_query()
-        except Exception as e:
-            errors.append(e)
-        finally:
-            if is_parallel:
-                from django.db import connection
-
-                connection.close()
+    def _run_sub_query(self, sub_query: FunnelsQuery) -> FunnelsQueryResponse:
+        runner = FunnelsQueryRunner(
+            query=sub_query,
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+            just_summarize=self.just_summarize,
+        )
+        return runner._calculate_single_query()
 
     def _calculate_single_cohort_breakdown(self) -> FunnelsQueryResponse:
-        from django.conf import settings
-
         cohort_id = self._single_cohort_id
         assert cohort_id is not None
 
@@ -230,30 +206,8 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         in_query = self._create_cohort_sub_query(cohort_id, negate=False)
         not_in_query = self._create_cohort_sub_query(cohort_id, negate=True)
 
-        responses: list[FunnelsQueryResponse | None] = [None, None]
-        errors: list[Exception] = []
-        is_parallel = not settings.IN_UNIT_TESTING
-
-        if is_parallel:
-            tags = query_tagging.get_query_tags().model_copy(deep=True)
-            jobs = [
-                threading.Thread(target=self._run_sub_query, args=(in_query, 0, True, responses, errors, tags)),
-                threading.Thread(target=self._run_sub_query, args=(not_in_query, 1, True, responses, errors, tags)),
-            ]
-            for j in jobs:
-                j.start()
-            for j in jobs:
-                j.join()
-        else:
-            self._run_sub_query(in_query, 0, False, responses, errors)
-            self._run_sub_query(not_in_query, 1, False, responses, errors)
-
-        if errors:
-            raise errors[0]
-
-        in_response = responses[0]
-        not_in_response = responses[1]
-        assert in_response is not None and not_in_response is not None
+        in_response = self._run_sub_query(in_query)
+        not_in_response = self._run_sub_query(not_in_query)
 
         timings = [*(in_response.timings or []), *(not_in_response.timings or [])]
         hogql = in_response.hogql or ""

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -3,11 +3,17 @@ from math import ceil
 from typing import Any, Optional
 
 from posthog.schema import (
+    BreakdownType,
     CachedFunnelsQueryResponse,
+    CohortPropertyFilter,
+    FilterLogicalOperator,
     FunnelsQuery,
     FunnelsQueryResponse,
     FunnelVizType,
     HogQLQueryModifiers,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
+    PropertyOperator,
     ResolvedDateRangeResponse,
 )
 
@@ -24,7 +30,9 @@ from posthog.hogql_queries.insights.funnels.funnel_time_to_convert import Funnel
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
+from posthog.models.cohort import Cohort
 from posthog.models.filters.mixins.utils import cached_property
+from posthog.queries.breakdown_props import NOT_IN_COHORT_ID
 
 
 class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
@@ -71,7 +79,30 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
     def to_actors_query(self) -> ast.SelectQuery:
         return self.funnel_actor_class.actor_query()
 
+    @cached_property
+    def _single_cohort_id(self) -> int | None:
+        """Returns the cohort ID if this is a single-cohort breakdown, else None."""
+        bf = self.query.breakdownFilter
+        if not bf or bf.breakdown_type != BreakdownType.COHORT:
+            return None
+        breakdown = bf.breakdown
+        if isinstance(breakdown, list) and len(breakdown) == 1 and breakdown[0] != "all":
+            try:
+                return int(breakdown[0])
+            except (ValueError, TypeError):
+                return None
+        if isinstance(breakdown, int):
+            return breakdown
+        return None
+
     def _calculate(self):
+        funnelVizType = self.context.funnelsFilter.funnelVizType
+        if self._single_cohort_id is not None and funnelVizType != FunnelVizType.TIME_TO_CONVERT:
+            return self._calculate_single_cohort_breakdown()
+
+        return self._calculate_single_query()
+
+    def _calculate_single_query(self):
         query = self.to_query()
         timings = []
 
@@ -107,6 +138,134 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
                 date_to=self.query_date_range.date_to(),
             ),
         )
+
+    def _create_cohort_sub_query(self, cohort_id: int, negate: bool) -> FunnelsQuery:
+        """Create a copy of the query filtered to cohort members (or non-members), with breakdown removed."""
+        sub_query = self.query.model_copy(deep=True)
+        sub_query.breakdownFilter = None
+
+        cohort_filter = CohortPropertyFilter(
+            key="id",
+            value=cohort_id,
+            operator=PropertyOperator.NOT_IN if negate else PropertyOperator.IN_,
+        )
+
+        existing_props = sub_query.properties or []
+        if isinstance(existing_props, list):
+            sub_query.properties = [*existing_props, cohort_filter]
+        else:
+            # PropertyGroupFilter — wrap with AND at the top level
+            sub_query.properties = PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    *existing_props.values,
+                    PropertyGroupFilterValue(
+                        type=FilterLogicalOperator.AND_,
+                        values=[cohort_filter],
+                    ),
+                ],
+            )
+
+        return sub_query
+
+    def _run_sub_query(self, sub_query: FunnelsQuery) -> FunnelsQueryResponse:
+        runner = FunnelsQueryRunner(
+            query=sub_query,
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+            just_summarize=self.just_summarize,
+        )
+        return runner._calculate_single_query()
+
+    def _calculate_single_cohort_breakdown(self) -> FunnelsQueryResponse:
+        cohort_id = self._single_cohort_id
+        assert cohort_id is not None
+
+        try:
+            cohort = Cohort.objects.get(pk=cohort_id, team__project_id=self.team.project_id)
+            cohort_name = cohort.name
+        except Cohort.DoesNotExist:
+            cohort_name = str(cohort_id)
+
+        in_query = self._create_cohort_sub_query(cohort_id, negate=False)
+        not_in_query = self._create_cohort_sub_query(cohort_id, negate=True)
+
+        in_response = self._run_sub_query(in_query)
+        not_in_response = self._run_sub_query(not_in_query)
+
+        timings = [*(in_response.timings or []), *(not_in_response.timings or [])]
+        hogql = in_response.hogql or ""
+
+        funnelVizType = self.context.funnelsFilter.funnelVizType
+
+        if funnelVizType == FunnelVizType.TRENDS:
+            results = self._merge_trends_results(in_response.results, not_in_response.results, cohort_id, cohort_name)
+        else:
+            results = self._merge_steps_results(in_response.results, not_in_response.results, cohort_id, cohort_name)
+
+        return FunnelsQueryResponse(
+            results=results,
+            timings=timings,
+            hogql=hogql,
+            modifiers=self.modifiers,
+            resolved_date_range=ResolvedDateRangeResponse(
+                date_from=self.query_date_range.date_from(),
+                date_to=self.query_date_range.date_to(),
+            ),
+        )
+
+    def _empty_steps(self) -> list[dict[str, Any]]:
+        """Generate zero-count step dicts for when a sub-query returns no results."""
+        steps = []
+        for index, step in enumerate(self.query.series):
+            serialized = self.funnel_class._serialize_step(step, 0, index, [])
+            serialized.update({"average_conversion_time": None, "median_conversion_time": None})
+            steps.append(serialized)
+        return steps
+
+    def _merge_steps_results(
+        self,
+        in_results: list,
+        not_in_results: list,
+        cohort_id: int,
+        cohort_name: str,
+    ) -> list[list[dict[str, Any]]]:
+        # Without a breakdown, _format_results returns a flat list of step dicts.
+        # With a breakdown, the frontend expects a list of lists (one per breakdown value).
+        in_steps = in_results if isinstance(in_results, list) and in_results else self._empty_steps()
+        not_in_steps = not_in_results if isinstance(not_in_results, list) and not_in_results else self._empty_steps()
+
+        for step in in_steps:
+            step["breakdown"] = cohort_name
+            step["breakdown_value"] = cohort_id
+
+        not_in_label = f"Not in {cohort_name}"
+        for step in not_in_steps:
+            step["breakdown"] = not_in_label
+            step["breakdown_value"] = NOT_IN_COHORT_ID
+
+        return [in_steps, not_in_steps]
+
+    def _merge_trends_results(
+        self,
+        in_results: list,
+        not_in_results: list,
+        cohort_id: int,
+        cohort_name: str,
+    ) -> list[dict[str, Any]]:
+        # Trends _format_results returns a list of dicts, each with optional breakdown_value.
+        # For single-cohort split, each sub-query returns one group (no breakdown_value key).
+        not_in_label = f"Not in {cohort_name}"
+
+        for entry in in_results:
+            entry["breakdown_value"] = cohort_name
+
+        for entry in not_in_results:
+            entry["breakdown_value"] = not_in_label
+
+        return [*in_results, *not_in_results]
 
     @cached_property
     def funnel_order_class(self):

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -2,6 +2,8 @@ from datetime import datetime, timedelta
 from math import ceil
 from typing import Any, Optional
 
+import structlog
+
 from posthog.schema import (
     BreakdownType,
     CachedFunnelsQueryResponse,
@@ -33,6 +35,8 @@ from posthog.models import Team
 from posthog.models.cohort import Cohort
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.queries.breakdown_props import NOT_IN_COHORT_ID
+
+logger = structlog.get_logger(__name__)
 
 
 class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
@@ -180,20 +184,39 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         return runner._calculate_single_query()
 
     def _calculate_single_cohort_breakdown(self) -> FunnelsQueryResponse:
+        from concurrent.futures import ThreadPoolExecutor
+
+        from django.db import connection
+
         cohort_id = self._single_cohort_id
         assert cohort_id is not None
 
         try:
             cohort = Cohort.objects.get(pk=cohort_id, team__project_id=self.team.project_id)
-            cohort_name = cohort.name
+            cohort_name = cohort.name or str(cohort_id)
         except Cohort.DoesNotExist:
             cohort_name = str(cohort_id)
+
+        logger.info(
+            "funnel_single_cohort_split",
+            cohort_id=cohort_id,
+            cohort_name=cohort_name,
+            team_id=self.team.pk,
+        )
 
         in_query = self._create_cohort_sub_query(cohort_id, negate=False)
         not_in_query = self._create_cohort_sub_query(cohort_id, negate=True)
 
-        in_response = self._run_sub_query(in_query)
-        not_in_response = self._run_sub_query(not_in_query)
+        if connection.in_atomic_block:
+            # Inside a transaction (e.g. tests) — threads can't see uncommitted data
+            in_response = self._run_sub_query(in_query)
+            not_in_response = self._run_sub_query(not_in_query)
+        else:
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                in_future = executor.submit(self._run_sub_query, in_query)
+                not_in_future = executor.submit(self._run_sub_query, not_in_query)
+                in_response = in_future.result()
+                not_in_response = not_in_future.result()
 
         timings = [*(in_response.timings or []), *(not_in_response.timings or [])]
         hogql = in_response.hogql or ""

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -158,11 +158,14 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
         if isinstance(existing_props, list):
             sub_query.properties = [*existing_props, cohort_filter]
         else:
-            # PropertyGroupFilter — wrap with AND at the top level
+            # PropertyGroupFilter — preserve existing group semantics (e.g. OR) as a nested value
             sub_query.properties = PropertyGroupFilter(
                 type=FilterLogicalOperator.AND_,
                 values=[
-                    *existing_props.values,
+                    PropertyGroupFilterValue(
+                        type=existing_props.type,
+                        values=existing_props.values,
+                    ),
                     PropertyGroupFilterValue(
                         type=FilterLogicalOperator.AND_,
                         values=[cohort_filter],

--- a/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
+++ b/posthog/hogql_queries/insights/funnels/test/breakdown_cases.py
@@ -1623,6 +1623,75 @@ def funnel_breakdown_test_factory(funnel_order_type: FunnelOrderType):
             assert not_in_cohort_results[0]["count"] == 1
             assert not_in_cohort_results[1]["count"] == 1
 
+        def test_funnel_single_cohort_breakdown_no_matching_events(self):
+            # Cohort exists with members, but no one performs the funnel events
+            _create_person(
+                distinct_ids=["person_in_cohort"],
+                team_id=self.team.pk,
+                properties={"key": "value"},
+            )
+
+            cohort = Cohort.objects.create(
+                team=self.team,
+                name="no_events_cohort",
+                groups=[{"properties": [{"key": "key", "value": "value", "type": "person"}]}],
+            )
+            cohort.calculate_people_ch(pending_version=0)
+
+            query = FunnelsQuery(
+                series=[
+                    EventsNode(event="sign up"),
+                    EventsNode(event="play movie"),
+                ],
+                dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-08"),
+                funnelsFilter=FunnelsFilter(funnelWindowInterval=7),
+                breakdownFilter=BreakdownFilter(
+                    breakdown=[cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+            )
+
+            results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+            assert len(results) == 2
+            breakdown_labels = {r[0]["breakdown"] for r in results}
+            assert "no_events_cohort" in breakdown_labels
+            assert "Not in no_events_cohort" in breakdown_labels
+
+            for group in results:
+                assert group[0]["count"] == 0
+                assert group[1]["count"] == 0
+
+        def test_funnel_single_cohort_breakdown_empty_results(self):
+            # No events at all — both groups should return zero-count steps
+            cohort = Cohort.objects.create(
+                team=self.team,
+                name="empty_cohort",
+                groups=[{"properties": [{"key": "key", "value": "value", "type": "person"}]}],
+            )
+            cohort.calculate_people_ch(pending_version=0)
+
+            query = FunnelsQuery(
+                series=[
+                    EventsNode(event="sign up"),
+                    EventsNode(event="play movie"),
+                ],
+                dateRange=DateRange(date_from="2020-01-01", date_to="2020-01-08"),
+                funnelsFilter=FunnelsFilter(funnelWindowInterval=7),
+                breakdownFilter=BreakdownFilter(
+                    breakdown=[cohort.pk],
+                    breakdown_type=BreakdownType.COHORT,
+                ),
+            )
+
+            results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+
+            assert len(results) == 2
+
+            for group in results:
+                assert group[0]["count"] == 0
+                assert group[1]["count"] == 0
+
         def test_basic_funnel_default_funnel_days_breakdown_event(self):
             events_by_person = {
                 "user_1": [


### PR DESCRIPTION
## Problem

Can see some funnel breakdowns fail with `UDF_EXECUTION_FAILED` because it's trying to return too much data.

Every instance of this error has been in team 2, I guess as we have most data? But other teams could get it too theoretically!

## Changes

 Instead of running one query with , run two simpler queries in parallel:                                                                      
  1. One filtered to users in the cohort (via a cohort property filter)                                                                                                     
  2. One filtered to users not in the cohort         

Each query filters using a WHERE clause before funnel processing starts, instead of having a single query evaluate cohort membership for every person... so this should be better!                                                                                   
                                                                                                                                                                            
                                                                                                                                                                            
Also edge case handled:                                                                                                                                                       
  - When a sub-query returns no results (e.g. nobody in the cohort performed any events), we generate zero-count placeholder steps so the frontend still renders both groups

## How did you test this code?

The tests I wrote for the original breakdown by funnel, still pass. We've just changed the querying so it's faster
It also works the same locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
