### PR TITLE
feat: Added failing test scenario where multiple queues are processed

### DIFF
--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -1,4 +1,5 @@
 import { chunk } from 'lodash'
+import { Gauge } from 'prom-client'
 
 import { parseJSON } from '~/utils/json-parse'
 
@@ -8,6 +9,11 @@ import { CdpConfig } from '../../config'
 import { CyclotronJobInvocation, CyclotronJobInvocationResult, CyclotronJobQueueKind } from '../../types'
 import { CyclotronV2DequeuedJob, CyclotronV2JobInit, CyclotronV2Manager, CyclotronV2Worker } from '../cyclotron-v2'
 import { cdpJobSizeCompressedKb, cdpJobSizeKb } from './shared'
+
+const pendingJobsGauge = new Gauge({
+    name: 'cdp_cyclotron_v2_pending_jobs',
+    help: 'Number of postgres-v2 jobs currently held in memory awaiting ack/fail/retry',
+})
 
 /**
  * State blob stored in the single `state` BYTEA column.
@@ -74,9 +80,11 @@ export class CyclotronJobQueuePostgresV2 {
                 invocations.push(v2JobToInvocation(job))
             }
 
+            pendingJobsGauge.set(this.pendingJobs.size)
+
             await consumeBatch(invocations)
 
-            // TODO: Some sanity check that all pending jobs are acked or failed
+            pendingJobsGauge.set(this.pendingJobs.size)
         })
     }
 

--- a/nodejs/src/cdp/services/job-queue/job-queue.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.test.ts
@@ -306,17 +306,22 @@ describe('CyclotronJobQueue', () => {
             }
         )
 
-        it('should not release when source matches target', async () => {
-            const queue = buildQueue('*:postgres')
-            const result = createResult('postgres')
+        it.each([
+            { mapping: '*:postgres', queueSource: 'postgres' as const },
+            { mapping: '*:postgres-v2', queueSource: 'postgres-v2' as const },
+        ])(
+            'should not release when source matches target: $mapping / $queueSource',
+            async ({ mapping, queueSource }) => {
+                const queue = buildQueue(mapping)
+                const result = createResult(queueSource)
 
-            await queue.queueInvocationResults([result])
+                await queue.queueInvocationResults([result])
 
-            // Should update, not create+release
-            expect(queue['jobQueuePostgres'].queueInvocationResults).toHaveBeenCalledTimes(1)
-            expect(queue['jobQueuePostgres'].releaseInvocations).not.toHaveBeenCalled()
-            expect(queue['jobQueuePostgresV2']!.releaseInvocations).not.toHaveBeenCalled()
-        })
+                // Should update, not create+release
+                expect(queue['jobQueuePostgres'].releaseInvocations).not.toHaveBeenCalled()
+                expect(queue['jobQueuePostgresV2']!.releaseInvocations).not.toHaveBeenCalled()
+            }
+        )
     })
 })
 

--- a/nodejs/src/cdp/services/job-queue/job-queue.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.test.ts
@@ -5,6 +5,7 @@ import { PluginsServerConfig } from '~/types'
 
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../../_tests/examples'
 import { createHogExecutionGlobals, createHogFunction } from '../../_tests/fixtures'
+import { CyclotronJobInvocationResult, CyclotronJobQueueSource } from '../../types'
 import { createInvocation } from '../../utils/invocation-utils'
 import {
     CyclotronJobQueue,
@@ -227,6 +228,94 @@ describe('CyclotronJobQueue', () => {
 
             expect(queue['jobQueuePostgres'].queueInvocations).toHaveBeenCalledWith([])
             expect(queue['jobQueueKafka'].queueInvocations).toHaveBeenCalledWith(invocations)
+        })
+    })
+
+    describe('queueInvocationResults', () => {
+        const buildQueue = (mapping: string) => {
+            config.CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING = mapping
+            config.CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING = ''
+            const queue = new CyclotronJobQueue(config.CONSUMER_BATCH_SIZE, config.KAFKA_CLIENT_RACK, config)
+
+            // Mock all sub-queue methods
+            queue['jobQueuePostgres'].queueInvocations = jest.fn()
+            queue['jobQueuePostgres'].queueInvocationResults = jest.fn()
+            queue['jobQueuePostgres'].releaseInvocations = jest.fn()
+            queue['jobQueueKafka'].queueInvocations = jest.fn()
+            queue['jobQueueKafka'].queueInvocationResults = jest.fn()
+            queue['jobQueuePostgresV2'] = {
+                queueInvocations: jest.fn(),
+                queueInvocationResults: jest.fn(),
+                releaseInvocations: jest.fn(),
+            } as any
+
+            return queue
+        }
+
+        const createResult = (
+            queueSource: CyclotronJobQueueSource
+        ): CyclotronJobInvocationResult => ({
+            invocation: {
+                ...createInvocation({ ...createHogExecutionGlobals(), inputs: {} }, exampleHogFunction),
+                queueSource,
+            },
+            finished: false,
+            error: null,
+            logs: [],
+            metrics: [],
+            capturedPostHogEvents: [],
+            warehouseWebhookPayloads: [],
+        })
+
+        it.each([
+            {
+                scenario: 'postgres-v2 source routed to postgres target',
+                mapping: '*:postgres',
+                queueSource: 'postgres-v2' as const,
+                expectReleasedFrom: 'jobQueuePostgresV2',
+            },
+            {
+                scenario: 'postgres source routed to postgres-v2 target',
+                mapping: '*:postgres-v2',
+                queueSource: 'postgres' as const,
+                expectReleasedFrom: 'jobQueuePostgres',
+            },
+            {
+                scenario: 'postgres source routed to kafka target',
+                mapping: '*:kafka',
+                queueSource: 'postgres' as const,
+                expectReleasedFrom: 'jobQueuePostgres',
+            },
+            {
+                scenario: 'postgres-v2 source routed to kafka target',
+                mapping: '*:kafka',
+                queueSource: 'postgres-v2' as const,
+                expectReleasedFrom: 'jobQueuePostgresV2',
+            },
+        ])(
+            'should release source job when cross-routing: $scenario',
+            async ({ mapping, queueSource, expectReleasedFrom }) => {
+                const queue = buildQueue(mapping)
+                const result = createResult(queueSource)
+
+                await queue.queueInvocationResults([result])
+
+                expect(
+                    (queue[expectReleasedFrom as keyof typeof queue] as any).releaseInvocations
+                ).toHaveBeenCalledTimes(1)
+            }
+        )
+
+        it('should not release when source matches target', async () => {
+            const queue = buildQueue('*:postgres')
+            const result = createResult('postgres')
+
+            await queue.queueInvocationResults([result])
+
+            // Should update, not create+release
+            expect(queue['jobQueuePostgres'].queueInvocationResults).toHaveBeenCalledTimes(1)
+            expect(queue['jobQueuePostgres'].releaseInvocations).not.toHaveBeenCalled()
+            expect(queue['jobQueuePostgresV2']!.releaseInvocations).not.toHaveBeenCalled()
         })
     })
 })

--- a/nodejs/src/cdp/services/job-queue/job-queue.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.test.ts
@@ -252,9 +252,7 @@ describe('CyclotronJobQueue', () => {
             return queue
         }
 
-        const createResult = (
-            queueSource: CyclotronJobQueueSource
-        ): CyclotronJobInvocationResult => ({
+        const createResult = (queueSource: CyclotronJobQueueSource): CyclotronJobInvocationResult => ({
             invocation: {
                 ...createInvocation({ ...createHogExecutionGlobals(), inputs: {} }, exampleHogFunction),
                 queueSource,

--- a/nodejs/src/cdp/services/job-queue/job-queue.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue.ts
@@ -342,6 +342,14 @@ export class CyclotronJobQueue {
 
         if (postgresInvocationsToCreate.length > 0) {
             promises.push(this.jobQueuePostgres.queueInvocations(postgresInvocationsToCreate.map((x) => x.invocation)))
+
+            // Release postgres-v2 source jobs that are being re-routed to postgres
+            const v2JobsToRelease = postgresInvocationsToCreate
+                .filter((x) => x.invocation.queueSource === 'postgres-v2')
+                .map((x) => x.invocation)
+            if (v2JobsToRelease.length > 0 && this.jobQueuePostgresV2) {
+                promises.push(this.jobQueuePostgresV2.releaseInvocations(v2JobsToRelease))
+            }
         }
 
         if (postgresV2InvocationsToUpdate.length > 0 && this.jobQueuePostgresV2) {
@@ -352,6 +360,14 @@ export class CyclotronJobQueue {
             promises.push(
                 this.jobQueuePostgresV2.queueInvocations(postgresV2InvocationsToCreate.map((x) => x.invocation))
             )
+
+            // Release postgres source jobs that are being re-routed to postgres-v2
+            const pgJobsToRelease = postgresV2InvocationsToCreate
+                .filter((x) => x.invocation.queueSource === 'postgres')
+                .map((x) => x.invocation)
+            if (pgJobsToRelease.length > 0) {
+                promises.push(this.jobQueuePostgres.releaseInvocations(pgJobsToRelease))
+            }
         }
 
         if (kafkaInvocations.length > 0) {


### PR DESCRIPTION
## Problem

We missed a case where jobs moving between postgres v1 and v2 dont get dequeued from the other DB. This is annoying given this is temporary switchover code but nonetheless something we have to make sure is covered

## Changes

* Adds tests for this failure case and fixes the issue

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
