### PR TITLE
fix: upsert session during user creation

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -6,6 +6,7 @@ from urllib.parse import quote, urlencode
 from django import forms
 from django.conf import settings
 from django.contrib.auth import login, password_validation
+from django.contrib.sessions.backends.base import SessionBase, UpdateError
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.shortcuts import redirect
@@ -40,6 +41,15 @@ from posthog.utils import get_can_create_org, is_relative_url
 from posthog.workos_radar import RadarAction, RadarAuthMethod, evaluate_auth_attempt
 
 logger = structlog.get_logger(__name__)
+
+
+def _save_session_with_recovery(session: SessionBase) -> None:
+    """Persist session state and recover from missing-row session races."""
+    try:
+        session.save()
+    except UpdateError:
+        # If another request deleted/recreated this session row, create a new row for this request.
+        session.create()
 
 
 def verify_email_or_login(request: Request, user: User) -> None:
@@ -235,7 +245,7 @@ class SignupSerializer(serializers.Serializer):
             request.session.pop(WEBAUTHN_SIGNUP_CREDENTIAL_KEY, None)
             request.session.pop(WEBAUTHN_SIGNUP_EMAIL_KEY, None)
             request.session.pop(WEBAUTHN_SIGNUP_USER_UUID_KEY, None)
-            request.session.save()
+            _save_session_with_recovery(request.session)
 
         user = self._user
 
@@ -488,7 +498,7 @@ class InviteSignupSerializer(serializers.Serializer):
             request.session.pop(WEBAUTHN_SIGNUP_CREDENTIAL_KEY, None)
             request.session.pop(WEBAUTHN_SIGNUP_EMAIL_KEY, None)
             request.session.pop(WEBAUTHN_SIGNUP_USER_UUID_KEY, None)
-            request.session.save()
+            _save_session_with_recovery(request.session)
 
         return user
 

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -9,6 +9,7 @@ from posthog.test.base import APIBaseTest
 from unittest import mock
 from unittest.mock import ANY, patch
 
+from django.contrib.sessions.backends.base import UpdateError
 from django.core import mail
 from django.core.cache import cache
 from django.urls.base import reverse
@@ -16,6 +17,7 @@ from django.utils import timezone
 
 from rest_framework import status
 
+from posthog.api.signup import _save_session_with_recovery
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.constants import AvailableFeature
 from posthog.models import Dashboard, Organization, Team, User
@@ -1479,6 +1481,25 @@ class TestPasskeySignupAPI(APIBaseTest):
             },
         )
         self.assertEqual(User.objects.count(), count)
+
+
+class TestSignupSessionSaveRecovery(unittest.TestCase):
+    def test_save_session_with_recovery_uses_save_when_row_exists(self):
+        session = mock.Mock()
+
+        _save_session_with_recovery(session)
+
+        session.save.assert_called_once_with()
+        session.create.assert_not_called()
+
+    def test_save_session_with_recovery_recreates_session_on_update_error(self):
+        session = mock.Mock()
+        session.save.side_effect = UpdateError
+
+        _save_session_with_recovery(session)
+
+        session.save.assert_called_once_with()
+        session.create.assert_called_once_with()
 
 
 class TestInviteSignupAPI(APIBaseTest):


### PR DESCRIPTION
## Problem
When creating a user it is possible for the current session to be deleted mid-creation, so we should be upserting the session to prevent race conditions which could cause an unexpected error during user creation.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Upsert the user's session when creating a new user.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
