### PR TITLE
fix(experiments): Hide 100% rollout tag when feature flag is disabled

### DIFF
--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -117,6 +117,7 @@ export function isSingleVariantShipped(experiment: Experiment): boolean {
 
     return (
         !!filters &&
+        experiment.feature_flag?.active !== false &&
         Array.isArray(filters.groups?.[0]?.properties) &&
         filters.groups?.[0]?.properties?.length === 0 &&
         filters.groups?.[0]?.rollout_percentage === 100 &&


### PR DESCRIPTION
## Problem

The "100% rollout" tag only checks release conditions, not whether the feature flag is active. I noticed in a session replay that a user who rolled out an experiment then disabled the flag still sees the tag.

## Changes

Add a `feature_flag.active !== false` check to `isSingleVariantShipped()`.

## How did you test this code?
👀 