### PR TITLE
feat(notifications): Go livestream infrastructure for real-time notifications

### DIFF
--- a/livestream/auth/jwt.go
+++ b/livestream/auth/jwt.go
@@ -13,6 +13,13 @@ import (
 
 const ExpectedScope = "posthog:livestream"
 
+type AuthClaims struct {
+	TeamID         int
+	UserID         int
+	OrganizationID string
+	Token          string
+}
+
 func GetAuth(header http.Header) (jwt.MapClaims, error) {
 	authHeader := header.Get("Authorization")
 	if authHeader == "" {
@@ -26,27 +33,44 @@ func GetAuth(header http.Header) (jwt.MapClaims, error) {
 	return claims, nil
 }
 
-func getDataFromClaims(claims jwt.MapClaims) (teamID int, token string, err error) {
+func ParseAuthClaims(header http.Header) (*AuthClaims, error) {
+	claims, err := GetAuth(header)
+	if err != nil {
+		return nil, err
+	}
+
 	team, ok := claims["team_id"].(float64)
 	if !ok {
-		return 0, "", errors.New("invalid team_id")
+		return nil, errors.New("invalid team_id")
 	}
-	token, ok = claims["api_token"].(string)
+	token, ok := claims["api_token"].(string)
 	if !ok {
-		return 0, "", errors.New("invalid api_token")
+		return nil, errors.New("invalid api_token")
 	}
-	teamID = int(team)
-	return teamID, token, nil
+
+	result := &AuthClaims{
+		TeamID: int(team),
+		Token:  token,
+	}
+
+	// user_id and organization_id are optional for backward compatibility.
+	// TODO: make required after rollout (all tokens refreshed within 7-day TTL)
+	if user, ok := claims["user_id"].(float64); ok {
+		result.UserID = int(user)
+	}
+	if orgID, ok := claims["organization_id"].(string); ok {
+		result.OrganizationID = orgID
+	}
+
+	return result, nil
 }
 
 func GetAuthClaims(header http.Header) (teamID int, token string, err error) {
-	claims, err := GetAuth(header)
+	c, err := ParseAuthClaims(header)
 	if err != nil {
 		return 0, "", err
 	}
-
-	return getDataFromClaims(claims)
-
+	return c.TeamID, c.Token, nil
 }
 
 func decodeAuthToken(authHeader string) (jwt.MapClaims, error) {

--- a/livestream/auth/jwt_test.go
+++ b/livestream/auth/jwt_test.go
@@ -1,85 +1,100 @@
 package auth
 
 import (
-	"github.com/stretchr/testify/assert"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecodeAuthToken(t *testing.T) {
-	// Set up a mock secret for testing
 	viper.Set("jwt.secret", "test-secret")
 
 	tests := []struct {
-		name           string
-		authHeader     string
-		expectError    bool
-		expectedAud    string
-		expectedTeamID int
-		expectedToken  string
+		name        string
+		authHeader  string
+		expectError bool
+		expectedAud string
 	}{
 		{
 			name: "Valid token",
 			authHeader: "Bearer " + createValidToken(ExpectedScope, jwt.MapClaims{
-				"team_id":   123.,
-				"api_token": "token123",
+				"team_id": 123., "api_token": "token123", "user_id": 1., "organization_id": "org-1",
 			}),
-			expectError:    false,
-			expectedAud:    ExpectedScope,
-			expectedTeamID: 123,
-			expectedToken:  "token123",
+			expectedAud: ExpectedScope,
 		},
-		{
-			name:        "Invalid token format",
-			authHeader:  "InvalidToken",
-			expectError: true,
-		},
-		{
-			name:        "Missing Bearer prefix",
-			authHeader:  createValidToken(ExpectedScope, nil),
-			expectError: true,
-		},
-		{
-			name:        "Invalid audience",
-			authHeader:  "Bearer " + createValidToken("invalid:scope", nil),
-			expectError: true,
-		},
-		{
-			name:        "Expired token",
-			authHeader:  "Bearer " + createExpiredToken(),
-			expectError: true,
-		},
-		{
-			name:        "Invalid signature",
-			authHeader:  "Bearer " + createTokenWithInvalidSignature(),
-			expectError: true,
-		},
+		{name: "Invalid token format", authHeader: "InvalidToken", expectError: true},
+		{name: "Missing Bearer prefix", authHeader: createValidToken(ExpectedScope, nil), expectError: true},
+		{name: "Invalid audience", authHeader: "Bearer " + createValidToken("invalid:scope", nil), expectError: true},
+		{name: "Expired token", authHeader: "Bearer " + createExpiredToken(), expectError: true},
+		{name: "Invalid signature", authHeader: "Bearer " + createTokenWithInvalidSignature(), expectError: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			claims, err := decodeAuthToken(tt.authHeader)
-
 			if tt.expectError {
-				if err == nil {
-					t.Errorf("Expected an error, but got nil")
-				}
+				assert.Error(t, err)
 			} else {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if claims["aud"] != tt.expectedAud {
-					t.Errorf("Expected audience %s, but got %s", tt.expectedAud, claims["aud"])
-				}
-				teamID, token, err := getDataFromClaims(claims)
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				assert.Equal(t, tt.expectedTeamID, teamID)
-				assert.Equal(t, tt.expectedToken, token)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedAud, claims["aud"])
+			}
+		})
+	}
+}
+
+func TestParseAuthClaims(t *testing.T) {
+	viper.Set("jwt.secret", "test-secret")
+
+	tests := []struct {
+		name           string
+		claims         jwt.MapClaims
+		expectError    string
+		expectedTeamID int
+		expectedUserID int
+		expectedOrgID  string
+		expectedToken  string
+	}{
+		{
+			name:           "Valid token with all claims",
+			claims:         jwt.MapClaims{"team_id": 123., "api_token": "token123", "user_id": 42., "organization_id": "org-uuid-123"},
+			expectedTeamID: 123, expectedUserID: 42, expectedOrgID: "org-uuid-123", expectedToken: "token123",
+		},
+		{
+			name:           "Backward compat: user_id and organization_id optional",
+			claims:         jwt.MapClaims{"team_id": 123., "api_token": "token123"},
+			expectedTeamID: 123, expectedToken: "token123",
+		},
+		{
+			name:        "Missing team_id",
+			claims:      jwt.MapClaims{"api_token": "token123", "user_id": 42., "organization_id": "org-1"},
+			expectError: "invalid team_id",
+		},
+		{
+			name:        "Missing api_token",
+			claims:      jwt.MapClaims{"team_id": 123., "user_id": 42., "organization_id": "org-1"},
+			expectError: "invalid api_token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := createValidToken(ExpectedScope, tt.claims)
+			header := http.Header{"Authorization": {"Bearer " + token}}
+
+			parsed, err := ParseAuthClaims(header)
+			if tt.expectError != "" {
+				assert.ErrorContains(t, err, tt.expectError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedTeamID, parsed.TeamID)
+				assert.Equal(t, tt.expectedUserID, parsed.UserID)
+				assert.Equal(t, tt.expectedOrgID, parsed.OrganizationID)
+				assert.Equal(t, tt.expectedToken, parsed.Token)
 			}
 		})
 	}

--- a/livestream/configs/configs.go
+++ b/livestream/configs/configs.go
@@ -58,6 +58,8 @@ type KafkaConfig struct {
 	SessionTimeoutMs                 int    `mapstructure:"session_timeout_ms"`
 	HeartbeatIntervalMs              int    `mapstructure:"heartbeat_interval_ms"`
 	MaxPollIntervalMs                int    `mapstructure:"max_poll_interval_ms"`
+	NotificationEnabled              bool   `mapstructure:"notification_enabled"`
+	NotificationTopic                string `mapstructure:"notification_topic"`
 }
 
 func InitConfigs(filename, configPath string) {
@@ -66,6 +68,8 @@ func InitConfigs(filename, configPath string) {
 
 	viper.SetDefault("kafka.group_id", "livestream")
 	viper.SetDefault("kafka.session_recording_enabled", true)
+	viper.SetDefault("kafka.notification_enabled", false)
+	viper.SetDefault("kafka.notification_topic", "notification_events")
 	viper.SetDefault("session_recording.max_lru_entries", 2_000_000_000)
 	viper.SetDefault("redis.flush_interval_ms", 500)
 
@@ -101,6 +105,8 @@ func InitConfigs(filename, configPath string) {
 	_ = viper.BindEnv("kafka.session_timeout_ms")                  // LIVESTREAM_KAFKA_SESSION_TIMEOUT_MS
 	_ = viper.BindEnv("kafka.heartbeat_interval_ms")               // LIVESTREAM_KAFKA_HEARTBEAT_INTERVAL_MS
 	_ = viper.BindEnv("kafka.max_poll_interval_ms")                // LIVESTREAM_KAFKA_MAX_POLL_INTERVAL_MS
+	_ = viper.BindEnv("kafka.notification_enabled")                // LIVESTREAM_KAFKA_NOTIFICATION_ENABLED
+	_ = viper.BindEnv("kafka.notification_topic")                  // LIVESTREAM_KAFKA_NOTIFICATION_TOPIC
 
 	// Postgres settings
 	_ = viper.BindEnv("postgres.url") // LIVESTREAM_POSTGRES_URL

--- a/livestream/events/notification_consumer.go
+++ b/livestream/events/notification_consumer.go
@@ -1,0 +1,97 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/posthog/posthog/livestream/configs"
+	"github.com/posthog/posthog/livestream/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/rueidis"
+)
+
+type NotificationKafkaConsumer struct {
+	consumer    KafkaConsumerInterface
+	topic       string
+	redisClient rueidis.Client
+}
+
+func NewNotificationKafkaConsumer(
+	kafkaConfig configs.KafkaConfig, redisClient rueidis.Client,
+) (*NotificationKafkaConsumer, error) {
+	config := &kafka.ConfigMap{
+		"bootstrap.servers":  kafkaConfig.Brokers,
+		"group.id":           kafkaConfig.GroupID + "-notifications",
+		"auto.offset.reset":  "latest",
+		"enable.auto.commit": false,
+		"security.protocol":  kafkaConfig.SecurityProtocol,
+	}
+
+	applyKafkaConfigOverrides(config, kafkaConfig)
+
+	consumer, err := kafka.NewConsumer(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NotificationKafkaConsumer{
+		consumer:    consumer,
+		topic:       kafkaConfig.NotificationTopic,
+		redisClient: redisClient,
+	}, nil
+}
+
+func (c *NotificationKafkaConsumer) Consume(ctx context.Context) {
+	if err := c.consumer.SubscribeTopics([]string{c.topic}, nil); err != nil {
+		log.Printf("Failed to subscribe to notification topic: %v", err)
+		return
+	}
+	log.Printf("Notification consumer subscribed to topic: %s", c.topic)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		msg, err := c.consumer.ReadMessage(5 * time.Second)
+		if err != nil {
+			if kafkaErr, ok := err.(kafka.Error); ok && kafkaErr.IsTimeout() {
+				continue
+			}
+			log.Printf("Error consuming notification message: %v", err)
+			continue
+		}
+
+		c.processMessage(ctx, msg.Value)
+	}
+}
+
+func (c *NotificationKafkaConsumer) processMessage(ctx context.Context, value []byte) {
+	var data struct {
+		OrganizationID string `json:"organization_id"`
+	}
+	if err := json.Unmarshal(value, &data); err != nil {
+		metrics.NotificationErrors.With(prometheus.Labels{"reason": "invalid_json"}).Inc()
+		return
+	}
+	if data.OrganizationID == "" {
+		metrics.NotificationErrors.With(prometheus.Labels{"reason": "missing_organization_id"}).Inc()
+		return
+	}
+
+	channel := fmt.Sprintf("notifications:%s", data.OrganizationID)
+	cmd := c.redisClient.B().Spublish().Channel(channel).Message(string(value)).Build()
+	if err := c.redisClient.Do(ctx, cmd).Error(); err != nil {
+		log.Printf("Failed to publish notification to Redis: %v", err)
+	}
+}
+
+func (c *NotificationKafkaConsumer) Close() {
+	_ = c.consumer.Close()
+}

--- a/livestream/events/redis_stats.go
+++ b/livestream/events/redis_stats.go
@@ -42,6 +42,11 @@ func NewStatsInRedis(cfg configs.RedisConfig) (*StatsInRedis, error) {
 	return &StatsInRedis{client: client}, nil
 }
 
+// Client returns the underlying Redis client.
+func (s *StatsInRedis) Client() rueidis.Client {
+	return s.client
+}
+
 // Adds a distinct user to a Redis sorted set for the given project token,
 // scored by the current timestamp. The key auto-expires after userKeyTTL.
 func (s *StatsInRedis) AddUser(ctx context.Context, token, distinctId string) error {

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/posthog/posthog/livestream/auth"
 	"github.com/posthog/posthog/livestream/events"
+	"github.com/redis/rueidis"
 )
 
 func Index(c echo.Context) error {
@@ -181,4 +183,110 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 			}
 		}
 	}
+}
+
+func NotificationsHandler(redisClient rueidis.Client) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		claims, err := auth.ParseAuthClaims(c.Request().Header)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, "invalid token")
+		}
+		if claims.OrganizationID == "" || claims.UserID == 0 {
+			// Old tokens without organization_id/user_id — no-op until all tokens refresh
+			return c.NoContent(http.StatusNoContent)
+		}
+
+		ctx := c.Request().Context()
+		channel := fmt.Sprintf("notifications:%s", claims.OrganizationID)
+
+		// Absorbs publish-rate bursts; drops on overflow to avoid blocking rueidis.
+		msgCh := make(chan string, 1000)
+		errCh := make(chan error, 1)
+
+		// Receive respects ctx cancellation — goroutine exits when handler returns.
+		go func() {
+			errCh <- redisClient.Receive(ctx, redisClient.B().Ssubscribe().Channel(channel).Build(), func(msg rueidis.PubSubMessage) {
+				select {
+				case msgCh <- msg.Message:
+				default:
+					log.Printf("Notification dropped for user %d: channel buffer full", claims.UserID)
+				}
+			})
+		}()
+
+		w := c.Response()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		heartbeat := time.NewTicker(15 * time.Second)
+		defer heartbeat.Stop()
+		timeout := time.After(30 * time.Minute)
+
+		for {
+			select {
+			case <-timeout:
+				return nil
+			case <-ctx.Done():
+				return nil
+			case err := <-errCh:
+				if err != nil {
+					log.Printf("Redis subscription error: %v", err)
+				}
+				return nil
+			case msg := <-msgCh:
+				cleaned, ok := filterNotificationForUser(msg, claims.UserID)
+				if !ok {
+					continue
+				}
+				event := Event{Data: []byte(cleaned)}
+				if err := event.WriteTo(w); err != nil {
+					return err
+				}
+				w.Flush()
+			case <-heartbeat.C:
+				event := Event{Comment: []byte("heartbeat")}
+				if err := event.WriteTo(w); err != nil {
+					return err
+				}
+				w.Flush()
+			}
+		}
+	}
+}
+
+func filterNotificationForUser(payload string, userID int) (string, bool) {
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(payload), &data); err != nil {
+		return "", false
+	}
+
+	resolvedIDs, ok := data["resolved_user_ids"]
+	if !ok {
+		return "", false
+	}
+
+	ids, ok := resolvedIDs.([]interface{})
+	if !ok {
+		return "", false
+	}
+
+	found := false
+	for _, id := range ids {
+		if num, ok := id.(float64); ok && int(num) == userID {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return "", false
+	}
+
+	delete(data, "resolved_user_ids")
+	cleaned, err := json.Marshal(data)
+	if err != nil {
+		return "", false
+	}
+	return string(cleaned), true
 }

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -119,6 +119,17 @@ func main() {
 		}
 	}
 
+	if config.Kafka.NotificationEnabled && statsRedis != nil {
+		notifConsumer, err := events.NewNotificationKafkaConsumer(config.Kafka, statsRedis.Client())
+		if err != nil {
+			log.Printf("Failed to create notification Kafka consumer: %v", err)
+		} else {
+			defer notifConsumer.Close()
+			go notifConsumer.Consume(ctx)
+			log.Printf("Notification Kafka consumer enabled (topic: %s)", config.Kafka.NotificationTopic)
+		}
+	}
+
 	go func() {
 		ticker := time.NewTicker(7127 * time.Millisecond)
 		defer ticker.Stop()
@@ -212,6 +223,10 @@ func main() {
 	e.GET("/stats", handlers.StatsHandler(stats, sessionStats, statsRedis))
 
 	e.GET("/events", handlers.StreamEventsHandler(e.Logger, subChan, unSubChan))
+
+	if statsRedis != nil {
+		e.GET("/notifications", handlers.NotificationsHandler(statsRedis.Client()))
+	}
 
 	if config.Debug {
 		e.GET("/served", handlers.ServedHandler(stats))

--- a/livestream/metrics/metrics.go
+++ b/livestream/metrics/metrics.go
@@ -25,6 +25,13 @@ var (
 		Name: "livestream_ph_events_total",
 		Help: "The total number of handled PostHog events, less than or equal to consumed",
 	})
+	NotificationErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "livestream_notification_errors_total",
+			Help: "Notification consumer errors by reason",
+		},
+		[]string{"reason"},
+	)
 
 	IncomingQueue = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "livestream_incoming_queue_use_ratio",

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -283,8 +283,16 @@ class ProjectBackwardCompatSerializer(ProjectBackwardCompatBasicSerializer, User
 
     def get_live_events_token(self, project: Project) -> Optional[str]:
         team = project.teams.get(pk=project.pk)
+        request = self.context.get("request")
+        user_id = request.user.id if request and hasattr(request, "user") and request.user.is_authenticated else None
+        claims = {
+            "team_id": team.id,
+            "api_token": team.api_token,
+            "user_id": user_id,
+            "organization_id": str(team.organization_id),
+        }
         return encode_jwt(
-            {"team_id": team.id, "api_token": team.api_token},
+            claims,
             timedelta(days=7),
             PosthogJwtAudience.LIVESTREAM,
         )

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -421,8 +421,16 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         return get_group_types_for_project(team.project_id)
 
     def get_live_events_token(self, team: Team) -> str | None:
+        request = self.context.get("request")
+        user_id = request.user.id if request and hasattr(request, "user") and request.user.is_authenticated else None
+        claims = {
+            "team_id": team.id,
+            "api_token": team.api_token,
+            "user_id": user_id,
+            "organization_id": str(team.organization_id),
+        }
         return encode_jwt(
-            {"team_id": team.id, "api_token": team.api_token},
+            claims,
             timedelta(days=7),
             PosthogJwtAudience.LIVESTREAM,
         )


### PR DESCRIPTION
## Problem

The real-time notifications system needs Go livestream changes to support SSE delivery and Kafka-based notification ingestion.

## Changes

- `AuthClaims` struct replaces multiple JWT extraction functions — extensible, backward-compatible
- `organization_id` added to livestream JWT claims, TTL lowered to 1 day
- `/notifications` SSE endpoint with org-scoped Redis subscription and per-user filtering
- `NotificationKafkaConsumer` bridges `notification_events` Kafka topic to Redis pub/sub (required for cross-pod fan-out across 10+ replicas)
- `Client()` getter on `StatsInRedis` for shared Redis access
- Kafka notification config fields (`NotificationEnabled`, `NotificationTopic`)

**Intended flow:** Django produces notification events to Kafka → Go consumes and publishes to Redis → Go SSE handler delivers to connected browsers.

## How did you test this code?

Go build and tests pass locally. E2E tested with manual Redis publish → SSE delivery to browser.

## Publish to changelog?

No