### PR TITLE
fix(error-tracking): skip property values API fetch for assignee properties

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -87,6 +87,7 @@ export function PropertyValue({
     const isDurationProperty =
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Duration
 
+    // Assignee values come from membersLogic/rolesLogic, not from the property values API
     const isAssigneeProperty =
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Assignee
 
@@ -129,25 +130,27 @@ export function PropertyValue({
     useEffect(() => {
         if (
             !isGroupKeyProperty &&
+            !isAssigneeProperty &&
             preloadValues &&
             propertyOptions?.status !== 'loading' &&
             propertyOptions?.status !== 'loaded'
         ) {
             load('')
         }
-    }, [preloadValues, load, propertyOptions?.status, isGroupKeyProperty])
+    }, [preloadValues, load, propertyOptions?.status, isGroupKeyProperty, isAssigneeProperty])
 
     // load options when propertyKey changes, unless it's a date/time property (since those don't have options to load)
     useEffect(() => {
         if (
             !isGroupKeyProperty &&
+            !isAssigneeProperty &&
             !isDateTimeProperty &&
             propertyOptions?.status !== 'loading' &&
             propertyOptions?.status !== 'loaded'
         ) {
             load('')
         }
-    }, [propertyKey, isDateTimeProperty, isGroupKeyProperty, load, propertyOptions?.status])
+    }, [propertyKey, isDateTimeProperty, isGroupKeyProperty, isAssigneeProperty, load, propertyOptions?.status])
 
     // set initial suggested values when options are loaded, but only if there is no search input
     // (to avoid overwriting suggestions based on search input)


### PR DESCRIPTION
## Problem

`PropertyValue` has two `useEffect`s that call `loadPropertyValues` whenever `propertyOptions` hasn't been loaded yet. For assignee properties (`PropertyType.Assignee`, e.g. `resource/assignee`), there is no backend endpoint at `api/resource/values`; assignee data is sourced from `membersLogic`/`rolesLogic` instead. This caused an infinite request loop: the call errors → status becomes `"error"` → effect re-fires → repeat.

## Changes

- Added `!isAssigneeProperty` guard to both `useEffect`s in `PropertyValue`, matching the existing `!isGroupKeyProperty` pattern
- Added a comment above `isAssigneeProperty` explaining why assignees skip the values API

## How did you test this code?

Code inspection: the bug is structural: the effect condition `status !== 'loading' && status !== 'loaded'` is always true for `'error'`, so guarding on `isAssigneeProperty` breaks the loop. The assignee UI is unaffected since it renders via `AssigneeSelect` (backed by `membersLogic`/`rolesLogic`) regardless.

+ tested manually before/after locally

## Publish to changelog?

No

## Docs update

No docs change needed.