### PR TITLE
fix: set COOP unsafe-none on /oauth/authorize for popup OAuth flows

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -676,26 +676,30 @@ class Fix204Middleware:
         return response
 
 
-class ToolbarOAuthCoopMiddleware:
+class PopupOAuthCoopMiddleware:
     """
     Override Cross-Origin-Opener-Policy for popup pages that need cross-origin communication.
 
     Django's SecurityMiddleware sets COOP to "same-origin" by default. This severs
     window.opener when a cross-origin popup navigates to our pages — breaking
-    Vercel's popup monitoring.
+    popup-based OAuth flows used by external clients (Lovable, Vercel, etc.).
 
     We set COOP to "unsafe-none" on the specific paths involved in popup flows
     so the opener reference is preserved.
     """
+
+    POPUP_PATHS = (
+        "/toolbar_oauth/",
+        "/connect/vercel/",
+        "/oauth/authorize",
+    )
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
-        is_toolbar_flow = request.path.startswith("/toolbar_oauth/")
-        is_vercel_connect = request.path.startswith("/connect/vercel/")
-        if is_toolbar_flow or is_vercel_connect:
+        if any(request.path.startswith(p) for p in self.POPUP_PATHS):
             response["Cross-Origin-Opener-Policy"] = "unsafe-none"
         return response
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -104,7 +104,7 @@ MIDDLEWARE = [
     "django_structlog.middlewares.RequestMiddleware",
     "posthog.middleware.Fix204Middleware",
     "django.middleware.security.SecurityMiddleware",
-    "posthog.middleware.ToolbarOAuthCoopMiddleware",
+    "posthog.middleware.PopupOAuthCoopMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
     # using dependencies that the healthcheck should be checking. It should be
     # ok below the above middlewares however.

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1,25 +1,26 @@
 import json
+import unittest
 from datetime import datetime, timedelta
-
-from freezegun import freeze_time
-from posthog.test.base import APIBaseTest, FuzzyInt, override_settings
 from unittest.mock import patch
 
 from django.conf import settings
 from django.core.cache import cache
-from django.test import Client as DjangoClient
+from django.test import Client as DjangoClient, RequestFactory
 from django.urls import reverse
-
+from freezegun import freeze_time
+from parameterized import parameterized
 from rest_framework import status
 from social_core.exceptions import AuthCanceled
 
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
+from posthog.middleware import PopupOAuthCoopMiddleware
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight
 from posthog.models.organization import Organization
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.settings import SITE_URL
+from posthog.test.base import APIBaseTest, FuzzyInt, override_settings
 
 
 class TestAccessMiddleware(APIBaseTest):
@@ -1388,3 +1389,39 @@ class TestSocialAuthExceptionMiddleware(APIBaseTest):
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response.url, "/login?error_code=oauth_cancelled")
+
+
+class TestPopupOAuthCoopMiddleware(unittest.TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = PopupOAuthCoopMiddleware(lambda request: self._make_response())
+
+    def _make_response(self):
+        from django.http import HttpResponse
+
+        return HttpResponse("OK")
+
+    @parameterized.expand(
+        [
+            ("/oauth/authorize",),
+            ("/oauth/authorize?client_id=abc",),
+            ("/toolbar_oauth/authorize/",),
+            ("/connect/vercel/configure/",),
+        ]
+    )
+    def test_popup_path_gets_unsafe_none(self, path):
+        request = self.factory.get(path)
+        response = self.middleware(request)
+        self.assertEqual(response["Cross-Origin-Opener-Policy"], "unsafe-none")
+
+    @parameterized.expand(
+        [
+            ("/api/projects/",),
+            ("/",),
+            ("/dashboard",),
+        ]
+    )
+    def test_non_popup_path_does_not_get_unsafe_none(self, path):
+        request = self.factory.get(path)
+        response = self.middleware(request)
+        self.assertNotIn("Cross-Origin-Opener-Policy", response)


### PR DESCRIPTION
## Problem

External clients like Lovable open our `/oauth/authorize` page in a popup window and need to detect when the OAuth flow completes. Django's default `Cross-Origin-Opener-Policy: same-origin` header severs the `window.opener` reference, so the parent window can never detect when the popup closes or completes the flow.

We already handle this for `/toolbar_oauth/` and `/connect/vercel/` paths but not for the general OAuth authorize endpoint used by MCP clients.

Reported by Samuel Bodin from Lovable.

## Changes

- Added `/oauth/authorize` to the list of paths where COOP is set to `unsafe-none`
- Renamed `ToolbarOAuthCoopMiddleware` to `PopupOAuthCoopMiddleware` since it now covers more than just the toolbar
- Extracted paths into a class-level `POPUP_PATHS` tuple for clarity

## How did you test this code?

- Manually tested with Chrome DevTools to verify the response header on `/oauth/authorize` is `Cross-Origin-Opener-Policy: unsafe-none`

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code.