### PR TITLE
chore: add clock skew metric to analytics capture

### DIFF
--- a/rust/batch-import-worker/src/parse/content/captured.rs
+++ b/rust/batch-import-worker/src/parse/content/captured.rs
@@ -81,7 +81,8 @@ pub fn captured_parse_fn(
             None, // No sent_at for historical data
             true, // Ignore sent_at
             now,
-        );
+        )
+        .timestamp;
 
         // Only return the event if import_events is enabled
         if context.import_events {

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -493,7 +493,8 @@ fn build_kafka_event(
         sent_at_utc,
         ignore_sent_at,
         now,
-    );
+    )
+    .timestamp;
 
     // Serialize the event to JSON (this is what goes in the "data" field)
     let data = serde_json::to_string(&parsed.event).map_err(|e| {

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -15,7 +15,7 @@ use crate::{
     api::CaptureError,
     debug_or_info, error_tracking_sampler,
     event_restrictions::{EventContext as RestrictionEventContext, EventRestrictionService},
-    prometheus::report_dropped_events,
+    prometheus::{report_clock_skew, report_dropped_events},
     router, sinks,
     utils::uuid_v7,
     v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata, ProcessingContext},
@@ -74,7 +74,7 @@ pub fn process_single_event(
         context.now,
     );
     if let Some(skew) = parsed_timestamp.clock_skew {
-        crate::prometheus::report_clock_skew(skew);
+        report_clock_skew(skew);
     }
 
     let event_name = event.event.clone();

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -66,20 +66,23 @@ pub fn process_single_event(
         .unwrap_or(false);
 
     // Parse the event timestamp
-    let computed_timestamp = common_types::timestamp::parse_event_timestamp(
+    let parsed_timestamp = common_types::timestamp::parse_event_timestamp(
         event.timestamp.as_deref(),
         event.offset,
         sent_at_utc,
         ignore_sent_at,
         context.now,
     );
+    if let Some(skew) = parsed_timestamp.clock_skew {
+        crate::prometheus::report_clock_skew(skew);
+    }
 
     let event_name = event.event.clone();
 
     let mut metadata = ProcessedEventMetadata {
         data_type,
         session_id: None,
-        computed_timestamp: Some(computed_timestamp),
+        computed_timestamp: Some(parsed_timestamp.timestamp),
         event_name: event_name.clone(),
         force_overflow: false,
         skip_person_processing: false,
@@ -87,7 +90,7 @@ pub fn process_single_event(
         redirect_to_topic: None,
     };
 
-    if historical_cfg.should_reroute(metadata.data_type, computed_timestamp) {
+    if historical_cfg.should_reroute(metadata.data_type, parsed_timestamp.timestamp) {
         metrics::counter!(
             "capture_events_rerouted_historical",
             &[("reason", "timestamp")]
@@ -110,7 +113,7 @@ pub fn process_single_event(
         sent_at: context.sent_at,
         token: context.token.clone(),
         event: event_name,
-        timestamp: computed_timestamp,
+        timestamp: parsed_timestamp.timestamp,
         is_cookieless_mode: event
             .extract_is_cookieless_mode()
             .ok_or(CaptureError::InvalidCookielessMode)?,

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -181,13 +181,14 @@ pub async fn process_replay_events(
     });
     let ignore_sent_at = events[0].properties.ignore_sent_at.unwrap_or(false);
 
-    let computed_timestamp = common_types::timestamp::parse_event_timestamp(
+    let parsed = common_types::timestamp::parse_event_timestamp(
         events[0].timestamp.as_deref(),
         events[0].offset,
         sent_at_utc,
         ignore_sent_at,
         context.now,
     );
+    let computed_timestamp = parsed.timestamp;
 
     // Extract metadata from first event by taking ownership (no clones!)
     // We split off the first event to extract metadata, then iterate over the rest

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -24,7 +24,7 @@ pub fn report_internal_error_metrics(err_type: &'static str, stage_tag: &'static
 }
 
 pub fn report_clock_skew(skew: chrono::Duration) {
-    let skew_seconds = skew.num_milliseconds().abs() as f64 / 1000.0;
+    let skew_seconds = skew.num_milliseconds().saturating_abs() as f64 / 1000.0;
     metrics::histogram!("capture_client_clock_skew_seconds").record(skew_seconds);
 }
 

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -23,6 +23,11 @@ pub fn report_internal_error_metrics(err_type: &'static str, stage_tag: &'static
     counter!("capture_error_by_stage_and_type", &tags).increment(1);
 }
 
+pub fn report_clock_skew(skew: chrono::Duration) {
+    let skew_seconds = skew.num_milliseconds().abs() as f64 / 1000.0;
+    metrics::histogram!("capture_client_clock_skew_seconds").record(skew_seconds);
+}
+
 pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> PrometheusHandle {
     // Ok I broke it at the end, but the limit on our ingress is 60 and that's a nicer way of reaching it
     const EXPONENTIAL_SECONDS: &[f64] = &[
@@ -102,6 +107,12 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
         100.0, 500.0, 1000.0, 5000.0, 10000.0, 15000.0, 30000.0, 60000.0,
     ];
 
+    // Absolute client clock skew buckets (in seconds).
+    // Fine granularity near zero for finding the right skew correction threshold.
+    const CLOCK_SKEW_SECONDS: &[f64] = &[
+        0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 300.0, 3600.0, 86400.0,
+    ];
+
     PrometheusBuilder::new()
         .add_global_label("role", role)
         .add_global_label("capture_mode", capture_mode)
@@ -175,6 +186,11 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
         .set_buckets_for_metric(
             Matcher::Full("global_rate_limiter_sync_staleness_ms".to_string()),
             GLOBAL_RATE_LIMITER_STALENESS_MS,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("capture_client_clock_skew_seconds".to_string()),
+            CLOCK_SKEW_SECONDS,
         )
         .unwrap()
         .install_recorder()

--- a/rust/common/types/src/timestamp.rs
+++ b/rust/common/types/src/timestamp.rs
@@ -32,23 +32,23 @@ pub fn parse_event_timestamp(
     let effective_sent_at = if ignore_sent_at { None } else { sent_at };
 
     // Handle timestamp parsing and clock skew adjustment
-    let (mut parsed_ts, clock_skew) = handle_timestamp(timestamp, offset, effective_sent_at, now);
+    let mut result = handle_timestamp(timestamp, offset, effective_sent_at, now);
 
     // Check for future events - clamp to now
-    let now_diff = parsed_ts.signed_duration_since(now).num_milliseconds();
+    let now_diff = result
+        .timestamp
+        .signed_duration_since(now)
+        .num_milliseconds();
     if now_diff > FUTURE_EVENT_HOURS_CUTOFF_MILLIS {
-        parsed_ts = now;
+        result.timestamp = now;
     }
 
     // Check if timestamp is out of bounds - fallback to epoch
-    if parsed_ts.year() < 0 || parsed_ts.year() > 9999 {
-        parsed_ts = DateTime::UNIX_EPOCH;
+    if result.timestamp.year() < 0 || result.timestamp.year() > 9999 {
+        result.timestamp = DateTime::UNIX_EPOCH;
     }
 
-    ParsedTimestamp {
-        timestamp: parsed_ts,
-        clock_skew,
-    }
+    result
 }
 
 fn handle_timestamp(
@@ -56,7 +56,7 @@ fn handle_timestamp(
     offset: Option<i64>,
     sent_at: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
-) -> (DateTime<Utc>, Option<Duration>) {
+) -> ParsedTimestamp {
     let mut parsed_ts = now;
     let mut clock_skew = None;
 
@@ -80,7 +80,10 @@ fn handle_timestamp(
         parsed_ts = now - Duration::milliseconds(offset_ms);
     }
 
-    (parsed_ts, clock_skew)
+    ParsedTimestamp {
+        timestamp: parsed_ts,
+        clock_skew,
+    }
 }
 
 /// Parse a date string using a streamlined approach
@@ -167,9 +170,7 @@ mod tests {
     use super::*;
 
     fn dt(s: &str) -> DateTime<Utc> {
-        DateTime::parse_from_rfc3339(s)
-            .unwrap()
-            .with_timezone(&Utc)
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
     }
 
     #[test]

--- a/rust/common/types/src/timestamp.rs
+++ b/rust/common/types/src/timestamp.rs
@@ -5,6 +5,14 @@ use std::borrow::Cow;
 
 const FUTURE_EVENT_HOURS_CUTOFF_MILLIS: i64 = 23 * 3600 * 1000; // 23 hours
 
+/// Result of parsing an event timestamp.
+pub struct ParsedTimestamp {
+    /// The parsed and validated event timestamp.
+    pub timestamp: DateTime<Utc>,
+    /// Clock skew (sent_at - now) when correction was applied, None otherwise.
+    pub clock_skew: Option<Duration>,
+}
+
 /// Parse event timestamp with clock skew adjustment and validation
 ///
 /// # Arguments
@@ -13,21 +21,18 @@ const FUTURE_EVENT_HOURS_CUTOFF_MILLIS: i64 = 23 * 3600 * 1000; // 23 hours
 /// * `sent_at` - The client-sent timestamp (optional)
 /// * `ignore_sent_at` - Whether to ignore sent_at for clock skew adjustment
 /// * `now` - The current server timestamp
-///
-/// # Returns
-/// * `DateTime<Utc>` - The parsed and validated timestamp
 pub fn parse_event_timestamp(
     timestamp: Option<&str>,
     offset: Option<i64>,
     sent_at: Option<DateTime<Utc>>,
     ignore_sent_at: bool,
     now: DateTime<Utc>,
-) -> DateTime<Utc> {
+) -> ParsedTimestamp {
     // Use sent_at only if not ignored
     let effective_sent_at = if ignore_sent_at { None } else { sent_at };
 
     // Handle timestamp parsing and clock skew adjustment
-    let mut parsed_ts = handle_timestamp(timestamp, offset, effective_sent_at, now);
+    let (mut parsed_ts, clock_skew) = handle_timestamp(timestamp, offset, effective_sent_at, now);
 
     // Check for future events - clamp to now
     let now_diff = parsed_ts.signed_duration_since(now).num_milliseconds();
@@ -40,7 +45,10 @@ pub fn parse_event_timestamp(
         parsed_ts = DateTime::UNIX_EPOCH;
     }
 
-    parsed_ts
+    ParsedTimestamp {
+        timestamp: parsed_ts,
+        clock_skew,
+    }
 }
 
 fn handle_timestamp(
@@ -48,18 +56,20 @@ fn handle_timestamp(
     offset: Option<i64>,
     sent_at: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
-) -> DateTime<Utc> {
+) -> (DateTime<Utc>, Option<Duration>) {
     let mut parsed_ts = now;
+    let mut clock_skew = None;
 
     if let Some(timestamp_str) = timestamp {
         let timestamp_parsed = parse_date(timestamp_str);
 
         if let (Some(sent_at), Some(timestamp_parsed)) = (sent_at, timestamp_parsed) {
-            // Handle clock skew between client and server
-            // skew = sent_at - now
-            // x = now + (timestamp - sent_at)
-            let duration = timestamp_parsed.signed_duration_since(sent_at);
-            parsed_ts = now + duration;
+            // Clock skew: how far the client clock is ahead of the server.
+            // We subtract this from the client-provided timestamp to get
+            // the event time in server clock terms.
+            let skew = sent_at - now;
+            parsed_ts = timestamp_parsed - skew;
+            clock_skew = Some(skew);
         } else if let Some(timestamp_parsed) = timestamp_parsed {
             parsed_ts = timestamp_parsed;
         }
@@ -70,7 +80,7 @@ fn handle_timestamp(
         parsed_ts = now - Duration::milliseconds(offset_ms);
     }
 
-    parsed_ts
+    (parsed_ts, clock_skew)
 }
 
 /// Parse a date string using a streamlined approach
@@ -150,4 +160,82 @@ fn convert_jiff_to_chrono(jiff_timestamp: jiff::Zoned) -> Option<DateTime<Utc>> 
     // Convert i32 to u32 safely (nanoseconds should always be positive)
     let nanos_u32 = nanos.try_into().ok()?;
     DateTime::from_timestamp(seconds, nanos_u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dt(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn positive_skew_client_clock_ahead() {
+        // Client clock is 10s ahead of server.
+        // Skew = sent_at - now = +10s
+        // Corrected = timestamp - skew = 11:00:00 - 10s = 10:59:50
+        let now = dt("2023-01-01T12:00:00Z");
+        let sent_at = Some(dt("2023-01-01T12:00:10Z"));
+        let result = parse_event_timestamp(Some("2023-01-01T11:00:00Z"), None, sent_at, false, now);
+        assert_eq!(result.timestamp, dt("2023-01-01T10:59:50Z"));
+        assert_eq!(result.clock_skew, Some(Duration::seconds(10)));
+    }
+
+    #[test]
+    fn negative_skew_client_clock_behind() {
+        // Client clock is 10s behind server.
+        // Skew = sent_at - now = -10s
+        // Corrected = timestamp - skew = 11:00:00 + 10s = 11:00:10
+        let now = dt("2023-01-01T12:00:00Z");
+        let sent_at = Some(dt("2023-01-01T11:59:50Z"));
+        let result = parse_event_timestamp(Some("2023-01-01T11:00:00Z"), None, sent_at, false, now);
+        assert_eq!(result.timestamp, dt("2023-01-01T11:00:10Z"));
+        assert_eq!(result.clock_skew, Some(Duration::seconds(-10)));
+    }
+
+    #[test]
+    fn zero_skew_clocks_aligned() {
+        let now = dt("2023-01-01T12:00:00Z");
+        let sent_at = Some(dt("2023-01-01T12:00:00Z"));
+        let result = parse_event_timestamp(Some("2023-01-01T11:00:00Z"), None, sent_at, false, now);
+        assert_eq!(result.timestamp, dt("2023-01-01T11:00:00Z"));
+        assert_eq!(result.clock_skew, Some(Duration::zero()));
+    }
+
+    #[test]
+    fn no_sent_at_no_correction() {
+        let now = dt("2023-01-01T12:00:00Z");
+        let result = parse_event_timestamp(Some("2023-01-01T11:00:00Z"), None, None, false, now);
+        assert_eq!(result.timestamp, dt("2023-01-01T11:00:00Z"));
+        assert!(result.clock_skew.is_none());
+    }
+
+    #[test]
+    fn ignore_sent_at_skips_correction() {
+        let now = dt("2023-01-01T12:00:00Z");
+        let sent_at = Some(dt("2023-01-01T12:00:10Z"));
+        let result = parse_event_timestamp(Some("2023-01-01T11:00:00Z"), None, sent_at, true, now);
+        assert_eq!(result.timestamp, dt("2023-01-01T11:00:00Z"));
+        assert!(result.clock_skew.is_none());
+    }
+
+    #[test]
+    fn no_timestamp_falls_back_to_now() {
+        let now = dt("2023-01-01T12:00:00Z");
+        let result = parse_event_timestamp(None, None, None, false, now);
+        assert_eq!(result.timestamp, now);
+        assert!(result.clock_skew.is_none());
+    }
+
+    #[test]
+    fn no_timestamp_with_sent_at_falls_back_to_now() {
+        let now = dt("2023-01-01T12:00:00Z");
+        let sent_at = Some(dt("2023-01-01T12:00:05Z"));
+        let result = parse_event_timestamp(None, None, sent_at, false, now);
+        assert_eq!(result.timestamp, now);
+        assert!(result.clock_skew.is_none());
+    }
 }


### PR DESCRIPTION
## Problem

As discussed in https://github.com/PostHog/requests-for-comments-internal/pull/1037 we need to gather metrics about current distribution of clock skew between SDK clients and our servers

## Changes

Introduce a new metrics `capture_client_clock_skew_seconds` and add a data point for each *event* (not batch) with the absolute value for the skew.

In order to do this cleanly, the parse_timestamp function was changed to return also the skew applied

## How did you test this code?

Unit tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
