### PR TITLE
feat(dashboards): allow toggling visibility of labels on insights directly from dashboards

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -54,6 +54,7 @@ import {
 
 import {
     canToggleDisplayLabelsInInsightQuery,
+    getDisplayLabelsToggleMode,
     isDisplayLabelsEnabledInInsightQuery,
     toggleDisplayLabelsInInsightQuery,
 } from './displayLabelsToggle'
@@ -144,6 +145,15 @@ export function InsightMeta({
     const isSqlInsight = isDataVisualizationNode(insight.query)
     const canToggleDisplayLabelsForQuery = canToggleDisplayLabelsInInsightQuery(insight.query)
     const displayLabelsShown = isDisplayLabelsEnabledInInsightQuery(insight.query)
+    const displayLabelsToggleMode = getDisplayLabelsToggleMode(insight.query)
+    const displayLabelsToggleText =
+        displayLabelsToggleMode === 'pie_labels'
+            ? displayLabelsShown
+                ? 'Hide labels on series'
+                : 'Show labels on series'
+            : displayLabelsShown
+              ? 'Hide values on series'
+              : 'Show values on series'
     const showCompactHeading = !showCompactTile || (!filtersOverride?.date_from && !isSqlInsight)
 
     const topHeadingProps = {
@@ -391,7 +401,7 @@ export function InsightMeta({
                                 }}
                                 fullWidth
                             >
-                                {displayLabelsShown ? 'Hide values on series' : 'Show values on series'}
+                                {displayLabelsToggleText}
                             </LemonButton>
                             <LemonDivider />
                         </>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -49,15 +49,11 @@ import {
     DashboardTile,
     ExporterFormat,
     InsightColor,
+    InsightLogicProps,
     QueryBasedInsightModel,
 } from '~/types'
 
-import {
-    canToggleDisplayLabelsInInsightQuery,
-    getDisplayLabelsToggleMode,
-    isDisplayLabelsEnabledInInsightQuery,
-    toggleDisplayLabelsInInsightQuery,
-} from './displayLabelsToggle'
+import { getDisplayLabelsToggleText, toggleDisplayLabelsInInsightQuery } from './displayLabelsToggle'
 import { InsightCardProps } from './InsightCard'
 import { InsightDetails } from './InsightDetails'
 import { InsightMoveToDashboardMenu } from './InsightMoveToDashboardMenu'
@@ -123,10 +119,18 @@ export function InsightMeta({
     onDragHandleMouseDown,
 }: InsightMetaProps): JSX.Element {
     const { short_id, name, dashboards, next_allowed_client_refresh: nextAllowedClientRefresh } = insight
-    const { insightProps, insightFeedback } = useValues(insightLogic)
-    const { setInsightFeedback } = useActions(insightLogic)
-    const { exportContext, insightData } = useValues(insightDataLogic(insightProps))
-    const { samplingFactor } = useValues(insightVizDataLogic(insightProps))
+    const insightLogicProps: InsightLogicProps = {
+        dashboardItemId: insight.short_id,
+        dashboardId,
+        cachedInsight: insight,
+        filtersOverride: filtersOverride ?? null,
+        variablesOverride: variablesOverride ?? null,
+        tileFiltersOverride: tile?.filters_overrides ?? null,
+    }
+    const { insightFeedback, canToggleDisplayLabelsForInsight } = useValues(insightLogic(insightLogicProps))
+    const { setInsightFeedback } = useActions(insightLogic(insightLogicProps))
+    const { exportContext, insightData } = useValues(insightDataLogic(insightLogicProps))
+    const { samplingFactor } = useValues(insightVizDataLogic(insightLogicProps))
     const { nameSortedDashboards } = useValues(dashboardsModel)
     const { updateInsightDirect } = useActions(insightsModel)
     const { reportDashboardInsightMetaUpdated, reportDashboardInsightValuesOnSeriesToggled } =
@@ -143,17 +147,7 @@ export function InsightMeta({
         placement === DashboardPlacement.Builtin
 
     const isSqlInsight = isDataVisualizationNode(insight.query)
-    const canToggleDisplayLabelsForQuery = canToggleDisplayLabelsInInsightQuery(insight.query)
-    const displayLabelsShown = isDisplayLabelsEnabledInInsightQuery(insight.query)
-    const displayLabelsToggleMode = getDisplayLabelsToggleMode(insight.query)
-    const displayLabelsToggleText =
-        displayLabelsToggleMode === 'pie_labels'
-            ? displayLabelsShown
-                ? 'Hide labels on series'
-                : 'Show labels on series'
-            : displayLabelsShown
-              ? 'Hide values on series'
-              : 'Show values on series'
+    const displayLabelsToggleText = getDisplayLabelsToggleText(insight.query)
     const showCompactHeading = !showCompactTile || (!filtersOverride?.date_from && !isSqlInsight)
 
     const topHeadingProps = {
@@ -178,7 +172,7 @@ export function InsightMeta({
                   AccessControlLevel.Editor
               )
             : true
-    const canToggleDisplayLabels = isDashboardCardPlacement && canEditInsight && canToggleDisplayLabelsForQuery
+    const canToggleDisplayLabels = isDashboardCardPlacement && canEditInsight && canToggleDisplayLabelsForInsight
 
     // For dashboard-specific actions (remove from dashboard, change tile color), check dashboard permissions
     const currentDashboard = dashboardId ? nameSortedDashboards.find((d) => d.id === dashboardId) : null
@@ -508,7 +502,7 @@ export function InsightMeta({
                                     {
                                         export_format: ExporterFormat.PNG,
                                         insight: insight.id,
-                                        dashboard: insightProps.dashboardId,
+                                        dashboard: insightLogicProps.dashboardId,
                                     },
                                     {
                                         export_format: ExporterFormat.CSV,

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -27,7 +27,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -52,6 +52,11 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
+import {
+    canToggleDisplayLabelsInInsightQuery,
+    isDisplayLabelsEnabledInInsightQuery,
+    toggleDisplayLabelsInInsightQuery,
+} from './displayLabelsToggle'
 import { InsightCardProps } from './InsightCard'
 import { InsightDetails } from './InsightDetails'
 import { InsightMoveToDashboardMenu } from './InsightMoveToDashboardMenu'
@@ -123,15 +128,22 @@ export function InsightMeta({
     const { samplingFactor } = useValues(insightVizDataLogic(insightProps))
     const { nameSortedDashboards } = useValues(dashboardsModel)
     const { updateInsightDirect } = useActions(insightsModel)
-    const { reportDashboardInsightMetaUpdated } = useActions(eventUsageLogic)
+    const { reportDashboardInsightMetaUpdated, reportDashboardInsightValuesOnSeriesToggled } =
+        useActions(eventUsageLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const showCompactTile =
         placement === DashboardPlacement.Dashboard ||
         placement === DashboardPlacement.ProjectHomepage ||
         placement === DashboardPlacement.Public
+    const isDashboardCardPlacement =
+        placement === DashboardPlacement.Dashboard ||
+        placement === DashboardPlacement.Public ||
+        placement === DashboardPlacement.Builtin
 
     const isSqlInsight = isDataVisualizationNode(insight.query)
+    const canToggleDisplayLabelsForQuery = canToggleDisplayLabelsInInsightQuery(insight.query)
+    const displayLabelsShown = isDisplayLabelsEnabledInInsightQuery(insight.query)
     const showCompactHeading = !showCompactTile || (!filtersOverride?.date_from && !isSqlInsight)
 
     const topHeadingProps = {
@@ -156,6 +168,7 @@ export function InsightMeta({
                   AccessControlLevel.Editor
               )
             : true
+    const canToggleDisplayLabels = isDashboardCardPlacement && canEditInsight && canToggleDisplayLabelsForQuery
 
     // For dashboard-specific actions (remove from dashboard, change tile color), check dashboard permissions
     const currentDashboard = dashboardId ? nameSortedDashboards.find((d) => d.id === dashboardId) : null
@@ -361,11 +374,33 @@ export function InsightMeta({
                     >
                         Duplicate
                     </LemonButton>
+                    {canToggleDisplayLabels && (
+                        <>
+                            <LemonDivider />
+                            <LemonButton
+                                onClick={() => {
+                                    const query = toggleDisplayLabelsInInsightQuery(insight.query)
+                                    if (query !== insight.query) {
+                                        updateInsightDirect(insight, { query })
+                                        reportDashboardInsightValuesOnSeriesToggled(
+                                            dashboardId,
+                                            insight.id,
+                                            DashboardEventSource.MoreDropdown
+                                        )
+                                    }
+                                }}
+                                fullWidth
+                            >
+                                {displayLabelsShown ? 'Hide values on series' : 'Show values on series'}
+                            </LemonButton>
+                            <LemonDivider />
+                        </>
+                    )}
 
                     {/* Dashboard related */}
                     {canEditDashboard && (
                         <>
-                            <LemonDivider />
+                            {!canToggleDisplayLabels && <LemonDivider />}
                             {showCompactTile && toggleShowDescription && !!insight.description && (
                                 <LemonButton onClick={toggleShowDescription} fullWidth>
                                     {tile?.show_description === false ? 'Show description' : 'Hide description'}

--- a/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.test.ts
@@ -88,36 +88,52 @@ describe('displayLabelsToggle', () => {
     })
 
     describe('toggleDisplayLabelsInInsightQuery', () => {
-        it('toggles display labels for trends pie insights', () => {
-            const query = {
+        it.each([
+            {
+                kind: NodeKind.TrendsQuery,
+                filter: 'trendsFilter',
+                display: ChartDisplayType.ActionsLineGraph,
+                field: 'showValuesOnSeries',
+            },
+            {
+                kind: NodeKind.TrendsQuery,
+                filter: 'trendsFilter',
+                display: ChartDisplayType.ActionsPie,
+                field: 'showLabelsOnSeries',
+            },
+            {
+                kind: NodeKind.StickinessQuery,
+                filter: 'stickinessFilter',
+                display: ChartDisplayType.ActionsLineGraph,
+                field: 'showValuesOnSeries',
+            },
+            {
+                kind: NodeKind.FunnelsQuery,
+                filter: 'funnelsFilter',
+                field: 'showValuesOnSeries',
+            },
+            {
+                kind: NodeKind.LifecycleQuery,
+                filter: 'lifecycleFilter',
+                field: 'showValuesOnSeries',
+            },
+        ])('toggles $field for $kind', ({ kind, filter, display, field }) => {
+            const makeQuery = (enabled: boolean): any => ({
                 kind: NodeKind.InsightVizNode,
                 source: {
-                    kind: NodeKind.TrendsQuery,
-                    trendsFilter: {
-                        display: ChartDisplayType.ActionsPie,
-                        showLabelsOnSeries: false,
+                    kind,
+                    [filter]: {
+                        ...(display ? { display } : {}),
+                        [field]: enabled,
                     },
                 },
-            } as any
+            })
 
-            const updatedQuery = toggleDisplayLabelsInInsightQuery(query) as any
-            expect(updatedQuery.source.trendsFilter?.showLabelsOnSeries).toBe(true)
-        })
+            const enabledQuery = toggleDisplayLabelsInInsightQuery(makeQuery(false)) as any
+            expect(enabledQuery.source[filter]?.[field]).toBe(true)
 
-        it('toggles values on series for trends line insights', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    trendsFilter: {
-                        display: ChartDisplayType.ActionsLineGraph,
-                        showValuesOnSeries: false,
-                    },
-                },
-            } as any
-
-            const updatedQuery = toggleDisplayLabelsInInsightQuery(query) as any
-            expect(updatedQuery.source.trendsFilter?.showValuesOnSeries).toBe(true)
+            const disabledQuery = toggleDisplayLabelsInInsightQuery(makeQuery(true)) as any
+            expect(disabledQuery.source[filter]?.[field]).toBe(false)
         })
 
         it('keeps query unchanged for trends displays without series values', () => {

--- a/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.test.ts
@@ -3,6 +3,7 @@ import { ChartDisplayType } from '~/types'
 
 import {
     canToggleDisplayLabelsInInsightQuery,
+    getDisplayLabelsToggleText,
     getDisplayLabelsToggleMode,
     isDisplayLabelsEnabledInInsightQuery,
     toggleDisplayLabelsInInsightQuery,
@@ -32,6 +33,41 @@ describe('displayLabelsToggle', () => {
             } as any
 
             expect(canToggleDisplayLabelsInInsightQuery(query)).toBe(false)
+        })
+
+        it('returns false for funnels steps visualization', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.FunnelsQuery,
+                    funnelsFilter: { funnelVizType: 'steps' },
+                },
+            } as any
+
+            expect(canToggleDisplayLabelsInInsightQuery(query)).toBe(false)
+        })
+
+        it('returns true for funnels trends visualization', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.FunnelsQuery,
+                    funnelsFilter: { funnelVizType: 'trends' },
+                },
+            } as any
+
+            expect(canToggleDisplayLabelsInInsightQuery(query)).toBe(true)
+        })
+
+        it('returns true for lifecycle insights', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.LifecycleQuery,
+                },
+            } as any
+
+            expect(canToggleDisplayLabelsInInsightQuery(query)).toBe(true)
         })
     })
 
@@ -84,6 +120,50 @@ describe('displayLabelsToggle', () => {
             } as any
 
             expect(getDisplayLabelsToggleMode(query)).toBe('series_values')
+        })
+    })
+
+    describe('getDisplayLabelsToggleText', () => {
+        it('returns labels wording for pie insights', () => {
+            const hiddenLabelsQuery = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsPie, showLabelsOnSeries: false },
+                },
+            } as any
+
+            const shownLabelsQuery = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsPie, showLabelsOnSeries: true },
+                },
+            } as any
+
+            expect(getDisplayLabelsToggleText(hiddenLabelsQuery)).toBe('Show labels on series')
+            expect(getDisplayLabelsToggleText(shownLabelsQuery)).toBe('Hide labels on series')
+        })
+
+        it('returns values wording for non-pie insights', () => {
+            const hiddenValuesQuery = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph, showValuesOnSeries: false },
+                },
+            } as any
+
+            const shownValuesQuery = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph, showValuesOnSeries: true },
+                },
+            } as any
+
+            expect(getDisplayLabelsToggleText(hiddenValuesQuery)).toBe('Show values on series')
+            expect(getDisplayLabelsToggleText(shownValuesQuery)).toBe('Hide values on series')
         })
     })
 

--- a/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.test.ts
@@ -1,0 +1,139 @@
+import { NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
+
+import {
+    canToggleDisplayLabelsInInsightQuery,
+    getDisplayLabelsToggleMode,
+    isDisplayLabelsEnabledInInsightQuery,
+    toggleDisplayLabelsInInsightQuery,
+} from './displayLabelsToggle'
+
+describe('displayLabelsToggle', () => {
+    describe('canToggleDisplayLabelsInInsightQuery', () => {
+        it('returns true for trends pie', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsPie },
+                },
+            } as any
+
+            expect(canToggleDisplayLabelsInInsightQuery(query)).toBe(true)
+        })
+
+        it('returns false for trends bold number', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.BoldNumber },
+                },
+            } as any
+
+            expect(canToggleDisplayLabelsInInsightQuery(query)).toBe(false)
+        })
+    })
+
+    describe('isDisplayLabelsEnabledInInsightQuery', () => {
+        it('reads trends pie label toggle', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsPie, showLabelsOnSeries: true },
+                },
+            } as any
+
+            expect(isDisplayLabelsEnabledInInsightQuery(query)).toBe(true)
+        })
+
+        it('reads trends line values toggle', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph, showValuesOnSeries: true },
+                },
+            } as any
+
+            expect(isDisplayLabelsEnabledInInsightQuery(query)).toBe(true)
+        })
+    })
+
+    describe('getDisplayLabelsToggleMode', () => {
+        it('returns pie_labels for trends pie', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsPie },
+                },
+            } as any
+
+            expect(getDisplayLabelsToggleMode(query)).toBe('pie_labels')
+        })
+
+        it('returns series_values for trends line', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
+                },
+            } as any
+
+            expect(getDisplayLabelsToggleMode(query)).toBe('series_values')
+        })
+    })
+
+    describe('toggleDisplayLabelsInInsightQuery', () => {
+        it('toggles display labels for trends pie insights', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: {
+                        display: ChartDisplayType.ActionsPie,
+                        showLabelsOnSeries: false,
+                    },
+                },
+            } as any
+
+            const updatedQuery = toggleDisplayLabelsInInsightQuery(query) as any
+            expect(updatedQuery.source.trendsFilter?.showLabelsOnSeries).toBe(true)
+        })
+
+        it('toggles values on series for trends line insights', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: {
+                        display: ChartDisplayType.ActionsLineGraph,
+                        showValuesOnSeries: false,
+                    },
+                },
+            } as any
+
+            const updatedQuery = toggleDisplayLabelsInInsightQuery(query) as any
+            expect(updatedQuery.source.trendsFilter?.showValuesOnSeries).toBe(true)
+        })
+
+        it('keeps query unchanged for trends displays without series values', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: {
+                        display: ChartDisplayType.BoldNumber,
+                        showValuesOnSeries: false,
+                    },
+                },
+            } as any
+
+            const updatedQuery = toggleDisplayLabelsInInsightQuery(query)
+            expect(updatedQuery).toBe(query)
+        })
+    })
+})

--- a/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.ts
@@ -1,0 +1,152 @@
+import { NON_VALUES_ON_SERIES_DISPLAY_TYPES } from 'lib/constants'
+
+import { isFunnelsQuery, isInsightVizNode, isLifecycleQuery, isStickinessQuery, isTrendsQuery } from '~/queries/utils'
+import { ChartDisplayType, QueryBasedInsightModel } from '~/types'
+
+export type DisplayLabelsToggleMode = 'pie_labels' | 'series_values'
+
+export function canToggleDisplayLabelsInInsightQuery(query: QueryBasedInsightModel['query']): boolean {
+    if (!isInsightVizNode(query)) {
+        return false
+    }
+
+    if (isTrendsQuery(query.source)) {
+        const display = query.source.trendsFilter?.display || ChartDisplayType.ActionsLineGraph
+        return display === ChartDisplayType.ActionsPie || !NON_VALUES_ON_SERIES_DISPLAY_TYPES.includes(display)
+    }
+
+    if (isStickinessQuery(query.source)) {
+        const display = query.source.stickinessFilter?.display || ChartDisplayType.ActionsLineGraph
+        return !NON_VALUES_ON_SERIES_DISPLAY_TYPES.includes(display)
+    }
+
+    return isFunnelsQuery(query.source) || isLifecycleQuery(query.source)
+}
+
+export function isDisplayLabelsEnabledInInsightQuery(query: QueryBasedInsightModel['query']): boolean {
+    if (!canToggleDisplayLabelsInInsightQuery(query) || !isInsightVizNode(query)) {
+        return false
+    }
+
+    if (isTrendsQuery(query.source)) {
+        const display = query.source.trendsFilter?.display || ChartDisplayType.ActionsLineGraph
+        return display === ChartDisplayType.ActionsPie
+            ? !!query.source.trendsFilter?.showLabelsOnSeries
+            : !!query.source.trendsFilter?.showValuesOnSeries
+    }
+
+    if (isStickinessQuery(query.source)) {
+        return !!query.source.stickinessFilter?.showValuesOnSeries
+    }
+
+    if (isFunnelsQuery(query.source)) {
+        return !!query.source.funnelsFilter?.showValuesOnSeries
+    }
+
+    return isLifecycleQuery(query.source) && !!query.source.lifecycleFilter?.showValuesOnSeries
+}
+
+export function getDisplayLabelsToggleMode(query: QueryBasedInsightModel['query']): DisplayLabelsToggleMode | null {
+    if (!isInsightVizNode(query)) {
+        return null
+    }
+
+    if (isTrendsQuery(query.source)) {
+        const display = query.source.trendsFilter?.display || ChartDisplayType.ActionsLineGraph
+        return display === ChartDisplayType.ActionsPie ? 'pie_labels' : 'series_values'
+    }
+
+    if (isStickinessQuery(query.source) || isFunnelsQuery(query.source) || isLifecycleQuery(query.source)) {
+        return 'series_values'
+    }
+
+    return null
+}
+
+export function toggleDisplayLabelsInInsightQuery(
+    query: QueryBasedInsightModel['query']
+): QueryBasedInsightModel['query'] {
+    if (!isInsightVizNode(query)) {
+        return query
+    }
+
+    const queryWithSource = query as any
+    const source = queryWithSource.source
+
+    if (isTrendsQuery(source)) {
+        const display = source.trendsFilter?.display || ChartDisplayType.ActionsLineGraph
+        if (display === ChartDisplayType.ActionsPie) {
+            return {
+                ...queryWithSource,
+                source: {
+                    ...source,
+                    trendsFilter: {
+                        ...source.trendsFilter,
+                        showLabelsOnSeries: !source.trendsFilter?.showLabelsOnSeries,
+                    },
+                },
+            } as QueryBasedInsightModel['query']
+        }
+
+        if (NON_VALUES_ON_SERIES_DISPLAY_TYPES.includes(display)) {
+            return query
+        }
+
+        return {
+            ...queryWithSource,
+            source: {
+                ...source,
+                trendsFilter: {
+                    ...source.trendsFilter,
+                    showValuesOnSeries: !source.trendsFilter?.showValuesOnSeries,
+                },
+            },
+        } as QueryBasedInsightModel['query']
+    }
+
+    if (isStickinessQuery(source)) {
+        const display = source.stickinessFilter?.display || ChartDisplayType.ActionsLineGraph
+        if (NON_VALUES_ON_SERIES_DISPLAY_TYPES.includes(display)) {
+            return query
+        }
+
+        return {
+            ...queryWithSource,
+            source: {
+                ...source,
+                stickinessFilter: {
+                    ...source.stickinessFilter,
+                    showValuesOnSeries: !source.stickinessFilter?.showValuesOnSeries,
+                },
+            },
+        } as QueryBasedInsightModel['query']
+    }
+
+    if (isFunnelsQuery(source)) {
+        return {
+            ...queryWithSource,
+            source: {
+                ...source,
+                funnelsFilter: {
+                    ...source.funnelsFilter,
+                    showValuesOnSeries: !source.funnelsFilter?.showValuesOnSeries,
+                },
+            },
+        } as QueryBasedInsightModel['query']
+    }
+
+    if (isLifecycleQuery(source)) {
+        return {
+            ...queryWithSource,
+            source: {
+                ...source,
+                lifecycleFilter: {
+                    ...source.lifecycleFilter,
+                    showValuesOnSeries: !source.lifecycleFilter?.showValuesOnSeries,
+                },
+            },
+        } as QueryBasedInsightModel['query']
+    }
+
+    return query
+}

--- a/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/displayLabelsToggle.ts
@@ -1,7 +1,7 @@
 import { NON_VALUES_ON_SERIES_DISPLAY_TYPES } from 'lib/constants'
 
 import { isFunnelsQuery, isInsightVizNode, isLifecycleQuery, isStickinessQuery, isTrendsQuery } from '~/queries/utils'
-import { ChartDisplayType, QueryBasedInsightModel } from '~/types'
+import { ChartDisplayType, FunnelVizType, QueryBasedInsightModel } from '~/types'
 
 export type DisplayLabelsToggleMode = 'pie_labels' | 'series_values'
 
@@ -20,7 +20,15 @@ export function canToggleDisplayLabelsInInsightQuery(query: QueryBasedInsightMod
         return !NON_VALUES_ON_SERIES_DISPLAY_TYPES.includes(display)
     }
 
-    return isFunnelsQuery(query.source) || isLifecycleQuery(query.source)
+    if (isFunnelsQuery(query.source)) {
+        return query.source.funnelsFilter?.funnelVizType === FunnelVizType.Trends
+    }
+
+    if (isLifecycleQuery(query.source)) {
+        return true
+    }
+
+    return false
 }
 
 export function isDisplayLabelsEnabledInInsightQuery(query: QueryBasedInsightModel['query']): boolean {
@@ -61,6 +69,17 @@ export function getDisplayLabelsToggleMode(query: QueryBasedInsightModel['query'
     }
 
     return null
+}
+
+export function getDisplayLabelsToggleText(query: QueryBasedInsightModel['query']): string {
+    const displayLabelsShown = isDisplayLabelsEnabledInInsightQuery(query)
+    const displayLabelsToggleMode = getDisplayLabelsToggleMode(query)
+
+    if (displayLabelsToggleMode === 'pie_labels') {
+        return displayLabelsShown ? 'Hide labels on series' : 'Show labels on series'
+    }
+
+    return displayLabelsShown ? 'Hide values on series' : 'Show values on series'
 }
 
 export function toggleDisplayLabelsInInsightQuery(

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -433,6 +433,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             insightId: number,
             attribute: 'name' | 'description'
         ) => ({ dashboardId, insightId, attribute }),
+        reportDashboardInsightValuesOnSeriesToggled: (
+            dashboardId: number | undefined,
+            insightId: number,
+            source: DashboardEventSource
+        ) => ({ dashboardId, insightId, source }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
@@ -1247,6 +1252,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 dashboard_id: dashboardId,
                 insight_id: insightId,
                 attribute,
+            })
+        },
+        reportDashboardInsightValuesOnSeriesToggled: async ({ dashboardId, insightId, source }) => {
+            posthog.capture('dashboard insight values on series toggled', {
+                dashboard_id: dashboardId,
+                insight_id: insightId,
+                source,
             })
         },
         reportUpgradeModalShown: async (payload) => {

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -16,7 +16,7 @@ export const insightsModel = kea<insightsModelType>([
     connect(() => ({ logic: [teamLogic] })),
     actions(() => ({
         renameInsight: (item: QueryBasedInsightModel) => ({ item }),
-        updateInsightDirect: (item: QueryBasedInsightModel, updates: { name?: string; description?: string }) => ({
+        updateInsightDirect: (item: QueryBasedInsightModel, updates: Partial<QueryBasedInsightModel>) => ({
             item,
             updates,
         }),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -732,9 +732,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         ...tiles[tileIndex],
                         insight: {
                             ...(tiles[tileIndex].insight as QueryBasedInsightModel),
-                            name: item.name,
-                            description: item.description,
-                            last_modified_at: item.last_modified_at,
+                            ...item,
                         },
                     }
 

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -7,6 +7,11 @@ import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
 
 import { ApiError } from 'lib/api'
 import { insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
+import {
+    canToggleDisplayLabelsInInsightQuery,
+    getDisplayLabelsToggleText,
+    isDisplayLabelsEnabledInInsightQuery,
+} from 'lib/components/Cards/InsightCard/displayLabelsToggle'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -440,6 +445,18 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                           AccessControlLevel.Editor
                       )
                     : true,
+        ],
+        canToggleDisplayLabelsForInsight: [
+            (s) => [s.insight],
+            (insight) => !!insight.query && canToggleDisplayLabelsInInsightQuery(insight.query),
+        ],
+        displayLabelsShownForInsight: [
+            (s) => [s.insight],
+            (insight) => !!insight.query && isDisplayLabelsEnabledInInsightQuery(insight.query),
+        ],
+        displayLabelsToggleTextForInsight: [
+            (s) => [s.insight],
+            (insight) => (insight.query ? getDisplayLabelsToggleText(insight.query) : 'Show values on series'),
         ],
         insightChanged: [
             (s) => [s.insight, s.savedInsight],


### PR DESCRIPTION
## Problem

Users are unable to show the labels on an insight without editing it directly it inside the insight. This means if they want to change it from the dashboard, they need to go into the insight, edit options, save, and them go back to the dashboard.

## Changes

Exposes a new dropdown for applicable insights on dashboard to quickly make this change.

https://github.com/user-attachments/assets/b5daa56c-29d2-413b-8641-b6bb590b10f0


## How did you test this code?
Locally.

Added new tests.

## Publish to changelog?
Yes.

