### PR TITLE
feat: add org disabled reason presets to admin

### DIFF
--- a/posthog/templates/admin/posthog/organization/change_form.html
+++ b/posthog/templates/admin/posthog/organization/change_form.html
@@ -1,6 +1,102 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 
+{% block extrahead %}
+    {{ block.super }}
+    <script nonce="{{ request.csp_nonce }}">
+        document.addEventListener("DOMContentLoaded", () => {
+            const isActiveCheckbox = document.getElementById("id_is_active")
+            const reasonField = document.getElementById("id_is_not_active_reason")
+
+            if (!isActiveCheckbox || !reasonField) {
+                return
+            }
+
+            const presets = [
+                "Access revoked due to unpaid balance.",
+                "Access disabled for compliance review.",
+                "Access revoked due to terms of service violation.",
+            ]
+
+            const reasonFieldRow = reasonField.closest(".form-row")
+            if (!reasonFieldRow) {
+                return
+            }
+
+            const reasonSelectRow = document.createElement("div")
+            reasonSelectRow.className = "form-row field-is_not_active_reason_select"
+            reasonSelectRow.style.marginBottom = "8px"
+
+            const reasonSelectLabel = document.createElement("label")
+            reasonSelectLabel.htmlFor = "id_is_not_active_reason_select"
+            reasonSelectLabel.textContent = "Reason:"
+
+            const reasonSelect = document.createElement("select")
+            reasonSelect.id = "id_is_not_active_reason_select"
+            reasonSelect.style.marginLeft = "8px"
+
+            const noneOption = document.createElement("option")
+            noneOption.value = "__none__"
+            noneOption.textContent = "None"
+            reasonSelect.appendChild(noneOption)
+
+            for (const preset of presets) {
+                const option = document.createElement("option")
+                option.value = preset
+                option.textContent = preset
+                reasonSelect.appendChild(option)
+            }
+
+            const customOption = document.createElement("option")
+            customOption.value = "__custom__"
+            customOption.textContent = "Custom"
+            reasonSelect.appendChild(customOption)
+
+            reasonSelectRow.appendChild(reasonSelectLabel)
+            reasonSelectRow.appendChild(reasonSelect)
+            reasonFieldRow.insertAdjacentElement("beforebegin", reasonSelectRow)
+
+            const setReasonUIFromSelect = () => {
+                if (reasonSelect.value === "__none__") {
+                    reasonField.value = ""
+                    reasonFieldRow.style.display = "none"
+                } else if (reasonSelect.value === "__custom__") {
+                    reasonFieldRow.style.removeProperty("display")
+                } else {
+                    reasonField.value = reasonSelect.value
+                    reasonFieldRow.style.display = "none"
+                }
+            }
+
+            const setVisibilityForActiveState = () => {
+                const isDisabled = !isActiveCheckbox.checked
+                reasonSelectRow.style.display = isDisabled ? "" : "none"
+                if (!isDisabled) {
+                    reasonFieldRow.style.display = "none"
+                    return
+                }
+                setReasonUIFromSelect()
+            }
+
+            const existingReason = reasonField.value.trim()
+            if (!existingReason) {
+                reasonSelect.value = "__none__"
+            } else if (presets.includes(existingReason)) {
+                reasonSelect.value = existingReason
+            } else {
+                reasonSelect.value = "__custom__"
+            }
+
+            reasonSelect.addEventListener("change", setReasonUIFromSelect)
+            isActiveCheckbox.addEventListener("change", setVisibilityForActiveState)
+
+            // Ensure the row is in the correct state before active/inactive gating.
+            setReasonUIFromSelect()
+            setVisibilityForActiveState()
+        })
+    </script>
+{% endblock %}
+
 {% block submit_buttons_bottom %}
     {{ block.super }}
 {% endblock %} 


### PR DESCRIPTION
## Problem

Whenever you disable an org and give a reason you have to manually type in a reason. Usually the reason is always the same and there is nothing extra to add.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add a preset select box to the disabled reason with a few options. When None is selected, an empty string is saved as the value. When Custom is selected, you see the original text box which lets you enter a reason. If you want to do a preset + custom text, select the preset then select custom and the text box will be prefilled with the preset.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
