### PR TITLE
fix(endpoints): close tree by default

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -36,9 +36,17 @@ interface QueryWindowProps {
     onSetMonacoAndEditor: (monaco: Monaco, editor: importedEditor.IStandaloneCodeEditor) => void
     tabId: string
     mode?: SQLEditorMode
+    showDatabaseTree: boolean
+    onShowDatabaseTree: () => void
 }
 
-export function QueryWindow({ onSetMonacoAndEditor, tabId, mode }: QueryWindowProps): JSX.Element {
+export function QueryWindow({
+    onSetMonacoAndEditor,
+    tabId,
+    mode,
+    showDatabaseTree,
+    onShowDatabaseTree,
+}: QueryWindowProps): JSX.Element {
     const codeEditorKey = `hogql-editor-${tabId}`
 
     const { queryInput, sourceQuery, originalQueryInput, suggestedQueryInput, editingView } = useValues(sqlEditorLogic)
@@ -62,7 +70,10 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId, mode }: QueryWindowPr
                 )}
             >
                 <div className="flex items-center gap-2">
-                    <ExpandDatabaseTreeButton />
+                    <ExpandDatabaseTreeButton
+                        showDatabaseTree={showDatabaseTree}
+                        onShowDatabaseTree={onShowDatabaseTree}
+                    />
                     <RunButton />
                     <CollapsedConnectionSelector mode={mode} isDirectQueryEnabled={isDirectQueryEnabled} />
                     <LemonDivider vertical />
@@ -172,11 +183,17 @@ export function QueryWindow({ onSetMonacoAndEditor, tabId, mode }: QueryWindowPr
     )
 }
 
-function ExpandDatabaseTreeButton(): JSX.Element | null {
+function ExpandDatabaseTreeButton({
+    showDatabaseTree,
+    onShowDatabaseTree,
+}: {
+    showDatabaseTree: boolean
+    onShowDatabaseTree: () => void
+}): JSX.Element | null {
     const { isDatabaseTreeCollapsed } = useValues(editorSizingLogic)
     const { toggleDatabaseTreeCollapsed } = useActions(editorSizingLogic)
 
-    if (!isDatabaseTreeCollapsed) {
+    if (showDatabaseTree && !isDatabaseTreeCollapsed) {
         return null
     }
 
@@ -186,7 +203,13 @@ function ExpandDatabaseTreeButton(): JSX.Element | null {
             type="secondary"
             size="small"
             tooltip="Expand database schema panel"
-            onClick={toggleDatabaseTreeCollapsed}
+            onClick={() => {
+                if (!showDatabaseTree) {
+                    onShowDatabaseTree()
+                    return
+                }
+                toggleDatabaseTreeCollapsed()
+            }}
         />
     )
 }

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -39,16 +39,23 @@ interface SQLEditorProps {
     tabId?: string
     mode?: SQLEditorMode
     showDatabaseTree?: boolean
+    defaultShowDatabaseTree?: boolean
 }
 
-export function SQLEditor({ tabId, mode = SQLEditorMode.FullScene, showDatabaseTree }: SQLEditorProps): JSX.Element {
+export function SQLEditor({
+    tabId,
+    mode = SQLEditorMode.FullScene,
+    showDatabaseTree,
+    defaultShowDatabaseTree = true,
+}: SQLEditorProps): JSX.Element {
     const ref = useRef(null)
     const navigatorRef = useRef(null)
     const queryPaneRef = useRef(null)
     const sidebarRef = useRef(null)
     const databaseTreeRef = useRef(null)
+    const [hasShownDatabaseTree, setHasShownDatabaseTree] = useState(defaultShowDatabaseTree)
 
-    const shouldShowDatabaseTree = showDatabaseTree ?? true
+    const shouldShowDatabaseTree = showDatabaseTree ?? hasShownDatabaseTree
 
     const editorSizingLogicProps = useMemo(
         () => ({
@@ -175,6 +182,8 @@ export function SQLEditor({ tabId, mode = SQLEditorMode.FullScene, showDatabaseT
                                                     <QueryWindow
                                                         mode={mode}
                                                         tabId={tabId || ''}
+                                                        showDatabaseTree={shouldShowDatabaseTree}
+                                                        onShowDatabaseTree={() => setHasShownDatabaseTree(true)}
                                                         onSetMonacoAndEditor={(nextMonaco, nextEditor) =>
                                                             setMonacoAndEditor([nextMonaco, nextEditor])
                                                         }

--- a/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
+++ b/products/endpoints/frontend/endpoint-tabs/EndpointQuery.tsx
@@ -117,7 +117,7 @@ function EndpointHogQLQuery({
         <div className="flex min-w-0 gap-4">
             <div className="flex min-w-0 flex-1 flex-col gap-2">
                 <ResizableSQLEditorContainer>
-                    <SQLEditor tabId={sqlEditorTabId} mode={SQLEditorMode.Embedded} />
+                    <SQLEditor tabId={sqlEditorTabId} mode={SQLEditorMode.Embedded} defaultShowDatabaseTree={false} />
                 </ResizableSQLEditorContainer>
             </div>
         </div>


### PR DESCRIPTION
## Problem

Not really a problem. Maybe a paperclip? Maybe intended and I'll close this.

When I open the endpoint sql editor, the existence of the sidebar confuses me. It's too close to the SQL editor itself... and It feels like I should do something with all the options that appear:

![2026-03-19 15 06 50](https://github.com/user-attachments/assets/b36a1ca8-d9ae-4130-ad26-018a2dc5f1cf)


## Changes

Instead, focus on the query itself. The schema sidebar is still there with a click of a button.

![2026-03-19 15 05 35](https://github.com/user-attachments/assets/ffbdc438-abd6-4994-8f2a-db5375345076)



## How did you test this code?

See screencast

## Publish to changelog?

no