### PR TITLE
fix(insights): sync math selector state with props to fix graph update

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -5,7 +5,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { BuiltLogic, useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import {
     IconCopy,
@@ -1061,6 +1061,22 @@ function useMathSelectorOptions({
     const [countPerActorMathTypeShown, setCountPerActorMathTypeShown] = useState<CountPerActorMathType>(
         isCountPerActorMath(math) ? math : CountPerActorMathType.Average
     )
+
+    // Sync internal state with the math prop when it changes externally (e.g., undo/redo,
+    // URL changes, or after the filter update round-trips through the query). Without this,
+    // the LemonSelect option value can desync from the actual math type, preventing the
+    // dropdown from reflecting or triggering further changes correctly.
+    useEffect(() => {
+        if (isPropertyValueMath(math)) {
+            setPropertyMathTypeShown(math)
+        }
+    }, [math])
+
+    useEffect(() => {
+        if (isCountPerActorMath(math)) {
+            setCountPerActorMathTypeShown(math)
+        }
+    }, [math])
 
     const [uniqueActorsShown, setUniqueActorsShown] = useState<string>(
         getActiveActor('unique_group', mathGroupTypeIndex)


### PR DESCRIPTION
## Problem

Closes #30356

When changing the math operation in the property value sub-selector (e.g. sum -> average), the graph may not update until the user re-selects the property from the dropdown.

The root cause is that `propertyMathTypeShown` and `countPerActorMathTypeShown` are initialized via `useState` but never synced when the `math` prop changes. This means the `LemonSelect` option's `value` can desync from the actual `mathType` derived from props, preventing the dropdown from correctly reflecting or triggering changes.

## Changes

Added `useEffect` hooks in `useMathSelectorOptions` to keep the internal dropdown state (`propertyMathTypeShown`, `countPerActorMathTypeShown`) in sync with the `math` prop. When the `math` prop changes (after the filter update round-trips through the query, or from external changes like undo/redo or URL navigation), the internal state is updated to match.

## How did you test this code?

I am an agent and have not tested this manually. The fix is a minimal defensive change that adds prop-to-state synchronization, which is a standard React pattern to prevent stale internal state. The change does not alter any existing behavior when the state is already in sync.

No

## 🤖 LLM context

This PR was co-authored by Claude Code. The fix was identified through static analysis of the math selector component's state management, specifically the desync between `useState` initialization and prop changes.