### PR TITLE
fix: Flakey personhog-leader integration test

### DIFF
--- a/rust/personhog-leader/tests/integration.rs
+++ b/rust/personhog-leader/tests/integration.rs
@@ -59,10 +59,13 @@ async fn service_accepts_requests_after_coordination_warmup() {
     })
     .await;
 
-    // All partitions should be warmed in the cache
-    for p in 0..NUM_PARTITIONS {
-        assert!(pod.cache.has_partition(p), "partition {p} should be warmed");
-    }
+    // Wait for all partitions to be warmed in the cache (may lag behind etcd state)
+    let check_cache = Arc::clone(&pod.cache);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let cache = Arc::clone(&check_cache);
+        async move { (0..NUM_PARTITIONS).all(|p| cache.has_partition(p)) }
+    })
+    .await;
 
     // Seed a person into partition 0
     let person = test_cached_person();
@@ -227,6 +230,14 @@ async fn release_partition_stops_serving() {
     })
     .await;
 
+    // Wait for cache to reflect assignments (may lag behind etcd state)
+    let check_cache = Arc::clone(&pod1.cache);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let cache = Arc::clone(&check_cache);
+        async move { (0..NUM_PARTITIONS).all(|p| cache.has_partition(p)) }
+    })
+    .await;
+
     // Seed a person into partition 0
     seed_person(&pod1.cache, 0, test_cached_person());
 
@@ -266,6 +277,16 @@ async fn release_partition_stops_serving() {
         .find(|a| a.owner == "leader-1")
         .expect("pod 2 should own at least one partition")
         .partition;
+
+    // Wait for caches to reflect the rebalance (may lag behind etcd state)
+    let check_cache1 = Arc::clone(&pod1.cache);
+    let check_cache2 = Arc::clone(&pod2.cache);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let c1 = Arc::clone(&check_cache1);
+        let c2 = Arc::clone(&check_cache2);
+        async move { !c1.has_partition(moved_partition) && c2.has_partition(moved_partition) }
+    })
+    .await;
 
     // Pod 1: released partition → FailedPrecondition
     let result = client1
@@ -366,13 +387,13 @@ async fn rewarm_after_pod_crash() {
     })
     .await;
 
-    // Pod 2 should own all partitions (re-warmed the crashed pod's partitions)
-    for p in 0..NUM_PARTITIONS {
-        assert!(
-            pod2.cache.has_partition(p),
-            "pod 2 should own partition {p} after crash"
-        );
-    }
+    // Wait for pod 2 to re-warm all partitions (may lag behind etcd state)
+    let check_cache = Arc::clone(&pod2.cache);
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let cache = Arc::clone(&check_cache);
+        async move { (0..NUM_PARTITIONS).all(|p| cache.has_partition(p)) }
+    })
+    .await;
 
     // Partitions are warm but empty → NotFound
     let mut client2 = create_leader_client(pod2.leader_addr).await;


### PR DESCRIPTION
## Problem

The `personhog-leader` integration tests are flaky on master because they wait on etcd state (assignments/handoffs) but immediately assert on local cache state, which may lag behind due to async processing.

## Changes

- Replace instant cache assertions with `wait_for_condition` polls on the cache in tests 1, 3, and 4
- Add cache synchronization waits after rebalance in `release_partition_stops_serving` for both the initial assignment and partition migration


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
