### PR TITLE
fix(ux): new ai first home page offramp fixes, add super power

### DIFF
--- a/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
+++ b/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
@@ -44,7 +44,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
     const homepageDisplayTitle = homepageTabForDisplay
         ? homepageTabForDisplay.customTitle || homepageTabForDisplay.title
         : isAIFirst
-          ? 'Home'
+          ? 'Launchpad'
           : "Project's default dashboard"
     const homepageSubtitle = isUsingProjectDefault
         ? isAIFirst
@@ -134,9 +134,9 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
         isHomepage?: (tab: SceneTab) => boolean
     ): JSX.Element => (
         <section className="space-y-3">
-            <div>
-                <h3 className="text-lg font-semibold text-primary">{title}</h3>
-                <p className="text-sm text-muted-alt">{description}</p>
+            <div className="flex flex-col">
+                <h3 className="text-lg font-semibold text-primary m-0">{title}</h3>
+                <p className="text-sm text-tertiary m-0">{description}</p>
             </div>
             {sectionTabs.length > 0 ? (
                 <div className="space-y-2">
@@ -153,6 +153,119 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
     return (
         <LemonModal isOpen={isOpen} onClose={onClose} title="Configure tabs & home" width="48rem">
             <div className="space-y-6">
+                <section className="flex flex-col gap-3">
+                    <div className="flex flex-col">
+                        <h3 className="text-lg font-semibold text-primary m-0">Homepage</h3>
+                        <p className="text-sm text-tertiary m-0">Choose your personal homepage for this project.</p>
+                    </div>
+                    <div className="flex flex-col gap-2">
+                        <div className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2 bg-surface-primary">
+                            <div className="flex min-w-0 items-center gap-2">
+                                <span className="shrink-0 text-lg text-muted-alt">{homepageIconElement}</span>
+                                <div className="min-w-0">
+                                    <div className="truncate font-medium text-primary">{homepageDisplayTitle}</div>
+                                    {homepageSubtitle && (
+                                        <div className="truncate text-xs text-muted">{homepageSubtitle}</div>
+                                    )}
+                                </div>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                {isAIFirst ? (
+                                    <>
+                                        <LemonButton
+                                            size="small"
+                                            type="secondary"
+                                            onClick={() => setHomepage(null)}
+                                            disabled={isUsingProjectDefault}
+                                        >
+                                            Launchpad
+                                        </LemonButton>
+                                        <LemonButton
+                                            size="small"
+                                            type="secondary"
+                                            onClick={() => setHomepage(newTabHomepage)}
+                                            disabled={isUsingNewTabHomepage}
+                                        >
+                                            Search
+                                        </LemonButton>
+                                        <LemonButton
+                                            size="small"
+                                            type="secondary"
+                                            onClick={() => {
+                                                const dashboardId = currentTeam?.primary_dashboard
+                                                if (dashboardId) {
+                                                    setHomepage({
+                                                        id: `homepage-dashboard-${dashboardId}`,
+                                                        pathname: urls.dashboard(dashboardId),
+                                                        search: '',
+                                                        hash: '',
+                                                        title: 'Default dashboard',
+                                                        iconType: 'dashboard',
+                                                        active: false,
+                                                        pinned: true,
+                                                        sceneId: Scene.Dashboard,
+                                                        sceneKey: `dashboard-${dashboardId}`,
+                                                        sceneParams: emptySceneParams,
+                                                    })
+                                                }
+                                            }}
+                                            disabled={isUsingDefaultDashboard || !currentTeam?.primary_dashboard}
+                                            disabledReason={
+                                                !currentTeam?.primary_dashboard
+                                                    ? 'No default dashboard configured'
+                                                    : undefined
+                                            }
+                                        >
+                                            Default dashboard
+                                        </LemonButton>
+                                    </>
+                                ) : (
+                                    <>
+                                        <LemonButton
+                                            size="small"
+                                            type="secondary"
+                                            onClick={() => setHomepage(null)}
+                                            disabled={isUsingProjectDefault}
+                                        >
+                                            Use default dashboard
+                                        </LemonButton>
+                                        <LemonButton
+                                            size="small"
+                                            type="secondary"
+                                            onClick={() => setHomepage(newTabHomepage)}
+                                            disabled={isUsingNewTabHomepage}
+                                        >
+                                            Use new tab page
+                                        </LemonButton>
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                        {(isAIFirst ? isUsingDefaultDashboard : isUsingProjectDefault) && (
+                            <section className="space-y-3 bg-surface-secondary rounded-lg p-3 border">
+                                <div className="flex flex-col">
+                                    <h4 className="text-base font-semibold text-primary m-0">
+                                        Set default dashboard (project based)
+                                    </h4>
+                                    <p className="text-sm text-tertiary m-0">
+                                        This dashboard opens by default for everyone who has not set a custom homepage.
+                                    </p>
+                                </div>
+                                <LemonSelect<number | null>
+                                    className="w-full"
+                                    fullWidth
+                                    options={projectDefaultDashboardOptions}
+                                    value={projectDefaultDashboardId}
+                                    onChange={(dashboardId) =>
+                                        updateCurrentTeam({ primary_dashboard: dashboardId ?? null })
+                                    }
+                                    disabledReason={dashboardsLoading ? 'Loading dashboards…' : undefined}
+                                />
+                            </section>
+                        )}
+                    </div>
+                </section>
+
                 {renderSection(
                     'Pinned tabs',
                     'Pinned tabs are only visible to you and persist with the project.',
@@ -169,110 +282,6 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                     'No regular tabs available to pin.',
                     (tab) => homepage?.id === tab.id
                 )}
-                <section className="space-y-3">
-                    <div>
-                        <h3 className="text-lg font-semibold text-primary">Homepage</h3>
-                        <p className="text-sm text-muted-alt">Choose your personal homepage for this project.</p>
-                    </div>
-                    <div className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2 bg-surface-primary">
-                        <div className="flex min-w-0 items-center gap-2">
-                            <span className="shrink-0 text-lg text-muted-alt">{homepageIconElement}</span>
-                            <div className="min-w-0">
-                                <div className="truncate font-medium text-primary">{homepageDisplayTitle}</div>
-                                {homepageSubtitle && (
-                                    <div className="truncate text-xs text-muted">{homepageSubtitle}</div>
-                                )}
-                            </div>
-                        </div>
-                        <div className="flex flex-wrap gap-2">
-                            {isAIFirst ? (
-                                <>
-                                    <LemonButton
-                                        size="small"
-                                        type="secondary"
-                                        onClick={() => setHomepage(null)}
-                                        disabled={isUsingProjectDefault}
-                                    >
-                                        Home
-                                    </LemonButton>
-                                    <LemonButton
-                                        size="small"
-                                        type="secondary"
-                                        onClick={() => {
-                                            const dashboardId = currentTeam?.primary_dashboard
-                                            if (dashboardId) {
-                                                setHomepage({
-                                                    id: `homepage-dashboard-${dashboardId}`,
-                                                    pathname: urls.dashboard(dashboardId),
-                                                    search: '',
-                                                    hash: '',
-                                                    title: 'Default dashboard',
-                                                    iconType: 'dashboard',
-                                                    active: false,
-                                                    pinned: true,
-                                                    sceneId: Scene.Dashboard,
-                                                    sceneKey: `dashboard-${dashboardId}`,
-                                                    sceneParams: emptySceneParams,
-                                                })
-                                            }
-                                        }}
-                                        disabled={isUsingDefaultDashboard || !currentTeam?.primary_dashboard}
-                                        disabledReason={
-                                            !currentTeam?.primary_dashboard
-                                                ? 'No default dashboard configured'
-                                                : undefined
-                                        }
-                                    >
-                                        Default dashboard
-                                    </LemonButton>
-                                    <LemonButton
-                                        size="small"
-                                        type="secondary"
-                                        onClick={() => setHomepage(newTabHomepage)}
-                                        disabled={isUsingNewTabHomepage}
-                                    >
-                                        Search
-                                    </LemonButton>
-                                </>
-                            ) : (
-                                <>
-                                    <LemonButton
-                                        size="small"
-                                        type="secondary"
-                                        onClick={() => setHomepage(null)}
-                                        disabled={isUsingProjectDefault}
-                                    >
-                                        Use default dashboard
-                                    </LemonButton>
-                                    <LemonButton
-                                        size="small"
-                                        type="secondary"
-                                        onClick={() => setHomepage(newTabHomepage)}
-                                        disabled={isUsingNewTabHomepage}
-                                    >
-                                        Use new tab page
-                                    </LemonButton>
-                                </>
-                            )}
-                        </div>
-                    </div>
-                </section>
-                <section className="space-y-3">
-                    <div>
-                        <h3 className="text-lg font-semibold text-primary">Project default dashboard</h3>
-                        <p className="text-sm text-muted-alt">
-                            This dashboard opens by default for everyone who has not set a custom homepage.
-                        </p>
-                    </div>
-                    <LemonSelect<number | null>
-                        className="w-full"
-                        fullWidth
-                        options={projectDefaultDashboardOptions}
-                        value={projectDefaultDashboardId}
-                        onChange={(dashboardId) => updateCurrentTeam({ primary_dashboard: dashboardId ?? null })}
-                        disabledReason={dashboardsLoading ? 'Loading dashboards…' : undefined}
-                    />
-                </section>
             </div>
         </LemonModal>
     )

--- a/frontend/src/lib/components/Superpowers/Superpowers.tsx
+++ b/frontend/src/lib/components/Superpowers/Superpowers.tsx
@@ -1,10 +1,13 @@
 import { useActions, useValues } from 'kea'
 
 import { IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonSelect } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonSelect, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
 import { SupermanHog } from 'lib/components/hedgehogs'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -36,6 +39,9 @@ function SuperpowersContent(): JSX.Element {
     const { user } = useValues(userLogic)
     const { fakeStatusOverride } = useValues(superpowersLogic)
     const { closeSuperpowers, setFakeStatusOverride } = useActions(superpowersLogic)
+    const { dataProcessingAccepted } = useValues(maxGlobalLogic)
+    const { updateOrganization } = useActions(organizationLogic)
+    const { isDev } = useValues(preflightLogic)
 
     const clearOnboardingTasks = (): void => {
         updateCurrentTeam({ onboarding_tasks: {} })
@@ -108,6 +114,34 @@ function SuperpowersContent(): JSX.Element {
                     </div>
                 </div>
             </div>
+
+            {isDev && (
+                <>
+                    <LemonDivider />
+
+                    <div>
+                        <h3 className="font-semibold mb-2">
+                            AI <LemonTag size="small">Dev only</LemonTag>
+                        </h3>
+                        <div className="space-y-2">
+                            <div className="flex items-center justify-between p-2 border rounded">
+                                <div>
+                                    <div className="font-medium">Enable AI data processing</div>
+                                    <div className="text-sm text-secondary">
+                                        Toggle organization-level AI data processing approval
+                                    </div>
+                                </div>
+                                <LemonSwitch
+                                    checked={dataProcessingAccepted}
+                                    onChange={(checked) =>
+                                        updateOrganization({ is_ai_data_processing_approved: checked })
+                                    }
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </>
+            )}
 
             <LemonDivider />
 

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef } from 'react'
 import {
     IconArrowRight,
     IconChevronRight,
+    IconGear,
     IconLightBulb,
     IconLock,
     IconNotification,
@@ -26,6 +27,7 @@ import { MaxThreadLogicProps, maxThreadLogic } from 'scenes/max/maxThreadLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
+import { navigationLogic } from '~/layout/navigation/navigationLogic'
 
 import { aiFirstHomepageLogic } from './aiFirstHomepageLogic'
 import { HOMEPAGE_TAB_ID } from './constants'
@@ -254,26 +256,46 @@ function SuggestionMenubar(): JSX.Element {
     const menubarRef = useRef<HTMLDivElement>(null)
 
     return (
-        <Menubar ref={menubarRef} className="flex gap-2 justify-center">
-            <SuggestionMenu
-                icon={<IconLightBulb className="size-4" />}
-                label="Learn"
-                suggestions={LEARN_SUGGESTIONS}
-                anchor={menubarRef}
-            />
-            <SuggestionMenu
-                icon={<IconRocket className="size-4" />}
-                label="Build"
-                suggestions={BUILD_SUGGESTIONS}
-                anchor={menubarRef}
-            />
-            <SuggestionMenu
-                icon={<IconNotification className="size-4" />}
-                label="Signals"
-                suggestions={SIGNALS_SUGGESTIONS}
-                anchor={menubarRef}
-            />
-        </Menubar>
+        <div className="flex gap-2 justify-center items-center">
+            <Menubar ref={menubarRef} className="flex gap-2 justify-center">
+                <SuggestionMenu
+                    icon={<IconLightBulb className="size-4" />}
+                    label="Learn"
+                    suggestions={LEARN_SUGGESTIONS}
+                    anchor={menubarRef}
+                />
+                <SuggestionMenu
+                    icon={<IconRocket className="size-4" />}
+                    label="Build"
+                    suggestions={BUILD_SUGGESTIONS}
+                    anchor={menubarRef}
+                />
+                <SuggestionMenu
+                    icon={<IconNotification className="size-4" />}
+                    label="Signals"
+                    suggestions={SIGNALS_SUGGESTIONS}
+                    anchor={menubarRef}
+                />
+            </Menubar>
+        </div>
+    )
+}
+
+function HomePageOfframp(): JSX.Element | null {
+    const { showConfigurePinnedTabsModal } = useActions(navigationLogic)
+
+    return (
+        <div className="flex items-center gap-2 group/colorful-product-icons colorful-product-icons-true">
+            <ButtonPrimitive
+                variant="panel"
+                onClick={() => showConfigurePinnedTabsModal()}
+                tooltip="Configure tabs & home"
+                className="text-tertiary hover:text-primary"
+            >
+                Configure home <IconGear className="size-4" />
+            </ButtonPrimitive>
+            <span className="text-xxs text-tertiary m-0" />
+        </div>
     )
 }
 
@@ -292,6 +314,8 @@ export function HomepageInput(): JSX.Element {
                     <p className="w-full flex justify-center text-xs text-tertiary m-0 grow">
                         PostHog AI can make mistakes. Please double-check responses
                     </p>
+
+                    <HomePageOfframp />
                 </div>
             )}
             {mode === 'ai' && <HomepageAiInput />}

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -281,7 +281,7 @@ function SuggestionMenubar(): JSX.Element {
     )
 }
 
-function HomePageOfframp(): JSX.Element | null {
+function HomePageOfframp(): JSX.Element {
     const { showConfigurePinnedTabsModal } = useActions(navigationLogic)
 
     return (

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -285,7 +285,7 @@ function HomePageOfframp(): JSX.Element | null {
     const { showConfigurePinnedTabsModal } = useActions(navigationLogic)
 
     return (
-        <div className="flex items-center gap-2 group/colorful-product-icons colorful-product-icons-true">
+        <div className="flex items-center gap-2">
             <ButtonPrimitive
                 variant="panel"
                 onClick={() => showConfigurePinnedTabsModal()}
@@ -294,7 +294,6 @@ function HomePageOfframp(): JSX.Element | null {
             >
                 Configure home <IconGear className="size-4" />
             </ButtonPrimitive>
-            <span className="text-xxs text-tertiary m-0" />
         </div>
     )
 }


### PR DESCRIPTION
## Problem
* Ai homepage: was a bit too jarring change
* Configure home/tabs modal: "Default" was now "Home", but that's confusing as Home is used a lot
* Configure home/tabs modal: was a bit of a mess
* Configure home/tabs modal: always showed "default dashboard" dropdown even if that option wasn't selected
* It's difficult to disable `is_ai_data_processing_approved` quickly for testing purposes

## Changes
* Ai homepage: Add "configure button" under the AI home page idle input
* Configure home/tabs modal: rename "home" to "launchpad"
* Configure home/tabs modal: Clean up the DOM/styles
* Configure home/tabs modal: Hide default dashboard dropdown from view when not selected as option
* Super power: Add super power `cmd shift p` to quickly toggle `is_ai_data_processing_approved` (dev only)

<img width="788" height="477" alt="Screenshot 2026-03-19 at 14 11 14" src="https://github.com/user-attachments/assets/122481f6-2981-4b22-a665-31bd284dc584" />
<img width="796" height="710" alt="Screenshot 2026-03-19 at 14 11 06" src="https://github.com/user-attachments/assets/fe015178-ccd3-4c52-9248-3a25892c789b" />
<img width="555" height="784" alt="image" src="https://github.com/user-attachments/assets/f02cd057-2b41-430e-a245-b4680726f0c0" />




## How did you test this code?
Locally

## Publish to changelog?
No