### PR TITLE
fix(error-tracking): respect OR/AND filter type in rule modal preview query

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.ts
@@ -9,7 +9,7 @@ import type { assignmentRuleModalLogicType } from './assignmentRuleModalLogicTyp
 function emptyRule(orderKey: number = 0): ErrorTrackingAssignmentRule {
     return {
         id: 'new',
-        filters: { type: FilterLogicalOperator.Or, values: [] },
+        filters: { type: FilterLogicalOperator.And, values: [] },
         assignee: null,
         disabled_data: null,
         order_key: orderKey,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/MatchResultBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/MatchResultBanner.tsx
@@ -6,7 +6,7 @@ import { urls } from 'scenes/urls'
 
 import { defaultDataTableColumns } from '~/queries/nodes/DataTable/utils'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { ActivityTab, AnyPropertyFilter } from '~/types'
+import { ActivityTab, AnyPropertyFilter, FilterLogicalOperator } from '~/types'
 
 const DATE_RANGE_LABELS: Record<string, string> = {
     '-7d': '7 days',
@@ -22,6 +22,7 @@ const NEXT_DATE_RANGE: Record<string, string> = {
 export function MatchResultBanner({
     matchResult,
     properties,
+    filterType = FilterLogicalOperator.And,
     suffix,
     dateRange = '-7d',
     onIncreaseDateRange,
@@ -29,6 +30,7 @@ export function MatchResultBanner({
 }: {
     matchResult: { exceptionCount: number; issueCount: number }
     properties: AnyPropertyFilter[]
+    filterType?: FilterLogicalOperator
     suffix: (issuesLink: JSX.Element, dateRangeLabel: string) => JSX.Element
     dateRange?: string
     onIncreaseDateRange?: () => void
@@ -51,7 +53,7 @@ export function MatchResultBanner({
     }
 
     const issuesUrl = urls.errorTracking({
-        filterGroup: { type: 'AND', values: [{ type: 'AND', values: properties }] },
+        filterGroup: { type: filterType, values: [{ type: filterType, values: properties }] },
         dateRange: { date_from: dateRange, date_to: null },
     })
 

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/RuleModal.tsx
@@ -195,6 +195,7 @@ export function RuleModal({
                         <MatchResultBanner
                             matchResult={matchResult}
                             properties={(rule.filters.values as AnyPropertyFilter[]) ?? []}
+                            filterType={rule.filters.type}
                             dateRange={dateRange}
                             onIncreaseDateRange={increaseDateRange}
                             suffix={suffix}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/ruleModalLogicFactory.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/ruleModalLogicFactory.ts
@@ -4,7 +4,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 
 import { NodeKind } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter, UniversalFiltersGroup } from '~/types'
+import { AnyPropertyFilter, FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
 import { rulesLogic } from './rulesLogic'
 import { ErrorTrackingBaseRule, ErrorTrackingRuleType } from './types'
@@ -93,7 +93,9 @@ export function createRuleModalLogic<T extends ErrorTrackingBaseRule>(options: R
                         }
 
                         if (properties.length > 0) {
-                            query.properties = properties
+                            query.fixedProperties = [
+                                { type: filters.type ?? FilterLogicalOperator.And, values: properties },
+                            ]
                         } else if (!allowEmptyFilters) {
                             return null
                         }


### PR DESCRIPTION
## Problem

The Any/All (OR/AND) toggle in rule modals (e.g. assignment rules) had no effect on the preview query results — the \"Test rule\" count always used AND logic regardless of the selected operator.

## Changes

- **`ruleModalLogicFactory.ts`**: Changed `loadMatchCount` to use `fixedProperties` instead of `properties` on the `EventsQuery`. The `properties` field only accepts a flat list (always AND), while `fixedProperties` accepts a `PropertyGroupFilterValue` with a `type` field (`FilterLogicalOperator.And` | `FilterLogicalOperator.Or`). Now passes `{ type: filters.type, values: properties }` so OR filters generate correct SQL.

- **`MatchResultBanner.tsx`**: Added a `filterType` prop (defaults to `FilterLogicalOperator.And`) and used it when constructing the issues URL. Previously the URL hardcoded `type: 'AND'` in the filter group, so clicking through to the issues list always showed AND-filtered results even when OR was selected.

- **`RuleModal.tsx`**: Passes `filterType={rule.filters.type}` down to `MatchResultBanner`.

## How did you test this code?

Tested manually on localhost: created an assignment rule with two filters, toggled between Any and All, clicked \"Test rule\" — exception counts correctly differed between OR and AND logic. Verified the issues link also reflects the correct operator.

## Publish to changelog?

No

## Docs update

No docs update needed.