### PR TITLE
chore: remove accounts:read from Typeform required scopes

### DIFF
--- a/posthog/temporal/data_imports/sources/typeform/source.py
+++ b/posthog/temporal/data_imports/sources/typeform/source.py
@@ -47,7 +47,6 @@ Supported endpoints:
 - `responses`
 
 Required scopes:
-- `accounts:read`
 - `forms:read`
 - `responses:read`
 


### PR DESCRIPTION
## Summary
- Remove `accounts:read` from the Typeform source's documented required scopes, as it's not actually needed

## Test plan
- Doc-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)