### PR TITLE
feat(hogli): emit devenv_started telemetry on hogli start

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -141,8 +141,9 @@ else
     GENERATED_CONFIG="$REPOSITORY_ROOT/.posthog/.generated/mprocs.yaml"
 
     # Generate/regenerate config using hogli (defaults to product_analytics if no config exists)
+    # HOGLI_PROCESS_MANAGER is picked up by dev:generate for telemetry
     if command -v hogli &>/dev/null; then
-        hogli dev:generate 2>/dev/null || true
+        HOGLI_PROCESS_MANAGER="$PROCESS_MANAGER" hogli dev:generate 2>/dev/null || true
     fi
 
     if [[ -f "$GENERATED_CONFIG" ]]; then

--- a/common/hogli/devenv/cli.py
+++ b/common/hogli/devenv/cli.py
@@ -5,6 +5,8 @@ Provides hogli dev:* commands for managing the development environment.
 
 from __future__ import annotations
 
+import os
+
 import click
 from hogli.core.cli import cli
 
@@ -92,6 +94,24 @@ def dev_generate(
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     generator.generate_and_save(resolved, output_path, saved_config)
+
+    # Emit devenv_started when called from bin/start (signaled via env var)
+    process_manager = os.environ.get("HOGLI_PROCESS_MANAGER")
+    if process_manager:
+        from hogli import telemetry
+
+        # Normalize "*/bin/phrocs" -> "phrocs"
+        pm_name = os.path.basename(process_manager)
+        telemetry.track(
+            "devenv_started",
+            {
+                "intents": sorted(resolved.intents),
+                "intent_count": len(resolved.intents),
+                "unit_count": len(resolved.units),
+                "docker_profiles": sorted(resolved.docker_profiles),
+                "process_manager": pm_name,
+            },
+        )
 
     click.echo("Generated mprocs config from saved config")
     click.echo(f"  Products: {', '.join(sorted(resolved.intents))}")


### PR DESCRIPTION
## Problem

`hogli start` never fires `command_completed` because `bin/start` does `exec` and it's unlikely to see a clean exit (rather, folks may close their terminal window completely), so we have no visibility into what developers are actually running in terms of the dev intents configured and such.

## Changes

- `bin/start` exports `HOGLI_PROCESS_MANAGER` before calling `hogli dev:generate`
- `dev:generate` emits a `devenv_started` event (gated on the env var) with intents, unit count, docker profiles, and process manager (phrocs/mprocs)
- Fixed existing dashboard insights to use correct event names and added 5 new tiles for the `devenv_started` event (via MCP, not in this diff)

## How did you test this code?

All 150 hogli tests pass.

## Publish to changelog?

no