### PR TITLE
fix: Remove keying of app metrics and log entries

### DIFF
--- a/nodejs/src/cdp/consumers/__snapshots__/cdp-cyclotron-worker-plugins.test.ts.snap
+++ b/nodejs/src/cdp/consumers/__snapshots__/cdp-cyclotron-worker-plugins.test.ts.snap
@@ -1,16 +1,16 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CdpCyclotronWorkerPlugins onEvent should handle and collect errors 2`] = `
 [
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-0>",
+    "key": null,
     "topic": "log_entries_test",
     "value": {
-      "instance_id": "<REPLACED-UUID-0>",
+      "instance_id": "<REPLACED-UUID-1>",
       "level": "error",
       "log_source": "hog_function",
-      "log_source_id": "<REPLACED-UUID-1>",
+      "log_source_id": "<REPLACED-UUID-0>",
       "message": "Plugin execution failed: Service is down, retry later",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.000",
@@ -18,11 +18,11 @@ exports[`CdpCyclotronWorkerPlugins onEvent should handle and collect errors 2`] 
   },
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-1>",
+    "key": null,
     "topic": "clickhouse_app_metrics2_test",
     "value": {
       "app_source": "hog_function",
-      "app_source_id": "<REPLACED-UUID-1>",
+      "app_source_id": "<REPLACED-UUID-0>",
       "count": 1,
       "metric_kind": "failure",
       "metric_name": "failed",

--- a/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-data-warehouse-events.consumer.test.ts
@@ -285,7 +285,7 @@ describe('CdpDatawarehouseEventsConsumer', () => {
             expect(mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')).toMatchObject(
                 [
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
                             app_source: 'hog_function',
@@ -299,7 +299,7 @@ describe('CdpDatawarehouseEventsConsumer', () => {
                     },
                     // Billing is per-event, not per-destination
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
                             app_source: 'hog_function',

--- a/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -252,7 +252,7 @@ describe.each([
                     mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
                 ).toMatchObject([
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
                             app_source: 'hog_function',
@@ -265,7 +265,7 @@ describe.each([
                         },
                     },
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
                             app_source: 'hog_function',
@@ -282,7 +282,7 @@ describe.each([
                         ? []
                         : [
                               {
-                                  key: expect.any(String),
+                                  key: null,
                                   topic: 'clickhouse_app_metrics2_test',
                                   value: {
                                       app_source: 'hog_function',
@@ -535,7 +535,7 @@ describe.each([
                 await processor.processBatch([globals])
                 expect(mockProducerObserver.getProducedKafkaMessages()).toMatchObject([
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
                             app_source: 'hog_function',

--- a/nodejs/src/cdp/hog-transformations/__snapshots__/hog-transformer.service.test.ts.snap
+++ b/nodejs/src/cdp/hog-transformations/__snapshots__/hog-transformer.service.test.ts.snap
@@ -4,13 +4,13 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
 [
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-0>",
+    "key": null,
     "topic": "log_entries_test",
     "value": {
-      "instance_id": "<REPLACED-UUID-0>",
+      "instance_id": "<REPLACED-UUID-1>",
       "level": "info",
       "log_source": "hog_function",
-      "log_source_id": "<REPLACED-UUID-1>",
+      "log_source_id": "<REPLACED-UUID-0>",
       "message": "geoip location data for ip: [REPLACED]",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.000",
@@ -18,13 +18,13 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
   },
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-0>",
+    "key": null,
     "topic": "log_entries_test",
     "value": {
-      "instance_id": "<REPLACED-UUID-0>",
+      "instance_id": "<REPLACED-UUID-1>",
       "level": "debug",
       "log_source": "hog_function",
-      "log_source_id": "<REPLACED-UUID-1>",
+      "log_source_id": "<REPLACED-UUID-0>",
       "message": "Function completed in [REPLACED]",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.001",
@@ -32,11 +32,11 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
   },
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-1>",
+    "key": null,
     "topic": "clickhouse_app_metrics2_test",
     "value": {
       "app_source": "hog_function",
-      "app_source_id": "<REPLACED-UUID-1>",
+      "app_source_id": "<REPLACED-UUID-0>",
       "count": 1,
       "metric_kind": "success",
       "metric_name": "succeeded",
@@ -46,13 +46,13 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
   },
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-2>",
+    "key": null,
     "topic": "log_entries_test",
     "value": {
-      "instance_id": "<REPLACED-UUID-2>",
+      "instance_id": "<REPLACED-UUID-3>",
       "level": "debug",
       "log_source": "hog_function",
-      "log_source_id": "<REPLACED-UUID-3>",
+      "log_source_id": "<REPLACED-UUID-2>",
       "message": "Function completed in [REPLACED]",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.000",
@@ -60,11 +60,11 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
   },
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-3>",
+    "key": null,
     "topic": "clickhouse_app_metrics2_test",
     "value": {
       "app_source": "hog_function",
-      "app_source_id": "<REPLACED-UUID-3>",
+      "app_source_id": "<REPLACED-UUID-2>",
       "count": 1,
       "metric_kind": "success",
       "metric_name": "succeeded",
@@ -74,13 +74,13 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
   },
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-4>",
+    "key": null,
     "topic": "log_entries_test",
     "value": {
-      "instance_id": "<REPLACED-UUID-4>",
+      "instance_id": "<REPLACED-UUID-5>",
       "level": "debug",
       "log_source": "hog_function",
-      "log_source_id": "<REPLACED-UUID-5>",
+      "log_source_id": "<REPLACED-UUID-4>",
       "message": "Function completed in [REPLACED]",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.000",
@@ -88,11 +88,11 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
   },
   {
     "headers": undefined,
-    "key": "<REPLACED-UUID-5>",
+    "key": null,
     "topic": "clickhouse_app_metrics2_test",
     "value": {
       "app_source": "hog_function",
-      "app_source_id": "<REPLACED-UUID-5>",
+      "app_source_id": "<REPLACED-UUID-4>",
       "count": 1,
       "metric_kind": "success",
       "metric_name": "succeeded",

--- a/nodejs/src/cdp/services/monitoring/hog-function-monitoring.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-function-monitoring.service.ts
@@ -49,7 +49,6 @@ export type HogFunctionMonitoringMessage = {
     topic: string
     value: LogEntrySerialized | AppMetricType
     headers?: Record<string, string>
-    key: string
 }
 
 // Check if the result is of type CyclotronJobInvocationHogFunction
@@ -96,7 +95,7 @@ export class HogFunctionMonitoringService {
                 return this.kafkaProducer
                     .produce({
                         topic: x.topic,
-                        key: x.key ? Buffer.from(x.key) : null,
+                        key: null,
                         value,
                         headers: x.headers,
                     })
@@ -107,7 +106,6 @@ export class HogFunctionMonitoringService {
                             error: String(error),
                             messageLength: value?.length,
                             topic: x.topic,
-                            key: x.key,
                             headers: x.headers,
                         })
 
@@ -147,7 +145,6 @@ export class HogFunctionMonitoringService {
         this.messagesToProduce.push({
             topic: this.appMetricsTopic,
             value: appMetric,
-            key: appMetric.app_source_id,
         })
         hogFunctionMonitoringPendingMessages.set(this.messagesToProduce.length)
     }
@@ -168,7 +165,6 @@ export class HogFunctionMonitoringService {
             this.messagesToProduce.push({
                 topic: this.logEntriesTopic,
                 value: logEntry,
-                key: logEntry.instance_id,
             })
         })
         hogFunctionMonitoringPendingMessages.set(this.messagesToProduce.length)

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -1329,7 +1329,7 @@ describe('IngestionConsumer', () => {
                     mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
                 expect(metricsMessages).toEqual([
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
                             app_source: 'hog_function',
@@ -1347,7 +1347,7 @@ describe('IngestionConsumer', () => {
                 const logMessages = mockProducerObserver.getProducedKafkaMessagesForTopic('log_entries_test')
                 expect(logMessages).toEqual([
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'log_entries_test',
                         value: {
                             instance_id: expect.any(String),
@@ -1360,7 +1360,7 @@ describe('IngestionConsumer', () => {
                         },
                     },
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'log_entries_test',
                         value: {
                             instance_id: expect.any(String),
@@ -1394,7 +1394,7 @@ describe('IngestionConsumer', () => {
                     mockProducerObserver.getProducedKafkaMessagesForTopic('clickhouse_app_metrics2_test')
                 expect(metricsMessages).toEqual([
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'clickhouse_app_metrics2_test',
                         value: {
                             app_source: 'hog_function',
@@ -1412,7 +1412,7 @@ describe('IngestionConsumer', () => {
                 const logMessages = mockProducerObserver.getProducedKafkaMessagesForTopic('log_entries_test')
                 expect(logMessages).toEqual([
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'log_entries_test',
                         value: {
                             instance_id: expect.any(String),
@@ -1425,7 +1425,7 @@ describe('IngestionConsumer', () => {
                         },
                     },
                     {
-                        key: expect.any(String),
+                        key: null,
                         topic: 'log_entries_test',
                         value: {
                             instance_id: expect.any(String),


### PR DESCRIPTION
## Problem

Pretty certain keying isn't at all necessary as this is just landing in the same table