### PR TITLE
chore: add tracking for ai-first homepage configuration

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -1,6 +1,7 @@
 import { cva } from 'cva'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 import { useRef } from 'react'
 
 import {
@@ -407,8 +408,12 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                                                 isSideActionRight
                                                                 onClick={(e) => {
                                                                     e.stopPropagation()
+                                                                    posthog.capture(
+                                                                        'navbar home side action configure home clicked'
+                                                                    )
                                                                     showConfigurePinnedTabsModal()
                                                                 }}
+                                                                data-attr="menu-item-side-action-configure-home"
                                                                 tooltip="Configure tabs & home"
                                                                 tooltipPlacement="right"
                                                                 className="opacity-0 group-hover:opacity-100 transition-all duration-50"

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -408,9 +408,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                                                 isSideActionRight
                                                                 onClick={(e) => {
                                                                     e.stopPropagation()
-                                                                    posthog.capture(
-                                                                        'navbar home side action configure home clicked'
-                                                                    )
+                                                                    posthog.capture('homepage configure home clicked', {
+                                                                        source: 'navbar',
+                                                                    })
                                                                     showConfigurePinnedTabsModal()
                                                                 }}
                                                                 data-attr="menu-item-side-action-configure-home"

--- a/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
@@ -67,7 +67,7 @@ export function NavLink({ to, label, icon, isCollapsed, 'data-attr': dataAttr, o
             </Link>
             {isHomePage && !isCollapsed && (
                 <ButtonPrimitive
-                    className="opacity-0 group-hover/wrapper:opacity-50 hover:!opacity-100 transition-all duration-50 -outline-offset-2 focus-visible:opacity-100"
+                    className="opacity-50 hover:!opacity-100 transition-all duration-50 -outline-offset-2 focus-visible:opacity-100"
                     iconOnly
                     isSideActionRight
                     onClick={(e) => {

--- a/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
+++ b/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
@@ -185,7 +185,10 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             data-attr="configure-homepage-modal-set-launchpad"
                                             disabled={isUsingProjectDefault}
                                         >
-                                            Launchpad
+                                            Launchpad{' '}
+                                            <LemonTag size="small" type="highlight" className="ml-1">
+                                                New
+                                            </LemonTag>
                                         </LemonButton>
                                         <LemonButton
                                             size="small"

--- a/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
+++ b/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
@@ -177,7 +177,9 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             size="small"
                                             type="secondary"
                                             onClick={() => {
-                                                posthog.capture('configure homepage modal set launchpad clicked')
+                                                posthog.capture('homepage configure set homepage', {
+                                                    value: 'launchpad',
+                                                })
                                                 setHomepage(null)
                                             }}
                                             data-attr="configure-homepage-modal-set-launchpad"
@@ -189,7 +191,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             size="small"
                                             type="secondary"
                                             onClick={() => {
-                                                posthog.capture('configure homepage modal set search clicked')
+                                                posthog.capture('homepage configure set homepage', { value: 'search' })
                                                 setHomepage(newTabHomepage)
                                             }}
                                             data-attr="configure-homepage-modal-set-search"
@@ -201,9 +203,9 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             size="small"
                                             type="secondary"
                                             onClick={() => {
-                                                posthog.capture(
-                                                    'configure homepage modal set default dashboard clicked'
-                                                )
+                                                posthog.capture('homepage configure set homepage', {
+                                                    value: 'default_dashboard',
+                                                })
                                                 const dashboardId = currentTeam?.primary_dashboard
                                                 if (dashboardId) {
                                                     setHomepage({
@@ -271,7 +273,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                     value={projectDefaultDashboardId}
                                     data-attr="configure-homepage-modal-set-default-dashboard-select"
                                     onChange={(dashboardId) => {
-                                        posthog.capture('configure homepage modal set default dashboard changed')
+                                        posthog.capture('homepage configure default dashboard changed')
                                         updateCurrentTeam({ primary_dashboard: dashboardId ?? null })
                                     }}
                                     disabledReason={dashboardsLoading ? 'Loading dashboards…' : undefined}

--- a/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
+++ b/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 
 import { LemonButton, LemonSelect, LemonSelectOptions, LemonTag } from '@posthog/lemon-ui'
 
@@ -175,7 +176,11 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                         <LemonButton
                                             size="small"
                                             type="secondary"
-                                            onClick={() => setHomepage(null)}
+                                            onClick={() => {
+                                                posthog.capture('configure homepage modal set launchpad clicked')
+                                                setHomepage(null)
+                                            }}
+                                            data-attr="configure-homepage-modal-set-launchpad"
                                             disabled={isUsingProjectDefault}
                                         >
                                             Launchpad
@@ -183,7 +188,11 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                         <LemonButton
                                             size="small"
                                             type="secondary"
-                                            onClick={() => setHomepage(newTabHomepage)}
+                                            onClick={() => {
+                                                posthog.capture('configure homepage modal set search clicked')
+                                                setHomepage(newTabHomepage)
+                                            }}
+                                            data-attr="configure-homepage-modal-set-search"
                                             disabled={isUsingNewTabHomepage}
                                         >
                                             Search
@@ -192,6 +201,9 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             size="small"
                                             type="secondary"
                                             onClick={() => {
+                                                posthog.capture(
+                                                    'configure homepage modal set default dashboard clicked'
+                                                )
                                                 const dashboardId = currentTeam?.primary_dashboard
                                                 if (dashboardId) {
                                                     setHomepage({
@@ -209,6 +221,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                                     })
                                                 }
                                             }}
+                                            data-attr="configure-homepage-modal-set-default-dashboard"
                                             disabled={isUsingDefaultDashboard || !currentTeam?.primary_dashboard}
                                             disabledReason={
                                                 !currentTeam?.primary_dashboard
@@ -256,9 +269,11 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                     fullWidth
                                     options={projectDefaultDashboardOptions}
                                     value={projectDefaultDashboardId}
-                                    onChange={(dashboardId) =>
+                                    data-attr="configure-homepage-modal-set-default-dashboard-select"
+                                    onChange={(dashboardId) => {
+                                        posthog.capture('configure homepage modal set default dashboard changed')
                                         updateCurrentTeam({ primary_dashboard: dashboardId ?? null })
-                                    }
+                                    }}
                                     disabledReason={dashboardsLoading ? 'Loading dashboards…' : undefined}
                                 />
                             </section>

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -288,7 +288,10 @@ function HomePageOfframp(): JSX.Element {
         <div className="flex items-center gap-2">
             <ButtonPrimitive
                 variant="panel"
-                onClick={() => showConfigurePinnedTabsModal()}
+                onClick={() => {
+                    posthog.capture('homepage offramp configure home clicked')
+                    showConfigurePinnedTabsModal()
+                }}
                 tooltip="Configure tabs & home"
                 className="text-tertiary hover:text-primary"
             >

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -289,7 +289,7 @@ function HomePageOfframp(): JSX.Element {
             <ButtonPrimitive
                 variant="panel"
                 onClick={() => {
-                    posthog.capture('homepage offramp configure home clicked')
+                    posthog.capture('homepage configure home clicked', { source: 'offramp' })
                     showConfigurePinnedTabsModal()
                 }}
                 tooltip="Configure tabs & home"

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -11,6 +11,7 @@ import {
     IconLightBulb,
     IconLock,
     IconNotification,
+    IconRewind,
     IconRocket,
     IconSearch,
 } from '@posthog/icons'
@@ -283,6 +284,8 @@ function SuggestionMenubar(): JSX.Element {
 
 function HomePageOfframp(): JSX.Element {
     const { showConfigurePinnedTabsModal } = useActions(navigationLogic)
+    const { revertToPreviousHomepage } = useActions(aiFirstHomepageLogic)
+    const { previousHomepage } = useValues(aiFirstHomepageLogic)
 
     return (
         <div className="flex items-center gap-2">
@@ -297,6 +300,24 @@ function HomePageOfframp(): JSX.Element {
             >
                 Configure home <IconGear className="size-4" />
             </ButtonPrimitive>
+
+            {previousHomepage && (
+                <ButtonPrimitive
+                    variant="panel"
+                    onClick={() => {
+                        posthog.capture('homepage revert clicked', {
+                            previous_homepage_id: previousHomepage.id,
+                            previous_homepage_title: previousHomepage.title,
+                        })
+                        revertToPreviousHomepage()
+                    }}
+                    tooltip={`Revert to ${previousHomepage.title || 'previous homepage'}`}
+                    className="text-tertiary hover:text-primary"
+                >
+                    Put my {previousHomepage.title.toLocaleLowerCase() || 'previous homepage'} back{' '}
+                    <IconRewind className="size-4" />
+                </ButtonPrimitive>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -2,7 +2,12 @@ import { actions, afterMount, connect, kea, listeners, path, reducers, selectors
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { maxLogic } from 'scenes/max/maxLogic'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
+
+import { sceneLogic } from '~/scenes/sceneLogic'
+import { emptySceneParams } from '~/scenes/scenes'
+import { Scene, SceneTab } from '~/scenes/sceneTypes'
 
 import type { aiFirstHomepageLogicType } from './aiFirstHomepageLogicType'
 import { HOMEPAGE_TAB_ID } from './constants'
@@ -15,12 +20,49 @@ export interface LayoutState {
     animationPhase: AnimationPhase
 }
 
+const PREVIOUS_HOMEPAGE_KEY = 'ai-first-previous-homepage'
+
+function getStorageKey(): string {
+    const teamId = teamLogic.findMounted()?.values.currentTeamId ?? 'null'
+    return `${PREVIOUS_HOMEPAGE_KEY}-${teamId}`
+}
+
+function loadPreviousHomepage(): SceneTab | null {
+    try {
+        const stored = localStorage.getItem(getStorageKey())
+        return stored ? JSON.parse(stored) : null
+    } catch {
+        return null
+    }
+}
+
+function savePreviousHomepage(tab: SceneTab | null): void {
+    const key = getStorageKey()
+    if (tab) {
+        localStorage.setItem(key, JSON.stringify(tab))
+    } else {
+        localStorage.removeItem(key)
+    }
+}
+
 export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
     path(['scenes', 'project-homepage', 'ai-first', 'aiFirstHomepageLogic']),
 
     connect(() => ({
-        values: [maxLogic({ tabId: HOMEPAGE_TAB_ID }), ['threadLogicKey', 'conversationId']],
-        actions: [maxLogic({ tabId: HOMEPAGE_TAB_ID }), ['openConversation', 'startNewConversation', 'setQuestion']],
+        values: [
+            maxLogic({ tabId: HOMEPAGE_TAB_ID }),
+            ['threadLogicKey', 'conversationId'],
+            teamLogic,
+            ['currentTeam'],
+            sceneLogic,
+            ['homepage'],
+        ],
+        actions: [
+            maxLogic({ tabId: HOMEPAGE_TAB_ID }),
+            ['openConversation', 'startNewConversation', 'setQuestion'],
+            sceneLogic,
+            ['setHomepage'],
+        ],
     })),
 
     actions({
@@ -30,6 +72,8 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         setAnimationPhase: (phase: AnimationPhase) => ({ phase }),
         setHoveredSuggestion: (suggestion: string | null) => ({ suggestion }),
         returnToIdle: true,
+        setPreviousHomepage: (tab: SceneTab | null) => ({ tab }),
+        revertToPreviousHomepage: true,
     }),
 
     reducers({
@@ -77,6 +121,12 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
                 setHoveredSuggestion: (_, { suggestion }) => suggestion,
             },
         ],
+        previousHomepage: [
+            null as SceneTab | null,
+            {
+                setPreviousHomepage: (_, { tab }) => tab,
+            },
+        ],
     }),
 
     selectors({
@@ -116,6 +166,16 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             // Set the trigger character after animation so the slash menu doesn't appear mid-transition
             if (trigger) {
                 actions.setQuestion(trigger)
+            }
+        },
+        setPreviousHomepage: ({ tab }) => {
+            savePreviousHomepage(tab)
+        },
+        revertToPreviousHomepage: () => {
+            const prev = values.previousHomepage
+            if (prev) {
+                actions.setHomepage(prev)
+                router.actions.push(prev.pathname || '/')
             }
         },
     })),
@@ -162,7 +222,39 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
         },
     })),
 
-    afterMount(({ actions }) => {
+    afterMount(({ actions, values }) => {
+        // Capture the previous homepage on first visit so we can revert later
+        const stored = loadPreviousHomepage()
+        if (stored) {
+            actions.setPreviousHomepage(stored)
+        } else {
+            // First time on AI-first homepage — snapshot what the user would have seen before
+            const currentHomepage = values.homepage
+            if (currentHomepage) {
+                // User had a custom homepage set
+                actions.setPreviousHomepage(currentHomepage)
+            } else {
+                // No custom homepage — they would have seen the primary dashboard or search
+                const dashboardId = values.currentTeam?.primary_dashboard
+                if (dashboardId) {
+                    actions.setPreviousHomepage({
+                        id: `homepage-dashboard-${dashboardId}`,
+                        pathname: urls.dashboard(dashboardId),
+                        search: '',
+                        hash: '',
+                        title: 'Default dashboard',
+                        iconType: 'dashboard',
+                        active: false,
+                        pinned: true,
+                        sceneId: Scene.Dashboard,
+                        sceneKey: `dashboard-${dashboardId}`,
+                        sceneParams: emptySceneParams,
+                    })
+                }
+                // If no dashboard either, previousHomepage stays null — no revert button shown
+            }
+        }
+
         const { searchParams } = router.values
         const urlMode = (searchParams.mode as HomepageMode) || 'idle'
         const urlQuery = (searchParams.q as string) || ''


### PR DESCRIPTION
## Summary
- Add `posthog.capture()` tracking events and `data-attr` attributes for homepage configuration actions (navbar configure button, offramp configure button, homepage modal options)
- Normalize event naming to follow `homepage configure <action>` pattern with property-based variants instead of verbose unique event names

## Test plan
- [ ] Verify events fire correctly when clicking configure home from navbar and offramp
- [ ] Verify homepage modal buttons (launchpad, search, default dashboard) send `homepage configure set homepage` with correct `value` property
- [ ] Verify dashboard dropdown change sends `homepage configure default dashboard changed`

