### PR TITLE
chore: remove dead code and orphaned cache invalidation

### DIFF
--- a/posthog/models/project_secret_api_key.py
+++ b/posthog/models/project_secret_api_key.py
@@ -1,55 +1,10 @@
-import json
-from typing import Optional
-
 from django.contrib.postgres.fields import ArrayField
-from django.core.cache import cache
 from django.db import models
 from django.utils import timezone
 
-from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
 
-from .personal_api_key import hash_key_value
 from .utils import generate_random_token
-
-FIVE_DAYS = 60 * 60 * 24 * 5  # 5 days in seconds
-
-
-def _get_cache_key(secure_value: str) -> str:
-    return f"project_secret_api_key:{secure_value}"
-
-
-def _get_cached_key_data(secure_value: str) -> Optional[dict]:
-    """Get cached project secret API key data."""
-    try:
-        cache_key = _get_cache_key(secure_value)
-        cached_data = cache.get(cache_key)
-        if cached_data:
-            try:
-                return json.loads(cached_data)
-            except json.JSONDecodeError as e:
-                capture_exception(e, {"cache_key": cache_key, "operation": "parse"})
-                cache.delete(cache_key)
-    except Exception as e:
-        capture_exception(e, {"cache_key": cache_key, "operation": "get"})
-    return None
-
-
-def _set_cached_key_data(secure_value: str, key_data: dict) -> None:
-    """Cache project secret API key data."""
-    try:
-        cache.set(_get_cache_key(secure_value), json.dumps(key_data), FIVE_DAYS)
-    except Exception:
-        # Redis unavailable
-        pass
-
-
-def invalidate_project_secret_api_key_cache(secure_value: str) -> None:
-    """Invalidate the cache for a project secret API key."""
-    try:
-        cache.delete(_get_cache_key(secure_value))
-    except Exception:
-        pass
 
 
 class ProjectSecretAPIKey(ModelActivityMixin, models.Model):
@@ -93,67 +48,3 @@ class ProjectSecretAPIKey(ModelActivityMixin, models.Model):
         db_table = "posthog_projectsecretapikey"
         indexes = [models.Index(fields=["team", "created_at"])]
         constraints = [models.UniqueConstraint(fields=["team", "label"], name="unique_team_label")]
-
-    def save(self, *args, **kwargs):
-        # Invalidate cache when key is updated (e.g., scopes changed, key rolled)
-        # We need to invalidate the OLD secure_value in case it was changed (key rolled)
-        if self.pk:
-            try:
-                old_instance = ProjectSecretAPIKey.objects.get(pk=self.pk)
-                if old_instance.secure_value:
-                    invalidate_project_secret_api_key_cache(old_instance.secure_value)
-            except ProjectSecretAPIKey.DoesNotExist:
-                pass
-        super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        if self.secure_value:
-            invalidate_project_secret_api_key_cache(self.secure_value)
-        super().delete(*args, **kwargs)
-
-    @classmethod
-    def find_project_secret_api_key(cls, token) -> tuple["ProjectSecretAPIKey", str] | None:
-        """
-        Find a project secret API key by token value.
-
-        Uses Redis caching with a 5-day TTL to avoid database hits on every request,
-        since endpoint execution can be high-traffic.
-        """
-        from posthog.models.team import Team
-
-        secure_value = hash_key_value(token, mode="sha256")
-
-        cached_data = _get_cached_key_data(secure_value)
-        if cached_data:
-            try:
-                team = Team(id=cached_data["team_id"], project_id=cached_data["team_id"])
-                key = cls(
-                    id=cached_data["id"],
-                    team=team,
-                    label=cached_data["label"],
-                    mask_value=cached_data["mask_value"],
-                    secure_value=cached_data["secure_value"],
-                    scopes=cached_data.get("scopes"),
-                )
-                return key, "sha256"
-            except Exception:
-                pass
-
-        try:
-            obj = cls.objects.select_related("team").get(secure_value=secure_value)
-
-            _set_cached_key_data(
-                secure_value,
-                {
-                    "id": obj.id,
-                    "team_id": obj.team.id,
-                    "label": obj.label,
-                    "mask_value": obj.mask_value,
-                    "secure_value": obj.secure_value,
-                    "scopes": obj.scopes,
-                },
-            )
-
-            return obj, "sha256"
-        except ProjectSecretAPIKey.DoesNotExist:
-            return None

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -4,7 +4,6 @@ from typing import Any, Optional, TypedDict
 
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.db import models, transaction
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from django_deprecate_fields import deprecate_field
@@ -19,7 +18,6 @@ from posthog.settings import INSTANCE_TAG, SITE_URL
 from posthog.utils import get_instance_realm
 
 from .organization import Organization, OrganizationMembership
-from .personal_api_key import PersonalAPIKey, hash_key_value
 from .team import Team
 from .utils import UUIDTClassicModel, generate_random_token, sane_repr
 
@@ -137,20 +135,6 @@ class UserManager(BaseUserManager):
             user = self.create_user(email=email, password=password, first_name=first_name, **extra_fields)
             user.join(organization=organization, level=level)
             return user
-
-    def get_from_personal_api_key(self, key_value: str) -> Optional["User"]:
-        try:
-            personal_api_key: PersonalAPIKey = (
-                PersonalAPIKey.objects.select_related("user")
-                .filter(user__is_active=True)
-                .get(secure_value=hash_key_value(key_value))
-            )
-        except PersonalAPIKey.DoesNotExist:
-            return None
-        else:
-            personal_api_key.last_used_at = timezone.now()
-            personal_api_key.save()
-            return personal_api_key.user
 
 
 def events_column_config_default() -> dict[str, Any]:

--- a/posthog/storage/test/test_team_metadata_cache.py
+++ b/posthog/storage/test/test_team_metadata_cache.py
@@ -188,45 +188,6 @@ class TestTeamMetadataCacheSignals(BaseTest):
         # Cache should NOT be cleared
         mock_clear.assert_not_called()
 
-    @patch("posthog.models.project_secret_api_key.invalidate_project_secret_api_key_cache")
-    def test_team_delete_clears_project_secret_api_key_cache(self, mock_invalidate):
-        """Test that deleting a team clears its project secret API key caches."""
-        from posthog.models.project_secret_api_key import ProjectSecretAPIKey
-
-        team = Team.objects.create(
-            organization=self.organization,
-            name="Test Team",
-        )
-
-        ProjectSecretAPIKey.objects.create(
-            team=team,
-            label="Key 1",
-            secure_value="hashed_value_1",
-        )
-        ProjectSecretAPIKey.objects.create(
-            team=team,
-            label="Key 2",
-            secure_value="hashed_value_2",
-        )
-
-        team.delete()
-
-        self.assertEqual(mock_invalidate.call_count, 2)
-        invalidated_values = {call.args[0] for call in mock_invalidate.call_args_list}
-        self.assertEqual(invalidated_values, {"hashed_value_1", "hashed_value_2"})
-
-    @patch("posthog.models.project_secret_api_key.invalidate_project_secret_api_key_cache")
-    def test_team_delete_handles_no_project_secret_api_keys(self, mock_invalidate):
-        """Test that deleting a team without project secret API keys doesn't error."""
-        team = Team.objects.create(
-            organization=self.organization,
-            name="Test Team",
-        )
-
-        team.delete()
-
-        mock_invalidate.assert_not_called()
-
 
 class TestCacheStats(BaseTest):
     """Test cache statistics functionality."""

--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -140,16 +140,6 @@ def clear_team_metadata_cache_on_delete(sender: type[Team], instance: Team, **kw
     clear_team_metadata_cache(instance, kinds=kinds)
 
 
-@receiver(pre_delete, sender=Team)
-def clear_project_secret_api_key_cache_on_delete(sender: type[Team], instance: Team, **kwargs: Any) -> None:
-    """Clear project secret API key caches when a Team is deleted."""
-    from posthog.models.project_secret_api_key import invalidate_project_secret_api_key_cache
-
-    for key in instance.project_secret_api_keys.all():
-        if key.secure_value:
-            invalidate_project_secret_api_key_cache(key.secure_value)
-
-
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
 def cleanup_stale_expiry_tracking_task() -> None:
     """


### PR DESCRIPTION
## Problem

Dead code cleanup — `UserManager.get_from_personal_api_key()` and `ProjectSecretAPIKey.find_project_secret_api_key()` have zero callers anywhere in the codebase. Their callers were removed in previous refactors (#46592 replaced the auth path for project secret API keys, and the personal API key auth path was consolidated into `PersonalAPIKeyAuthentication`).

## Changes

- Remove `UserManager.get_from_personal_api_key()` and its unused import
- Remove `ProjectSecretAPIKey.find_project_secret_api_key()` and its supporting infrastructure:
  - `_get_cached_key_data()`, `_set_cached_key_data()`, `_get_cache_key()`, `FIVE_DAYS` constant
  - `invalidate_project_secret_api_key_cache()` and all call sites
  - `ProjectSecretAPIKey.save()`/`delete()` overrides that performed cache invalidation
  - `clear_project_secret_api_key_cache_on_delete` signal handler in `team_metadata.py`
- Remove associated test code for the deleted signal handler

The cache invalidation was orphaned — with `_set_cached_key_data` removed, nothing wrote to the `project_secret_api_key:{secure_value}` cache keys, making all invalidation calls no-ops (including an extra `SELECT` query on every `save()`).

## How did you test this code?

Verified zero references to all removed symbols via codebase-wide search (`grep`/`git log -S`). Confirmed the auth path now uses `Team.get_team_from_cache_or_secret_api_token()` with a separate cache pattern (`team_token:{token}`).

## Publish to changelog?

no