### PR TITLE
fix: Removed keys for kafka production 

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.test.ts
@@ -235,7 +235,6 @@ describe('CdpPrecalculatedFiltersConsumer', () => {
             expect(precalculatedEvents).toHaveLength(1)
 
             const preCalculatedEvent = precalculatedEvents[0]
-            expect(preCalculatedEvent.key).toBe(distinctId) // Partitioned by distinct_id
 
             expect(preCalculatedEvent.payload).toMatchObject({
                 uuid: eventUuid,
@@ -255,7 +254,6 @@ describe('CdpPrecalculatedFiltersConsumer', () => {
             expect(kafkaMessages).toHaveLength(1)
 
             const publishedMessage = kafkaMessages[0]
-            expect(publishedMessage.key).toBe(distinctId)
             expect(publishedMessage.value).toEqual(preCalculatedEvent.payload)
         })
 
@@ -443,12 +441,10 @@ describe('CdpPrecalculatedFiltersConsumer', () => {
             // First event should be for pageview filter
             expect(event1.payload.condition).toBe(conditionHash1)
             expect(event1.payload.source).toBe(`cohort_filter_${conditionHash1}`)
-            expect(event1.key).toBe(distinctId)
 
             // Second event should be for Chrome + pageview filter
             expect(event2.payload.condition).toBe(conditionHash2)
             expect(event2.payload.source).toBe(`cohort_filter_${conditionHash2}`)
-            expect(event2.key).toBe(distinctId)
         })
 
         it('should handle complex billing cohort filter with OR/AND structure', async () => {
@@ -548,7 +544,6 @@ describe('CdpPrecalculatedFiltersConsumer', () => {
             expect(events1).toHaveLength(1)
 
             const preCalculatedEvent1 = events1[0]
-            expect(preCalculatedEvent1.key).toBe(distinctId1)
             expect(preCalculatedEvent1.payload).toMatchObject({
                 uuid: eventUuid1,
                 team_id: team.id,
@@ -691,7 +686,6 @@ describe('CdpPrecalculatedFiltersConsumer', () => {
             expect(precalculatedEvents).toHaveLength(1)
 
             const preCalculatedEvent = precalculatedEvents[0]
-            expect(preCalculatedEvent.key).toBe(distinctId)
             expect(preCalculatedEvent.payload).toMatchObject({
                 uuid: eventUuid,
                 team_id: team.id,

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
@@ -42,7 +42,6 @@ export type PreCalculatedEvent = {
 }
 
 export type ProducedEvent = {
-    key: string
     payload: PreCalculatedEvent
 }
 
@@ -76,7 +75,6 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         try {
             const messages = events.map((event) => ({
                 value: JSON.stringify(event.payload),
-                key: event.key,
             }))
 
             await this.kafkaProducer.queueMessages({ topic: KAFKA_CDP_CLICKHOUSE_PREFILTERED_EVENTS, messages })
@@ -98,7 +96,6 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         try {
             const messages = events.map((event) => ({
                 value: JSON.stringify(event.payload),
-                key: event.key,
             }))
 
             await this.kafkaProducer.queueMessages({
@@ -244,7 +241,6 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
                             // Only publish if event matches the filter (don't publish non-matches)
                             if (matches) {
                                 const preCalculatedEvent: ProducedEvent = {
-                                    key: filterGlobals.distinct_id,
                                     payload: {
                                         uuid: filterGlobals.uuid,
                                         team_id: clickHouseEvent.team_id,
@@ -279,7 +275,6 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
                                 // CRITICAL: Always emit - both matches AND non-matches
                                 // Person properties are mutable state, need to track changes
                                 const personPropertyEvent: ProducedPersonPropertiesEvent = {
-                                    key: clickHouseEvent.distinct_id,
                                     payload: {
                                         distinct_id: clickHouseEvent.distinct_id,
                                         person_id: clickHouseEvent.person_id!,

--- a/nodejs/src/cdp/types-person-properties.ts
+++ b/nodejs/src/cdp/types-person-properties.ts
@@ -10,6 +10,5 @@ export type PreCalculatedPersonProperties = {
 }
 
 export type ProducedPersonPropertiesEvent = {
-    key: string // distinct_id
     payload: PreCalculatedPersonProperties
 }


### PR DESCRIPTION
## Problem

We don't need the keys for ordering so we can remove it and avoid hot partitions