### PR TITLE
feat: add SLO event framework for operation tracking

### DIFF
--- a/posthog/slo/events.py
+++ b/posthog/slo/events.py
@@ -1,0 +1,39 @@
+import os
+
+import posthoganalytics
+
+from posthog.slo.types import SloCompletedProperties, SloStartedProperties
+
+
+def emit_slo_started(
+    distinct_id: str,
+    properties: SloStartedProperties,
+    extra_properties: dict | None = None,
+) -> None:
+    all_properties = properties.to_dict()
+    all_properties["deploy_sha"] = os.environ.get("COMMIT_SHA")
+    if extra_properties:
+        all_properties.update(extra_properties)
+
+    posthoganalytics.capture(
+        distinct_id=distinct_id,
+        event="slo_operation_started",
+        properties=all_properties,
+    )
+
+
+def emit_slo_completed(
+    distinct_id: str,
+    properties: SloCompletedProperties,
+    extra_properties: dict | None = None,
+) -> None:
+    all_properties = properties.to_dict()
+    all_properties["deploy_sha"] = os.environ.get("COMMIT_SHA")
+    if extra_properties:
+        all_properties.update(extra_properties)
+
+    posthoganalytics.capture(
+        distinct_id=distinct_id,
+        event="slo_operation_completed",
+        properties=all_properties,
+    )

--- a/posthog/slo/events.py
+++ b/posthog/slo/events.py
@@ -1,8 +1,48 @@
 import os
 
 import posthoganalytics
+from prometheus_client import Counter, Histogram
 
 from posthog.slo.types import SloCompletedProperties, SloStartedProperties
+
+OPERATION_STARTED_COUNTER = Counter(
+    "slo_operation_started",
+    "A counter keeping track of when a slo-measured operation has started.",
+    labelnames=["area", "operation"],
+)
+OPERATION_COMPLETED_COUNTER = Counter(
+    "slo_operation_completed",
+    "A counter keeping track of when a slo-measured operation has completed.",
+    labelnames=["area", "operation", "outcome"],
+)
+OPERATION_DURATION = Histogram(
+    "slo_operation_duration_seconds",
+    "Time spent for a slo-measured operation",
+    labelnames=["area", "operation", "outcome"],
+    buckets=(
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.075,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        30.0,
+        60.0,
+        120.0,
+        300.0,
+        600.0,
+        1200.0,
+        float("inf"),
+    ),
+)
 
 
 def emit_slo_started(
@@ -20,6 +60,10 @@ def emit_slo_started(
         event="slo_operation_started",
         properties=all_properties,
     )
+    OPERATION_STARTED_COUNTER.labels(
+        area=properties.area,
+        operation=properties.operation,
+    ).inc()
 
 
 def emit_slo_completed(
@@ -37,3 +81,15 @@ def emit_slo_completed(
         event="slo_operation_completed",
         properties=all_properties,
     )
+    OPERATION_COMPLETED_COUNTER.labels(
+        area=properties.area,
+        operation=properties.operation,
+        outcome=properties.outcome,
+    ).inc()
+
+    if properties.duration_ms is not None:
+        OPERATION_DURATION.labels(
+            area=properties.area,
+            operation=properties.operation,
+            outcome=properties.outcome,
+        ).observe(properties.duration_ms / 1000)

--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -1,0 +1,43 @@
+import dataclasses
+from enum import StrEnum
+from typing import Optional
+
+
+class SloArea(StrEnum):
+    ANALYTIC_PLATFORM = "analytic-platform"
+
+
+class SloOperation(StrEnum):
+    EXPORT = "export"
+    SUBSCRIPTION_DELIVERY = "subscription_delivery"
+    ALERT_CHECK = "alert_check"
+
+
+class SloOutcome(StrEnum):
+    SUCCESS = "success"
+    PARTIAL_SUCCESS = "partial_success"
+    FAILURE = "failure"
+
+
+@dataclasses.dataclass
+class SloStartedProperties:
+    operation: SloOperation
+    area: SloArea
+    team_id: int
+    resource_id: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}
+
+
+@dataclasses.dataclass
+class SloCompletedProperties:
+    operation: SloOperation
+    area: SloArea
+    team_id: int
+    outcome: SloOutcome
+    resource_id: Optional[str] = None
+    duration_ms: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}

--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -15,14 +15,13 @@ class SloOperation(StrEnum):
 
 class SloOutcome(StrEnum):
     SUCCESS = "success"
-    PARTIAL_SUCCESS = "partial_success"
     FAILURE = "failure"
 
 
 @dataclasses.dataclass
 class SloStartedProperties:
-    operation: SloOperation
     area: SloArea
+    operation: SloOperation
     team_id: int
     resource_id: Optional[str] = None
 
@@ -32,8 +31,8 @@ class SloStartedProperties:
 
 @dataclasses.dataclass
 class SloCompletedProperties:
-    operation: SloOperation
     area: SloArea
+    operation: SloOperation
     team_id: int
     outcome: SloOutcome
     resource_id: Optional[str] = None


### PR DESCRIPTION
## Problem

Currently we do not have a standard way to measure SLO's across different product. Every product emits their own "total" version and their own "success" version. Whilst this works, it makes managing the respective dashboards painful as for every new product, we need to add a new insight or adjust existing queries.

Additionally, we run a risk of having to reinvent the wheel every time we want to add a new SLO measurement as we do not have canonical properties that are "enforced" to set best practices.

## Changes

Added a new SLO tracking system with the following components:

- **Event emission functions**: `emit_slo_started()` and `emit_slo_completed()` to capture operation lifecycle events
- **Type definitions**: Enums for `SloArea`, `SloOperation`, and `SloOutcome` to standardize SLO categorization.
- **Data classes**: `SloStartedProperties` and `SloCompletedProperties` to structure event data with fields like operation type, team ID, duration, and outcome
- **Analytics integration**: Events are sent to PostHog analytics with deploy SHA tracking for better observability

## How did you test this code?

N/A this is not used yet, will be used in subsequent PR's in this stack. Just extracting this so it's out already and to simplify the rest of the stack. 

## Publish to changelog?

No

## Docs update

This is an internal monitoring feature that doesn't require user-facing documentation updates.