### PR TITLE
fix(phrocs): correct j/k vim keybindings

### DIFF
--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -105,31 +105,31 @@ func TestUpdate_windowSizeSetsReady(t *testing.T) {
 
 func TestNavigation_nextProc(t *testing.T) {
 	m := readyModel(t, "backend", "celery", "frontend")
-	// k = next proc
-	m = update(m, keypress('k'))
+	// j = next proc
+	m = update(m, keypress('j'))
 	if m.servicesCursor != 1 {
-		t.Errorf("cursor after k: got %d, want 1", m.servicesCursor)
+		t.Errorf("cursor after j: got %d, want 1", m.servicesCursor)
 	}
-	m = update(m, keypress('k'))
+	m = update(m, keypress('j'))
 	if m.servicesCursor != 2 {
-		t.Errorf("cursor after k k: got %d, want 2", m.servicesCursor)
+		t.Errorf("cursor after j j: got %d, want 2", m.servicesCursor)
 	}
 }
 
 func TestNavigation_prevProc(t *testing.T) {
 	m := readyModel(t, "backend", "celery", "frontend")
 	m.servicesCursor = 2
-	// j = prev proc
-	m = update(m, keypress('j'))
+	// k = prev proc
+	m = update(m, keypress('k'))
 	if m.servicesCursor != 1 {
-		t.Errorf("cursor after j: got %d, want 1", m.servicesCursor)
+		t.Errorf("cursor after k: got %d, want 1", m.servicesCursor)
 	}
 }
 
 func TestNavigation_clampsAtBottom(t *testing.T) {
 	m := readyModel(t, "backend", "frontend")
 	m.servicesCursor = 1
-	m = update(m, keypress('k'))
+	m = update(m, keypress('j'))
 	if m.servicesCursor != 1 {
 		t.Errorf("cursor should clamp at %d, got %d", 1, m.servicesCursor)
 	}
@@ -138,7 +138,7 @@ func TestNavigation_clampsAtBottom(t *testing.T) {
 func TestNavigation_clampsAtTop(t *testing.T) {
 	m := readyModel(t, "backend", "frontend")
 	m.servicesCursor = 0
-	m = update(m, keypress('j'))
+	m = update(m, keypress('k'))
 	if m.servicesCursor != 0 {
 		t.Errorf("cursor should clamp at 0, got %d", m.servicesCursor)
 	}
@@ -250,15 +250,15 @@ func TestCopyMode_navigation(t *testing.T) {
 	m = update(m, keypress('c')) // enter copy mode
 	initial := m.copyCursor
 
-	// k = next line in copy mode
-	m = update(m, keypress('k'))
-	if m.copyCursor != initial+1 {
-		t.Errorf("k in copy mode: copyCursor want %d, got %d", initial+1, m.copyCursor)
-	}
-	// j = prev line in copy mode
+	// j = next line in copy mode
 	m = update(m, keypress('j'))
+	if m.copyCursor != initial+1 {
+		t.Errorf("j in copy mode: copyCursor want %d, got %d", initial+1, m.copyCursor)
+	}
+	// k = prev line in copy mode
+	m = update(m, keypress('k'))
 	if m.copyCursor != initial {
-		t.Errorf("j in copy mode: copyCursor want %d, got %d", initial, m.copyCursor)
+		t.Errorf("k in copy mode: copyCursor want %d, got %d", initial, m.copyCursor)
 	}
 }
 

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -26,11 +26,11 @@ type keyMap struct {
 func defaultKeyMap() keyMap {
 	return keyMap{
 		PrevProc: key.NewBinding(
-			key.WithKeys("j", "up"),
+			key.WithKeys("k", "up"),
 			key.WithHelp("↑:", "prev"),
 		),
 		NextProc: key.NewBinding(
-			key.WithKeys("k", "down"),
+			key.WithKeys("j", "down"),
 			key.WithHelp("↓:", "next"),
 		),
 		ScrollUp: key.NewBinding(


### PR DESCRIPTION
## Problem

`j` and `k` were reversed relative to vim convention: `j` moved to the previous process (up) and `k` moved to the next (down). In vim, `j` = down and `k` = up.

kinda _assuming_ we wanted vim keybindings, sorry if not - twitchy eye when it went the other way around 😆 

## Changes

Swapped `j`/`k` bindings in `tools/phrocs/internal/tui/keymap.go` so `j` moves to the next process and `k` moves to the previous.

## How did you test this code?

Code-only change — swapping two key strings. Verified by reading the keymap against vim conventions.

## Publish to changelog?

No

## Docs update

No docs needed.