### PR TITLE
feat(phrocs): Add process info panel with `i` key

### DIFF
--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -54,6 +54,9 @@ type Model struct {
 	containerLogStream *docker.ContainerLogStream
 	composeArgs        docker.ComposeArgs
 
+	// Info mode: replaces the output viewport with process stats
+	infoMode bool
+
 	// Hedgehog mode: animated hedgehog walks across the output pane
 	hedgehogMode  bool
 	hedgehogX     int
@@ -132,13 +135,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
 		cmds = append(cmds, cmd)
+		// Refresh info panel on each spinner tick to keep uptime current
+		if m.infoMode {
+			m.refreshInfoContent()
+		}
 
 	case process.OutputMsg:
 		// Rebuild viewport content only for the active process to keep rendering cheap
 		if m.ready && m.activeProc() != nil && m.activeProc().Name == msg.Name {
 			// In docker mode the viewport shows the status table or container logs,
 			// not the process's combined output
-			if m.isDockerMode() {
+			if m.isDockerMode() || m.infoMode {
 				break
 			}
 			m.viewport.SetContent(m.buildContent())
@@ -207,16 +214,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		m.dbg("key: %q", msg.String())
+		var handled bool
 		if m.searchMode {
-			return m.handleSearchKey(msg, cmds)
+			m, cmds, handled = m.handleSearchKey(msg, cmds)
+		} else if m.copyMode {
+			m, cmds, handled = m.handleCopyKey(msg, cmds)
+		} else if m.infoMode {
+			m, cmds, handled = m.handleInfoKey(msg, cmds)
+		} else if m.hedgehogMode {
+			m, cmds, handled = m.handleHedgehogKey(msg, cmds)
 		}
-		if m.copyMode {
-			return m.handleCopyKey(msg, cmds)
+		if !handled {
+			return m.handleNormalKey(msg, cmds)
 		}
-		if m.hedgehogMode {
-			return m.handleHedgehogKey(msg, cmds)
-		}
-		return m.handleNormalKey(msg, cmds)
 
 	case tea.MouseClickMsg:
 		return m.handleMouseClick(msg, cmds)

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -54,6 +54,12 @@ type Model struct {
 	containerLogStream *docker.ContainerLogStream
 	composeArgs        docker.ComposeArgs
 
+	// Hedgehog mode: animated hedgehog walks across the output pane
+	hedgehogMode  bool
+	hedgehogX     int
+	hedgehogDir   int // +1 right, -1 left
+	hedgehogFrame int
+
 	keys     keyMap
 	help     help.Model
 	spinner  spinner.Model
@@ -189,6 +195,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.searchQuery != "" {
 				m.updateSearchForLine(msg.Line, lineIndex, evicted)
 			}
+		}
+
+	case hedgehogTickMsg:
+		if m.hedgehogMode {
+			m.advanceHedgehog()
+			cmds = append(cmds, hedgehogTick())
 		}
 
 	case tea.KeyPressMsg:

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -57,6 +57,8 @@ type Model struct {
 	// Hedgehog mode: animated hedgehog walks across the output pane
 	hedgehogMode  bool
 	hedgehogX     int
+	hedgehogY     int // vertical offset from ground (positive = up)
+	hedgehogVelY  int // vertical velocity (positive = upward, decreases each tick)
 	hedgehogDir   int // +1 right, -1 left
 	hedgehogFrame int
 
@@ -210,6 +212,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.copyMode {
 			return m.handleCopyKey(msg, cmds)
+		}
+		if m.hedgehogMode {
+			return m.handleHedgehogKey(msg, cmds)
 		}
 		return m.handleNormalKey(msg, cmds)
 

--- a/tools/phrocs/internal/tui/hedgehog.go
+++ b/tools/phrocs/internal/tui/hedgehog.go
@@ -53,7 +53,17 @@ func (m *Model) advanceHedgehog() {
 	m.hedgehogX += m.hedgehogDir
 	m.hedgehogFrame = (m.hedgehogFrame + 1) % 2
 
-	maxX := max(m.viewport.Width() - len(hedgehogFramesLeft[0][0]), 0)
+	// Apply gravity to vertical movement
+	if m.hedgehogY > 0 || m.hedgehogVelY > 0 {
+		m.hedgehogY += m.hedgehogVelY
+		m.hedgehogVelY--
+		if m.hedgehogY <= 0 {
+			m.hedgehogY = 0
+			m.hedgehogVelY = 0
+		}
+	}
+
+	maxX := max(m.viewport.Width()-len(hedgehogFramesLeft[0][0]), 0)
 	if m.hedgehogX >= maxX {
 		m.hedgehogX = maxX
 		m.hedgehogDir = -1
@@ -68,8 +78,9 @@ func (m Model) overlayHedgehog(view string) string {
 	lines := strings.Split(view, "\n")
 	vpH := m.viewport.Height()
 
-	// Place hedgehog at the bottom of the visible viewport
-	startLine := max(vpH - len(hedgehogFramesLeft[0]), 0)
+	// Place hedgehog at the bottom of the visible viewport, offset by jump height
+	spriteH := len(hedgehogFramesLeft[0])
+	startLine := max(vpH-spriteH-m.hedgehogY, 0)
 
 	// Pad lines if needed
 	for len(lines) < vpH {

--- a/tools/phrocs/internal/tui/hedgehog.go
+++ b/tools/phrocs/internal/tui/hedgehog.go
@@ -103,8 +103,14 @@ func (m Model) overlayHedgehog(view string) string {
 			break
 		}
 
-		rendered := spikeStyle.Render(spriteLine)
-		lines[lineIdx] = overwriteAt(lines[lineIdx], rendered, m.hedgehogX, m.viewport.Width())
+		// Strip leading/trailing whitespace from the sprite line so the
+		// hedgehog doesn't overwrite surrounding content with blanks.
+		trimmed := strings.TrimRight(spriteLine, " ")
+		leading := len(spriteLine) - len(strings.TrimLeft(spriteLine, " "))
+		trimmed = trimmed[leading:]
+
+		rendered := spikeStyle.Render(trimmed)
+		lines[lineIdx] = overwriteAt(lines[lineIdx], rendered, m.hedgehogX+leading, m.viewport.Width())
 	}
 
 	return strings.Join(lines[:vpH], "\n")

--- a/tools/phrocs/internal/tui/hedgehog.go
+++ b/tools/phrocs/internal/tui/hedgehog.go
@@ -1,0 +1,122 @@
+package tui
+
+import (
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+var hedgehogFramesRight = [][]string{
+	{
+		`  .::::::::..   `,
+		` :::::::::::::  `,
+		`:::::::::::' .\ `,
+		`':::;::::::_,__o`,
+	},
+	{
+		`  .::::::::..   `,
+		` :::::::::::::  `,
+		`:::::::::::' .\ `,
+		`'::;:::::::,___o`,
+	},
+}
+
+var hedgehogFramesLeft = [][]string{
+	{
+		`   ..::::::::.  `,
+		`  ::::::::::::: `,
+		` /. ':::::::::::`,
+		`o__,_::::::;:::'`,
+	},
+	{
+		`   ..::::::::.  `,
+		`  ::::::::::::: `,
+		` /. ':::::::::::`,
+		`o___,:::::::;::'`,
+	},
+}
+
+const hedgehogTickInterval = 150 * time.Millisecond
+
+type hedgehogTickMsg struct{}
+
+func hedgehogTick() tea.Cmd {
+	return tea.Tick(hedgehogTickInterval, func(time.Time) tea.Msg {
+		return hedgehogTickMsg{}
+	})
+}
+
+func (m *Model) advanceHedgehog() {
+	m.hedgehogX += m.hedgehogDir
+	m.hedgehogFrame = (m.hedgehogFrame + 1) % 2
+
+	maxX := max(m.viewport.Width() - len(hedgehogFramesLeft[0][0]), 0)
+	if m.hedgehogX >= maxX {
+		m.hedgehogX = maxX
+		m.hedgehogDir = -1
+	} else if m.hedgehogX <= 0 {
+		m.hedgehogX = 0
+		m.hedgehogDir = 1
+	}
+}
+
+// Overlays the hedgehog sprite onto the viewport content string
+func (m Model) overlayHedgehog(view string) string {
+	lines := strings.Split(view, "\n")
+	vpH := m.viewport.Height()
+
+	// Place hedgehog at the bottom of the visible viewport
+	startLine := max(vpH - len(hedgehogFramesLeft[0]), 0)
+
+	// Pad lines if needed
+	for len(lines) < vpH {
+		lines = append(lines, "")
+	}
+
+	frames := hedgehogFramesRight
+	if m.hedgehogDir < 0 {
+		frames = hedgehogFramesLeft
+	}
+	sprite := frames[m.hedgehogFrame]
+
+	spikeStyle := lipgloss.NewStyle().
+		Foreground(colorYellow).
+		Bold(true)
+
+	for i, spriteLine := range sprite {
+		lineIdx := startLine + i
+		if lineIdx >= len(lines) {
+			break
+		}
+
+		rendered := spikeStyle.Render(spriteLine)
+		lines[lineIdx] = overwriteAt(lines[lineIdx], rendered, m.hedgehogX, m.viewport.Width())
+	}
+
+	return strings.Join(lines[:vpH], "\n")
+}
+
+// Overwrites a portion of a styled line at a given column position
+func overwriteAt(line, overlay string, col, maxW int) string {
+	lineW := lipgloss.Width(line)
+	overlayW := lipgloss.Width(overlay)
+
+	// Ensure line is wide enough
+	if lineW < col+overlayW {
+		line += strings.Repeat(" ", col+overlayW-lineW)
+	}
+
+	// Truncate the line at col, insert overlay, then append remainder
+	before := ansi.Truncate(line, col, "")
+	afterStart := col + overlayW
+	var after string
+	if afterStart < maxW && afterStart < lipgloss.Width(line) {
+		// Cut the first afterStart columns and keep the rest
+		after = ansi.TruncateLeft(line, afterStart, "")
+	}
+
+	return before + overlay + after
+}

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -14,7 +14,6 @@ type keyMap struct {
 	Restart    key.Binding
 	Stop       key.Binding
 	CopyMode   key.Binding
-	CopyEsc    key.Binding
 	Search     key.Binding
 	SearchNext key.Binding
 	SearchPrev key.Binding
@@ -69,10 +68,6 @@ func defaultKeyMap() keyMap {
 		CopyMode: key.NewBinding(
 			key.WithKeys("c"),
 			key.WithHelp("c:", "copy"),
-		),
-		CopyEsc: key.NewBinding(
-			key.WithKeys("esc"),
-			key.WithHelp("esc:", "esc copy"),
 		),
 		Search: key.NewBinding(
 			key.WithKeys("/"),

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -21,6 +21,7 @@ type keyMap struct {
 	Quit       key.Binding
 	Help       key.Binding
 	Backspace  key.Binding
+	Hedgehog   key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -96,6 +97,10 @@ func defaultKeyMap() keyMap {
 		Backspace: key.NewBinding(
 			key.WithKeys("backspace"),
 			key.WithHelp("⌫:", "del char"),
+		),
+		Hedgehog: key.NewBinding(
+			key.WithKeys("h"),
+			key.WithHelp("h:", "hedgehog"),
 		),
 	}
 }

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -21,6 +21,7 @@ type keyMap struct {
 	Help       key.Binding
 	Backspace  key.Binding
 	Hedgehog   key.Binding
+	Info       key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -97,6 +98,10 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("h"),
 			key.WithHelp("h:", "hedgehog"),
 		),
+		Info: key.NewBinding(
+			key.WithKeys("i"),
+			key.WithHelp("i:", "info"),
+		),
 	}
 }
 
@@ -110,7 +115,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.ScrollUp, k.ScrollDown},
 		{k.GotoTop, k.GotoBottom},
 		{k.NextPane, k.PrevPane},
-		{k.Restart, k.Stop},
+		{k.Restart, k.Stop, k.Info},
 		{k.Search, k.SearchNext, k.SearchPrev},
 		{k.CopyMode, k.Quit, k.Help},
 	}

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -40,7 +40,7 @@ func (m *Model) cyclePane(dir int) {
 
 func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	switch {
-	case key.Matches(msg, m.keys.Quit), key.Matches(msg, m.keys.CopyEsc):
+	case key.Matches(msg, m.keys.Quit), msg.Code == tea.KeyEscape:
 		m.searchMode = false
 		m.clearSearch()
 		m = m.applySize()
@@ -80,7 +80,7 @@ func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 
 func (m Model) handleCopyKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
 	switch {
-	case key.Matches(msg, m.keys.Quit), key.Matches(msg, m.keys.CopyEsc):
+	case key.Matches(msg, m.keys.Quit), msg.Code == tea.KeyEscape:
 		m.dbg("copy mode: exit")
 		m.copyMode = false
 		m.applyCopyStyle()
@@ -128,6 +128,23 @@ func (m Model) handleCopyKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, te
 		}
 		m.ensureCopyCursorVisible()
 		m.applyCopyStyle()
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, m.keys.Hedgehog), key.Matches(msg, m.keys.Quit), msg.Code == tea.KeyEscape:
+		m.hedgehogMode = false
+		m.dbg("hedgehog mode: exit")
+
+	case msg.Code == tea.KeySpace:
+		// Jump only when on the ground
+		if m.hedgehogY == 0 {
+			m.hedgehogVelY = 1
+			m.hedgehogY = 1
+			m.dbg("hedgehog: jump!")
+		}
 	}
 	return m, tea.Batch(cmds...)
 }

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -141,9 +141,11 @@ func (m Model) handleInfoKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.
 
 	case key.Matches(msg, m.keys.Info), msg.Code == tea.KeyEscape:
 		m.infoMode = false
-		m.viewport.SetContent(m.buildContent())
-		m.viewport.GotoBottom()
-		m.viewportAtBottom = true
+		if !m.isDockerMode() {
+			m.viewport.SetContent(m.buildContent())
+			m.viewport.GotoBottom()
+			m.viewportAtBottom = true
+		}
 		m.dbg("info mode: exit")
 
 	default:

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -229,6 +229,16 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		m.applyCopyStyle()
 		m.dbg("copy mode: enter at line %d", m.copyCursor)
 
+	case key.Matches(msg, m.keys.Hedgehog):
+		m.hedgehogMode = !m.hedgehogMode
+		m.dbg("hedgehog mode: %v", m.hedgehogMode)
+		if m.hedgehogMode {
+			m.hedgehogX = 0
+			m.hedgehogDir = 1
+			m.hedgehogFrame = 0
+			cmds = append(cmds, hedgehogTick())
+		}
+
 	default:
 		if m.focusedPane == focusOutput {
 			cmds = append(cmds, m.forwardToViewport(msg))

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -38,7 +38,7 @@ func (m *Model) cyclePane(dir int) {
 	}
 }
 
-func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.Cmd, bool) {
 	switch {
 	case key.Matches(msg, m.keys.Quit), msg.Code == tea.KeyEscape:
 		m.searchMode = false
@@ -63,6 +63,7 @@ func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 			m.recomputeSearch()
 		}
 	default:
+		// Search consumes all printable characters for the query
 		s := msg.String()
 		var ch string
 		if s == "space" {
@@ -75,10 +76,10 @@ func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 			m.recomputeSearch()
 		}
 	}
-	return m, tea.Batch(cmds...)
+	return m, cmds, true
 }
 
-func (m Model) handleCopyKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+func (m Model) handleCopyKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.Cmd, bool) {
 	switch {
 	case key.Matches(msg, m.keys.Quit), msg.Code == tea.KeyEscape:
 		m.dbg("copy mode: exit")
@@ -96,7 +97,7 @@ func (m Model) handleCopyKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, te
 			m.copyMode = false
 			m.applyCopyStyle()
 			m = m.applySize()
-			return m, tea.SetClipboard(text)
+			cmds = append(cmds, tea.SetClipboard(text))
 		} else {
 			m.copyAnchor = -1
 			m.dbg("copy mode: anchor cleared")
@@ -128,13 +129,32 @@ func (m Model) handleCopyKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, te
 		}
 		m.ensureCopyCursorVisible()
 		m.applyCopyStyle()
+
+	default:
+		return m, cmds, false
 	}
-	return m, tea.Batch(cmds...)
+	return m, cmds, true
 }
 
-func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
+func (m Model) handleInfoKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.Cmd, bool) {
 	switch {
-	case key.Matches(msg, m.keys.Hedgehog), key.Matches(msg, m.keys.Quit), msg.Code == tea.KeyEscape:
+
+	case key.Matches(msg, m.keys.Info), msg.Code == tea.KeyEscape:
+		m.infoMode = false
+		m.viewport.SetContent(m.buildContent())
+		m.viewport.GotoBottom()
+		m.viewportAtBottom = true
+		m.dbg("info mode: exit")
+
+	default:
+		return m, cmds, false
+	}
+	return m, cmds, true
+}
+
+func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.Cmd, bool) {
+	switch {
+	case key.Matches(msg, m.keys.Hedgehog), msg.Code == tea.KeyEscape:
 		m.hedgehogMode = false
 		m.dbg("hedgehog mode: exit")
 
@@ -145,8 +165,11 @@ func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model
 			m.hedgehogY = 1
 			m.dbg("hedgehog: jump!")
 		}
+
+	default:
+		return m, cmds, false
 	}
-	return m, tea.Batch(cmds...)
+	return m, cmds, true
 }
 
 func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, tea.Cmd) {
@@ -245,6 +268,12 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		m.copyAnchor = -1
 		m.applyCopyStyle()
 		m.dbg("copy mode: enter at line %d", m.copyCursor)
+
+	case key.Matches(msg, m.keys.Info):
+		m.infoMode = true
+		m.refreshInfoContent()
+		m.viewport.GotoTop()
+		m.dbg("info mode: enter")
 
 	case key.Matches(msg, m.keys.Hedgehog):
 		m.hedgehogMode = !m.hedgehogMode

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -127,10 +127,6 @@ func (m Model) renderOutput() string {
 	if m.focusedPane == focusOutput {
 		style = borderFocusedStyle
 	}
-	if m.infoMode {
-		content := lipgloss.JoinHorizontal(lipgloss.Top, m.viewportWithIndicator())
-		return style.Render(content)
-	}
 	content := lipgloss.JoinHorizontal(lipgloss.Top, m.viewportWithIndicator())
 	return style.Render(content)
 }
@@ -219,7 +215,6 @@ func (m Model) renderFooter() string {
 }
 
 // Rebuilds the info content and sets it on the viewport.
-// Each line is truncated to the viewport width to prevent wrapping.
 func (m *Model) refreshInfoContent() {
 	info := m.renderInfo()
 	lines := strings.Split(info, "\n")

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -133,6 +133,9 @@ func (m Model) renderOutput() string {
 // Overlays a -line counter in the top-right corner of the viewport
 func (m Model) viewportWithIndicator() string {
 	view := m.viewport.View()
+	if m.hedgehogMode {
+		view = m.overlayHedgehog(view)
+	}
 	total := m.viewport.TotalLineCount()
 	if total <= m.viewport.Height() {
 		return view

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -126,6 +127,10 @@ func (m Model) renderOutput() string {
 	if m.focusedPane == focusOutput {
 		style = borderFocusedStyle
 	}
+	if m.infoMode {
+		content := lipgloss.JoinHorizontal(lipgloss.Top, m.viewportWithIndicator())
+		return style.Render(content)
+	}
 	content := lipgloss.JoinHorizontal(lipgloss.Top, m.viewportWithIndicator())
 	return style.Render(content)
 }
@@ -175,6 +180,11 @@ func (m Model) renderFooter() string {
 		return footerStyle.Width(m.width - 2).Render(
 			lipgloss.NewStyle().Foreground(colorBlue).Render(hint),
 		)
+	} else if m.infoMode {
+		hint := "-- INFO --  i/esc: close"
+		return footerStyle.Width(m.width - 2).Render(
+			lipgloss.NewStyle().Foreground(colorYellow).Render(hint),
+		)
 	} else if m.searchMode {
 		var matchInfo string
 		if m.searchQuery == "" {
@@ -206,4 +216,118 @@ func (m Model) renderFooter() string {
 		content = m.help.ShortHelpView(m.keys.ShortHelp())
 	}
 	return footerStyle.Width(m.width - 2).Render(content)
+}
+
+// Rebuilds the info content and sets it on the viewport.
+// Each line is truncated to the viewport width to prevent wrapping.
+func (m *Model) refreshInfoContent() {
+	info := m.renderInfo()
+	lines := strings.Split(info, "\n")
+	m.viewport.SetContent(strings.Join(lines, "\n"))
+}
+
+func (m Model) renderInfo() string {
+	p := m.activeProc()
+	if p == nil {
+		return ""
+	}
+	snap := p.Snapshot()
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(colorYellow)
+	labelStyle := lipgloss.NewStyle().Foreground(colorGrey).Width(20)
+	valueStyle := lipgloss.NewStyle().Foreground(colorWhite)
+
+	row := func(label, value string) string {
+		return labelStyle.Render(label) + valueStyle.Render(value)
+	}
+
+	var lines []string
+	lines = append(lines, "")
+
+	// Status
+	icon := statusIconChar(p.Status())
+	iconColor := statusIconColor(p.Status())
+	styledIcon := lipgloss.NewStyle().Foreground(iconColor).Render(icon)
+	lines = append(lines, labelStyle.Render("  Status")+styledIcon+" "+valueStyle.Render(snap.Status))
+
+	// PID
+	if snap.PID > 0 {
+		lines = append(lines, row("  PID", fmt.Sprintf("%d", snap.PID)))
+	}
+
+	// Ready
+	readyStr := "no"
+	if snap.Ready {
+		readyStr = "yes"
+	}
+	lines = append(lines, row("  Ready", readyStr))
+
+	// Exit code
+	if snap.ExitCode != nil {
+		lines = append(lines, row("  Exit code", fmt.Sprintf("%d", *snap.ExitCode)))
+	}
+
+	// Timing
+	lines = append(lines, "")
+	lines = append(lines, titleStyle.Render("  Timing"))
+
+	if !snap.StartedAt.IsZero() {
+		lines = append(lines, row("  Started", snap.StartedAt.Format(time.RFC3339)))
+		lines = append(lines, row("  Uptime", formatDuration(time.Since(snap.StartedAt))))
+	}
+	if snap.StartupDurationS != nil {
+		lines = append(lines, row("  Startup", fmt.Sprintf("%.1fs", *snap.StartupDurationS)))
+	}
+
+	// Resources (only if metrics have been sampled)
+	if snap.MemRSSMB != nil {
+		lines = append(lines, "")
+		lines = append(lines, titleStyle.Render("  Resources"))
+
+		lines = append(lines, row("  Memory (RSS)", fmt.Sprintf("%.1f MB", *snap.MemRSSMB)))
+		if snap.PeakMemRSSMB != nil {
+			lines = append(lines, row("  Peak memory", fmt.Sprintf("%.1f MB", *snap.PeakMemRSSMB)))
+		}
+		if snap.CPUPercent != nil {
+			lines = append(lines, row("  CPU", fmt.Sprintf("%.1f%%", *snap.CPUPercent)))
+		}
+		if snap.CPUTimeS != nil {
+			lines = append(lines, row("  CPU time", fmt.Sprintf("%.1fs", *snap.CPUTimeS)))
+		}
+		if snap.ThreadCount != nil {
+			lines = append(lines, row("  Threads", fmt.Sprintf("%d", *snap.ThreadCount)))
+		}
+		if snap.ChildProcessCount != nil {
+			lines = append(lines, row("  Children", fmt.Sprintf("%d", *snap.ChildProcessCount)))
+		}
+		if snap.FDCount != nil {
+			lines = append(lines, row("  File descriptors", fmt.Sprintf("%d", *snap.FDCount)))
+		}
+	}
+
+	// Config
+	lines = append(lines, "")
+	lines = append(lines, titleStyle.Render("  Config"))
+	lines = append(lines, row("  Command", p.Cfg.Shell))
+	if p.Cfg.ReadyPattern != "" {
+		lines = append(lines, row("  Ready pattern", p.Cfg.ReadyPattern))
+	}
+	if p.Cfg.Autorestart {
+		lines = append(lines, row("  Autorestart", "yes"))
+	}
+
+	// Buffered lines
+	lines = append(lines, row("  Buffered lines", fmt.Sprintf("%d", len(p.Lines()))))
+
+	return strings.Join(lines, "\n")
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%.0fs", d.Seconds())
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("%dh %dm", int(d.Hours()), int(d.Minutes())%60)
 }


### PR DESCRIPTION
Summary

- Adds an info mode (toggled with `i`) that replaces the output viewport with a formatted view of process stats: status, PID, timing, resource usage, and config
- Unhandled keys in modal modes (info, hedgehog, copy) now fall through to normal key handling instead of being swallowed
- Adds a simple animation of a hedgehog walking when `h` is pressed