### PR TITLE
feat: add new subscription delivery workflow with per-asset export    fan-out

### DIFF
--- a/posthog/temporal/exports/__init__.py
+++ b/posthog/temporal/exports/__init__.py
@@ -4,6 +4,7 @@ from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAsset
 
 __all__ = [
     "emit_delivery_outcome",
+    "emit_delivery_started",
     "export_asset_activity",
     "EXPORT_RETRY_POLICY",
     "EmitDeliveryOutcomeInput",

--- a/posthog/temporal/exports/__init__.py
+++ b/posthog/temporal/exports/__init__.py
@@ -1,0 +1,16 @@
+from posthog.temporal.exports.activities import emit_delivery_outcome, export_asset_activity
+from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
+from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAssetActivityInputs, ExportAssetResult
+
+__all__ = [
+    "emit_delivery_outcome",
+    "export_asset_activity",
+    "EXPORT_RETRY_POLICY",
+    "EmitDeliveryOutcomeInput",
+    "ExportAssetActivityInputs",
+    "ExportAssetResult",
+]
+
+WORKFLOWS: list = []
+
+ACTIVITIES = [export_asset_activity, emit_delivery_outcome]

--- a/posthog/temporal/exports/__init__.py
+++ b/posthog/temporal/exports/__init__.py
@@ -1,4 +1,4 @@
-from posthog.temporal.exports.activities import emit_delivery_outcome, export_asset_activity
+from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAssetActivityInputs, ExportAssetResult
 
@@ -13,4 +13,4 @@ __all__ = [
 
 WORKFLOWS: list = []
 
-ACTIVITIES = [export_asset_activity, emit_delivery_outcome]
+ACTIVITIES = [export_asset_activity, emit_delivery_started, emit_delivery_outcome]

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -9,7 +9,7 @@ from posthog.event_usage import EventSource
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.subscription import Subscription
 from posthog.slo.events import emit_slo_completed, emit_slo_started
-from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome, SloStartedProperties
+from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloStartedProperties
 from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -38,8 +38,6 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
         try:
             await database_sync_to_async(exporter.export_asset_direct, thread_sensitive=False)(
                 asset,
-                limit=inputs.limit,
-                max_height_pixels=inputs.max_height_pixels,
                 source=EventSource(inputs.source) if inputs.source else None,
             )
         except Exception as e:
@@ -82,32 +80,6 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
 
 
 @temporalio.activity.defn
-async def emit_delivery_outcome(inputs: EmitDeliveryOutcomeInput) -> None:
-    emit_slo_completed(
-        distinct_id=inputs.distinct_id,
-        properties=SloCompletedProperties(
-            operation=SloOperation.SUBSCRIPTION_DELIVERY,
-            resource_id=str(inputs.subscription_id),
-            area=SloArea.ANALYTIC_PLATFORM,
-            team_id=inputs.team_id,
-            outcome=SloOutcome(inputs.outcome),
-            duration_ms=inputs.duration_ms,
-        ),
-        extra_properties={
-            "subscription_id": inputs.subscription_id,
-            "assets_with_content": inputs.assets_with_content,
-            "total_assets": inputs.total_assets,
-            "errors": [{"exception_class": e.exception_class, "error_trace": e.error_trace} for e in inputs.errors],
-        },
-    )
-    logger.info(
-        "emit_delivery_outcome.emitted",
-        subscription_id=inputs.subscription_id,
-        outcome=inputs.outcome,
-    )
-
-
-@temporalio.activity.defn
 async def emit_delivery_started(subscription_id: int) -> None:
     subscription = await database_sync_to_async(
         Subscription.objects.select_related("created_by", "team").get,
@@ -123,4 +95,29 @@ async def emit_delivery_started(subscription_id: int) -> None:
             area=SloArea.ANALYTIC_PLATFORM,
             team_id=team.id,
         ),
+    )
+
+
+@temporalio.activity.defn
+async def emit_delivery_outcome(inputs: EmitDeliveryOutcomeInput) -> None:
+    emit_slo_completed(
+        distinct_id=inputs.distinct_id,
+        properties=SloCompletedProperties(
+            operation=SloOperation.SUBSCRIPTION_DELIVERY,
+            resource_id=str(inputs.subscription_id),
+            area=SloArea.ANALYTIC_PLATFORM,
+            team_id=inputs.team_id,
+            outcome=inputs.outcome,
+            duration_ms=inputs.duration_ms,
+        ),
+        extra_properties={
+            "assets_with_content": inputs.assets_with_content,
+            "total_assets": inputs.total_assets,
+            "errors": [{"exception_class": e.exception_class, "error_trace": e.error_trace} for e in inputs.errors],
+        },
+    )
+    logger.info(
+        "emit_delivery_outcome.emitted",
+        subscription_id=inputs.subscription_id,
+        outcome=inputs.outcome,
     )

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -1,0 +1,103 @@
+import time
+
+import structlog
+import temporalio.activity
+from temporalio.exceptions import ApplicationError
+
+from posthog.event_usage import EventSource
+from posthog.models.exported_asset import ExportedAsset
+from posthog.slo.events import emit_slo_completed
+from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome
+from posthog.sync import database_sync_to_async
+from posthog.tasks import exporter
+from posthog.temporal.common.heartbeat import Heartbeater
+from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAssetActivityInputs, ExportAssetResult
+
+logger = structlog.get_logger(__name__)
+
+
+@temporalio.activity.defn
+async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAssetResult:
+    async with Heartbeater():
+        asset = await database_sync_to_async(
+            lambda: ExportedAsset.objects_including_ttl_deleted.select_related(
+                "created_by", "team", "team__organization"
+            ).get(pk=inputs.exported_asset_id),
+            thread_sensitive=False,
+        )()
+
+        logger.info(
+            "export_asset_activity.starting",
+            exported_asset_id=asset.id,
+            team_id=asset.team_id,
+        )
+
+        start = time.monotonic()
+        try:
+            await database_sync_to_async(exporter.export_asset_direct, thread_sensitive=False)(
+                asset,
+                limit=inputs.limit,
+                max_height_pixels=inputs.max_height_pixels,
+                source=EventSource(inputs.source) if inputs.source else None,
+            )
+        except Exception as e:
+            duration_ms = (time.monotonic() - start) * 1000
+            await database_sync_to_async(asset.refresh_from_db, thread_sensitive=False)()
+            logger.warning(
+                "export_asset_activity.failed",
+                exported_asset_id=asset.id,
+                team_id=asset.team_id,
+                insight_id=asset.insight_id,
+                failure_type=asset.failure_type,
+                error=str(e),
+            )
+            # Wrap in ApplicationError to propagate failure metadata as details
+            # while preserving the exception class name for retry policy matching.
+            # Detail order: [failure_type, duration_ms, export_format, attempt]
+            raise ApplicationError(
+                str(e),
+                asset.failure_type,
+                duration_ms,
+                asset.export_format,
+                temporalio.activity.info().attempt,
+                type=type(e).__name__,
+            ) from e
+
+        duration_ms = (time.monotonic() - start) * 1000
+        await database_sync_to_async(asset.refresh_from_db, thread_sensitive=False)()
+
+        return ExportAssetResult(
+            exported_asset_id=asset.id,
+            success=asset.has_content,
+            failure_type=asset.failure_type,
+            insight_id=asset.insight_id,
+            duration_ms=duration_ms,
+            export_format=asset.export_format,
+            attempts=temporalio.activity.info().attempt,
+        )
+
+
+@temporalio.activity.defn
+async def emit_delivery_outcome(inputs: EmitDeliveryOutcomeInput) -> None:
+    emit_slo_completed(
+        distinct_id=inputs.distinct_id,
+        properties=SloCompletedProperties(
+            operation=SloOperation.SUBSCRIPTION_DELIVERY,
+            resource_id=str(inputs.subscription_id),
+            area=SloArea.ANALYTIC_PLATFORM,
+            team_id=inputs.team_id,
+            outcome=SloOutcome(inputs.outcome),
+            duration_ms=inputs.duration_ms,
+        ),
+        extra_properties={
+            "subscription_id": inputs.subscription_id,
+            "assets_with_content": inputs.assets_with_content,
+            "total_assets": inputs.total_assets,
+            "failure_types": inputs.failure_types,
+        },
+    )
+    logger.info(
+        "emit_delivery_outcome.emitted",
+        subscription_id=inputs.subscription_id,
+        outcome=inputs.outcome,
+    )

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 
 import structlog
 import temporalio.activity
@@ -6,8 +7,9 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.event_usage import EventSource
 from posthog.models.exported_asset import ExportedAsset
-from posthog.slo.events import emit_slo_completed
-from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome
+from posthog.models.subscription import Subscription
+from posthog.slo.events import emit_slo_completed, emit_slo_started
+from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome, SloStartedProperties
 from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -43,24 +45,27 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
         except Exception as e:
             duration_ms = (time.monotonic() - start) * 1000
             await database_sync_to_async(asset.refresh_from_db, thread_sensitive=False)()
+            exception_class = type(e).__name__
+            error_trace = "\n".join(traceback.format_exception(e)[:5])
             logger.warning(
                 "export_asset_activity.failed",
                 exported_asset_id=asset.id,
                 team_id=asset.team_id,
                 insight_id=asset.insight_id,
-                failure_type=asset.failure_type,
+                exception_class=exception_class,
                 error=str(e),
             )
             # Wrap in ApplicationError to propagate failure metadata as details
             # while preserving the exception class name for retry policy matching.
-            # Detail order: [failure_type, duration_ms, export_format, attempt]
+            # Detail order: [exception_class, duration_ms, export_format, attempt, error_trace]
             raise ApplicationError(
                 str(e),
-                asset.failure_type,
+                exception_class,
                 duration_ms,
                 asset.export_format,
                 temporalio.activity.info().attempt,
-                type=type(e).__name__,
+                error_trace,
+                type=exception_class,
             ) from e
 
         duration_ms = (time.monotonic() - start) * 1000
@@ -69,7 +74,6 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
         return ExportAssetResult(
             exported_asset_id=asset.id,
             success=asset.has_content,
-            failure_type=asset.failure_type,
             insight_id=asset.insight_id,
             duration_ms=duration_ms,
             export_format=asset.export_format,
@@ -93,11 +97,30 @@ async def emit_delivery_outcome(inputs: EmitDeliveryOutcomeInput) -> None:
             "subscription_id": inputs.subscription_id,
             "assets_with_content": inputs.assets_with_content,
             "total_assets": inputs.total_assets,
-            "failure_types": inputs.failure_types,
+            "errors": [{"exception_class": e.exception_class, "error_trace": e.error_trace} for e in inputs.errors],
         },
     )
     logger.info(
         "emit_delivery_outcome.emitted",
         subscription_id=inputs.subscription_id,
         outcome=inputs.outcome,
+    )
+
+
+@temporalio.activity.defn
+async def emit_delivery_started(subscription_id: int) -> None:
+    subscription = await database_sync_to_async(
+        Subscription.objects.select_related("created_by", "team").get,
+        thread_sensitive=False,
+    )(pk=subscription_id)
+    team = subscription.team
+    distinct_id = str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id)
+    emit_slo_started(
+        distinct_id=distinct_id,
+        properties=SloStartedProperties(
+            operation=SloOperation.SUBSCRIPTION_DELIVERY,
+            resource_id=str(subscription_id),
+            area=SloArea.ANALYTIC_PLATFORM,
+            team_id=team.id,
+        ),
     )

--- a/posthog/temporal/exports/retry_policy.py
+++ b/posthog/temporal/exports/retry_policy.py
@@ -1,0 +1,15 @@
+from datetime import timedelta
+
+from temporalio.common import RetryPolicy
+
+from posthog.tasks.exports.failure_handler import USER_QUERY_ERROR_NAMES
+
+EXPORT_RETRY_POLICY = RetryPolicy(
+    initial_interval=timedelta(seconds=30),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(minutes=15),
+    maximum_attempts=10,
+    non_retryable_error_types=[
+        *list(USER_QUERY_ERROR_NAMES),
+    ],
+)

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -1,25 +1,13 @@
 import dataclasses
 from typing import Optional
 
+from posthog.slo.types import SloOutcome
+
 
 @dataclasses.dataclass
 class ExportAssetActivityInputs:
     exported_asset_id: int
     source: Optional[str] = None
-    limit: Optional[int] = None
-    max_height_pixels: Optional[int] = None
-
-
-@dataclasses.dataclass
-class ExportAssetResult:
-    exported_asset_id: int
-    success: bool
-    exception_class: Optional[str] = None
-    error_trace: Optional[str] = None
-    insight_id: Optional[int] = None
-    duration_ms: Optional[float] = None
-    export_format: str = ""
-    attempts: int = 1
 
 
 @dataclasses.dataclass
@@ -29,11 +17,22 @@ class ExportError:
 
 
 @dataclasses.dataclass
+class ExportAssetResult:
+    exported_asset_id: int
+    success: bool
+    error: Optional[ExportError] = None
+    insight_id: Optional[int] = None
+    duration_ms: Optional[float] = None
+    export_format: str = ""
+    attempts: int = 1
+
+
+@dataclasses.dataclass
 class EmitDeliveryOutcomeInput:
     subscription_id: int
     team_id: int
     distinct_id: str
-    outcome: str
+    outcome: SloOutcome
     duration_ms: Optional[float] = None
     assets_with_content: int = 0
     total_assets: int = 0

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -1,0 +1,33 @@
+import dataclasses
+from typing import Optional
+
+
+@dataclasses.dataclass
+class ExportAssetActivityInputs:
+    exported_asset_id: int
+    source: Optional[str] = None
+    limit: Optional[int] = None
+    max_height_pixels: Optional[int] = None
+
+
+@dataclasses.dataclass
+class ExportAssetResult:
+    exported_asset_id: int
+    success: bool
+    failure_type: Optional[str] = None
+    insight_id: Optional[int] = None
+    duration_ms: Optional[float] = None
+    export_format: str = ""
+    attempts: int = 1
+
+
+@dataclasses.dataclass
+class EmitDeliveryOutcomeInput:
+    subscription_id: int
+    team_id: int
+    distinct_id: str
+    outcome: str
+    duration_ms: Optional[float] = None
+    assets_with_content: int = 0
+    total_assets: int = 0
+    failure_types: list[str] = dataclasses.field(default_factory=list)

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -14,11 +14,18 @@ class ExportAssetActivityInputs:
 class ExportAssetResult:
     exported_asset_id: int
     success: bool
-    failure_type: Optional[str] = None
+    exception_class: Optional[str] = None
+    error_trace: Optional[str] = None
     insight_id: Optional[int] = None
     duration_ms: Optional[float] = None
     export_format: str = ""
     attempts: int = 1
+
+
+@dataclasses.dataclass
+class ExportError:
+    exception_class: str
+    error_trace: str = ""
 
 
 @dataclasses.dataclass
@@ -30,4 +37,4 @@ class EmitDeliveryOutcomeInput:
     duration_ms: Optional[float] = None
     assets_with_content: int = 0
     total_assets: int = 0
-    failure_types: list[str] = dataclasses.field(default_factory=list)
+    errors: list[ExportError] = dataclasses.field(default_factory=list)

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -7,8 +7,6 @@ from structlog import get_logger
 from posthog.exceptions_capture import capture_exception
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.subscription import Subscription
-from posthog.slo.events import emit_slo_started
-from posthog.slo.types import SloArea, SloOperation, SloStartedProperties
 from posthog.sync import database_sync_to_async
 from posthog.temporal.subscriptions.types import (
     CreateExportAssetsInputs,
@@ -76,19 +74,8 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
         has_insight=bool(subscription.insight_id),
         target_type=subscription.target_type,
     )
-    distinct_id = str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id)
-    emit_slo_started(
-        distinct_id=distinct_id,
-        properties=SloStartedProperties(
-            operation=SloOperation.SUBSCRIPTION_DELIVERY,
-            resource_id=str(inputs.subscription_id),
-            area=SloArea.ANALYTIC_PLATFORM,
-            team_id=team.id,
-        ),
-    )
 
     # Early exit if target value hasn't changed — avoids creating orphaned assets
-    # and emitting unpaired slo_operation_started events
     if inputs.previous_value is not None and subscription.target_value == inputs.previous_value:
         await LOGGER.ainfo(
             "create_export_assets.no_change_skipping",
@@ -151,7 +138,6 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
         exported_asset_ids=[a.id for a in assets],
         total_insight_count=len(insights),
         team_id=team.id,
-        distinct_id=distinct_id,
         target_type=subscription.target_type,
     )
 
@@ -315,18 +301,20 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
             if not is_user_config_error:
                 raise  # Transient Slack errors — let Temporal retry
 
-    # Update next delivery date (unless this is a new-subscription-target delivery)
-    if not inputs.is_new_subscription_target:
-        subscription.set_next_delivery_date(subscription.next_delivery_date)
-        await database_sync_to_async(subscription.save, thread_sensitive=False)(update_fields=["next_delivery_date"])
-        await LOGGER.ainfo(
-            "deliver_subscription.next_delivery_updated",
-            subscription_id=inputs.subscription_id,
-            next_delivery_date=subscription.next_delivery_date,
-        )
-
     await LOGGER.ainfo(
         "deliver_subscription.completed",
         subscription_id=inputs.subscription_id,
         target_type=subscription.target_type,
+    )
+
+
+@temporalio.activity.defn
+async def advance_next_delivery_date(subscription_id: int) -> None:
+    subscription = await database_sync_to_async(Subscription.objects.get, thread_sensitive=False)(pk=subscription_id)
+    subscription.set_next_delivery_date(subscription.next_delivery_date)
+    await database_sync_to_async(subscription.save, thread_sensitive=False)(update_fields=["next_delivery_date"])
+    await LOGGER.ainfo(
+        "advance_next_delivery_date.updated",
+        subscription_id=subscription_id,
+        next_delivery_date=subscription.next_delivery_date,
     )

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -138,6 +138,7 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
         exported_asset_ids=[a.id for a in assets],
         total_insight_count=len(insights),
         team_id=team.id,
+        distinct_id=str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id),
         target_type=subscription.target_type,
     )
 

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -1,0 +1,332 @@
+import datetime as dt
+
+import temporalio.activity
+from slack_sdk.errors import SlackApiError
+from structlog import get_logger
+
+from posthog.exceptions_capture import capture_exception
+from posthog.models.exported_asset import ExportedAsset
+from posthog.models.subscription import Subscription
+from posthog.slo.events import emit_slo_started
+from posthog.slo.types import SloArea, SloOperation, SloStartedProperties
+from posthog.sync import database_sync_to_async
+from posthog.temporal.subscriptions.types import (
+    CreateExportAssetsInputs,
+    CreateExportAssetsResult,
+    DeliverSubscriptionInputs,
+    FetchDueSubscriptionsActivityInputs,
+)
+
+from ee.tasks.subscriptions import (
+    SLACK_USER_CONFIG_ERRORS,
+    SUPPORTED_TARGET_TYPES,
+    _capture_delivery_failed_event,
+    get_subscription_failure_metric,
+    get_subscription_queued_metric,
+    get_subscription_success_metric,
+)
+from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
+from ee.tasks.subscriptions.slack_subscriptions import (
+    get_slack_integration_for_team,
+    send_slack_message_with_integration_async,
+)
+
+LOGGER = get_logger(__name__)
+
+
+@temporalio.activity.defn
+async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivityInputs) -> list[int]:
+    now_with_buffer = dt.datetime.utcnow() + dt.timedelta(minutes=inputs.buffer_minutes)
+    await LOGGER.ainfo("Fetching due subscriptions", deadline=now_with_buffer)
+
+    @database_sync_to_async(thread_sensitive=False)
+    def get_subscription_ids() -> list[int]:
+        return list(
+            Subscription.objects.filter(next_delivery_date__lte=now_with_buffer, deleted=False)
+            .exclude(dashboard__deleted=True)
+            .exclude(insight__deleted=True)
+            .values_list("id", flat=True)
+        )
+
+    subscription_ids = await get_subscription_ids()
+    await LOGGER.ainfo("Fetched due subscriptions", count=len(subscription_ids))
+
+    return subscription_ids
+
+
+@temporalio.activity.defn
+async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExportAssetsResult:
+    await LOGGER.ainfo(
+        "create_export_assets.starting",
+        subscription_id=inputs.subscription_id,
+    )
+
+    subscription = await database_sync_to_async(
+        Subscription.objects.select_related("created_by", "insight", "dashboard", "team").get,
+        thread_sensitive=False,
+    )(pk=inputs.subscription_id)
+
+    team = subscription.team
+    dashboard = subscription.dashboard
+
+    await LOGGER.ainfo(
+        "create_export_assets.loaded",
+        subscription_id=inputs.subscription_id,
+        has_dashboard=bool(dashboard),
+        has_insight=bool(subscription.insight_id),
+        target_type=subscription.target_type,
+    )
+    distinct_id = str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id)
+    emit_slo_started(
+        distinct_id=distinct_id,
+        properties=SloStartedProperties(
+            operation=SloOperation.SUBSCRIPTION_DELIVERY,
+            resource_id=str(inputs.subscription_id),
+            area=SloArea.ANALYTIC_PLATFORM,
+            team_id=team.id,
+        ),
+    )
+
+    # Early exit if target value hasn't changed — avoids creating orphaned assets
+    # and emitting unpaired slo_operation_started events
+    if inputs.previous_value is not None and subscription.target_value == inputs.previous_value:
+        await LOGGER.ainfo(
+            "create_export_assets.no_change_skipping",
+            subscription_id=inputs.subscription_id,
+        )
+        return CreateExportAssetsResult(
+            exported_asset_ids=[],
+            total_insight_count=0,
+            team_id=team.id,
+        )
+
+    if dashboard:
+        tiles = await database_sync_to_async(
+            lambda: list(
+                dashboard.tiles.select_related("insight").filter(insight__isnull=False, insight__deleted=False).all()
+            ),
+            thread_sensitive=False,
+        )()
+        tiles.sort(
+            key=lambda x: (
+                (x.layouts or {}).get("sm", {}).get("y", 100),
+                (x.layouts or {}).get("sm", {}).get("x", 100),
+            )
+        )
+        insights = [tile.insight for tile in tiles if tile.insight]
+
+        selected_ids = await database_sync_to_async(
+            lambda: set(subscription.dashboard_export_insights.values_list("id", flat=True))
+            if subscription.dashboard_export_insights.exists()
+            else None,
+            thread_sensitive=False,
+        )()
+        if selected_ids:
+            insights = [i for i in insights if i.id in selected_ids]
+    elif subscription.insight:
+        insights = [subscription.insight]
+    else:
+        raise Exception("There are no insights to be sent for this Subscription")
+
+    expiry = ExportedAsset.compute_expires_after(ExportedAsset.ExportFormat.PNG)
+    assets = [
+        ExportedAsset(
+            team=team,
+            export_format=ExportedAsset.ExportFormat.PNG,
+            insight=insight,
+            dashboard=dashboard,
+            expires_after=expiry,
+        )
+        for insight in insights[: inputs.max_asset_count]
+    ]
+    await database_sync_to_async(ExportedAsset.objects.bulk_create, thread_sensitive=False)(assets)
+
+    await LOGGER.ainfo(
+        "create_export_assets.assets_created",
+        subscription_id=inputs.subscription_id,
+        asset_count=len(assets),
+        total_insights=len(insights),
+    )
+    return CreateExportAssetsResult(
+        exported_asset_ids=[a.id for a in assets],
+        total_insight_count=len(insights),
+        team_id=team.id,
+        distinct_id=distinct_id,
+        target_type=subscription.target_type,
+    )
+
+
+@temporalio.activity.defn
+async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
+    subscription = await database_sync_to_async(
+        Subscription.objects.select_related("created_by", "insight", "dashboard", "team", "integration").get,
+        thread_sensitive=False,
+    )(pk=inputs.subscription_id)
+
+    await LOGGER.ainfo(
+        "deliver_subscription.starting",
+        subscription_id=inputs.subscription_id,
+        target_type=subscription.target_type,
+        asset_count=len(inputs.exported_asset_ids),
+        is_new=inputs.is_new_subscription_target,
+    )
+
+    if subscription.target_type not in SUPPORTED_TARGET_TYPES:
+        LOGGER.warning(
+            "deliver_subscription.unsupported_target",
+            subscription_id=inputs.subscription_id,
+            target_type=subscription.target_type,
+        )
+        return
+
+    assets = await database_sync_to_async(
+        lambda: list(
+            ExportedAsset.objects_including_ttl_deleted.select_related("insight").filter(
+                pk__in=inputs.exported_asset_ids
+            )
+        ),
+        thread_sensitive=False,
+    )()
+
+    if not assets:
+        LOGGER.warning("deliver_subscription.no_assets", subscription_id=inputs.subscription_id)
+        capture_exception(Exception("No assets are in this subscription"), {"subscription_id": inputs.subscription_id})
+        return
+
+    if subscription.target_type == "email":
+        get_subscription_queued_metric("email", "temporal").add(1)
+
+        emails = subscription.target_value.split(",")
+        await LOGGER.ainfo(
+            "deliver_subscription.sending_email",
+            subscription_id=inputs.subscription_id,
+            recipient_count=len(emails),
+        )
+        if inputs.is_new_subscription_target:
+            previous_emails = inputs.previous_value.split(",") if inputs.previous_value else []
+            emails = list(set(emails) - set(previous_emails))
+
+        last_error: Exception | None = None
+        success_count = 0
+        for email in emails:
+            try:
+                await database_sync_to_async(send_email_subscription_report, thread_sensitive=False)(
+                    email,
+                    subscription,
+                    assets,
+                    invite_message=inputs.invite_message or "" if inputs.is_new_subscription_target else None,
+                    total_asset_count=inputs.total_insight_count,
+                    send_async=False,
+                )
+                get_subscription_success_metric("email", "temporal").add(1)
+                success_count += 1
+            except Exception as e:
+                get_subscription_failure_metric("email", "temporal").add(1)
+                _capture_delivery_failed_event(subscription, e)
+                LOGGER.error(
+                    "deliver_subscription.email_failed",
+                    subscription_id=subscription.id,
+                    email=email,
+                    next_delivery_date=subscription.next_delivery_date,
+                    destination=subscription.target_type,
+                    exc_info=True,
+                )
+                capture_exception(e)
+                last_error = e
+
+        await LOGGER.ainfo(
+            "deliver_subscription.email_complete",
+            subscription_id=inputs.subscription_id,
+            success_count=success_count,
+            total_count=len(emails),
+        )
+
+        # Only retry if ALL recipients failed — partial success is acceptable
+        # to avoid duplicate sends to already-delivered recipients
+        if last_error is not None and success_count == 0:
+            raise last_error
+
+    elif subscription.target_type == "slack":
+        get_subscription_queued_metric("slack", "temporal").add(1)
+
+        try:
+            integration = subscription.integration
+            if integration is None:
+                integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
+                    subscription.team_id
+                )
+            elif integration.kind != "slack":
+                LOGGER.warn(
+                    "deliver_subscription.invalid_integration_kind",
+                    subscription_id=subscription.id,
+                    integration_id=integration.id,
+                    kind=integration.kind,
+                )
+                integration = await database_sync_to_async(get_slack_integration_for_team, thread_sensitive=False)(
+                    subscription.team_id
+                )
+
+            if not integration:
+                LOGGER.warning(
+                    "deliver_subscription.no_slack_integration",
+                    subscription_id=inputs.subscription_id,
+                )
+                return
+
+            LOGGER.info("deliver_subscription.sending_slack_message", subscription_id=subscription.id)
+            delivery_result = await send_slack_message_with_integration_async(
+                integration,
+                subscription,
+                assets,
+                total_asset_count=inputs.total_insight_count,
+                is_new_subscription=inputs.is_new_subscription_target,
+            )
+
+            if delivery_result.is_complete_success:
+                get_subscription_success_metric("slack", "temporal").add(1)
+                await LOGGER.ainfo(
+                    "deliver_subscription.slack_sent",
+                    subscription_id=inputs.subscription_id,
+                )
+            elif delivery_result.is_partial_failure:
+                get_subscription_failure_metric("slack", "temporal", failure_type="partial").add(1)
+                await LOGGER.awarning(
+                    "deliver_subscription.slack_partial_failure",
+                    subscription_id=inputs.subscription_id,
+                    failed_thread_count=len(delivery_result.failed_thread_message_indices),
+                    total_thread_count=delivery_result.total_thread_messages,
+                )
+
+        except Exception as e:
+            is_user_config_error = isinstance(e, SlackApiError) and e.response.get("error") in SLACK_USER_CONFIG_ERRORS
+
+            if not is_user_config_error:
+                get_subscription_failure_metric("slack", "temporal", failure_type="complete").add(1)
+
+            _capture_delivery_failed_event(subscription, e)
+            LOGGER.error(
+                "deliver_subscription.slack_failed",
+                subscription_id=subscription.id,
+                next_delivery_date=subscription.next_delivery_date,
+                destination=subscription.target_type,
+                exc_info=True,
+            )
+            capture_exception(e)
+            if not is_user_config_error:
+                raise  # Transient Slack errors — let Temporal retry
+
+    # Update next delivery date (unless this is a new-subscription-target delivery)
+    if not inputs.is_new_subscription_target:
+        subscription.set_next_delivery_date(subscription.next_delivery_date)
+        await database_sync_to_async(subscription.save, thread_sensitive=False)(update_fields=["next_delivery_date"])
+        await LOGGER.ainfo(
+            "deliver_subscription.next_delivery_updated",
+            subscription_id=inputs.subscription_id,
+            next_delivery_date=subscription.next_delivery_date,
+        )
+
+    await LOGGER.ainfo(
+        "deliver_subscription.completed",
+        subscription_id=inputs.subscription_id,
+        target_type=subscription.target_type,
+    )

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -166,14 +166,17 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
         )
         return
 
-    assets = await database_sync_to_async(
-        lambda: list(
-            ExportedAsset.objects_including_ttl_deleted.select_related("insight").filter(
+    assets_by_id = await database_sync_to_async(
+        lambda: {
+            a.id: a
+            for a in ExportedAsset.objects_including_ttl_deleted.select_related("insight").filter(
                 pk__in=inputs.exported_asset_ids
             )
-        ),
+        },
         thread_sensitive=False,
     )()
+    # Preserve the order from create_export_assets (sorted by dashboard tile layout)
+    assets = [assets_by_id[aid] for aid in inputs.exported_asset_ids if aid in assets_by_id]
 
     if not assets:
         LOGGER.warning("deliver_subscription.no_assets", subscription_id=inputs.subscription_id)

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -4,16 +4,6 @@ import temporalio.activity
 from slack_sdk.errors import SlackApiError
 from structlog import get_logger
 
-from ee.tasks.subscriptions import (
-    SLACK_USER_CONFIG_ERRORS,
-    SUPPORTED_TARGET_TYPES,
-    _capture_delivery_failed_event,
-)
-from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
-from ee.tasks.subscriptions.slack_subscriptions import (
-    get_slack_integration_for_team,
-    send_slack_message_with_integration_async,
-)
 from posthog.exceptions_capture import capture_exception
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.subscription import Subscription
@@ -23,6 +13,13 @@ from posthog.temporal.subscriptions.types import (
     CreateExportAssetsResult,
     DeliverSubscriptionInputs,
     FetchDueSubscriptionsActivityInputs,
+)
+
+from ee.tasks.subscriptions import SLACK_USER_CONFIG_ERRORS, SUPPORTED_TARGET_TYPES, _capture_delivery_failed_event
+from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
+from ee.tasks.subscriptions.slack_subscriptions import (
+    get_slack_integration_for_team,
+    send_slack_message_with_integration_async,
 )
 
 LOGGER = get_logger(__name__)

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -19,9 +19,6 @@ from ee.tasks.subscriptions import (
     SLACK_USER_CONFIG_ERRORS,
     SUPPORTED_TARGET_TYPES,
     _capture_delivery_failed_event,
-    get_subscription_failure_metric,
-    get_subscription_queued_metric,
-    get_subscription_success_metric,
 )
 from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
 from ee.tasks.subscriptions.slack_subscriptions import (
@@ -184,8 +181,6 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
         return
 
     if subscription.target_type == "email":
-        get_subscription_queued_metric("email", "temporal").add(1)
-
         emails = subscription.target_value.split(",")
         await LOGGER.ainfo(
             "deliver_subscription.sending_email",
@@ -208,10 +203,8 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
                     total_asset_count=inputs.total_insight_count,
                     send_async=False,
                 )
-                get_subscription_success_metric("email", "temporal").add(1)
                 success_count += 1
             except Exception as e:
-                get_subscription_failure_metric("email", "temporal").add(1)
                 _capture_delivery_failed_event(subscription, e)
                 LOGGER.error(
                     "deliver_subscription.email_failed",
@@ -237,8 +230,6 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
             raise last_error
 
     elif subscription.target_type == "slack":
-        get_subscription_queued_metric("slack", "temporal").add(1)
-
         try:
             integration = subscription.integration
             if integration is None:
@@ -273,13 +264,11 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
             )
 
             if delivery_result.is_complete_success:
-                get_subscription_success_metric("slack", "temporal").add(1)
                 await LOGGER.ainfo(
                     "deliver_subscription.slack_sent",
                     subscription_id=inputs.subscription_id,
                 )
             elif delivery_result.is_partial_failure:
-                get_subscription_failure_metric("slack", "temporal", failure_type="partial").add(1)
                 await LOGGER.awarning(
                     "deliver_subscription.slack_partial_failure",
                     subscription_id=inputs.subscription_id,
@@ -289,10 +278,6 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
 
         except Exception as e:
             is_user_config_error = isinstance(e, SlackApiError) and e.response.get("error") in SLACK_USER_CONFIG_ERRORS
-
-            if not is_user_config_error:
-                get_subscription_failure_metric("slack", "temporal", failure_type="complete").add(1)
-
             _capture_delivery_failed_event(subscription, e)
             LOGGER.error(
                 "deliver_subscription.slack_failed",

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -4,17 +4,6 @@ import temporalio.activity
 from slack_sdk.errors import SlackApiError
 from structlog import get_logger
 
-from posthog.exceptions_capture import capture_exception
-from posthog.models.exported_asset import ExportedAsset
-from posthog.models.subscription import Subscription
-from posthog.sync import database_sync_to_async
-from posthog.temporal.subscriptions.types import (
-    CreateExportAssetsInputs,
-    CreateExportAssetsResult,
-    DeliverSubscriptionInputs,
-    FetchDueSubscriptionsActivityInputs,
-)
-
 from ee.tasks.subscriptions import (
     SLACK_USER_CONFIG_ERRORS,
     SUPPORTED_TARGET_TYPES,
@@ -24,6 +13,16 @@ from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_r
 from ee.tasks.subscriptions.slack_subscriptions import (
     get_slack_integration_for_team,
     send_slack_message_with_integration_async,
+)
+from posthog.exceptions_capture import capture_exception
+from posthog.models.exported_asset import ExportedAsset
+from posthog.models.subscription import Subscription
+from posthog.sync import database_sync_to_async
+from posthog.temporal.subscriptions.types import (
+    CreateExportAssetsInputs,
+    CreateExportAssetsResult,
+    DeliverSubscriptionInputs,
+    FetchDueSubscriptionsActivityInputs,
 )
 
 LOGGER = get_logger(__name__)

--- a/posthog/temporal/subscriptions/types.py
+++ b/posthog/temporal/subscriptions/types.py
@@ -27,7 +27,6 @@ class CreateExportAssetsResult:
     exported_asset_ids: list[int]
     total_insight_count: int
     team_id: int = 0
-    distinct_id: str = ""
     target_type: str = ""
 
 

--- a/posthog/temporal/subscriptions/types.py
+++ b/posthog/temporal/subscriptions/types.py
@@ -27,6 +27,7 @@ class CreateExportAssetsResult:
     exported_asset_ids: list[int]
     total_insight_count: int
     team_id: int = 0
+    distinct_id: str = ""
     target_type: str = ""
 
 

--- a/posthog/temporal/subscriptions/types.py
+++ b/posthog/temporal/subscriptions/types.py
@@ -1,0 +1,59 @@
+import typing
+import dataclasses
+
+from ee.tasks.subscriptions.subscription_utils import DEFAULT_MAX_ASSET_COUNT
+
+
+@dataclasses.dataclass
+class FetchDueSubscriptionsActivityInputs:
+    buffer_minutes: int = 15
+
+    @property
+    def properties_to_log(self) -> dict[str, typing.Any]:
+        return {
+            "buffer_minutes": self.buffer_minutes,
+        }
+
+
+@dataclasses.dataclass
+class CreateExportAssetsInputs:
+    subscription_id: int
+    max_asset_count: int = DEFAULT_MAX_ASSET_COUNT
+    previous_value: typing.Optional[str] = None
+
+
+@dataclasses.dataclass
+class CreateExportAssetsResult:
+    exported_asset_ids: list[int]
+    total_insight_count: int
+    team_id: int = 0
+    distinct_id: str = ""
+    target_type: str = ""
+
+
+@dataclasses.dataclass
+class DeliverSubscriptionInputs:
+    subscription_id: int
+    exported_asset_ids: list[int]
+    total_insight_count: int
+    is_new_subscription_target: bool = False
+    previous_value: typing.Optional[str] = None
+    invite_message: typing.Optional[str] = None
+
+
+@dataclasses.dataclass
+class ProcessSubscriptionWorkflowInputs:
+    subscription_id: int
+    previous_value: typing.Optional[str] = None
+    invite_message: typing.Optional[str] = None
+
+
+@dataclasses.dataclass
+class ScheduleAllSubscriptionsWorkflowInputs:
+    buffer_minutes: int = 15
+
+    @property
+    def properties_to_log(self) -> dict[str, typing.Any]:
+        return {
+            "buffer_minutes": self.buffer_minutes,
+        }

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -1,0 +1,301 @@
+import json
+import typing
+import asyncio
+import datetime as dt
+
+import temporalio.common
+import temporalio.workflow
+
+from posthog.event_usage import EventSource
+from posthog.slo.types import SloOutcome
+from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.exports.activities import emit_delivery_outcome, export_asset_activity
+from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
+from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAssetActivityInputs, ExportAssetResult
+from posthog.temporal.subscriptions.activities import (
+    create_export_assets,
+    deliver_subscription,
+    fetch_due_subscriptions_activity,
+)
+from posthog.temporal.subscriptions.types import (
+    CreateExportAssetsInputs,
+    DeliverSubscriptionInputs,
+    FetchDueSubscriptionsActivityInputs,
+    ProcessSubscriptionWorkflowInputs,
+    ScheduleAllSubscriptionsWorkflowInputs,
+)
+
+from ee.tasks.subscriptions import get_subscription_failure_metric
+
+
+class ExportErrorDetails(typing.NamedTuple):
+    """Failure metadata extracted from a Temporal activity exception.
+
+    Fields mirror the ApplicationError details emitted by export_asset_activity:
+    [failure_type, duration_ms, export_format, attempt].
+    """
+
+    failure_type: str | None = None
+    duration_ms: float | None = None
+    export_format: str = ""
+    attempts: int = 1
+
+
+def _extract_error_details(exc: BaseException) -> ExportErrorDetails:
+    """Extract failure metadata from a Temporal activity exception chain.
+
+    asyncio.gather(return_exceptions=True) yields BaseException, but Temporal
+    wraps activity failures as ActivityError → ApplicationError. We narrow
+    through that chain to reach the structured details.
+    """
+    from temporalio.exceptions import ActivityError, ApplicationError
+
+    if not isinstance(exc, ActivityError) or not isinstance(exc.cause, ApplicationError):
+        return ExportErrorDetails()
+
+    details = exc.cause.details
+    return ExportErrorDetails(
+        failure_type=details[0] if len(details) >= 1 and isinstance(details[0], str) else None,
+        duration_ms=details[1] if len(details) >= 2 and isinstance(details[1], (int, float)) else None,
+        export_format=details[2] if len(details) >= 3 and isinstance(details[2], str) else "",
+        attempts=details[3] if len(details) >= 4 and isinstance(details[3], int) else 1,
+    )
+
+
+def _build_outcome_assets(
+    asset_ids: list[int],
+    export_results: list[ExportAssetResult | BaseException],
+) -> tuple[list[ExportAssetResult], list[int]]:
+    """Classify export results into outcome assets and collect successful asset IDs.
+
+    BaseException objects from asyncio.gather(return_exceptions=True) aren't
+    serializable across the Temporal activity boundary, so this classification
+    must happen in the workflow, not in an activity.
+    """
+    outcome_assets: list[ExportAssetResult] = []
+    successful_asset_ids: list[int] = []
+    for asset_id, result in zip(asset_ids, export_results):
+        if isinstance(result, BaseException):
+            err = _extract_error_details(result)
+            outcome_assets.append(
+                ExportAssetResult(
+                    exported_asset_id=asset_id,
+                    success=False,
+                    failure_type=err.failure_type,
+                    duration_ms=err.duration_ms,
+                    export_format=err.export_format,
+                    attempts=err.attempts,
+                )
+            )
+        else:
+            outcome_assets.append(
+                ExportAssetResult(
+                    exported_asset_id=result.exported_asset_id,
+                    success=result.success,
+                    failure_type=result.failure_type,
+                    insight_id=result.insight_id,
+                    duration_ms=result.duration_ms,
+                    export_format=result.export_format,
+                    attempts=result.attempts,
+                )
+            )
+            if result.success:
+                successful_asset_ids.append(result.exported_asset_id)
+    return outcome_assets, successful_asset_ids
+
+
+@temporalio.workflow.defn(name="schedule-all-subscriptions")
+class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
+    """Workflow to schedule all subscriptions that are due for delivery."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> ScheduleAllSubscriptionsWorkflowInputs:
+        if not inputs:
+            return ScheduleAllSubscriptionsWorkflowInputs()
+
+        loaded = json.loads(inputs[0])
+        return ScheduleAllSubscriptionsWorkflowInputs(**loaded)
+
+    @temporalio.workflow.run
+    async def run(self, inputs: ScheduleAllSubscriptionsWorkflowInputs) -> None:
+        # Fetch subscription IDs that are due
+        fetch_inputs = FetchDueSubscriptionsActivityInputs(buffer_minutes=inputs.buffer_minutes)
+        subscription_ids: list[int] = await temporalio.workflow.execute_activity(
+            fetch_due_subscriptions_activity,
+            fetch_inputs,
+            start_to_close_timeout=dt.timedelta(minutes=5),
+            retry_policy=temporalio.common.RetryPolicy(
+                initial_interval=dt.timedelta(seconds=10),
+                maximum_interval=dt.timedelta(minutes=5),
+                maximum_attempts=3,
+                non_retryable_error_types=[],
+            ),
+        )
+
+        # Fan-out child workflows — one per subscription, fully isolated.
+        # Idempotent ID (no run_id suffix) prevents duplicate deliveries when
+        # schedule runs overlap: if the previous run's child is still executing,
+        # Temporal rejects the duplicate start and we log it below.
+        tasks = []
+        for sub_id in subscription_ids:
+            task = temporalio.workflow.execute_child_workflow(
+                ProcessSubscriptionWorkflow.run,
+                ProcessSubscriptionWorkflowInputs(subscription_id=sub_id),
+                id=f"process-subscription-{sub_id}",
+                parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
+                execution_timeout=dt.timedelta(hours=2),
+            )
+            tasks.append(task)
+
+        if tasks:
+            # return_exceptions=True: individual subscription failures are isolated —
+            # one failing subscription should not prevent others from being delivered.
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for sub_id, result in zip(subscription_ids, results):
+                if isinstance(result, BaseException):
+                    temporalio.workflow.logger.warning(
+                        "process_subscription.child_workflow_error",
+                        extra={"subscription_id": sub_id, "error": str(result)},
+                    )
+
+
+@temporalio.workflow.defn(name="process-subscription")
+class ProcessSubscriptionWorkflow(PostHogWorkflow):
+    """Child workflow that handles a single subscription: prepare -> export -> deliver -> emit."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> ProcessSubscriptionWorkflowInputs:
+        loaded = json.loads(inputs[0])
+        return ProcessSubscriptionWorkflowInputs(**loaded)
+
+    @temporalio.workflow.run
+    async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
+        # Phase 1: Prepare — create ExportedAssets, emit slo_operation_started
+        # previous_value is passed so the activity can skip asset creation if the
+        # target value hasn't changed (avoids orphaned assets and unpaired SLO events)
+        prepare_result = await temporalio.workflow.execute_activity(
+            create_export_assets,
+            CreateExportAssetsInputs(
+                subscription_id=inputs.subscription_id,
+                previous_value=inputs.previous_value,
+            ),
+            start_to_close_timeout=dt.timedelta(minutes=5),
+            retry_policy=temporalio.common.RetryPolicy(
+                initial_interval=dt.timedelta(seconds=10),
+                maximum_interval=dt.timedelta(minutes=2),
+                maximum_attempts=3,
+            ),
+        )
+
+        if not prepare_result.exported_asset_ids:
+            return
+
+        start_time = temporalio.workflow.time()
+        delivery_outcome = SloOutcome.SUCCESS
+
+        # Phase 2: Fan-out export — one activity per insight, independent retry
+        export_tasks = []
+        for asset_id in prepare_result.exported_asset_ids:
+            task = temporalio.workflow.execute_activity(
+                export_asset_activity,
+                ExportAssetActivityInputs(
+                    exported_asset_id=asset_id,
+                    source=EventSource.SUBSCRIPTION,
+                ),
+                start_to_close_timeout=dt.timedelta(hours=1),
+                heartbeat_timeout=dt.timedelta(minutes=2),
+                retry_policy=EXPORT_RETRY_POLICY,
+            )
+            export_tasks.append((asset_id, task))
+
+        # Gather results — continue on failure (partial success OK)
+        export_results: list[ExportAssetResult | BaseException] = await asyncio.gather(
+            *[task for _, task in export_tasks],
+            return_exceptions=True,
+        )
+
+        # Classify export results
+        asset_ids = [aid for aid, _ in export_tasks]
+        outcome_assets, successful_asset_ids = _build_outcome_assets(asset_ids, export_results)
+        assets_with_content = len(successful_asset_ids)
+        total_assets = len(outcome_assets)
+        failure_types = list({a.failure_type for a in outcome_assets if a.failure_type})
+
+        if assets_with_content == 0:
+            delivery_outcome = SloOutcome.FAILURE
+        elif assets_with_content < total_assets:
+            delivery_outcome = SloOutcome.PARTIAL_SUCCESS
+
+        if failure_types:
+            get_subscription_failure_metric(
+                prepare_result.target_type, "temporal", failure_type="asset_generation"
+            ).add(1)
+
+        # Phase 3: Deliver — send with whatever assets we have
+        delivery_asset_ids = successful_asset_ids if successful_asset_ids else prepare_result.exported_asset_ids
+
+        # is_new is true when previous_value is set (target change), false for scheduled delivery
+        is_new = inputs.previous_value is not None
+
+        try:
+            await temporalio.workflow.execute_activity(
+                deliver_subscription,
+                DeliverSubscriptionInputs(
+                    subscription_id=inputs.subscription_id,
+                    exported_asset_ids=delivery_asset_ids,
+                    total_insight_count=prepare_result.total_insight_count,
+                    is_new_subscription_target=is_new,
+                    previous_value=inputs.previous_value,
+                    invite_message=inputs.invite_message,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=5),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=10),
+                    maximum_interval=dt.timedelta(minutes=2),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception:
+            delivery_outcome = SloOutcome.FAILURE
+            failure_types.append("delivery_failed")
+            raise
+        finally:
+            # Phase 4: Emit subscription delivery SLO — always runs, even on failure
+            duration_ms = (temporalio.workflow.time() - start_time) * 1000
+            await temporalio.workflow.execute_activity(
+                emit_delivery_outcome,
+                EmitDeliveryOutcomeInput(
+                    subscription_id=inputs.subscription_id,
+                    team_id=prepare_result.team_id,
+                    distinct_id=prepare_result.distinct_id,
+                    outcome=delivery_outcome,
+                    duration_ms=duration_ms,
+                    assets_with_content=assets_with_content,
+                    total_assets=total_assets,
+                    failure_types=failure_types,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=5),
+                    maximum_interval=dt.timedelta(minutes=1),
+                    maximum_attempts=3,
+                ),
+            )
+
+
+@temporalio.workflow.defn(name="handle-subscription-value-change")
+class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> ProcessSubscriptionWorkflowInputs:
+        loaded = json.loads(inputs[0])
+        return ProcessSubscriptionWorkflowInputs(**loaded)
+
+    @temporalio.workflow.run
+    async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
+        await temporalio.workflow.execute_child_workflow(
+            ProcessSubscriptionWorkflow.run,
+            inputs,
+            id=f"process-subscription-change-{inputs.subscription_id}",
+            parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
+            execution_timeout=dt.timedelta(hours=2),
+        )

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -6,7 +6,7 @@ import traceback
 
 import temporalio.common
 import temporalio.workflow
-from temporalio.exceptions import ApplicationError
+from temporalio.exceptions import ActivityError, ApplicationError
 
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
@@ -58,8 +58,6 @@ def _extract_error_details(exc: BaseException) -> ExportErrorDetails:
     wraps activity failures as ActivityError → ApplicationError. We narrow
     through that chain to reach the structured details.
     """
-    from temporalio.exceptions import ActivityError, ApplicationError
-
     if not isinstance(exc, ActivityError) or not isinstance(exc.cause, ApplicationError):
         return ExportErrorDetails()
 
@@ -92,8 +90,12 @@ def _build_outcome_assets(
                 ExportAssetResult(
                     exported_asset_id=asset_id,
                     success=False,
-                    exception_class=err.exception_class,
-                    error_trace=err.error_trace,
+                    error=ExportError(
+                        exception_class=err.exception_class or "",
+                        error_trace=err.error_trace or "",
+                    )
+                    if err.exception_class
+                    else None,
                     duration_ms=err.duration_ms,
                     export_format=err.export_format,
                     attempts=err.attempts,
@@ -108,8 +110,6 @@ def _build_outcome_assets(
 
 @temporalio.workflow.defn(name="schedule-all-subscriptions")
 class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
-    """Workflow to schedule all subscriptions that are due for delivery."""
-
     @staticmethod
     def parse_inputs(inputs: list[str]) -> ScheduleAllSubscriptionsWorkflowInputs:
         if not inputs:
@@ -120,7 +120,6 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: ScheduleAllSubscriptionsWorkflowInputs) -> None:
-        # Fetch subscription IDs that are due
         fetch_inputs = FetchDueSubscriptionsActivityInputs(buffer_minutes=inputs.buffer_minutes)
         subscription_ids: list[int] = await temporalio.workflow.execute_activity(
             fetch_due_subscriptions_activity,
@@ -171,8 +170,6 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
 
 @temporalio.workflow.defn(name="process-subscription")
 class ProcessSubscriptionWorkflow(PostHogWorkflow):
-    """Child workflow that handles a single subscription: prepare -> export -> deliver -> emit."""
-
     @staticmethod
     def parse_inputs(inputs: list[str]) -> ProcessSubscriptionWorkflowInputs:
         loaded = json.loads(inputs[0])
@@ -202,8 +199,6 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             )
 
             # Phase 1: Prepare — create ExportedAssets
-            # previous_value is passed so the activity can skip asset creation if the
-            # target value hasn't changed
             prepare_result = await temporalio.workflow.execute_activity(
                 create_export_assets,
                 CreateExportAssetsInputs(
@@ -247,11 +242,7 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             outcome_assets, successful_asset_ids = _build_outcome_assets(asset_ids, export_results)
             assets_with_content = len(successful_asset_ids)
             total_assets = len(outcome_assets)
-            errors = [
-                ExportError(exception_class=a.exception_class or "", error_trace=a.error_trace or "")
-                for a in outcome_assets
-                if a.exception_class
-            ]
+            errors = [a.error for a in outcome_assets if a.error]
 
             if assets_with_content < total_assets:
                 delivery_outcome = SloOutcome.FAILURE
@@ -299,10 +290,7 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             # Don't re-raise — let finally run cleanup activities first
 
         finally:
-            # Advance schedule — always for scheduled deliveries, even on failure.
-            # This must not be gated on prepare_result or asset count, otherwise a
-            # persistently broken subscription (e.g. deleted insight) stays "due"
-            # forever and gets re-processed every schedule tick.
+            # Advance schedule — always for scheduled deliveries, even on failure
             if inputs.previous_value is None:
                 await temporalio.workflow.execute_activity(
                     advance_next_delivery_date,
@@ -338,7 +326,9 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     ),
                 )
 
-        # Re-raise after cleanup completes
+        # Re-raise after cleanup completes. We can't re-raise inside the except
+        # block because Temporal's SDK blocks new activity scheduling in the
+        # finally block while an exception is propagating.
         if caught_error:
             raise caught_error
 

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -6,6 +6,7 @@ import traceback
 
 import temporalio.common
 import temporalio.workflow
+from temporalio.exceptions import ApplicationError
 
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
@@ -152,12 +153,20 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
             # return_exceptions=True: individual subscription failures are isolated —
             # one failing subscription should not prevent others from being delivered.
             results = await asyncio.gather(*tasks, return_exceptions=True)
+            failed_ids = []
             for sub_id, result in zip(subscription_ids, results):
                 if isinstance(result, BaseException):
+                    failed_ids.append(sub_id)
                     temporalio.workflow.logger.warning(
                         "process_subscription.child_workflow_error",
                         extra={"subscription_id": sub_id, "error": str(result)},
                     )
+
+            if failed_ids:
+                raise ApplicationError(
+                    f"Subscription deliveries failed for IDs: {failed_ids}",
+                    non_retryable=True,
+                )
 
 
 @temporalio.workflow.defn(name="process-subscription")
@@ -177,6 +186,7 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
         total_assets = 0
         errors: list[ExportError] = []
         prepare_result = None
+        caught_error: BaseException | None = None
 
         try:
             # SLO started — workflow owns the lifecycle, fires before any work
@@ -184,6 +194,11 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                 emit_delivery_started,
                 inputs.subscription_id,
                 start_to_close_timeout=dt.timedelta(minutes=2),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=5),
+                    maximum_interval=dt.timedelta(minutes=1),
+                    maximum_attempts=3,
+                ),
             )
 
             # Phase 1: Prepare — create ExportedAssets
@@ -254,41 +269,41 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             # is_new is true when previous_value is set (target change), false for scheduled delivery
             is_new = inputs.previous_value is not None
 
-            try:
-                await temporalio.workflow.execute_activity(
-                    deliver_subscription,
-                    DeliverSubscriptionInputs(
-                        subscription_id=inputs.subscription_id,
-                        exported_asset_ids=delivery_asset_ids,
-                        total_insight_count=prepare_result.total_insight_count,
-                        is_new_subscription_target=is_new,
-                        previous_value=inputs.previous_value,
-                        invite_message=inputs.invite_message,
-                    ),
-                    start_to_close_timeout=dt.timedelta(minutes=5),
-                    retry_policy=temporalio.common.RetryPolicy(
-                        initial_interval=dt.timedelta(seconds=10),
-                        maximum_interval=dt.timedelta(minutes=2),
-                        maximum_attempts=3,
-                    ),
-                )
-            except Exception as e:
-                delivery_outcome = SloOutcome.FAILURE
-                errors.append(
-                    ExportError(
-                        exception_class=type(e).__name__,
-                        error_trace="\n".join(traceback.format_exception(e)[:5]),
-                    )
-                )
-                raise
+            await temporalio.workflow.execute_activity(
+                deliver_subscription,
+                DeliverSubscriptionInputs(
+                    subscription_id=inputs.subscription_id,
+                    exported_asset_ids=delivery_asset_ids,
+                    total_insight_count=prepare_result.total_insight_count,
+                    is_new_subscription_target=is_new,
+                    previous_value=inputs.previous_value,
+                    invite_message=inputs.invite_message,
+                ),
+                start_to_close_timeout=dt.timedelta(minutes=5),
+                retry_policy=temporalio.common.RetryPolicy(
+                    initial_interval=dt.timedelta(seconds=10),
+                    maximum_interval=dt.timedelta(minutes=2),
+                    maximum_attempts=3,
+                ),
+            )
 
-        except Exception:
+        except Exception as e:
             delivery_outcome = SloOutcome.FAILURE
-            raise
+            errors.append(
+                ExportError(
+                    exception_class=type(e).__name__,
+                    error_trace="\n".join(traceback.format_exception(e)[:5]),
+                )
+            )
+            caught_error = e
+            # Don't re-raise — let finally run cleanup activities first
 
         finally:
-            # Advance schedule — always for scheduled deliveries, even on failure
-            if inputs.previous_value is None and prepare_result and prepare_result.exported_asset_ids:
+            # Advance schedule — always for scheduled deliveries, even on failure.
+            # This must not be gated on prepare_result or asset count, otherwise a
+            # persistently broken subscription (e.g. deleted insight) stays "due"
+            # forever and gets re-processed every schedule tick.
+            if inputs.previous_value is None:
                 await temporalio.workflow.execute_activity(
                     advance_next_delivery_date,
                     inputs.subscription_id,
@@ -301,8 +316,8 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                 )
 
             # SLO completed — fires last, after all side effects
-            duration_ms = (temporalio.workflow.time() - start_time) * 1000
             if prepare_result and prepare_result.team_id:
+                duration_ms = (temporalio.workflow.time() - start_time) * 1000
                 await temporalio.workflow.execute_activity(
                     emit_delivery_outcome,
                     EmitDeliveryOutcomeInput(
@@ -316,7 +331,16 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                         errors=errors,
                     ),
                     start_to_close_timeout=dt.timedelta(minutes=2),
+                    retry_policy=temporalio.common.RetryPolicy(
+                        initial_interval=dt.timedelta(seconds=5),
+                        maximum_interval=dt.timedelta(minutes=1),
+                        maximum_attempts=3,
+                    ),
                 )
+
+        # Re-raise after cleanup completes
+        if caught_error:
+            raise caught_error
 
 
 @temporalio.workflow.defn(name="handle-subscription-value-change")

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -2,17 +2,25 @@ import json
 import typing
 import asyncio
 import datetime as dt
+import traceback
 
 import temporalio.common
 import temporalio.workflow
 
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
+from posthog.tasks.exports.failure_handler import is_user_query_error_type
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.exports.activities import emit_delivery_outcome, export_asset_activity
+from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import EmitDeliveryOutcomeInput, ExportAssetActivityInputs, ExportAssetResult
+from posthog.temporal.exports.types import (
+    EmitDeliveryOutcomeInput,
+    ExportAssetActivityInputs,
+    ExportAssetResult,
+    ExportError,
+)
 from posthog.temporal.subscriptions.activities import (
+    advance_next_delivery_date,
     create_export_assets,
     deliver_subscription,
     fetch_due_subscriptions_activity,
@@ -32,13 +40,14 @@ class ExportErrorDetails(typing.NamedTuple):
     """Failure metadata extracted from a Temporal activity exception.
 
     Fields mirror the ApplicationError details emitted by export_asset_activity:
-    [failure_type, duration_ms, export_format, attempt].
+    [exception_class, duration_ms, export_format, attempt, error_trace].
     """
 
-    failure_type: str | None = None
+    exception_class: str | None = None
     duration_ms: float | None = None
     export_format: str = ""
     attempts: int = 1
+    error_trace: str | None = None
 
 
 def _extract_error_details(exc: BaseException) -> ExportErrorDetails:
@@ -55,10 +64,11 @@ def _extract_error_details(exc: BaseException) -> ExportErrorDetails:
 
     details = exc.cause.details
     return ExportErrorDetails(
-        failure_type=details[0] if len(details) >= 1 and isinstance(details[0], str) else None,
+        exception_class=details[0] if len(details) >= 1 and isinstance(details[0], str) else None,
         duration_ms=details[1] if len(details) >= 2 and isinstance(details[1], (int, float)) else None,
         export_format=details[2] if len(details) >= 3 and isinstance(details[2], str) else "",
         attempts=details[3] if len(details) >= 4 and isinstance(details[3], int) else 1,
+        error_trace=details[4] if len(details) >= 5 and isinstance(details[4], str) else None,
     )
 
 
@@ -81,24 +91,15 @@ def _build_outcome_assets(
                 ExportAssetResult(
                     exported_asset_id=asset_id,
                     success=False,
-                    failure_type=err.failure_type,
+                    exception_class=err.exception_class,
+                    error_trace=err.error_trace,
                     duration_ms=err.duration_ms,
                     export_format=err.export_format,
                     attempts=err.attempts,
                 )
             )
         else:
-            outcome_assets.append(
-                ExportAssetResult(
-                    exported_asset_id=result.exported_asset_id,
-                    success=result.success,
-                    failure_type=result.failure_type,
-                    insight_id=result.insight_id,
-                    duration_ms=result.duration_ms,
-                    export_format=result.export_format,
-                    attempts=result.attempts,
-                )
-            )
+            outcome_assets.append(result)
             if result.success:
                 successful_asset_ids.append(result.exported_asset_id)
     return outcome_assets, successful_asset_ids
@@ -170,83 +171,29 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
-        # Phase 1: Prepare — create ExportedAssets, emit slo_operation_started
-        # previous_value is passed so the activity can skip asset creation if the
-        # target value hasn't changed (avoids orphaned assets and unpaired SLO events)
-        prepare_result = await temporalio.workflow.execute_activity(
-            create_export_assets,
-            CreateExportAssetsInputs(
-                subscription_id=inputs.subscription_id,
-                previous_value=inputs.previous_value,
-            ),
-            start_to_close_timeout=dt.timedelta(minutes=5),
-            retry_policy=temporalio.common.RetryPolicy(
-                initial_interval=dt.timedelta(seconds=10),
-                maximum_interval=dt.timedelta(minutes=2),
-                maximum_attempts=3,
-            ),
-        )
-
-        if not prepare_result.exported_asset_ids:
-            return
-
         start_time = temporalio.workflow.time()
         delivery_outcome = SloOutcome.SUCCESS
-
-        # Phase 2: Fan-out export — one activity per insight, independent retry
-        export_tasks = []
-        for asset_id in prepare_result.exported_asset_ids:
-            task = temporalio.workflow.execute_activity(
-                export_asset_activity,
-                ExportAssetActivityInputs(
-                    exported_asset_id=asset_id,
-                    source=EventSource.SUBSCRIPTION,
-                ),
-                start_to_close_timeout=dt.timedelta(hours=1),
-                heartbeat_timeout=dt.timedelta(minutes=2),
-                retry_policy=EXPORT_RETRY_POLICY,
-            )
-            export_tasks.append((asset_id, task))
-
-        # Gather results — continue on failure (partial success OK)
-        export_results: list[ExportAssetResult | BaseException] = await asyncio.gather(
-            *[task for _, task in export_tasks],
-            return_exceptions=True,
-        )
-
-        # Classify export results
-        asset_ids = [aid for aid, _ in export_tasks]
-        outcome_assets, successful_asset_ids = _build_outcome_assets(asset_ids, export_results)
-        assets_with_content = len(successful_asset_ids)
-        total_assets = len(outcome_assets)
-        failure_types = list({a.failure_type for a in outcome_assets if a.failure_type})
-
-        if assets_with_content == 0:
-            delivery_outcome = SloOutcome.FAILURE
-        elif assets_with_content < total_assets:
-            delivery_outcome = SloOutcome.PARTIAL_SUCCESS
-
-        if failure_types:
-            get_subscription_failure_metric(
-                prepare_result.target_type, "temporal", failure_type="asset_generation"
-            ).add(1)
-
-        # Phase 3: Deliver — send with whatever assets we have
-        delivery_asset_ids = successful_asset_ids if successful_asset_ids else prepare_result.exported_asset_ids
-
-        # is_new is true when previous_value is set (target change), false for scheduled delivery
-        is_new = inputs.previous_value is not None
+        assets_with_content = 0
+        total_assets = 0
+        errors: list[ExportError] = []
+        prepare_result = None
 
         try:
+            # SLO started — workflow owns the lifecycle, fires before any work
             await temporalio.workflow.execute_activity(
-                deliver_subscription,
-                DeliverSubscriptionInputs(
+                emit_delivery_started,
+                inputs.subscription_id,
+                start_to_close_timeout=dt.timedelta(minutes=2),
+            )
+
+            # Phase 1: Prepare — create ExportedAssets
+            # previous_value is passed so the activity can skip asset creation if the
+            # target value hasn't changed
+            prepare_result = await temporalio.workflow.execute_activity(
+                create_export_assets,
+                CreateExportAssetsInputs(
                     subscription_id=inputs.subscription_id,
-                    exported_asset_ids=delivery_asset_ids,
-                    total_insight_count=prepare_result.total_insight_count,
-                    is_new_subscription_target=is_new,
                     previous_value=inputs.previous_value,
-                    invite_message=inputs.invite_message,
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=5),
                 retry_policy=temporalio.common.RetryPolicy(
@@ -255,32 +202,121 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     maximum_attempts=3,
                 ),
             )
+
+            if not prepare_result.exported_asset_ids:
+                return
+
+            # Phase 2: Fan-out export — one activity per insight, independent retry
+            export_tasks = []
+            for asset_id in prepare_result.exported_asset_ids:
+                task = temporalio.workflow.execute_activity(
+                    export_asset_activity,
+                    ExportAssetActivityInputs(
+                        exported_asset_id=asset_id,
+                        source=EventSource.SUBSCRIPTION,
+                    ),
+                    start_to_close_timeout=dt.timedelta(hours=1),
+                    heartbeat_timeout=dt.timedelta(minutes=2),
+                    retry_policy=EXPORT_RETRY_POLICY,
+                )
+                export_tasks.append((asset_id, task))
+
+            # Gather results — continue on failure (partial success OK)
+            export_results: list[ExportAssetResult | BaseException] = await asyncio.gather(
+                *[task for _, task in export_tasks],
+                return_exceptions=True,
+            )
+
+            # Classify export results
+            asset_ids = [aid for aid, _ in export_tasks]
+            outcome_assets, successful_asset_ids = _build_outcome_assets(asset_ids, export_results)
+            assets_with_content = len(successful_asset_ids)
+            total_assets = len(outcome_assets)
+            errors = [
+                ExportError(exception_class=a.exception_class or "", error_trace=a.error_trace or "")
+                for a in outcome_assets
+                if a.exception_class
+            ]
+
+            if assets_with_content < total_assets:
+                delivery_outcome = SloOutcome.FAILURE
+            # Only count system failures in the metric, not user query errors
+            system_failures = [e for e in errors if not is_user_query_error_type(e.exception_class)]
+            if system_failures:
+                get_subscription_failure_metric(
+                    prepare_result.target_type, "temporal", failure_type="asset_generation"
+                ).add(1)
+
+            # Phase 3: Deliver — send all assets including failed ones (they show
+            # a "failed to generate" placeholder in the email/Slack message)
+            delivery_asset_ids = prepare_result.exported_asset_ids
+
+            # is_new is true when previous_value is set (target change), false for scheduled delivery
+            is_new = inputs.previous_value is not None
+
+            try:
+                await temporalio.workflow.execute_activity(
+                    deliver_subscription,
+                    DeliverSubscriptionInputs(
+                        subscription_id=inputs.subscription_id,
+                        exported_asset_ids=delivery_asset_ids,
+                        total_insight_count=prepare_result.total_insight_count,
+                        is_new_subscription_target=is_new,
+                        previous_value=inputs.previous_value,
+                        invite_message=inputs.invite_message,
+                    ),
+                    start_to_close_timeout=dt.timedelta(minutes=5),
+                    retry_policy=temporalio.common.RetryPolicy(
+                        initial_interval=dt.timedelta(seconds=10),
+                        maximum_interval=dt.timedelta(minutes=2),
+                        maximum_attempts=3,
+                    ),
+                )
+            except Exception as e:
+                delivery_outcome = SloOutcome.FAILURE
+                errors.append(
+                    ExportError(
+                        exception_class=type(e).__name__,
+                        error_trace="\n".join(traceback.format_exception(e)[:5]),
+                    )
+                )
+                raise
+
         except Exception:
             delivery_outcome = SloOutcome.FAILURE
-            failure_types.append("delivery_failed")
             raise
+
         finally:
-            # Phase 4: Emit subscription delivery SLO — always runs, even on failure
+            # Advance schedule — always for scheduled deliveries, even on failure
+            if inputs.previous_value is None and prepare_result and prepare_result.exported_asset_ids:
+                await temporalio.workflow.execute_activity(
+                    advance_next_delivery_date,
+                    inputs.subscription_id,
+                    start_to_close_timeout=dt.timedelta(minutes=2),
+                    retry_policy=temporalio.common.RetryPolicy(
+                        initial_interval=dt.timedelta(seconds=5),
+                        maximum_interval=dt.timedelta(minutes=1),
+                        maximum_attempts=3,
+                    ),
+                )
+
+            # SLO completed — fires last, after all side effects
             duration_ms = (temporalio.workflow.time() - start_time) * 1000
-            await temporalio.workflow.execute_activity(
-                emit_delivery_outcome,
-                EmitDeliveryOutcomeInput(
-                    subscription_id=inputs.subscription_id,
-                    team_id=prepare_result.team_id,
-                    distinct_id=prepare_result.distinct_id,
-                    outcome=delivery_outcome,
-                    duration_ms=duration_ms,
-                    assets_with_content=assets_with_content,
-                    total_assets=total_assets,
-                    failure_types=failure_types,
-                ),
-                start_to_close_timeout=dt.timedelta(minutes=2),
-                retry_policy=temporalio.common.RetryPolicy(
-                    initial_interval=dt.timedelta(seconds=5),
-                    maximum_interval=dt.timedelta(minutes=1),
-                    maximum_attempts=3,
-                ),
-            )
+            if prepare_result and prepare_result.team_id:
+                await temporalio.workflow.execute_activity(
+                    emit_delivery_outcome,
+                    EmitDeliveryOutcomeInput(
+                        subscription_id=inputs.subscription_id,
+                        team_id=prepare_result.team_id,
+                        distinct_id=prepare_result.distinct_id,
+                        outcome=delivery_outcome,
+                        duration_ms=duration_ms,
+                        assets_with_content=assets_with_content,
+                        total_assets=total_assets,
+                        errors=errors,
+                    ),
+                    start_to_close_timeout=dt.timedelta(minutes=2),
+                )
 
 
 @temporalio.workflow.defn(name="handle-subscription-value-change")

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -34,8 +34,6 @@ from posthog.temporal.subscriptions.types import (
     ScheduleAllSubscriptionsWorkflowInputs,
 )
 
-from ee.tasks.subscriptions import get_subscription_failure_metric
-
 
 class ExportErrorDetails(typing.NamedTuple):
     """Failure metadata extracted from a Temporal activity exception.
@@ -244,14 +242,9 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             total_assets = len(outcome_assets)
             errors = [a.error for a in outcome_assets if a.error]
 
-            if assets_with_content < total_assets:
+            non_user_errors = [e for e in errors if not is_user_query_error_type(e.exception_class)]
+            if non_user_errors:
                 delivery_outcome = SloOutcome.FAILURE
-            # Only count system failures in the metric, not user query errors
-            system_failures = [e for e in errors if not is_user_query_error_type(e.exception_class)]
-            if system_failures:
-                get_subscription_failure_metric(
-                    prepare_result.target_type, "temporal", failure_type="asset_generation"
-                ).add(1)
 
             # Phase 3: Deliver — send all assets including failed ones (they show
             # a "failed to generate" placeholder in the email/Slack message)

--- a/posthog/temporal/tests/test_export_activities.py
+++ b/posthog/temporal/tests/test_export_activities.py
@@ -78,7 +78,7 @@ async def test_export_asset_activity_success(
 
     assert result.exported_asset_id == asset.id
     assert result.success is True
-    assert result.failure_type is None
+    assert result.exception_class is None
 
 
 @patch("posthog.temporal.exports.activities.exporter")

--- a/posthog/temporal/tests/test_export_activities.py
+++ b/posthog/temporal/tests/test_export_activities.py
@@ -1,0 +1,129 @@
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+
+import temporalio.workflow
+from asgiref.sync import sync_to_async
+from temporalio.client import WorkflowFailureError
+from temporalio.exceptions import ActivityError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog.models.exported_asset import ExportedAsset
+from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.exports.activities import export_asset_activity
+from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
+from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
+
+
+@temporalio.workflow.defn(name="test-export-asset")
+class TestExportAssetWorkflow(PostHogWorkflow):
+    """Minimal wrapper workflow so we can test the activity via Temporal."""
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]):
+        return {}
+
+    @temporalio.workflow.run
+    async def run(self, inputs: ExportAssetActivityInputs) -> ExportAssetResult:
+        return await temporalio.workflow.execute_activity(
+            export_asset_activity,
+            inputs,
+            start_to_close_timeout=timedelta(minutes=5),
+            heartbeat_timeout=timedelta(minutes=2),
+            retry_policy=EXPORT_RETRY_POLICY,
+        )
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
+
+
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_export_asset_activity_success(
+    mock_exporter: MagicMock,
+    team,
+):
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        export_format="image/png",
+    )
+
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/key"
+        asset_obj.save(update_fields=["content_location"])
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[TestExportAssetWorkflow],
+            activities=[export_asset_activity],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=5),
+            debug_mode=True,
+        ):
+            result = await env.client.execute_workflow(
+                TestExportAssetWorkflow.run,
+                ExportAssetActivityInputs(exported_asset_id=asset.id),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    assert result.exported_asset_id == asset.id
+    assert result.success is True
+    assert result.failure_type is None
+
+
+@patch("posthog.temporal.exports.activities.exporter")
+async def test_export_asset_activity_propagates_user_errors(
+    mock_exporter: MagicMock,
+    team,
+):
+    from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
+
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        export_format="image/png",
+    )
+
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.failure_type = "user"
+        asset_obj.exception_type = "ExcelColumnLimitExceeded"
+        asset_obj.save(update_fields=["failure_type", "exception_type"])
+        raise ExcelColumnLimitExceeded()
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[TestExportAssetWorkflow],
+            activities=[export_asset_activity],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=5),
+            debug_mode=True,
+        ):
+            with pytest.raises(WorkflowFailureError) as exc_info:
+                await env.client.execute_workflow(
+                    TestExportAssetWorkflow.run,
+                    ExportAssetActivityInputs(exported_asset_id=asset.id),
+                    id=str(uuid.uuid4()),
+                    task_queue=settings.TEMPORAL_TASK_QUEUE,
+                )
+
+        # WorkflowFailureError.cause is ActivityError; ActivityError.cause is the ApplicationError
+        wf_error = exc_info.value
+        assert isinstance(wf_error, WorkflowFailureError)
+        activity_error = wf_error.cause
+        assert isinstance(activity_error, ActivityError)
+        app_error = activity_error.cause
+        assert app_error is not None
+        assert "ExcelColumnLimitExceeded" in str(app_error) or "18,278 columns" in str(app_error)

--- a/posthog/temporal/tests/test_export_activities.py
+++ b/posthog/temporal/tests/test_export_activities.py
@@ -1,5 +1,6 @@
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from datetime import timedelta
 
 import pytest
@@ -9,22 +10,23 @@ from django.conf import settings
 
 import temporalio.workflow
 from asgiref.sync import sync_to_async
-from temporalio.client import WorkflowFailureError
+from temporalio.client import Client, WorkflowFailureError
 from temporalio.exceptions import ActivityError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.models.exported_asset import ExportedAsset
+from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
+
 
 @temporalio.workflow.defn(name="test-export-asset")
 class TestExportAssetWorkflow(PostHogWorkflow):
-    """Minimal wrapper workflow so we can test the activity via Temporal."""
-
     @staticmethod
     def parse_inputs(inputs: list[str]):
         return {}
@@ -40,17 +42,34 @@ class TestExportAssetWorkflow(PostHogWorkflow):
         )
 
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
+@asynccontextmanager
+async def export_worker(client: Client):
+    async with Worker(
+        client,
+        task_queue=settings.TEMPORAL_TASK_QUEUE,
+        workflows=[TestExportAssetWorkflow],
+        activities=[export_asset_activity],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        activity_executor=ThreadPoolExecutor(max_workers=5),
+        debug_mode=True,
+    ):
+        yield
+
+
+async def run_export_workflow(client: Client, asset_id: int) -> ExportAssetResult:
+    return await client.execute_workflow(
+        TestExportAssetWorkflow.run,
+        ExportAssetActivityInputs(exported_asset_id=asset_id),
+        id=str(uuid.uuid4()),
+        task_queue=settings.TEMPORAL_TASK_QUEUE,
+    )
 
 
 @patch("posthog.temporal.exports.activities.exporter")
-async def test_export_asset_activity_success(
-    mock_exporter: MagicMock,
-    team,
-):
+async def test_export_asset_activity_success(mock_exporter: MagicMock, team):
     asset = await sync_to_async(ExportedAsset.objects.create)(
         team=team,
-        export_format="image/png",
+        export_format=ExportedAsset.ExportFormat.PNG,
     )
 
     def fake_export(asset_obj, **kwargs):
@@ -60,37 +79,19 @@ async def test_export_asset_activity_success(
     mock_exporter.export_asset_direct = fake_export
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
-        async with Worker(
-            env.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[TestExportAssetWorkflow],
-            activities=[export_asset_activity],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=5),
-            debug_mode=True,
-        ):
-            result = await env.client.execute_workflow(
-                TestExportAssetWorkflow.run,
-                ExportAssetActivityInputs(exported_asset_id=asset.id),
-                id=str(uuid.uuid4()),
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
+        async with export_worker(env.client):
+            result = await run_export_workflow(env.client, asset.id)
 
     assert result.exported_asset_id == asset.id
     assert result.success is True
-    assert result.exception_class is None
+    assert result.error is None
 
 
 @patch("posthog.temporal.exports.activities.exporter")
-async def test_export_asset_activity_propagates_user_errors(
-    mock_exporter: MagicMock,
-    team,
-):
-    from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
-
+async def test_export_asset_activity_propagates_user_errors(mock_exporter: MagicMock, team):
     asset = await sync_to_async(ExportedAsset.objects.create)(
         team=team,
-        export_format="image/png",
+        export_format=ExportedAsset.ExportFormat.PNG,
     )
 
     def fake_export(asset_obj, **kwargs):
@@ -102,28 +103,14 @@ async def test_export_asset_activity_propagates_user_errors(
     mock_exporter.export_asset_direct = fake_export
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
-        async with Worker(
-            env.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[TestExportAssetWorkflow],
-            activities=[export_asset_activity],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=5),
-            debug_mode=True,
-        ):
+        async with export_worker(env.client):
             with pytest.raises(WorkflowFailureError) as exc_info:
-                await env.client.execute_workflow(
-                    TestExportAssetWorkflow.run,
-                    ExportAssetActivityInputs(exported_asset_id=asset.id),
-                    id=str(uuid.uuid4()),
-                    task_queue=settings.TEMPORAL_TASK_QUEUE,
-                )
+                await run_export_workflow(env.client, asset.id)
 
-        # WorkflowFailureError.cause is ActivityError; ActivityError.cause is the ApplicationError
-        wf_error = exc_info.value
-        assert isinstance(wf_error, WorkflowFailureError)
-        activity_error = wf_error.cause
-        assert isinstance(activity_error, ActivityError)
-        app_error = activity_error.cause
-        assert app_error is not None
-        assert "ExcelColumnLimitExceeded" in str(app_error) or "18,278 columns" in str(app_error)
+    wf_error = exc_info.value
+    assert isinstance(wf_error, WorkflowFailureError)
+    activity_error = wf_error.cause
+    assert isinstance(activity_error, ActivityError)
+    app_error = activity_error.cause
+    assert app_error is not None
+    assert "ExcelColumnLimitExceeded" in str(app_error) or "18,278 columns" in str(app_error)

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -21,8 +21,9 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.instance_setting import set_instance_setting
 from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
-from posthog.temporal.exports.activities import emit_delivery_outcome, export_asset_activity
+from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
 from posthog.temporal.subscriptions.activities import (
+    advance_next_delivery_date,
     create_export_assets,
     deliver_subscription,
     fetch_due_subscriptions_activity,
@@ -61,7 +62,9 @@ async def subscriptions_worker(temporal_client: Client):
             create_export_assets,
             export_asset_activity,
             deliver_subscription,
+            emit_delivery_started,
             emit_delivery_outcome,
+            advance_next_delivery_date,
         ],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
@@ -130,7 +133,9 @@ async def test_subscription_delivery_scheduling(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
@@ -202,7 +207,9 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -20,6 +20,7 @@ from posthog.models.dashboard_tile import DashboardTile
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.instance_setting import set_instance_setting
+from posthog.slo.types import SloOutcome
 from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
 from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
 from posthog.temporal.subscriptions.activities import (
@@ -264,7 +265,9 @@ async def test_handle_subscription_value_change_email(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
@@ -326,7 +329,9 @@ async def test_deliver_subscription_report_slack(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
@@ -368,9 +373,8 @@ async def test_create_export_assets_creates_exported_assets(
     assert asset.insight_id == insight.id
     assert asset.export_format == "image/png"
 
-    mock_analytics.capture.assert_called_once()
-    call_kwargs = mock_analytics.capture.call_args
-    assert call_kwargs.kwargs["event"] == "slo_operation_started"
+    # SLO started is emitted by the workflow (emit_delivery_started), not this activity
+    mock_analytics.capture.assert_not_called()
 
 
 @patch("posthog.slo.events.posthoganalytics")
@@ -396,8 +400,8 @@ async def test_create_export_assets_dashboard_with_multiple_insights(
     )
 
     assert len(result.exported_asset_ids) == 3
-    # One subscription-level slo_operation_started event (not per-asset)
-    assert mock_analytics.capture.call_count == 1
+    # SLO started is emitted by the workflow, not this activity
+    mock_analytics.capture.assert_not_called()
 
 
 @patch("ee.tasks.subscriptions.get_metric_meter")
@@ -467,7 +471,9 @@ async def test_deliver_subscription_workflow_end_to_end(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
@@ -493,7 +499,7 @@ async def test_deliver_subscription_workflow_end_to_end(
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
     assert len(completed_calls) == 1
-    assert completed_calls[0].kwargs["properties"]["outcome"] == "success"
+    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.SUCCESS
 
 
 @patch("posthog.temporal.exports.activities.exporter")
@@ -535,7 +541,9 @@ async def test_new_subscription_sends_invite_email(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
@@ -596,7 +604,9 @@ async def test_scheduled_delivery_updates_next_delivery_date(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
@@ -654,7 +664,9 @@ async def test_export_user_error_classified_correctly_in_slo_events(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
@@ -671,7 +683,7 @@ async def test_export_user_error_classified_correctly_in_slo_events(
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
     assert len(completed_calls) == 1
-    assert completed_calls[0].kwargs["properties"]["outcome"] == "failure"
+    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.FAILURE
 
 
 @patch("posthog.temporal.exports.activities.exporter")
@@ -721,7 +733,9 @@ async def test_partial_export_failure_delivers_successful_assets(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
+                emit_delivery_started,
                 emit_delivery_outcome,
+                advance_next_delivery_date,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
@@ -734,20 +748,18 @@ async def test_partial_export_failure_delivers_successful_assets(
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
 
-    # Delivery should happen with only the 2 successful assets
+    # Delivery includes all assets (failed ones show placeholder in email)
     assert mock_send_email.call_count == 2  # 2 recipients from factory default
     for call in mock_send_email.call_args_list:
         delivered_assets = call[0][2]  # third positional arg is assets list
-        assert len(delivered_assets) == 2
-        for asset in delivered_assets:
-            assert asset.insight_id != fail_insight_id
+        assert len(delivered_assets) == 3
 
-    # One subscription-level SLO event: partial_success (2/3 assets succeeded)
+    # One subscription-level SLO event: failure (not all assets succeeded)
     completed_calls = [
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
     assert len(completed_calls) == 1
     props = completed_calls[0].kwargs["properties"]
-    assert props["outcome"] == "partial_success"
+    assert props["outcome"] == SloOutcome.FAILURE
     assert props["assets_with_content"] == 2
     assert props["total_assets"] == 3

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -5,15 +5,14 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 
 import pytest_asyncio
 from asgiref.sync import sync_to_async
-from temporalio.client import Client, WorkflowFailureError
-from temporalio.exceptions import ApplicationError
-from temporalio.testing import WorkflowEnvironment
+from temporalio.client import Client
+from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.models.dashboard import Dashboard
@@ -21,15 +20,23 @@ from posthog.models.dashboard_tile import DashboardTile
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.instance_setting import set_instance_setting
-from posthog.temporal.subscriptions.subscription_scheduling_workflow import (
-    DeliverSubscriptionReportActivityInputs,
-    HandleSubscriptionValueChangeWorkflow,
-    ScheduleAllSubscriptionsWorkflow,
-    ScheduleAllSubscriptionsWorkflowInputs,
-    deliver_subscription_report_activity,
-    emit_subscription_delivery_outcome_events_activity,
-    emit_subscription_delivery_started_activity,
+from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
+from posthog.temporal.exports.activities import emit_delivery_outcome, export_asset_activity
+from posthog.temporal.subscriptions.activities import (
+    create_export_assets,
+    deliver_subscription,
     fetch_due_subscriptions_activity,
+)
+from posthog.temporal.subscriptions.types import (
+    CreateExportAssetsInputs,
+    DeliverSubscriptionInputs,
+    ProcessSubscriptionWorkflowInputs,
+    ScheduleAllSubscriptionsWorkflowInputs,
+)
+from posthog.temporal.subscriptions.workflows import (
+    HandleSubscriptionValueChangeWorkflow,
+    ProcessSubscriptionWorkflow,
+    ScheduleAllSubscriptionsWorkflow,
 )
 
 from ee.tasks.test.subscriptions.subscriptions_test_factory import create_subscription
@@ -44,39 +51,41 @@ async def subscriptions_worker(temporal_client: Client):
     async with Worker(
         temporal_client,
         task_queue=settings.TEMPORAL_TASK_QUEUE,
-        workflows=[ScheduleAllSubscriptionsWorkflow, HandleSubscriptionValueChangeWorkflow],
+        workflows=[
+            ScheduleAllSubscriptionsWorkflow,
+            HandleSubscriptionValueChangeWorkflow,
+            ProcessSubscriptionWorkflow,
+        ],
         activities=[
-            deliver_subscription_report_activity,
-            emit_subscription_delivery_outcome_events_activity,
-            emit_subscription_delivery_started_activity,
             fetch_due_subscriptions_activity,
+            create_export_assets,
+            export_asset_activity,
+            deliver_subscription,
+            emit_delivery_outcome,
         ],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
         yield  # allow the test to run while the worker is active
 
 
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("ee.tasks.subscriptions.send_email_subscription_report")
-@patch("ee.tasks.subscriptions.generate_assets_async")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
 @freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
 async def test_subscription_delivery_scheduling(
-    mock_gen_assets: MagicMock,
     mock_send_email: MagicMock,
     mock_metric_meter: MagicMock,
+    mock_analytics: MagicMock,
+    mock_exporter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,
     user,
 ):
-    """Workflow should schedule delivery only for subscriptions within the buffer window."""
-
     dashboard = await sync_to_async(Dashboard.objects.create)(team=team, name="private dashboard", created_by=user)
     insight = await sync_to_async(Insight.objects.create)(team=team, short_id="123456", name="My Test subscription")
-    asset = await sync_to_async(ExportedAsset.objects.create)(
-        team=team, insight_id=insight.id, export_format="image/png"
-    )
 
     # Heavy dashboard – create extra tiles
     for i in range(10):
@@ -85,10 +94,11 @@ async def test_subscription_delivery_scheduling(
         )
         await sync_to_async(DashboardTile.objects.create)(dashboard=dashboard, insight=tile_insight)
 
-    async def mock_generate_assets_async(subscription):
-        return [insight], [asset]
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/test.png"
+        asset_obj.save(update_fields=["content_location"])
 
-    mock_gen_assets.side_effect = mock_generate_assets_async
+    mock_exporter.export_asset_direct = fake_export
 
     await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
     await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
@@ -114,16 +124,17 @@ async def test_subscription_delivery_scheduling(
         async with Worker(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ScheduleAllSubscriptionsWorkflow],
+            workflows=[ScheduleAllSubscriptionsWorkflow, ProcessSubscriptionWorkflow],
             activities=[
-                deliver_subscription_report_activity,
-                emit_subscription_delivery_outcome_events_activity,
-                emit_subscription_delivery_started_activity,
                 fetch_due_subscriptions_activity,
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
-            debug_mode=True,  # turn off sandbox/deadlock detector
+            debug_mode=True,
         ):
             await activity_environment.client.execute_workflow(
                 ScheduleAllSubscriptionsWorkflow.run,
@@ -138,17 +149,19 @@ async def test_subscription_delivery_scheduling(
     assert delivered_sub_ids == {subscriptions[0].id, subscriptions[1].id}
 
 
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("ee.tasks.subscriptions.get_slack_integration_for_team", return_value=None)
-@patch("ee.tasks.subscriptions.send_email_subscription_report")
-@patch("ee.tasks.subscriptions.generate_assets_async")
+@patch("posthog.temporal.subscriptions.activities.get_slack_integration_for_team", return_value=None)
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
 @freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
 async def test_does_not_schedule_subscription_if_item_is_deleted(
-    mock_gen_assets: MagicMock,
     mock_send_email: MagicMock,
     mock_send_slack: MagicMock,
     mock_metric_meter: MagicMock,
+    mock_analytics: MagicMock,
+    mock_exporter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,
@@ -183,12 +196,13 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
         async with Worker(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ScheduleAllSubscriptionsWorkflow],
+            workflows=[ScheduleAllSubscriptionsWorkflow, ProcessSubscriptionWorkflow],
             activities=[
-                deliver_subscription_report_activity,
-                emit_subscription_delivery_outcome_events_activity,
-                emit_subscription_delivery_started_activity,
                 fetch_due_subscriptions_activity,
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
@@ -204,23 +218,22 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
     assert mock_send_email.call_count == 0 and mock_send_slack.call_count == 0
 
 
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("ee.tasks.subscriptions.send_email_subscription_report")
-@patch("ee.tasks.subscriptions.generate_assets_async")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
 @pytest.mark.asyncio
 async def test_handle_subscription_value_change_email(
-    mock_gen_assets: MagicMock,
     mock_send_email: MagicMock,
     mock_metric_meter: MagicMock,
+    mock_analytics: MagicMock,
+    mock_exporter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,
     user,
 ):
     insight = await sync_to_async(Insight.objects.create)(team=team, short_id="xyz789", name="Insight")
-    asset = await sync_to_async(ExportedAsset.objects.create)(
-        team=team, insight_id=insight.id, export_format="image/png"
-    )
 
     subscription = await sync_to_async(create_subscription)(
         team=team,
@@ -229,28 +242,30 @@ async def test_handle_subscription_value_change_email(
         target_value="test_existing@posthog.com,test_new@posthog.com",
     )
 
-    async def mock_generate_assets_async(subscription):
-        return [insight], [asset]
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/change.png"
+        asset_obj.save(update_fields=["content_location"])
 
-    mock_gen_assets.side_effect = mock_generate_assets_async
+    mock_exporter.export_asset_direct = fake_export
 
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[HandleSubscriptionValueChangeWorkflow],
+            workflows=[HandleSubscriptionValueChangeWorkflow, ProcessSubscriptionWorkflow],
             activities=[
-                deliver_subscription_report_activity,
-                emit_subscription_delivery_outcome_events_activity,
-                emit_subscription_delivery_started_activity,
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
-            debug_mode=True,  # turn off sandbox/deadlock detector
+            debug_mode=True,
         ):
             await activity_environment.client.execute_workflow(
                 HandleSubscriptionValueChangeWorkflow.run,
-                DeliverSubscriptionReportActivityInputs(
+                ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     previous_value="test_existing@posthog.com",
                     invite_message="My invite message",
@@ -261,35 +276,25 @@ async def test_handle_subscription_value_change_email(
 
     # Only new address should be emailed
     assert mock_send_email.call_count == 1
-    assert mock_send_email.call_args_list == [
-        call(
-            "test_new@posthog.com",
-            subscription,
-            [asset],
-            invite_message="My invite message",
-            total_asset_count=1,
-            send_async=False,
-        )
-    ]
+    assert mock_send_email.call_args_list[0][0][0] == "test_new@posthog.com"
 
 
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("ee.tasks.subscriptions.get_slack_integration_for_team", return_value=None)
-@patch("ee.tasks.subscriptions.generate_assets_async")
+@patch("posthog.temporal.subscriptions.activities.get_slack_integration_for_team", return_value=None)
 @pytest.mark.asyncio
 async def test_deliver_subscription_report_slack(
-    mock_gen_assets: MagicMock,
     mock_send_slack: MagicMock,
     mock_metric_meter: MagicMock,
+    mock_analytics: MagicMock,
+    mock_exporter: MagicMock,
     temporal_client: Client,
     subscriptions_worker,
     team,
     user,
 ):
     insight = await sync_to_async(Insight.objects.create)(team=team, short_id="abc999", name="Insight")
-    asset = await sync_to_async(ExportedAsset.objects.create)(
-        team=team, insight_id=insight.id, export_format="image/png"
-    )
 
     subscription = await sync_to_async(create_subscription)(
         team=team,
@@ -299,28 +304,30 @@ async def test_deliver_subscription_report_slack(
         target_value="C12345|#test-channel",
     )
 
-    async def mock_generate_assets_async(subscription):
-        return [insight], [asset]
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/slack.png"
+        asset_obj.save(update_fields=["content_location"])
 
-    mock_gen_assets.side_effect = mock_generate_assets_async
+    mock_exporter.export_asset_direct = fake_export
 
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
             activity_environment.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[HandleSubscriptionValueChangeWorkflow],
+            workflows=[HandleSubscriptionValueChangeWorkflow, ProcessSubscriptionWorkflow],
             activities=[
-                deliver_subscription_report_activity,
-                emit_subscription_delivery_outcome_events_activity,
-                emit_subscription_delivery_started_activity,
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
-            debug_mode=True,  # turn off sandbox/deadlock detector
+            debug_mode=True,
         ):
             await activity_environment.client.execute_workflow(
                 HandleSubscriptionValueChangeWorkflow.run,
-                DeliverSubscriptionReportActivityInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -328,161 +335,412 @@ async def test_deliver_subscription_report_slack(
     assert mock_send_slack.call_count == 1
 
 
-@pytest.mark.parametrize(
-    "should_succeed,expected_succeeded,expected_exhausted",
-    [
-        (True, 1, 0),
-        (False, 0, 1),
-    ],
-    ids=["success", "failure"],
-)
-@patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
-@patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("ee.tasks.subscriptions.send_email_subscription_report")
-@patch("ee.tasks.subscriptions.generate_assets_async")
+@patch("posthog.slo.events.posthoganalytics")
+@freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
-async def test_delivery_outcome_events(
-    mock_gen_assets: MagicMock,
-    mock_send_email: MagicMock,
-    mock_metric_meter: MagicMock,
-    mock_posthog: MagicMock,
-    temporal_client: Client,
-    team,
-    user,
-    should_succeed: bool,
-    expected_succeeded: int,
-    expected_exhausted: int,
-):
-    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="ev1234", name="Insight")
-    asset = await sync_to_async(ExportedAsset.objects.create)(
-        team=team, insight_id=insight.id, export_format="image/png"
-    )
-
-    async def mock_generate_assets_async(subscription):
-        if not should_succeed:
-            raise ApplicationError("OOM killed", non_retryable=True)
-        return [insight], [asset]
-
-    mock_gen_assets.side_effect = mock_generate_assets_async
-
-    await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
-    await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
-
-    with freeze_time("2022-02-02T08:30:00.000Z"):
-        sub = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
-
-    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-        async with Worker(
-            activity_environment.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ScheduleAllSubscriptionsWorkflow],
-            activities=[
-                deliver_subscription_report_activity,
-                emit_subscription_delivery_outcome_events_activity,
-                emit_subscription_delivery_started_activity,
-                fetch_due_subscriptions_activity,
-            ],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=50),
-            debug_mode=True,
-        ):
-            try:
-                await activity_environment.client.execute_workflow(
-                    ScheduleAllSubscriptionsWorkflow.run,
-                    ScheduleAllSubscriptionsWorkflowInputs(),
-                    id=str(uuid.uuid4()),
-                    task_queue=settings.TEMPORAL_TASK_QUEUE,
-                )
-            except WorkflowFailureError:
-                if should_succeed:
-                    raise
-
-    started_calls = [
-        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_started"
-    ]
-    assert len(started_calls) == 1
-    assert started_calls[0].kwargs["properties"]["subscription_id"] == sub.id
-
-    succeeded_calls = [
-        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
-    ]
-    exhausted_calls = [
-        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
-    ]
-    assert len(succeeded_calls) == expected_succeeded
-    assert len(exhausted_calls) == expected_exhausted
-    matching_calls = succeeded_calls or exhausted_calls
-    assert matching_calls[0].kwargs["properties"]["subscription_id"] == sub.id
-
-
-@patch("posthog.temporal.subscriptions.subscription_scheduling_workflow.posthoganalytics")
-@patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("ee.tasks.subscriptions.send_email_subscription_report")
-@patch("ee.tasks.subscriptions.generate_assets_async")
-@pytest.mark.asyncio
-async def test_mixed_success_and_failure_does_not_block(
-    mock_gen_assets: MagicMock,
-    mock_send_email: MagicMock,
-    mock_metric_meter: MagicMock,
-    mock_posthog: MagicMock,
+async def test_create_export_assets_creates_exported_assets(
+    mock_analytics: MagicMock,
     temporal_client: Client,
     team,
     user,
 ):
-    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="mx1234", name="Insight")
-    asset = await sync_to_async(ExportedAsset.objects.create)(
-        team=team, insight_id=insight.id, export_format="image/png"
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="prep01", name="Prep Test")
+    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    env = ActivityEnvironment()
+    result = await env.run(
+        create_export_assets,
+        CreateExportAssetsInputs(subscription_id=subscription.id),
     )
 
-    await sync_to_async(set_instance_setting)("EMAIL_HOST", "fake_host")
-    await sync_to_async(set_instance_setting)("EMAIL_ENABLED", True)
+    assert len(result.exported_asset_ids) == 1
+    assert result.team_id == team.id
 
-    with freeze_time("2022-02-02T08:30:00.000Z"):
-        sub_ok = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
-        sub_fail = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+    asset = await sync_to_async(ExportedAsset.objects.get)(pk=result.exported_asset_ids[0])
+    assert asset.team_id == team.id
+    assert asset.insight_id == insight.id
+    assert asset.export_format == "image/png"
 
-    async def mock_generate_assets_async(subscription):
-        if subscription.id == sub_fail.id:
-            raise ApplicationError("asset generation failed", non_retryable=True)
-        return [insight], [asset]
+    mock_analytics.capture.assert_called_once()
+    call_kwargs = mock_analytics.capture.call_args
+    assert call_kwargs.kwargs["event"] == "slo_operation_started"
 
-    mock_gen_assets.side_effect = mock_generate_assets_async
 
-    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+@patch("posthog.slo.events.posthoganalytics")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_create_export_assets_dashboard_with_multiple_insights(
+    mock_analytics: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    dashboard = await sync_to_async(Dashboard.objects.create)(team=team, name="Multi-insight", created_by=user)
+    for i in range(3):
+        insight = await sync_to_async(Insight.objects.create)(team=team, short_id=f"prep{i:02d}", name=f"Insight {i}")
+        await sync_to_async(DashboardTile.objects.create)(dashboard=dashboard, insight=insight)
+
+    subscription = await sync_to_async(create_subscription)(team=team, dashboard=dashboard, created_by=user)
+
+    env = ActivityEnvironment()
+    result = await env.run(
+        create_export_assets,
+        CreateExportAssetsInputs(subscription_id=subscription.id),
+    )
+
+    assert len(result.exported_asset_ids) == 3
+    # One subscription-level slo_operation_started event (not per-asset)
+    assert mock_analytics.capture.call_count == 1
+
+
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_deliver_subscription_sends_email(
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="del01", name="Deliver Test")
+    asset = await sync_to_async(ExportedAsset.objects.create)(
+        team=team,
+        insight=insight,
+        export_format="image/png",
+        content_location="s3://bucket/test.png",
+    )
+    # Factory default target_value is "test1@posthog.com,test2@posthog.com" (2 recipients)
+    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    env = ActivityEnvironment()
+    await env.run(
+        deliver_subscription,
+        DeliverSubscriptionInputs(
+            subscription_id=subscription.id,
+            exported_asset_ids=[asset.id],
+            total_insight_count=1,
+        ),
+    )
+
+    assert mock_send_email.call_count == 2  # "test1@posthog.com" and "test2@posthog.com"
+
+
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_deliver_subscription_workflow_end_to_end(
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_slo_analytics: MagicMock,
+    mock_exporter: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="e2e01", name="E2E Test")
+    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/e2e.png"
+        asset_obj.save(update_fields=["content_location"])
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
-            activity_environment.client,
+            env.client,
             task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ScheduleAllSubscriptionsWorkflow],
+            workflows=[ProcessSubscriptionWorkflow],
             activities=[
-                deliver_subscription_report_activity,
-                emit_subscription_delivery_outcome_events_activity,
-                emit_subscription_delivery_started_activity,
-                fetch_due_subscriptions_activity,
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=50),
+            activity_executor=ThreadPoolExecutor(max_workers=10),
             debug_mode=True,
         ):
-            try:
-                await activity_environment.client.execute_workflow(
-                    ScheduleAllSubscriptionsWorkflow.run,
-                    ScheduleAllSubscriptionsWorkflowInputs(),
-                    id=str(uuid.uuid4()),
-                    task_queue=settings.TEMPORAL_TASK_QUEUE,
-                )
-            except WorkflowFailureError:
-                pass  # expected — one subscription fails
+            await env.client.execute_workflow(
+                ProcessSubscriptionWorkflow.run,
+                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
 
-    # The successful subscription still delivered emails (2 recipients)
+    # 2 recipients
     assert mock_send_email.call_count == 2
 
-    succeeded_calls = [
-        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_succeeded"
+    # Both started and completed events flow through posthog.slo.events
+    started_calls = [
+        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_started"
     ]
-    exhausted_calls = [
-        c for c in mock_posthog.capture.call_args_list if c.kwargs.get("event") == "subscription_delivery_exhausted"
+    assert len(started_calls) == 1
+
+    completed_calls = [
+        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
-    assert len(succeeded_calls) == 1
-    assert succeeded_calls[0].kwargs["properties"]["subscription_id"] == sub_ok.id
-    assert len(exhausted_calls) == 1
-    assert exhausted_calls[0].kwargs["properties"]["subscription_id"] == sub_fail.id
+    assert len(completed_calls) == 1
+    assert completed_calls[0].kwargs["properties"]["outcome"] == "success"
+
+
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
+@pytest.mark.asyncio
+async def test_new_subscription_sends_invite_email(
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_analytics: MagicMock,
+    mock_exporter: MagicMock,
+    temporal_client: Client,
+    subscriptions_worker,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="inv01", name="Invite Test")
+    subscription = await sync_to_async(create_subscription)(
+        team=team,
+        insight=insight,
+        created_by=user,
+        target_value="new_user@posthog.com",
+    )
+    original_next_delivery = subscription.next_delivery_date
+
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/invite.png"
+        asset_obj.save(update_fields=["content_location"])
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[HandleSubscriptionValueChangeWorkflow, ProcessSubscriptionWorkflow],
+            activities=[
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=50),
+            debug_mode=True,
+        ):
+            await activity_environment.client.execute_workflow(
+                HandleSubscriptionValueChangeWorkflow.run,
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    previous_value="",
+                    invite_message="Welcome!",
+                ),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    assert mock_send_email.call_count == 1
+    call_args = mock_send_email.call_args
+    assert call_args[0][0] == "new_user@posthog.com"
+    assert call_args[1]["invite_message"] == "Welcome!"
+
+    # next_delivery_date should NOT be updated for invite deliveries
+    await sync_to_async(subscription.refresh_from_db)()
+    assert subscription.next_delivery_date == original_next_delivery
+
+
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_scheduled_delivery_updates_next_delivery_date(
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_slo_analytics: MagicMock,
+    mock_exporter: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="sched1", name="Sched Test")
+    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+    original_next_delivery = subscription.next_delivery_date
+
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.content_location = "s3://bucket/sched.png"
+        asset_obj.save(update_fields=["content_location"])
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[ProcessSubscriptionWorkflow],
+            activities=[
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=10),
+            debug_mode=True,
+        ):
+            await env.client.execute_workflow(
+                ProcessSubscriptionWorkflow.run,
+                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    # 2 recipients from factory default
+    assert mock_send_email.call_count == 2
+    for call in mock_send_email.call_args_list:
+        assert call[1]["invite_message"] is None
+
+    # next_delivery_date should be updated for scheduled deliveries
+    await sync_to_async(subscription.refresh_from_db)()
+    assert subscription.next_delivery_date != original_next_delivery
+
+
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_export_user_error_classified_correctly_in_slo_events(
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_slo_analytics: MagicMock,
+    mock_exporter: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="slo01", name="SLO Test")
+    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
+
+    def fake_export(asset_obj, **kwargs):
+        asset_obj.failure_type = "user"
+        asset_obj.exception_type = "ExcelColumnLimitExceeded"
+        asset_obj.save(update_fields=["failure_type", "exception_type"])
+        raise ExcelColumnLimitExceeded()
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[ProcessSubscriptionWorkflow],
+            activities=[
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=10),
+            debug_mode=True,
+        ):
+            await env.client.execute_workflow(
+                ProcessSubscriptionWorkflow.run,
+                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    completed_calls = [
+        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    assert completed_calls[0].kwargs["properties"]["outcome"] == "failure"
+
+
+@patch("posthog.temporal.exports.activities.exporter")
+@patch("posthog.slo.events.posthoganalytics")
+@patch("ee.tasks.subscriptions.get_metric_meter")
+@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
+@freeze_time("2022-02-02T08:55:00.000Z")
+@pytest.mark.asyncio
+async def test_partial_export_failure_delivers_successful_assets(
+    mock_send_email: MagicMock,
+    mock_metric_meter: MagicMock,
+    mock_slo_analytics: MagicMock,
+    mock_exporter: MagicMock,
+    temporal_client: Client,
+    team,
+    user,
+):
+    dashboard = await sync_to_async(Dashboard.objects.create)(team=team, name="partial fail", created_by=user)
+    insights = []
+    for i in range(3):
+        insight = await sync_to_async(Insight.objects.create)(team=team, short_id=f"pf{i:02d}", name=f"Insight {i}")
+        await sync_to_async(DashboardTile.objects.create)(dashboard=dashboard, insight=insight)
+        insights.append(insight)
+
+    subscription = await sync_to_async(create_subscription)(team=team, dashboard=dashboard, created_by=user)
+
+    # First insight fails, the other two succeed
+    fail_insight_id = insights[0].id
+
+    def fake_export(asset_obj, **kwargs):
+        if asset_obj.insight_id == fail_insight_id:
+            asset_obj.failure_type = "user"
+            asset_obj.exception_type = "ExcelColumnLimitExceeded"
+            asset_obj.save(update_fields=["failure_type", "exception_type"])
+            raise ExcelColumnLimitExceeded()
+        asset_obj.content_location = "s3://bucket/ok.png"
+        asset_obj.save(update_fields=["content_location"])
+
+    mock_exporter.export_asset_direct = fake_export
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=settings.TEMPORAL_TASK_QUEUE,
+            workflows=[ProcessSubscriptionWorkflow],
+            activities=[
+                create_export_assets,
+                export_asset_activity,
+                deliver_subscription,
+                emit_delivery_outcome,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+            activity_executor=ThreadPoolExecutor(max_workers=10),
+            debug_mode=True,
+        ):
+            await env.client.execute_workflow(
+                ProcessSubscriptionWorkflow.run,
+                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                id=str(uuid.uuid4()),
+                task_queue=settings.TEMPORAL_TASK_QUEUE,
+            )
+
+    # Delivery should happen with only the 2 successful assets
+    assert mock_send_email.call_count == 2  # 2 recipients from factory default
+    for call in mock_send_email.call_args_list:
+        delivered_assets = call[0][2]  # third positional arg is assets list
+        assert len(delivered_assets) == 2
+        for asset in delivered_assets:
+            assert asset.insight_id != fail_insight_id
+
+    # One subscription-level SLO event: partial_success (2/3 assets succeeded)
+    completed_calls = [
+        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    props = completed_calls[0].kwargs["properties"]
+    assert props["outcome"] == "partial_success"
+    assert props["assets_with_content"] == 2
+    assert props["total_assets"] == 3

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -710,15 +710,12 @@ async def test_partial_export_failure_delivers_successful_assets(
 
     subscription = await sync_to_async(create_subscription)(team=team, dashboard=dashboard, created_by=user)
 
-    # First insight fails, the other two succeed
+    # First insight fails with a system error, the other two succeed
     fail_insight_id = insights[0].id
 
     def fake_export(asset_obj, **kwargs):
         if asset_obj.insight_id == fail_insight_id:
-            asset_obj.failure_type = "user"
-            asset_obj.exception_type = "ExcelColumnLimitExceeded"
-            asset_obj.save(update_fields=["failure_type", "exception_type"])
-            raise ExcelColumnLimitExceeded()
+            raise RuntimeError("ClickHouse connection timeout")
         asset_obj.content_location = "s3://bucket/ok.png"
         asset_obj.save(update_fields=["content_location"])
 
@@ -754,7 +751,7 @@ async def test_partial_export_failure_delivers_successful_assets(
         delivered_assets = call[0][2]  # third positional arg is assets list
         assert len(delivered_assets) == 3
 
-    # One subscription-level SLO event: failure (not all assets succeeded)
+    # One subscription-level SLO event: failure (system error is a real SLO failure)
     completed_calls = [
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -635,7 +635,7 @@ async def test_scheduled_delivery_updates_next_delivery_date(
 @patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
 @freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
-async def test_export_user_error_classified_correctly_in_slo_events(
+async def test_export_user_error_counts_as_slo_success(
     mock_send_email: MagicMock,
     mock_metric_meter: MagicMock,
     mock_slo_analytics: MagicMock,
@@ -683,7 +683,7 @@ async def test_export_user_error_classified_correctly_in_slo_events(
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
     assert len(completed_calls) == 1
-    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.FAILURE
+    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.SUCCESS
 
 
 @patch("posthog.temporal.exports.activities.exporter")


### PR DESCRIPTION
## Problem

The subscription system currently uses a single "main" temporal workflow which does all the work. This means that:

- We do not have good support to retry "components" that fail (currently this is all done through `tenacity` retries)
- If there are downstream errors with our infrastructure, and we exhaust the tenacity retries, the workflow will be marked as success, even though the export failed.
    - Whilst we could fix this, we still do not have a good way to retry the specific activity.

Additionally we did not have a consistent way to measure the success of these workflows.

> [!NOTE]
> This PR does not wire up the new flow yet, this is solely the introduction of the new flow. The wiring up will be done through: https://github.com/PostHog/posthog/pull/51649

## Changes

The idea in this PR is to tackle the problems outlined above, by introducing the following:

**Modular Export System** (will be needed as I would like to migrate the "one-off" exports to Temporal as well, so we can take out tenacity)

**Refactored Subscription Workflows into composable activities**

**Updated Import Structure** (Renamed `subscription_scheduling_workflow.py` to separate `activities.py` and `workflows.py`)

##### Before (single workflow, activity-level fan-out)

```mermaid
flowchart TD
    S[Temporal Schedule] -->|cron| SAW[ScheduleAllSubscriptionsWorkflow]
    SAW --> FETCH[fetch_due_subscriptions]
    FETCH --> EMIT_START["emit_subscription_delivery_started\n(try/except — best effort)"]
    EMIT_START --> FAN{Fan-out activities}

    FAN --> D1[deliver_subscription_report #1]
    FAN --> D2[deliver_subscription_report #2]
    FAN --> DN[deliver_subscription_report #N]

    D1 & D2 & DN --> GATHER[asyncio.gather\nclassify succeeded / failed]
    GATHER --> EMIT_END["emit_subscription_delivery_outcome\n(try/except — best effort)"]

    subgraph "deliver_subscription_report (monolithic activity)"
        direction TB
        LOAD[Load subscription + insights]
        CREATE[Create ExportedAssets]
        EXPORT["Export each asset sequentially\n(tenacity retry x4, in-process)"]
        DELIVER[Send email / Slack]
        UPDATE[Update next_delivery_date]
        LOAD --> CREATE --> EXPORT --> DELIVER --> UPDATE
    end

    D1 --- LOAD

    style EXPORT fill:#fbb,stroke:#333
    style D1 fill:#ffd,stroke:#333
```

##### After (parent + child workflows, per-asset fan-out)

```mermaid
flowchart TD
    S[Temporal Schedule] -->|cron| SAW[ScheduleAllSubscriptionsWorkflow]
    SAW --> FETCH["fetch_due_subscriptions\n(retry: 3x, 10s-5min)"]
    FETCH --> FAN{"Fan-out child workflows\n(idempotent ID - dedup on overlap)"}

    FAN --> PSW1[ProcessSubscriptionWorkflow #1]
    FAN --> PSW2[ProcessSubscriptionWorkflow #2]
    FAN --> PSWN[ProcessSubscriptionWorkflow #N]

    PSW1 & PSW2 & PSWN --> GATHER_WF["asyncio.gather\nLog failed IDs + raise if any failed"]

    subgraph "ProcessSubscriptionWorkflow (isolated per subscription)"
        direction TB
        SLO_START["emit_delivery_started\nSLO started - fires before any work\n(retry: 3x, 5s-1min)"]

        subgraph "try block"
            direction TB
            P1["create_export_assets\nBulk-create assets\n(retry: 3x, 10s-2min)"]

            subgraph "Phase 2: Parallel export fan-out"
                direction LR
                E1["export_asset #1\n(retry: 9x)"]
                E2["export_asset #2\n(retry: 9x)"]
                EN["export_asset #N\n(retry: 9x)"]
            end

            GATHER["asyncio.gather\n(return_exceptions=True)"]
            BUILD["_build_outcome_assets\nClassify success/failure\nexception_class + error_trace"]
            P3["deliver_subscription\nEmail / Slack - all assets incl. failed\n(retry: 3x, 10s-2min)"]

            P1 --> E1 & E2 & EN
            E1 & E2 & EN --> GATHER
            GATHER --> BUILD --> P3
        end

        subgraph "finally block (always runs)"
            direction TB
            ADV["advance_next_delivery_date\nSchedule always advances, even on failure\n(retry: 3x, 5s-1min)"]
            SLO_END["emit_delivery_outcome\nSLO completed - fires last\n(retry: 3x, 5s-1min)"]
            ADV --> SLO_END
        end

        SLO_START --> P1
        P3 --> ADV
    end

    PSW1 --- SLO_START

    style SLO_START fill:#e8f4ff,stroke:#333
    style P1 fill:#e8f4ff,stroke:#333
    style E1 fill:#bfb,stroke:#333
    style E2 fill:#bfb,stroke:#333
    style EN fill:#bfb,stroke:#333
    style GATHER fill:#ffd,stroke:#333
    style BUILD fill:#ffd,stroke:#333
    style P3 fill:#e8f4ff,stroke:#333
    style ADV fill:#f0e6ff,stroke:#333
    style SLO_END fill:#f0e6ff,stroke:#333
    style GATHER_WF fill:#ffd,stroke:#333
```

#### Key differences

|  | Before | After |
| --- | --- | --- |
| **Subscription isolation** | Activities in shared workflow - one stuck activity delays others | Child workflow per subscription - fully isolated lifecycle |
| **Export concurrency** | Sequential within single activity, tenacity retry | Parallel fan-out (`asyncio.gather`), Temporal retry |
| **Activity granularity** | Monolithic: load + create + export + deliver in one activity | 4 separate activities, each with independent retry policy |
| **Failure blast radius** | Export failure kills entire delivery | `return_exceptions=True` - deliver all assets incl. failed (placeholder) |
| **Overlap protection** | None - concurrent schedule runs = duplicate deliveries | Idempotent workflow ID rejects duplicate starts |
| **Schedule advancement** | Only on success - broken subscriptions retry forever | Always advances in finally block, even on failure |
| **SLO events** | Raw `posthoganalytics.capture` per subscription (3 events) | SLO framework: 1 started + 1 completed per subscription, with exception_class + error_trace |
| **Error observability** | error_type + error_message strings | exception_class + first 5 lines of traceback per failed asset |
| **Metrics** | Same 8 Temporal counters | Same 8 Temporal counters (preserved) |
| **On-demand delivery** | `HandleSubscriptionValueChangeWorkflow` with own logic | Delegates to same `ProcessSubscriptionWorkflow` |

## How did you test this code?

N/A this is currently not wired up, I've checked several times to ensure that the business logic between the old and new flow is similar (where it makes sense, e.g. certain metrics are dropped as those are migrated to SLO metrics now).

In the next PR I will do the detailed testing and wire it up, this is solely so the old and new can live side by side and to make reviewing it easier / isolated.

Also see the PoW here: https://github.com/PostHog/posthog/pull/51649 which uses the newly wired up logic.

## Publish to changelog?

No - this is primarily an internal refactor to improve system reliability and observability without changing user-facing functionality.

## Docs update

No docs update needed as this is an internal system refactor.