### PR TITLE
feat(logs-alerts): implement alert state machine and utility functions

### DIFF
--- a/products/logs/backend/alert_state_machine.py
+++ b/products/logs/backend/alert_state_machine.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum, StrEnum
+
+
+class AlertState(StrEnum):
+    NOT_FIRING = "not_firing"
+    FIRING = "firing"
+    PENDING_RESOLVE = "pending_resolve"
+    ERRORED = "errored"
+    SNOOZED = "snoozed"
+
+
+class NotificationAction(Enum):
+    NONE = "none"
+    FIRE = "fire"
+    RESOLVE = "resolve"
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    result_count: int | None
+    threshold_breached: bool
+    error_message: str | None = None
+    query_duration_ms: int | None = None
+
+
+@dataclass(frozen=True)
+class AlertSnapshot:
+    state: AlertState
+    evaluation_periods: int
+    datapoints_to_alarm: int
+    cooldown_minutes: int
+    last_notified_at: datetime | None
+    snooze_until: datetime | None
+    consecutive_failures: int
+    recent_checks_breached: tuple[bool, ...]
+
+
+@dataclass(frozen=True)
+class AlertCheckOutcome:
+    new_state: AlertState
+    notification: NotificationAction
+    consecutive_failures: int
+    update_last_notified_at: bool
+    error_message: str | None
+
+
+def evaluate_alert_check(
+    snapshot: AlertSnapshot,
+    check: CheckResult,
+    now: datetime,
+) -> AlertCheckOutcome:
+    """Implements the RFC state table: N-of-M sliding-window trigger
+    (CloudWatch-style), PENDING_RESOLVE for symmetric resolution, and
+    cooldown suppression.
+    """
+    if snapshot.state == AlertState.SNOOZED:
+        if snapshot.snooze_until is not None and snapshot.snooze_until > now:
+            return AlertCheckOutcome(
+                new_state=AlertState.SNOOZED,
+                notification=NotificationAction.NONE,
+                consecutive_failures=snapshot.consecutive_failures,
+                update_last_notified_at=False,
+                error_message=None,
+            )
+        effective_state = AlertState.NOT_FIRING
+    else:
+        effective_state = snapshot.state
+
+    if check.error_message is not None:
+        return AlertCheckOutcome(
+            new_state=AlertState.ERRORED,
+            notification=NotificationAction.NONE,
+            consecutive_failures=snapshot.consecutive_failures + 1,
+            update_last_notified_at=False,
+            error_message=check.error_message,
+        )
+
+    consecutive_failures = 0
+
+    window = [check.threshold_breached, *snapshot.recent_checks_breached]
+    m = snapshot.evaluation_periods
+    window = window[:m]
+
+    breach_count = sum(1 for b in window if b)
+    n = snapshot.datapoints_to_alarm
+    is_simple = n == 1 and m == 1
+
+    if effective_state == AlertState.ERRORED:
+        effective_state = AlertState.NOT_FIRING
+
+    new_state: AlertState
+    notification = NotificationAction.NONE
+
+    if effective_state == AlertState.NOT_FIRING:
+        if breach_count >= n:
+            new_state = AlertState.FIRING
+            notification = NotificationAction.FIRE
+        else:
+            new_state = AlertState.NOT_FIRING
+
+    elif effective_state == AlertState.FIRING:
+        if check.threshold_breached:
+            new_state = AlertState.FIRING
+        elif is_simple:
+            new_state = AlertState.NOT_FIRING
+            notification = NotificationAction.RESOLVE
+        else:
+            new_state = AlertState.PENDING_RESOLVE
+
+    elif effective_state == AlertState.PENDING_RESOLVE:
+        if check.threshold_breached:
+            new_state = AlertState.FIRING
+        elif len(window) - breach_count >= n:
+            new_state = AlertState.NOT_FIRING
+            notification = NotificationAction.RESOLVE
+        else:
+            new_state = AlertState.PENDING_RESOLVE
+
+    else:
+        new_state = AlertState.NOT_FIRING
+
+    update_last_notified_at = False
+    if notification != NotificationAction.NONE:
+        if _is_within_cooldown(snapshot.last_notified_at, snapshot.cooldown_minutes, now):
+            notification = NotificationAction.NONE
+        else:
+            update_last_notified_at = True
+
+    return AlertCheckOutcome(
+        new_state=new_state,
+        notification=notification,
+        consecutive_failures=consecutive_failures,
+        update_last_notified_at=update_last_notified_at,
+        error_message=None,
+    )
+
+
+def _is_within_cooldown(
+    last_notified_at: datetime | None,
+    cooldown_minutes: int,
+    now: datetime,
+) -> bool:
+    if cooldown_minutes <= 0 or last_notified_at is None:
+        return False
+    return now < last_notified_at + timedelta(minutes=cooldown_minutes)

--- a/products/logs/backend/alert_utils.py
+++ b/products/logs/backend/alert_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+
+def advance_next_check_at(
+    current_next_check_at: datetime | None,
+    check_interval_minutes: int,
+    now: datetime,
+) -> datetime:
+    """Schedule-relative advancement. Skips forward past now if multiple intervals elapsed."""
+    if check_interval_minutes <= 0:
+        raise ValueError(f"check_interval_minutes must be positive, got {check_interval_minutes}")
+    interval = timedelta(minutes=check_interval_minutes)
+
+    if current_next_check_at is None:
+        return now + interval
+
+    next_at = current_next_check_at + interval
+    if next_at <= now:
+        elapsed = (now - next_at).total_seconds()
+        intervals_to_skip = int(elapsed // interval.total_seconds()) + 1
+        next_at += interval * intervals_to_skip
+    return next_at

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -1,3 +1,6 @@
+from datetime import UTC, datetime
+from typing import Final
+
 from django.db import transaction
 from django.db.models import QuerySet
 
@@ -17,6 +20,11 @@ from products.logs.backend.models import LogsAlertConfiguration
 
 ALLOWED_WINDOW_MINUTES = {1, 5, 10, 15, 30, 60}
 MAX_ALERTS_PER_TEAM = 20
+_SENTINEL: Final = object()
+
+
+def _any_field_changed(instance: LogsAlertConfiguration, validated_data: dict, fields: set[str]) -> bool:
+    return any(f in validated_data and validated_data[f] != getattr(instance, f) for f in fields)
 
 
 class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
@@ -106,7 +114,43 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
                 }
             )
 
+        snooze_until = attrs.get("snooze_until")
+        if snooze_until is not None and snooze_until <= datetime.now(UTC):
+            raise ValidationError({"snooze_until": "Must be a future datetime."})
+
         return attrs
+
+    def update(self, instance: LogsAlertConfiguration, validated_data: dict) -> LogsAlertConfiguration:
+        snooze_data = validated_data.pop("snooze_until", _SENTINEL)
+
+        threshold_or_filter_fields = {
+            "threshold_count",
+            "threshold_operator",
+            "filters",
+            "datapoints_to_alarm",
+            "evaluation_periods",
+        }
+
+        threshold_changed = _any_field_changed(instance, validated_data, threshold_or_filter_fields)
+        window_changed = _any_field_changed(instance, validated_data, {"window_minutes"})
+
+        already_snoozed = snooze_data is _SENTINEL and instance.state == LogsAlertConfiguration.State.SNOOZED
+
+        if threshold_changed:
+            instance.mark_for_recheck(reset_state=not already_snoozed)
+        elif window_changed:
+            instance.mark_for_recheck(reset_state=False)
+
+        # Apply snooze last so it takes priority over the recheck state reset
+        if snooze_data is not _SENTINEL:
+            if snooze_data is None:
+                instance.state = LogsAlertConfiguration.State.NOT_FIRING
+                instance.snooze_until = None
+            else:
+                instance.state = LogsAlertConfiguration.State.SNOOZED
+                instance.snooze_until = snooze_data
+
+        return super().update(instance, validated_data)
 
     def create(self, validated_data: dict) -> LogsAlertConfiguration:
         validated_data["team_id"] = self.context["team_id"]

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -101,6 +101,24 @@ class LogsAlertConfiguration(ModelActivityMixin, CreatedMetaFields, UpdatedMetaF
     def __str__(self) -> str:
         return f"{self.name} (Team: {self.team})"
 
+    def mark_for_recheck(self, *, reset_state: bool = False) -> list[str]:
+        """Returns field names modified (for use with update_fields)."""
+        updated: list[str] = []
+        if reset_state:
+            self.state = self.State.NOT_FIRING
+            updated.append("state")
+        self.next_check_at = None
+        updated.append("next_check_at")
+        return updated
+
+    def get_recent_breaches(self) -> tuple[bool, ...]:
+        """Last M non-errored checks' threshold_breached values, newest first."""
+        return tuple(
+            LogsAlertCheck.objects.filter(alert=self, error_message__isnull=True)
+            .order_by("-created_at")
+            .values_list("threshold_breached", flat=True)[: self.evaluation_periods]
+        )
+
     def clean(self) -> None:
         super().clean()
         if self.datapoints_to_alarm > self.evaluation_periods:

--- a/products/logs/backend/test/test_alert_state_machine.py
+++ b/products/logs/backend/test/test_alert_state_machine.py
@@ -1,0 +1,313 @@
+from datetime import UTC, datetime, timedelta
+
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from products.logs.backend.alert_state_machine import (
+    AlertCheckOutcome,
+    AlertSnapshot,
+    AlertState,
+    CheckResult,
+    NotificationAction,
+    evaluate_alert_check,
+)
+
+ERRORED = AlertState.ERRORED
+FIRING = AlertState.FIRING
+NOT_FIRING = AlertState.NOT_FIRING
+PENDING_RESOLVE = AlertState.PENDING_RESOLVE
+SNOOZED = AlertState.SNOOZED
+
+NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+
+
+def _snapshot(
+    state: AlertState = NOT_FIRING,
+    evaluation_periods: int = 1,
+    datapoints_to_alarm: int = 1,
+    cooldown_minutes: int = 0,
+    last_notified_at: datetime | None = None,
+    snooze_until: datetime | None = None,
+    consecutive_failures: int = 0,
+    recent_checks_breached: tuple[bool, ...] | None = None,
+) -> AlertSnapshot:
+    return AlertSnapshot(
+        state=state,
+        evaluation_periods=evaluation_periods,
+        datapoints_to_alarm=datapoints_to_alarm,
+        cooldown_minutes=cooldown_minutes,
+        last_notified_at=last_notified_at,
+        snooze_until=snooze_until,
+        consecutive_failures=consecutive_failures,
+        recent_checks_breached=recent_checks_breached or (),
+    )
+
+
+def _check(breached: bool = False, error: str | None = None) -> CheckResult:
+    return CheckResult(
+        result_count=100 if breached else 0,
+        threshold_breached=breached,
+        error_message=error,
+    )
+
+
+class TestNotFiringTransitions(TestCase):
+    @parameterized.expand(
+        [
+            ("1_of_1_breach", 1, 1, (), True, FIRING, NotificationAction.FIRE),
+            ("1_of_1_no_breach", 1, 1, (), False, NOT_FIRING, NotificationAction.NONE),
+            ("2_of_3_breach_met", 2, 3, (True, False), True, FIRING, NotificationAction.FIRE),
+            ("2_of_3_breach_not_met", 2, 3, (False, False), True, NOT_FIRING, NotificationAction.NONE),
+            ("3_of_5_breach_met", 3, 5, (True, True, False, True), True, FIRING, NotificationAction.FIRE),
+            ("3_of_5_breach_not_met", 3, 5, (False, False, False, False), True, NOT_FIRING, NotificationAction.NONE),
+            ("first_ever_check_breach", 1, 1, (), True, FIRING, NotificationAction.FIRE),
+            ("first_ever_check_no_breach", 1, 1, (), False, NOT_FIRING, NotificationAction.NONE),
+            ("first_check_2_of_3_insufficient", 2, 3, (), True, NOT_FIRING, NotificationAction.NONE),
+        ]
+    )
+    def test_not_firing_transitions(
+        self,
+        _name: str,
+        n: int,
+        m: int,
+        recent: tuple[bool, ...],
+        breached: bool,
+        expected_state: AlertState,
+        expected_action: NotificationAction,
+    ) -> None:
+        snapshot = _snapshot(
+            state=NOT_FIRING,
+            datapoints_to_alarm=n,
+            evaluation_periods=m,
+            recent_checks_breached=recent,
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=breached), NOW)
+        assert outcome.new_state == expected_state
+        assert outcome.notification == expected_action
+
+
+class TestFiringTransitions(TestCase):
+    @parameterized.expand(
+        [
+            ("still_breaching_1_of_1", 1, 1, (), True, FIRING, NotificationAction.NONE),
+            ("still_breaching_2_of_3", 2, 3, (True, True), True, FIRING, NotificationAction.NONE),
+            ("clears_1_of_1", 1, 1, (), False, NOT_FIRING, NotificationAction.RESOLVE),
+            ("clears_enters_pending_2_of_3", 2, 3, (True, True), False, PENDING_RESOLVE, NotificationAction.NONE),
+        ]
+    )
+    def test_firing_transitions(
+        self,
+        _name: str,
+        n: int,
+        m: int,
+        recent: tuple[bool, ...],
+        breached: bool,
+        expected_state: AlertState,
+        expected_action: NotificationAction,
+    ) -> None:
+        snapshot = _snapshot(
+            state=FIRING,
+            datapoints_to_alarm=n,
+            evaluation_periods=m,
+            recent_checks_breached=recent,
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=breached), NOW)
+        assert outcome.new_state == expected_state
+        assert outcome.notification == expected_action
+
+
+class TestPendingResolveTransitions(TestCase):
+    @parameterized.expand(
+        [
+            # 2-of-3: window [False, False, True] -> 2 clears >= 2 -> resolve
+            ("clears_fully", 2, 3, (False, True), False, NOT_FIRING, NotificationAction.RESOLVE),
+            # 2-of-3: window [True, False, True] -> 2 breaches >= 2 -> back to FIRING
+            ("re_breaches", 2, 3, (False, True), True, FIRING, NotificationAction.NONE),
+            # 2-of-3: window [False, True, True] -> 1 clear < 2, 2 breach >= 2 -> FIRING
+            ("mixed_still_breaching", 2, 3, (True, True), False, PENDING_RESOLVE, NotificationAction.NONE),
+        ]
+    )
+    def test_pending_resolve_transitions(
+        self,
+        _name: str,
+        n: int,
+        m: int,
+        recent: tuple[bool, ...],
+        breached: bool,
+        expected_state: AlertState,
+        expected_action: NotificationAction,
+    ) -> None:
+        snapshot = _snapshot(
+            state=PENDING_RESOLVE,
+            datapoints_to_alarm=n,
+            evaluation_periods=m,
+            recent_checks_breached=recent,
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=breached), NOW)
+        assert outcome.new_state == expected_state
+        assert outcome.notification == expected_action
+
+
+class TestCooldownSuppression(TestCase):
+    def test_suppresses_fire_notification(self) -> None:
+        snapshot = _snapshot(
+            state=NOT_FIRING,
+            cooldown_minutes=10,
+            last_notified_at=NOW - timedelta(minutes=5),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.new_state == FIRING
+        assert outcome.notification == NotificationAction.NONE
+        assert outcome.update_last_notified_at is False
+
+    def test_suppresses_resolve_notification(self) -> None:
+        snapshot = _snapshot(
+            state=FIRING,
+            cooldown_minutes=10,
+            last_notified_at=NOW - timedelta(minutes=5),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
+        assert outcome.new_state == NOT_FIRING
+        assert outcome.notification == NotificationAction.NONE
+
+    def test_expired_cooldown_allows_notification(self) -> None:
+        snapshot = _snapshot(
+            state=NOT_FIRING,
+            cooldown_minutes=10,
+            last_notified_at=NOW - timedelta(minutes=15),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.new_state == FIRING
+        assert outcome.notification == NotificationAction.FIRE
+        assert outcome.update_last_notified_at is True
+
+    def test_zero_cooldown_never_suppresses(self) -> None:
+        snapshot = _snapshot(
+            state=NOT_FIRING,
+            cooldown_minutes=0,
+            last_notified_at=NOW - timedelta(seconds=1),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.notification == NotificationAction.FIRE
+
+    def test_no_prior_notification_never_suppresses(self) -> None:
+        snapshot = _snapshot(
+            state=NOT_FIRING,
+            cooldown_minutes=10,
+            last_notified_at=None,
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.notification == NotificationAction.FIRE
+
+
+class TestErrorHandling(TestCase):
+    def test_error_transitions_to_errored(self) -> None:
+        snapshot = _snapshot(state=NOT_FIRING)
+        outcome = evaluate_alert_check(snapshot, _check(error="ClickHouse timeout"), NOW)
+        assert outcome.new_state == ERRORED
+        assert outcome.notification == NotificationAction.NONE
+        assert outcome.error_message == "ClickHouse timeout"
+
+    def test_error_increments_consecutive_failures(self) -> None:
+        snapshot = _snapshot(state=NOT_FIRING, consecutive_failures=2)
+        outcome = evaluate_alert_check(snapshot, _check(error="timeout"), NOW)
+        assert outcome.consecutive_failures == 3
+
+    def test_success_resets_consecutive_failures(self) -> None:
+        snapshot = _snapshot(state=NOT_FIRING, consecutive_failures=3)
+        outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
+        assert outcome.consecutive_failures == 0
+
+    def test_error_from_firing_state(self) -> None:
+        snapshot = _snapshot(state=FIRING)
+        outcome = evaluate_alert_check(snapshot, _check(error="timeout"), NOW)
+        assert outcome.new_state == ERRORED
+
+    def test_errored_recovery_with_breach(self) -> None:
+        snapshot = _snapshot(state=ERRORED)
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.new_state == FIRING
+        assert outcome.notification == NotificationAction.FIRE
+
+    def test_errored_recovery_without_breach(self) -> None:
+        snapshot = _snapshot(state=ERRORED)
+        outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
+        assert outcome.new_state == NOT_FIRING
+        assert outcome.notification == NotificationAction.NONE
+
+
+class TestSnooze(TestCase):
+    def test_active_snooze_stays_snoozed(self) -> None:
+        snapshot = _snapshot(
+            state=SNOOZED,
+            snooze_until=NOW + timedelta(hours=1),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.new_state == SNOOZED
+        assert outcome.notification == NotificationAction.NONE
+
+    def test_expired_snooze_resumes_as_not_firing(self) -> None:
+        snapshot = _snapshot(
+            state=SNOOZED,
+            snooze_until=NOW - timedelta(minutes=1),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
+        assert outcome.new_state == NOT_FIRING
+
+    def test_expired_snooze_with_breach_fires(self) -> None:
+        snapshot = _snapshot(
+            state=SNOOZED,
+            snooze_until=NOW - timedelta(minutes=1),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.new_state == FIRING
+        assert outcome.notification == NotificationAction.FIRE
+
+    def test_snooze_with_none_expiry_resumes_not_firing(self) -> None:
+        snapshot = _snapshot(
+            state=SNOOZED,
+            snooze_until=None,
+        )
+        # snooze_until=None means it doesn't expire by time, treat as expired
+        outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
+        assert outcome.new_state == NOT_FIRING
+
+
+class TestEdgeCases(TestCase):
+    def test_1_of_1_skips_pending_resolve(self) -> None:
+        snapshot = _snapshot(state=FIRING, datapoints_to_alarm=1, evaluation_periods=1)
+        outcome = evaluate_alert_check(snapshot, _check(breached=False), NOW)
+        assert outcome.new_state == NOT_FIRING
+        assert outcome.notification == NotificationAction.RESOLVE
+
+    def test_window_truncated_to_m(self) -> None:
+        snapshot = _snapshot(
+            state=NOT_FIRING,
+            datapoints_to_alarm=2,
+            evaluation_periods=3,
+            recent_checks_breached=(True, True, True, True, True),
+        )
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        # Window is [True, True, True] (truncated to M=3), 3 breaches >= N=2
+        assert outcome.new_state == FIRING
+
+    def test_update_last_notified_at_on_fire(self) -> None:
+        snapshot = _snapshot(state=NOT_FIRING)
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.update_last_notified_at is True
+
+    def test_no_update_last_notified_at_on_suppress(self) -> None:
+        snapshot = _snapshot(state=FIRING)
+        outcome = evaluate_alert_check(snapshot, _check(breached=True), NOW)
+        assert outcome.update_last_notified_at is False
+
+    def test_outcome_is_frozen_dataclass(self) -> None:
+        snapshot = _snapshot()
+        outcome = evaluate_alert_check(snapshot, _check(), NOW)
+        assert isinstance(outcome, AlertCheckOutcome)
+
+    def test_alert_state_matches_model_state(self) -> None:
+        from products.logs.backend.models import LogsAlertConfiguration
+
+        assert set(AlertState) == {s.value for s in LogsAlertConfiguration.State}

--- a/products/logs/backend/test/test_alert_utils.py
+++ b/products/logs/backend/test/test_alert_utils.py
@@ -1,0 +1,86 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from products.logs.backend.alert_utils import advance_next_check_at
+
+
+class TestAdvanceNextCheckAt(TestCase):
+    @parameterized.expand(
+        [
+            (
+                "schedule_relative_not_execution_relative",
+                datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+                5,
+                datetime(2026, 3, 19, 12, 7, tzinfo=UTC),
+                # Schedule: :00, :05, :10. Ran at :07. Next future slot = :10 (not :12)
+                datetime(2026, 3, 19, 12, 10, tzinfo=UTC),
+            ),
+            (
+                "first_run_uses_now_plus_interval",
+                None,
+                1,
+                datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 1, tzinfo=UTC),
+            ),
+            (
+                "on_time_execution",
+                datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+                1,
+                datetime(2026, 3, 19, 12, 0, 30, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 1, tzinfo=UTC),
+            ),
+            (
+                "skip_forward_after_downtime",
+                datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+                1,
+                datetime(2026, 3, 19, 12, 10, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 11, tzinfo=UTC),
+            ),
+            (
+                "5_minute_interval",
+                datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+                5,
+                datetime(2026, 3, 19, 12, 3, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 5, tzinfo=UTC),
+            ),
+            (
+                "5_minute_interval_skip_forward",
+                datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+                5,
+                datetime(2026, 3, 19, 12, 12, tzinfo=UTC),
+                datetime(2026, 3, 19, 12, 15, tzinfo=UTC),
+            ),
+        ]
+    )
+    def test_advance_next_check_at(
+        self,
+        _name: str,
+        current_next_check_at: datetime | None,
+        interval_minutes: int,
+        now: datetime,
+        expected: datetime,
+    ) -> None:
+        result = advance_next_check_at(current_next_check_at, interval_minutes, now)
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_next_check_is_always_in_the_future(self) -> None:
+        now = datetime(2026, 3, 19, 12, 0, tzinfo=UTC)
+        result = advance_next_check_at(now, 1, now)
+        assert result > now
+
+    @parameterized.expand([(0,), (-1,), (-5,)])
+    def test_rejects_non_positive_interval(self, interval: int) -> None:
+        now = datetime(2026, 3, 19, 12, 0, tzinfo=UTC)
+        with pytest.raises(ValueError, match="must be positive"):
+            advance_next_check_at(now, interval, now)
+
+    def test_long_downtime_skips_correctly(self) -> None:
+        scheduled = datetime(2026, 3, 19, 12, 0, tzinfo=UTC)
+        now = scheduled + timedelta(hours=2)
+        result = advance_next_check_at(scheduled, 1, now)
+        assert result > now
+        assert result <= now + timedelta(minutes=1)

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -335,3 +337,147 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["state"] == "not_firing"
         assert response.json()["enabled"] is False
+
+    # --- Edit behavior: recheck and state reset ---
+
+    def test_threshold_change_resets_state_and_clears_next_check(self):
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state="firing",
+            next_check_at=datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+        )
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"threshold_count": 50},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+        assert response.json()["next_check_at"] is None
+
+    def test_filter_change_resets_state(self):
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(state="firing")
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"filters": {"severityLevels": ["warn"]}},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+
+    def test_window_change_preserves_state_and_clears_next_check(self):
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state="firing",
+            next_check_at=datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+        )
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"window_minutes": 10},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "firing"
+        assert response.json()["next_check_at"] is None
+
+    def test_name_change_preserves_state_and_next_check(self):
+        next_check = datetime(2026, 3, 19, 12, 0, tzinfo=UTC)
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state="firing",
+            next_check_at=next_check,
+        )
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"name": "Renamed"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "firing"
+        assert response.json()["next_check_at"] is not None
+
+    # --- Snooze ---
+
+    def test_snooze_sets_snoozed_state(self):
+        created = self._create_via_api()
+        snooze_time = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"snooze_until": snooze_time},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "snoozed"
+        assert response.json()["snooze_until"] is not None
+
+    def test_unsnooze_sets_not_firing_state(self):
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state="snoozed",
+            snooze_until=datetime.now(UTC) + timedelta(hours=1),
+        )
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"snooze_until": None},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"] == "not_firing"
+        assert response.json()["snooze_until"] is None
+
+    def test_snooze_rejects_past_datetime(self):
+        created = self._create_via_api()
+        past_time = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"snooze_until": past_time},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_snooze_with_threshold_change_preserves_snoozed_state(self):
+        created = self._create_via_api()
+        snooze_time = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"snooze_until": snooze_time, "threshold_count": 100},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["state"] == "snoozed"
+        assert data["snooze_until"] is not None
+        assert data["threshold_count"] == 100
+
+    def test_already_snoozed_threshold_change_preserves_snooze(self):
+        created = self._create_via_api()
+        snooze_time = datetime.now(UTC) + timedelta(hours=1)
+
+        # First snooze the alert
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"snooze_until": snooze_time.isoformat()},
+            format="json",
+        )
+        assert response.json()["state"] == "snoozed"
+
+        # Now change threshold without touching snooze_until
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"threshold_count": 200},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["state"] == "snoozed"
+        assert data["snooze_until"] is not None
+        assert data["threshold_count"] == 200

--- a/products/logs/backend/test/test_models.py
+++ b/products/logs/backend/test/test_models.py
@@ -60,6 +60,60 @@ class TestLogsAlertConfiguration(BaseTest):
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.FIRING
 
+    def test_mark_for_recheck_resets_state(self):
+        alert = self._create_alert(
+            state=LogsAlertConfiguration.State.FIRING,
+            next_check_at=datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+        )
+        updated = alert.mark_for_recheck(reset_state=True)
+        alert.save(update_fields=updated)
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
+        assert alert.next_check_at is None
+        assert "state" in updated
+        assert "next_check_at" in updated
+
+    def test_mark_for_recheck_preserves_state(self):
+        alert = self._create_alert(
+            state=LogsAlertConfiguration.State.FIRING,
+            next_check_at=datetime(2026, 3, 19, 12, 0, tzinfo=UTC),
+        )
+        updated = alert.mark_for_recheck(reset_state=False)
+        alert.save(update_fields=updated)
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.FIRING
+        assert alert.next_check_at is None
+        assert "state" not in updated
+
+    def test_get_recent_breaches_ordering_and_limit(self):
+        alert = self._create_alert(evaluation_periods=3)
+        for i, breached in enumerate([False, True, False, True, True]):
+            check = LogsAlertCheck.objects.create(
+                alert=alert,
+                threshold_breached=breached,
+                state_before="not_firing",
+                state_after="not_firing",
+            )
+            LogsAlertCheck.objects.filter(pk=check.pk).update(created_at=datetime(2026, 3, 19, 12, i, tzinfo=UTC))
+
+        result = alert.get_recent_breaches()
+        assert result == (True, True, False)
+
+    def test_get_recent_breaches_excludes_errored_checks(self):
+        alert = self._create_alert(evaluation_periods=5)
+        for i, (breached, error) in enumerate([(True, None), (False, "timeout"), (False, None)]):
+            check = LogsAlertCheck.objects.create(
+                alert=alert,
+                threshold_breached=breached,
+                state_before="not_firing",
+                state_after="not_firing",
+                error_message=error,
+            )
+            LogsAlertCheck.objects.filter(pk=check.pk).update(created_at=datetime(2026, 3, 19, 12, i, tzinfo=UTC))
+
+        result = alert.get_recent_breaches()
+        assert result == (False, True)
+
     def test_clean_valid_n_of_m(self):
         alert = self._create_alert(datapoints_to_alarm=2, evaluation_periods=3, filters={"severityLevels": ["error"]})
         alert.full_clean()


### PR DESCRIPTION
## Problem

Log alert rules are silent without notification destinations, and there's no decision engine for when to actually send notifications. Users need to configure "alert me when X, notify via Y" in one flow, and the system needs to handle edge cases like flapping alerts, transient spikes, and notification spam.

## Changes

**Frontend — inline notification destinations:**

- Registered `logs-alerting` context and `logs-alert-firing` sub-templates (Slack + Webhook variants)
- `logsAlertNotificationLogic` — manages pending/existing HogFunction destinations
- `LogsAlertNotifications` — inline UI with Slack channel picker, webhook URL input, pending/existing cards
- Updated `LogsAlertForm` with collapsible Notifications section
- Two-step save in `logsAlertFormLogic`: create alert, then create pending HogFunctions

**Backend — alert state machine + utilities:**

- `alert_state_machine.py` — pure `evaluate_alert_check()` function: given current state + check result, returns new state + whether to notify. Handles N-of-M consecutive trigger, cooldown suppression, snooze, and PENDING_RESOLVE for symmetric resolution
- `alert_utils.py` — `advance_next_check_at()` with O(1) schedule-relative advancement (prevents drift after late execution or downtime)
- `models.py` — `mark_for_recheck()`, `get_recent_breaches()` instance method
- `alerts_api.py` — serializer `update()` with edit-behavior rules (threshold/filter changes reset state, window changes recheck without reset) + snooze validation

## How did you test this code?

- 44 pure unit tests for state machine (all state transitions, N-of-M, cooldown, snooze, error handling) and schedule advancement — no Django/DB required, run in 0.1s
- 14 Django model tests for `mark_for_recheck`, `get_recent_breaches`, edit-behavior, snooze API
- 10 frontend logic tests for notification CRUD and `logsAlertUtils`

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

## Docs update

skip-inkeep-docs