### PR TITLE
feat(analytics-platform): Add query tagging of source file name

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -31,6 +31,7 @@ from posthog.clickhouse.query_tagging import (
     Feature,
     Product,
     QueryTags,
+    get_caller_source,
     get_query_tag_value,
     get_query_tags,
 )
@@ -322,6 +323,10 @@ def sync_execute(
             tags=",".join(missing),
             stacktrace="".join(traceback.format_stack()),
         )
+
+    source_file, source_line = get_caller_source()
+    tags.source_file = source_file
+    tags.source_line = source_line
 
     settings = {
         **core_settings,

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -325,12 +325,13 @@ def sync_execute(
         )
 
     source_file, source_line = get_caller_source()
-    tags.source_file = source_file
-    tags.source_line = source_line
+    query_log_tags = tags.model_copy(deep=True)
+    query_log_tags.source_file = source_file
+    query_log_tags.source_line = source_line
 
     settings = {
         **core_settings,
-        "log_comment": tags.to_json(),
+        "log_comment": query_log_tags.to_json(),
     }
     if workload == Workload.OFFLINE:
         # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -1,5 +1,8 @@
 # This module is responsible for adding tags/metadata to outgoing clickhouse queries in a thread-safe manner
+import os
+import sys
 import uuid
+import types
 import contextvars
 from collections.abc import Generator
 from contextlib import contextmanager, suppress
@@ -185,6 +188,10 @@ class QueryTags(BaseModel):
     mcp_protocol_version: Optional[str] = None
     mcp_oauth_client_name: Optional[str] = None
 
+    # caller source location (set automatically in sync_execute via stack inspection)
+    source_file: Optional[str] = None
+    source_line: Optional[int] = None
+
     # constant query tags
     git_commit: Optional[str] = None
     container_hostname: Optional[str] = None
@@ -323,3 +330,51 @@ def tags_context(**tags_to_set: Any) -> Generator[None, None, None]:
     finally:
         if tags_copy:
             query_tags.set(tags_copy)
+
+
+# Stack inspection for source_file / source_line tagging
+_THIS_FILE = os.path.abspath(__file__)
+_PROJECT_ROOT = os.path.normpath(os.path.join(os.path.dirname(_THIS_FILE), os.pardir, os.pardir))
+_PROJECT_ROOT_PREFIX = _PROJECT_ROOT + os.sep
+
+# Files/directories in the query execution infrastructure to skip when walking the stack
+_SOURCE_SKIP_PREFIXES: tuple[str, ...] = (
+    os.path.join(_PROJECT_ROOT, "posthog", "clickhouse", "client") + os.sep,
+    _THIS_FILE,
+    os.path.join(_PROJECT_ROOT, "posthog", "hogql", "query.py"),
+    os.path.join(_PROJECT_ROOT, "posthog", "utils.py"),
+)
+
+_MAX_CALLER_STACK_DEPTH = 30
+
+
+def get_caller_source() -> tuple[Optional[str], Optional[int]]:
+    """Walk the call stack to find the first caller outside of query execution infrastructure.
+
+    Returns (source_file, source_line) where source_file is relative to the project root,
+    or (None, None) if no suitable caller is found.
+    """
+    try:
+        frame: Optional[types.FrameType] = sys._getframe(1)
+
+        for _ in range(_MAX_CALLER_STACK_DEPTH):
+            if frame is None:
+                break
+
+            filename = frame.f_code.co_filename
+
+            # Only consider frames within the project
+            if not filename.startswith(_PROJECT_ROOT_PREFIX):
+                frame = frame.f_back
+                continue
+
+            # Skip query execution infrastructure
+            if any(filename.startswith(prefix) for prefix in _SOURCE_SKIP_PREFIXES):
+                frame = frame.f_back
+                continue
+
+            return filename[len(_PROJECT_ROOT_PREFIX) :], frame.f_lineno
+
+        return None, None
+    except Exception:
+        return None, None

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -1,16 +1,24 @@
+import json
 import uuid
 import asyncio
 
 import pytest
+from posthog.test.base import BaseTest, ClickhouseTestMixin
 
 from pydantic import ValidationError
 
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import (
+    _PROJECT_ROOT_PREFIX,
+    _SOURCE_SKIP_PREFIXES,
     Product,
     QueryTags,
     TemporalTags,
     clear_tag,
     create_base_tags,
+    get_caller_source,
     get_query_tag_value,
     get_query_tags,
     reset_query_tags,
@@ -260,3 +268,69 @@ async def test_async_tasks_have_isolated_tags_with_clear_tag():
     # Task B cleared team_id, should still have user_id
     assert results["task_b"]["team_id"] is None
     assert results["task_b"]["user_id"] == 50
+
+
+def test_get_caller_source_returns_this_file():
+    source_file, source_line = get_caller_source()
+    assert source_file == "posthog/clickhouse/test/test_query_tagging.py"
+    assert source_line is not None
+
+
+def test_get_caller_source_skips_infrastructure():
+    for prefix in _SOURCE_SKIP_PREFIXES:
+        assert prefix.startswith(_PROJECT_ROOT_PREFIX)
+
+
+def test_source_file_excluded_from_json_when_none():
+    qt = QueryTags(git_commit="test", container_hostname="test", service_name="test")
+    data = qt.to_json()
+    assert "source_file" not in data
+    assert "source_line" not in data
+
+
+def test_source_file_included_in_json_when_set():
+    qt = QueryTags(
+        source_file="posthog/api/query.py",
+        source_line=42,
+        git_commit="test",
+        container_hostname="test",
+        service_name="test",
+    )
+    data = qt.to_json()
+    assert '"source_file":"posthog/api/query.py"' in data
+    assert '"source_line":42' in data
+
+
+class TestQueryTaggingSourceInQueryLog(BaseTest, ClickhouseTestMixin):
+    def _get_log_comment(self, marker: str) -> dict:
+        sync_execute("SYSTEM FLUSH LOGS")
+        rows = sync_execute(
+            "SELECT log_comment FROM system.query_log "
+            "WHERE query LIKE %(marker)s AND type = 'QueryFinish' "
+            "ORDER BY event_time DESC LIMIT 1",
+            {"marker": f"%{marker}%"},
+        )
+        assert rows, f"No query log entry found containing marker {marker}"
+        return json.loads(rows[0][0])
+
+    def test_sync_execute_populates_source_tags(self):
+        marker = str(uuid.uuid4())
+        reset_query_tags()
+        tag_queries(kind="request", id="test")
+        sync_execute(f"SELECT '{marker}'")  # noqa: S608
+
+        comment = self._get_log_comment(marker)
+
+        assert comment["source_file"] == "posthog/clickhouse/test/test_query_tagging.py"
+        assert comment["source_line"] > 0
+
+    def test_execute_hogql_query_populates_source_tags(self):
+        marker = str(uuid.uuid4())
+        reset_query_tags()
+        tag_queries(kind="request", id="test")
+        execute_hogql_query(f"SELECT '{marker}'", team=self.team, query_type="HogQLQuery")  # noqa: S608
+
+        comment = self._get_log_comment(marker)
+
+        assert comment["source_file"] == "posthog/clickhouse/test/test_query_tagging.py"
+        assert comment["source_line"] > 0


### PR DESCRIPTION
## Problem

Analytics platform -> platform analytics

I want to hunt down the untagged queries, so use introspection to tag them with their source file, to make them much easier to hunt down

## Changes

Add introspection of the python backtrace to find the nearest caller that isn't part of the querying system itself.

Also add a couple of tests for this.

## How did you test this code?

The backtrace logic has a couple of unit tests, and I have a test for sync_execute and execute_hogql_query to make sure that the correct value appears in the query log


## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
