### PR TITLE
fix(insights): restrict cohort breakdown filter to cohorts category only

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
@@ -31,13 +31,15 @@ export const TaxonomicBreakdownPopover = ({
     const { insightProps } = useValues(insightLogic)
     const { allEventNames, query } = useValues(insightVizDataLogic(insightProps))
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { includeSessions } = useValues(taxonomicBreakdownFilterLogic)
+    const { includeSessions, taxonomicBreakdownType } = useValues(taxonomicBreakdownFilterLogic)
 
     const { currentDataWarehouseSchemaColumns } = useValues(taxonomicBreakdownFilterLogic)
     const { addBreakdown, replaceBreakdown } = useActions(taxonomicBreakdownFilterLogic)
 
     let taxonomicGroupTypes: TaxonomicFilterGroupType[]
-    if (isRetentionQuery(query) || (isInsightVizNode(query) && isRetentionQuery(query.source))) {
+    if (taxonomicBreakdownType === TaxonomicFilterGroupType.CohortsWithAllUsers) {
+        taxonomicGroupTypes = [TaxonomicFilterGroupType.CohortsWithAllUsers]
+    } else if (isRetentionQuery(query) || (isInsightVizNode(query) && isRetentionQuery(query.source))) {
         taxonomicGroupTypes = [
             TaxonomicFilterGroupType.EventProperties,
             TaxonomicFilterGroupType.PersonProperties,


### PR DESCRIPTION
## Problem

When breaking down by cohorts and clicking "+ Cohort", the taxonomic filter now only shows the cohorts category instead of all categories.

https://posthog.slack.com/archives/C0ACRAMJUAG/p1773940689338509

## Changes

Only show the cohorts category when in cohort breakdown mode

## How did you test this code?

Tested locally