### PR TITLE
fix: vary message keys to improve partition distribution

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
@@ -94,8 +94,10 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         }
 
         try {
-            const messages = events.map((event) => ({
+            // Batch messages while varying keys to encourage partition distribution
+            const messages = events.map((event, index) => ({
                 value: JSON.stringify(event.payload),
+                key: String(index),
             }))
 
             await this.kafkaProducer.queueMessages({

--- a/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-precalculated-filters.consumer.ts
@@ -1,5 +1,6 @@
 import { Message } from 'node-rdkafka'
 import { Histogram } from 'prom-client'
+import { v4 as uuidv4 } from 'uuid'
 
 import { instrumentFn, instrumented } from '~/common/tracing/tracing-utils'
 import {
@@ -94,10 +95,10 @@ export class CdpPrecalculatedFiltersConsumer extends CdpConsumerBase {
         }
 
         try {
-            // Batch messages while varying keys to encourage partition distribution
-            const messages = events.map((event, index) => ({
+            // Use random UUIDs as keys to ensure proper partition distribution
+            const messages = events.map((event) => ({
                 value: JSON.stringify(event.payload),
-                key: String(index),
+                key: uuidv4(),
             }))
 
             await this.kafkaProducer.queueMessages({


### PR DESCRIPTION
Add sequential keys to person property messages to improve partition distribution across Kafka.