### PR TITLE
fix(integrations): show actionable error on 403 when connecting integrations

### DIFF
--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -165,8 +165,12 @@ export const integrationsLogic = kea<integrationsLogicType>([
                         'Your request to connect to GitHub has been sent to the organization owners. They will need to complete the installation.'
                     )
                 }
-            } catch {
-                lemonToast.error(`Something went wrong. Please try again.`)
+            } catch (e: any) {
+                if (e.status === 403) {
+                    lemonToast.error('You need at least Admin access to connect integrations.')
+                } else {
+                    lemonToast.error(`Something went wrong. Please try again.`)
+                }
             } finally {
                 router.actions.replace(replaceUrl)
             }
@@ -204,8 +208,12 @@ export const integrationsLogic = kea<integrationsLogicType>([
                     actions.loadIntegrations()
                     lemonToast.success(`Integration successful.`)
                 }
-            } catch {
-                lemonToast.error(`Something went wrong. Please try again.`)
+            } catch (e: any) {
+                if (e.status === 403) {
+                    lemonToast.error('You need at least Admin access to connect integrations.')
+                } else {
+                    lemonToast.error(`Something went wrong. Please try again.`)
+                }
             } finally {
                 router.actions.replace(replaceUrl)
             }

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -166,11 +166,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
                     )
                 }
             } catch (e: any) {
-                if (e.status === 403) {
-                    lemonToast.error('You need at least Admin access to connect integrations.')
-                } else {
-                    lemonToast.error(`Something went wrong. Please try again.`)
-                }
+                lemonToast.error(e.detail || `Something went wrong. Please try again.`)
             } finally {
                 router.actions.replace(replaceUrl)
             }
@@ -209,11 +205,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
                     lemonToast.success(`Integration successful.`)
                 }
             } catch (e: any) {
-                if (e.status === 403) {
-                    lemonToast.error('You need at least Admin access to connect integrations.')
-                } else {
-                    lemonToast.error(`Something went wrong. Please try again.`)
-                }
+                lemonToast.error(e.detail || `Something went wrong. Please try again.`)
             } finally {
                 router.actions.replace(replaceUrl)
             }

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -4,7 +4,7 @@ import { router, urlToAction } from 'kea-router'
 
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
-import api, { getCookie } from 'lib/api'
+import api, { ApiError, getCookie } from 'lib/api'
 import { globalSetupLogic } from 'lib/components/ProductSetup'
 import { fromParamsGivenUrl, isKeyOf } from 'lib/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -19,6 +19,11 @@ import { ChannelType } from 'products/workflows/frontend/Channels/MessageChannel
 
 import type { integrationsLogicType } from './integrationsLogicType'
 import { ICONS } from './utils'
+
+function toastApiError(e: unknown): void {
+    const detail = e instanceof ApiError ? e.detail : null
+    lemonToast.error(detail || 'Something went wrong. Please try again.')
+}
 
 export const integrationsLogic = kea<integrationsLogicType>([
     path(['lib', 'integrations', 'integrationsLogic']),
@@ -165,8 +170,8 @@ export const integrationsLogic = kea<integrationsLogicType>([
                         'Your request to connect to GitHub has been sent to the organization owners. They will need to complete the installation.'
                     )
                 }
-            } catch (e: any) {
-                lemonToast.error(e.detail || `Something went wrong. Please try again.`)
+            } catch (e) {
+                toastApiError(e)
             } finally {
                 router.actions.replace(replaceUrl)
             }
@@ -204,8 +209,8 @@ export const integrationsLogic = kea<integrationsLogicType>([
                     actions.loadIntegrations()
                     lemonToast.success(`Integration successful.`)
                 }
-            } catch (e: any) {
-                lemonToast.error(e.detail || `Something went wrong. Please try again.`)
+            } catch (e) {
+                toastApiError(e)
             } finally {
                 router.actions.replace(replaceUrl)
             }


### PR DESCRIPTION
## Problem

When a user without Admin access tries to connect an OAuth integration (Salesforce, GitHub, etc.), they see a generic "Something went wrong. Please try again." toast. The underlying issue is a 403 from `TeamMemberStrictManagementPermission`, but the frontend catch blocks discard the error context entirely, showing no actionable information.

## Changes

Updated both `handleGithubCallback` and `handleOauthCallback` catch blocks in `integrationsLogic.ts` to use the `detail` field from the `ApiError` response (e.g. `"You don't have sufficient permissions in the project."`), falling back to the generic message only when no detail is available. This surfaces whatever the backend returns rather than hardcoding a specific message.

## How did you test this code?

- Tested by forcing a console redirect from a Salesforce token setup:
```
document.cookie = 'ph_oauth_state=test; path=/'
window.location = '/integrations/salesforce/callback?state=' + encodeURIComponent('token=test') + '&code=test'
```

<img width="402" height="80" alt="image" src="https://github.com/user-attachments/assets/ca3bfa9d-9383-4532-b3f6-23e98e380bfe" />


## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code. The investigation traced the issue from the generic toast through the frontend OAuth callback flow to the backend `TeamMemberStrictManagementPermission` check, confirming the 403 is a permissions issue.