### PR TITLE
fix(funnels): Widen PropVal types to support breakdown IDs

### DIFF
--- a/funnel-udf/src/main.rs
+++ b/funnel-udf/src/main.rs
@@ -13,7 +13,26 @@ use std::io::{self, BufRead, Write};
 enum PropVal {
     String(String),
     Vec(Vec<String>),
-    Int(u32),
+    Int(u64),
+    VecInt(Vec<u64>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(r#""hello""#, PropVal::String("hello".to_string()))]
+    #[case(r#"42"#, PropVal::Int(42))]
+    #[case(r#"4503599627370496"#, PropVal::Int(4503599627370496))] // 2^52 (NOT_IN_COHORT_ID)
+    #[case(r#"["a","b"]"#, PropVal::Vec(vec!["a".to_string(), "b".to_string()]))]
+    #[case(r#"[1, 2, 3]"#, PropVal::VecInt(vec![1, 2, 3]))]
+    #[case(r#"[4503599627370496]"#, PropVal::VecInt(vec![4503599627370496]))]
+    fn test_propval_deserialization(#[case] json: &str, #[case] expected: PropVal) {
+        let result: PropVal = serde_json::from_str(json).unwrap();
+        assert_eq!(result, expected);
+    }
 }
 
 fn main() {


### PR DESCRIPTION
## Problem

Seeing this error to do with funnel breakdown by cohort:
> Invalid JSON input: Error("data did not match any variant of untagged enum PropVal", line: 1, column: 152)   

Looks like a serialisation issue with cohort ids

## Changes

 - Add PropVal::VecInt(Vec<u64>) variant to handle prop_vals arriving as an integer array from ClickHouse's Array(UInt64) type 
 - Widen PropVal::Int from u32 to u64 for large IDs like NOT_IN_COHORT_ID (2^52)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
