### PR TITLE
feat: add pipeline step timing metric

### DIFF
--- a/nodejs/src/common/tracing/tracing-utils.ts
+++ b/nodejs/src/common/tracing/tracing-utils.ts
@@ -85,6 +85,7 @@ interface FunctionInstrumentationOptions {
     getLoggingContext?: () => Record<string, any>
     logExecutionTime?: boolean
     sendException?: boolean
+    measureTime?: boolean
 }
 
 /**
@@ -102,25 +103,24 @@ export async function instrumentFn<T>(
     const timeout = (typeof options === 'string' ? undefined : options.timeoutMs) ?? defaultConfig.TASK_TIMEOUT * 1000
     const sendException = (typeof options === 'string' ? undefined : options.sendException) ?? true
     const logExecutionTime = (typeof options === 'string' ? undefined : options.logExecutionTime) ?? false
+    const measureTime = (typeof options === 'string' ? undefined : options.measureTime) ?? true
 
     const t = timeoutGuard(timeoutMessage, getLoggingContext, timeout, sendException)
     const startTime = performance.now()
-    const end = instrumentedFunctionDuration.startTimer({
-        function: key,
-    })
+    const end = measureTime ? instrumentedFunctionDuration.startTimer({ function: key }) : undefined
 
     try {
         // Skip expensive span creation when tracing is disabled
         const result = defaultConfig.DISABLE_OPENTELEMETRY_TRACING
             ? await func()
             : await withSpan('instrumented_function', key, {}, func)
-        end({ success: 'true' })
+        end?.({ success: 'true' })
         if (logExecutionTime) {
             logTime(startTime, key)
         }
         return result
     } catch (error) {
-        end({ success: 'false' })
+        end?.({ success: 'false' })
         logger.info('🔔', error)
         if (logExecutionTime) {
             logTime(startTime, key, error)

--- a/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
@@ -1,5 +1,6 @@
 import { instrumentFn } from '../../common/tracing/tracing-utils'
 import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
+import { pipelineStepDurationHistogram } from './metrics'
 import { PipelineResultWithContext } from './pipeline.interface'
 import { PipelineResult, PipelineResultOk, isOkResult } from './results'
 
@@ -44,9 +45,11 @@ export class BaseBatchPipeline<TInput, TIntermediate, TOutput, CInput, COutput =
         // Apply current step to successful values
         let stepResults: PipelineResult<TOutput>[] = []
         if (successfulValues.length > 0) {
+            const end = pipelineStepDurationHistogram.startTimer({ step_name: this.stepName, step_type: 'batch' })
             stepResults = await instrumentFn({ key: this.stepName, sendException: false }, () =>
                 this.currentStep(successfulValues)
             )
+            end()
             if (stepResults.length !== successfulValues.length) {
                 throw new Error(
                     `Batch pipeline step ${this.stepName} returned different number of results than input values: ${stepResults.length} !== ${successfulValues.length}`

--- a/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
@@ -46,10 +46,15 @@ export class BaseBatchPipeline<TInput, TIntermediate, TOutput, CInput, COutput =
         let stepResults: PipelineResult<TOutput>[] = []
         if (successfulValues.length > 0) {
             const end = pipelineStepDurationHistogram.startTimer({ step_name: this.stepName, step_type: 'batch' })
-            stepResults = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
-                this.currentStep(successfulValues)
-            )
-            end({ result: 'batch' })
+            try {
+                stepResults = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
+                    this.currentStep(successfulValues)
+                )
+                end({ result: 'batch' })
+            } catch (e) {
+                end({ result: 'exception' })
+                throw e
+            }
             if (stepResults.length !== successfulValues.length) {
                 throw new Error(
                     `Batch pipeline step ${this.stepName} returned different number of results than input values: ${stepResults.length} !== ${successfulValues.length}`

--- a/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
@@ -49,7 +49,7 @@ export class BaseBatchPipeline<TInput, TIntermediate, TOutput, CInput, COutput =
             stepResults = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
                 this.currentStep(successfulValues)
             )
-            end()
+            end({ result: 'batch' })
             if (stepResults.length !== successfulValues.length) {
                 throw new Error(
                     `Batch pipeline step ${this.stepName} returned different number of results than input values: ${stepResults.length} !== ${successfulValues.length}`

--- a/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/base-batch-pipeline.ts
@@ -46,7 +46,7 @@ export class BaseBatchPipeline<TInput, TIntermediate, TOutput, CInput, COutput =
         let stepResults: PipelineResult<TOutput>[] = []
         if (successfulValues.length > 0) {
             const end = pipelineStepDurationHistogram.startTimer({ step_name: this.stepName, step_type: 'batch' })
-            stepResults = await instrumentFn({ key: this.stepName, sendException: false }, () =>
+            stepResults = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
                 this.currentStep(successfulValues)
             )
             end()

--- a/nodejs/src/ingestion/pipelines/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/metrics.ts
@@ -1,7 +1,14 @@
-import { Counter } from 'prom-client'
+import { Counter, Histogram, exponentialBuckets } from 'prom-client'
 
 export const sideEffectResultCounter = new Counter({
     name: 'pipelines_side_effects_total',
     help: 'Total number of side effects processed with their results',
     labelNames: ['result'],
+})
+
+export const pipelineStepDurationHistogram = new Histogram({
+    name: 'ingestion_pipeline_step_duration_seconds',
+    help: 'Duration of pipeline step execution',
+    labelNames: ['step_name', 'step_type'],
+    buckets: exponentialBuckets(0.001, 2, 15), // 1ms -> ~16s
 })

--- a/nodejs/src/ingestion/pipelines/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/metrics.ts
@@ -9,6 +9,6 @@ export const sideEffectResultCounter = new Counter({
 export const pipelineStepDurationHistogram = new Histogram({
     name: 'ingestion_pipeline_step_duration_seconds',
     help: 'Duration of pipeline step execution',
-    labelNames: ['step_name', 'step_type'],
+    labelNames: ['step_name', 'step_type', 'result'],
     buckets: exponentialBuckets(0.001, 2, 15), // 1ms -> ~16s
 })

--- a/nodejs/src/ingestion/pipelines/result-handling-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/result-handling-pipeline.test.ts
@@ -468,22 +468,22 @@ describe('ResultHandlingPipeline', () => {
             // Verify all results were recorded with correct step names
             expect(mockIngestionPipelineResultCounter.labels).toHaveBeenCalledWith({
                 result: 'ok',
-                step_name: 'validationStep',
+                last_step_name: 'validationStep',
                 details: '',
             })
             expect(mockIngestionPipelineResultCounter.labels).toHaveBeenCalledWith({
                 result: 'drop',
-                step_name: 'filterStep',
+                last_step_name: 'filterStep',
                 details: 'dropped item',
             })
             expect(mockIngestionPipelineResultCounter.labels).toHaveBeenCalledWith({
                 result: 'redirect',
-                step_name: 'routingStep',
+                last_step_name: 'routingStep',
                 details: 'overflow-topic(preserve_key=true)',
             })
             expect(mockIngestionPipelineResultCounter.labels).toHaveBeenCalledWith({
                 result: 'dlq',
-                step_name: 'processingStep',
+                last_step_name: 'processingStep',
                 details: 'dlq item',
             })
         })
@@ -509,7 +509,7 @@ describe('ResultHandlingPipeline', () => {
             // Verify result was recorded with 'unknown' step name
             expect(mockIngestionPipelineResultCounter.labels).toHaveBeenCalledWith({
                 result: 'ok',
-                step_name: 'unknown',
+                last_step_name: 'unknown',
                 details: '',
             })
         })

--- a/nodejs/src/ingestion/pipelines/result-handling-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/result-handling-pipeline.ts
@@ -53,7 +53,7 @@ export class ResultHandlingPipeline<
         for (const resultWithContext of results) {
             const stepName = resultWithContext.context.lastStep || 'unknown'
             const { result: resultType, details } = resultDetails(resultWithContext.result)
-            ingestionPipelineResultCounter.labels({ result: resultType, step_name: stepName, details }).inc()
+            ingestionPipelineResultCounter.labels({ result: resultType, last_step_name: stepName, details }).inc()
 
             if (isOkResult(resultWithContext.result)) {
                 processedResults.push(resultWithContext)

--- a/nodejs/src/ingestion/pipelines/step-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/step-pipeline.ts
@@ -30,10 +30,16 @@ export class StepPipeline<TInput, TIntermediate, TOutput, C> implements Pipeline
         }
 
         const end = pipelineStepDurationHistogram.startTimer({ step_name: this.stepName, step_type: 'element' })
-        const currentResult = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
-            this.currentStep(previousResult.value)
-        )
-        end({ result: PipelineResultType[currentResult.type].toLowerCase() })
+        let currentResult: PipelineResult<TOutput>
+        try {
+            currentResult = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
+                this.currentStep(previousResult.value)
+            )
+            end({ result: PipelineResultType[currentResult.type].toLowerCase() })
+        } catch (e) {
+            end({ result: 'exception' })
+            throw e
+        }
         return {
             result: currentResult,
             context: {

--- a/nodejs/src/ingestion/pipelines/step-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/step-pipeline.ts
@@ -30,7 +30,7 @@ export class StepPipeline<TInput, TIntermediate, TOutput, C> implements Pipeline
         }
 
         const end = pipelineStepDurationHistogram.startTimer({ step_name: this.stepName, step_type: 'element' })
-        const currentResult = await instrumentFn({ key: this.stepName, sendException: false }, () =>
+        const currentResult = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
             this.currentStep(previousResult.value)
         )
         end()

--- a/nodejs/src/ingestion/pipelines/step-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/step-pipeline.ts
@@ -1,4 +1,5 @@
 import { instrumentFn } from '../../common/tracing/tracing-utils'
+import { pipelineStepDurationHistogram } from './metrics'
 import { Pipeline, PipelineResultWithContext } from './pipeline.interface'
 import { PipelineResult, isOkResult } from './results'
 import { ProcessingStep } from './steps'
@@ -28,9 +29,11 @@ export class StepPipeline<TInput, TIntermediate, TOutput, C> implements Pipeline
             }
         }
 
+        const end = pipelineStepDurationHistogram.startTimer({ step_name: this.stepName, step_type: 'element' })
         const currentResult = await instrumentFn({ key: this.stepName, sendException: false }, () =>
             this.currentStep(previousResult.value)
         )
+        end()
         return {
             result: currentResult,
             context: {

--- a/nodejs/src/ingestion/pipelines/step-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/step-pipeline.ts
@@ -1,7 +1,7 @@
 import { instrumentFn } from '../../common/tracing/tracing-utils'
 import { pipelineStepDurationHistogram } from './metrics'
 import { Pipeline, PipelineResultWithContext } from './pipeline.interface'
-import { PipelineResult, isOkResult } from './results'
+import { PipelineResult, PipelineResultType, isOkResult } from './results'
 import { ProcessingStep } from './steps'
 
 export class StepPipeline<TInput, TIntermediate, TOutput, C> implements Pipeline<TInput, TOutput, C> {
@@ -33,7 +33,7 @@ export class StepPipeline<TInput, TIntermediate, TOutput, C> implements Pipeline
         const currentResult = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
             this.currentStep(previousResult.value)
         )
-        end()
+        end({ result: PipelineResultType[currentResult.type].toLowerCase() })
         return {
             result: currentResult,
             context: {

--- a/nodejs/src/worker/ingestion/event-pipeline/metrics.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/metrics.ts
@@ -29,7 +29,7 @@ export const eventProcessedAndIngestedCounter = new Counter({
 export const ingestionPipelineResultCounter = new Counter({
     name: 'ingestion_pipeline_results',
     help: 'Count of pipeline results by type',
-    labelNames: ['result', 'step_name', 'details'],
+    labelNames: ['result', 'last_step_name', 'details'],
 })
 
 export const invalidTimestampCounter = new Counter({


### PR DESCRIPTION
## Problem

We have step timing from the `instrumentFn` helper, but it's hard to select just the pipeline step timing.

## Changes

- Adds a separate histogram metric for pipeline steps timing
- Disables timing within the pipeline steps for `instrumentFn`
- Renames results label to `last_step_name` to avoid confusion

## How did you test this code?

Just metrics - will review results on prod.