### PR TITLE
feat(workflows): auto save recipient preferences

### DIFF
--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -90,7 +90,7 @@
                     const formData = new FormData()
                     formData.append('token', document.querySelector('input[name="token"]').value)
                     toggles.forEach((toggle) => {
-                        formData.append('preferences[]', toggle.name + ':' + toggle.checked)
+                        formData.append('preferences[]', `${toggle.name}:${toggle.checked}`)
                     })
 
                     try {

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -60,7 +60,7 @@
             document.addEventListener('DOMContentLoaded', function () {
                 const toggles = document.querySelectorAll('.toggle-checkbox')
 
-                function setStatusLabel(toggle, text, colorClass) {
+                function updateStatusLabel(toggle, text, colorClass) {
                     const statusLabel = document.querySelector('[data-status-for="' + toggle.name + '"]')
                     if (!statusLabel) return
                     statusLabel.textContent = text
@@ -85,7 +85,7 @@
                 }
 
                 async function savePreferences(changedToggle) {
-                    setStatusLabel(changedToggle, 'Saving…', 'text-amber-600')
+                    updateStatusLabel(changedToggle, 'Saving…', 'text-amber-600')
 
                     const formData = new FormData()
                     formData.append('token', document.querySelector('input[name="token"]').value)
@@ -108,12 +108,12 @@
                         }
 
                         toggles.forEach(t => { t.defaultChecked = t.checked })
-                        setStatusLabel(changedToggle, changedToggle.checked ? 'Subscribed' : 'Not subscribed', changedToggle.checked ? 'text-green-700' : 'text-gray-500')
+                        updateStatusLabel(changedToggle, changedToggle.checked ? 'Subscribed' : 'Not subscribed', changedToggle.checked ? 'text-green-700' : 'text-gray-500')
                         showToast('Preferences updated successfully', false)
                     } catch (error) {
                         // Revert the toggle on failure
                         changedToggle.checked = !changedToggle.checked
-                        setStatusLabel(changedToggle, changedToggle.checked ? 'Subscribed' : 'Not subscribed', changedToggle.checked ? 'text-green-700' : 'text-gray-500')
+                        updateStatusLabel(changedToggle, changedToggle.checked ? 'Subscribed' : 'Not subscribed', changedToggle.checked ? 'text-green-700' : 'text-gray-500')
                         showToast(error.message || 'Failed to update preferences', true)
                     }
                 }

--- a/posthog/templates/message_preferences/preferences.html
+++ b/posthog/templates/message_preferences/preferences.html
@@ -12,13 +12,16 @@
             <div class="max-w-2xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
                 <div class="bg-white shadow-xl rounded-xl p-8 mb-12">
                     <h1 class="text-2xl font-bold text-gray-900 mb-2">Message preferences for {{ recipient.identifier|escape }}</h1>
-                    <p class="text-gray-600 text-base mb-8">Choose which emails you'd like to receive. Changes are only applied when you click Save preferences.</p>
+                    <p class="text-gray-600 text-base mb-8">Choose which emails you'd like to receive. Changes are saved automatically.</p>
 
                     <form id="preferences-form" class="space-y-6">
                         {% csrf_token %}
                         <input type="hidden" name="token" value="{{ token }}" />
 
                         {% for category in categories %}
+                        {% if forloop.last %}
+                        <hr class="border-gray-200" />
+                        {% endif %}
                         <div class="bg-gray-50 rounded-lg p-6 transition-all duration-200 hover:shadow-md">
                             <div class="flex items-start justify-between gap-4">
                                 <div class="flex-1 min-w-0">
@@ -47,81 +50,47 @@
                         </div>
                         {% endfor %}
 
-                        <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
-                            <div class="max-w-2xl mx-auto p-4">
-                            <p id="unsaved-hint" class="hidden text-sm text-amber-600 font-medium mb-2 text-center">You have unsaved changes</p>
-                            <button
-                                id="save-btn"
-                                type="submit"
-                                disabled
-                                class="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-default transition duration-150 ease-in-out"
-                            >
-                                Save preferences
-                            </button>
-                            </div>
-                        </div>
                     </form>
 
-                    <div id="success-message" class="hidden mt-4 p-4 rounded-md bg-green-50 text-green-700">
-                        <p class="text-sm font-medium">Your preferences have been updated successfully!</p>
-                    </div>
-
-                    <div id="error-message" class="hidden mt-4 p-4 rounded-md bg-red-50 text-red-700">
-                        <p class="text-sm font-medium">
-                            There was an error updating your preferences. Please try again.
-                        </p>
-                    </div>
                 </div>
             </div>
         </div>
 
         <script nonce="{{ request.csp_nonce }}">
             document.addEventListener('DOMContentLoaded', function () {
-                const form = document.getElementById('preferences-form')
                 const toggles = document.querySelectorAll('.toggle-checkbox')
 
-                function updateStatusLabel(toggle) {
+                function setStatusLabel(toggle, text, colorClass) {
                     const statusLabel = document.querySelector('[data-status-for="' + toggle.name + '"]')
                     if (!statusLabel) return
-                    const isChanged = toggle.checked !== toggle.defaultChecked
-                    if (isChanged) {
-                        statusLabel.textContent = toggle.checked ? 'Will subscribe' : 'Will unsubscribe'
-                        statusLabel.className = 'text-xs font-medium mt-1 text-right text-amber-600'
-                    } else {
-                        statusLabel.textContent = toggle.checked ? 'Subscribed' : 'Not subscribed'
-                        statusLabel.className = 'text-xs font-medium mt-1 text-right ' + (toggle.checked ? 'text-green-700' : 'text-gray-500')
-                    }
+                    statusLabel.textContent = text
+                    statusLabel.className = 'text-xs font-medium mt-1 text-right ' + colorClass
                 }
 
-                toggles.forEach((toggle) => {
-                    toggle.addEventListener('change', function () {
-                        const card = this.closest('.bg-gray-50')
-                        card.style.transform = 'scale(1.02)'
-                        setTimeout(() => {
-                            card.style.transform = 'scale(1)'
-                        }, 200)
+                function showToast(message, isError) {
+                    const toast = document.createElement('div')
+                    toast.className =
+                        'fixed top-4 right-4 ' + (isError ? 'bg-red-500' : 'bg-green-500') + ' text-white px-6 py-4 rounded-lg shadow-xl transform transition-all duration-500 ease-out'
+                    const iconPath = isError
+                        ? 'M6 18L18 6M6 6l12 12'
+                        : 'M5 13l4 4L19 7'
+                    toast.innerHTML = '<div class="flex items-center space-x-2"><svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="' + iconPath + '"/></svg><span class="font-medium">' + message + '</span></div>'
+                    document.body.appendChild(toast)
+                    toast.style.transform = 'translateX(100%)'
+                    requestAnimationFrame(() => { toast.style.transform = 'translateX(0)' })
+                    setTimeout(() => {
+                        toast.style.transform = 'translateX(100%)'
+                        setTimeout(() => toast.remove(), 500)
+                    }, 2500)
+                }
 
-                        // Update status label: show pending state if changed, saved state if reverted
-                        updateStatusLabel(this)
-
-                        // Show/hide unsaved hint and enable/disable save button
-                        const anyChanged = Array.from(toggles).some(t => t.checked !== t.defaultChecked)
-                        document.getElementById('unsaved-hint').classList.toggle('hidden', !anyChanged)
-                        document.getElementById('save-btn').disabled = !anyChanged
-                    })
-                })
-
-                form.addEventListener('submit', async function (e) {
-                    e.preventDefault()
-                    const submitButton = form.querySelector('button[type="submit"]')
-                    submitButton.disabled = true
+                async function savePreferences(changedToggle) {
+                    setStatusLabel(changedToggle, 'Saving…', 'text-amber-600')
 
                     const formData = new FormData()
                     formData.append('token', document.querySelector('input[name="token"]').value)
-
-                    // Add all toggle states to formData using the full category key
                     toggles.forEach((toggle) => {
-                        formData.append('preferences[]', `${toggle.name}:${toggle.checked}`)
+                        formData.append('preferences[]', toggle.name + ':' + toggle.checked)
                     })
 
                     try {
@@ -138,68 +107,25 @@
                             throw new Error(data.error)
                         }
 
-                        // Update saved state and resolve all labels
-                        toggles.forEach(t => {
-                            t.defaultChecked = t.checked
-                            updateStatusLabel(t)
-                        })
-                        document.getElementById('unsaved-hint').classList.add('hidden')
-                        document.getElementById('save-btn').disabled = true
-
-                        // Enhanced success message
-                        const successMsg = document.createElement('div')
-                        successMsg.className =
-                            'fixed top-4 right-4 bg-green-500 text-white px-6 py-4 rounded-lg shadow-xl transform transition-all duration-500 ease-out'
-                        successMsg.innerHTML = `
-                <div class="flex items-center space-x-2">
-                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                    </svg>
-                    <span class="font-medium">Preferences updated successfully</span>
-                </div>
-            `
-                        document.body.appendChild(successMsg)
-
-                        // Animate in
-                        successMsg.style.transform = 'translateX(100%)'
-                        requestAnimationFrame(() => {
-                            successMsg.style.transform = 'translateX(0)'
-                        })
-
-                        // Animate out
-                        setTimeout(() => {
-                            successMsg.style.transform = 'translateX(100%)'
-                            setTimeout(() => successMsg.remove(), 500)
-                        }, 2500)
+                        toggles.forEach(t => { t.defaultChecked = t.checked })
+                        setStatusLabel(changedToggle, changedToggle.checked ? 'Subscribed' : 'Not subscribed', changedToggle.checked ? 'text-green-700' : 'text-gray-500')
+                        showToast('Preferences updated successfully', false)
                     } catch (error) {
-                        // Enhanced error message
-                        const errorMsg = document.createElement('div')
-                        errorMsg.className =
-                            'fixed top-4 right-4 bg-red-500 text-white px-6 py-4 rounded-lg shadow-xl transform transition-all duration-500 ease-out'
-                        errorMsg.innerHTML = `
-                <div class="flex items-center space-x-2">
-                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                    </svg>
-                    <span class="font-medium">${error.message || 'Failed to update preferences'}</span>
-                </div>
-            `
-                        document.body.appendChild(errorMsg)
-
-                        // Animate in
-                        errorMsg.style.transform = 'translateX(100%)'
-                        requestAnimationFrame(() => {
-                            errorMsg.style.transform = 'translateX(0)'
-                        })
-
-                        // Animate out
-                        setTimeout(() => {
-                            errorMsg.style.transform = 'translateX(100%)'
-                            setTimeout(() => errorMsg.remove(), 500)
-                        }, 2500)
-
-                        submitButton.disabled = false
+                        // Revert the toggle on failure
+                        changedToggle.checked = !changedToggle.checked
+                        setStatusLabel(changedToggle, changedToggle.checked ? 'Subscribed' : 'Not subscribed', changedToggle.checked ? 'text-green-700' : 'text-gray-500')
+                        showToast(error.message || 'Failed to update preferences', true)
                     }
+                }
+
+                toggles.forEach((toggle) => {
+                    toggle.addEventListener('change', function () {
+                        const card = this.closest('.bg-gray-50')
+                        card.style.transform = 'scale(1.02)'
+                        setTimeout(() => { card.style.transform = 'scale(1)' }, 200)
+
+                        savePreferences(this)
+                    })
                 })
             })
         </script>

--- a/products/workflows/frontend/OptOuts/OptOutCategories.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutCategories.tsx
@@ -114,7 +114,7 @@ export function OptOutCategories(): JSX.Element {
                             )}
                         </div>
                         <div>
-                            <h4 className="font-medium mb-2">Opt-out list</h4>
+                            <h4 className="font-medium mb-4">Opt-out list</h4>
                             {category.category_type === 'marketing' ? (
                                 <OptOutList category={category} />
                             ) : (

--- a/products/workflows/frontend/OptOuts/OptOutList.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutList.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronLeft, IconChevronRight, IconExternal } from '@posthog/icons'
+import { IconChevronLeft, IconChevronRight, IconExternal, IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonModal, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
@@ -14,7 +14,8 @@ import { OptOutEntry, optOutListLogic } from './optOutListLogic'
 
 export function OptOutList({ category }: { category?: MessageCategory }): JSX.Element {
     const logic = optOutListLogic({ category })
-    const { setSelectedIdentifier, openPreferencesPage, loadNextPage, loadPreviousPage } = useActions(logic)
+    const { setSelectedIdentifier, openPreferencesPage, loadNextPage, loadPreviousPage, loadOptOutPersons } =
+        useActions(logic)
     const { selectedIdentifier, optOutPersons, optOutPersonsLoading, preferencesUrlLoading, currentPage } =
         useValues(logic)
 
@@ -83,6 +84,17 @@ export function OptOutList({ category }: { category?: MessageCategory }): JSX.El
 
     return (
         <>
+            <div className="flex justify-end mb-2 mt-[-3rem]">
+                <LemonButton
+                    icon={<IconRefresh />}
+                    size="small"
+                    type="secondary"
+                    onClick={loadOptOutPersons}
+                    loading={optOutPersonsLoading}
+                >
+                    Reload
+                </LemonButton>
+            </div>
             <div className="max-h-64 overflow-y-auto">
                 <LemonTable
                     columns={columns}

--- a/products/workflows/frontend/OptOuts/OptOutScene.tsx
+++ b/products/workflows/frontend/OptOuts/OptOutScene.tsx
@@ -55,7 +55,7 @@ export function OptOutScene(): JSX.Element {
 
             <div>
                 <h2 className="text-xl font-semibold">Marketing opt-out list</h2>
-                <p className="mt-6">Message recipients who have opted out of all marketing messages</p>
+                <p className="mt-2">Message recipients who have opted out of all marketing messages</p>
                 <OptOutList />
             </div>
 


### PR DESCRIPTION
## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/52920 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55766)

The subscription preferences page is still a bit too involved without reading closely

## Changes

- Make subscription preferences save as soon as a switch is flipped on / off
- Add a horizontal separator to the "All marketing communications" section
<img width="656" height="493" alt="Screenshot 2026-03-19 at 2 40 19 PM" src="https://github.com/user-attachments/assets/e0952770-a9ec-42c8-819b-38eb45fbe6eb" />
- Add reload buttons to the opt out lists

## How did you test this code?


https://github.com/user-attachments/assets/ea165cf4-0435-42fb-a72f-dcd8165c94f2



## Publish to changelog?

No