### PR TITLE
fix(dashboard): fixes a paper cut with dashboard for refresh interval and AI Icon

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
+++ b/frontend/src/scenes/dashboard/DashboardReloadAction.tsx
@@ -14,6 +14,7 @@ import { usePageVisibilityCb } from 'lib/hooks/usePageVisibility'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { humanFriendlyDuration } from 'lib/utils'
+import { cn } from 'lib/utils/css-classes'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { Scene } from 'scenes/sceneTypes'
 
@@ -197,7 +198,10 @@ export function DashboardReloadAction(): JSX.Element {
                     {!itemsLoading && dashboardAIRefreshEnabled && (
                         <Tooltip title="Refresh and analyze with AI">
                             <button
-                                className="absolute -top-2 -right-2 z-10 flex items-center justify-center w-5 h-5 rounded-full bg-bg-light border border-border cursor-pointer p-0 hover:[&>svg]:animate-hue-rotate"
+                                className={cn(
+                                    'absolute z-10 flex items-center justify-center w-5 h-5 rounded-full bg-bg-light border border-border cursor-pointer p-0 hover:[&>svg]:animate-hue-rotate',
+                                    autoRefresh.enabled ? '-bottom-2 -right-2' : '-top-2 -right-2'
+                                )}
                                 onClick={(e) => {
                                     e.stopPropagation()
                                     triggerDashboardRefresh({ withAnalysis: true })


### PR DESCRIPTION
## Problem

<img width="654" height="194" alt="CleanShot 2026-03-19 at 16 34 01@2x" src="https://github.com/user-attachments/assets/07725479-1d39-4fe5-9431-e142fec6f985" />

## Changes

<img width="444" height="144" alt="CleanShot 2026-03-19 at 16 29 39@2x" src="https://github.com/user-attachments/assets/624f15eb-c877-458d-944a-9300aefe0a95" />

## How did you test this code?

Locally.

## Publish to changelog?

No.