### PR TITLE
fix(hogql): percentile_cont in duckdb

### DIFF
--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -40,6 +40,9 @@ class PostgresPrinter(HogQLPrinter):
         return self.visit(node.type)
 
     def visit_call(self, node: ast.Call):
+        if node.name.lower() in {"percentile_cont", "percentile_disc"}:
+            return super().visit_call(node)
+
         if node.name in {
             "toStartOfSecond",
             "toStartOfMinute",
@@ -84,9 +87,7 @@ class PostgresPrinter(HogQLPrinter):
         if func_name in POSTGRES_PASSTHROUGH_FUNCTIONS:
             return f"{func_name}({', '.join(args)})"
 
-        raise QueryError(
-            f"Function '{node.name}' is not supported in the Postgres dialect. It may only be available in ClickHouse."
-        )
+        raise QueryError(f"Function '{node.name}' is not supported in the Postgres dialect.")
 
     def _visit_to_start_of_call(self, node: ast.Call) -> str:
         if len(node.args) == 0:

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4460,6 +4460,13 @@ class TestPostgresPrinter(BaseTest):
         self.assertNotIn("lagInFrame", printed)
         self.assertNotIn("ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING", printed)
 
+    @parameterized.expand([["percentile_cont"], ["percentile_disc"]])
+    def test_percentile_within_group_renders_in_postgres(self, function_name: str):
+        self.assertEqual(
+            self._expr(f"{function_name}(0.5) within group (order by timestamp desc)"),
+            f"{function_name}(0.5) WITHIN GROUP (ORDER BY events.timestamp DESC)",
+        )
+
     def test_in_operations_render_value_lists(self):
         self.assertEqual(self._expr("1 in (1, 2, 3)"), "(1 IN (1, 2, 3))")
         self.assertEqual(self._expr("1 in (1)"), "(1 IN (1))")
@@ -4842,6 +4849,7 @@ class TestPostgresPrinter(BaseTest):
         with self.assertRaises(QueryError) as ctx:
             self._expr(expr)
         self.assertIn("not supported in the Postgres dialect", str(ctx.exception))
+        self.assertNotIn("ClickHouse", str(ctx.exception))
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

PR https://github.com/PostHog/posthog/pull/51660 added "within group" support to HogQL, but missed one thing.

We now get these errors:

- in clickhouse: Aggregation 'percentile_cont' with WITHIN GROUP is not supported in ClickHouse dialect
- in postgres: Function 'percentile_cont' is not supported in the Postgres dialect. It may only be available in ClickHouse.

## Changes

No more error in postgres/duckdb

## How did you test this code?

Clicked in the UI locally, changed a test

## Publish to changelog?

no

## Docs update

no