### PR TITLE
chore: hide Hog and Web Analytics insight types from filter

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -616,7 +616,7 @@ export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = 
         name: 'Hog',
         description: 'Use Hog to query your data.',
         icon: IconHogQL,
-        inMenu: true,
+        inMenu: false,
     },
     [InsightType.WEB_ANALYTICS]: {
         name: 'Web Analytics',
@@ -628,11 +628,13 @@ export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = 
 
 export const INSIGHT_TYPE_OPTIONS: LemonSelectOptions<string> = [
     { value: 'All types', label: 'All types' },
-    ...Object.entries(INSIGHT_TYPES_METADATA).map(([value, meta]) => ({
-        value,
-        label: meta.name,
-        icon: meta.icon ? <meta.icon /> : undefined,
-    })),
+    ...Object.entries(INSIGHT_TYPES_METADATA)
+        .filter(([, meta]) => meta.inMenu !== false)
+        .map(([value, meta]) => ({
+            value,
+            label: meta.name,
+            icon: meta.icon ? <meta.icon /> : undefined,
+        })),
 ]
 
 export const scene: SceneExport = {


### PR DESCRIPTION
## Problem

The Hog insight type should not be displayed in the insight type selection menu.

## Changes

- Set `inMenu: false` for the Hog insight type in `INSIGHT_TYPES_METADATA`
- Updated `INSIGHT_TYPE_OPTIONS` to filter out insight types where `inMenu` is explicitly set to `false`

This ensures that while the Hog insight type remains defined in the metadata, it won't appear as an option when users are selecting insight types.

## How did you test this code?

The change is straightforward configuration and filtering logic. The filter condition `meta.inMenu !== false` will exclude any insight types with `inMenu: false` from the dropdown options while maintaining backward compatibility with existing insight types that don't have this property explicitly set.

## Publish to changelog?

no

https://claude.ai/code/session_01MxdUCWUPgiUkkCCvxxmYxb