### PR TITLE
fix(frontend): Add fallback to `@current` removal from api calls

### DIFF
--- a/frontend/src/scenes/organizationLogic.test.ts
+++ b/frontend/src/scenes/organizationLogic.test.ts
@@ -32,14 +32,14 @@ describe('organizationLogic', () => {
         })
     })
 
-    describe('currentOrganizationId throws before load', () => {
-        it('throws when currentOrganization is null', () => {
+    describe('currentOrganizationId before load', () => {
+        it('returns @current fallback when currentOrganization is null', () => {
             // Clear the user/organization context so currentOrganization starts as null
             window.POSTHOG_APP_CONTEXT = { current_user: null } as unknown as AppContext
             initKeaTests(false)
             logic = organizationLogic()
             logic.mount()
-            expect(() => logic.values.currentOrganizationId).toThrow('accessed before')
+            expect(logic.values.currentOrganizationId).toBe('@current')
         })
     })
 

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -1,6 +1,7 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 
 import api, { ApiConfig, ApiError } from 'lib/api'
 import { timeSensitiveAuthenticationLogic } from 'lib/components/TimeSensitiveAuthentication/timeSensitiveAuthenticationLogic'
@@ -113,7 +114,13 @@ export const organizationLogic = kea<organizationLogicType>([
             (s) => [s.currentOrganization],
             (currentOrganization): string => {
                 if (!currentOrganization || !currentOrganization.id) {
-                    throw new Error('currentOrganizationId accessed before organization loaded')
+                    // TODO: Fix callers that access currentOrganizationId before the organization is loaded,
+                    // then restore the throw. Temporarily falling back to "@current" to avoid crashes.
+                    posthog.captureException(new Error('currentOrganizationId accessed before organization loaded'), {
+                        severity: 'warning',
+                        tag: 'selector_accessed_before_loaded',
+                    })
+                    return '@current'
                 }
                 return currentOrganization.id
             },

--- a/frontend/src/scenes/teamLogic.test.ts
+++ b/frontend/src/scenes/teamLogic.test.ts
@@ -40,12 +40,12 @@ describe('teamLogic', () => {
             logic.mount()
         })
 
-        it('currentTeamIdStrict throws', () => {
-            expect(() => logic.values.currentTeamIdStrict).toThrow('accessed before')
+        it('currentTeamIdStrict returns @current fallback', () => {
+            expect(logic.values.currentTeamIdStrict).toBe('@current')
         })
 
-        it('currentProjectId throws', () => {
-            expect(() => logic.values.currentProjectId).toThrow('accessed before')
+        it('currentProjectId returns @current fallback', () => {
+            expect(logic.values.currentProjectId).toBe('@current')
         })
 
         it('currentTeamId returns null (non-breaking)', () => {

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -1,5 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api, { ApiConfig } from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
@@ -264,18 +265,30 @@ export const teamLogic = kea<teamLogicType>([
         // currentTeamId and so that currentTeamIdStrict can be removed.
         currentTeamIdStrict: [
             (selectors) => [selectors.currentTeam],
-            (currentTeam): number => {
+            (currentTeam): number | string => {
                 if (!currentTeam || !currentTeam.id) {
-                    throw new Error('currentTeamId accessed before team loaded')
+                    // TODO: Fix callers that access currentTeamIdStrict before the team is loaded,
+                    // then restore the throw. Temporarily falling back to "@current" to avoid crashes.
+                    posthog.captureException(new Error('currentTeamId accessed before team loaded'), {
+                        severity: 'warning',
+                        tag: 'selector_accessed_before_loaded',
+                    })
+                    return '@current'
                 }
                 return currentTeam.id
             },
         ],
         currentProjectId: [
             (selectors) => [selectors.currentTeam],
-            (currentTeam): number => {
+            (currentTeam): number | string => {
                 if (!currentTeam || !currentTeam.project_id) {
-                    throw new Error('currentProjectId accessed before team loaded')
+                    // TODO: Fix callers that access currentProjectId before the team is loaded,
+                    // then restore the throw. Temporarily falling back to "@current" to avoid crashes.
+                    posthog.captureException(new Error('currentProjectId accessed before team loaded'), {
+                        severity: 'warning',
+                        tag: 'selector_accessed_before_loaded',
+                    })
+                    return '@current'
                 }
                 return currentTeam.project_id
             },


### PR DESCRIPTION
## Problem

We removed `@current` from API calls in https://github.com/PostHog/posthog/pull/51622 and https://github.com/PostHog/posthog/pull/51110. Even though we paid attention to keeping `@current` in the initial loaders and toolbar, there are a few exceptions thrown meaning there are further cases where the acessors are not yet loaded.

This PR introduces a graceful fallback until remaining cases are cleaned up as well

## Changes

- Fallback to `@current` (previous implicit behavior), but only in case the state is not accessible
- Keep tracking such cases for future debugging just without crash

## How did you test this code?

Hard to test since existing test cases did not catch those cases in the first place and we need to track down the root cause of remaining crashes first.

The current behavior is a hard crash, this PR introduces a more graceful behavior. And the fallback is to `@current` which was the previous behavior.

## Publish to changelog?

No