### PR TITLE
fix(insights): hide Hog and Web Analytics insight types from menu

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -616,7 +616,7 @@ export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = 
         name: 'Hog',
         description: 'Use Hog to query your data.',
         icon: IconHogQL,
-        inMenu: true,
+        inMenu: false,
     },
     [InsightType.WEB_ANALYTICS]: {
         name: 'Web Analytics',
@@ -628,11 +628,13 @@ export const INSIGHT_TYPES_METADATA: Record<InsightType, InsightTypeMetadata> = 
 
 export const INSIGHT_TYPE_OPTIONS: LemonSelectOptions<string> = [
     { value: 'All types', label: 'All types' },
-    ...Object.entries(INSIGHT_TYPES_METADATA).map(([value, meta]) => ({
-        value,
-        label: meta.name,
-        icon: meta.icon ? <meta.icon /> : undefined,
-    })),
+    ...Object.entries(INSIGHT_TYPES_METADATA)
+        .filter(([, meta]) => meta.inMenu !== false)
+        .map(([value, meta]) => ({
+            value,
+            label: meta.name,
+            icon: meta.icon ? <meta.icon /> : undefined,
+        })),
 ]
 
 export const scene: SceneExport = {


### PR DESCRIPTION
## Problem

The Hog insight type should not be displayed in the insight type selection menu.

## Changes

- Set `inMenu: false` for the Hog insight type in `INSIGHT_TYPES_METADATA`
- Updated `INSIGHT_TYPE_OPTIONS` to filter out insight types where `inMenu` is explicitly set to `false`

## How did you test this code?

Just reusing what we already use for the new button