### PR TITLE
feat(slack): Unfurl insight/dashboard links

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -46,11 +46,13 @@ from posthog.temporal.common.client import sync_connect
 from posthog.user_permissions import UserPermissions
 from posthog.utils import get_instance_region
 
+from products.slack_app.backend.slack_link_unfurl import handle_posthog_link_unfurl
+
 from ee.models.assistant import Conversation
 
 logger = structlog.get_logger(__name__)
 
-HANDLED_EVENT_TYPES = ["app_mention"]
+HANDLED_EVENT_TYPES = ["app_mention", "link_shared"]
 
 ROUTE_HANDLED_LOCALLY = "handled_locally"
 ROUTE_PROXIED = "proxied"
@@ -206,9 +208,15 @@ def _post_slack_user_feedback(
 
 
 def resolve_slack_user(
-    slack: SlackIntegration, integration: Integration, slack_user_id: str, channel: str, thread_ts: str
+    slack: SlackIntegration,
+    integration: Integration,
+    slack_user_id: str,
+    channel: str,
+    thread_ts: str,
+    *,
+    post_feedback: bool = True,
 ) -> SlackUserContext | None:
-    """Resolve a Slack user to a PostHog user. Posts an ephemeral error message and returns None on failure."""
+    """Resolve a Slack user to a PostHog user. Posts an ephemeral error message and returns None on failure (unless post_feedback is False)."""
     try:
         slack_user_info = _get_slack_user_info(slack, integration, slack_user_id)
         slack_email = slack_user_info.get("user", {}).get("profile", {}).get("email")
@@ -225,18 +233,19 @@ def resolve_slack_user(
 
         if not slack_email:
             logger.exception("slack_app_no_user_email", slack_user_id=slack_user_id)
-            _post_slack_user_feedback(
-                slack,
-                channel,
-                slack_user_id,
-                thread_ts,
-                (
-                    "Sorry, I couldn't find your email address in Slack. "
-                    "Please make sure your email is visible in your Slack profile, "
-                    "and contact the PostHog team if the issue persists."
-                ),
-                prefer_thread_message=True,
-            )
+            if post_feedback:
+                _post_slack_user_feedback(
+                    slack,
+                    channel,
+                    slack_user_id,
+                    thread_ts,
+                    (
+                        "Sorry, I couldn't find your email address in Slack. "
+                        "Please make sure your email is visible in your Slack profile, "
+                        "and contact the PostHog team if the issue persists."
+                    ),
+                    prefer_thread_message=True,
+                )
             return None
 
         if get_instance_region() == "DEV":
@@ -256,16 +265,17 @@ def resolve_slack_user(
         )
         if not membership or not membership.user:
             organization_name = integration.team.organization.name
-            _post_slack_user_feedback(
-                slack,
-                channel,
-                slack_user_id,
-                thread_ts,
-                (
-                    f"Sorry, I couldn't find {slack_email} in the {organization_name} organization. "
-                    f"Please make sure you're a member of that PostHog organization."
-                ),
-            )
+            if post_feedback:
+                _post_slack_user_feedback(
+                    slack,
+                    channel,
+                    slack_user_id,
+                    thread_ts,
+                    (
+                        f"Sorry, I couldn't find {slack_email} in the {organization_name} organization. "
+                        f"Please make sure you're a member of that PostHog organization."
+                    ),
+                )
             return None
 
         posthog_user = membership.user
@@ -278,28 +288,30 @@ def resolve_slack_user(
                 team_id=integration.team_id,
                 organization_id=integration.team.organization_id,
             )
-            _post_slack_user_feedback(
-                slack,
-                channel,
-                slack_user_id,
-                thread_ts,
-                (
-                    "Sorry, you don't have access to the PostHog project connected to this Slack workspace. "
-                    "Please ask an admin of your PostHog organization to grant you access."
-                ),
-            )
+            if post_feedback:
+                _post_slack_user_feedback(
+                    slack,
+                    channel,
+                    slack_user_id,
+                    thread_ts,
+                    (
+                        "Sorry, you don't have access to the PostHog project connected to this Slack workspace. "
+                        "Please ask an admin of your PostHog organization to grant you access."
+                    ),
+                )
             return None
 
         return SlackUserContext(user=posthog_user, slack_email=slack_email)
     except Exception as e:
         logger.exception("slack_app_user_lookup_failed", error=str(e))
-        _post_slack_user_feedback(
-            slack,
-            channel,
-            slack_user_id,
-            thread_ts,
-            "Sorry, I encountered an error looking up your user account. Please try again later.",
-        )
+        if post_feedback:
+            _post_slack_user_feedback(
+                slack,
+                channel,
+                slack_user_id,
+                thread_ts,
+                "Sorry, I encountered an error looking up your user account. Please try again later.",
+            )
         return None
 
 
@@ -336,6 +348,8 @@ def route_slack_event_to_relevant_region(request: HttpRequest, event: dict, slac
         # We're in the right region
         if event.get("type") == "app_mention":
             handle_app_mention(event, integration)
+        elif event.get("type") == "link_shared":
+            handle_posthog_link_unfurl(event, integration)
     elif request.get_host() == SLACK_PRIMARY_REGION_DOMAIN:
         # We aren't in the right region OR the Slack workspace is not connected to any PostHog project in ANY region
         # OR we're in dev and the request hasn't been proxied once yet
@@ -606,7 +620,9 @@ def slack_event_handler(request: HttpRequest) -> HttpResponse:
 
     This endpoint handles:
     - URL verification challenges from Slack
-    - Event callbacks (app_mention, etc.)
+    - Event callbacks (app_mention, link_shared for PostHog insight/dashboard unfurls, etc.)
+
+    The Slack app must subscribe to `link_shared` and register PostHog app domains for unfurling.
     """
     if request.method != "POST":
         return HttpResponse(status=405)

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -1,0 +1,252 @@
+"""Slack link unfurling for PostHog insight and dashboard URLs (metadata only)."""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import urlparse
+
+import structlog
+
+from posthog.models import Dashboard, Insight
+from posthog.models.integration import Integration, SlackIntegration
+from posthog.rbac.user_access_control import UserAccessControl, access_level_satisfied_for_resource
+
+logger = structlog.get_logger(__name__)
+
+_MAX_DESCRIPTION_CHARS = 2800
+
+# Query `source.kind` / top-level `kind` → short name before " insight" (sync with InsightType / query kinds).
+_QUERY_KIND_TO_SHORT_NAME: dict[str, str] = {
+    "TrendsQuery": "Trends",
+    "FunnelsQuery": "Funnel",
+    "FunnelCorrelationQuery": "Funnel correlation",
+    "RetentionQuery": "Retention",
+    "PathsQuery": "Paths",
+    "StickinessQuery": "Stickiness",
+    "LifecycleQuery": "Lifecycle",
+    "WebStatsTableQuery": "Web analytics",
+    "WebOverviewQuery": "Web analytics",
+    "HogQLQuery": "SQL",
+    "HogQuery": "Hog",
+}
+
+# Legacy `filters.insight` string (see InsightType in frontend).
+_LEGACY_FILTER_INSIGHT_TO_SHORT_NAME: dict[str, str] = {
+    "TRENDS": "Trends",
+    "STICKINESS": "Stickiness",
+    "LIFECYCLE": "Lifecycle",
+    "FUNNELS": "Funnel",
+    "PATHS": "Paths",
+    "RETENTION": "Retention",
+    "JSON": "JSON",
+    "SQL": "SQL",
+    "HOG": "Hog",
+    "WEB_ANALYTICS": "Web analytics",
+    "SESSIONS": "Sessions",
+}
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def parse_posthog_resource_link(url: str) -> tuple[Literal["insight", "dashboard"], str | int] | None:
+    """
+    Parse a PostHog app URL into (resource kind, reference id).
+
+    Reference is insight short_id (str) or dashboard primary key (int).
+
+    If the path includes `/project/:id`, that segment is ignored — lookup is always scoped to the
+    Slack-connected project and the resolved PostHog user, not to any project id in the URL.
+
+    Related: `removeProjectIdIfPresent` + `urlToResource` (`router-utils.ts`, `urls.ts`); legacy paths in `get_target_queryset` (`middleware.py`).
+    """
+    parsed = urlparse(url)
+    parts = [p for p in parsed.path.split("/") if p]
+    if not parts:
+        return None
+
+    idx = 0
+    if len(parts) >= 2 and parts[0] == "project":
+        # Skip project/{anything} — do not use for authorization (see handle_posthog_link_unfurl).
+        idx = 2
+
+    if len(parts) > idx and parts[idx] == "i" and len(parts) > idx + 1:
+        short_id = parts[idx + 1]
+        if short_id == "new":
+            return None
+        return ("insight", short_id)
+
+    if len(parts) > idx and parts[idx] == "insights" and len(parts) > idx + 1:
+        short_id = parts[idx + 1]
+        if short_id in ("new", "options"):
+            return None
+        return ("insight", short_id)
+
+    if len(parts) > idx and parts[idx] == "dashboard" and len(parts) > idx + 1:
+        try:
+            dashboard_id = int(parts[idx + 1])
+        except ValueError:
+            return None
+        return ("dashboard", dashboard_id)
+
+    return None
+
+
+def _extract_query_source_kind(query: dict) -> str | None:
+    """Return the inner query kind (e.g. TrendsQuery, HogQLQuery) for labeling; no DB access."""
+    kind = query.get("kind")
+    if not isinstance(kind, str):
+        return None
+
+    source = query.get("source")
+    source = source if isinstance(source, dict) else None
+
+    if kind == "InsightVizNode" and source:
+        return source.get("kind") if isinstance(source.get("kind"), str) else None
+
+    if kind in ("DataVisualizationNode", "DataTableNode") and source:
+        sk = source.get("kind")
+        if sk == "HogQLQuery":
+            return "HogQLQuery"
+        if sk == "InsightVizNode":
+            nested = source.get("source")
+            if isinstance(nested, dict) and isinstance(nested.get("kind"), str):
+                return nested.get("kind")
+        if isinstance(sk, str):
+            return sk
+
+    if kind == "HogQLQuery":
+        return "HogQLQuery"
+    if kind == "HogQuery":
+        return "HogQuery"
+
+    if kind in _QUERY_KIND_TO_SHORT_NAME:
+        return kind
+
+    return None
+
+
+def _insight_resource_label(insight: Insight) -> str:
+    """e.g. 'Trends insight', 'SQL insight' — from query JSON or legacy filters only (no execution)."""
+    q = insight.query
+    if isinstance(q, dict) and q:
+        inner = _extract_query_source_kind(q)
+        if inner:
+            short = _QUERY_KIND_TO_SHORT_NAME.get(inner)
+            if short:
+                return f"{short} insight"
+            if inner.endswith("Query"):
+                return f"{inner[: -len('Query')]} insight"
+            return f"{inner} insight"
+
+    filters = insight.filters if isinstance(insight.filters, dict) else {}
+    legacy = filters.get("insight")
+    if isinstance(legacy, str):
+        short = _LEGACY_FILTER_INSIGHT_TO_SHORT_NAME.get(legacy)
+        if short:
+            return f"{short} insight"
+
+    return "Insight"
+
+
+def _unfurl_payload(*, resource_label: str, title: str, description: str | None) -> dict:
+    title = title or "Untitled"
+    body = f"*{title} • {resource_label}*"
+    if description:
+        body += "\n\n" + _truncate(description.strip(), _MAX_DESCRIPTION_CHARS)
+    return {"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": body}}]}
+
+
+def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
+    """
+    Unfurl PostHog insight/dashboard links with title and description for viewers who may access the resource.
+
+    Scope is always the Slack workspace's connected PostHog project (`integration.team`) and the
+    PostHog user resolved from Slack email — never the `/project/:id` segment in pasted URLs.
+    """
+    slack = SlackIntegration(integration)
+    channel = event.get("channel")
+    message_ts = event.get("message_ts")
+    slack_user_id = event.get("user")
+    unfurl_id = event.get("unfurl_id")
+    source = event.get("source")
+    links = event.get("links") or []
+
+    if not channel or not message_ts or not slack_user_id or not links:
+        logger.info("slack_link_unfurl_skip_missing_fields", has_channel=bool(channel), has_ts=bool(message_ts))
+        return
+
+    # Imported here to avoid circular import with api (api imports this module at load time).
+    from products.slack_app.backend.api import resolve_slack_user
+
+    user_context = resolve_slack_user(
+        slack,
+        integration,
+        slack_user_id,
+        channel,
+        message_ts,
+        post_feedback=False,
+    )
+    if not user_context:
+        return
+
+    user = user_context.user
+    team = integration.team
+    uac = UserAccessControl(user, team=team)
+
+    unfurls: dict[str, dict] = {}
+
+    for link_obj in links:
+        raw_url = link_obj.get("url")
+        if not raw_url:
+            continue
+
+        parsed = parse_posthog_resource_link(raw_url)
+        if not parsed:
+            continue
+
+        kind, ref = parsed
+
+        if kind == "insight":
+            if not isinstance(ref, str):
+                continue
+            insight = Insight.objects.filter(team_id=team.pk, short_id=ref).first()
+            if not insight:
+                continue
+            level = uac.get_user_access_level(insight)
+            if not level or not access_level_satisfied_for_resource("insight", level, "viewer"):
+                continue
+            title = insight.name or insight.derived_name or "Untitled"
+            desc = (insight.description or "").strip() or None
+            unfurls[raw_url] = _unfurl_payload(
+                resource_label=_insight_resource_label(insight), title=title, description=desc
+            )
+        else:
+            if not isinstance(ref, int):
+                continue
+            dashboard = Dashboard.objects.filter(pk=ref, team_id=team.pk).first()
+            if not dashboard:
+                continue
+            level = uac.get_user_access_level(dashboard)
+            if not level or not access_level_satisfied_for_resource("dashboard", level, "viewer"):
+                continue
+            title = dashboard.name or "Untitled"
+            desc = (dashboard.description or "").strip() or None
+            unfurls[raw_url] = _unfurl_payload(resource_label="Dashboard", title=title, description=desc)
+
+    if not unfurls:
+        return
+
+    unfurl_kwargs: dict = {"channel": channel, "ts": message_ts, "unfurls": unfurls}
+    if unfurl_id:
+        unfurl_kwargs["unfurl_id"] = unfurl_id
+    if source:
+        unfurl_kwargs["source"] = source
+
+    try:
+        slack.client.chat_unfurl(**unfurl_kwargs)
+    except Exception:
+        logger.exception("slack_link_unfurl_chat_unfurl_failed", team_id=team.pk)

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -1,0 +1,180 @@
+import pytest
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from posthog.models import Dashboard, Insight
+from posthog.models.integration import Integration
+
+from products.slack_app.backend.slack_link_unfurl import (
+    _insight_resource_label,
+    handle_posthog_link_unfurl,
+    parse_posthog_resource_link,
+)
+
+
+class TestParsePosthogResourceLink:
+    def test_project_insight(self):
+        assert parse_posthog_resource_link("https://us.posthog.com/project/42/insights/abc123") == ("insight", "abc123")
+
+    def test_project_insight_with_subpath(self):
+        assert parse_posthog_resource_link("https://eu.posthog.com/project/42/insights/abc123/edit") == (
+            "insight",
+            "abc123",
+        )
+
+    def test_short_insight_path(self):
+        assert parse_posthog_resource_link("https://app.posthog.com/i/xyz789") == ("insight", "xyz789")
+
+    def test_project_dashboard(self):
+        assert parse_posthog_resource_link("https://us.posthog.com/project/3/dashboard/99") == ("dashboard", 99)
+
+    def test_skips_insight_new(self):
+        assert parse_posthog_resource_link("https://x.com/project/1/insights/new") is None
+
+    def test_unrelated_url(self):
+        assert parse_posthog_resource_link("https://example.com/foo") is None
+
+
+class TestInsightResourceLabel:
+    def test_insight_viz_trends(self):
+        insight = Insight(
+            team_id=1,
+            query={"kind": "InsightVizNode", "source": {"kind": "TrendsQuery"}},
+        )
+        assert _insight_resource_label(insight) == "Trends insight"
+
+    def test_data_viz_sql(self):
+        insight = Insight(
+            team_id=1,
+            query={"kind": "DataVisualizationNode", "source": {"kind": "HogQLQuery", "query": "SELECT 1"}},
+        )
+        assert _insight_resource_label(insight) == "SQL insight"
+
+    def test_legacy_filters(self):
+        insight = Insight(team_id=1, filters={"insight": "FUNNELS"})
+        assert _insight_resource_label(insight) == "Funnel insight"
+
+    def test_fallback(self):
+        insight = Insight(team_id=1)
+        assert _insight_resource_label(insight) == "Insight"
+
+
+@pytest.mark.django_db
+class TestHandlePosthogLinkUnfurl(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id="TSlack01",
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+        self.insight = Insight.objects.create(
+            team=self.team,
+            short_id="insight1",
+            name="Weekly active users",
+            description="A test description",
+            saved=True,
+            query={"kind": "InsightVizNode", "source": {"kind": "TrendsQuery"}},
+        )
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_unfurls_insight_when_user_resolved(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_slack_integration_class.return_value.client = mock_client
+
+        site = "http://testserver"
+        url = f"{site}/project/{self.team.pk}/insights/{self.insight.short_id}"
+
+        handle_posthog_link_unfurl(
+            {
+                "channel": "C1",
+                "message_ts": "123.456",
+                "user": "U1",
+                "links": [{"url": url, "domain": "testserver"}],
+            },
+            self.integration,
+        )
+
+        mock_client.chat_unfurl.assert_called_once()
+        call_kw = mock_client.chat_unfurl.call_args.kwargs
+        assert url in call_kw["unfurls"]
+        text = call_kw["unfurls"][url]["blocks"][0]["text"]["text"]
+        assert "Trends insight" in text
+        assert "Weekly active users" in text
+        assert "A test description" in text
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_skips_when_user_not_resolved(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        mock_resolve.return_value = None
+        mock_client = MagicMock()
+        mock_slack_integration_class.return_value.client = mock_client
+
+        handle_posthog_link_unfurl(
+            {
+                "channel": "C1",
+                "message_ts": "123.456",
+                "user": "U1",
+                "links": [{"url": f"http://testserver/project/{self.team.pk}/insights/{self.insight.short_id}"}],
+            },
+            self.integration,
+        )
+
+        mock_client.chat_unfurl.assert_not_called()
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_unfurls_insight_when_project_segment_mismatched(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        """Project id in the URL is ignored; lookup uses the connected team + short_id only."""
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_slack_integration_class.return_value.client = mock_client
+
+        url = f"http://testserver/project/99999/insights/{self.insight.short_id}"
+        handle_posthog_link_unfurl(
+            {
+                "channel": "C1",
+                "message_ts": "123.456",
+                "user": "U1",
+                "links": [{"url": url}],
+            },
+            self.integration,
+        )
+
+        mock_client.chat_unfurl.assert_called_once()
+        assert url in mock_client.chat_unfurl.call_args.kwargs["unfurls"]
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_unfurls_dashboard(self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock) -> None:
+        dashboard = Dashboard.objects.create(team=self.team, name="Main board", description="Overview")
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_slack_integration_class.return_value.client = mock_client
+
+        site = "http://testserver"
+        url = f"{site}/project/{self.team.pk}/dashboard/{dashboard.pk}"
+
+        handle_posthog_link_unfurl(
+            {
+                "channel": "C1",
+                "message_ts": "123.456",
+                "user": "U1",
+                "links": [{"url": url}],
+            },
+            self.integration,
+        )
+
+        mock_client.chat_unfurl.assert_called_once()
+        text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
+        assert "Dashboard" in text
+        assert "Main board" in text


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Slack app review vol. way-more-than-I'd-like:

They have noted we requested the link unfurling scope, but it doesn't work in the dev region. Well…

> Please can share a video demo of your links unfurling? Since I'm testing in your dev environment, the links specified as unfurls aren't unfurling as they don't match the production ones (https://app.dev.posthog.dev/ vs [posthog.com](http://posthog.com)). I tried testing a few links but none of them unfurled.

Yes, Tim's prototype didn't make it in, while we did request the scope to allow this. Or at least in the near future, has been the idea.

The problem is, Slack guidelines do say there can be no "dead" scopes. But now to _remove_ a scope request in the marketplace submission, we'd have to start the review process anew, which would be annoying to say the least.

## Changes

What seems really simplest: Do the most basic link unfurling, unblocking future more robust efforts AND getting the app approved right away.

Presenting, dashboards and insights:

![CleanShot 2026-03-19 at 22.07.03@2x.png](https://app.graphite.com/user-attachments/assets/40fbde7b-b77d-478d-b20b-f9b8215b9536.png)

No graphs, no results, but it does work and is actually helpful.

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Nope.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->