### PR TITLE
fix(personhog-replica): rm test before acquire

### DIFF
--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -30,7 +30,7 @@ async fn create_storage(config: &Config) -> Arc<PostgresStorage> {
                 max_connections: config.max_pg_connections,
                 acquire_timeout: config.acquire_timeout(),
                 idle_timeout: config.idle_timeout(),
-                test_before_acquire: true,
+                test_before_acquire: false,
                 statement_timeout_ms: config.statement_timeout(),
                 pool_name: Some("primary".to_string()),
             };


### PR DESCRIPTION
## Problem

The `personhog_replica_db_pool_acquire_duration_ms` p99 metric shows a ~5ms baseline with frequent spikes to 30ms+. Every `pool.acquire()` call sends a health-check ping through PgBouncer to Postgres before returning the connection, adding a full network roundtrip to every single query.

With `test_before_acquire: true`, sqlx pings every connection before returning it from the pool. The ~5ms baseline *is* that ping roundtrip through PgBouncer. The 30ms+ spikes are variance in that roundtrip (PgBouncer server-connection reassignment, replica replay pressure, etc.).

Since PgBouncer runs in transaction mode, it reassigns backend Postgres connections between transactions anyway — the client connection (sqlx → PgBouncer) stays alive regardless. The ping isn't protecting against stale connections, it's just adding latency. This is confirmed by pool saturation sitting near 0% and connection churn being flat (connections aren't going stale).

## Changes

Disable `test_before_acquire` on the personhog-replica database pool. This is safe because:

- PgBouncer in transaction mode means the sqlx → PgBouncer connection doesn't silently close
- The personhog-router already has retry logic (max 3 retries with backoff) that handles transient connection errors
- `is_transient_error` in `common/database` classifies IO and connection errors as retryable

Pool acquisition time should drop from ~5ms baseline to near-zero, and the 30ms+ p99 spikes should disappear.

## How did you test this code?

Will monitor personhog-replica post deploy to see if we get the perf gains
