### PR TITLE
chore(devex): add tach boundary check to product lint

### DIFF
--- a/common/hogli/product/checks.py
+++ b/common/hogli/product/checks.py
@@ -197,14 +197,30 @@ class FileFolderConflictsCheck(ProductCheck):
         return CheckResult(lines=["✓ ok"])
 
 
-class TachInterfacesCheck(ProductCheck):
-    label = "tach interfaces"
-    for_lenient = False
+class TachCheck(ProductCheck):
+    label = "tach boundaries"
+
+    def _has_python_files(self, product_dir: Path) -> bool:
+        return any(p for p in product_dir.rglob("*.py") if p.name != "__init__.py")
 
     def run(self, ctx: CheckContext) -> CheckResult:
+        if not self._has_python_files(ctx.product_dir):
+            return CheckResult(skip=True)
+
         module_path = f"products.{ctx.name}"
         tach_content = TACH_TOML.read_text() if TACH_TOML.exists() else ""
-        if "interfaces" not in get_tach_block(tach_content, module_path):
+        tach_block = get_tach_block(tach_content, module_path)
+
+        if not tach_block:
+            return CheckResult(
+                lines=["✗ missing from tach.toml"],
+                issues=[
+                    f"Product has Python files but no [[modules]] entry in tach.toml — "
+                    f'add a block with path = "{module_path}"'
+                ],
+            )
+
+        if ctx.is_isolated and "interfaces" not in tach_block:
             return CheckResult(
                 lines=["✗ missing interfaces declaration"],
                 issues=[
@@ -213,6 +229,7 @@ class TachInterfacesCheck(ProductCheck):
                     f'"{module_path}.backend.presentation.views"]'
                 ],
             )
+
         return CheckResult(lines=["✓ ok"])
 
 
@@ -406,6 +423,6 @@ CHECKS: list[ProductCheck] = [
     PackageJsonScriptsCheck(),
     MisplacedFilesCheck(),
     FileFolderConflictsCheck(),
-    TachInterfacesCheck(),
+    TachCheck(),
     IsolationProgressCheck(),
 ]

--- a/common/hogli/product/lint.py
+++ b/common/hogli/product/lint.py
@@ -70,7 +70,7 @@ def lint_all_products() -> None:
     click.echo(f"Linting {len(product_dirs)} products ({len(strict)} strict, {len(lenient)} lenient)")
     click.echo(
         "Checks: required root files, package.json scripts, misplaced files (strict), "
-        "file/folder conflicts, tach interfaces (strict), isolation progress (lenient)\n"
+        "file/folder conflicts, tach boundaries (+ interfaces for strict), isolation progress (lenient)\n"
     )
 
     structure = load_structure()

--- a/tach.toml
+++ b/tach.toml
@@ -41,13 +41,17 @@ path = "ee"
 depends_on = [
     "<root>",
     "posthog",
+    "products.alerts",
     "products.data_warehouse",
     "products.error_tracking",
     "products.event_definitions",
     "products.experiments",
     "products.feature_flags",
     "products.llm_analytics",
+    "products.mcp_store",
     "products.notebooks",
+    "products.posthog_ai",
+    "products.product_tours",
     "products.replay",
     "products.revenue_analytics",
     "products.surveys",
@@ -59,7 +63,9 @@ path = "posthog"
 depends_on = [
     "<root>",
     "ee",
+    "products.analytics_platform",
     "products.batch_exports",
+    "products.conversations",
     "products.customer_analytics",
     "products.data_modeling",
     "products.data_warehouse",
@@ -70,13 +76,17 @@ depends_on = [
     "products.event_definitions",
     "products.experiments",
     "products.feature_flags",
+    "products.growth",
     "products.links",
     "products.live_debugger",
     "products.llm_analytics",
     "products.logs",
     "products.marketing_analytics",
+    "products.mcp_store",
     "products.notebooks",
     "products.notifications",
+    "products.posthog_ai",
+    "products.product_tours",
     "products.revenue_analytics",
     "products.signals",
     "products.slack_app",
@@ -90,6 +100,21 @@ depends_on = [
 ]
 
 [[modules]]
+path = "products.alerts"
+depends_on = [
+    "ee",
+    "posthog",
+]
+layer = "non_isolated"
+
+[[modules]]
+path = "products.analytics_platform"
+depends_on = [
+    "posthog",
+]
+layer = "non_isolated"
+
+[[modules]]
 path = "products.batch_exports"
 depends_on = [
     "ee",
@@ -99,6 +124,14 @@ layer = "non_isolated"
 
 [[modules]]
 path = "products.cdp"
+depends_on = [
+    "ee",
+    "posthog",
+]
+layer = "non_isolated"
+
+[[modules]]
+path = "products.conversations"
 depends_on = [
     "ee",
     "posthog",
@@ -190,6 +223,14 @@ depends_on = [
 layer = "non_isolated"
 
 [[modules]]
+path = "products.growth"
+depends_on = [
+    "ee",
+    "posthog",
+]
+layer = "non_isolated"
+
+[[modules]]
 path = "products.links"
 depends_on = [
     "posthog",
@@ -225,6 +266,14 @@ depends_on = []
 layer = "non_isolated"
 
 [[modules]]
+path = "products.mcp_store"
+depends_on = [
+    "ee",
+    "posthog",
+]
+layer = "non_isolated"
+
+[[modules]]
 path = "products.marketing_analytics"
 depends_on = [
     "posthog",
@@ -256,6 +305,26 @@ interfaces = [
 [[modules]]
 path = "products.product_analytics"
 depends_on = []
+layer = "non_isolated"
+
+[[modules]]
+path = "products.posthog_ai"
+depends_on = [
+    "ee",
+    "posthog",
+    "products.error_tracking",
+    "products.event_definitions",
+    "products.llm_analytics",
+    "products.logs",
+]
+layer = "non_isolated"
+
+[[modules]]
+path = "products.product_tours"
+depends_on = [
+    "ee",
+    "posthog",
+]
 layer = "non_isolated"
 
 [[modules]]


### PR DESCRIPTION
tach has no built-in way to detect undeclared modules — if a new Python package appears in `products/` without a `[[modules]]` entry in `tach.toml`, it can import anything freely with zero enforcement.

**What changed**

Merged the old `TachInterfacesCheck` (isolated-only) into a single `TachCheck` that runs for all products with Python files. It first verifies a `[[modules]]` entry exists, then checks for `interfaces` on isolated products.

Also registered the 7 products that were missing from `tach.toml`: `alerts`, `analytics_platform`, `conversations`, `growth`, `mcp_store`, `posthog_ai`, `product_tours`.