### PR TITLE
fix: revert previous changes to backfill logics

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfills.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportBackfills.tsx
@@ -14,11 +14,8 @@ import { BatchExportBackfill } from '~/types'
 import { BatchExportBackfillModal } from './BatchExportBackfillModal'
 import { BatchExportBackfillsLogicProps, batchExportBackfillsLogic } from './batchExportBackfillsLogic'
 
-export function BatchExportBackfills({
-    id,
-    batchExportConfig: initialConfig,
-}: BatchExportBackfillsLogicProps): JSX.Element {
-    const logic = batchExportBackfillsLogic({ id, batchExportConfig: initialConfig })
+export function BatchExportBackfills({ id }: BatchExportBackfillsLogicProps): JSX.Element {
+    const logic = batchExportBackfillsLogic({ id })
     const { batchExportConfig } = useValues(logic)
 
     if (!batchExportConfig) {

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.tsx
@@ -269,7 +269,7 @@ function BatchExportSceneContentInner({
             ? {
                   label: 'Backfills',
                   key: 'backfills',
-                  content: <BatchExportBackfills id={id} batchExportConfig={batchExportConfig} />,
+                  content: <BatchExportBackfills id={id} />,
               }
             : null,
     ]

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillModalLogic.tsx
@@ -12,7 +12,7 @@ import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-genera
 import { BatchExportConfiguration } from '~/types'
 
 import type { batchExportBackfillModalLogicType } from './batchExportBackfillModalLogicType'
-import { batchExportBackfillsLogic } from './batchExportBackfillsLogic'
+import { batchExportConfigurationLogic } from './batchExportConfigurationLogic'
 import { dayOptions } from './utils'
 
 export interface BatchExportBackfillModalLogicProps {
@@ -120,13 +120,20 @@ export const batchExportBackfillModalLogic = kea<batchExportBackfillModalLogicTy
     key(({ id }) => id),
     path((key) => ['scenes', 'pipeline', 'batchExportBackfillModalLogic', key]),
     connect((props: BatchExportBackfillModalLogicProps) => ({
-        values: [teamLogic, ['timezone as teamTimezone'], batchExportBackfillsLogic(props), ['batchExportConfig']],
-        actions: [batchExportBackfillsLogic(props), ['openBackfillModal', 'backfillCreated']],
+        values: [
+            batchExportConfigurationLogic({
+                id: props.id,
+                service: null,
+            }),
+            ['batchExportConfig'],
+        ],
     })),
     actions({
+        openBackfillModal: true,
         closeBackfillModal: true,
         setEarliestBackfill: true,
         unsetEarliestBackfill: true,
+        backfillCreated: (backfillId: string) => ({ backfillId }),
     }),
     reducers({
         isBackfillModalOpen: [
@@ -150,7 +157,7 @@ export const batchExportBackfillModalLogic = kea<batchExportBackfillModalLogicTy
             (batchExportConfig: BatchExportConfiguration | null): string | undefined => batchExportConfig?.interval,
         ],
         timezone: [
-            (s) => [s.batchExportConfig, s.teamTimezone],
+            (s) => [s.batchExportConfig, teamLogic.selectors.timezone],
             (batchExportConfig: BatchExportConfiguration | null, teamTimezone: string): string => {
                 // How timezones are handled:
                 // - If the batch export's interval is day or week, we use the timezone from the batch export config.

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillsLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillsLogic.test.ts
@@ -104,11 +104,11 @@ describe('batchExportBackfillsLogic', () => {
         const configLogic = batchExportConfigurationLogic({ id: MOCK_BATCH_EXPORT_ID, service: null })
         configLogic.mount()
         await expectLogic(configLogic).toFinishAllListeners()
+        const modalLogic = batchExportBackfillModalLogic({ id: MOCK_BATCH_EXPORT_ID })
+        modalLogic.mount()
         logic = batchExportBackfillsLogic({ id: MOCK_BATCH_EXPORT_ID })
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
-        const modalLogic = batchExportBackfillModalLogic({ id: MOCK_BATCH_EXPORT_ID })
-        modalLogic.mount()
     }
 
     describe('loadBackfills', () => {
@@ -166,8 +166,7 @@ describe('batchExportBackfillsLogic', () => {
         })
 
         afterEach(async () => {
-            // Ensure any remaining polling resolves immediately with an estimate so it stops cleanly
-            jest.spyOn(api.batchExports, 'getBackfill').mockResolvedValue(makeBackfill({ total_records_count: 1 }))
+            // Exhaust any remaining polling iterations to prevent leaking into the next test
             for (let i = 0; i < 12; i++) {
                 await jest.advanceTimersByTimeAsync(POLL_ADVANCE_MS)
             }

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillsLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportBackfillsLogic.tsx
@@ -6,37 +6,40 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { BatchExportBackfill, BatchExportConfiguration, RawBatchExportBackfill } from '~/types'
+import { BatchExportBackfill, RawBatchExportBackfill } from '~/types'
 
+import { batchExportBackfillModalLogic } from './batchExportBackfillModalLogic'
 import type { batchExportBackfillsLogicType } from './batchExportBackfillsLogicType'
+import { batchExportConfigurationLogic } from './batchExportConfigurationLogic'
 
 export interface BatchExportBackfillsLogicProps {
     id: string
-    batchExportConfig?: BatchExportConfiguration | null
 }
 
 export const batchExportBackfillsLogic = kea<batchExportBackfillsLogicType>([
     props({} as BatchExportBackfillsLogicProps),
     key(({ id }) => id),
     path((key) => ['scenes', 'pipeline', 'batchExportBackfillsLogic', key]),
-    connect(() => ({
-        values: [teamLogic(), ['currentTeamId']],
+    connect((props: BatchExportBackfillsLogicProps) => ({
+        values: [
+            teamLogic(),
+            ['currentTeamId'],
+            batchExportConfigurationLogic({
+                id: props.id,
+                service: null,
+            }),
+            ['batchExportConfig'],
+        ],
+        actions: [
+            batchExportBackfillModalLogic(props),
+            ['submitBackfillFormSuccess', 'openBackfillModal', 'backfillCreated'],
+        ],
     })),
     actions({
         loadBackfills: true,
         cancelBackfill: (backfill: BatchExportBackfill) => ({ backfill }),
-        openBackfillModal: true,
-        backfillCreated: (backfillId: string) => ({ backfillId }),
     }),
     loaders(({ props, values }) => ({
-        batchExportConfig: [
-            (props.batchExportConfig ?? null) as BatchExportConfiguration | null,
-            {
-                loadBatchExportConfig: async () => {
-                    return await api.batchExports.get(props.id)
-                },
-            },
-        ],
         backfillsPaginatedResponse: [
             null as PaginatedResponse<RawBatchExportBackfill> | null,
             {
@@ -112,6 +115,11 @@ export const batchExportBackfillsLogic = kea<batchExportBackfillsLogicType>([
                 lemonToast.error('Failed to cancel backfill. Please try again.')
             }
         },
+        submitBackfillFormSuccess: () => {
+            setTimeout(() => {
+                actions.loadBackfills()
+            }, 1000)
+        },
         backfillCreated: async ({ backfillId }, breakpoint) => {
             const MAX_POLL_ATTEMPTS = 10
             const POLL_INTERVAL_MS = 1000
@@ -157,10 +165,7 @@ export const batchExportBackfillsLogic = kea<batchExportBackfillsLogicType>([
             }
         },
     })),
-    afterMount(({ actions, props }) => {
-        if (!props.batchExportConfig) {
-            actions.loadBatchExportConfig()
-        }
+    afterMount(({ actions }) => {
         actions.loadBackfills()
     }),
 ])


### PR DESCRIPTION
## Problem

PR https://github.com/PostHog/posthog/pull/51458 broke the Runs tab in batch exports (unless Backfills had been loaded first). 

## Changes

Revert the changes made to the Kea logics in the previous PR.

We will fix properly in a follow up PR.

## How did you test this code?

Manual testing using local stack

