### PR TITLE
feat(flags): add drag and drop for release conditions

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -291,6 +291,7 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: #team-feature-flags
     FEATURE_FLAG_CREATION_INTENTS: 'feature-flag-creation-intents', // owner: #team-feature-flags
     FEATURE_FLAGS_V2: 'feature-flags-v2', // owner: @dmarticus #team-feature-flags
+    FEATURE_FLAG_DRAG_DROP_CONDITIONS: 'feature-flag-drag-drop-conditions', // owner: @gustavo #team-feature-flags
     FEATURE_FLAG_USAGE_DASHBOARD_CHECKBOX: 'feature-flag-usage-dashboard-checkbox', // owner: #team-feature-flags, globally disabled, enables opt-out of auto dashboard creation
     FLAG_BUCKETING_IDENTIFIER: 'flag-bucketing-identifier', // owner: @andehen #team-experiments
     FLAG_EVALUATION_RUNTIMES: 'flag-evaluation-runtimes', // owner: @dmarticus #team-feature-flags

--- a/frontend/src/scenes/feature-flags/FeatureFlagConditionDragHandle.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagConditionDragHandle.tsx
@@ -1,0 +1,45 @@
+import { DraggableSyntheticListeners } from '@dnd-kit/core'
+
+import { SortableDragIcon } from 'lib/lemon-ui/icons'
+
+interface FeatureFlagConditionDragHandleProps {
+    listeners: DraggableSyntheticListeners | undefined
+    attributes: Record<string, any>
+    setActivatorNodeRef: (element: HTMLElement | null) => void
+    hasMultipleConditions: boolean
+}
+
+const DragHandle = ({
+    listeners,
+    attributes,
+    setActivatorNodeRef,
+}: {
+    listeners: DraggableSyntheticListeners | undefined
+    attributes: Record<string, any>
+    setActivatorNodeRef: (element: HTMLElement | null) => void
+}): JSX.Element => (
+    <button
+        type="button"
+        ref={setActivatorNodeRef}
+        className="FeatureFlagConditionDragHandle cursor-grab active:cursor-grabbing text-muted hover:text-default transition-colors border-none bg-transparent p-1 hover:bg-bg-dark rounded"
+        aria-label="Reorder condition"
+        {...listeners}
+        {...attributes}
+        data-attr="feature-flag-condition-drag-handle"
+    >
+        <SortableDragIcon />
+    </button>
+)
+
+export function FeatureFlagConditionDragHandle({
+    listeners,
+    attributes,
+    setActivatorNodeRef,
+    hasMultipleConditions,
+}: FeatureFlagConditionDragHandleProps): JSX.Element | null {
+    if (!hasMultipleConditions) {
+        return null
+    }
+
+    return <DragHandle listeners={listeners} attributes={attributes} setActivatorNodeRef={setActivatorNodeRef} />
+}

--- a/frontend/src/scenes/feature-flags/FeatureFlagConditionDragHandle.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagConditionDragHandle.tsx
@@ -1,5 +1,7 @@
 import { DraggableSyntheticListeners } from '@dnd-kit/core'
 
+import { Tooltip } from '@posthog/lemon-ui'
+
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
 
 interface FeatureFlagConditionDragHandleProps {
@@ -13,22 +15,20 @@ const DragHandle = ({
     listeners,
     attributes,
     setActivatorNodeRef,
-}: {
-    listeners: DraggableSyntheticListeners | undefined
-    attributes: Record<string, any>
-    setActivatorNodeRef: (element: HTMLElement | null) => void
-}): JSX.Element => (
-    <button
-        type="button"
-        ref={setActivatorNodeRef}
-        className="FeatureFlagConditionDragHandle cursor-grab active:cursor-grabbing text-muted hover:text-default transition-colors border-none bg-transparent p-1 hover:bg-bg-dark rounded"
-        aria-label="Reorder condition"
-        {...listeners}
-        {...attributes}
-        data-attr="feature-flag-condition-drag-handle"
-    >
-        <SortableDragIcon />
-    </button>
+}: Omit<FeatureFlagConditionDragHandleProps, 'hasMultipleConditions'>): JSX.Element => (
+    <Tooltip title="Drag to reorder conditions">
+        <button
+            type="button"
+            ref={setActivatorNodeRef}
+            className="FeatureFlagConditionDragHandle cursor-grab active:cursor-grabbing text-muted hover:text-default transition-colors border-none bg-transparent p-1 hover:bg-bg-dark rounded"
+            aria-label="Reorder condition"
+            {...listeners}
+            {...attributes}
+            data-attr="feature-flag-condition-drag-handle"
+        >
+            <SortableDragIcon />
+        </button>
+    </Tooltip>
 )
 
 export function FeatureFlagConditionDragHandle({

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -279,7 +279,7 @@ const SortableCondition = ({
     group: FeatureFlagGroupType
     index: number
     totalGroups: number
-    affectedUsers: Record<string, number>
+    affectedUsers: Record<string, number | undefined>
     totalUsers: number | null
     aggregationTargetName: string
     onMoveUp: () => void
@@ -934,7 +934,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                     openConditions={openConditions}
                                     handleOpenConditionsChange={handleOpenConditionsChange}
                                     flagId={flagId}
-                                    id={id}
+                                    id={id || 'feature-flag-conditions'}
                                     isAnyItemDragging={isAnyItemDragging}
                                 />
                             </React.Fragment>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -22,11 +22,13 @@ import { EditableField } from 'lib/components/EditableField/EditableField'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType, TaxonomicFilterProps } from 'lib/components/TaxonomicFilter/types'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { humanFriendlyNumber } from 'lib/utils'
 import { clamp } from 'lib/utils'
 
@@ -275,6 +277,7 @@ const SortableCondition = ({
     flagId,
     id,
     isAnyItemDragging,
+    isDragDropEnabled = false,
 }: {
     group: FeatureFlagGroupType
     index: number
@@ -302,6 +305,7 @@ const SortableCondition = ({
     flagId?: FeatureFlagLogicProps['id']
     id: string
     isAnyItemDragging: boolean
+    isDragDropEnabled?: boolean
 }): JSX.Element => {
     const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
         id: group.sort_key || index.toString(),
@@ -575,12 +579,14 @@ const SortableCondition = ({
                 </div>
                 {totalGroups > 1 && (
                     <div className="flex flex-col items-center gap-1 pr-2">
-                        <FeatureFlagConditionDragHandle
-                            listeners={listeners}
-                            attributes={attributes}
-                            setActivatorNodeRef={setActivatorNodeRef}
-                            hasMultipleConditions={true}
-                        />
+                        {isDragDropEnabled && (
+                            <FeatureFlagConditionDragHandle
+                                listeners={listeners}
+                                attributes={attributes}
+                                setActivatorNodeRef={setActivatorNodeRef}
+                                hasMultipleConditions={true}
+                            />
+                        )}
                         <div className="flex flex-col gap-0.5">
                             {index > 0 && (
                                 <LemonButton
@@ -649,6 +655,9 @@ export function FeatureFlagReleaseConditionsCollapsible({
         openConditions,
         properties,
     } = useValues(releaseConditionsLogic)
+
+    const { featureFlags } = useValues(featureFlagLogic)
+    const isDragDropEnabled = !!featureFlags[FEATURE_FLAGS.FEATURE_FLAG_DRAG_DROP_CONDITIONS]
 
     const {
         updateConditionSet,
@@ -893,83 +902,122 @@ export function FeatureFlagReleaseConditionsCollapsible({
             </div>
 
             <div ref={collapseRef}>
-                <DndContext
-                    sensors={sensors}
-                    collisionDetection={rectIntersection}
-                    onDragStart={handleDragStart}
-                    onDragEnd={handleDragEnd}
-                    onDragCancel={() => {
-                        setIsAnyItemDragging(false)
-                        setDraggedGroup(null)
-                    }}
-                >
-                    <SortableContext
-                        items={filterGroups.map((group, index) => group.sort_key || index.toString())}
-                        strategy={verticalListSortingStrategy}
+                {isDragDropEnabled ? (
+                    <DndContext
+                        sensors={sensors}
+                        collisionDetection={rectIntersection}
+                        onDragStart={handleDragStart}
+                        onDragEnd={handleDragEnd}
+                        onDragCancel={() => {
+                            setIsAnyItemDragging(false)
+                            setDraggedGroup(null)
+                        }}
                     >
-                        {filterGroups.map((group, index) => (
-                            <React.Fragment key={`fragment-${group.sort_key ?? index}`}>
-                                {index > 0 && (
-                                    <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
-                                        or
-                                    </div>
-                                )}
-                                <SortableCondition
-                                    key={`condition-${group.sort_key ?? index}`}
-                                    group={group}
-                                    index={index}
-                                    totalGroups={filterGroups.length}
-                                    affectedUsers={affectedUsers}
-                                    totalUsers={totalUsers}
-                                    aggregationTargetName={aggregationTargetName}
-                                    onMoveUp={() => moveConditionSetUp(index)}
-                                    onMoveDown={() => moveConditionSetDown(index)}
-                                    onDuplicate={() => duplicateConditionSet(index)}
-                                    onRemove={() => removeConditionSet(index)}
-                                    updateConditionSet={updateConditionSet}
-                                    taxonomicGroupTypes={taxonomicGroupTypes}
-                                    filtersTaxonomicOptions={filtersTaxonomicOptions}
-                                    releaseFilters={releaseFilters}
-                                    variants={variants}
-                                    openConditions={openConditions}
-                                    handleOpenConditionsChange={handleOpenConditionsChange}
-                                    flagId={flagId}
-                                    id={id || 'feature-flag-conditions'}
-                                    isAnyItemDragging={isAnyItemDragging}
-                                />
-                            </React.Fragment>
-                        ))}
-                    </SortableContext>
-                    <DragOverlay>
-                        {draggedGroup ? (
-                            <div
-                                className="border rounded bg-bg-light"
-                                style={{ opacity: 0.9, boxShadow: '0 8px 25px rgba(0, 0, 0, 0.15)' }}
-                            >
-                                <div className="flex items-center justify-between w-full p-3">
-                                    <div className="flex items-start gap-2 min-w-0">
-                                        <span className="font-medium text-xs bg-bg-light rounded px-1.5 py-0.5 shrink-0">
-                                            {filterGroups.findIndex((g) => g.sort_key === draggedGroup.sort_key) + 1}
-                                        </span>
-                                        <span className="text-sm break-all">
-                                            {draggedGroup.description ||
-                                                summarizeProperties(
-                                                    draggedGroup.properties || [],
-                                                    aggregationTargetName
-                                                )}
-                                        </span>
-                                    </div>
-                                    <div className="flex items-center gap-1 shrink-0">
-                                        <span className="text-sm text-muted mr-2">
-                                            ({draggedGroup.rollout_percentage ?? 100}%
-                                            {draggedGroup.variant && ` · ${draggedGroup.variant}`})
-                                        </span>
+                        <SortableContext
+                            items={filterGroups.map((group, index) => group.sort_key || index.toString())}
+                            strategy={verticalListSortingStrategy}
+                        >
+                            {filterGroups.map((group, index) => (
+                                <React.Fragment key={`fragment-${group.sort_key ?? index}`}>
+                                    {index > 0 && (
+                                        <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
+                                            or
+                                        </div>
+                                    )}
+                                    <SortableCondition
+                                        key={`condition-${group.sort_key ?? index}`}
+                                        group={group}
+                                        index={index}
+                                        totalGroups={filterGroups.length}
+                                        affectedUsers={affectedUsers}
+                                        totalUsers={totalUsers}
+                                        aggregationTargetName={aggregationTargetName}
+                                        onMoveUp={() => moveConditionSetUp(index)}
+                                        onMoveDown={() => moveConditionSetDown(index)}
+                                        onDuplicate={() => duplicateConditionSet(index)}
+                                        onRemove={() => removeConditionSet(index)}
+                                        updateConditionSet={updateConditionSet}
+                                        taxonomicGroupTypes={taxonomicGroupTypes}
+                                        filtersTaxonomicOptions={filtersTaxonomicOptions}
+                                        releaseFilters={releaseFilters}
+                                        variants={variants}
+                                        openConditions={openConditions}
+                                        handleOpenConditionsChange={handleOpenConditionsChange}
+                                        flagId={flagId}
+                                        id={id || 'feature-flag-conditions'}
+                                        isAnyItemDragging={isAnyItemDragging}
+                                        isDragDropEnabled={isDragDropEnabled}
+                                    />
+                                </React.Fragment>
+                            ))}
+                        </SortableContext>
+                        <DragOverlay>
+                            {draggedGroup ? (
+                                <div
+                                    className="border rounded bg-bg-light"
+                                    style={{ opacity: 0.9, boxShadow: '0 8px 25px rgba(0, 0, 0, 0.15)' }}
+                                >
+                                    <div className="flex items-center justify-between w-full p-3">
+                                        <div className="flex items-start gap-2 min-w-0">
+                                            <span className="font-medium text-xs bg-bg-light rounded px-1.5 py-0.5 shrink-0">
+                                                {filterGroups.findIndex((g) => g.sort_key === draggedGroup.sort_key) +
+                                                    1}
+                                            </span>
+                                            <span className="text-sm break-all">
+                                                {draggedGroup.description ||
+                                                    summarizeProperties(
+                                                        draggedGroup.properties || [],
+                                                        aggregationTargetName
+                                                    )}
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center gap-1 shrink-0">
+                                            <span className="text-sm text-muted mr-2">
+                                                ({draggedGroup.rollout_percentage ?? 100}%
+                                                {draggedGroup.variant && ` · ${draggedGroup.variant}`})
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        ) : null}
-                    </DragOverlay>
-                </DndContext>
+                            ) : null}
+                        </DragOverlay>
+                    </DndContext>
+                ) : (
+                    // Fallback to non-draggable conditions when feature flag is disabled
+                    filterGroups.map((group, index) => (
+                        <React.Fragment key={`fragment-${group.sort_key ?? index}`}>
+                            {index > 0 && (
+                                <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
+                                    or
+                                </div>
+                            )}
+                            <SortableCondition
+                                key={`condition-${group.sort_key ?? index}`}
+                                group={group}
+                                index={index}
+                                totalGroups={filterGroups.length}
+                                affectedUsers={affectedUsers}
+                                totalUsers={totalUsers}
+                                aggregationTargetName={aggregationTargetName}
+                                onMoveUp={() => moveConditionSetUp(index)}
+                                onMoveDown={() => moveConditionSetDown(index)}
+                                onDuplicate={() => duplicateConditionSet(index)}
+                                onRemove={() => removeConditionSet(index)}
+                                updateConditionSet={updateConditionSet}
+                                taxonomicGroupTypes={taxonomicGroupTypes}
+                                filtersTaxonomicOptions={filtersTaxonomicOptions}
+                                releaseFilters={releaseFilters}
+                                variants={variants}
+                                openConditions={openConditions}
+                                handleOpenConditionsChange={handleOpenConditionsChange}
+                                flagId={flagId}
+                                id={id || 'feature-flag-conditions'}
+                                isAnyItemDragging={false}
+                                isDragDropEnabled={false}
+                            />
+                        </React.Fragment>
+                    ))
+                )}
             </div>
 
             <LemonButton type="secondary" icon={<IconPlus />} onClick={handleAddConditionSet} className="mt-1">

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -1,23 +1,27 @@
+import {
+    DndContext,
+    DragEndEvent,
+    DragOverlay,
+    DragStartEvent,
+    PointerSensor,
+    useSensor,
+    useSensors,
+    rectIntersection,
+} from '@dnd-kit/core'
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { useActions, useValues } from 'kea'
-import { useRef } from 'react'
+import React, { useRef, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
-import { IconCopy, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
-import {
-    LemonBanner,
-    LemonButton,
-    LemonCollapse,
-    LemonInput,
-    LemonLabel,
-    LemonSelect,
-    Spinner,
-    Tooltip,
-} from '@posthog/lemon-ui'
+import { IconCollapse, IconCopy, IconExpand, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonInput, LemonLabel, LemonSelect, Spinner, Tooltip } from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
+import { TaxonomicFilterGroupType, TaxonomicFilterProps } from 'lib/components/TaxonomicFilter/types'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
@@ -30,6 +34,7 @@ import {
     AnyPropertyFilter,
     FeatureFlagBucketingIdentifier,
     FeatureFlagEvaluationRuntime,
+    FeatureFlagFilters,
     FeatureFlagGroupType,
     MultivariateFlagVariant,
     PropertyFilterType,
@@ -37,6 +42,7 @@ import {
 
 import { INTENT_METADATA } from 'products/feature_flags/frontend/featureFlagTemplateConstants'
 
+import { FeatureFlagConditionDragHandle } from './FeatureFlagConditionDragHandle'
 import { FeatureFlagConditionWarning } from './FeatureFlagConditionWarning'
 import { FlagIntent, featureFlagIntentWarningLogic } from './featureFlagIntentWarningLogic'
 import { FeatureFlagLogicProps } from './featureFlagLogic'
@@ -104,8 +110,6 @@ interface ConditionHeaderProps {
     affectedUserCount: number | undefined
     totalUsers: number | null
     aggregationTargetName: string
-    onMoveUp: () => void
-    onMoveDown: () => void
     onDuplicate: () => void
     onRemove: () => void
 }
@@ -117,8 +121,6 @@ function ConditionHeader({
     affectedUserCount,
     totalUsers,
     aggregationTargetName,
-    onMoveUp,
-    onMoveDown,
     onDuplicate,
     onRemove,
 }: ConditionHeaderProps): JSX.Element {
@@ -133,8 +135,8 @@ function ConditionHeader({
             : null
 
     return (
-        <div className="flex items-start justify-between w-full gap-2">
-            <div className="flex items-start gap-2 min-w-0">
+        <div className="flex items-center justify-between w-full gap-2">
+            <div className="flex items-center gap-2 min-w-0">
                 <span className="font-medium text-xs bg-bg-light rounded px-1.5 py-0.5 shrink-0">{index + 1}</span>
                 <span className="text-sm break-all">{summary}</span>
             </div>
@@ -146,53 +148,29 @@ function ConditionHeader({
                         ` · ${humanFriendlyNumber(actualUserCount)} ${aggregationTargetName}`}
                     )
                 </span>
-                {totalGroups > 1 && (
-                    <>
-                        <LemonButton
-                            icon={<IconArrowDown />}
-                            size="xsmall"
-                            noPadding
-                            tooltip="Move down"
-                            disabledReason={index >= totalGroups - 1 ? 'Already at bottom' : undefined}
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                onMoveDown()
-                            }}
-                        />
-                        <LemonButton
-                            icon={<IconArrowUp />}
-                            size="xsmall"
-                            noPadding
-                            tooltip="Move up"
-                            disabledReason={index === 0 ? 'Already at top' : undefined}
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                onMoveUp()
-                            }}
-                        />
-                    </>
-                )}
-                <LemonButton
-                    icon={<IconCopy />}
-                    size="xsmall"
-                    noPadding
-                    tooltip="Duplicate condition set"
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        onDuplicate()
-                    }}
-                />
-                {totalGroups > 1 && (
-                    <LemonButton
-                        icon={<IconTrash />}
-                        size="xsmall"
-                        noPadding
-                        tooltip="Remove condition set"
+                <Tooltip title="Duplicate condition set">
+                    <span
+                        className="cursor-pointer p-1 hover:bg-bg-dark rounded text-muted hover:text-default transition-colors"
                         onClick={(e) => {
                             e.stopPropagation()
-                            onRemove()
+                            onDuplicate()
                         }}
-                    />
+                    >
+                        <IconCopy className="w-4 h-4" />
+                    </span>
+                </Tooltip>
+                {totalGroups > 1 && (
+                    <Tooltip title="Remove condition set">
+                        <span
+                            className="cursor-pointer p-1 hover:bg-bg-dark rounded text-muted hover:text-default transition-colors"
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                onRemove()
+                            }}
+                        >
+                            <IconTrash className="w-4 h-4" />
+                        </span>
+                    </Tooltip>
                 )}
             </div>
         </div>
@@ -276,6 +254,366 @@ function UnreachableConditionBanner({
     )
 }
 
+const SortableCondition = ({
+    group,
+    index,
+    totalGroups,
+    affectedUsers,
+    totalUsers,
+    aggregationTargetName,
+    onMoveUp,
+    onMoveDown,
+    onDuplicate,
+    onRemove,
+    updateConditionSet,
+    taxonomicGroupTypes,
+    filtersTaxonomicOptions,
+    releaseFilters,
+    variants,
+    openConditions,
+    handleOpenConditionsChange,
+    flagId,
+    id,
+    isAnyItemDragging,
+}: {
+    group: FeatureFlagGroupType
+    index: number
+    totalGroups: number
+    affectedUsers: Record<string, number>
+    totalUsers: number | null
+    aggregationTargetName: string
+    onMoveUp: () => void
+    onMoveDown: () => void
+    onDuplicate: () => void
+    onRemove: () => void
+    updateConditionSet: (
+        index: number,
+        rollout?: number,
+        properties?: AnyPropertyFilter[],
+        variant?: string | null,
+        description?: string
+    ) => void
+    taxonomicGroupTypes: TaxonomicFilterGroupType[]
+    filtersTaxonomicOptions: TaxonomicFilterProps['optionsFromProp']
+    releaseFilters: FeatureFlagFilters
+    variants?: MultivariateFlagVariant[]
+    openConditions: string[]
+    handleOpenConditionsChange: (newKeys: string[]) => void
+    flagId?: FeatureFlagLogicProps['id']
+    id: string
+    isAnyItemDragging: boolean
+}): JSX.Element => {
+    const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
+        id: group.sort_key || index.toString(),
+    })
+
+    const [originalWidth, setOriginalWidth] = useState<number | undefined>(undefined)
+
+    // Combined ref callback
+    const combinedRef = (element: HTMLDivElement | null): void => {
+        setNodeRef(element)
+
+        // Capture original width when element is first mounted
+        if (element && !originalWidth) {
+            setOriginalWidth(element.offsetWidth)
+        }
+    }
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition: isDragging ? undefined : transition,
+        opacity: isDragging ? 0.8 : 1,
+        zIndex: isDragging ? 1000 : 'auto',
+        // Maintain original width during drag operations
+        ...(isDragging && originalWidth && { width: originalWidth }),
+        // Add shadow and background for better visual separation
+        ...(isDragging && {
+            boxShadow: '0 8px 25px rgba(0, 0, 0, 0.15)',
+            backgroundColor: 'var(--bg-light)',
+        }),
+    }
+
+    return (
+        <div
+            ref={combinedRef}
+            style={style}
+            className={isDragging ? 'opacity-50 border-2 border-dashed border-border-light bg-bg-3000 rounded' : ''}
+        >
+            {flagId && <UnreachableConditionBanner flagId={flagId} groupIndex={index} />}
+            <div className="flex items-start gap-3">
+                <div className="flex-1">
+                    <div className="border rounded bg-bg-light">
+                        <div
+                            className="flex items-center justify-between w-full p-3 cursor-pointer hover:bg-bg-dark transition-colors"
+                            role="button"
+                            tabIndex={0}
+                            aria-expanded={openConditions.includes(`condition-${group.sort_key ?? index}`)}
+                            aria-label={`Toggle condition ${index + 1} details`}
+                            onClick={() => {
+                                // Prevent collapse/expand during ANY drag operation to maintain consistent heights
+                                if (isAnyItemDragging) {
+                                    return
+                                }
+
+                                const isOpen = openConditions.includes(`condition-${group.sort_key ?? index}`)
+                                const newOpenConditions = isOpen
+                                    ? openConditions.filter((key) => key !== `condition-${group.sort_key ?? index}`)
+                                    : [...openConditions, `condition-${group.sort_key ?? index}`]
+                                handleOpenConditionsChange(newOpenConditions)
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    // Prevent collapse/expand during ANY drag operation to maintain consistent heights
+                                    if (isAnyItemDragging) {
+                                        return
+                                    }
+
+                                    const isOpen = openConditions.includes(`condition-${group.sort_key ?? index}`)
+                                    const newOpenConditions = isOpen
+                                        ? openConditions.filter((key) => key !== `condition-${group.sort_key ?? index}`)
+                                        : [...openConditions, `condition-${group.sort_key ?? index}`]
+                                    handleOpenConditionsChange(newOpenConditions)
+                                }
+                            }}
+                        >
+                            <ConditionHeader
+                                group={group}
+                                index={index}
+                                totalGroups={totalGroups}
+                                affectedUserCount={group.sort_key ? affectedUsers[group.sort_key] : undefined}
+                                totalUsers={totalUsers}
+                                aggregationTargetName={aggregationTargetName}
+                                onDuplicate={onDuplicate}
+                                onRemove={onRemove}
+                            />
+                            <span className="ml-2">
+                                {openConditions.includes(`condition-${group.sort_key ?? index}`) ? (
+                                    <IconCollapse className="w-4 h-4" />
+                                ) : (
+                                    <IconExpand className="w-4 h-4" />
+                                )}
+                            </span>
+                        </div>
+                        {openConditions.includes(`condition-${group.sort_key ?? index}`) && (
+                            <div className="p-3 pt-0 border-t">
+                                <div className="flex flex-col gap-3 pt-2">
+                                    <div className="max-w-md">
+                                        <EditableField
+                                            multiline
+                                            name="description"
+                                            value={group.description || ''}
+                                            placeholder="Description (optional)"
+                                            onSave={(value) =>
+                                                updateConditionSet(index, undefined, undefined, undefined, value)
+                                            }
+                                            saveOnBlur={true}
+                                            maxLength={600}
+                                            data-attr={`condition-set-${index}-description`}
+                                            compactButtons
+                                        />
+                                    </div>
+
+                                    <div>
+                                        <LemonLabel className="mb-1">Match filters</LemonLabel>
+                                        <PropertyFilters
+                                            orFiltering={true}
+                                            pageKey={`feature-flag-workflow-${id}-${group.sort_key ?? index}`}
+                                            propertyFilters={group?.properties}
+                                            logicalRowDivider
+                                            addText="Add filter"
+                                            onChange={(properties) => {
+                                                updateConditionSet(index, undefined, properties)
+                                            }}
+                                            taxonomicGroupTypes={taxonomicGroupTypes}
+                                            taxonomicFilterOptionsFromProp={filtersTaxonomicOptions}
+                                            hasRowOperator={false}
+                                        />
+                                    </div>
+
+                                    <div>
+                                        <LemonLabel className="mb-1">Rollout percentage</LemonLabel>
+                                        <div className="flex items-start gap-6">
+                                            <LemonSlider
+                                                value={group.rollout_percentage ?? 100}
+                                                onChange={(value) => updateConditionSet(index, value)}
+                                                min={0}
+                                                max={100}
+                                                step={1}
+                                                className="w-80"
+                                                ticks={[
+                                                    { value: 0, label: '0%' },
+                                                    { value: 10, label: '10%' },
+                                                    { value: 25, label: '25%' },
+                                                    { value: 50, label: '50%' },
+                                                    { value: 75, label: '75%' },
+                                                    { value: 100, label: '100%' },
+                                                ]}
+                                            />
+                                            <LemonInput
+                                                type="number"
+                                                min={0}
+                                                max={100}
+                                                value={group.rollout_percentage ?? 100}
+                                                onChange={(value) => {
+                                                    const numValue = value ? parseInt(value.toString()) : 0
+                                                    updateConditionSet(index, Math.min(100, Math.max(0, numValue)))
+                                                }}
+                                                suffix={<span>%</span>}
+                                                className="w-20"
+                                            />
+                                        </div>
+                                        {group.sort_key && affectedUsers[group.sort_key] !== undefined ? (
+                                            <div className="text-xs text-muted mt-2">
+                                                {(() => {
+                                                    const affectedUserCount = group.sort_key
+                                                        ? affectedUsers[group.sort_key]
+                                                        : undefined
+                                                    const rolloutPct = Number.isNaN(group.rollout_percentage)
+                                                        ? 0
+                                                        : (group.rollout_percentage ?? 100)
+
+                                                    if (
+                                                        affectedUserCount === undefined ||
+                                                        affectedUserCount < 0 ||
+                                                        totalUsers === null
+                                                    ) {
+                                                        return null
+                                                    }
+
+                                                    const usersReceivingFlag = Math.floor(
+                                                        (affectedUserCount * clamp(rolloutPct, 0, 100)) / 100
+                                                    )
+
+                                                    if (rolloutPct === 100) {
+                                                        return (
+                                                            <>
+                                                                <b>{humanFriendlyNumber(affectedUserCount)}</b> of{' '}
+                                                                {humanFriendlyNumber(totalUsers)}{' '}
+                                                                {aggregationTargetName} match these filters
+                                                            </>
+                                                        )
+                                                    }
+                                                    return (
+                                                        <>
+                                                            Will match ~<b>{humanFriendlyNumber(usersReceivingFlag)}</b>{' '}
+                                                            of {humanFriendlyNumber(totalUsers)} {aggregationTargetName}{' '}
+                                                            ({rolloutPct}% of {humanFriendlyNumber(affectedUserCount)}{' '}
+                                                            matching the filters)
+                                                        </>
+                                                    )
+                                                })()}
+                                                {releaseFilters.aggregation_group_type_index == null && (
+                                                    <Tooltip
+                                                        title={
+                                                            <>
+                                                                A user may have{' '}
+                                                                <Link
+                                                                    to="https://posthog.com/docs/data/persons#duplicate-person-profiles"
+                                                                    target="_blank"
+                                                                >
+                                                                    multiple profiles
+                                                                </Link>
+                                                            </>
+                                                        }
+                                                        interactive
+                                                    >
+                                                        <IconInfo className="text-muted text-xs ml-0.5" />
+                                                    </Tooltip>
+                                                )}
+                                            </div>
+                                        ) : (
+                                            <div className="text-xs text-muted mt-2 flex items-center gap-1">
+                                                <Spinner className="text-sm" /> Calculating affected{' '}
+                                                {aggregationTargetName}…
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    {variants && variants.length > 0 && (
+                                        <div className="flex items-center gap-2 flex-wrap text-sm text-muted">
+                                            <span className="flex items-center gap-1">
+                                                <span className="font-medium text-default">Optional override</span>
+                                                <Tooltip
+                                                    title={
+                                                        <>
+                                                            Force all matching {aggregationTargetName} to receive a
+                                                            specific variant.{' '}
+                                                            <Link
+                                                                to="https://posthog.com/docs/feature-flags/testing#method-1-assign-a-user-a-specific-flag-value"
+                                                                target="_blank"
+                                                            >
+                                                                Learn more
+                                                            </Link>
+                                                        </>
+                                                    }
+                                                >
+                                                    <IconInfo className="text-base" />
+                                                </Tooltip>
+                                            </span>
+                                            <span>Set variant for all {aggregationTargetName} in this set to</span>
+                                            <LemonSelect
+                                                placeholder="Select variant"
+                                                allowClear={true}
+                                                value={group.variant ?? null}
+                                                onChange={(value) =>
+                                                    updateConditionSet(index, undefined, undefined, value)
+                                                }
+                                                options={variants.map((variant) => ({
+                                                    label: variant.key,
+                                                    value: variant.key,
+                                                }))}
+                                                size="small"
+                                                data-attr="feature-flags-variant-override-select"
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+                {totalGroups > 1 && (
+                    <div className="flex flex-col items-center gap-1 pr-2">
+                        <FeatureFlagConditionDragHandle
+                            listeners={listeners}
+                            attributes={attributes}
+                            setActivatorNodeRef={setActivatorNodeRef}
+                            hasMultipleConditions={true}
+                        />
+                        <div className="flex flex-col gap-0.5">
+                            {index > 0 && (
+                                <LemonButton
+                                    icon={<IconArrowUp />}
+                                    size="xsmall"
+                                    noPadding
+                                    tooltip="Move up"
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        onMoveUp()
+                                    }}
+                                />
+                            )}
+                            {index < totalGroups - 1 && (
+                                <LemonButton
+                                    icon={<IconArrowDown />}
+                                    size="xsmall"
+                                    noPadding
+                                    tooltip="Move down"
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        onMoveDown()
+                                    }}
+                                />
+                            )}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
 export function FeatureFlagReleaseConditionsCollapsible({
     id,
     flagId,
@@ -288,12 +626,16 @@ export function FeatureFlagReleaseConditionsCollapsible({
     onBucketingIdentifierChange,
     evaluationRuntime,
 }: FeatureFlagReleaseConditionsCollapsibleProps): JSX.Element {
-    const releaseConditionsLogic = featureFlagReleaseConditionsLogic({
-        id,
-        readOnly,
-        filters,
-        onChange,
-    })
+    const releaseConditionsLogic = useMemo(
+        () =>
+            featureFlagReleaseConditionsLogic({
+                id,
+                readOnly,
+                filters,
+                onChange,
+            }),
+        [id, readOnly, filters, onChange]
+    )
 
     const {
         taxonomicGroupTypes,
@@ -315,12 +657,36 @@ export function FeatureFlagReleaseConditionsCollapsible({
         duplicateConditionSet,
         moveConditionSetUp,
         moveConditionSetDown,
+        reorderConditionSets,
         setAggregationGroupTypeIndex,
         setOpenConditions,
     } = useActions(releaseConditionsLogic)
 
     const handleAddConditionSet = (): void => {
         addConditionSet(uuidv4())
+    }
+
+    const sensors = useSensors(useSensor(PointerSensor))
+    const [isAnyItemDragging, setIsAnyItemDragging] = useState(false)
+    const [draggedGroup, setDraggedGroup] = useState<FeatureFlagGroupType | null>(null)
+
+    const handleDragStart = (event: DragStartEvent): void => {
+        setIsAnyItemDragging(true)
+
+        // Find the group being dragged
+        const draggedItem = filterGroups.find(
+            (group, index) => (group.sort_key || index.toString()) === String(event.active.id)
+        )
+        setDraggedGroup(draggedItem || null)
+    }
+
+    const handleDragEnd = (event: DragEndEvent): void => {
+        const { active, over } = event
+        if (over && active.id !== over.id) {
+            reorderConditionSets(String(active.id), String(over.id))
+        }
+        setIsAnyItemDragging(false)
+        setDraggedGroup(null)
     }
 
     const collapseRef = useRef<HTMLDivElement>(null)
@@ -399,345 +765,211 @@ export function FeatureFlagReleaseConditionsCollapsible({
 
             <FeatureFlagConditionWarning properties={properties} evaluationRuntime={evaluationRuntime} />
 
-            {/* Match by selector */}
-            {(showGroupsOptions || onBucketingIdentifierChange) && (
-                <div className="mb-2">
-                    <LemonLabel className="mb-2">Match by</LemonLabel>
-                    <LemonRadio
-                        data-attr="feature-flag-aggregation-filter"
-                        value={
-                            releaseFilters.aggregation_group_type_index != null
-                                ? 'group'
-                                : bucketingIdentifier === FeatureFlagBucketingIdentifier.DEVICE_ID
-                                  ? 'device'
-                                  : 'user'
-                        }
-                        onChange={(value: string) => {
-                            if (value === 'user') {
-                                setAggregationGroupTypeIndex(null)
-                                onBucketingIdentifierChange?.(FeatureFlagBucketingIdentifier.DISTINCT_ID)
-                            } else if (value === 'device') {
-                                setAggregationGroupTypeIndex(null)
-                                onBucketingIdentifierChange?.(FeatureFlagBucketingIdentifier.DEVICE_ID)
-                            } else if (value === 'group') {
-                                const firstGroupType = Array.from(groupTypes.values())[0]
-                                if (firstGroupType) {
-                                    setAggregationGroupTypeIndex(firstGroupType.group_type_index)
+            {flagId && <IntentWarningsBanner flagId={flagId} />}
+
+            {/* Two-column layout for Match by selector and Collapse all button */}
+            <div className="flex items-end justify-between mb-2">
+                <div className="flex-1">
+                    {/* Match by selector */}
+                    {(showGroupsOptions || onBucketingIdentifierChange) && (
+                        <div>
+                            <LemonLabel className="mb-2">Match by</LemonLabel>
+                            <LemonRadio
+                                data-attr="feature-flag-aggregation-filter"
+                                value={
+                                    releaseFilters.aggregation_group_type_index != null
+                                        ? 'group'
+                                        : bucketingIdentifier === FeatureFlagBucketingIdentifier.DEVICE_ID
+                                          ? 'device'
+                                          : 'user'
                                 }
-                                onBucketingIdentifierChange?.(null)
-                            }
-                        }}
-                        options={[
-                            {
-                                value: 'user',
-                                label: (
-                                    <div>
-                                        <div className="font-medium">User</div>
-                                        <div className="text-xs text-muted">
-                                            Stable assignment for logged-in users based on their distinct ID.
-                                        </div>
-                                    </div>
-                                ),
-                            },
-                            ...(onBucketingIdentifierChange
-                                ? [
-                                      {
-                                          value: 'device',
-                                          label: (
-                                              <div>
-                                                  <div className="font-medium">
-                                                      Device{' '}
-                                                      <LemonTag type="warning" size="small">
-                                                          BETA
-                                                      </LemonTag>
-                                                  </div>
-                                                  <div className="text-xs text-muted">
-                                                      Stable assignment per device. Good fit for experiments on
-                                                      anonymous users.{' '}
-                                                      <Link
-                                                          to="https://posthog.com/docs/feature-flags/device-bucketing"
-                                                          target="_blank"
-                                                      >
-                                                          Learn more
-                                                      </Link>
-                                                  </div>
-                                              </div>
-                                          ),
-                                      },
-                                  ]
-                                : []),
-                            ...(showGroupsOptions
-                                ? [
-                                      {
-                                          value: 'group',
-                                          label: (
-                                              <div>
-                                                  <div className="font-medium">Group</div>
-                                                  <div className="text-xs text-muted">
-                                                      Stable assignment for everyone in an organization, company, or
-                                                      other custom group type.
-                                                  </div>
-                                              </div>
-                                          ),
-                                      },
-                                  ]
-                                : []),
-                        ]}
-                        radioPosition="top"
-                    />
-                    {releaseFilters.aggregation_group_type_index != null && groupTypes.size > 0 && (
-                        <div className="mt-3 ml-6">
-                            <LemonSelect
-                                dropdownMatchSelectWidth={false}
-                                data-attr="feature-flag-group-type-select"
-                                value={releaseFilters.aggregation_group_type_index}
-                                onChange={(value) => {
-                                    if (value != null) {
-                                        setAggregationGroupTypeIndex(value)
+                                onChange={(value: string) => {
+                                    if (value === 'user') {
+                                        setAggregationGroupTypeIndex(null)
+                                        onBucketingIdentifierChange?.(FeatureFlagBucketingIdentifier.DISTINCT_ID)
+                                    } else if (value === 'device') {
+                                        setAggregationGroupTypeIndex(null)
+                                        onBucketingIdentifierChange?.(FeatureFlagBucketingIdentifier.DEVICE_ID)
+                                    } else if (value === 'group') {
+                                        const firstGroupType = Array.from(groupTypes.values())[0]
+                                        if (firstGroupType) {
+                                            setAggregationGroupTypeIndex(firstGroupType.group_type_index)
+                                        }
+                                        onBucketingIdentifierChange?.(null)
                                     }
                                 }}
-                                options={Array.from(groupTypes.values()).map((groupType) => ({
-                                    value: groupType.group_type_index,
-                                    label: groupType.group_type,
-                                }))}
+                                options={[
+                                    {
+                                        value: 'user',
+                                        label: (
+                                            <div>
+                                                <div className="font-medium">User</div>
+                                                <div className="text-xs text-muted">
+                                                    Stable assignment for logged-in users based on their distinct ID.
+                                                </div>
+                                            </div>
+                                        ),
+                                    },
+                                    ...(onBucketingIdentifierChange
+                                        ? [
+                                              {
+                                                  value: 'device',
+                                                  label: (
+                                                      <div>
+                                                          <div className="font-medium">
+                                                              Device{' '}
+                                                              <LemonTag type="warning" size="small">
+                                                                  BETA
+                                                              </LemonTag>
+                                                          </div>
+                                                          <div className="text-xs text-muted">
+                                                              Stable assignment per device. Good fit for experiments on
+                                                              anonymous users.{' '}
+                                                              <Link
+                                                                  to="https://posthog.com/docs/feature-flags/device-bucketing"
+                                                                  target="_blank"
+                                                              >
+                                                                  Learn more
+                                                              </Link>
+                                                          </div>
+                                                      </div>
+                                                  ),
+                                              },
+                                          ]
+                                        : []),
+                                    ...(showGroupsOptions
+                                        ? [
+                                              {
+                                                  value: 'group',
+                                                  label: (
+                                                      <div>
+                                                          <div className="font-medium">Group</div>
+                                                          <div className="text-xs text-muted">
+                                                              Stable assignment for everyone in an organization,
+                                                              company, or other custom group type.
+                                                          </div>
+                                                      </div>
+                                                  ),
+                                              },
+                                          ]
+                                        : []),
+                                ]}
+                                radioPosition="top"
                             />
+                            {releaseFilters.aggregation_group_type_index != null && groupTypes.size > 0 && (
+                                <div className="mt-3 ml-6">
+                                    <LemonSelect
+                                        dropdownMatchSelectWidth={false}
+                                        data-attr="feature-flag-group-type-select"
+                                        value={releaseFilters.aggregation_group_type_index}
+                                        onChange={(value) => {
+                                            if (value != null) {
+                                                setAggregationGroupTypeIndex(value)
+                                            }
+                                        }}
+                                        options={Array.from(groupTypes.values()).map((groupType) => ({
+                                            value: groupType.group_type_index,
+                                            label: groupType.group_type,
+                                        }))}
+                                    />
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>
-            )}
-
-            {flagId && <IntentWarningsBanner flagId={flagId} />}
+                <div className="flex items-start">
+                    {filterGroups.length > 1 && openConditions.length > 0 && (
+                        <LemonButton
+                            size="xsmall"
+                            type="tertiary"
+                            icon={<IconCollapse />}
+                            onClick={() => handleOpenConditionsChange([])}
+                            data-attr="collapse-all-conditions"
+                        >
+                            Collapse all
+                        </LemonButton>
+                    )}
+                </div>
+            </div>
 
             <div ref={collapseRef}>
-                {filterGroups.map((group, index) => (
-                    <div key={group.sort_key ?? index}>
-                        {index > 0 && (
-                            <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
-                                or
-                            </div>
-                        )}
-                        {flagId && <UnreachableConditionBanner flagId={flagId} groupIndex={index} />}
-                        <LemonCollapse
-                            multiple
-                            activeKeys={openConditions}
-                            onChange={handleOpenConditionsChange}
-                            panels={[
-                                {
-                                    key: `condition-${group.sort_key ?? index}`,
-                                    header: {
-                                        children: (
-                                            <ConditionHeader
-                                                group={group}
-                                                index={index}
-                                                totalGroups={filterGroups.length}
-                                                affectedUserCount={
-                                                    group.sort_key ? affectedUsers[group.sort_key] : undefined
-                                                }
-                                                totalUsers={totalUsers}
-                                                aggregationTargetName={aggregationTargetName}
-                                                onMoveUp={() => moveConditionSetUp(index)}
-                                                onMoveDown={() => moveConditionSetDown(index)}
-                                                onDuplicate={() => duplicateConditionSet(index)}
-                                                onRemove={() => removeConditionSet(index)}
-                                            />
-                                        ),
-                                        className: 'bg-bg-light',
-                                    },
-                                    className: 'bg-bg-light',
-                                    content: (
-                                        <div className="flex flex-col gap-3 pt-2">
-                                            <div className="max-w-md">
-                                                <EditableField
-                                                    multiline
-                                                    name="description"
-                                                    value={group.description || ''}
-                                                    placeholder="Description (optional)"
-                                                    onSave={(value) =>
-                                                        updateConditionSet(
-                                                            index,
-                                                            undefined,
-                                                            undefined,
-                                                            undefined,
-                                                            value
-                                                        )
-                                                    }
-                                                    saveOnBlur={true}
-                                                    maxLength={600}
-                                                    data-attr={`condition-set-${index}-description`}
-                                                    compactButtons
-                                                />
-                                            </div>
-
-                                            <div>
-                                                <LemonLabel className="mb-1">Match filters</LemonLabel>
-                                                <PropertyFilters
-                                                    orFiltering={true}
-                                                    pageKey={`feature-flag-workflow-${id}-${group.sort_key ?? index}`}
-                                                    propertyFilters={group?.properties}
-                                                    logicalRowDivider
-                                                    addText="Add filter"
-                                                    onChange={(properties) => {
-                                                        updateConditionSet(index, undefined, properties)
-                                                    }}
-                                                    taxonomicGroupTypes={taxonomicGroupTypes}
-                                                    taxonomicFilterOptionsFromProp={filtersTaxonomicOptions}
-                                                    hasRowOperator={false}
-                                                />
-                                            </div>
-
-                                            <div>
-                                                <LemonLabel className="mb-1">Rollout percentage</LemonLabel>
-                                                <div className="flex items-start gap-6">
-                                                    <LemonSlider
-                                                        value={group.rollout_percentage ?? 100}
-                                                        onChange={(value) => updateConditionSet(index, value)}
-                                                        min={0}
-                                                        max={100}
-                                                        step={1}
-                                                        className="w-80"
-                                                        ticks={[
-                                                            { value: 0, label: '0%' },
-                                                            { value: 10, label: '10%' },
-                                                            { value: 25, label: '25%' },
-                                                            { value: 50, label: '50%' },
-                                                            { value: 75, label: '75%' },
-                                                            { value: 100, label: '100%' },
-                                                        ]}
-                                                    />
-                                                    <LemonInput
-                                                        type="number"
-                                                        min={0}
-                                                        max={100}
-                                                        value={group.rollout_percentage ?? 100}
-                                                        onChange={(value) => {
-                                                            const numValue = value ? parseInt(value.toString()) : 0
-                                                            updateConditionSet(
-                                                                index,
-                                                                Math.min(100, Math.max(0, numValue))
-                                                            )
-                                                        }}
-                                                        suffix={<span>%</span>}
-                                                        className="w-20"
-                                                    />
-                                                </div>
-                                                {group.sort_key && affectedUsers[group.sort_key] !== undefined ? (
-                                                    <div className="text-xs text-muted mt-2">
-                                                        {(() => {
-                                                            const affectedUserCount = group.sort_key
-                                                                ? affectedUsers[group.sort_key]
-                                                                : undefined
-                                                            const rolloutPct = Number.isNaN(group.rollout_percentage)
-                                                                ? 0
-                                                                : (group.rollout_percentage ?? 100)
-
-                                                            if (
-                                                                affectedUserCount === undefined ||
-                                                                affectedUserCount < 0 ||
-                                                                totalUsers === null
-                                                            ) {
-                                                                return null
-                                                            }
-
-                                                            const usersReceivingFlag = Math.floor(
-                                                                (affectedUserCount * clamp(rolloutPct, 0, 100)) / 100
-                                                            )
-
-                                                            if (rolloutPct === 100) {
-                                                                return (
-                                                                    <>
-                                                                        <b>{humanFriendlyNumber(affectedUserCount)}</b>{' '}
-                                                                        of {humanFriendlyNumber(totalUsers)}{' '}
-                                                                        {aggregationTargetName} match these filters
-                                                                    </>
-                                                                )
-                                                            }
-                                                            return (
-                                                                <>
-                                                                    Will match ~
-                                                                    <b>{humanFriendlyNumber(usersReceivingFlag)}</b> of{' '}
-                                                                    {humanFriendlyNumber(totalUsers)}{' '}
-                                                                    {aggregationTargetName} ({rolloutPct}% of{' '}
-                                                                    {humanFriendlyNumber(affectedUserCount)} matching
-                                                                    the filters)
-                                                                </>
-                                                            )
-                                                        })()}
-                                                        {releaseFilters.aggregation_group_type_index == null && (
-                                                            <Tooltip
-                                                                title={
-                                                                    <>
-                                                                        A user may have{' '}
-                                                                        <Link
-                                                                            to="https://posthog.com/docs/data/persons#duplicate-person-profiles"
-                                                                            target="_blank"
-                                                                        >
-                                                                            multiple profiles
-                                                                        </Link>
-                                                                    </>
-                                                                }
-                                                                interactive
-                                                            >
-                                                                <IconInfo className="text-muted text-xs ml-0.5" />
-                                                            </Tooltip>
-                                                        )}
-                                                    </div>
-                                                ) : (
-                                                    <div className="text-xs text-muted mt-2 flex items-center gap-1">
-                                                        <Spinner className="text-sm" /> Calculating affected{' '}
-                                                        {aggregationTargetName}…
-                                                    </div>
+                <DndContext
+                    sensors={sensors}
+                    collisionDetection={rectIntersection}
+                    onDragStart={handleDragStart}
+                    onDragEnd={handleDragEnd}
+                    onDragCancel={() => {
+                        setIsAnyItemDragging(false)
+                        setDraggedGroup(null)
+                    }}
+                >
+                    <SortableContext
+                        items={filterGroups.map((group, index) => group.sort_key || index.toString())}
+                        strategy={verticalListSortingStrategy}
+                    >
+                        {filterGroups.map((group, index) => (
+                            <React.Fragment key={`fragment-${group.sort_key ?? index}`}>
+                                {index > 0 && (
+                                    <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
+                                        or
+                                    </div>
+                                )}
+                                <SortableCondition
+                                    key={`condition-${group.sort_key ?? index}`}
+                                    group={group}
+                                    index={index}
+                                    totalGroups={filterGroups.length}
+                                    affectedUsers={affectedUsers}
+                                    totalUsers={totalUsers}
+                                    aggregationTargetName={aggregationTargetName}
+                                    onMoveUp={() => moveConditionSetUp(index)}
+                                    onMoveDown={() => moveConditionSetDown(index)}
+                                    onDuplicate={() => duplicateConditionSet(index)}
+                                    onRemove={() => removeConditionSet(index)}
+                                    updateConditionSet={updateConditionSet}
+                                    taxonomicGroupTypes={taxonomicGroupTypes}
+                                    filtersTaxonomicOptions={filtersTaxonomicOptions}
+                                    releaseFilters={releaseFilters}
+                                    variants={variants}
+                                    openConditions={openConditions}
+                                    handleOpenConditionsChange={handleOpenConditionsChange}
+                                    flagId={flagId}
+                                    id={id}
+                                    isAnyItemDragging={isAnyItemDragging}
+                                />
+                            </React.Fragment>
+                        ))}
+                    </SortableContext>
+                    <DragOverlay>
+                        {draggedGroup ? (
+                            <div
+                                className="border rounded bg-bg-light"
+                                style={{ opacity: 0.9, boxShadow: '0 8px 25px rgba(0, 0, 0, 0.15)' }}
+                            >
+                                <div className="flex items-center justify-between w-full p-3">
+                                    <div className="flex items-start gap-2 min-w-0">
+                                        <span className="font-medium text-xs bg-bg-light rounded px-1.5 py-0.5 shrink-0">
+                                            {filterGroups.findIndex((g) => g.sort_key === draggedGroup.sort_key) + 1}
+                                        </span>
+                                        <span className="text-sm break-all">
+                                            {draggedGroup.description ||
+                                                summarizeProperties(
+                                                    draggedGroup.properties || [],
+                                                    aggregationTargetName
                                                 )}
-                                            </div>
-
-                                            {variants && variants.length > 0 && (
-                                                <div className="flex items-center gap-2 flex-wrap text-sm text-muted">
-                                                    <span className="flex items-center gap-1">
-                                                        <span className="font-medium text-default">
-                                                            Optional override
-                                                        </span>
-                                                        <Tooltip
-                                                            title={
-                                                                <>
-                                                                    Force all matching {aggregationTargetName} to
-                                                                    receive a specific variant.{' '}
-                                                                    <Link
-                                                                        to="https://posthog.com/docs/feature-flags/testing#method-1-assign-a-user-a-specific-flag-value"
-                                                                        target="_blank"
-                                                                    >
-                                                                        Learn more
-                                                                    </Link>
-                                                                </>
-                                                            }
-                                                        >
-                                                            <IconInfo className="text-base" />
-                                                        </Tooltip>
-                                                    </span>
-                                                    <span>
-                                                        Set variant for all {aggregationTargetName} in this set to
-                                                    </span>
-                                                    <LemonSelect
-                                                        placeholder="Select variant"
-                                                        allowClear={true}
-                                                        value={group.variant ?? null}
-                                                        onChange={(value) =>
-                                                            updateConditionSet(index, undefined, undefined, value)
-                                                        }
-                                                        options={variants.map((variant) => ({
-                                                            label: variant.key,
-                                                            value: variant.key,
-                                                        }))}
-                                                        size="small"
-                                                        data-attr="feature-flags-variant-override-select"
-                                                    />
-                                                </div>
-                                            )}
-                                        </div>
-                                    ),
-                                },
-                            ]}
-                        />
-                    </div>
-                ))}
+                                        </span>
+                                    </div>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                        <span className="text-sm text-muted mr-2">
+                                            ({draggedGroup.rollout_percentage ?? 100}%
+                                            {draggedGroup.variant && ` · ${draggedGroup.variant}`})
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        ) : null}
+                    </DragOverlay>
+                </DndContext>
             </div>
 
             <LemonButton type="secondary" icon={<IconPlus />} onClick={handleAddConditionSet} className="mt-1">

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -256,29 +256,7 @@ function UnreachableConditionBanner({
     )
 }
 
-const SortableCondition = ({
-    group,
-    index,
-    totalGroups,
-    affectedUsers,
-    totalUsers,
-    aggregationTargetName,
-    onMoveUp,
-    onMoveDown,
-    onDuplicate,
-    onRemove,
-    updateConditionSet,
-    taxonomicGroupTypes,
-    filtersTaxonomicOptions,
-    releaseFilters,
-    variants,
-    openConditions,
-    handleOpenConditionsChange,
-    flagId,
-    id,
-    isAnyItemDragging,
-    isDragDropEnabled = false,
-}: {
+interface ConditionProps {
     group: FeatureFlagGroupTypeWithSortKey
     index: number
     totalGroups: number
@@ -305,12 +283,83 @@ const SortableCondition = ({
     flagId?: FeatureFlagLogicProps['id']
     id: string
     isAnyItemDragging: boolean
-    isDragDropEnabled?: boolean
-}): JSX.Element => {
+}
+
+const DraggableCondition = (props: ConditionProps): JSX.Element => {
     const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
-        id: group.sort_key!, // sort_key is guaranteed by ensureSortKeys() in the logic
+        id: props.group.sort_key!, // sort_key is guaranteed by ensureSortKeys() in the logic
     })
 
+    return (
+        <ConditionContent
+            {...props}
+            attributes={attributes}
+            listeners={listeners}
+            setNodeRef={setNodeRef}
+            setActivatorNodeRef={setActivatorNodeRef}
+            transform={transform}
+            transition={transition}
+            isDragging={isDragging}
+            isDragDropEnabled={true}
+        />
+    )
+}
+
+const StaticCondition = (props: ConditionProps): JSX.Element => {
+    return (
+        <ConditionContent
+            {...props}
+            attributes={{}}
+            listeners={undefined}
+            setNodeRef={() => {}}
+            setActivatorNodeRef={() => {}}
+            transform={null}
+            transition={undefined}
+            isDragging={false}
+            isDragDropEnabled={false}
+        />
+    )
+}
+
+const ConditionContent = ({
+    group,
+    index,
+    totalGroups,
+    affectedUsers,
+    totalUsers,
+    aggregationTargetName,
+    onMoveUp,
+    onMoveDown,
+    onDuplicate,
+    onRemove,
+    updateConditionSet,
+    taxonomicGroupTypes,
+    filtersTaxonomicOptions,
+    releaseFilters,
+    variants,
+    openConditions,
+    handleOpenConditionsChange,
+    flagId,
+    id,
+    isAnyItemDragging,
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isDragDropEnabled,
+}: ConditionProps & {
+    attributes: any
+    listeners: any
+    setNodeRef: any
+    setActivatorNodeRef: any
+    transform: any
+    transition: any
+    isDragging: boolean
+    isDragDropEnabled: boolean
+}): JSX.Element => {
     const [originalWidth, setOriginalWidth] = useState<number | undefined>(undefined)
 
     // Combined ref callback
@@ -953,7 +1002,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                             or
                                         </div>
                                     )}
-                                    <SortableCondition
+                                    <DraggableCondition
                                         key={`condition-${group.sort_key!}`}
                                         group={group as FeatureFlagGroupTypeWithSortKey}
                                         index={index}
@@ -975,7 +1024,6 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                         flagId={flagId}
                                         id={id || 'feature-flag-conditions'}
                                         isAnyItemDragging={isAnyItemDragging}
-                                        isDragDropEnabled={isDragDropEnabled}
                                     />
                                 </React.Fragment>
                             ))}
@@ -1021,7 +1069,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                     or
                                 </div>
                             )}
-                            <SortableCondition
+                            <StaticCondition
                                 key={`condition-${group.sort_key!}`}
                                 group={group as FeatureFlagGroupTypeWithSortKey}
                                 index={index}
@@ -1043,7 +1091,6 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                 flagId={flagId}
                                 id={id || 'feature-flag-conditions'}
                                 isAnyItemDragging={false}
-                                isDragDropEnabled={false}
                             />
                         </React.Fragment>
                     ))

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -428,7 +428,7 @@ const SortableCondition = ({
                                         <LemonLabel className="mb-1">Match filters</LemonLabel>
                                         <PropertyFilters
                                             orFiltering={true}
-                                            pageKey={`feature-flag-workflow-${id}-${group.sort_key ?? index}`}
+                                            pageKey={`feature-flag-workflow-${id}-${group.sort_key!}`}
                                             propertyFilters={group?.properties}
                                             logicalRowDivider
                                             addText="Add filter"
@@ -690,7 +690,9 @@ export function FeatureFlagReleaseConditionsCollapsible({
         setIsAnyItemDragging(true)
 
         // Find the group being dragged
-        const draggedItem = filterGroups.find((group) => group.sort_key === String(event.active.id))
+        const draggedItem = filterGroups.find(
+            (group: FeatureFlagGroupType) => group.sort_key === String(event.active.id)
+        )
         setDraggedGroup(draggedItem || null)
     }
 
@@ -714,7 +716,9 @@ export function FeatureFlagReleaseConditionsCollapsible({
         if (newlyOpened.length > 0 && collapseRef.current) {
             // Extract the index from the key (format: "condition-{sort_key}")
             const openedKey = newlyOpened[0]
-            const panelIndex = filterGroups.findIndex((g, i) => `condition-${g.sort_key ?? i}` === openedKey)
+            const panelIndex = filterGroups.findIndex(
+                (g: FeatureFlagGroupType) => `condition-${g.sort_key!}` === openedKey
+            )
 
             setTimeout(() => {
                 // Find the panel by its position in the collapse
@@ -730,7 +734,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
         return (
             <div className="flex flex-col gap-2">
                 <LemonLabel>Release conditions</LemonLabel>
-                {filterGroups.map((group, index) => {
+                {filterGroups.map((group: FeatureFlagGroupType, index: number) => {
                     // Use description if available, otherwise summarize the filters
                     const summary =
                         group.description || summarizeProperties(group.properties || [], aggregationTargetName)
@@ -891,17 +895,37 @@ export function FeatureFlagReleaseConditionsCollapsible({
                         </div>
                     )}
                 </div>
-                <div className="flex items-start">
-                    {filterGroups.length > 1 && openConditions.length > 0 && (
-                        <LemonButton
-                            size="xsmall"
-                            type="tertiary"
-                            icon={<IconCollapse />}
-                            onClick={() => handleOpenConditionsChange([])}
-                            data-attr="collapse-all-conditions"
-                        >
-                            Collapse all
-                        </LemonButton>
+                <div className="flex items-start gap-2">
+                    {filterGroups.length > 1 && (
+                        <>
+                            {openConditions.length < filterGroups.length && (
+                                <LemonButton
+                                    size="xsmall"
+                                    type="tertiary"
+                                    icon={<IconExpand />}
+                                    onClick={() => {
+                                        const allConditionKeys = filterGroups.map(
+                                            (group: FeatureFlagGroupType) => `condition-${group.sort_key!}`
+                                        )
+                                        handleOpenConditionsChange(allConditionKeys)
+                                    }}
+                                    data-attr="expand-all-conditions"
+                                >
+                                    Expand all
+                                </LemonButton>
+                            )}
+                            {openConditions.length > 0 && (
+                                <LemonButton
+                                    size="xsmall"
+                                    type="tertiary"
+                                    icon={<IconCollapse />}
+                                    onClick={() => handleOpenConditionsChange([])}
+                                    data-attr="collapse-all-conditions"
+                                >
+                                    Collapse all
+                                </LemonButton>
+                            )}
+                        </>
                     )}
                 </div>
             </div>
@@ -919,10 +943,10 @@ export function FeatureFlagReleaseConditionsCollapsible({
                         }}
                     >
                         <SortableContext
-                            items={filterGroups.map((group) => group.sort_key!)}
+                            items={filterGroups.map((group: FeatureFlagGroupType) => group.sort_key!)}
                             strategy={verticalListSortingStrategy}
                         >
-                            {filterGroups.map((group, index) => (
+                            {filterGroups.map((group: FeatureFlagGroupType, index: number) => (
                                 <React.Fragment key={`fragment-${group.sort_key!}`}>
                                     {index > 0 && (
                                         <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
@@ -931,7 +955,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                     )}
                                     <SortableCondition
                                         key={`condition-${group.sort_key!}`}
-                                        group={group}
+                                        group={group as FeatureFlagGroupTypeWithSortKey}
                                         index={index}
                                         totalGroups={filterGroups.length}
                                         affectedUsers={affectedUsers}
@@ -965,8 +989,9 @@ export function FeatureFlagReleaseConditionsCollapsible({
                                     <div className="flex items-center justify-between w-full p-3">
                                         <div className="flex items-start gap-2 min-w-0">
                                             <span className="font-medium text-xs bg-bg-light rounded px-1.5 py-0.5 shrink-0">
-                                                {filterGroups.findIndex((g) => g.sort_key === draggedGroup.sort_key) +
-                                                    1}
+                                                {filterGroups.findIndex(
+                                                    (g: FeatureFlagGroupType) => g.sort_key === draggedGroup.sort_key
+                                                ) + 1}
                                             </span>
                                             <span className="text-sm break-all">
                                                 {draggedGroup.description ||
@@ -989,16 +1014,16 @@ export function FeatureFlagReleaseConditionsCollapsible({
                     </DndContext>
                 ) : (
                     // Fallback to non-draggable conditions when feature flag is disabled
-                    filterGroups.map((group, index) => (
-                        <React.Fragment key={`fragment-${group.sort_key ?? index}`}>
+                    filterGroups.map((group: FeatureFlagGroupType, index: number) => (
+                        <React.Fragment key={`fragment-${group.sort_key!}`}>
                             {index > 0 && (
                                 <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
                                     or
                                 </div>
                             )}
                             <SortableCondition
-                                key={`condition-${group.sort_key ?? index}`}
-                                group={group}
+                                key={`condition-${group.sort_key!}`}
+                                group={group as FeatureFlagGroupTypeWithSortKey}
                                 index={index}
                                 totalGroups={filterGroups.length}
                                 affectedUsers={affectedUsers}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -3,6 +3,7 @@ import {
     DragEndEvent,
     DragOverlay,
     DragStartEvent,
+    KeyboardSensor,
     PointerSensor,
     useSensor,
     useSensors,
@@ -11,7 +12,7 @@ import {
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useActions, useValues } from 'kea'
-import React, { useRef, useMemo, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 import { IconCollapse, IconCopy, IconExpand, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
@@ -50,6 +51,7 @@ import { FlagIntent, featureFlagIntentWarningLogic } from './featureFlagIntentWa
 import { FeatureFlagLogicProps } from './featureFlagLogic'
 import {
     FeatureFlagReleaseConditionsLogicProps,
+    FeatureFlagGroupTypeWithSortKey,
     featureFlagReleaseConditionsLogic,
 } from './featureFlagReleaseConditionsLogic'
 
@@ -150,29 +152,27 @@ function ConditionHeader({
                         ` · ${humanFriendlyNumber(actualUserCount)} ${aggregationTargetName}`}
                     )
                 </span>
-                <Tooltip title="Duplicate condition set">
-                    <span
-                        className="cursor-pointer p-1 hover:bg-bg-dark rounded text-muted hover:text-default transition-colors"
+                <LemonButton
+                    icon={<IconCopy />}
+                    size="xsmall"
+                    noPadding
+                    tooltip="Duplicate condition set"
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        onDuplicate()
+                    }}
+                />
+                {totalGroups > 1 && (
+                    <LemonButton
+                        icon={<IconTrash />}
+                        size="xsmall"
+                        noPadding
+                        tooltip="Remove condition set"
                         onClick={(e) => {
                             e.stopPropagation()
-                            onDuplicate()
+                            onRemove()
                         }}
-                    >
-                        <IconCopy className="w-4 h-4" />
-                    </span>
-                </Tooltip>
-                {totalGroups > 1 && (
-                    <Tooltip title="Remove condition set">
-                        <span
-                            className="cursor-pointer p-1 hover:bg-bg-dark rounded text-muted hover:text-default transition-colors"
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                onRemove()
-                            }}
-                        >
-                            <IconTrash className="w-4 h-4" />
-                        </span>
-                    </Tooltip>
+                    />
                 )}
             </div>
         </div>
@@ -279,7 +279,7 @@ const SortableCondition = ({
     isAnyItemDragging,
     isDragDropEnabled = false,
 }: {
-    group: FeatureFlagGroupType
+    group: FeatureFlagGroupTypeWithSortKey
     index: number
     totalGroups: number
     affectedUsers: Record<string, number | undefined>
@@ -308,7 +308,7 @@ const SortableCondition = ({
     isDragDropEnabled?: boolean
 }): JSX.Element => {
     const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
-        id: group.sort_key || index.toString(),
+        id: group.sort_key!, // sort_key is guaranteed by ensureSortKeys() in the logic
     })
 
     const [originalWidth, setOriginalWidth] = useState<number | undefined>(undefined)
@@ -337,11 +337,25 @@ const SortableCondition = ({
         }),
     }
 
+    const toggleCondition = (): void => {
+        // Prevent collapse/expand during ANY drag operation to maintain consistent heights
+        if (isAnyItemDragging) {
+            return
+        }
+
+        const conditionKey = `condition-${group.sort_key!}`
+        const isOpen = openConditions.includes(conditionKey)
+        const newOpenConditions = isOpen
+            ? openConditions.filter((key) => key !== conditionKey)
+            : [...openConditions, conditionKey]
+        handleOpenConditionsChange(newOpenConditions)
+    }
+
     return (
         <div
             ref={combinedRef}
             style={style}
-            className={isDragging ? 'opacity-50 border-2 border-dashed border-border-light bg-bg-3000 rounded' : ''}
+            className={isDragging ? 'border-2 border-dashed border-border-light bg-bg-3000 rounded' : ''}
         >
             {flagId && <UnreachableConditionBanner flagId={flagId} groupIndex={index} />}
             <div className="flex items-start gap-3">
@@ -351,7 +365,7 @@ const SortableCondition = ({
                             className="flex items-center justify-between w-full p-3 cursor-pointer hover:bg-bg-dark transition-colors"
                             role="button"
                             tabIndex={0}
-                            aria-expanded={openConditions.includes(`condition-${group.sort_key ?? index}`)}
+                            aria-expanded={openConditions.includes(`condition-${group.sort_key!}`)}
                             aria-label={`Toggle condition ${index + 1} details`}
                             onClick={() => {
                                 // Prevent collapse/expand during ANY drag operation to maintain consistent heights
@@ -359,11 +373,7 @@ const SortableCondition = ({
                                     return
                                 }
 
-                                const isOpen = openConditions.includes(`condition-${group.sort_key ?? index}`)
-                                const newOpenConditions = isOpen
-                                    ? openConditions.filter((key) => key !== `condition-${group.sort_key ?? index}`)
-                                    : [...openConditions, `condition-${group.sort_key ?? index}`]
-                                handleOpenConditionsChange(newOpenConditions)
+                                toggleCondition()
                             }}
                             onKeyDown={(e) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
@@ -373,11 +383,7 @@ const SortableCondition = ({
                                         return
                                     }
 
-                                    const isOpen = openConditions.includes(`condition-${group.sort_key ?? index}`)
-                                    const newOpenConditions = isOpen
-                                        ? openConditions.filter((key) => key !== `condition-${group.sort_key ?? index}`)
-                                        : [...openConditions, `condition-${group.sort_key ?? index}`]
-                                    handleOpenConditionsChange(newOpenConditions)
+                                    toggleCondition()
                                 }
                             }}
                         >
@@ -392,14 +398,14 @@ const SortableCondition = ({
                                 onRemove={onRemove}
                             />
                             <span className="ml-2">
-                                {openConditions.includes(`condition-${group.sort_key ?? index}`) ? (
+                                {openConditions.includes(`condition-${group.sort_key!}`) ? (
                                     <IconCollapse className="w-4 h-4" />
                                 ) : (
                                     <IconExpand className="w-4 h-4" />
                                 )}
                             </span>
                         </div>
-                        {openConditions.includes(`condition-${group.sort_key ?? index}`) && (
+                        {openConditions.includes(`condition-${group.sort_key!}`) && (
                             <div className="p-3 pt-0 border-t">
                                 <div className="flex flex-col gap-3 pt-2">
                                     <div className="max-w-md">
@@ -578,7 +584,7 @@ const SortableCondition = ({
                     </div>
                 </div>
                 {totalGroups > 1 && (
-                    <div className="flex flex-col items-center gap-1 pr-2">
+                    <div className="flex flex-col items-center pr-2">
                         {isDragDropEnabled && (
                             <FeatureFlagConditionDragHandle
                                 listeners={listeners}
@@ -587,7 +593,7 @@ const SortableCondition = ({
                                 hasMultipleConditions={true}
                             />
                         )}
-                        <div className="flex flex-col gap-0.5">
+                        <div className="flex flex-row gap-0.5 w-6 justify-center">
                             {index > 0 && (
                                 <LemonButton
                                     icon={<IconArrowUp />}
@@ -632,16 +638,12 @@ export function FeatureFlagReleaseConditionsCollapsible({
     onBucketingIdentifierChange,
     evaluationRuntime,
 }: FeatureFlagReleaseConditionsCollapsibleProps): JSX.Element {
-    const releaseConditionsLogic = useMemo(
-        () =>
-            featureFlagReleaseConditionsLogic({
-                id,
-                readOnly,
-                filters,
-                onChange,
-            }),
-        [id, readOnly, filters, onChange]
-    )
+    const releaseConditionsLogic = featureFlagReleaseConditionsLogic({
+        id,
+        readOnly,
+        filters,
+        onChange,
+    })
 
     const {
         taxonomicGroupTypes,
@@ -675,7 +677,12 @@ export function FeatureFlagReleaseConditionsCollapsible({
         addConditionSet(uuidv4())
     }
 
-    const sensors = useSensors(useSensor(PointerSensor))
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 8 },
+        }),
+        useSensor(KeyboardSensor)
+    )
     const [isAnyItemDragging, setIsAnyItemDragging] = useState(false)
     const [draggedGroup, setDraggedGroup] = useState<FeatureFlagGroupType | null>(null)
 
@@ -683,9 +690,7 @@ export function FeatureFlagReleaseConditionsCollapsible({
         setIsAnyItemDragging(true)
 
         // Find the group being dragged
-        const draggedItem = filterGroups.find(
-            (group, index) => (group.sort_key || index.toString()) === String(event.active.id)
-        )
+        const draggedItem = filterGroups.find((group) => group.sort_key === String(event.active.id))
         setDraggedGroup(draggedItem || null)
     }
 
@@ -914,18 +919,18 @@ export function FeatureFlagReleaseConditionsCollapsible({
                         }}
                     >
                         <SortableContext
-                            items={filterGroups.map((group, index) => group.sort_key || index.toString())}
+                            items={filterGroups.map((group) => group.sort_key!)}
                             strategy={verticalListSortingStrategy}
                         >
                             {filterGroups.map((group, index) => (
-                                <React.Fragment key={`fragment-${group.sort_key ?? index}`}>
+                                <React.Fragment key={`fragment-${group.sort_key!}`}>
                                     {index > 0 && (
                                         <div className="text-xs font-medium text-muted uppercase tracking-wide text-center w-full py-2">
                                             or
                                         </div>
                                     )}
                                     <SortableCondition
-                                        key={`condition-${group.sort_key ?? index}`}
+                                        key={`condition-${group.sort_key!}`}
                                         group={group}
                                         index={index}
                                         totalGroups={filterGroups.length}

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.test.ts
@@ -48,6 +48,7 @@ describe('the feature flag release conditions logic', () => {
                 {
                     properties: [],
                     rollout_percentage: 50,
+                    sort_key: 'group-1',
                     variant: null,
                 },
             ]),
@@ -814,6 +815,84 @@ describe('the feature flag release conditions logic', () => {
                     // The open state should be preserved by index (first condition stays open)
                     openConditions: ['condition-NEW-KEY'],
                 })
+        })
+
+        it('can reorder condition sets', async () => {
+            logic?.unmount()
+
+            // Create logic with multiple condition sets
+            logic = featureFlagReleaseConditionsLogic({
+                id: 'reorder-test',
+                filters: generateFeatureFlagFilters([
+                    { properties: [], rollout_percentage: 50, variant: null, sort_key: 'first' },
+                    { properties: [], rollout_percentage: 30, variant: null, sort_key: 'second' },
+                    { properties: [], rollout_percentage: 20, variant: null, sort_key: 'third' },
+                ]),
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            }).toMatchValues({
+                filterGroups: [
+                    expect.objectContaining({ sort_key: 'first', rollout_percentage: 50 }),
+                    expect.objectContaining({ sort_key: 'second', rollout_percentage: 30 }),
+                    expect.objectContaining({ sort_key: 'third', rollout_percentage: 20 }),
+                ],
+            })
+
+            // Reorder: move 'first' to after 'second'
+            await expectLogic(logic, () => {
+                logic.actions.reorderConditionSets('first', 'second')
+            }).toMatchValues({
+                filterGroups: [
+                    expect.objectContaining({ sort_key: 'second', rollout_percentage: 30 }),
+                    expect.objectContaining({ sort_key: 'first', rollout_percentage: 50 }),
+                    expect.objectContaining({ sort_key: 'third', rollout_percentage: 20 }),
+                ],
+            })
+
+            // Reorder: move 'third' to the beginning
+            await expectLogic(logic, () => {
+                logic.actions.reorderConditionSets('third', 'second')
+            }).toMatchValues({
+                filterGroups: [
+                    expect.objectContaining({ sort_key: 'third', rollout_percentage: 20 }),
+                    expect.objectContaining({ sort_key: 'second', rollout_percentage: 30 }),
+                    expect.objectContaining({ sort_key: 'first', rollout_percentage: 50 }),
+                ],
+            })
+        })
+
+        it('ignores reorder when activeId equals overId', async () => {
+            logic?.unmount()
+
+            logic = featureFlagReleaseConditionsLogic({
+                id: 'reorder-same-test',
+                filters: generateFeatureFlagFilters([
+                    { properties: [], rollout_percentage: 50, variant: null, sort_key: 'first' },
+                    { properties: [], rollout_percentage: 30, variant: null, sort_key: 'second' },
+                ]),
+            })
+
+            await expectLogic(logic, () => {
+                logic.mount()
+            }).toMatchValues({
+                filterGroups: [
+                    expect.objectContaining({ sort_key: 'first', rollout_percentage: 50 }),
+                    expect.objectContaining({ sort_key: 'second', rollout_percentage: 30 }),
+                ],
+            })
+
+            // Try to reorder same item to itself - should be ignored
+            await expectLogic(logic, () => {
+                logic.actions.reorderConditionSets('first', 'first')
+            }).toMatchValues({
+                // Should remain unchanged
+                filterGroups: [
+                    expect.objectContaining({ sort_key: 'first', rollout_percentage: 50 }),
+                    expect.objectContaining({ sort_key: 'second', rollout_percentage: 30 }),
+                ],
+            })
         })
     })
 })

--- a/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts
@@ -94,6 +94,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         duplicateConditionSet: (index: number) => ({ index }),
         moveConditionSetUp: (index: number) => ({ index }),
         moveConditionSetDown: (index: number) => ({ index }),
+        reorderConditionSets: (activeId: string, overId: string) => ({ activeId, overId }),
         updateConditionSet: (
             index: number,
             newRolloutPercentage?: number,
@@ -245,6 +246,23 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 return {
                     ...state,
                     groups: moveConditionSet(state.groups, index, index - 1),
+                }
+            },
+            reorderConditionSets: (state, { activeId, overId }) => {
+                if (!state || activeId === overId) {
+                    return state
+                }
+
+                const activeIndex = state.groups.findIndex((group) => group.sort_key === activeId)
+                const overIndex = state.groups.findIndex((group) => group.sort_key === overId)
+
+                if (activeIndex === -1 || overIndex === -1) {
+                    return state
+                }
+
+                return {
+                    ...state,
+                    groups: moveConditionSet(state.groups, activeIndex, overIndex),
                 }
             },
         },


### PR DESCRIPTION
## Problem

The new UI for feature flag release conditions didn't have drag and drop functionality to reorder conditions.

## Changes

- Add drag and drop reordering for condition sets using @dnd-kit
- Move up/down buttons to the right side of conditions
- Add "Collapse all" button at the top
- Visual feedback during drag operations with placeholders and overlay

![chrome-capture-2026-03-23](https://github.com/user-attachments/assets/9fa3f930-111b-48ac-b173-9b876454619f)

## How did you test this code?

- Tested drag and drop reordering with multiple condition sets
- Verified up/down buttons work correctly
- Tested collapse all functionality