### PR TITLE
fix: use HogQL placeholders for data warehouse fields

### DIFF
--- a/.agents/security.md
+++ b/.agents/security.md
@@ -42,6 +42,7 @@ parse_expr("{x}", placeholders={"x": ast.Constant(value=self.query.field)})  # S
 
 - `ast.Constant(value=...)` - wraps values safely
 - `ast.Tuple(exprs=...)` - for lists of values
+- `ast.Field(chain=[...])` - wraps identifiers (table names, column names) safely
 
 ## Semgrep Rules
 
@@ -49,12 +50,12 @@ Run `semgrep --config .semgrep/rules/hogql-no-fstring.yaml .` to check for HogQL
 
 Two rules:
 
-1. `hogql-injection-taint` - Flags user data (`self.query.*`, etc.) interpolated into f-strings passed to parse functions (HIGH confidence)
+1. `hogql-injection-taint` - Flags user data (`self.query.*`, `self.$obj.$field`, etc.) interpolated into f-strings passed to parse functions (HIGH confidence)
 2. `hogql-fstring-audit` - Flags all f-strings in parse functions for manual review (LOW confidence)
 
 **When semgrep flags your code:**
 
-- If user data is interpolated into f-string → wrap with `ast.Constant()` in placeholders
+- If user data is interpolated into f-string → wrap with `ast.Constant()` or `ast.Field(chain=[...])` in placeholders
 - If f-string uses safe values (loop index, enum, dict lookup) → add `# nosemgrep: <rule-id>` with explanation
 
 **Running tests:**

--- a/.semgrep/rules/hogql-no-fstring.py
+++ b/.semgrep/rules/hogql-no-fstring.py
@@ -527,12 +527,7 @@ class TestTaintNestedAttrVulnerable:
 
 
 # ============================================================================
-# hogql-injection-taint: SHOULD NOT FIND - Nested attr sanitized
-# ============================================================================
-
-
-# ============================================================================
-# hogql-injection-taint: SHOULD NOT FIND - Excluded internal objects
+# hogql-injection-taint: SHOULD NOT FIND - Nested attr (sanitized / excluded)
 # ============================================================================
 
 

--- a/.semgrep/rules/hogql-no-fstring.py
+++ b/.semgrep/rules/hogql-no-fstring.py
@@ -508,6 +508,73 @@ class TestFstringSafeTernary:
 
 
 # ============================================================================
+# hogql-injection-taint: SHOULD FIND - Nested self attribute access
+# ============================================================================
+
+
+class TestTaintNestedAttrVulnerable:
+    def test_self_source_table_name(self):
+        # ruleid: hogql-injection-taint, hogql-fstring-audit
+        parse_select(f"SELECT * FROM {self.source.table_name}")
+
+    def test_self_metric_source_field(self):
+        # ruleid: hogql-injection-taint, hogql-fstring-audit
+        parse_expr(f"{self.metric.source.timestamp_field} AS ts")
+
+    def test_self_source_info_field(self):
+        # ruleid: hogql-injection-taint, hogql-fstring-audit
+        parse_select(f"SELECT {self.source_info.timestamp_field} FROM events")
+
+
+# ============================================================================
+# hogql-injection-taint: SHOULD NOT FIND - Nested attr sanitized
+# ============================================================================
+
+
+# ============================================================================
+# hogql-injection-taint: SHOULD NOT FIND - Excluded internal objects
+# ============================================================================
+
+
+class TestTaintInternalObjectsSafe:
+    def test_context_max_steps(self):
+        # ok: hogql-injection-taint
+        # ruleid: hogql-fstring-audit
+        parse_expr(f"steps <= {self.context.max_steps}")
+
+    def test_context_funnel_order_type(self):
+        # ok: hogql-injection-taint
+        # ruleid: hogql-fstring-audit
+        parse_select(f"SELECT '{self.context.funnelOrderType}'")
+
+    def test_query_date_range_lookahead(self):
+        # ok: hogql-injection-taint
+        # ruleid: hogql-fstring-audit
+        parse_expr(f"arraySlice(arr, 1, {self.query_date_range.lookahead})")
+
+    def test_query_date_range_interval_name(self):
+        # ok: hogql-injection-taint
+        # ruleid: hogql-fstring-audit
+        parse_expr(f"toInterval{self.query_date_range.interval_name}(x)")
+
+    def test_team_timezone(self):
+        # ok: hogql-injection-taint
+        # ruleid: hogql-fstring-audit
+        parse_expr(f"toTimeZone(ts, '{self.team.timezone}')")
+
+
+class TestTaintNestedAttrSafe:
+    def test_sanitized_with_ast_field(self):
+        # ok: hogql-injection-taint
+        parse_select("{x}", placeholders={"x": ast.Field(chain=[self.source.table_name])})
+
+    def test_sanitized_with_direct_pass(self):
+        # Safe: user provides entire expression (no f-string, no context to escape)
+        # ok: hogql-injection-taint
+        parse_expr(self.source.timestamp_field)
+
+
+# ============================================================================
 # clickhouse-injection-taint: SHOULD FIND (user data in f-strings to execute)
 # ============================================================================
 

--- a/.semgrep/rules/hogql-no-fstring.yaml
+++ b/.semgrep/rules/hogql-no-fstring.yaml
@@ -1,149 +1,164 @@
 rules:
-    # Rule 1: Taint tracking for user input interpolated into HogQL strings
-    # Only flags when user data is INSIDE an f-string (vulnerable pattern),
-    # NOT when user provides the entire expression (safe pattern).
-    - id: hogql-injection-taint
-      mode: taint
-      languages: [python]
-      severity: WARNING
-      message: |
-          User-controlled data interpolated into HogQL string flows to parse function.
-          Use ast.Constant in placeholders: parse_expr("{x}", placeholders={"x": ast.Constant(value=...)})
-      pattern-sources:
-          # Direct interpolation in f-strings
-          - patterns:
-                - pattern-either:
-                      - pattern: self.query.$FIELD
-                      - pattern: self.context.includeProperties
-                      - pattern: self.series.math_hogql
-                - pattern-inside: f"..."
-          # Loop variable from taint source used in f-string
-          - patterns:
-                - pattern: $VAR
-                - pattern-inside: |
-                      for $VAR in self.query.$FIELD:
-                          ...
-                - pattern-inside: f"..."
-          - patterns:
-                - pattern: $VAR
-                - pattern-inside: |
-                      for $VAR in self.context.includeProperties:
-                          ...
-                - pattern-inside: f"..."
-      pattern-sinks:
-          - pattern: parse_select(...)
-          - pattern: parse_expr(...)
-          - pattern: parse_order_expr(...)
-      pattern-sanitizers:
-          - pattern: ast.Constant(value=...)
-          - pattern: ast.Tuple(exprs=...)
-      metadata:
-          category: security
-          subcategory:
-              - vuln
-          cwe: 'CWE-89: SQL Injection'
-          owasp: 'A03:2021 - Injection'
-          confidence: HIGH
-      paths:
-          exclude:
-              - '**/test/**'
-              - '**/tests/**'
-              - '**/.semgrep/**'
-
-    # Rule 2: Audit rule for f-strings (catch interpolation patterns)
-    - id: hogql-fstring-audit
-      patterns:
+  # Rule 1: Taint tracking for user input interpolated into HogQL strings
+  # Only flags when user data is INSIDE an f-string (vulnerable pattern),
+  # NOT when user provides the entire expression (safe pattern).
+  - id: hogql-injection-taint
+    mode: taint
+    languages: [python]
+    severity: WARNING
+    message: |
+      User-controlled data interpolated into HogQL string flows to parse function.
+      Use ast.Constant in placeholders: parse_expr("{x}", placeholders={"x": ast.Constant(value=...)})
+    options:
+      taint_assume_safe_numbers: true
+      taint_assume_safe_booleans: true
+    pattern-sources:
+      # Direct interpolation in f-strings
+      - patterns:
           - pattern-either:
-                - pattern: parse_select(f"...", ...)
-                - pattern: parse_expr(f"...")
-                - pattern: parse_order_expr(f"...", ...)
-          # Exclude known-safe patterns (each entry is OR'd together)
-          - pattern-not-regex: "step_\\{|latest_\\{|exclusion_\\{"
-          - pattern-not-regex: "\\.pk\\}|\\{table_alias\\}"
-          # Loop indices (safe: always integers)
-          - pattern-not-regex: "\\{i\\}|\\{index\\}"
-          # Funnel step integers (safe: from self.context.max_steps, range(), etc)
-          - pattern-not-regex: "\\{step_num|\\{funnelStep|\\{target_step|\\{final_step|\\{first_step"
-          - pattern-not-regex: "\\{absolute_actors_step|\\{from_step|\\{to_step|\\{prior_required|\\{max_steps\\}"
-          - pattern-not-regex: "\\{bin_count"
-          # Array indexing with integer vars (safe: e.g. matched_events_array[{target_step}])
-          - pattern-not-regex: "\\[\\{[a-z_]+\\s*[+\\-]?\\s*\\d*\\}\\]"
-          # Internal constant strings (safe: hardcoded ASC/DESC, field names)
-          - pattern-not-regex: "\\{order_dir\\}|\\{order_clause\\}|\\{actor\\}|\\{field\\}"
-          # Internally computed SQL fragments (safe: built from internal logic, not user input)
-          - pattern-not-regex: "\\{statement\\}|\\{event_clause\\}|\\{prop_selector\\}|\\{prop_vals\\}"
-          - pattern-not-regex: "\\{conversion_filter\\}|\\{event_join_query\\}|\\{recording_event_select_statement\\}"
-          - pattern-not-regex: "\\{funnel_step_names\\}|\\{percentile_function\\}|\\{metric_value_field\\}"
-          - pattern-not-regex: "\\{default_breakdown_selector\\}|\\{where_clause\\}|\\{array_join_query\\}"
-          # Funnel computed values (safe: join of internally-built strings)
-          - pattern-not-regex: "\\{step_results|\\{conversion_time_arrays\\}|\\{final_prop\\}|\\{order_by\\}"
-          - pattern-not-regex: "\\{mean_conversion_times\\}|\\{median_conversion_times\\}|\\{conversion_rate_expr\\}"
-          # Interval/time patterns (safe: integers or validated enums)
-          - pattern-not-regex: "\\{interval\\}|\\{interval_unit\\}"
-          # Method calls returning safe internal values
-          - pattern-not-regex: "self\\._get_breakdown|timezone_wrapper\\("
-          # Explicit int() conversion (safe: guarantees integer)
-          - pattern-not-regex: "int\\(self\\."
-          # Common limit/offset/count patterns (safe: always integers)
-          - pattern-not-regex: "\\{limit\\}|\\{offset\\}|\\{count\\}"
-          # Computed expression names (safe: internally built SQL fragments)
-          - pattern-not-regex: "\\{timestamp_expr\\}|\\{array_merge_operation\\}"
-          # Date filter patterns (safe: computed from internal date range)
-          - pattern-not-regex: "\\{date_to_filter\\}|\\{date_from_filter\\}"
-          # Inline ternary conditions (safe: boolean conditions creating constant strings)
-          - pattern-not-regex: "\\{'[^']*'\\s+if\\s+\\w+\\s+else"
-          - pattern-not-regex: "\\{\"[^\"]*\"\\s+if\\s+\\w+\\s+else"
-      message: 'HogQL f-string - review if user input is interpolated'
-      languages: [python]
-      severity: INFO
-      metadata:
-          category: security
-          subcategory:
-              - audit
-          cwe: 'CWE-89: SQL Injection'
-          owasp: 'A03:2021 - Injection'
-          confidence: LOW
-      paths:
-          exclude:
-              - '**/test/**'
-              - '**/tests/**'
-              - '**/.semgrep/**'
+              - pattern: self.query.$FIELD
+              - pattern: self.context.includeProperties
+              - pattern: self.series.math_hogql
+          - pattern-inside: f"..."
+      # Nested attribute access on self (catches schema/dataclass fields
+      # like self.metric.source.table_name, self.source_info.timestamp_field)
+      - patterns:
+          - pattern: self.$OBJ.$FIELD
+          - pattern-not: self.$OBJ.pk
+          # Internally-computed objects that don't carry user-injectable strings
+          - pattern-not: self.context.$FIELD
+          - pattern-not: self.query_date_range.$FIELD
+          - pattern-not: self.team.$FIELD
+          - pattern-inside: f"..."
+      # Loop variable from taint source used in f-string
+      - patterns:
+          - pattern: $VAR
+          - pattern-inside: |
+              for $VAR in self.query.$FIELD:
+                  ...
+          - pattern-inside: f"..."
+      - patterns:
+          - pattern: $VAR
+          - pattern-inside: |
+              for $VAR in self.context.includeProperties:
+                  ...
+          - pattern-inside: f"..."
+    pattern-sinks:
+      - pattern: parse_select(...)
+      - pattern: parse_expr(...)
+      - pattern: parse_order_expr(...)
+    pattern-sanitizers:
+      - pattern: ast.Constant(value=...)
+      - pattern: ast.Tuple(exprs=...)
+      - pattern: ast.Field(chain=...)
+      - pattern: int(...)
+    metadata:
+      category: security
+      subcategory:
+        - vuln
+      cwe: "CWE-89: SQL Injection"
+      owasp: "A03:2021 - Injection"
+      confidence: HIGH
+    paths:
+      exclude:
+        - "**/test/**"
+        - "**/tests/**"
+        - "**/.semgrep/**"
 
-    # Rule 3: Taint tracking for user input interpolated into ClickHouse queries
-    # Only flags when user data is INSIDE an f-string that flows to sync_execute/async_execute.
-    - id: clickhouse-injection-taint
-      mode: taint
-      languages: [python]
-      severity: WARNING
-      message: |
-          User-controlled data interpolated into ClickHouse query.
-          Use escape_clickhouse_identifier() for identifiers or %(name)s placeholders for values.
-      options:
-          taint_assume_safe_numbers: true
-          taint_assume_safe_booleans: true
-      pattern-sources:
-          # self.* fields in f-strings (user-controlled query parameters and instance attributes)
-          - patterns:
-                - pattern-either:
-                      - pattern: self.query.$FIELD
-                      - pattern: self.$FIELD
-                - pattern-inside: f"..."
-      pattern-sinks:
-          - pattern: sync_execute(...)
-          - pattern: async_execute(...)
-      pattern-sanitizers:
-          - pattern: escape_clickhouse_identifier(...)
-          - pattern: escape_hogql_identifier(...)
-          - pattern: int(...)
-      metadata:
-          category: security
-          subcategory:
-              - vuln
-          cwe: 'CWE-89: SQL Injection'
-          owasp: 'A03:2021 - Injection'
-          confidence: HIGH
-      paths:
-          exclude:
-              - '**/test/**'
-              - '**/tests/**'
-              - '**/.semgrep/**'
+  # Rule 2: Audit rule for f-strings (catch interpolation patterns)
+  - id: hogql-fstring-audit
+    patterns:
+      - pattern-either:
+          - pattern: parse_select(f"...", ...)
+          - pattern: parse_expr(f"...")
+          - pattern: parse_order_expr(f"...", ...)
+      # Exclude known-safe patterns (each entry is OR'd together)
+      - pattern-not-regex: "step_\\{|latest_\\{|exclusion_\\{"
+      - pattern-not-regex: "\\.pk\\}|\\{table_alias\\}"
+      # Loop indices (safe: always integers)
+      - pattern-not-regex: "\\{i\\}|\\{index\\}"
+      # Funnel step integers (safe: from self.context.max_steps, range(), etc)
+      - pattern-not-regex: "\\{step_num|\\{funnelStep|\\{target_step|\\{final_step|\\{first_step"
+      - pattern-not-regex: "\\{absolute_actors_step|\\{from_step|\\{to_step|\\{prior_required|\\{max_steps\\}"
+      - pattern-not-regex: "\\{bin_count"
+      # Array indexing with integer vars (safe: e.g. matched_events_array[{target_step}])
+      - pattern-not-regex: "\\[\\{[a-z_]+\\s*[+\\-]?\\s*\\d*\\}\\]"
+      # Internal constant strings (safe: hardcoded ASC/DESC, field names)
+      - pattern-not-regex: "\\{order_dir\\}|\\{order_clause\\}|\\{actor\\}|\\{field\\}"
+      # Internally computed SQL fragments (safe: built from internal logic, not user input)
+      - pattern-not-regex: "\\{statement\\}|\\{event_clause\\}|\\{prop_selector\\}|\\{prop_vals\\}"
+      - pattern-not-regex: "\\{conversion_filter\\}|\\{event_join_query\\}|\\{recording_event_select_statement\\}"
+      - pattern-not-regex: "\\{funnel_step_names\\}|\\{percentile_function\\}|\\{metric_value_field\\}"
+      - pattern-not-regex: "\\{default_breakdown_selector\\}|\\{where_clause\\}|\\{array_join_query\\}"
+      # Funnel computed values (safe: join of internally-built strings)
+      - pattern-not-regex: "\\{step_results|\\{conversion_time_arrays\\}|\\{final_prop\\}|\\{order_by\\}"
+      - pattern-not-regex: "\\{mean_conversion_times\\}|\\{median_conversion_times\\}|\\{conversion_rate_expr\\}"
+      # Interval/time patterns (safe: integers or validated enums)
+      - pattern-not-regex: "\\{interval\\}|\\{interval_unit\\}"
+      # Method calls returning safe internal values
+      - pattern-not-regex: "self\\._get_breakdown|timezone_wrapper\\("
+      # Explicit int() conversion (safe: guarantees integer)
+      - pattern-not-regex: "int\\(self\\."
+      # Common limit/offset/count patterns (safe: always integers)
+      - pattern-not-regex: "\\{limit\\}|\\{offset\\}|\\{count\\}"
+      # Computed expression names (safe: internally built SQL fragments)
+      - pattern-not-regex: "\\{timestamp_expr\\}|\\{array_merge_operation\\}"
+      # Date filter patterns (safe: computed from internal date range)
+      - pattern-not-regex: "\\{date_to_filter\\}|\\{date_from_filter\\}"
+      # Inline ternary conditions (safe: boolean conditions creating constant strings)
+      - pattern-not-regex: "\\{'[^']*'\\s+if\\s+\\w+\\s+else"
+      - pattern-not-regex: "\\{\"[^\"]*\"\\s+if\\s+\\w+\\s+else"
+    message: "HogQL f-string - review if user input is interpolated"
+    languages: [python]
+    severity: INFO
+    metadata:
+      category: security
+      subcategory:
+        - audit
+      cwe: "CWE-89: SQL Injection"
+      owasp: "A03:2021 - Injection"
+      confidence: LOW
+    paths:
+      exclude:
+        - "**/test/**"
+        - "**/tests/**"
+        - "**/.semgrep/**"
+
+  # Rule 4: Taint tracking for user input interpolated into ClickHouse queries
+  # Only flags when user data is INSIDE an f-string that flows to sync_execute/async_execute.
+  - id: clickhouse-injection-taint
+    mode: taint
+    languages: [python]
+    severity: WARNING
+    message: |
+      User-controlled data interpolated into ClickHouse query.
+      Use escape_clickhouse_identifier() for identifiers or %(name)s placeholders for values.
+    options:
+      taint_assume_safe_numbers: true
+      taint_assume_safe_booleans: true
+    pattern-sources:
+      # self.* fields in f-strings (user-controlled query parameters and instance attributes)
+      - patterns:
+          - pattern-either:
+              - pattern: self.query.$FIELD
+              - pattern: self.$FIELD
+          - pattern-inside: f"..."
+    pattern-sinks:
+      - pattern: sync_execute(...)
+      - pattern: async_execute(...)
+    pattern-sanitizers:
+      - pattern: escape_clickhouse_identifier(...)
+      - pattern: escape_hogql_identifier(...)
+      - pattern: int(...)
+    metadata:
+      category: security
+      subcategory:
+        - vuln
+      cwe: "CWE-89: SQL Injection"
+      owasp: "A03:2021 - Injection"
+      confidence: HIGH
+    paths:
+      exclude:
+        - "**/test/**"
+        - "**/tests/**"
+        - "**/.semgrep/**"

--- a/.semgrep/rules/hogql-no-fstring.yaml
+++ b/.semgrep/rules/hogql-no-fstring.yaml
@@ -1,164 +1,164 @@
 rules:
-  # Rule 1: Taint tracking for user input interpolated into HogQL strings
-  # Only flags when user data is INSIDE an f-string (vulnerable pattern),
-  # NOT when user provides the entire expression (safe pattern).
-  - id: hogql-injection-taint
-    mode: taint
-    languages: [python]
-    severity: WARNING
-    message: |
-      User-controlled data interpolated into HogQL string flows to parse function.
-      Use ast.Constant in placeholders: parse_expr("{x}", placeholders={"x": ast.Constant(value=...)})
-    options:
-      taint_assume_safe_numbers: true
-      taint_assume_safe_booleans: true
-    pattern-sources:
-      # Direct interpolation in f-strings
-      - patterns:
-          - pattern-either:
-              - pattern: self.query.$FIELD
-              - pattern: self.context.includeProperties
-              - pattern: self.series.math_hogql
-          - pattern-inside: f"..."
-      # Nested attribute access on self (catches schema/dataclass fields
-      # like self.metric.source.table_name, self.source_info.timestamp_field)
-      - patterns:
-          - pattern: self.$OBJ.$FIELD
-          - pattern-not: self.$OBJ.pk
-          # Internally-computed objects that don't carry user-injectable strings
-          - pattern-not: self.context.$FIELD
-          - pattern-not: self.query_date_range.$FIELD
-          - pattern-not: self.team.$FIELD
-          - pattern-inside: f"..."
-      # Loop variable from taint source used in f-string
-      - patterns:
-          - pattern: $VAR
-          - pattern-inside: |
-              for $VAR in self.query.$FIELD:
-                  ...
-          - pattern-inside: f"..."
-      - patterns:
-          - pattern: $VAR
-          - pattern-inside: |
-              for $VAR in self.context.includeProperties:
-                  ...
-          - pattern-inside: f"..."
-    pattern-sinks:
-      - pattern: parse_select(...)
-      - pattern: parse_expr(...)
-      - pattern: parse_order_expr(...)
-    pattern-sanitizers:
-      - pattern: ast.Constant(value=...)
-      - pattern: ast.Tuple(exprs=...)
-      - pattern: ast.Field(chain=...)
-      - pattern: int(...)
-    metadata:
-      category: security
-      subcategory:
-        - vuln
-      cwe: "CWE-89: SQL Injection"
-      owasp: "A03:2021 - Injection"
-      confidence: HIGH
-    paths:
-      exclude:
-        - "**/test/**"
-        - "**/tests/**"
-        - "**/.semgrep/**"
+    # Rule 1: Taint tracking for user input interpolated into HogQL strings
+    # Only flags when user data is INSIDE an f-string (vulnerable pattern),
+    # NOT when user provides the entire expression (safe pattern).
+    - id: hogql-injection-taint
+      mode: taint
+      languages: [python]
+      severity: WARNING
+      message: |
+          User-controlled data interpolated into HogQL string flows to parse function.
+          Use ast.Constant in placeholders: parse_expr("{x}", placeholders={"x": ast.Constant(value=...)})
+      options:
+          taint_assume_safe_numbers: true
+          taint_assume_safe_booleans: true
+      pattern-sources:
+          # Direct interpolation in f-strings
+          - patterns:
+                - pattern-either:
+                      - pattern: self.query.$FIELD
+                      - pattern: self.context.includeProperties
+                      - pattern: self.series.math_hogql
+                - pattern-inside: f"..."
+          # Nested attribute access on self (catches schema/dataclass fields
+          # like self.metric.source.table_name, self.source_info.timestamp_field)
+          - patterns:
+                - pattern: self.$OBJ.$FIELD
+                - pattern-not: self.$OBJ.pk
+                # Internally-computed objects that don't carry user-injectable strings
+                - pattern-not: self.context.$FIELD
+                - pattern-not: self.query_date_range.$FIELD
+                - pattern-not: self.team.$FIELD
+                - pattern-inside: f"..."
+          # Loop variable from taint source used in f-string
+          - patterns:
+                - pattern: $VAR
+                - pattern-inside: |
+                      for $VAR in self.query.$FIELD:
+                          ...
+                - pattern-inside: f"..."
+          - patterns:
+                - pattern: $VAR
+                - pattern-inside: |
+                      for $VAR in self.context.includeProperties:
+                          ...
+                - pattern-inside: f"..."
+      pattern-sinks:
+          - pattern: parse_select(...)
+          - pattern: parse_expr(...)
+          - pattern: parse_order_expr(...)
+      pattern-sanitizers:
+          - pattern: ast.Constant(value=...)
+          - pattern: ast.Tuple(exprs=...)
+          - pattern: ast.Field(chain=...)
+          - pattern: int(...)
+      metadata:
+          category: security
+          subcategory:
+              - vuln
+          cwe: 'CWE-89: SQL Injection'
+          owasp: 'A03:2021 - Injection'
+          confidence: HIGH
+      paths:
+          exclude:
+              - '**/test/**'
+              - '**/tests/**'
+              - '**/.semgrep/**'
 
-  # Rule 2: Audit rule for f-strings (catch interpolation patterns)
-  - id: hogql-fstring-audit
-    patterns:
-      - pattern-either:
-          - pattern: parse_select(f"...", ...)
-          - pattern: parse_expr(f"...")
-          - pattern: parse_order_expr(f"...", ...)
-      # Exclude known-safe patterns (each entry is OR'd together)
-      - pattern-not-regex: "step_\\{|latest_\\{|exclusion_\\{"
-      - pattern-not-regex: "\\.pk\\}|\\{table_alias\\}"
-      # Loop indices (safe: always integers)
-      - pattern-not-regex: "\\{i\\}|\\{index\\}"
-      # Funnel step integers (safe: from self.context.max_steps, range(), etc)
-      - pattern-not-regex: "\\{step_num|\\{funnelStep|\\{target_step|\\{final_step|\\{first_step"
-      - pattern-not-regex: "\\{absolute_actors_step|\\{from_step|\\{to_step|\\{prior_required|\\{max_steps\\}"
-      - pattern-not-regex: "\\{bin_count"
-      # Array indexing with integer vars (safe: e.g. matched_events_array[{target_step}])
-      - pattern-not-regex: "\\[\\{[a-z_]+\\s*[+\\-]?\\s*\\d*\\}\\]"
-      # Internal constant strings (safe: hardcoded ASC/DESC, field names)
-      - pattern-not-regex: "\\{order_dir\\}|\\{order_clause\\}|\\{actor\\}|\\{field\\}"
-      # Internally computed SQL fragments (safe: built from internal logic, not user input)
-      - pattern-not-regex: "\\{statement\\}|\\{event_clause\\}|\\{prop_selector\\}|\\{prop_vals\\}"
-      - pattern-not-regex: "\\{conversion_filter\\}|\\{event_join_query\\}|\\{recording_event_select_statement\\}"
-      - pattern-not-regex: "\\{funnel_step_names\\}|\\{percentile_function\\}|\\{metric_value_field\\}"
-      - pattern-not-regex: "\\{default_breakdown_selector\\}|\\{where_clause\\}|\\{array_join_query\\}"
-      # Funnel computed values (safe: join of internally-built strings)
-      - pattern-not-regex: "\\{step_results|\\{conversion_time_arrays\\}|\\{final_prop\\}|\\{order_by\\}"
-      - pattern-not-regex: "\\{mean_conversion_times\\}|\\{median_conversion_times\\}|\\{conversion_rate_expr\\}"
-      # Interval/time patterns (safe: integers or validated enums)
-      - pattern-not-regex: "\\{interval\\}|\\{interval_unit\\}"
-      # Method calls returning safe internal values
-      - pattern-not-regex: "self\\._get_breakdown|timezone_wrapper\\("
-      # Explicit int() conversion (safe: guarantees integer)
-      - pattern-not-regex: "int\\(self\\."
-      # Common limit/offset/count patterns (safe: always integers)
-      - pattern-not-regex: "\\{limit\\}|\\{offset\\}|\\{count\\}"
-      # Computed expression names (safe: internally built SQL fragments)
-      - pattern-not-regex: "\\{timestamp_expr\\}|\\{array_merge_operation\\}"
-      # Date filter patterns (safe: computed from internal date range)
-      - pattern-not-regex: "\\{date_to_filter\\}|\\{date_from_filter\\}"
-      # Inline ternary conditions (safe: boolean conditions creating constant strings)
-      - pattern-not-regex: "\\{'[^']*'\\s+if\\s+\\w+\\s+else"
-      - pattern-not-regex: "\\{\"[^\"]*\"\\s+if\\s+\\w+\\s+else"
-    message: "HogQL f-string - review if user input is interpolated"
-    languages: [python]
-    severity: INFO
-    metadata:
-      category: security
-      subcategory:
-        - audit
-      cwe: "CWE-89: SQL Injection"
-      owasp: "A03:2021 - Injection"
-      confidence: LOW
-    paths:
-      exclude:
-        - "**/test/**"
-        - "**/tests/**"
-        - "**/.semgrep/**"
-
-  # Rule 4: Taint tracking for user input interpolated into ClickHouse queries
-  # Only flags when user data is INSIDE an f-string that flows to sync_execute/async_execute.
-  - id: clickhouse-injection-taint
-    mode: taint
-    languages: [python]
-    severity: WARNING
-    message: |
-      User-controlled data interpolated into ClickHouse query.
-      Use escape_clickhouse_identifier() for identifiers or %(name)s placeholders for values.
-    options:
-      taint_assume_safe_numbers: true
-      taint_assume_safe_booleans: true
-    pattern-sources:
-      # self.* fields in f-strings (user-controlled query parameters and instance attributes)
-      - patterns:
+    # Rule 2: Audit rule for f-strings (catch interpolation patterns)
+    - id: hogql-fstring-audit
+      patterns:
           - pattern-either:
-              - pattern: self.query.$FIELD
-              - pattern: self.$FIELD
-          - pattern-inside: f"..."
-    pattern-sinks:
-      - pattern: sync_execute(...)
-      - pattern: async_execute(...)
-    pattern-sanitizers:
-      - pattern: escape_clickhouse_identifier(...)
-      - pattern: escape_hogql_identifier(...)
-      - pattern: int(...)
-    metadata:
-      category: security
-      subcategory:
-        - vuln
-      cwe: "CWE-89: SQL Injection"
-      owasp: "A03:2021 - Injection"
-      confidence: HIGH
-    paths:
-      exclude:
-        - "**/test/**"
-        - "**/tests/**"
-        - "**/.semgrep/**"
+                - pattern: parse_select(f"...", ...)
+                - pattern: parse_expr(f"...")
+                - pattern: parse_order_expr(f"...", ...)
+          # Exclude known-safe patterns (each entry is OR'd together)
+          - pattern-not-regex: "step_\\{|latest_\\{|exclusion_\\{"
+          - pattern-not-regex: "\\.pk\\}|\\{table_alias\\}"
+          # Loop indices (safe: always integers)
+          - pattern-not-regex: "\\{i\\}|\\{index\\}"
+          # Funnel step integers (safe: from self.context.max_steps, range(), etc)
+          - pattern-not-regex: "\\{step_num|\\{funnelStep|\\{target_step|\\{final_step|\\{first_step"
+          - pattern-not-regex: "\\{absolute_actors_step|\\{from_step|\\{to_step|\\{prior_required|\\{max_steps\\}"
+          - pattern-not-regex: "\\{bin_count"
+          # Array indexing with integer vars (safe: e.g. matched_events_array[{target_step}])
+          - pattern-not-regex: "\\[\\{[a-z_]+\\s*[+\\-]?\\s*\\d*\\}\\]"
+          # Internal constant strings (safe: hardcoded ASC/DESC, field names)
+          - pattern-not-regex: "\\{order_dir\\}|\\{order_clause\\}|\\{actor\\}|\\{field\\}"
+          # Internally computed SQL fragments (safe: built from internal logic, not user input)
+          - pattern-not-regex: "\\{statement\\}|\\{event_clause\\}|\\{prop_selector\\}|\\{prop_vals\\}"
+          - pattern-not-regex: "\\{conversion_filter\\}|\\{event_join_query\\}|\\{recording_event_select_statement\\}"
+          - pattern-not-regex: "\\{funnel_step_names\\}|\\{percentile_function\\}|\\{metric_value_field\\}"
+          - pattern-not-regex: "\\{default_breakdown_selector\\}|\\{where_clause\\}|\\{array_join_query\\}"
+          # Funnel computed values (safe: join of internally-built strings)
+          - pattern-not-regex: "\\{step_results|\\{conversion_time_arrays\\}|\\{final_prop\\}|\\{order_by\\}"
+          - pattern-not-regex: "\\{mean_conversion_times\\}|\\{median_conversion_times\\}|\\{conversion_rate_expr\\}"
+          # Interval/time patterns (safe: integers or validated enums)
+          - pattern-not-regex: "\\{interval\\}|\\{interval_unit\\}"
+          # Method calls returning safe internal values
+          - pattern-not-regex: "self\\._get_breakdown|timezone_wrapper\\("
+          # Explicit int() conversion (safe: guarantees integer)
+          - pattern-not-regex: "int\\(self\\."
+          # Common limit/offset/count patterns (safe: always integers)
+          - pattern-not-regex: "\\{limit\\}|\\{offset\\}|\\{count\\}"
+          # Computed expression names (safe: internally built SQL fragments)
+          - pattern-not-regex: "\\{timestamp_expr\\}|\\{array_merge_operation\\}"
+          # Date filter patterns (safe: computed from internal date range)
+          - pattern-not-regex: "\\{date_to_filter\\}|\\{date_from_filter\\}"
+          # Inline ternary conditions (safe: boolean conditions creating constant strings)
+          - pattern-not-regex: "\\{'[^']*'\\s+if\\s+\\w+\\s+else"
+          - pattern-not-regex: "\\{\"[^\"]*\"\\s+if\\s+\\w+\\s+else"
+      message: 'HogQL f-string - review if user input is interpolated'
+      languages: [python]
+      severity: INFO
+      metadata:
+          category: security
+          subcategory:
+              - audit
+          cwe: 'CWE-89: SQL Injection'
+          owasp: 'A03:2021 - Injection'
+          confidence: LOW
+      paths:
+          exclude:
+              - '**/test/**'
+              - '**/tests/**'
+              - '**/.semgrep/**'
+
+    # Rule 4: Taint tracking for user input interpolated into ClickHouse queries
+    # Only flags when user data is INSIDE an f-string that flows to sync_execute/async_execute.
+    - id: clickhouse-injection-taint
+      mode: taint
+      languages: [python]
+      severity: WARNING
+      message: |
+          User-controlled data interpolated into ClickHouse query.
+          Use escape_clickhouse_identifier() for identifiers or %(name)s placeholders for values.
+      options:
+          taint_assume_safe_numbers: true
+          taint_assume_safe_booleans: true
+      pattern-sources:
+          # self.* fields in f-strings (user-controlled query parameters and instance attributes)
+          - patterns:
+                - pattern-either:
+                      - pattern: self.query.$FIELD
+                      - pattern: self.$FIELD
+                - pattern-inside: f"..."
+      pattern-sinks:
+          - pattern: sync_execute(...)
+          - pattern: async_execute(...)
+      pattern-sanitizers:
+          - pattern: escape_clickhouse_identifier(...)
+          - pattern: escape_hogql_identifier(...)
+          - pattern: int(...)
+      metadata:
+          category: security
+          subcategory:
+              - vuln
+          cwe: 'CWE-89: SQL Injection'
+          owasp: 'A03:2021 - Injection'
+          confidence: HIGH
+      paths:
+          exclude:
+              - '**/test/**'
+              - '**/tests/**'
+              - '**/.semgrep/**'

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -461,10 +461,10 @@ class ExperimentQueryBuilder:
             metric_events AS (
                 SELECT
                     {{entity_key}} AS entity_id,
-                    {source_info.timestamp_field} AS timestamp,
+                    {{metric_timestamp_field}} AS timestamp,
                     {{value_expr}} AS value
                     -- breakdown columns added programmatically below
-                FROM {source_info.table_name}
+                FROM {{metric_table}}
                 WHERE {{metric_predicate}}
             ),
 
@@ -517,6 +517,8 @@ class ExperimentQueryBuilder:
         placeholders: dict = {
             "exposure_select_query": exposure_query,
             "entity_key": source_info.entity_key,
+            "metric_timestamp_field": ast.Field(chain=[source_info.timestamp_field]),
+            "metric_table": ast.Field(chain=[source_info.table_name]),
             "metric_predicate": self._build_metric_predicate(table_alias=source_info.table_name),
             "value_expr": self._build_value_expr(),
             "value_agg": self._build_value_aggregation_expr(),
@@ -755,18 +757,18 @@ class ExperimentQueryBuilder:
             numerator_events AS (
                 SELECT
                     {{num_entity_key}} AS entity_id,
-                    {num_timestamp_field} AS timestamp,
+                    {{num_timestamp_field}} AS timestamp,
                     {{numerator_value_expr}} AS value
-                FROM {num_table}
+                FROM {{num_table}}
                 WHERE {{numerator_predicate}}
             ),
 
             denominator_events AS (
                 SELECT
                     {{denom_entity_key}} AS entity_id,
-                    {denom_timestamp_field} AS timestamp,
+                    {{denom_timestamp_field}} AS timestamp,
                     {{denominator_value_expr}} AS value
-                FROM {denom_table}
+                FROM {{denom_table}}
                 WHERE {{denominator_predicate}}
             ),
 
@@ -826,6 +828,10 @@ class ExperimentQueryBuilder:
                 "exposure_select_query": exposure_query,
                 "num_entity_key": num_entity_field,
                 "denom_entity_key": denom_entity_field,
+                "num_timestamp_field": ast.Field(chain=[num_timestamp_field]),
+                "num_table": ast.Field(chain=[num_table]),
+                "denom_timestamp_field": ast.Field(chain=[denom_timestamp_field]),
+                "denom_table": ast.Field(chain=[denom_table]),
                 "numerator_predicate": self._build_metric_predicate(
                     source=self.metric.numerator, table_alias=num_table
                 ),

--- a/posthog/hogql_queries/experiments/test/test_hogql_injection.py
+++ b/posthog/hogql_queries/experiments/test/test_hogql_injection.py
@@ -1,0 +1,86 @@
+from posthog.test.base import BaseTest
+
+from posthog.schema import ExperimentDataWarehouseNode
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+
+from posthog.hogql_queries.experiments.metric_source import MetricSourceInfo
+
+
+class TestHogQLInjectionPrevention(BaseTest):
+    """Verify that user-controlled table_name and timestamp_field from
+    ExperimentDataWarehouseNode cannot inject arbitrary HogQL when used
+    in experiment query templates via placeholders."""
+
+    def test_timestamp_field_function_call_treated_as_identifier(self):
+        """A timestamp_field like 'sleep(3)' must be treated as a field
+        reference via ast.Field, not an executable function call."""
+        source = ExperimentDataWarehouseNode(
+            table_name="some_table",
+            timestamp_field="sleep(3)",
+            data_warehouse_join_key="distinct_id",
+            events_join_key="distinct_id",
+        )
+        info = MetricSourceInfo.from_source(source)
+
+        # Use the placeholder pattern (the fix) — timestamp_field goes through
+        # ast.Field so the parser treats it as a column reference
+        result = parse_select(
+            "SELECT {ts} AS timestamp FROM events",
+            placeholders={"ts": ast.Field(chain=[info.timestamp_field])},
+        )
+        assert isinstance(result, ast.SelectQuery)
+
+        select_expr = result.select[0]
+        if isinstance(select_expr, ast.Alias):
+            select_expr = select_expr.expr
+
+        assert isinstance(select_expr, ast.Field), f"Expected ast.Field, got {type(select_expr).__name__}"
+        # The malicious string is treated as a literal field name, not parsed as code
+        assert select_expr.chain == ["sleep(3)"]
+
+    def test_table_name_injection_treated_as_identifier(self):
+        """A table_name with SQL injection payload must be treated as a
+        single table identifier via ast.Field."""
+        source = ExperimentDataWarehouseNode(
+            table_name="events) SELECT 1 --",
+            timestamp_field="ts",
+            data_warehouse_join_key="distinct_id",
+            events_join_key="distinct_id",
+        )
+        info = MetricSourceInfo.from_source(source)
+
+        result = parse_select(
+            "SELECT 1 AS x FROM {tbl}",
+            placeholders={"tbl": ast.Field(chain=[info.table_name])},
+        )
+        assert isinstance(result, ast.SelectQuery)
+        assert result.select_from is not None
+        assert isinstance(result.select_from.table, ast.Field)
+        # The malicious string is a single field chain element, not parsed SQL
+        assert result.select_from.table.chain == ["events) SELECT 1 --"]
+
+    def test_timestamp_field_subquery_treated_as_identifier(self):
+        """A timestamp_field like '(SELECT currentDatabase())' must be
+        treated as a field reference, not a subquery."""
+        source = ExperimentDataWarehouseNode(
+            table_name="some_table",
+            timestamp_field="(SELECT currentDatabase())",
+            data_warehouse_join_key="distinct_id",
+            events_join_key="distinct_id",
+        )
+        info = MetricSourceInfo.from_source(source)
+
+        result = parse_select(
+            "SELECT {ts} AS timestamp FROM events",
+            placeholders={"ts": ast.Field(chain=[info.timestamp_field])},
+        )
+        assert isinstance(result, ast.SelectQuery)
+
+        select_expr = result.select[0]
+        if isinstance(select_expr, ast.Alias):
+            select_expr = select_expr.expr
+
+        assert isinstance(select_expr, ast.Field)
+        assert select_expr.chain == ["(SELECT currentDatabase())"]


### PR DESCRIPTION
Replace f-string interpolation of `table_name` and `timestamp_field` with HogQL placeholder mechanism in experiment mean and ratio query builders.