### PR TITLE
feat: extend query coalescing to include force_blocking mode

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -149,6 +149,9 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         The returned execution_mode may differ from the input: force_blocking followers
         are downgraded to blocking so they hit the cache populated by the leader.
         """
+        # Coalescing applies to both regular blocking queries and force_blocking queries.
+        # force_blocking followers are downgraded to RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+        # on DONE so they read from the cache the leader just populated, rather than recalculating.
         if execution_mode not in (
             ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
             ExecutionMode.CALCULATE_BLOCKING_ALWAYS,

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -141,10 +141,19 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
 
     def _try_coalesce(
         self, query: BaseModel, execution_mode: ExecutionMode, client_query_id: str
-    ) -> Optional[Response]:
-        """Attempt query coalescing. Returns Response for follower-error, None otherwise."""
-        if execution_mode != ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE:
-            return None
+    ) -> tuple[Optional[Response], ExecutionMode]:
+        """Attempt query coalescing.
+
+        Returns a (response, execution_mode) tuple.  The response is non-None only
+        when a follower must short-circuit (e.g. replay an error or report a timeout).
+        The returned execution_mode may differ from the input: force_blocking followers
+        are downgraded to blocking so they hit the cache populated by the leader.
+        """
+        if execution_mode not in (
+            ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+            ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+        ):
+            return None, execution_mode
 
         enabled = posthoganalytics.feature_enabled(
             "http-query-coalescing",
@@ -164,15 +173,15 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             is_leader = coalescer.try_acquire()
         except RedisError:
             log.warning("query_coalescing_redis_error", msg="redis unavailable, skipping coalescing")
-            return None
+            return None, execution_mode
 
         if is_leader:
             log.info("query_coalescing_leader_start")
             self._coalescer = coalescer
-            return None
+            return None, execution_mode
 
         if not enabled:
-            return None
+            return None, execution_mode
 
         # Follower path
         log.info("query_coalescing_follower_waiting")
@@ -181,7 +190,9 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
 
         if signal == CoalesceSignal.DONE:
             log.info("query_coalescing_follower_done")
-            return None
+            # Followers fall through to cache-aware mode so they read the result
+            # the leader just wrote, instead of recalculating.
+            return None, ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
 
         if signal == CoalesceSignal.ERROR:
             error_data = coalescer.get_error_response()
@@ -191,24 +202,24 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                     body = orjson.loads(error_data["body"])
                 except Exception:
                     log.warning("query_coalescing_follower_body_parse_failed")
-                    return None
+                    return None, execution_mode
                 return Response(
                     data=body,
                     status=error_data["status"],
-                )
+                ), execution_mode
             # Couldn't read error, fall through
             log.warning("query_coalescing_follower_error_read_failed")
-            return None
+            return None, execution_mode
 
         if signal == CoalesceSignal.TIMEOUT:
             log.warning("query_coalescing_follower_timeout")
             return Response(
                 data={"type": "server_error", "detail": "Query is still running, please try again shortly."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+            ), execution_mode
 
         log.info("query_coalescing_follower_fallthrough", signal=signal)
-        return None
+        return None, execution_mode
 
     def finalize_response(self, request, response, *args, **kwargs):
         try:
@@ -245,7 +256,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 data, self.team, data.client_query_id, request.user
             )
 
-            error = self._try_coalesce(query, execution_mode, client_query_id)
+            error, execution_mode = self._try_coalesce(query, execution_mode, client_query_id)
             if error is not None:
                 return error
 

--- a/posthog/api/test/test_query_coalescing.py
+++ b/posthog/api/test/test_query_coalescing.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from django.test import TestCase
 
+from parameterized import parameterized
 from redis.exceptions import RedisError
 
 from posthog import redis as posthog_redis
@@ -25,6 +26,7 @@ from posthog.api.query_coalescer import (
     query_coalesce_counter,
 )
 from posthog.api.services.query import process_query_model  # used in wraps= mock
+from posthog.hogql_queries.query_runner import ExecutionMode
 
 
 def _fake_clock(step: float):
@@ -352,48 +354,13 @@ class TestQueryCoalescingEndpoint(ClickhouseTestMixin, APIBaseTest):
         finally:
             redis.delete(f"{LOCK_KEY_PREFIX}:{key}")
 
-    def test_follower_waits_for_leader_and_hits_cache(self):
-        _create_event(team=self.team, event="test_event", distinct_id="user1")
-        flush_persons_and_events()
-
-        query, key = self._query_and_key()
-
-        # First request populates the cache (as leader, no lock held)
-        with mock.patch("posthog.api.query.posthoganalytics.feature_enabled", return_value=True):
-            first = self.client.post(
-                f"/api/environments/{self.team.id}/query/",
-                {"query": query.model_dump()},
-            )
-        self.assertEqual(first.status_code, 200)
-
-        # Now simulate a leader holding the lock with done signal
-        redis = posthog_redis.get_client()
-        redis.set(f"{LOCK_KEY_PREFIX}:{key}", "other_leader", ex=60)
-        redis.set(f"{DONE_KEY_PREFIX}:{key}", "1", ex=60)
-
-        before_follower = query_coalesce_counter.labels(outcome="follower")._value.get()
-        before_done = query_coalesce_counter.labels(outcome="follower_done")._value.get()
-
-        try:
-            with mock.patch("posthog.api.query.posthoganalytics.feature_enabled", return_value=True):
-                response = self.client.post(
-                    f"/api/environments/{self.team.id}/query/",
-                    {"query": query.model_dump()},
-                )
-
-            self.assertEqual(response.status_code, 200)
-            self.assertTrue(response.json().get("is_cached"))
-            events = [row[0] for row in response.json()["results"]]
-            self.assertIn("test_event", events)
-            after_follower = query_coalesce_counter.labels(outcome="follower")._value.get()
-            after_done = query_coalesce_counter.labels(outcome="follower_done")._value.get()
-            self.assertEqual(after_follower, before_follower + 1)
-            self.assertEqual(after_done, before_done + 1)
-        finally:
-            redis.delete(f"{LOCK_KEY_PREFIX}:{key}")
-            redis.delete(f"{DONE_KEY_PREFIX}:{key}")
-
-    def test_force_blocking_follower_waits_and_downgrades_to_blocking(self):
+    @parameterized.expand(
+        [
+            ("default_blocking", {}, False),
+            ("force_blocking", {"refresh": "force_blocking"}, True),
+        ]
+    )
+    def test_follower_waits_for_leader_done_and_hits_cache(self, _name, extra_payload, expect_downgrade):
         _create_event(team=self.team, event="test_event", distinct_id="user1")
         flush_persons_and_events()
 
@@ -420,20 +387,19 @@ class TestQueryCoalescingEndpoint(ClickhouseTestMixin, APIBaseTest):
             ):
                 response = self.client.post(
                     f"/api/environments/{self.team.id}/query/",
-                    {"query": query.model_dump(), "refresh": "force_blocking"},
+                    {"query": query.model_dump(), **extra_payload},
                 )
 
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.json().get("is_cached"))
+            events = [row[0] for row in response.json()["results"]]
+            self.assertIn("test_event", events)
 
-            # Verify the follower actually waited for the leader
             mock_wait.assert_called_once()
 
-            # Verify execution mode was downgraded from force_blocking to blocking
-            from posthog.hogql_queries.query_runner import ExecutionMode
-
-            _call_kwargs = mock_pqm.call_args.kwargs
-            self.assertEqual(_call_kwargs["execution_mode"], ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
+            if expect_downgrade:
+                _call_kwargs = mock_pqm.call_args.kwargs
+                self.assertEqual(_call_kwargs["execution_mode"], ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
         finally:
             redis.delete(f"{LOCK_KEY_PREFIX}:{key}")
             redis.delete(f"{DONE_KEY_PREFIX}:{key}")

--- a/posthog/api/test/test_query_coalescing.py
+++ b/posthog/api/test/test_query_coalescing.py
@@ -391,3 +391,44 @@ class TestQueryCoalescingEndpoint(ClickhouseTestMixin, APIBaseTest):
         finally:
             redis.delete(f"{LOCK_KEY_PREFIX}:{key}")
             redis.delete(f"{DONE_KEY_PREFIX}:{key}")
+
+    def test_force_blocking_follower_waits_for_leader_and_hits_cache(self):
+        _create_event(team=self.team, event="test_event", distinct_id="user1")
+        flush_persons_and_events()
+
+        query, key = self._query_and_key()
+
+        # First request populates the cache (as leader, no lock held)
+        with mock.patch("posthog.api.query.posthoganalytics.feature_enabled", return_value=True):
+            first = self.client.post(
+                f"/api/environments/{self.team.id}/query/",
+                {"query": query.model_dump()},
+            )
+        self.assertEqual(first.status_code, 200)
+
+        # Now simulate a leader holding the lock with done signal
+        redis = posthog_redis.get_client()
+        redis.set(f"{LOCK_KEY_PREFIX}:{key}", "other_leader", ex=60)
+        redis.set(f"{DONE_KEY_PREFIX}:{key}", "1", ex=60)
+
+        before_follower = query_coalesce_counter.labels(outcome="follower")._value.get()
+        before_done = query_coalesce_counter.labels(outcome="follower_done")._value.get()
+
+        try:
+            with mock.patch("posthog.api.query.posthoganalytics.feature_enabled", return_value=True):
+                response = self.client.post(
+                    f"/api/environments/{self.team.id}/query/",
+                    {"query": query.model_dump(), "refresh": "force_blocking"},
+                )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.json().get("is_cached"))
+            events = [row[0] for row in response.json()["results"]]
+            self.assertIn("test_event", events)
+            after_follower = query_coalesce_counter.labels(outcome="follower")._value.get()
+            after_done = query_coalesce_counter.labels(outcome="follower_done")._value.get()
+            self.assertEqual(after_follower, before_follower + 1)
+            self.assertEqual(after_done, before_done + 1)
+        finally:
+            redis.delete(f"{LOCK_KEY_PREFIX}:{key}")
+            redis.delete(f"{DONE_KEY_PREFIX}:{key}")

--- a/posthog/api/test/test_query_coalescing.py
+++ b/posthog/api/test/test_query_coalescing.py
@@ -24,6 +24,7 @@ from posthog.api.query_coalescer import (
     compute_coalescing_key,
     query_coalesce_counter,
 )
+from posthog.api.services.query import process_query_model  # used in wraps= mock
 
 
 def _fake_clock(step: float):
@@ -392,7 +393,7 @@ class TestQueryCoalescingEndpoint(ClickhouseTestMixin, APIBaseTest):
             redis.delete(f"{LOCK_KEY_PREFIX}:{key}")
             redis.delete(f"{DONE_KEY_PREFIX}:{key}")
 
-    def test_force_blocking_follower_waits_for_leader_and_hits_cache(self):
+    def test_force_blocking_follower_waits_and_downgrades_to_blocking(self):
         _create_event(team=self.team, event="test_event", distinct_id="user1")
         flush_persons_and_events()
 
@@ -411,11 +412,12 @@ class TestQueryCoalescingEndpoint(ClickhouseTestMixin, APIBaseTest):
         redis.set(f"{LOCK_KEY_PREFIX}:{key}", "other_leader", ex=60)
         redis.set(f"{DONE_KEY_PREFIX}:{key}", "1", ex=60)
 
-        before_follower = query_coalesce_counter.labels(outcome="follower")._value.get()
-        before_done = query_coalesce_counter.labels(outcome="follower_done")._value.get()
-
         try:
-            with mock.patch("posthog.api.query.posthoganalytics.feature_enabled", return_value=True):
+            with (
+                mock.patch("posthog.api.query.posthoganalytics.feature_enabled", return_value=True),
+                mock.patch("posthog.api.query.process_query_model", wraps=process_query_model) as mock_pqm,
+                mock.patch.object(QueryCoalescer, "wait_for_signal", return_value=CoalesceSignal.DONE) as mock_wait,
+            ):
                 response = self.client.post(
                     f"/api/environments/{self.team.id}/query/",
                     {"query": query.model_dump(), "refresh": "force_blocking"},
@@ -423,12 +425,15 @@ class TestQueryCoalescingEndpoint(ClickhouseTestMixin, APIBaseTest):
 
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.json().get("is_cached"))
-            events = [row[0] for row in response.json()["results"]]
-            self.assertIn("test_event", events)
-            after_follower = query_coalesce_counter.labels(outcome="follower")._value.get()
-            after_done = query_coalesce_counter.labels(outcome="follower_done")._value.get()
-            self.assertEqual(after_follower, before_follower + 1)
-            self.assertEqual(after_done, before_done + 1)
+
+            # Verify the follower actually waited for the leader
+            mock_wait.assert_called_once()
+
+            # Verify execution mode was downgraded from force_blocking to blocking
+            from posthog.hogql_queries.query_runner import ExecutionMode
+
+            _call_kwargs = mock_pqm.call_args.kwargs
+            self.assertEqual(_call_kwargs["execution_mode"], ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE)
         finally:
             redis.delete(f"{LOCK_KEY_PREFIX}:{key}")
             redis.delete(f"{DONE_KEY_PREFIX}:{key}")


### PR DESCRIPTION
## Problem

When users send `force_blocking` queries, identical concurrent requests all hit ClickHouse independently. Currently,  query coalescing only applies to the `blocking` execution mode and has been fully rolled out since 03-17-2026. 

<img width="1725" height="858" alt="Screenshot 2026-03-19 at 7 39 05 PM" src="https://github.com/user-attachments/assets/f9824cff-bbc6-413b-84f7-85a9425fa3ab" />

https://grafana.prod-us.posthog.dev/d/af9h9hoy427swd/query-cache?folderUid=ae39cxpeaic5cd&orgId=1&from=2026-03-19T17:39:23.486Z&to=2026-03-19T23:39:23.486Z&timezone=browser&refresh=5s&var-teamid=2&showCategory=Panel%20options&viewPanel=panel-26

## Changes

- Expanded the coalescing guard in `_try_coalesce` to also accept the `force_blocking` execution mode
- Changed `_try_coalesce` return type to `tuple[Optional[Response], ExecutionMode]` so followers can have their execution mode downgraded
- When a `force_blocking` follower receives the `DONE` signal, its execution mode is downgraded to `blocking` so it reads the cached result the leader just wrote instead of recalculating

## How did you test this code?

- Added a test verifying the force_blocking follower path
- Manually tested locally by sending duplicate queries and verified metrics showed coalescing

## Publish to changelog?

No

## Docs update

N/A