### PR TITLE
fix(auth): scope export renderer JWT tokens with dedicated audience

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -774,13 +774,13 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
                     session_id=session_recording_id, team=resource.team
                 )
 
-                # Create a JWT for the recording
+                # Create a scoped JWT for the recording
                 export_access_token = ""
                 if resource.created_by and resource.created_by.id:
                     export_access_token = encode_jwt(
                         {"id": resource.created_by.id},
                         timedelta(minutes=5),  # 5 mins should be enough for the export to complete
-                        PosthogJwtAudience.IMPERSONATED_USER,
+                        PosthogJwtAudience.EXPORT_RENDERER,
                     )
 
                 asset_title = "Session Recording"
@@ -831,13 +831,13 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
                 raise NotFound("Invalid heatmap export - missing heatmap_type")
 
             try:
-                # Create a JWT to access the heatmap data
+                # Create a scoped JWT to access the heatmap data
                 export_access_token = ""
                 if resource.created_by and resource.created_by.id:
                     export_access_token = encode_jwt(
                         {"id": resource.created_by.id},
                         timedelta(minutes=5),
-                        PosthogJwtAudience.IMPERSONATED_USER,
+                        PosthogJwtAudience.EXPORT_RENDERER,
                     )
 
                 asset_title = "Heatmap"

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -412,7 +412,7 @@ class JwtAuthentication(authentication.BaseAuthentication):
 
 class ExportRendererAuthentication(authentication.BaseAuthentication):
     """
-    Scoped authentication for the Chromium export renderer.
+    Read-only authentication for the Chromium export renderer.
     Only viewsets that explicitly include this in authentication_classes will accept these tokens.
     Tokens use the EXPORT_RENDERER audience, which JwtAuthentication does not accept.
     """
@@ -430,9 +430,7 @@ class ExportRendererAuthentication(authentication.BaseAuthentication):
             info = decode_jwt(token, PosthogJwtAudience.EXPORT_RENDERER)
             user = User.objects.get(pk=info["id"])
             return user, None
-        except jwt.DecodeError:
-            return None
-        except jwt.InvalidAudienceError:
+        except (jwt.DecodeError, jwt.InvalidAudienceError, jwt.ExpiredSignatureError):
             return None
         except Exception:
             raise AuthenticationFailed(detail="Token invalid.")

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -410,6 +410,37 @@ class JwtAuthentication(authentication.BaseAuthentication):
         return cls.keyword
 
 
+class ExportRendererAuthentication(authentication.BaseAuthentication):
+    """
+    Scoped authentication for the Chromium export renderer.
+    Only viewsets that explicitly include this in authentication_classes will accept these tokens.
+    Tokens use the EXPORT_RENDERER audience, which JwtAuthentication does not accept.
+    """
+
+    keyword = "Bearer"
+
+    def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[tuple[Any, None]]:
+        if "authorization" not in request.headers:
+            return None
+        authorization_match = re.match(rf"^Bearer\s+(\S.+)$", request.headers["authorization"])
+        if not authorization_match:
+            return None
+        try:
+            token = authorization_match.group(1).strip()
+            info = decode_jwt(token, PosthogJwtAudience.EXPORT_RENDERER)
+            user = User.objects.get(pk=info["id"])
+            return user, None
+        except jwt.DecodeError:
+            return None
+        except jwt.InvalidAudienceError:
+            return None
+        except Exception:
+            raise AuthenticationFailed(detail="Token invalid.")
+
+    def authenticate_header(self, request) -> str:
+        return self.keyword
+
+
 class SharingAccessTokenAuthentication(authentication.BaseAuthentication):
     """Limited access for sharing views e.g. insights/dashboards for refreshing.
     Remember to add access restrictions based on `sharing_configuration` using `SharingTokenPermission` or manually.

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -412,9 +412,7 @@ class JwtAuthentication(authentication.BaseAuthentication):
 
 class ExportRendererAuthentication(authentication.BaseAuthentication):
     """
-    Read-only authentication for the Chromium export renderer.
-    Only viewsets that explicitly include this in authentication_classes will accept these tokens.
-    Tokens use the EXPORT_RENDERER audience, which JwtAuthentication does not accept.
+    Scoped JWT auth for the export renderer. Only accepted on viewsets that opt in.
     """
 
     keyword = "Bearer"

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -418,6 +418,8 @@ class ExportRendererAuthentication(authentication.BaseAuthentication):
     keyword = "Bearer"
 
     def authenticate(self, request: Union[HttpRequest, Request]) -> Optional[tuple[Any, None]]:
+        if request.method not in ("GET", "HEAD"):
+            return None
         if "authorization" not in request.headers:
             return None
         authorization_match = re.match(rf"^Bearer\s+(\S.+)$", request.headers["authorization"])
@@ -428,7 +430,7 @@ class ExportRendererAuthentication(authentication.BaseAuthentication):
             info = decode_jwt(token, PosthogJwtAudience.EXPORT_RENDERER)
             user = User.objects.get(pk=info["id"])
             return user, None
-        except (jwt.DecodeError, jwt.InvalidAudienceError, jwt.ExpiredSignatureError):
+        except (jwt.DecodeError, jwt.InvalidAudienceError):
             return None
         except Exception:
             raise AuthenticationFailed(detail="Token invalid.")

--- a/posthog/heatmaps/heatmaps_api.py
+++ b/posthog/heatmaps/heatmaps_api.py
@@ -23,6 +23,7 @@ from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
+from posthog.auth import ExportRendererAuthentication
 from posthog.heatmaps.heatmaps_utils import DEFAULT_TARGET_WIDTHS
 from posthog.models import User
 from posthog.models.activity_logging.activity_log import Detail, log_activity
@@ -224,6 +225,7 @@ class HeatmapEventsResponseSerializer(serializers.Serializer):
 
 
 class HeatmapViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    authentication_classes = [ExportRendererAuthentication]
     scope_object = "heatmap"
     scope_object_read_actions = ["list", "retrieve", "events"]
 

--- a/posthog/jwt.py
+++ b/posthog/jwt.py
@@ -11,6 +11,9 @@ class PosthogJwtAudience(Enum):
     UNSUBSCRIBE = "posthog:unsubscribe"
     EXPORTED_ASSET = "posthog:exported_asset"
     IMPERSONATED_USER = "posthog:impersonted_user"  # This is used by background jobs on behalf of the user e.g. exports
+    EXPORT_RENDERER = (
+        "posthog:export_renderer"  # Scoped token for Chromium export renderer, only accepted on opted-in viewsets
+    )
     LIVESTREAM = "posthog:livestream"
     SHARING_PASSWORD_PROTECTED = "posthog:sharing_password_protected"
 

--- a/posthog/jwt.py
+++ b/posthog/jwt.py
@@ -10,10 +10,8 @@ import jwt
 class PosthogJwtAudience(Enum):
     UNSUBSCRIBE = "posthog:unsubscribe"
     EXPORTED_ASSET = "posthog:exported_asset"
-    IMPERSONATED_USER = "posthog:impersonted_user"  # This is used by background jobs on behalf of the user e.g. exports
-    EXPORT_RENDERER = (
-        "posthog:export_renderer"  # Scoped token for Chromium export renderer, only accepted on opted-in viewsets
-    )
+    IMPERSONATED_USER = "posthog:impersonted_user"
+    EXPORT_RENDERER = "posthog:export_renderer"
     LIVESTREAM = "posthog:livestream"
     SHARING_PASSWORD_PROTECTED = "posthog:sharing_password_protected"
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -58,6 +58,7 @@ from posthog.api.person import MinimalPersonSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import ServerTimingsGathered, action, safe_clickhouse_string
 from posthog.auth import (
+    ExportRendererAuthentication,
     JwtAuthentication,
     OAuthAccessTokenAuthentication,
     PersonalAPIKeyAuthentication,
@@ -673,6 +674,7 @@ def clean_referer_url(current_url: str | None) -> str:
 class SessionRecordingViewSet(
     TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.GenericViewSet, UpdateModelMixin
 ):
+    authentication_classes = [ExportRendererAuthentication]
     scope_object = "session_recording"
     scope_object_read_actions = ["list", "retrieve", "snapshots"]
     throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]

--- a/posthog/test/test_export_renderer_auth.py
+++ b/posthog/test/test_export_renderer_auth.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from posthog.test.base import APIBaseTest
 
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from posthog.jwt import PosthogJwtAudience, encode_jwt
 
@@ -15,87 +16,55 @@ class TestExportRendererAuthentication(APIBaseTest):
             PosthogJwtAudience.EXPORT_RENDERER,
         )
 
-    def _make_impersonated_user_token(self) -> str:
-        return encode_jwt(
-            {"id": self.user.id},
-            timedelta(minutes=5),
-            PosthogJwtAudience.IMPERSONATED_USER,
-        )
+    @staticmethod
+    def _unauthenticated_client() -> APIClient:
+        return APIClient()
 
     def test_export_renderer_token_accepted_on_session_recordings(self):
-        self.client.logout()
+        client = self._unauthenticated_client()
         token = self._make_export_renderer_token()
-        response = self.client.get(
+        response = client.get(
             f"/api/environments/{self.team.id}/session_recordings",
             headers={"authorization": f"Bearer {token}"},
         )
         assert response.status_code == status.HTTP_200_OK
 
     def test_export_renderer_token_accepted_on_heatmaps(self):
-        self.client.logout()
+        client = self._unauthenticated_client()
         token = self._make_export_renderer_token()
-        response = self.client.get(
+        response = client.get(
             f"/api/environments/{self.team.id}/heatmaps?type=click&date_from=2024-01-01&url_exact=https://example.com&viewport_width_min=0",
             headers={"authorization": f"Bearer {token}"},
         )
-        # 200 means auth succeeded (query may return empty results but that's fine)
         assert response.status_code == status.HTTP_200_OK
 
     def test_export_renderer_token_rejected_on_dashboards(self):
-        self.client.logout()
+        client = self._unauthenticated_client()
         token = self._make_export_renderer_token()
-        response = self.client.get(
+        response = client.get(
             f"/api/projects/{self.team.id}/dashboards/",
             headers={"authorization": f"Bearer {token}"},
         )
-        # 401 or 403 — either way, the token does not grant access
-        assert response.status_code in (
-            status.HTTP_401_UNAUTHORIZED,
-            status.HTTP_403_FORBIDDEN,
-        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_export_renderer_token_rejected_on_insights(self):
-        self.client.logout()
+    def test_export_renderer_token_rejected_on_user_api(self):
+        client = self._unauthenticated_client()
         token = self._make_export_renderer_token()
-        response = self.client.get(
-            f"/api/projects/{self.team.id}/insights/",
+        response = client.get(
+            "/api/users/@me/",
             headers={"authorization": f"Bearer {token}"},
         )
-        assert response.status_code in (
-            status.HTTP_401_UNAUTHORIZED,
-            status.HTTP_403_FORBIDDEN,
-        )
-
-    def test_impersonated_user_token_still_works_on_session_recordings(self):
-        self.client.logout()
-        token = self._make_impersonated_user_token()
-        response = self.client.get(
-            f"/api/environments/{self.team.id}/session_recordings",
-            headers={"authorization": f"Bearer {token}"},
-        )
-        assert response.status_code == status.HTTP_200_OK
-
-    def test_impersonated_user_token_still_works_on_dashboards(self):
-        self.client.logout()
-        token = self._make_impersonated_user_token()
-        response = self.client.get(
-            f"/api/projects/{self.team.id}/dashboards/",
-            headers={"authorization": f"Bearer {token}"},
-        )
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_expired_export_renderer_token_rejected(self):
-        self.client.logout()
+        client = self._unauthenticated_client()
         token = encode_jwt(
             {"id": self.user.id},
             timedelta(seconds=-1),
             PosthogJwtAudience.EXPORT_RENDERER,
         )
-        response = self.client.get(
+        response = client.get(
             f"/api/environments/{self.team.id}/session_recordings",
             headers={"authorization": f"Bearer {token}"},
         )
-        assert response.status_code in (
-            status.HTTP_401_UNAUTHORIZED,
-            status.HTTP_403_FORBIDDEN,
-        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/posthog/test/test_export_renderer_auth.py
+++ b/posthog/test/test_export_renderer_auth.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -20,38 +21,35 @@ class TestExportRendererAuthentication(APIBaseTest):
     def _unauthenticated_client() -> APIClient:
         return APIClient()
 
-    def test_export_renderer_token_accepted_on_session_recordings(self):
+    @parameterized.expand(
+        [
+            ("session_recordings", "/api/environments/{team_id}/session_recordings"),
+            (
+                "heatmaps",
+                "/api/environments/{team_id}/heatmaps?type=click&date_from=2024-01-01&url_exact=https://example.com&viewport_width_min=0",
+            ),
+        ]
+    )
+    def test_export_renderer_token_accepted_on_opted_in_endpoint(self, _name: str, url_template: str):
         client = self._unauthenticated_client()
         token = self._make_export_renderer_token()
         response = client.get(
-            f"/api/environments/{self.team.id}/session_recordings",
+            url_template.format(team_id=self.team.id),
             headers={"authorization": f"Bearer {token}"},
         )
         assert response.status_code == status.HTTP_200_OK
 
-    def test_export_renderer_token_accepted_on_heatmaps(self):
+    @parameterized.expand(
+        [
+            ("dashboards", "/api/projects/{team_id}/dashboards/"),
+            ("user_api", "/api/users/@me/"),
+        ]
+    )
+    def test_export_renderer_token_rejected_on_non_opted_in_endpoint(self, _name: str, url_template: str):
         client = self._unauthenticated_client()
         token = self._make_export_renderer_token()
         response = client.get(
-            f"/api/environments/{self.team.id}/heatmaps?type=click&date_from=2024-01-01&url_exact=https://example.com&viewport_width_min=0",
-            headers={"authorization": f"Bearer {token}"},
-        )
-        assert response.status_code == status.HTTP_200_OK
-
-    def test_export_renderer_token_rejected_on_dashboards(self):
-        client = self._unauthenticated_client()
-        token = self._make_export_renderer_token()
-        response = client.get(
-            f"/api/projects/{self.team.id}/dashboards/",
-            headers={"authorization": f"Bearer {token}"},
-        )
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_export_renderer_token_rejected_on_user_api(self):
-        client = self._unauthenticated_client()
-        token = self._make_export_renderer_token()
-        response = client.get(
-            "/api/users/@me/",
+            url_template.format(team_id=self.team.id),
             headers={"authorization": f"Bearer {token}"},
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/posthog/test/test_export_renderer_auth.py
+++ b/posthog/test/test_export_renderer_auth.py
@@ -1,0 +1,101 @@
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from posthog.jwt import PosthogJwtAudience, encode_jwt
+
+
+class TestExportRendererAuthentication(APIBaseTest):
+    def _make_export_renderer_token(self) -> str:
+        return encode_jwt(
+            {"id": self.user.id},
+            timedelta(minutes=5),
+            PosthogJwtAudience.EXPORT_RENDERER,
+        )
+
+    def _make_impersonated_user_token(self) -> str:
+        return encode_jwt(
+            {"id": self.user.id},
+            timedelta(minutes=5),
+            PosthogJwtAudience.IMPERSONATED_USER,
+        )
+
+    def test_export_renderer_token_accepted_on_session_recordings(self):
+        self.client.logout()
+        token = self._make_export_renderer_token()
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/session_recordings",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_export_renderer_token_accepted_on_heatmaps(self):
+        self.client.logout()
+        token = self._make_export_renderer_token()
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/heatmaps?type=click&date_from=2024-01-01&url_exact=https://example.com&viewport_width_min=0",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        # 200 means auth succeeded (query may return empty results but that's fine)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_export_renderer_token_rejected_on_dashboards(self):
+        self.client.logout()
+        token = self._make_export_renderer_token()
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/dashboards/",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        # 401 or 403 — either way, the token does not grant access
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_export_renderer_token_rejected_on_insights(self):
+        self.client.logout()
+        token = self._make_export_renderer_token()
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/insights/",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_impersonated_user_token_still_works_on_session_recordings(self):
+        self.client.logout()
+        token = self._make_impersonated_user_token()
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/session_recordings",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_impersonated_user_token_still_works_on_dashboards(self):
+        self.client.logout()
+        token = self._make_impersonated_user_token()
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/dashboards/",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_expired_export_renderer_token_rejected(self):
+        self.client.logout()
+        token = encode_jwt(
+            {"id": self.user.id},
+            timedelta(seconds=-1),
+            PosthogJwtAudience.EXPORT_RENDERER,
+        )
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/session_recordings",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )

--- a/posthog/test/test_export_renderer_auth.py
+++ b/posthog/test/test_export_renderer_auth.py
@@ -54,6 +54,23 @@ class TestExportRendererAuthentication(APIBaseTest):
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    @parameterized.expand(
+        [
+            ("post",),
+            ("put",),
+            ("patch",),
+            ("delete",),
+        ]
+    )
+    def test_export_renderer_token_rejected_for_write_method(self, method: str):
+        client = self._unauthenticated_client()
+        token = self._make_export_renderer_token()
+        response = getattr(client, method)(
+            f"/api/environments/{self.team.id}/session_recordings",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
     def test_expired_export_renderer_token_rejected(self):
         client = self._unauthenticated_client()
         token = encode_jwt(


### PR DESCRIPTION
## Problem

The SharingViewerPageViewSet generates IMPERSONATED_USER JWT tokens for session recording and heatmap exports. These tokens grant full API access as the export creator, but the export renderer only needs to read recording snapshots and heatmap data.

## Changes

Introduces a new `EXPORT_RENDERER` JWT audience that is only accepted on viewsets that explicitly opt in, replacing `IMPERSONATED_USER` 

## How did you test this code?

- New tests in `posthog/test/test_export_renderer_auth.py`

## Publish to changelog?

No

## Docs update

No docs changes needed.
