### PR TITLE
feat(clickhouse): default to HTTP protocol for ClickHouse connections

### DIFF
--- a/posthog/clickhouse/test/test_http_migration.py
+++ b/posthog/clickhouse/test/test_http_migration.py
@@ -1,0 +1,174 @@
+from contextlib import contextmanager
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.clickhouse.client.connection import ProxyClient, get_client_from_pool, get_http_client
+
+
+class TestDefaultUsesHTTP:
+    def test_default_uses_http(self):
+        """With default settings (CLICKHOUSE_USE_HTTP=True), get_client_from_pool returns an HTTP ProxyClient."""
+        mock_http_client = MagicMock()
+
+        with patch(
+            "posthog.clickhouse.client.connection.get_http_client",
+            return_value=contextmanager(lambda: (yield mock_http_client))(),
+        ) as mock_get_http:
+            with patch("posthog.clickhouse.client.connection.settings") as mock_settings:
+                mock_settings.CLICKHOUSE_USE_HTTP = True
+                mock_settings.CLICKHOUSE_USE_HTTP_PER_TEAM = set()
+                get_client_from_pool()
+                mock_get_http.assert_called_once()
+
+    @pytest.mark.parametrize("team_id", [None, 1, 99])
+    def test_default_uses_http_regardless_of_team(self, team_id):
+        with patch(
+            "posthog.clickhouse.client.connection.get_http_client",
+            return_value=contextmanager(lambda: (yield MagicMock()))(),
+        ) as mock_get_http:
+            with patch("posthog.clickhouse.client.connection.settings") as mock_settings:
+                mock_settings.CLICKHOUSE_USE_HTTP = True
+                mock_settings.CLICKHOUSE_USE_HTTP_PER_TEAM = set()
+                get_client_from_pool(team_id=team_id)
+                mock_get_http.assert_called_once()
+
+
+class TestEnvVarCanForceTCP:
+    def test_env_var_false_uses_tcp_pool(self):
+        mock_pool = MagicMock()
+        mock_pool.get_client.return_value = MagicMock()
+
+        with patch("posthog.clickhouse.client.connection.settings") as mock_settings:
+            mock_settings.CLICKHOUSE_USE_HTTP = False
+            mock_settings.CLICKHOUSE_USE_HTTP_PER_TEAM = set()
+            with patch("posthog.clickhouse.client.connection.get_pool", return_value=mock_pool) as mock_get_pool:
+                get_client_from_pool()
+                mock_get_pool.assert_called_once()
+                mock_pool.get_client.assert_called_once()
+
+
+class TestPerTeamOverride:
+    def test_per_team_override_routes_to_http(self):
+        with patch(
+            "posthog.clickhouse.client.connection.get_http_client",
+            return_value=contextmanager(lambda: (yield MagicMock()))(),
+        ) as mock_get_http:
+            with patch("posthog.clickhouse.client.connection.settings") as mock_settings:
+                mock_settings.CLICKHOUSE_USE_HTTP = False
+                mock_settings.CLICKHOUSE_USE_HTTP_PER_TEAM = {42}
+                get_client_from_pool(team_id=42)
+                mock_get_http.assert_called_once()
+
+    def test_per_team_override_does_not_affect_other_teams(self):
+        mock_pool = MagicMock()
+        mock_pool.get_client.return_value = MagicMock()
+
+        with patch("posthog.clickhouse.client.connection.settings") as mock_settings:
+            mock_settings.CLICKHOUSE_USE_HTTP = False
+            mock_settings.CLICKHOUSE_USE_HTTP_PER_TEAM = {42}
+            with patch("posthog.clickhouse.client.connection.get_pool", return_value=mock_pool):
+                get_client_from_pool(team_id=99)
+                mock_pool.get_client.assert_called_once()
+
+
+class TestProxyClientExecute:
+    def test_execute_forwards_to_clickhouse_connect(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = [("row1",), ("row2",)]
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("SELECT 1", params={"key": "val"}, settings={"max_threads": 4})
+
+        mock_client.query.assert_called_once_with(
+            query="SELECT 1",
+            parameters={"key": "val"},
+            settings={"max_threads": 4},
+            column_oriented=False,
+        )
+        assert result == [("row1",), ("row2",)]
+
+    def test_execute_with_query_id(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = []
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        settings = {"max_threads": 4}
+        proxy.execute("SELECT 1", query_id="test-id", settings=settings)
+
+        assert settings["query_id"] == "test-id"
+
+    def test_execute_insert_returns_written_rows(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "5"}
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("INSERT INTO t VALUES", settings={})
+
+        assert result == 5
+
+
+class TestProxyClientReturnsCorrectFormat:
+    def test_with_column_types(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = [("Alice", 30), ("Bob", 25)]
+
+        mock_name_type = MagicMock()
+        mock_name_type.name = "String"
+        mock_age_type = MagicMock()
+        mock_age_type.name = "UInt32"
+
+        mock_result.column_names = ["name", "age"]
+        mock_result.column_types = [mock_name_type, mock_age_type]
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result_set, column_types = proxy.execute("SELECT name, age FROM t", with_column_types=True, settings={})
+
+        assert result_set == [("Alice", 30), ("Bob", 25)]
+        assert column_types == [("name", "String"), ("age", "UInt32")]
+
+    def test_without_column_types(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = [(1,), (2,)]
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("SELECT 1", settings={})
+
+        assert result == [(1,), (2,)]
+
+    def test_context_manager_protocol(self):
+        mock_client = MagicMock()
+        proxy = ProxyClient(mock_client)
+
+        with proxy as p:
+            assert p is proxy
+
+
+class TestGetHttpClientContextManager:
+    def test_get_http_client_yields_proxy_client(self):
+        mock_cc_client = MagicMock()
+
+        with patch("posthog.clickhouse.client.connection.get_client", return_value=mock_cc_client):
+            with patch("posthog.clickhouse.client.connection.settings") as mock_settings:
+                mock_settings.CLICKHOUSE_HOST = "localhost"
+                mock_settings.CLICKHOUSE_DATABASE = "default"
+                mock_settings.CLICKHOUSE_SECURE = False
+                mock_settings.CLICKHOUSE_USER = "default"
+                mock_settings.CLICKHOUSE_PASSWORD = ""
+                mock_settings.TEST = True
+                with get_http_client() as client:
+                    assert isinstance(client, ProxyClient)

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -29,13 +29,25 @@ IGNORED_DUPLICATE_MIGRATION_NUMBERS = frozenset(
 
 
 def get_all_migrations() -> list[tuple[str, str]]:
-    """Get all migrations as (index, name) tuples."""
+    """Get all migrations as (index, name) tuples.
+
+    Matches both .py files (0001_name.py) and directories (0220_name/).
+    """
     migrations: list[tuple[str, str]] = []
     for filename in os.listdir(MIGRATIONS_DIR):
+        # Match .py files: 0001_name.py
         match = re.match(r"([0-9]+)_([a-zA-Z_0-9]+)\.py", filename)
         if match:
             groups = match.groups()
             migrations.append((groups[0], groups[1]))
+            continue
+        # Match directories: 0220_name/ (must contain manifest.yaml to count)
+        dir_match = re.match(r"([0-9]+)_([a-zA-Z_0-9]+)$", filename)
+        if dir_match:
+            dir_path = os.path.join(MIGRATIONS_DIR, filename)
+            if os.path.isdir(dir_path) and os.path.exists(os.path.join(dir_path, "manifest.yaml")):
+                groups = dir_match.groups()
+                migrations.append((groups[0], groups[1]))
     return sorted(migrations, key=lambda x: (int(x[0]), x[1]))
 
 
@@ -51,7 +63,7 @@ def check_no_duplicate_migration_numbers() -> bool:
 
     if duplicates:
         for index, names in sorted(duplicates.items()):
-            logger.error(f"Duplicate migration {index}: {', '.join(f'{index}_{n}.py' for n in names)}")
+            logger.error(f"Duplicate migration {index}: {', '.join(f'{index}_{n}' for n in names)}")
         return False
     return True
 
@@ -121,14 +133,25 @@ class Command(BaseCommand):
 
         old_migrations = []
         for filename in master_migrations:
+            # Match .py files
             match = re.findall(r"([0-9]+)_([a-zA-Z_0-9]+)\.py", filename)
             if match:
                 old_migrations.append(match[0])
+                continue
+            # Match directories
+            dir_match = re.findall(r"^([0-9]+)_([a-zA-Z_0-9]+)$", filename)
+            if dir_match:
+                old_migrations.append(dir_match[0])
 
         try:
-            _, index, name = re.findall(r"([a-z]+)/clickhouse/migrations/([0-9]+)_([a-zA-Z_0-9]+)\.py", new_migration)[
-                0
-            ]
+            # Try .py file pattern first
+            matches = re.findall(r"([a-z]+)/clickhouse/migrations/([0-9]+)_([a-zA-Z_0-9]+)\.py", new_migration)
+            if not matches:
+                # Try directory pattern (path may end with / or not)
+                matches = re.findall(
+                    r"([a-z]+)/clickhouse/migrations/([0-9]+)_([a-zA-Z_0-9]+)/?$", new_migration
+                )
+            _, index, name = matches[0]
         except (IndexError, CommandError) as exc:
             logger.warning("Could not parse migration path '%s': %s", new_migration, exc)
             return

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -228,7 +228,7 @@ CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER = get_from_env(
     "CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER", default=False, type_cast=str_to_bool
 )
 
-CLICKHOUSE_USE_HTTP: str = get_from_env("CLICKHOUSE_USE_HTTP", False, type_cast=str_to_bool)
+CLICKHOUSE_USE_HTTP: bool = get_from_env("CLICKHOUSE_USE_HTTP", True, type_cast=str_to_bool)
 CLICKHOUSE_USE_HTTP_PER_TEAM = set[int]([])
 with suppress(Exception):
     as_json = json.loads(os.getenv("CLICKHOUSE_USE_HTTP_PER_TEAM", "[]"))


### PR DESCRIPTION
## Summary
Phase 0 prerequisite for the ClickHouse Query Gateway ([RFC #1044](https://github.com/PostHog/requests-for-comments-internal/pull/1044)).

Flips `CLICKHOUSE_USE_HTTP` default from `False` to `True`. The HTTP path via `ProxyClient` + `clickhouse-connect` (v0.8.17) has been opt-in and production-tested via `CLICKHOUSE_USE_HTTP_PER_TEAM`.

- Temporal already uses HTTP (own async client, verified)
- Plugin Server already uses HTTP
- This change affects Django (the last TCP holdout)
- Rollback: `CLICKHOUSE_USE_HTTP=false` env var

## Test plan
- 14 unit tests covering default behavior, TCP fallback, per-team override, ProxyClient compatibility