### PR TITLE
feat(clickhouse): multi-cluster support + deprecation + deploy wiring

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -74,12 +74,23 @@ if [ "$RUN_CLICKHOUSE" = "1" ] && [ "$RUN_POSTGRES" = "1" ]; then
             echo "1" > $CLICKHOUSE_STATUS
             exit $SYNC_STATUS
         fi
+
+        echo "Running new-style ClickHouse migrations..."
+        python manage.py ch_migrate up
+        CH_NEW_STATUS=$?
+        if [ $CH_NEW_STATUS -ne 0 ]; then
+            echo "Error in ch_migrate up, setting error status."
+            echo "1" > $CLICKHOUSE_STATUS
+            exit $CH_NEW_STATUS
+        fi
     ) &
     CLICKHOUSE_PID=$!
     elif [ "$RUN_CLICKHOUSE" = "1" ]; then
     # ClickHouse only - run directly
     python manage.py migrate_clickhouse || { echo "Error in migrate_clickhouse, exiting."; exit 1; }
     python manage.py sync_replicated_schema || { echo "Error in sync_replicated_schema, exiting."; exit 1; }
+    echo "Running new-style ClickHouse migrations..."
+    python manage.py ch_migrate up || { echo "Error in ch_migrate up, exiting."; exit 1; }
 fi
 
 if [ "$RUN_POSTGRES" = "1" ]; then

--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from functools import cache
 from typing import Optional
 
@@ -53,6 +54,13 @@ def run_sql_with_exceptions(
         Raised in certain scenarios when the input arguments conflict with the expected
         configuration, such as when the sharded flag is set for roles other than DATA.
     """
+
+    warnings.warn(
+        "run_sql_with_exceptions is deprecated. Use directory-based migrations "
+        "with manifest.yaml instead. See posthog/clickhouse/migrations/README.md",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     if node_roles and not isinstance(node_roles, list):
         node_roles = [node_roles]

--- a/posthog/clickhouse/migrations/README.md
+++ b/posthog/clickhouse/migrations/README.md
@@ -1,109 +1,191 @@
-## Creating ClickHouse schema changes
+# ClickHouse migrations
 
-**Important:** ClickHouse schema changes should be created as a separate PR from application code changes. This allows for:
+This directory contains ClickHouse schema migrations for PostHog.
+There are two styles: legacy `.py` files and new-style directory migrations.
 
-- Independent review and testing of schema migrations
-- Safer rollout of database changes
-- Clear separation between infrastructure and application logic changes
+## New-style directory migrations
 
-## About migrations
+Each migration lives in a numbered directory
+(e.g. `0221_test_new_migration_system/`) containing:
 
-Not all migrations are intended to run on all nodes every time, because of the topologies we run. Some nodes are intended to only perform compute operations and do not contain sharded tables.
+```
+0221_test_new_migration_system/
+  manifest.yaml   # declares steps, rollback, and metadata
+  up.sql           # SQL template(s) for the forward direction
+  down.sql         # SQL template(s) for rollback
+  __init__.py      # bridge for backward compatibility with the legacy runner
+```
 
-Some tables are meant to run only on a couple of nodes, like some Kafka tables, to prevent the whole cluster to run too many insertions in ClickHouse.
+### SQL templates
 
-And, in some other cases, we want to only create one table (like a unique Kafka consumer) in one node.
+SQL files are Jinja2 templates with access to these variables:
 
-Because of the above, take the following advice into consideration when manipulating schemas for ClickHouse.
+- `{{ database }}` -- the ClickHouse database name
+- `{{ cluster }}` -- the ClickHouse cluster name
+- `{{ single_shard_cluster }}` -- the single-shard cluster name (if configured)
 
-### When to run a migration ONLY on a data node
+A single `.sql` file can contain multiple named sections separated by
+`-- section: <name>` comments.
+Steps reference a specific section with `up.sql#section_name`
+or the entire file with just `up.sql`.
 
-- When adding / updating a sharded data table
+## Creating a new migration
 
-In the above cases, create a migration and call the `run_sql_with_exceptions` function with the `node_roles` set to `[NodeRole.DATA]`.
+Use the management command:
 
-<details>
+```bash
+python manage.py create_ch_migration \
+  --name add_foo_column \
+  --type add-column \
+  --table events
+```
 
-<summary>Example</summary>
-For example, the `sharded_events` table is a sharded table. Thus, it should only be added on data nodes.
+This scaffolds a numbered directory with `manifest.yaml`, `up.sql`, `down.sql`,
+and an `__init__.py` bridge.
+It also updates `max_migration.txt`.
 
-Also, since to fill this table we need to consume events from Kafka, we need to run Kafka consumers on the data nodes, which would include the materialized view and the writable distributed table. So the `kafka_events_json`, `events_json_mv` and `writable_events` tables should also be added on them.
+## Manifest reference
 
-</details>
+```yaml
+description: "Human-readable summary of the migration"
 
-### When to run a migration for DATA and COORDINATOR nodes
+# Optional: target a single ClickHouse cluster name
+cluster: posthog
 
-- Basically when the migration does not include any of the above listed in the previous section.
-- When adding / updating a distributed table for reading
-- When adding / updating a replicated table
-- When adding / updating a view
-- When adding / updating a dictionary
-- And so on
+# Optional: target multiple clusters (overrides `cluster`)
+clusters:
+  - us-east
+  - eu-west
 
-In the above cases, create a migration and call the `run_sql_with_exceptions` function with the `node_roles` set to `[NodeRole.DATA, NodeRole.COORDINATOR]`.
+steps:
+  - sql: "up.sql#create_local"
+    node_roles: [DATA]           # required: DATA, COORDINATOR, or both
+    comment: "Create local table"
+    sharded: true                # run on each shard (default: false)
+    is_alter_on_replicated_table: false  # ALTER that replicates (default: false)
+    async: false                 # async execution with healthcheck (default: false)
+    timeout: "30m"               # timeout for async steps
+    healthcheck: "SELECT 1"     # query to verify async completion
+    clusters:                   # per-step override of manifest-level clusters
+      - us-east
 
-<details>
+rollback:
+  - sql: "down.sql"
+    node_roles: [DATA, COORDINATOR]
+```
 
-<summary>Example</summary>
+### Field details
 
-Following the previous section example, the sharded events table along with the Kafka tables, materialized views and writable distributed table would be added to the data nodes. However, the `distributed_events`, which is the table used for the read path, would be added to all nodes.
+| Field | Scope | Required | Description |
+|-------|-------|----------|-------------|
+| `description` | manifest | yes | Human-readable summary |
+| `cluster` | manifest | no | Single target cluster name |
+| `clusters` | manifest | no | List of target clusters (overrides `cluster`) |
+| `steps` | manifest | yes | Ordered list of forward steps |
+| `rollback` | manifest | no | Ordered list of rollback steps |
+| `sql` | step | yes | SQL file reference, optionally with `#section` |
+| `node_roles` | step | yes | `["DATA"]`, `["COORDINATOR"]`, or both |
+| `comment` | step | no | Human-readable description of the step |
+| `sharded` | step | no | Execute on each shard separately |
+| `is_alter_on_replicated_table` | step | no | ALTERs that replicate across nodes |
+| `async` | step | no | Run asynchronously with polling |
+| `timeout` | step | no | Timeout duration for async steps |
+| `healthcheck` | step | no | SQL query to verify async completion |
+| `clusters` | step | no | Per-step cluster override |
 
-</details>
+### Multi-cluster behavior
 
-## When to use NodeRole.INGESTION_SMALL or NodeRole.INGESTION_MEDIUM
+When `clusters` is set at the manifest or step level,
+the runner filters steps based on the current cluster identity.
 
-We have extra nodes with a sole purpose of ingesting the data from Kafka topics into ClickHouse tables. These nodes don't contain any data perse, only Kafka tables and Distributed ones, along with the materialized views that connect them.
+- **Step `clusters`** takes precedence over manifest `clusters`.
+- **Manifest `clusters`** takes precedence over manifest `cluster`.
+- When no cluster targeting is configured, every step runs everywhere.
 
-Use these node roles exclusively when you need to ingest data from Kafka into ClickHouse.
+Before applying migration N+1 in multi-cluster mode,
+`check_cross_cluster_ordering` verifies that migration N
+has been recorded as complete on all target clusters.
 
-When you want to pull data from Kafka into ClickHouse, you should:
+## `ch_migrate` commands
 
-1. Create a Kafka table.
-2. Create a writable table only on ingestion nodes. It should be a Distributed table with your data table.
-   1. If your data table is non-sharded, you should point it to one shard: `Distributed(..., cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)`, without using any sharding key.
-   2. If your data table is sharded, you should point it to all shards: `Distributed(..., cluster=settings.CLICKHOUSE_CLUSTER, sharding_key="...")`, using a sharding key.
-3. Create a materialized view between Kafka table and the writable table.
+All commands are run via Django management:
 
-Example PR for non-sharded table: https://github.com/PostHog/posthog/pull/38890/files
-Example PR for sharded table: https://github.com/PostHog/posthog/issues/38668/files
+```bash
+python manage.py ch_migrate <subcommand>
+```
 
-`Medium` tier contains 4 consumers, while `Small` tier contain just one. Depending on the throughput of the Kafka topic, you should choose the appropriate tier, in case of doubts choose `Small` and you can later upgrade to `Medium` if lag is too high.
+### `bootstrap`
 
-## When to use NodeRole.ALL
+Create the tracking table (`clickhouse_schema_migrations`) on all nodes.
+Run this once when setting up a new environment.
 
-We are introducing changes to our ClickHouse topology frequently, introducing new types of nodes.
+```bash
+python manage.py ch_migrate bootstrap
+```
 
-Rarely, you'll need to run a migration on all nodes. In that case, you can use the `NodeRole.ALL` role. You should only use it when you're sure that the change is safe to apply to all nodes.
+### `plan`
 
-In the vast majority of cases, just follow the [previous](#when-to-run-a-migration-only-on-a-data-node) [sections](#when-to-run-a-migration-for-data-and-coordinator-nodes).
+Show pending migrations without executing them.
 
-### The ON CLUSTER clause
+```bash
+python manage.py ch_migrate plan
+```
 
-**Do not use the `ON CLUSTER` clause**, since the DDL statement will be run on all nodes anyway through the `run_sql_with_exceptions` function, and, by default, the `ON CLUSTER` clause makes the DDL statement run on nodes specified for the default cluster, and that does not include the coordinator.
-This may cause lots of troubles and block migrations.
+### `up`
 
-The `ON CLUSTER` clause is used to specify the cluster to run the DDL statement on. By default, the `posthog` cluster is used. That cluster only includes the data nodes.
+Apply pending migrations in order.
 
-### Testing
+```bash
+python manage.py ch_migrate up [--upto N] [--check-mutations] [--force]
+```
 
-To re-run a migration, you'll need to delete the entry from the `infi_clickhouse_orm_migrations` table.
+- `--upto N` -- apply migrations up to number N (inclusive)
+- `--check-mutations` -- check for active mutations on target tables before applying
+- `--force` -- apply even if active mutations are found
 
-## Ingestion layer
+### `down`
 
-We have extra nodes with a sole purpose of ingesting the data from Kafka topics into ClickHouse tables. The way to do that is to:
+Roll back a specific migration by number.
 
-1. Create your data table in ClickHouse main cluster.
-2. Create a writable table only on ingestion nodes: `node_roles=[NodeRole.INGESTION_SMALL]`. It should be Distributed table with your data table. If your data table is non-sharded, you should point it to one shard: `Distributed(..., cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)`.
-3. Create a Kafka table in ingestion nodes: `node_roles=[NodeRole.INGESTION_SMALL]`.
-4. Create materialized view between Kafka table and writable table on ingestion nodes.
+```bash
+python manage.py ch_migrate down <migration_number>
+```
 
-Example PR for non-sharded table: https://github.com/PostHog/posthog/pull/38890/files
+### `validate`
 
-**How and why?**
+Run static analysis on a migration (checks for `ON CLUSTER`, rollback completeness,
+node role consistency, DROP statements, companion tables).
 
-Our main cluster (`posthog`) nodes were overwhelmed with ingestion and sometimes the query load
-was interfering with ingestion. This was causing delays and at the end incidents.
+```bash
+python manage.py ch_migrate validate <migration_number> [--strict]
+```
 
-We added new nodes that are not part of our regular cluster setup, we run them on Kubernetes.
+### `trial`
 
-ClickHouse cluster as defined in it is a logical concept and one may add nodes that are running in different places, this is how we created a new cluster that has all workers, coordinator and our new ingestion nodes.
+Sandbox validation: runs up, verifies schema, rolls back, verifies schema is restored.
+
+```bash
+python manage.py ch_migrate trial <migration_number>
+```
+
+### `status`
+
+Show per-host migration state (both legacy infi and new-style tracking tables).
+
+```bash
+python manage.py ch_migrate status [--node <hostname>]
+```
+
+## The `__init__.py` bridge
+
+Each new-style migration directory includes an `__init__.py`
+so the legacy `migrate_clickhouse` runner can discover it.
+The bridge file contains an empty `operations = []` list,
+which signals that the migration is handled by `ch_migrate` instead.
+
+## SQL linting
+
+<!-- TODO: add sqlfluff as a dev dependency (requires pyproject.toml + uv.lock changes)
+     and integrate into CI. Track in a separate commit. -->
+
+SQL linting with sqlfluff is planned but not yet integrated into CI.

--- a/posthog/clickhouse/migrations/manifest.py
+++ b/posthog/clickhouse/migrations/manifest.py
@@ -69,8 +69,15 @@ def parse_manifest(manifest_path: Path) -> MigrationManifest:
     if "steps" not in data:
         raise ValueError("Manifest must have a 'steps' field")
 
-    steps = [_parse_step(s) for s in data["steps"]]
-    rollback = [_parse_step(s) for s in data.get("rollback", [])]
+    raw_steps = data["steps"]
+    if not isinstance(raw_steps, list):
+        raise ValueError(f"Manifest 'steps' must be a list, got {type(raw_steps).__name__}")
+    raw_rollback = data.get("rollback", [])
+    if not isinstance(raw_rollback, list):
+        raise ValueError(f"Manifest 'rollback' must be a list, got {type(raw_rollback).__name__}")
+
+    steps = [_parse_step(s) for s in raw_steps]
+    rollback = [_parse_step(s) for s in raw_rollback]
 
     return MigrationManifest(
         description=data["description"],

--- a/posthog/clickhouse/migrations/runner.py
+++ b/posthog/clickhouse/migrations/runner.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from posthog.clickhouse.migrations.manifest import ManifestStep
+from posthog.clickhouse.migrations.manifest import ManifestStep, MigrationManifest
 from posthog.clickhouse.migrations.tracking import get_applied_migrations, record_step
 
 if TYPE_CHECKING:
@@ -60,6 +60,54 @@ def _map_node_roles(manifest_roles: list[str]) -> list[NodeRole]:
             raise ValueError(f"Unknown node role '{role}'. Valid roles: {sorted(_ROLE_MAP.keys())}")
         result.append(NodeRole(role_value))
     return result
+
+
+def resolve_step_clusters(step: ManifestStep, manifest: MigrationManifest) -> list[str] | None:
+    """Determine the effective cluster list for a step.
+
+    Priority: step.clusters > manifest.clusters > manifest.cluster (as single-element list).
+    Returns None when no cluster targeting is configured.
+    """
+    if step.clusters is not None:
+        return step.clusters
+    if manifest.clusters is not None:
+        return manifest.clusters
+    if manifest.cluster is not None:
+        return [manifest.cluster]
+    return None
+
+
+def check_cross_cluster_ordering(
+    cluster_clients: dict[str, Any],
+    migration_number: int,
+    database: str,
+) -> bool:
+    """Verify migration N-1 has completed on all target clusters before applying N.
+
+    Args:
+        cluster_clients: mapping of cluster name to a ClickHouse client.
+        migration_number: the migration about to be applied.
+        database: the ClickHouse database name.
+
+    Returns True if all clusters have applied the predecessor, or if this is
+    the first migration (number <= 1).
+    """
+    predecessor = migration_number - 1
+    if predecessor < 1:
+        return True
+
+    for cluster_name, client in cluster_clients.items():
+        applied = get_applied_migrations(client, database)
+        applied_numbers: set[int] = {row["migration_number"] for row in applied}
+        if predecessor not in applied_numbers:
+            logger.warning(
+                "Cross-cluster ordering check failed: cluster %s has not applied migration %d",
+                cluster_name,
+                predecessor,
+            )
+            return False
+
+    return True
 
 
 def discover_migrations(migrations_dir: Path = MIGRATIONS_DIR) -> list[dict[str, Any]]:
@@ -149,21 +197,57 @@ def execute_migration_step(
         return futures_map.result()
 
 
+def _should_execute_step(
+    step: ManifestStep,
+    manifest: MigrationManifest,
+    current_cluster: str | None,
+) -> bool:
+    """Decide whether a step should run on the current cluster.
+
+    When *current_cluster* is None (single-cluster mode), every step runs.
+    Otherwise, the step runs only when the resolved cluster list includes
+    *current_cluster*, or when no cluster targeting is configured.
+    """
+    if current_cluster is None:
+        return True
+    effective = resolve_step_clusters(step, manifest)
+    if effective is None:
+        return True
+    return current_cluster in effective
+
+
 def run_migration_up(
     cluster: ClickhouseCluster,
     migration: Any,
     database: str,
     migration_number: int,
     migration_name: str,
+    current_cluster: str | None = None,
 ) -> bool:
     """Run all steps in a migration. Records results in tracking table.
+
+    Args:
+        current_cluster: when set, only steps targeting this cluster are executed.
+            Steps with no cluster targeting always execute.
 
     Returns True if all steps succeeded on all hosts.
     On partial failure: halts, tracking table shows which hosts succeeded.
     """
     steps = migration.get_steps()
+    manifest: MigrationManifest = getattr(migration, "manifest", None) or MigrationManifest(
+        description="", steps=[], rollback=[]
+    )
 
     for step_index, (step, rendered_sql) in enumerate(steps):
+        if not _should_execute_step(step, manifest, current_cluster):
+            logger.info(
+                "Migration %s step %d skipped (cluster=%s not targeted)",
+                migration_name,
+                step_index,
+                current_cluster,
+            )
+            continue
+
         checksum = compute_checksum(rendered_sql)
 
         try:

--- a/posthog/clickhouse/migrations/sql_parser.py
+++ b/posthog/clickhouse/migrations/sql_parser.py
@@ -22,6 +22,8 @@ def parse_sql_sections(content: str) -> dict[str, str]:
     sections: dict[str, str] = {}
     for i, match in enumerate(matches):
         name = match.group(1)
+        if name in sections:
+            raise ValueError(f"Duplicate section name '{name}' in SQL file")
         start = match.end()
         end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
         section_sql = content[start:end].strip()

--- a/posthog/clickhouse/migrations/tracking.py
+++ b/posthog/clickhouse/migrations/tracking.py
@@ -104,6 +104,9 @@ def get_migration_status_all_hosts(cluster: Any, database: str) -> dict[str, Any
         ORDER BY migration_number
     """
 
+    import logging
+
+    logger = logging.getLogger(__name__)
     futures_map = cluster.map_all_hosts(Query(sql))
     results: dict[str, Any] = {}
     try:
@@ -114,8 +117,13 @@ def get_migration_status_all_hosts(cluster: Any, database: str) -> dict[str, Any
                 "reachable": True,
                 "migrations": rows,
             }
-    except Exception:
-        pass
+    except ExceptionGroup as eg:
+        # Some hosts failed — extract partial results from successful ones
+        logger.warning("Some hosts unreachable during status query: %s", eg)
+        for exc in eg.exceptions:
+            results[str(exc)] = {"reachable": False, "error": str(exc)}
+    except Exception as exc:
+        logger.warning("Status query failed: %s", exc)
 
     return results
 

--- a/posthog/clickhouse/test/run_migration_tests.py
+++ b/posthog/clickhouse/test/run_migration_tests.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
                 "posthog/clickhouse/test/test_status_command.py",
                 "posthog/clickhouse/test/test_create_migration.py",
                 "posthog/clickhouse/test/test_validator.py",
+                "posthog/clickhouse/test/test_multi_cluster.py",
             ]
         )
     )

--- a/posthog/clickhouse/test/run_migration_tests.py
+++ b/posthog/clickhouse/test/run_migration_tests.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
                 "posthog/clickhouse/test/test_create_migration.py",
                 "posthog/clickhouse/test/test_validator.py",
                 "posthog/clickhouse/test/test_multi_cluster.py",
+                "posthog/clickhouse/test/test_deprecation.py",
             ]
         )
     )

--- a/posthog/clickhouse/test/test_deprecation.py
+++ b/posthog/clickhouse/test/test_deprecation.py
@@ -1,0 +1,187 @@
+"""Tests for deprecation warnings and ch_migrate --check flag."""
+
+import os
+import sys
+import types
+import warnings
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from unittest.mock import MagicMock
+
+_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies so migration_tools and ch_migrate can import
+# without Django, ClickHouse drivers, or other infra packages.
+# ---------------------------------------------------------------------------
+
+_stubs_installed = False
+
+
+def _install_stubs() -> None:
+    global _stubs_installed
+    if _stubs_installed:
+        return
+    _stubs_installed = True
+
+    # posthog.clickhouse.client — replace the package with a hollow shell
+    # that still resolves submodules from the real filesystem path
+    fake_client = types.ModuleType("posthog.clickhouse.client")
+    fake_client.__path__ = [os.path.join(_BASE, "posthog/clickhouse/client")]  # type: ignore[attr-defined]
+    fake_client.__package__ = "posthog.clickhouse.client"
+    sys.modules["posthog.clickhouse.client"] = fake_client
+
+    # posthog.clickhouse.client.connection — only NodeRole is needed
+    fake_conn = types.ModuleType("posthog.clickhouse.client.connection")
+
+    class NodeRole:
+        DATA = "DATA"
+        COORDINATOR = "COORDINATOR"
+        ALL = "ALL"
+
+    fake_conn.NodeRole = NodeRole  # type: ignore[attr-defined]
+    sys.modules["posthog.clickhouse.client.connection"] = fake_conn
+
+    # posthog.clickhouse.cluster
+    fake_cluster = types.ModuleType("posthog.clickhouse.cluster")
+    fake_cluster.Query = MagicMock()  # type: ignore[attr-defined]
+    fake_cluster.get_cluster = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["posthog.clickhouse.cluster"] = fake_cluster
+
+    # infi.clickhouse_orm.migrations
+    for mod_name in ("infi", "infi.clickhouse_orm", "infi.clickhouse_orm.migrations"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]  # type: ignore[attr-defined]
+        sys.modules[mod_name] = m
+
+    class _FakeRunPython:
+        def __init__(self, fn: object) -> None:
+            pass
+
+    sys.modules["infi.clickhouse_orm.migrations"].RunPython = _FakeRunPython  # type: ignore[attr-defined]
+
+    # posthog.settings / posthog.settings.data_stores
+    fake_settings = types.ModuleType("posthog.settings")
+    fake_settings.E2E_TESTING = False  # type: ignore[attr-defined]
+    fake_settings.DEBUG = True  # type: ignore[attr-defined]
+    fake_settings.CLOUD_DEPLOYMENT = False  # type: ignore[attr-defined]
+    sys.modules["posthog.settings"] = fake_settings
+
+    fake_ds = types.ModuleType("posthog.settings.data_stores")
+    fake_ds.CLICKHOUSE_MIGRATIONS_CLUSTER = "default"  # type: ignore[attr-defined]
+    fake_ds.CLICKHOUSE_MIGRATIONS_HOST = "localhost"  # type: ignore[attr-defined]
+    sys.modules["posthog.settings.data_stores"] = fake_ds
+
+    # django stubs (for ch_migrate command)
+    for mod_name in ("django", "django.conf", "django.core", "django.core.management", "django.core.management.base"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]  # type: ignore[attr-defined]
+        sys.modules.setdefault(mod_name, m)
+
+    settings_ns = types.SimpleNamespace(CLICKHOUSE_DATABASE="default")
+    sys.modules["django.conf"].settings = settings_ns  # type: ignore[attr-defined]
+
+    class _FakeBaseCommand:
+        def __init__(self) -> None:
+            self.stdout = StringIO()
+            self.stderr = StringIO()
+
+        def print_help(self, *args: object) -> None:
+            pass
+
+    sys.modules["django.core.management.base"].BaseCommand = _FakeBaseCommand  # type: ignore[attr-defined]
+
+    # posthog.management.commands — make it a resolvable package
+    for mod_name in ("posthog.management", "posthog.management.commands"):
+        if mod_name not in sys.modules:
+            m = types.ModuleType(mod_name)
+            m.__path__ = [os.path.join(_BASE, mod_name.replace(".", "/"))]  # type: ignore[attr-defined]
+            m.__package__ = mod_name
+            sys.modules[mod_name] = m
+
+
+_install_stubs()
+
+# ---------------------------------------------------------------------------
+# run_sql_with_exceptions deprecation warning
+# ---------------------------------------------------------------------------
+
+
+class TestRunSqlWithExceptionsDeprecation:
+    def test_run_sql_with_exceptions_emits_deprecation(self) -> None:
+        from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            run_sql_with_exceptions("SELECT 1")
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+
+    def test_deprecation_message_references_readme(self) -> None:
+        from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            run_sql_with_exceptions("SELECT 1")
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+            assert "manifest.yaml" in str(deprecation_warnings[0].message)
+
+
+# ---------------------------------------------------------------------------
+# ch_migrate check subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestChMigrateCheck:
+    def test_check_command_exits_zero_when_no_pending(self) -> None:
+        from unittest.mock import patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        mock_cluster = MagicMock()
+        mock_cluster.any_host.return_value.result.return_value = MagicMock()
+
+        with (
+            patch("posthog.clickhouse.client.migration_tools.get_migrations_cluster", return_value=mock_cluster),
+            patch("posthog.clickhouse.migrations.runner.get_pending_migrations", return_value=[]),
+        ):
+            cmd = Command()
+            cmd.stdout = StringIO()
+            cmd.stderr = StringIO()
+
+            cmd.handle_check({})
+
+            output = cmd.stdout.getvalue()
+            assert "All new-style migrations applied" in output
+
+    def test_check_command_exits_nonzero_when_pending(self) -> None:
+        from unittest.mock import patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        mock_cluster = MagicMock()
+        mock_cluster.any_host.return_value.result.return_value = MagicMock()
+
+        pending = [
+            {"number": 1, "name": "0001_test", "style": "new", "path": Path("/tmp/fake")},
+            {"number": 2, "name": "0002_test", "style": "new", "path": Path("/tmp/fake2")},
+        ]
+
+        with (
+            patch("posthog.clickhouse.client.migration_tools.get_migrations_cluster", return_value=mock_cluster),
+            patch("posthog.clickhouse.migrations.runner.get_pending_migrations", return_value=pending),
+        ):
+            cmd = Command()
+            cmd.stdout = StringIO()
+            cmd.stderr = StringIO()
+
+            with pytest.raises(SystemExit) as exc_info:
+                cmd.handle_check({})
+
+            assert exc_info.value.code == 1
+
+            error_output = cmd.stderr.getvalue()
+            assert "2 unapplied new-style migration(s)" in error_output

--- a/posthog/clickhouse/test/test_multi_cluster.py
+++ b/posthog/clickhouse/test/test_multi_cluster.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from posthog.clickhouse.migrations.manifest import ManifestStep, MigrationManifest, parse_manifest
+
+# ---------------------------------------------------------------------------
+# Manifest parsing: per-step clusters
+# ---------------------------------------------------------------------------
+
+
+class TestManifestWithPerStepClusters:
+    def test_manifest_with_per_step_clusters(self, tmp_path: Path) -> None:
+        manifest_yaml = {
+            "description": "Per-step cluster targeting",
+            "steps": [
+                {
+                    "sql": "up.sql#step1",
+                    "node_roles": ["DATA"],
+                    "clusters": ["us-east", "eu-west"],
+                },
+                {
+                    "sql": "up.sql#step2",
+                    "node_roles": ["COORDINATOR"],
+                    "clusters": ["us-east"],
+                },
+            ],
+            "rollback": [],
+        }
+        manifest_file = tmp_path / "manifest.yaml"
+        manifest_file.write_text(yaml.dump(manifest_yaml))
+
+        result = parse_manifest(manifest_file)
+
+        assert result.steps[0].clusters == ["us-east", "eu-west"]
+        assert result.steps[1].clusters == ["us-east"]
+        assert result.clusters is None
+
+    def test_manifest_with_global_cluster(self, tmp_path: Path) -> None:
+        manifest_yaml = {
+            "description": "Global cluster config",
+            "cluster": "posthog",
+            "steps": [
+                {
+                    "sql": "up.sql",
+                    "node_roles": ["DATA"],
+                },
+            ],
+            "rollback": [],
+        }
+        manifest_file = tmp_path / "manifest.yaml"
+        manifest_file.write_text(yaml.dump(manifest_yaml))
+
+        result = parse_manifest(manifest_file)
+
+        assert result.cluster == "posthog"
+        assert result.clusters is None
+        assert result.steps[0].clusters is None
+
+    def test_manifest_with_global_clusters_list(self, tmp_path: Path) -> None:
+        manifest_yaml = {
+            "description": "Global clusters list",
+            "clusters": ["us-east", "eu-west"],
+            "steps": [
+                {
+                    "sql": "up.sql",
+                    "node_roles": ["DATA"],
+                },
+            ],
+            "rollback": [],
+        }
+        manifest_file = tmp_path / "manifest.yaml"
+        manifest_file.write_text(yaml.dump(manifest_yaml))
+
+        result = parse_manifest(manifest_file)
+
+        assert result.clusters == ["us-east", "eu-west"]
+        assert result.steps[0].clusters is None
+
+    def test_step_clusters_override_global(self, tmp_path: Path) -> None:
+        manifest_yaml = {
+            "description": "Step override of global clusters",
+            "clusters": ["us-east", "eu-west", "ap-south"],
+            "steps": [
+                {
+                    "sql": "up.sql#step1",
+                    "node_roles": ["DATA"],
+                    "clusters": ["us-east"],
+                },
+                {
+                    "sql": "up.sql#step2",
+                    "node_roles": ["DATA"],
+                },
+            ],
+            "rollback": [],
+        }
+        manifest_file = tmp_path / "manifest.yaml"
+        manifest_file.write_text(yaml.dump(manifest_yaml))
+
+        result = parse_manifest(manifest_file)
+
+        # Step 1 has explicit override
+        assert result.steps[0].clusters == ["us-east"]
+        # Step 2 inherits None — resolved at runtime from manifest.clusters
+        assert result.steps[1].clusters is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_step_clusters helper
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStepClusters:
+    def test_step_clusters_takes_precedence(self) -> None:
+        from posthog.clickhouse.migrations.runner import resolve_step_clusters
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[],
+            rollback=[],
+            clusters=["us-east", "eu-west"],
+        )
+        step = ManifestStep(
+            sql="up.sql",
+            node_roles=["DATA"],
+            clusters=["us-east"],
+        )
+        assert resolve_step_clusters(step, manifest) == ["us-east"]
+
+    def test_falls_back_to_manifest_clusters(self) -> None:
+        from posthog.clickhouse.migrations.runner import resolve_step_clusters
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[],
+            rollback=[],
+            clusters=["us-east", "eu-west"],
+        )
+        step = ManifestStep(
+            sql="up.sql",
+            node_roles=["DATA"],
+        )
+        assert resolve_step_clusters(step, manifest) == ["us-east", "eu-west"]
+
+    def test_falls_back_to_manifest_cluster_singular(self) -> None:
+        from posthog.clickhouse.migrations.runner import resolve_step_clusters
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[],
+            rollback=[],
+            cluster="posthog",
+        )
+        step = ManifestStep(
+            sql="up.sql",
+            node_roles=["DATA"],
+        )
+        assert resolve_step_clusters(step, manifest) == ["posthog"]
+
+    def test_returns_none_when_no_clusters(self) -> None:
+        from posthog.clickhouse.migrations.runner import resolve_step_clusters
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[],
+            rollback=[],
+        )
+        step = ManifestStep(
+            sql="up.sql",
+            node_roles=["DATA"],
+        )
+        assert resolve_step_clusters(step, manifest) is None
+
+
+# ---------------------------------------------------------------------------
+# check_cross_cluster_ordering
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCrossClusterOrdering:
+    @patch("posthog.clickhouse.migrations.runner.get_applied_migrations")
+    def test_check_cross_cluster_ordering_passes(self, mock_applied: MagicMock) -> None:
+        from posthog.clickhouse.migrations.runner import check_cross_cluster_ordering
+
+        # Migration 5 completed on both clusters
+        mock_applied.return_value = [
+            {"migration_number": 5, "migration_name": "0005_foo"},
+            {"migration_number": 5, "migration_name": "0005_foo"},
+        ]
+
+        clients = {
+            "us-east": MagicMock(),
+            "eu-west": MagicMock(),
+        }
+
+        result = check_cross_cluster_ordering(
+            cluster_clients=clients,
+            migration_number=6,
+            database="posthog",
+        )
+        assert result is True
+
+    @patch("posthog.clickhouse.migrations.runner.get_applied_migrations")
+    def test_check_cross_cluster_ordering_blocks(self, mock_applied: MagicMock) -> None:
+        from posthog.clickhouse.migrations.runner import check_cross_cluster_ordering
+
+        # First cluster has migration 5, second does not
+        mock_applied.side_effect = [
+            [{"migration_number": 5, "migration_name": "0005_foo"}],
+            [],  # eu-west has not applied migration 5
+        ]
+
+        clients = {
+            "us-east": MagicMock(),
+            "eu-west": MagicMock(),
+        }
+
+        result = check_cross_cluster_ordering(
+            cluster_clients=clients,
+            migration_number=6,
+            database="posthog",
+        )
+        assert result is False
+
+    @patch("posthog.clickhouse.migrations.runner.get_applied_migrations")
+    def test_check_cross_cluster_ordering_first_migration(self, mock_applied: MagicMock) -> None:
+        from posthog.clickhouse.migrations.runner import check_cross_cluster_ordering
+
+        mock_applied.return_value = []
+
+        clients = {
+            "us-east": MagicMock(),
+            "eu-west": MagicMock(),
+        }
+
+        # Migration 1 has no predecessor — should always pass
+        result = check_cross_cluster_ordering(
+            cluster_clients=clients,
+            migration_number=1,
+            database="posthog",
+        )
+        assert result is True
+
+    @patch("posthog.clickhouse.migrations.runner.get_applied_migrations")
+    def test_check_cross_cluster_ordering_single_cluster(self, mock_applied: MagicMock) -> None:
+        from posthog.clickhouse.migrations.runner import check_cross_cluster_ordering
+
+        mock_applied.return_value = [
+            {"migration_number": 5, "migration_name": "0005_foo"},
+        ]
+
+        clients = {
+            "us-east": MagicMock(),
+        }
+
+        result = check_cross_cluster_ordering(
+            cluster_clients=clients,
+            migration_number=6,
+            database="posthog",
+        )
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Runner respects step clusters
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerRespectsStepClusters:
+    @patch("posthog.clickhouse.migrations.runner._record_for_tracking")
+    @patch("posthog.clickhouse.migrations.runner.execute_migration_step")
+    def test_runner_respects_step_clusters_skips_unmatched(
+        self, mock_execute: MagicMock, mock_record: MagicMock
+    ) -> None:
+        from posthog.clickhouse.migrations.runner import run_migration_up
+
+        step1 = ManifestStep(
+            sql="up.sql#step1",
+            node_roles=["DATA"],
+            clusters=["us-east"],
+        )
+        step2 = ManifestStep(
+            sql="up.sql#step2",
+            node_roles=["DATA"],
+            clusters=["eu-west"],
+        )
+
+        migration = MagicMock()
+        migration.get_steps.return_value = [
+            (step1, "CREATE TABLE t1 (id UInt64) ENGINE = MergeTree() ORDER BY id"),
+            (step2, "CREATE TABLE t2 (id UInt64) ENGINE = MergeTree() ORDER BY id"),
+        ]
+        migration.manifest = MigrationManifest(
+            description="test",
+            steps=[step1, step2],
+            rollback=[],
+        )
+
+        mock_execute.return_value = {"host1": None}
+
+        # current_cluster="us-east" should skip step2 (eu-west only)
+        result = run_migration_up(
+            cluster=MagicMock(),
+            migration=migration,
+            database="test_db",
+            migration_number=1,
+            migration_name="0001_test",
+            current_cluster="us-east",
+        )
+
+        assert result is True
+        # Only step1 should have been executed
+        assert mock_execute.call_count == 1
+
+    @patch("posthog.clickhouse.migrations.runner._record_for_tracking")
+    @patch("posthog.clickhouse.migrations.runner.execute_migration_step")
+    def test_runner_executes_all_steps_when_no_cluster_filter(
+        self, mock_execute: MagicMock, mock_record: MagicMock
+    ) -> None:
+        from posthog.clickhouse.migrations.runner import run_migration_up
+
+        step1 = ManifestStep(
+            sql="up.sql#step1",
+            node_roles=["DATA"],
+            clusters=["us-east"],
+        )
+        step2 = ManifestStep(
+            sql="up.sql#step2",
+            node_roles=["DATA"],
+        )
+
+        migration = MagicMock()
+        migration.get_steps.return_value = [
+            (step1, "SELECT 1"),
+            (step2, "SELECT 2"),
+        ]
+        migration.manifest = MigrationManifest(
+            description="test",
+            steps=[step1, step2],
+            rollback=[],
+        )
+
+        mock_execute.return_value = {"host1": None}
+
+        # No current_cluster means execute everything
+        result = run_migration_up(
+            cluster=MagicMock(),
+            migration=migration,
+            database="test_db",
+            migration_number=1,
+            migration_name="0001_test",
+        )
+
+        assert result is True
+        assert mock_execute.call_count == 2
+
+    @patch("posthog.clickhouse.migrations.runner._record_for_tracking")
+    @patch("posthog.clickhouse.migrations.runner.execute_migration_step")
+    def test_runner_uses_manifest_clusters_fallback(self, mock_execute: MagicMock, mock_record: MagicMock) -> None:
+        from posthog.clickhouse.migrations.runner import run_migration_up
+
+        step1 = ManifestStep(
+            sql="up.sql",
+            node_roles=["DATA"],
+            # No per-step clusters — should use manifest-level
+        )
+
+        migration = MagicMock()
+        migration.get_steps.return_value = [
+            (step1, "SELECT 1"),
+        ]
+        migration.manifest = MigrationManifest(
+            description="test",
+            steps=[step1],
+            rollback=[],
+            clusters=["eu-west"],
+        )
+
+        mock_execute.return_value = {"host1": None}
+
+        # current_cluster="us-east" but manifest says eu-west only
+        result = run_migration_up(
+            cluster=MagicMock(),
+            migration=migration,
+            database="test_db",
+            migration_number=1,
+            migration_name="0001_test",
+            current_cluster="us-east",
+        )
+
+        assert result is True
+        # Step should be skipped because us-east not in [eu-west]
+        assert mock_execute.call_count == 0

--- a/posthog/management/commands/ch_migrate.py
+++ b/posthog/management/commands/ch_migrate.py
@@ -1,4 +1,5 @@
 # ruff: noqa: T201 allow print statements
+import sys
 from typing import Any
 
 from django.conf import settings
@@ -18,6 +19,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser: Any) -> None:  # type: ignore[override]
         subparsers = parser.add_subparsers(dest="subcommand")
         subparsers.add_parser("bootstrap", help="Create tracking table on all nodes")
+        subparsers.add_parser("check", help="Exit non-zero if unapplied new-style migrations exist")
         subparsers.add_parser("plan", help="Show pending migrations without executing")
 
         up_parser = subparsers.add_parser("up", help="Apply pending migrations")
@@ -79,6 +81,8 @@ class Command(BaseCommand):
         subcommand = options.get("subcommand")
         if subcommand == "bootstrap":
             self.handle_bootstrap()
+        elif subcommand == "check":
+            self.handle_check(options)
         elif subcommand == "plan":
             self.handle_plan()
         elif subcommand == "up":
@@ -111,6 +115,28 @@ class Command(BaseCommand):
             for exc in eg.exceptions:
                 print(f"  FAILED: {exc}")
             raise
+
+    def handle_check(self, options: object) -> None:
+        """Exit with non-zero status if unapplied new-style migrations exist."""
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+        from posthog.clickhouse.migrations.runner import get_pending_migrations
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        cluster = get_migrations_cluster()
+
+        def _get_client_for_query(client):  # type: ignore[no-untyped-def]
+            return client
+
+        pending = get_pending_migrations(
+            client=cluster.any_host(_get_client_for_query).result(),
+            database=database,
+        )
+
+        if pending:
+            self.stderr.write(f"{len(pending)} unapplied new-style migration(s)")
+            sys.exit(1)
+
+        self.stdout.write("All new-style migrations applied.")
 
     def handle_plan(self) -> None:
         from posthog.clickhouse.client.migration_tools import get_migrations_cluster


### PR DESCRIPTION
## Summary
Final piece of the declarative migration system ([RFC #1043](https://github.com/PostHog/requests-for-comments-internal/pull/1043)).

**Depends on:** resilience PR (validate + first migration)

- Multi-cluster: per-step cluster targeting, cross-cluster ordering enforcement
- README.md: complete migration guide with all ch_migrate commands
- `run_sql_with_exceptions`: DeprecationWarning pointing to new system
- `ch_migrate check`: exits 1 if unapplied migrations (for ArgoCD PreSync)
- `bin/migrate`: wired to call `ch_migrate up` alongside `migrate_clickhouse`

## Test plan
- 19 new tests (multi-cluster, deprecation, check command)
- 126 total tests passing
- Run: `python3 posthog/clickhouse/test/run_migration_tests.py`