### PR TITLE
feat(clickhouse): ch_migrate validate + mutation check + first test migration

### DIFF
--- a/posthog/clickhouse/migrations/0221_test_new_migration_system/__init__.py
+++ b/posthog/clickhouse/migrations/0221_test_new_migration_system/__init__.py
@@ -1,0 +1,3 @@
+# Compatibility bridge for new-style migration directory.
+# This file allows the directory to be treated as a Python package
+# by legacy tooling that expects importable migration modules.

--- a/posthog/clickhouse/migrations/0221_test_new_migration_system/down.sql
+++ b/posthog/clickhouse/migrations/0221_test_new_migration_system/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS posthog_test.ch_migrate_test

--- a/posthog/clickhouse/migrations/0221_test_new_migration_system/manifest.yaml
+++ b/posthog/clickhouse/migrations/0221_test_new_migration_system/manifest.yaml
@@ -1,0 +1,11 @@
+description: "Test new migration system — creates and drops a no-op table"
+
+steps:
+  - sql: "up.sql"
+    node_roles: ["DATA"]
+    comment: "create test table"
+
+rollback:
+  - sql: "down.sql"
+    node_roles: ["DATA"]
+    comment: "drop test table"

--- a/posthog/clickhouse/migrations/0221_test_new_migration_system/up.sql
+++ b/posthog/clickhouse/migrations/0221_test_new_migration_system/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE IF NOT EXISTS posthog_test.ch_migrate_test (id UInt64) ENGINE = MergeTree() ORDER BY id

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0220_materialize_ai_experiment_id
+0221_test_new_migration_system

--- a/posthog/clickhouse/migrations/runner.py
+++ b/posthog/clickhouse/migrations/runner.py
@@ -298,3 +298,38 @@ def run_migration_down(
 def compute_checksum(sql: str) -> str:
     """SHA256 of rendered SQL."""
     return hashlib.sha256(sql.encode()).hexdigest()
+
+
+def check_active_mutations(
+    cluster: ClickhouseCluster,
+    database: str,
+    tables: list[str],
+) -> list[dict[str, Any]]:
+    """Query system.mutations WHERE is_done = 0 on target tables.
+
+    Returns list of active mutation dicts across all hosts.
+    """
+    if not tables:
+        return []
+
+    table_list = ", ".join(f"'{t}'" for t in tables)
+    sql = (
+        f"SELECT database, table, mutation_id, command, create_time "
+        f"FROM system.mutations "
+        f"WHERE is_done = 0 AND database = '{database}' AND table IN ({table_list}) "
+        f"ORDER BY create_time"
+    )
+
+    query = _make_query(sql)
+
+    NodeRole = _get_node_role_enum()
+    futures_map = cluster.map_hosts_by_roles(query, node_roles=[NodeRole("data")])
+    host_results = futures_map.result()
+
+    active: list[dict[str, Any]] = []
+    for _host, rows in host_results.items():
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict):
+                    active.append(row)
+    return active

--- a/posthog/clickhouse/migrations/validator.py
+++ b/posthog/clickhouse/migrations/validator.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from posthog.clickhouse.migrations.manifest import MigrationManifest, parse_manifest
+
+
+@dataclass
+class ValidationResult:
+    rule: str
+    severity: str  # "error" or "warning"
+    message: str
+
+
+def validate_migration(migration_dir: Path, *, strict: bool = False) -> list[ValidationResult]:
+    """Run all validation rules on a migration directory. Returns list of issues."""
+    manifest = parse_manifest(migration_dir / "manifest.yaml")
+
+    # Collect all SQL content from referenced files
+    sql_content = _collect_sql_content(migration_dir, manifest)
+
+    results: list[ValidationResult] = []
+    results.extend(check_companion_tables(manifest, sql_content))
+    results.extend(check_on_cluster(sql_content))
+    results.extend(check_rollback_completeness(manifest))
+    results.extend(check_node_role_consistency(manifest))
+    results.extend(check_drop_statements(sql_content, strict=strict))
+    return results
+
+
+def _collect_sql_content(migration_dir: Path, manifest: MigrationManifest) -> str:
+    """Read all unique SQL files referenced by manifest steps."""
+    seen_files: set[str] = set()
+    parts: list[str] = []
+
+    for step in [*manifest.steps, *manifest.rollback]:
+        filename = step.sql.split("#")[0]
+        if filename not in seen_files:
+            seen_files.add(filename)
+            sql_path = migration_dir / filename
+            if sql_path.exists():
+                parts.append(sql_path.read_text())
+
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Rule: companion_tables
+# ---------------------------------------------------------------------------
+
+# Patterns for companion table types in SQL
+_ALTER_TABLE_RE = re.compile(r"ALTER\s+TABLE\s+(\S+)", re.IGNORECASE)
+_KAFKA_TABLE_RE = re.compile(r"(?:kafka_)", re.IGNORECASE)
+_MV_TABLE_RE = re.compile(r"(?:_mv\b|materialized)", re.IGNORECASE)
+_WRITABLE_TABLE_RE = re.compile(r"(?:writable_)", re.IGNORECASE)
+
+
+def check_companion_tables(manifest: MigrationManifest, sql_content: str) -> list[ValidationResult]:
+    """If any step ALTERs a sharded table, check for companion table steps.
+
+    When a sharded table is altered, the migration should also include steps
+    for the Kafka table, writable Distributed table, and MV on ingestion roles.
+    """
+    results: list[ValidationResult] = []
+
+    has_sharded_alter = False
+    for step in manifest.steps:
+        if step.sharded and "DATA" in step.node_roles:
+            if _ALTER_TABLE_RE.search(sql_content):
+                has_sharded_alter = True
+                break
+
+    if not has_sharded_alter:
+        return results
+
+    # Check that companion tables are referenced somewhere in the SQL
+    has_kafka = bool(_KAFKA_TABLE_RE.search(sql_content))
+    has_mv = bool(_MV_TABLE_RE.search(sql_content))
+    has_writable = bool(_WRITABLE_TABLE_RE.search(sql_content))
+
+    missing: list[str] = []
+    if not has_kafka:
+        missing.append("Kafka table")
+    if not has_mv:
+        missing.append("materialized view")
+    if not has_writable:
+        missing.append("writable Distributed table")
+
+    if missing:
+        results.append(
+            ValidationResult(
+                rule="companion_tables",
+                severity="warning",
+                message=f"Sharded ALTER detected but missing companion steps for: {', '.join(missing)}. "
+                "When altering a sharded table, also update the Kafka table, writable Distributed table, and MV.",
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rule: on_cluster
+# ---------------------------------------------------------------------------
+
+_ON_CLUSTER_RE = re.compile(r"\bON\s+CLUSTER\b", re.IGNORECASE)
+
+
+def check_on_cluster(sql_content: str) -> list[ValidationResult]:
+    """Scan all SQL for ON CLUSTER usage. Error if found.
+
+    The new migration system handles cluster routing via manifest node_roles,
+    so SQL should never contain ON CLUSTER directly.
+    """
+    results: list[ValidationResult] = []
+    if _ON_CLUSTER_RE.search(sql_content):
+        results.append(
+            ValidationResult(
+                rule="on_cluster",
+                severity="error",
+                message="SQL contains 'ON CLUSTER'. The migration system handles cluster routing via "
+                "manifest node_roles. Remove ON CLUSTER from your SQL.",
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rule: rollback_completeness
+# ---------------------------------------------------------------------------
+
+
+def check_rollback_completeness(manifest: MigrationManifest) -> list[ValidationResult]:
+    """Every step entry must have a corresponding rollback entry (matched by count)."""
+    results: list[ValidationResult] = []
+    n_steps = len(manifest.steps)
+    n_rollback = len(manifest.rollback)
+
+    if n_steps > 0 and n_rollback != n_steps:
+        results.append(
+            ValidationResult(
+                rule="rollback_completeness",
+                severity="error",
+                message=f"Migration has {n_steps} steps but {n_rollback} rollback entries. "
+                "Each step should have a corresponding rollback entry.",
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rule: node_role_consistency
+# ---------------------------------------------------------------------------
+
+
+def check_node_role_consistency(manifest: MigrationManifest) -> list[ValidationResult]:
+    """Sharded operations should target DATA, not COORDINATOR alone."""
+    results: list[ValidationResult] = []
+
+    for i, step in enumerate(manifest.steps):
+        if step.sharded and "DATA" not in step.node_roles:
+            results.append(
+                ValidationResult(
+                    rule="node_role_consistency",
+                    severity="warning",
+                    message=f"Step {i} is marked sharded=True but does not target DATA role "
+                    f"(targets: {step.node_roles}). Sharded operations should include DATA.",
+                )
+            )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rule: drop_statement
+# ---------------------------------------------------------------------------
+
+_DROP_STMT_RE = re.compile(r"^\s*DROP\s+", re.IGNORECASE | re.MULTILINE)
+_COMMENT_LINE_RE = re.compile(r"^\s*--.*$", re.MULTILINE)
+
+
+def check_drop_statements(sql_content: str, *, strict: bool = False) -> list[ValidationResult]:
+    """Scan .up.sql for DROP statements. Warning by default, error in strict mode.
+
+    Lines that are SQL comments (starting with --) are ignored.
+    """
+    results: list[ValidationResult] = []
+
+    # Strip comment lines before checking
+    stripped = _COMMENT_LINE_RE.sub("", sql_content)
+
+    if _DROP_STMT_RE.search(stripped):
+        results.append(
+            ValidationResult(
+                rule="drop_statement",
+                severity="error" if strict else "warning",
+                message="SQL contains DROP statement(s). Ensure this is intentional and "
+                "that data loss has been considered.",
+            )
+        )
+    return results

--- a/posthog/clickhouse/test/run_migration_tests.py
+++ b/posthog/clickhouse/test/run_migration_tests.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
                 "posthog/clickhouse/test/test_trial.py",
                 "posthog/clickhouse/test/test_status_command.py",
                 "posthog/clickhouse/test/test_create_migration.py",
+                "posthog/clickhouse/test/test_validator.py",
             ]
         )
     )

--- a/posthog/clickhouse/test/test_validator.py
+++ b/posthog/clickhouse/test/test_validator.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from posthog.clickhouse.migrations.manifest import ManifestStep, MigrationManifest
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_migration(tmp_path: Path, manifest_data: dict, sql_files: dict[str, str] | None = None) -> Path:
+    """Create a migration directory with manifest.yaml and optional SQL files."""
+    mig_dir = tmp_path / "0100_test_migration"
+    mig_dir.mkdir(parents=True, exist_ok=True)
+    (mig_dir / "manifest.yaml").write_text(yaml.dump(manifest_data))
+    if sql_files:
+        for name, content in sql_files.items():
+            (mig_dir / name).write_text(content)
+    return mig_dir
+
+
+def _valid_manifest() -> dict:
+    return {
+        "description": "A valid test migration",
+        "steps": [
+            {"sql": "up.sql", "node_roles": ["DATA"], "comment": "create table"},
+        ],
+        "rollback": [
+            {"sql": "down.sql", "node_roles": ["DATA"], "comment": "drop table"},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# ValidationResult basics
+# ---------------------------------------------------------------------------
+
+
+class TestValidationResult:
+    def test_validation_result_fields(self):
+        from posthog.clickhouse.migrations.validator import ValidationResult
+
+        r = ValidationResult(rule="test_rule", severity="error", message="something broke")
+        assert r.rule == "test_rule"
+        assert r.severity == "error"
+        assert r.message == "something broke"
+
+    def test_validation_result_warning(self):
+        from posthog.clickhouse.migrations.validator import ValidationResult
+
+        r = ValidationResult(rule="test_rule", severity="warning", message="heads up")
+        assert r.severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# check_on_cluster
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOnCluster:
+    def test_detect_on_cluster(self):
+        from posthog.clickhouse.migrations.validator import check_on_cluster
+
+        sql = "CREATE TABLE foo ON CLUSTER '{cluster}' (id UInt64) ENGINE = MergeTree()"
+        results = check_on_cluster(sql)
+        assert len(results) == 1
+        assert results[0].severity == "error"
+        assert results[0].rule == "on_cluster"
+
+    def test_detect_on_cluster_case_insensitive(self):
+        from posthog.clickhouse.migrations.validator import check_on_cluster
+
+        sql = "ALTER TABLE foo on cluster my_cluster ADD COLUMN bar String"
+        results = check_on_cluster(sql)
+        assert len(results) == 1
+        assert results[0].severity == "error"
+
+    def test_no_on_cluster_passes(self):
+        from posthog.clickhouse.migrations.validator import check_on_cluster
+
+        sql = "CREATE TABLE foo (id UInt64) ENGINE = MergeTree() ORDER BY id"
+        results = check_on_cluster(sql)
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_rollback_completeness
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRollbackCompleteness:
+    def test_detect_missing_rollback(self):
+        from posthog.clickhouse.migrations.validator import check_rollback_completeness
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[
+                ManifestStep(sql="up.sql", node_roles=["DATA"]),
+                ManifestStep(sql="up.sql#step2", node_roles=["DATA"]),
+            ],
+            rollback=[
+                ManifestStep(sql="down.sql", node_roles=["DATA"]),
+            ],
+        )
+        results = check_rollback_completeness(manifest)
+        assert len(results) == 1
+        assert results[0].severity == "error"
+        assert results[0].rule == "rollback_completeness"
+        assert "2 steps but 1 rollback" in results[0].message
+
+    def test_matching_counts_passes(self):
+        from posthog.clickhouse.migrations.validator import check_rollback_completeness
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[ManifestStep(sql="up.sql", node_roles=["DATA"])],
+            rollback=[ManifestStep(sql="down.sql", node_roles=["DATA"])],
+        )
+        results = check_rollback_completeness(manifest)
+        assert len(results) == 0
+
+    def test_empty_rollback_warns(self):
+        from posthog.clickhouse.migrations.validator import check_rollback_completeness
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[ManifestStep(sql="up.sql", node_roles=["DATA"])],
+            rollback=[],
+        )
+        results = check_rollback_completeness(manifest)
+        assert len(results) == 1
+        assert results[0].severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# check_node_role_consistency
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNodeRoleConsistency:
+    def test_detect_node_role_mismatch_sharded_on_coordinator(self):
+        from posthog.clickhouse.migrations.validator import check_node_role_consistency
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[
+                ManifestStep(sql="up.sql", node_roles=["COORDINATOR"], sharded=True),
+            ],
+            rollback=[],
+        )
+        results = check_node_role_consistency(manifest)
+        assert len(results) >= 1
+        assert any(r.severity == "warning" and r.rule == "node_role_consistency" for r in results)
+
+    def test_sharded_on_data_passes(self):
+        from posthog.clickhouse.migrations.validator import check_node_role_consistency
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[
+                ManifestStep(sql="up.sql", node_roles=["DATA"], sharded=True),
+            ],
+            rollback=[],
+        )
+        results = check_node_role_consistency(manifest)
+        assert len(results) == 0
+
+    def test_non_sharded_any_role_passes(self):
+        from posthog.clickhouse.migrations.validator import check_node_role_consistency
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[
+                ManifestStep(sql="up.sql", node_roles=["COORDINATOR"]),
+            ],
+            rollback=[],
+        )
+        results = check_node_role_consistency(manifest)
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_drop_statements
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDropStatements:
+    def test_detect_drop_statement_warning(self):
+        from posthog.clickhouse.migrations.validator import check_drop_statements
+
+        sql = "DROP TABLE IF EXISTS posthog_test.my_table"
+        results = check_drop_statements(sql, strict=False)
+        assert len(results) == 1
+        assert results[0].severity == "warning"
+        assert results[0].rule == "drop_statement"
+
+    def test_detect_drop_statement_strict(self):
+        from posthog.clickhouse.migrations.validator import check_drop_statements
+
+        sql = "DROP TABLE IF EXISTS posthog_test.my_table"
+        results = check_drop_statements(sql, strict=True)
+        assert len(results) == 1
+        assert results[0].severity == "error"
+
+    def test_no_drop_passes(self):
+        from posthog.clickhouse.migrations.validator import check_drop_statements
+
+        sql = "CREATE TABLE foo (id UInt64) ENGINE = MergeTree() ORDER BY id"
+        results = check_drop_statements(sql, strict=False)
+        assert len(results) == 0
+
+    def test_drop_in_comment_ignored(self):
+        from posthog.clickhouse.migrations.validator import check_drop_statements
+
+        sql = "-- DROP TABLE old_table\nCREATE TABLE foo (id UInt64) ENGINE = MergeTree() ORDER BY id"
+        results = check_drop_statements(sql, strict=False)
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_companion_tables
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCompanionTables:
+    def test_detect_missing_companion_tables(self):
+        from posthog.clickhouse.migrations.validator import check_companion_tables
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[
+                ManifestStep(
+                    sql="up.sql",
+                    node_roles=["DATA"],
+                    sharded=True,
+                ),
+            ],
+            rollback=[],
+        )
+        sql_content = "ALTER TABLE sharded_events ADD COLUMN foo String"
+        results = check_companion_tables(manifest, sql_content)
+        assert len(results) >= 1
+        assert any(r.rule == "companion_tables" for r in results)
+
+    def test_non_sharded_alter_no_warning(self):
+        from posthog.clickhouse.migrations.validator import check_companion_tables
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[
+                ManifestStep(sql="up.sql", node_roles=["DATA"], sharded=False),
+            ],
+            rollback=[],
+        )
+        sql_content = "ALTER TABLE events ADD COLUMN foo String"
+        results = check_companion_tables(manifest, sql_content)
+        assert len(results) == 0
+
+    def test_sharded_alter_with_companion_passes(self):
+        from posthog.clickhouse.migrations.validator import check_companion_tables
+
+        manifest = MigrationManifest(
+            description="test",
+            steps=[
+                ManifestStep(sql="up.sql#alter_sharded", node_roles=["DATA"], sharded=True),
+                ManifestStep(sql="up.sql#alter_kafka", node_roles=["DATA"]),
+                ManifestStep(sql="up.sql#alter_mv", node_roles=["DATA"]),
+                ManifestStep(sql="up.sql#alter_writable", node_roles=["DATA"]),
+            ],
+            rollback=[],
+        )
+        sql_content = (
+            "-- @section: alter_sharded\n"
+            "ALTER TABLE sharded_events ADD COLUMN foo String\n"
+            "-- @section: alter_kafka\n"
+            "ALTER TABLE kafka_events ADD COLUMN foo String\n"
+            "-- @section: alter_mv\n"
+            "ALTER TABLE events_mv MODIFY QUERY SELECT foo FROM kafka_events\n"
+            "-- @section: alter_writable\n"
+            "ALTER TABLE writable_events ADD COLUMN foo String\n"
+        )
+        results = check_companion_tables(manifest, sql_content)
+        assert len(results) == 0
+
+
+# ---------------------------------------------------------------------------
+# validate_migration (integration of all rules)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMigration:
+    def test_validate_valid_migration(self, tmp_path):
+        from posthog.clickhouse.migrations.validator import validate_migration
+
+        mig_dir = _write_migration(
+            tmp_path,
+            _valid_manifest(),
+            {
+                "up.sql": "CREATE TABLE IF NOT EXISTS posthog_test.ch_migrate_test (id UInt64) ENGINE = MergeTree() ORDER BY id",
+                "down.sql": "DROP TABLE IF EXISTS posthog_test.ch_migrate_test",
+            },
+        )
+        results = validate_migration(mig_dir)
+        errors = [r for r in results if r.severity == "error"]
+        assert len(errors) == 0
+
+    def test_validate_multiple_issues(self, tmp_path):
+        from posthog.clickhouse.migrations.validator import validate_migration
+
+        manifest_data = {
+            "description": "bad migration",
+            "steps": [
+                {"sql": "up.sql", "node_roles": ["COORDINATOR"], "sharded": True},
+            ],
+            "rollback": [],
+        }
+        mig_dir = _write_migration(
+            tmp_path,
+            manifest_data,
+            {
+                "up.sql": "DROP TABLE foo ON CLUSTER '{cluster}'",
+                "down.sql": "",
+            },
+        )
+        results = validate_migration(mig_dir)
+        rules = {r.rule for r in results}
+        assert "on_cluster" in rules
+        assert "rollback_completeness" in rules
+        assert "node_role_consistency" in rules
+
+    def test_validate_strict_mode(self, tmp_path):
+        from posthog.clickhouse.migrations.validator import validate_migration
+
+        mig_dir = _write_migration(
+            tmp_path,
+            _valid_manifest(),
+            {
+                "up.sql": "DROP TABLE IF EXISTS posthog_test.old_table",
+                "down.sql": "CREATE TABLE posthog_test.old_table (id UInt64) ENGINE = MergeTree() ORDER BY id",
+            },
+        )
+        results_normal = validate_migration(mig_dir, strict=False)
+        results_strict = validate_migration(mig_dir, strict=True)
+        normal_errors = [r for r in results_normal if r.severity == "error"]
+        strict_errors = [r for r in results_strict if r.severity == "error"]
+        assert len(strict_errors) > len(normal_errors)
+
+
+# ---------------------------------------------------------------------------
+# check_active_mutations
+# ---------------------------------------------------------------------------
+
+
+class TestCheckActiveMutations:
+    @patch("posthog.clickhouse.migrations.runner._get_node_role_enum")
+    @patch("posthog.clickhouse.migrations.runner._make_query", side_effect=lambda sql: sql)
+    def test_check_active_mutations_returns_results(self, _mock_query, mock_role_enum):
+        from posthog.clickhouse.migrations.runner import check_active_mutations
+
+        mock_role_enum.return_value = lambda v: v
+
+        cluster = MagicMock()
+        mock_futures = MagicMock()
+        # Simulate per-host results: host -> list of mutation rows
+        mock_futures.result.return_value = {
+            "host1": [
+                {"table": "events", "mutation_id": "mut_001", "command": "ALTER TABLE events DELETE WHERE 1"},
+            ],
+        }
+        cluster.map_hosts_by_roles.return_value = mock_futures
+
+        results = check_active_mutations(cluster, "posthog", ["events"])
+        assert len(results) >= 1
+        assert results[0]["table"] == "events"
+
+    @patch("posthog.clickhouse.migrations.runner._get_node_role_enum")
+    @patch("posthog.clickhouse.migrations.runner._make_query", side_effect=lambda sql: sql)
+    def test_check_active_mutations_empty(self, _mock_query, mock_role_enum):
+        from posthog.clickhouse.migrations.runner import check_active_mutations
+
+        mock_role_enum.return_value = lambda v: v
+
+        cluster = MagicMock()
+        mock_futures = MagicMock()
+        mock_futures.result.return_value = {"host1": []}
+        cluster.map_hosts_by_roles.return_value = mock_futures
+
+        results = check_active_mutations(cluster, "posthog", ["events"])
+        assert results == []
+
+    @patch("posthog.clickhouse.migrations.runner._get_node_role_enum")
+    @patch("posthog.clickhouse.migrations.runner._make_query", side_effect=lambda sql: sql)
+    def test_check_active_mutations_queries_correct_tables(self, _mock_query, mock_role_enum):
+        from posthog.clickhouse.migrations.runner import check_active_mutations
+
+        mock_role_enum.return_value = lambda v: v
+
+        cluster = MagicMock()
+        mock_futures = MagicMock()
+        mock_futures.result.return_value = {"host1": []}
+        cluster.map_hosts_by_roles.return_value = mock_futures
+
+        check_active_mutations(cluster, "posthog", ["events", "persons"])
+
+        # Verify the SQL query was constructed with the table names
+        call_args = cluster.map_hosts_by_roles.call_args
+        query_sql = call_args[0][0]  # first positional arg is the query
+        assert "events" in query_sql
+        assert "persons" in query_sql
+
+
+# ---------------------------------------------------------------------------
+# First migration (0220) passes validation
+# ---------------------------------------------------------------------------
+
+
+class TestFirstMigrationValidation:
+    def test_first_migration_passes_validation(self, tmp_path):
+        from posthog.clickhouse.migrations.validator import validate_migration
+
+        manifest_data = {
+            "description": "Test new migration system",
+            "steps": [
+                {
+                    "sql": "up.sql",
+                    "node_roles": ["DATA"],
+                    "comment": "create test table",
+                },
+            ],
+            "rollback": [
+                {
+                    "sql": "down.sql",
+                    "node_roles": ["DATA"],
+                    "comment": "drop test table",
+                },
+            ],
+        }
+        mig_dir = _write_migration(
+            tmp_path,
+            manifest_data,
+            {
+                "up.sql": "CREATE TABLE IF NOT EXISTS posthog_test.ch_migrate_test (id UInt64) ENGINE = MergeTree() ORDER BY id",
+                "down.sql": "DROP TABLE IF EXISTS posthog_test.ch_migrate_test",
+            },
+        )
+        results = validate_migration(mig_dir)
+        errors = [r for r in results if r.severity == "error"]
+        assert len(errors) == 0
+
+    def test_real_0220_migration_validates(self):
+        from posthog.clickhouse.migrations.validator import validate_migration
+
+        mig_dir = Path("posthog/clickhouse/migrations/0221_test_new_migration_system")
+        if not mig_dir.exists():
+            return
+        results = validate_migration(mig_dir)
+        errors = [r for r in results if r.severity == "error"]
+        assert len(errors) == 0

--- a/posthog/management/commands/ch_migrate.py
+++ b/posthog/management/commands/ch_migrate.py
@@ -27,6 +27,18 @@ class Command(BaseCommand):
             default=99_999,
             help="Apply migrations up to this number (inclusive).",
         )
+        up_parser.add_argument(
+            "--check-mutations",
+            action="store_true",
+            default=False,
+            help="Check for active mutations on target tables before applying.",
+        )
+        up_parser.add_argument(
+            "--force",
+            action="store_true",
+            default=False,
+            help="Force apply even if active mutations are found.",
+        )
 
         down_parser = subparsers.add_parser("down", help="Roll back a specific migration")
         down_parser.add_argument(
@@ -41,6 +53,19 @@ class Command(BaseCommand):
             type=str,
             default=None,
             help="Filter to a specific node hostname (e.g. host1:9000).",
+        )
+
+        validate_parser = subparsers.add_parser("validate", help="Static analysis validation of a migration")
+        validate_parser.add_argument(
+            "migration_number",
+            type=int,
+            help="Migration number to validate.",
+        )
+        validate_parser.add_argument(
+            "--strict",
+            action="store_true",
+            default=False,
+            help="Treat warnings as errors.",
         )
 
         trial_parser = subparsers.add_parser("trial", help="Sandbox validation: up, verify, down, verify")
@@ -62,6 +87,8 @@ class Command(BaseCommand):
             self.handle_status(options)
         elif subcommand == "down":
             self.handle_down(options)
+        elif subcommand == "validate":
+            self.handle_validate(options)
         elif subcommand == "trial":
             self.handle_trial(options)
         else:
@@ -131,10 +158,17 @@ class Command(BaseCommand):
     def handle_up(self, options: object) -> None:
         from posthog.clickhouse.client.migration_tools import get_migrations_cluster
         from posthog.clickhouse.migrations.new_style import NewStyleMigration
-        from posthog.clickhouse.migrations.runner import get_pending_migrations, is_new_style, run_migration_up
+        from posthog.clickhouse.migrations.runner import (
+            check_active_mutations,
+            get_pending_migrations,
+            is_new_style,
+            run_migration_up,
+        )
 
         database: str = settings.CLICKHOUSE_DATABASE
         upto: int = options.get("upto", 99_999)  # type: ignore[union-attr]
+        check_mutations: bool = options.get("check_mutations", False)  # type: ignore[union-attr]
+        force: bool = options.get("force", False)  # type: ignore[union-attr]
         cluster = get_migrations_cluster()
 
         def _get_client_for_query(client):  # type: ignore[no-untyped-def]
@@ -150,6 +184,33 @@ class Command(BaseCommand):
         if not pending:
             print("All migrations are up to date.")
             return
+
+        if check_mutations:
+            # Extract table names from pending new-style migrations for mutation check
+            tables_to_check: list[str] = []
+            for mig in pending:
+                if mig["style"] == "new" and is_new_style(mig["path"]):
+                    try:
+                        m = NewStyleMigration(mig["path"])
+                        for step, _sql in m.get_steps():
+                            if step.sharded or step.is_alter_on_replicated_table:
+                                # Try to extract table name from SQL
+                                import re
+
+                                match = re.search(r"ALTER\s+TABLE\s+(\S+)", _sql, re.IGNORECASE)
+                                if match:
+                                    tables_to_check.append(match.group(1).split(".")[-1])
+                    except Exception:
+                        pass
+
+            if tables_to_check:
+                active = check_active_mutations(cluster, database, tables_to_check)
+                if active and not force:
+                    print("Active mutations found on target tables:")
+                    for mut in active:
+                        print(f"  table={mut.get('table')}, mutation_id={mut.get('mutation_id')}")
+                    print("\nUse --force to apply anyway.")
+                    return
 
         print(f"Applying {len(pending)} migration(s)...\n")
 
@@ -222,6 +283,44 @@ class Command(BaseCommand):
                 self.stdout.write("  New-style migrations: none\n")
 
         self.stdout.write("\n")
+
+    def handle_validate(self, options: object) -> None:
+        from posthog.clickhouse.migrations.runner import discover_migrations, is_new_style
+        from posthog.clickhouse.migrations.validator import validate_migration
+
+        target: int = options.get("migration_number")  # type: ignore[union-attr]
+        strict: bool = options.get("strict", False)  # type: ignore[union-attr]
+
+        all_migrations = discover_migrations()
+        target_mig = next((m for m in all_migrations if m["number"] == target), None)
+
+        if target_mig is None:
+            print(f"Migration {target} not found.")
+            return
+
+        if target_mig["style"] != "new" or not is_new_style(target_mig["path"]):
+            print(f"Migration {target_mig['name']} is not a new-style migration. Validation not supported.")
+            return
+
+        print(f"Validating {target_mig['name']}...")
+        results = validate_migration(target_mig["path"], strict=strict)
+
+        if not results:
+            print("  No issues found.")
+            return
+
+        has_errors = False
+        for r in results:
+            icon = "ERROR" if r.severity == "error" else "WARN"
+            print(f"  [{icon}] ({r.rule}) {r.message}")
+            if r.severity == "error":
+                has_errors = True
+
+        if has_errors:
+            print(f"\nValidation FAILED for {target_mig['name']}.")
+            raise SystemExit(1)
+        else:
+            print(f"\nValidation passed with warnings for {target_mig['name']}.")
 
     def handle_down(self, options: object) -> None:
         from posthog.clickhouse.client.migration_tools import get_migrations_cluster


### PR DESCRIPTION
## Summary
Validation pipeline for the declarative migration system ([RFC #1043](https://github.com/PostHog/requests-for-comments-internal/pull/1043)).

**Depends on:** #51719

- `validator.py`: 5 static analysis rules (companion tables, ON CLUSTER, rollback completeness, node roles, DROP detection with --strict)
- `ch_migrate validate N`: run all rules, exit 1 on errors
- `ch_migrate up --check-mutations`: warn on active `system.mutations`, require `--force`
- `0221_test_new_migration_system`: first migration using the new directory format

## Test plan
- 24 new tests for validation rules and mutation checks