### PR TITLE
feat(clickhouse): ClickHouse Query Gateway scaffold (Rust)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "personhog-proto",
     "personhog-replica",
     "personhog-router",
+    "clickhouse-gateway",
 ]
 
 [workspace.lints.rust]

--- a/rust/clickhouse-gateway/Cargo.toml
+++ b/rust/clickhouse-gateway/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "clickhouse-gateway"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+envconfig = { workspace = true }
+hyper = { workspace = true }
+lifecycle = { path = "../common/lifecycle" }
+common-alloc = { path = "../common/alloc" }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+reqwest = { workspace = true }
+sha2 = { workspace = true }
+uuid = { workspace = true }
+rand = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+axum-test = "16"

--- a/rust/clickhouse-gateway/Dockerfile
+++ b/rust/clickhouse-gateway/Dockerfile
@@ -1,0 +1,41 @@
+# This service uses the shared multi-stage Rust Dockerfile at rust/Dockerfile.
+# Build with:
+#   docker build -f rust/Dockerfile --build-arg BIN=clickhouse-gateway -t clickhouse-gateway rust/
+#
+# Alternatively, for a standalone build:
+
+FROM rust:1.91-bookworm AS base
+RUN cargo install --locked cargo-chef sccache@0.12.0
+ENV RUSTC_WRAPPER=sccache SCCACHE_DIR=/sccache
+
+FROM base AS planner
+WORKDIR /app
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin clickhouse-gateway
+
+FROM base AS builder
+WORKDIR /app
+RUN apt-get update && apt-get install build-essential libssl-dev pkg-config cmake -y
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
+    cargo chef cook --release --recipe-path recipe.json --bin clickhouse-gateway && \
+    sccache --show-stats
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
+    SCCACHE_NO_DAEMON=1 SCCACHE_START_SERVER=1 sccache 2>&1 & \
+    cargo build --release --bin clickhouse-gateway && \
+    sccache --show-stats
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libssl-dev ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+USER nobody
+COPY --from=builder /app/target/release/clickhouse-gateway /usr/local/bin/clickhouse-gateway
+ENTRYPOINT ["/usr/local/bin/clickhouse-gateway"]

--- a/rust/clickhouse-gateway/src/config.rs
+++ b/rust/clickhouse-gateway/src/config.rs
@@ -1,0 +1,134 @@
+use envconfig::Envconfig;
+
+#[derive(Envconfig, Clone, Debug)]
+pub struct Config {
+    #[envconfig(from = "GATEWAY_HOST", default = "0.0.0.0")]
+    pub host: String,
+
+    #[envconfig(from = "GATEWAY_PORT", default = "3100")]
+    pub port: u16,
+
+    #[envconfig(from = "CLICKHOUSE_ONLINE_HOSTS", default = "http://localhost:8123")]
+    pub clickhouse_online_hosts: String,
+
+    #[envconfig(from = "CLICKHOUSE_OFFLINE_HOSTS", default = "http://localhost:8123")]
+    pub clickhouse_offline_hosts: String,
+
+    #[envconfig(from = "CLICKHOUSE_LOGS_HOSTS", default = "http://localhost:8123")]
+    pub clickhouse_logs_hosts: String,
+
+    #[envconfig(from = "CLICKHOUSE_ENDPOINTS_HOSTS", default = "http://localhost:8123")]
+    pub clickhouse_endpoints_hosts: String,
+
+    // Per-workload concurrency limits
+    #[envconfig(from = "GATEWAY_ONLINE_MAX_CONCURRENT", default = "50")]
+    pub online_max_concurrent: u32,
+
+    #[envconfig(from = "GATEWAY_ONLINE_MAX_EXECUTION_TIME", default = "30")]
+    pub online_max_execution_time: u32,
+
+    #[envconfig(from = "GATEWAY_OFFLINE_MAX_CONCURRENT", default = "10")]
+    pub offline_max_concurrent: u32,
+
+    #[envconfig(from = "GATEWAY_OFFLINE_MAX_EXECUTION_TIME", default = "600")]
+    pub offline_max_execution_time: u32,
+
+    #[envconfig(from = "GATEWAY_LOGS_MAX_CONCURRENT", default = "20")]
+    pub logs_max_concurrent: u32,
+
+    #[envconfig(from = "GATEWAY_LOGS_MAX_EXECUTION_TIME", default = "60")]
+    pub logs_max_execution_time: u32,
+
+    #[envconfig(from = "GATEWAY_ENDPOINTS_MAX_CONCURRENT", default = "30")]
+    pub endpoints_max_concurrent: u32,
+
+    #[envconfig(from = "GATEWAY_ENDPOINTS_MAX_EXECUTION_TIME", default = "120")]
+    pub endpoints_max_execution_time: u32,
+
+    // Metrics export
+    #[envconfig(from = "GATEWAY_METRICS_PORT", default = "9090")]
+    pub metrics_port: u16,
+
+    #[envconfig(from = "GATEWAY_LOG_LEVEL", default = "info")]
+    pub log_level: String,
+}
+
+impl Config {
+    /// Parse a comma-separated host string into a list of host URLs.
+    pub fn parse_hosts(hosts: &str) -> Vec<String> {
+        hosts
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    pub fn online_hosts(&self) -> Vec<String> {
+        Self::parse_hosts(&self.clickhouse_online_hosts)
+    }
+
+    pub fn offline_hosts(&self) -> Vec<String> {
+        Self::parse_hosts(&self.clickhouse_offline_hosts)
+    }
+
+    pub fn logs_hosts(&self) -> Vec<String> {
+        Self::parse_hosts(&self.clickhouse_logs_hosts)
+    }
+
+    pub fn endpoints_hosts(&self) -> Vec<String> {
+        Self::parse_hosts(&self.clickhouse_endpoints_hosts)
+    }
+
+    /// Returns (max_concurrent, max_execution_time) for a given workload.
+    pub fn limits_for_workload(&self, workload: &crate::routing::Workload) -> (u32, u32) {
+        match workload {
+            crate::routing::Workload::Online => {
+                (self.online_max_concurrent, self.online_max_execution_time)
+            }
+            crate::routing::Workload::Offline => {
+                (self.offline_max_concurrent, self.offline_max_execution_time)
+            }
+            crate::routing::Workload::Logs => {
+                (self.logs_max_concurrent, self.logs_max_execution_time)
+            }
+            crate::routing::Workload::Endpoints => {
+                (self.endpoints_max_concurrent, self.endpoints_max_execution_time)
+            }
+            crate::routing::Workload::Default => {
+                (self.online_max_concurrent, self.online_max_execution_time)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_hosts_single() {
+        let hosts = Config::parse_hosts("http://localhost:8123");
+        assert_eq!(hosts, vec!["http://localhost:8123"]);
+    }
+
+    #[test]
+    fn test_parse_hosts_multiple() {
+        let hosts = Config::parse_hosts("http://ch1:8123,http://ch2:8123,http://ch3:8123");
+        assert_eq!(
+            hosts,
+            vec!["http://ch1:8123", "http://ch2:8123", "http://ch3:8123"]
+        );
+    }
+
+    #[test]
+    fn test_parse_hosts_with_whitespace() {
+        let hosts = Config::parse_hosts("http://ch1:8123 , http://ch2:8123");
+        assert_eq!(hosts, vec!["http://ch1:8123", "http://ch2:8123"]);
+    }
+
+    #[test]
+    fn test_parse_hosts_empty() {
+        let hosts = Config::parse_hosts("");
+        assert!(hosts.is_empty());
+    }
+}

--- a/rust/clickhouse-gateway/src/error.rs
+++ b/rust/clickhouse-gateway/src/error.rs
@@ -1,0 +1,66 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum GatewayError {
+    #[error("invalid workload: {0}")]
+    InvalidWorkload(String),
+
+    #[error("write queries are not allowed when read_only is true")]
+    WriteNotAllowed,
+
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("clickhouse error: {0}")]
+    ClickHouseError(String),
+
+    #[error("upstream timeout after {0}s")]
+    Timeout(u32),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+    error_type: String,
+}
+
+impl GatewayError {
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            GatewayError::InvalidWorkload(_) => "invalid_workload",
+            GatewayError::WriteNotAllowed => "write_not_allowed",
+            GatewayError::InvalidRequest(_) => "invalid_request",
+            GatewayError::ClickHouseError(_) => "clickhouse_error",
+            GatewayError::Timeout(_) => "timeout",
+            GatewayError::Internal(_) => "internal_error",
+        }
+    }
+
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            GatewayError::InvalidWorkload(_) => StatusCode::BAD_REQUEST,
+            GatewayError::WriteNotAllowed => StatusCode::FORBIDDEN,
+            GatewayError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+            GatewayError::ClickHouseError(_) => StatusCode::BAD_GATEWAY,
+            GatewayError::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
+            GatewayError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl IntoResponse for GatewayError {
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let body = ErrorResponse {
+            error: self.to_string(),
+            error_type: self.error_type().to_string(),
+        };
+        (status, Json(body)).into_response()
+    }
+}

--- a/rust/clickhouse-gateway/src/lib.rs
+++ b/rust/clickhouse-gateway/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod config;
+pub mod error;
+pub mod query;
+pub mod routing;
+pub mod state;
+pub mod validation;

--- a/rust/clickhouse-gateway/src/main.rs
+++ b/rust/clickhouse-gateway/src/main.rs
@@ -1,0 +1,114 @@
+use std::time::Duration;
+
+use axum::routing::{get, post};
+use axum::Router;
+use envconfig::Envconfig;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
+use clickhouse_gateway::config::Config;
+use clickhouse_gateway::query::handle_query;
+use clickhouse_gateway::state::AppState;
+
+common_alloc::used!();
+
+#[tokio::main]
+async fn main() {
+    let config = Config::init_from_env().expect("Invalid configuration:");
+
+    // Initialize tracing
+    let log_layer = tracing_subscriber::fmt::layer()
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true)
+        .json()
+        .flatten_event(true)
+        .with_span_list(true)
+        .with_current_span(true)
+        .with_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .boxed();
+
+    tracing_subscriber::registry().with(log_layer).init();
+
+    // Root span with pod hostname for Loki/Grafana filtering
+    let pod = std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
+    let _root_span = tracing::info_span!("service", pod = %pod).entered();
+
+    let bind_addr = format!("{}:{}", config.host, config.port);
+    let metrics_addr = format!("{}:{}", config.host, config.metrics_port);
+
+    tracing::info!(
+        bind = %bind_addr,
+        metrics = %metrics_addr,
+        "starting clickhouse-gateway"
+    );
+
+    let state = AppState::new(config);
+
+    // Main API router
+    let app = Router::new()
+        .route("/query", post(handle_query))
+        .route("/_health", get(health_handler))
+        .route("/_ready", get(readiness_handler))
+        .with_state(state.clone());
+
+    // Metrics router (separate port)
+    let metrics_router = common_metrics::setup_metrics_routes(Router::new());
+
+    // Lifecycle manager for graceful shutdown
+    let mut manager = lifecycle::Manager::builder("clickhouse-gateway")
+        .with_trap_signals(true)
+        .with_prestop_check(true)
+        .with_health_poll_interval(Duration::from_secs(2))
+        .build();
+
+    let guard = manager.monitor_background();
+
+    // Bind listeners
+    let listener = tokio::net::TcpListener::bind(&bind_addr)
+        .await
+        .expect("could not bind main port");
+    tracing::info!("listening on {}", listener.local_addr().unwrap());
+
+    let metrics_listener = tokio::net::TcpListener::bind(&metrics_addr)
+        .await
+        .expect("could not bind metrics port");
+    tracing::info!(
+        "metrics listening on {}",
+        metrics_listener.local_addr().unwrap()
+    );
+
+    // Serve metrics on a separate task
+    tokio::spawn(async move {
+        axum::serve(metrics_listener, metrics_router)
+            .await
+            .expect("metrics server failed");
+    });
+
+    // Serve main API
+    axum::serve(listener, app).await.expect("server failed");
+
+    match guard.wait().await {
+        Ok(()) => tracing::info!("All lifecycle components completed cleanly"),
+        Err(e) => tracing::warn!("Lifecycle monitor reported: {e}"),
+    }
+    tracing::info!("Shutdown complete");
+}
+
+async fn health_handler() -> axum::http::StatusCode {
+    axum::http::StatusCode::OK
+}
+
+async fn readiness_handler() -> axum::http::StatusCode {
+    // Check for prestop shutdown file (k8s rolling deployment pattern)
+    if std::path::Path::new("/tmp/shutdown").exists() {
+        return axum::http::StatusCode::SERVICE_UNAVAILABLE;
+    }
+    axum::http::StatusCode::OK
+}

--- a/rust/clickhouse-gateway/src/query.rs
+++ b/rust/clickhouse-gateway/src/query.rs
@@ -1,0 +1,222 @@
+use std::time::Instant;
+
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::error::GatewayError;
+use crate::routing::Workload;
+use crate::state::AppState;
+use crate::validation;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct QueryRequest {
+    pub sql: String,
+    pub params: Option<serde_json::Value>,
+    /// ONLINE, OFFLINE, LOGS, ENDPOINTS, or DEFAULT
+    pub workload: String,
+    /// Caller identity: APP, API, BATCH_EXPORT, etc.
+    pub ch_user: String,
+    pub team_id: u64,
+    pub org_id: Option<u64>,
+    pub read_only: bool,
+    pub priority: Option<String>,
+    pub cache_ttl_seconds: Option<u64>,
+    pub settings: Option<serde_json::Value>,
+    pub query_tags: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct QueryResponse {
+    pub data: serde_json::Value,
+    pub rows: u64,
+    pub bytes_read: u64,
+    pub elapsed_ms: u64,
+}
+
+/// POST /query — the primary gateway endpoint.
+///
+/// 1. Validates the request (readonly check, settings ceiling)
+/// 2. Routes to the correct ClickHouse cluster based on workload
+/// 3. Enforces max_execution_time from config (not caller-overridable)
+/// 4. Constructs log_comment JSON from query_tags
+/// 5. Forwards the query to ClickHouse via HTTP
+/// 6. Records metrics
+/// 7. Returns the response
+pub async fn handle_query(
+    State(state): State<AppState>,
+    Json(req): Json<QueryRequest>,
+) -> Result<Json<QueryResponse>, GatewayError> {
+    let start = Instant::now();
+
+    // Parse and validate workload
+    let workload = Workload::from_str_value(&req.workload)
+        .map_err(|e| GatewayError::InvalidWorkload(e))?;
+
+    // Validate read-only constraint
+    validation::validate_readonly(&req)?;
+
+    // Get workload limits from config
+    let (_max_concurrent, max_execution_time) = state.config.limits_for_workload(&workload);
+
+    // Enforce settings ceiling
+    let mut settings = req.settings.clone().unwrap_or_else(|| serde_json::json!({}));
+    validation::enforce_settings_ceiling(&mut settings, max_execution_time);
+
+    // Always set max_execution_time to the config ceiling
+    if let Some(obj) = settings.as_object_mut() {
+        obj.entry("max_execution_time".to_string())
+            .or_insert_with(|| serde_json::Value::Number(max_execution_time.into()));
+    }
+
+    // Build log_comment for ClickHouse query attribution
+    let log_comment = validation::build_log_comment(req.team_id, &req.ch_user, &req.query_tags);
+
+    // Route to the correct cluster host
+    let host = state.router.route(&workload);
+
+    info!(
+        team_id = req.team_id,
+        workload = workload.as_str(),
+        ch_user = %req.ch_user,
+        host = %host,
+        "routing query"
+    );
+
+    // Forward to ClickHouse via HTTP POST
+    let response = execute_clickhouse_query(
+        &state.http_client,
+        host,
+        &req.sql,
+        &req.params,
+        &settings,
+        &log_comment,
+        max_execution_time,
+    )
+    .await?;
+
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+
+    // Record metrics
+    let labels = [
+        ("workload".to_string(), workload.as_str().to_string()),
+        ("ch_user".to_string(), req.ch_user.clone()),
+    ];
+    metrics::counter!("gateway_queries_total", &labels).increment(1);
+    metrics::histogram!("gateway_query_duration_ms", &labels).record(elapsed_ms as f64);
+
+    Ok(Json(QueryResponse {
+        data: response.data,
+        rows: response.rows,
+        bytes_read: response.bytes_read,
+        elapsed_ms,
+    }))
+}
+
+struct ClickHouseResponse {
+    data: serde_json::Value,
+    rows: u64,
+    bytes_read: u64,
+}
+
+async fn execute_clickhouse_query(
+    client: &reqwest::Client,
+    host: &str,
+    sql: &str,
+    params: &Option<serde_json::Value>,
+    settings: &serde_json::Value,
+    log_comment: &str,
+    max_execution_time: u32,
+) -> Result<ClickHouseResponse, GatewayError> {
+    let url = format!("{host}/");
+
+    // Build query parameters for the ClickHouse HTTP interface
+    let mut query_params: Vec<(String, String)> = vec![
+        ("log_comment".to_string(), log_comment.to_string()),
+        (
+            "max_execution_time".to_string(),
+            max_execution_time.to_string(),
+        ),
+        ("output_format_json_quote_64bit_integers".to_string(), "0".to_string()),
+    ];
+
+    // Merge caller settings into query params
+    if let Some(obj) = settings.as_object() {
+        for (k, v) in obj {
+            if k == "max_execution_time" {
+                continue; // already set above at the ceiling
+            }
+            let val = match v {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            query_params.push((k.clone(), val));
+        }
+    }
+
+    // Add parameterized query params (param_X for ClickHouse)
+    if let Some(p) = params {
+        if let Some(obj) = p.as_object() {
+            for (k, v) in obj {
+                let val = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                query_params.push((format!("param_{k}"), val));
+            }
+        }
+    }
+
+    let resp = client
+        .post(&url)
+        .query(&query_params)
+        .header("Content-Type", "text/plain")
+        .body(format!("{sql} FORMAT JSON"))
+        .send()
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "clickhouse request failed");
+            if e.is_timeout() {
+                GatewayError::Timeout(max_execution_time)
+            } else {
+                GatewayError::ClickHouseError(e.to_string())
+            }
+        })?;
+
+    let status = resp.status();
+    let body = resp.text().await.map_err(|e| {
+        GatewayError::ClickHouseError(format!("failed to read response body: {e}"))
+    })?;
+
+    if !status.is_success() {
+        warn!(
+            status = %status,
+            body_prefix = &body[..body.len().min(500)],
+            "clickhouse returned error"
+        );
+        return Err(GatewayError::ClickHouseError(format!(
+            "ClickHouse returned {status}: {body}",
+            body = &body[..body.len().min(500)]
+        )));
+    }
+
+    // Parse ClickHouse JSON response
+    let parsed: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
+        GatewayError::ClickHouseError(format!("failed to parse response JSON: {e}"))
+    })?;
+
+    let rows = parsed["rows"]
+        .as_u64()
+        .unwrap_or(0);
+
+    let bytes_read = parsed["statistics"]["bytes_read"]
+        .as_u64()
+        .unwrap_or(0);
+
+    Ok(ClickHouseResponse {
+        data: parsed.get("data").cloned().unwrap_or(serde_json::Value::Array(vec![])),
+        rows,
+        bytes_read,
+    })
+}

--- a/rust/clickhouse-gateway/src/routing.rs
+++ b/rust/clickhouse-gateway/src/routing.rs
@@ -1,0 +1,164 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::config::Config;
+
+/// The type of workload determines which ClickHouse cluster receives the query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Workload {
+    Online,
+    Offline,
+    Logs,
+    Endpoints,
+    Default,
+}
+
+impl Workload {
+    pub fn from_str_value(s: &str) -> Result<Self, String> {
+        match s.to_uppercase().as_str() {
+            "ONLINE" => Ok(Workload::Online),
+            "OFFLINE" => Ok(Workload::Offline),
+            "LOGS" => Ok(Workload::Logs),
+            "ENDPOINTS" => Ok(Workload::Endpoints),
+            "DEFAULT" => Ok(Workload::Default),
+            other => Err(format!("unknown workload: {other}")),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Workload::Online => "ONLINE",
+            Workload::Offline => "OFFLINE",
+            Workload::Logs => "LOGS",
+            Workload::Endpoints => "ENDPOINTS",
+            Workload::Default => "DEFAULT",
+        }
+    }
+}
+
+/// Routes queries to the appropriate ClickHouse cluster using round-robin
+/// selection within each workload's host list.
+pub struct WorkloadRouter {
+    online_hosts: Vec<String>,
+    offline_hosts: Vec<String>,
+    logs_hosts: Vec<String>,
+    endpoints_hosts: Vec<String>,
+    online_counter: AtomicUsize,
+    offline_counter: AtomicUsize,
+    logs_counter: AtomicUsize,
+    endpoints_counter: AtomicUsize,
+}
+
+impl WorkloadRouter {
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            online_hosts: config.online_hosts(),
+            offline_hosts: config.offline_hosts(),
+            logs_hosts: config.logs_hosts(),
+            endpoints_hosts: config.endpoints_hosts(),
+            online_counter: AtomicUsize::new(0),
+            offline_counter: AtomicUsize::new(0),
+            logs_counter: AtomicUsize::new(0),
+            endpoints_counter: AtomicUsize::new(0),
+        }
+    }
+
+    /// Select a host for the given workload using round-robin.
+    pub fn route(&self, workload: &Workload) -> &str {
+        let (hosts, counter) = match workload {
+            Workload::Online | Workload::Default => {
+                (&self.online_hosts, &self.online_counter)
+            }
+            Workload::Offline => (&self.offline_hosts, &self.offline_counter),
+            Workload::Logs => (&self.logs_hosts, &self.logs_counter),
+            Workload::Endpoints => (&self.endpoints_hosts, &self.endpoints_counter),
+        };
+
+        if hosts.is_empty() {
+            // Fallback — should never happen with valid config
+            return "http://localhost:8123";
+        }
+
+        let idx = counter.fetch_add(1, Ordering::Relaxed) % hosts.len();
+        &hosts[idx]
+    }
+
+    /// Returns all hosts for a given workload (useful for health checks).
+    pub fn hosts_for(&self, workload: &Workload) -> &[String] {
+        match workload {
+            Workload::Online | Workload::Default => &self.online_hosts,
+            Workload::Offline => &self.offline_hosts,
+            Workload::Logs => &self.logs_hosts,
+            Workload::Endpoints => &self.endpoints_hosts,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_router() -> WorkloadRouter {
+        WorkloadRouter {
+            online_hosts: vec![
+                "http://online1:8123".to_string(),
+                "http://online2:8123".to_string(),
+            ],
+            offline_hosts: vec![
+                "http://offline1:8123".to_string(),
+                "http://offline2:8123".to_string(),
+                "http://offline3:8123".to_string(),
+            ],
+            logs_hosts: vec!["http://logs1:8123".to_string()],
+            endpoints_hosts: vec!["http://endpoints1:8123".to_string()],
+            online_counter: AtomicUsize::new(0),
+            offline_counter: AtomicUsize::new(0),
+            logs_counter: AtomicUsize::new(0),
+            endpoints_counter: AtomicUsize::new(0),
+        }
+    }
+
+    #[test]
+    fn test_route_online_round_robin() {
+        let router = make_router();
+        assert_eq!(router.route(&Workload::Online), "http://online1:8123");
+        assert_eq!(router.route(&Workload::Online), "http://online2:8123");
+        assert_eq!(router.route(&Workload::Online), "http://online1:8123");
+    }
+
+    #[test]
+    fn test_route_offline() {
+        let router = make_router();
+        assert_eq!(router.route(&Workload::Offline), "http://offline1:8123");
+        assert_eq!(router.route(&Workload::Offline), "http://offline2:8123");
+        assert_eq!(router.route(&Workload::Offline), "http://offline3:8123");
+        assert_eq!(router.route(&Workload::Offline), "http://offline1:8123");
+    }
+
+    #[test]
+    fn test_route_default_uses_online() {
+        let router = make_router();
+        let host = router.route(&Workload::Default);
+        assert!(host.contains("online"));
+    }
+
+    #[test]
+    fn test_workload_from_str() {
+        assert_eq!(Workload::from_str_value("ONLINE").unwrap(), Workload::Online);
+        assert_eq!(Workload::from_str_value("offline").unwrap(), Workload::Offline);
+        assert_eq!(Workload::from_str_value("Logs").unwrap(), Workload::Logs);
+        assert_eq!(
+            Workload::from_str_value("ENDPOINTS").unwrap(),
+            Workload::Endpoints
+        );
+        assert!(Workload::from_str_value("INVALID").is_err());
+    }
+
+    #[test]
+    fn test_hosts_for() {
+        let router = make_router();
+        assert_eq!(router.hosts_for(&Workload::Online).len(), 2);
+        assert_eq!(router.hosts_for(&Workload::Offline).len(), 3);
+        assert_eq!(router.hosts_for(&Workload::Logs).len(), 1);
+        assert_eq!(router.hosts_for(&Workload::Endpoints).len(), 1);
+    }
+}

--- a/rust/clickhouse-gateway/src/state.rs
+++ b/rust/clickhouse-gateway/src/state.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use crate::config::Config;
+use crate::routing::WorkloadRouter;
+
+/// Shared application state accessible from all handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Arc<Config>,
+    pub router: Arc<WorkloadRouter>,
+    pub http_client: reqwest::Client,
+}
+
+impl AppState {
+    pub fn new(config: Config) -> Self {
+        let router = WorkloadRouter::from_config(&config);
+        let http_client = reqwest::Client::builder()
+            .pool_max_idle_per_host(10)
+            .timeout(std::time::Duration::from_secs(
+                config.offline_max_execution_time as u64 + 5,
+            ))
+            .build()
+            .expect("failed to build HTTP client");
+
+        Self {
+            config: Arc::new(config),
+            router: Arc::new(router),
+            http_client,
+        }
+    }
+}

--- a/rust/clickhouse-gateway/src/validation.rs
+++ b/rust/clickhouse-gateway/src/validation.rs
@@ -1,0 +1,193 @@
+use crate::error::GatewayError;
+use crate::query::QueryRequest;
+
+/// Patterns that indicate a write operation in SQL.
+const WRITE_PATTERNS: &[&str] = &[
+    "INSERT",
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "TRUNCATE",
+    "RENAME",
+    "ATTACH",
+    "DETACH",
+    "OPTIMIZE",
+    "KILL",
+];
+
+/// Validates that a query marked as read_only does not contain write operations.
+pub fn validate_readonly(req: &QueryRequest) -> Result<(), GatewayError> {
+    if !req.read_only {
+        return Ok(());
+    }
+
+    let sql_upper = req.sql.trim().to_uppercase();
+    for pattern in WRITE_PATTERNS {
+        if sql_upper.starts_with(pattern) {
+            return Err(GatewayError::WriteNotAllowed);
+        }
+    }
+
+    Ok(())
+}
+
+/// Enforces the max_execution_time ceiling from server config.
+/// Callers cannot set a value higher than the workload's configured maximum.
+pub fn enforce_settings_ceiling(
+    settings: &mut serde_json::Value,
+    config_max_execution_time: u32,
+) {
+    if let Some(obj) = settings.as_object_mut() {
+        if let Some(met) = obj.get("max_execution_time") {
+            if let Some(requested) = met.as_u64() {
+                if requested > config_max_execution_time as u64 {
+                    obj.insert(
+                        "max_execution_time".to_string(),
+                        serde_json::Value::Number(config_max_execution_time.into()),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Constructs a ClickHouse `log_comment` JSON string from query_tags and request metadata.
+pub fn build_log_comment(
+    team_id: u64,
+    ch_user: &str,
+    query_tags: &Option<serde_json::Value>,
+) -> String {
+    let mut comment = serde_json::json!({
+        "team_id": team_id,
+        "ch_user": ch_user,
+    });
+
+    if let Some(tags) = query_tags {
+        if let Some(tags_obj) = tags.as_object() {
+            if let Some(comment_obj) = comment.as_object_mut() {
+                for (k, v) in tags_obj {
+                    comment_obj.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+
+    comment.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_readonly_allows_select() {
+        let req = QueryRequest {
+            sql: "SELECT count() FROM events".to_string(),
+            params: None,
+            workload: "ONLINE".to_string(),
+            ch_user: "APP".to_string(),
+            team_id: 1,
+            org_id: None,
+            read_only: true,
+            priority: None,
+            cache_ttl_seconds: None,
+            settings: None,
+            query_tags: None,
+        };
+        assert!(validate_readonly(&req).is_ok());
+    }
+
+    #[test]
+    fn test_validate_readonly_rejects_insert() {
+        let req = QueryRequest {
+            sql: "INSERT INTO events VALUES (1, 2, 3)".to_string(),
+            params: None,
+            workload: "ONLINE".to_string(),
+            ch_user: "APP".to_string(),
+            team_id: 1,
+            org_id: None,
+            read_only: true,
+            priority: None,
+            cache_ttl_seconds: None,
+            settings: None,
+            query_tags: None,
+        };
+        assert!(validate_readonly(&req).is_err());
+    }
+
+    #[test]
+    fn test_validate_readonly_allows_insert_when_not_readonly() {
+        let req = QueryRequest {
+            sql: "INSERT INTO events VALUES (1, 2, 3)".to_string(),
+            params: None,
+            workload: "ONLINE".to_string(),
+            ch_user: "APP".to_string(),
+            team_id: 1,
+            org_id: None,
+            read_only: false,
+            priority: None,
+            cache_ttl_seconds: None,
+            settings: None,
+            query_tags: None,
+        };
+        assert!(validate_readonly(&req).is_ok());
+    }
+
+    #[test]
+    fn test_validate_readonly_rejects_drop() {
+        let req = QueryRequest {
+            sql: "DROP TABLE events".to_string(),
+            params: None,
+            workload: "ONLINE".to_string(),
+            ch_user: "APP".to_string(),
+            team_id: 1,
+            org_id: None,
+            read_only: true,
+            priority: None,
+            cache_ttl_seconds: None,
+            settings: None,
+            query_tags: None,
+        };
+        assert!(validate_readonly(&req).is_err());
+    }
+
+    #[test]
+    fn test_enforce_settings_ceiling_caps_value() {
+        let mut settings = serde_json::json!({
+            "max_execution_time": 999
+        });
+        enforce_settings_ceiling(&mut settings, 30);
+        assert_eq!(settings["max_execution_time"], 30);
+    }
+
+    #[test]
+    fn test_enforce_settings_ceiling_allows_lower() {
+        let mut settings = serde_json::json!({
+            "max_execution_time": 10
+        });
+        enforce_settings_ceiling(&mut settings, 30);
+        assert_eq!(settings["max_execution_time"], 10);
+    }
+
+    #[test]
+    fn test_build_log_comment_without_tags() {
+        let comment = build_log_comment(42, "APP", &None);
+        let parsed: serde_json::Value = serde_json::from_str(&comment).unwrap();
+        assert_eq!(parsed["team_id"], 42);
+        assert_eq!(parsed["ch_user"], "APP");
+    }
+
+    #[test]
+    fn test_build_log_comment_with_tags() {
+        let tags = Some(serde_json::json!({
+            "query_id": "abc-123",
+            "source": "insights"
+        }));
+        let comment = build_log_comment(42, "APP", &tags);
+        let parsed: serde_json::Value = serde_json::from_str(&comment).unwrap();
+        assert_eq!(parsed["team_id"], 42);
+        assert_eq!(parsed["ch_user"], "APP");
+        assert_eq!(parsed["query_id"], "abc-123");
+        assert_eq!(parsed["source"], "insights");
+    }
+}

--- a/rust/clickhouse-gateway/tests/test_query.rs
+++ b/rust/clickhouse-gateway/tests/test_query.rs
@@ -1,0 +1,234 @@
+use clickhouse_gateway::query::QueryRequest;
+use clickhouse_gateway::routing::{Workload, WorkloadRouter};
+use clickhouse_gateway::validation;
+use std::sync::atomic::AtomicUsize;
+
+fn sample_request() -> QueryRequest {
+    QueryRequest {
+        sql: "SELECT count() FROM events WHERE team_id = {team_id:UInt64}".to_string(),
+        params: Some(serde_json::json!({"team_id": "42"})),
+        workload: "ONLINE".to_string(),
+        ch_user: "APP".to_string(),
+        team_id: 42,
+        org_id: Some(1),
+        read_only: true,
+        priority: None,
+        cache_ttl_seconds: None,
+        settings: Some(serde_json::json!({"max_execution_time": 10})),
+        query_tags: Some(serde_json::json!({"query_id": "test-123", "source": "insights"})),
+    }
+}
+
+fn make_test_router() -> WorkloadRouter {
+    WorkloadRouter::from_config(&clickhouse_gateway::config::Config {
+        host: "0.0.0.0".to_string(),
+        port: 3100,
+        clickhouse_online_hosts: "http://online1:8123,http://online2:8123".to_string(),
+        clickhouse_offline_hosts: "http://offline1:8123".to_string(),
+        clickhouse_logs_hosts: "http://logs1:8123".to_string(),
+        clickhouse_endpoints_hosts: "http://endpoints1:8123".to_string(),
+        online_max_concurrent: 50,
+        online_max_execution_time: 30,
+        offline_max_concurrent: 10,
+        offline_max_execution_time: 600,
+        logs_max_concurrent: 20,
+        logs_max_execution_time: 60,
+        endpoints_max_concurrent: 30,
+        endpoints_max_execution_time: 120,
+        metrics_port: 9090,
+        log_level: "info".to_string(),
+    })
+}
+
+// -- Deserialization tests --
+
+#[test]
+fn test_parse_query_request() {
+    let json = serde_json::json!({
+        "sql": "SELECT 1",
+        "workload": "ONLINE",
+        "ch_user": "APP",
+        "team_id": 42,
+        "read_only": true
+    });
+
+    let req: QueryRequest = serde_json::from_value(json).unwrap();
+    assert_eq!(req.sql, "SELECT 1");
+    assert_eq!(req.workload, "ONLINE");
+    assert_eq!(req.ch_user, "APP");
+    assert_eq!(req.team_id, 42);
+    assert!(req.read_only);
+    assert!(req.params.is_none());
+    assert!(req.settings.is_none());
+    assert!(req.query_tags.is_none());
+}
+
+#[test]
+fn test_parse_query_request_full() {
+    let json = serde_json::json!({
+        "sql": "SELECT count() FROM events WHERE team_id = {team_id:UInt64}",
+        "params": {"team_id": "42"},
+        "workload": "OFFLINE",
+        "ch_user": "BATCH_EXPORT",
+        "team_id": 99,
+        "org_id": 7,
+        "read_only": true,
+        "priority": "low",
+        "cache_ttl_seconds": 300,
+        "settings": {"max_execution_time": 120},
+        "query_tags": {"query_id": "abc", "source": "batch"}
+    });
+
+    let req: QueryRequest = serde_json::from_value(json).unwrap();
+    assert_eq!(req.workload, "OFFLINE");
+    assert_eq!(req.ch_user, "BATCH_EXPORT");
+    assert_eq!(req.team_id, 99);
+    assert_eq!(req.org_id, Some(7));
+    assert_eq!(req.priority, Some("low".to_string()));
+    assert_eq!(req.cache_ttl_seconds, Some(300));
+}
+
+// -- Routing tests --
+
+#[test]
+fn test_route_online() {
+    let router = make_test_router();
+    let host = router.route(&Workload::Online);
+    assert!(host.contains("online"));
+}
+
+#[test]
+fn test_route_offline() {
+    let router = make_test_router();
+    let host = router.route(&Workload::Offline);
+    assert!(host.contains("offline"));
+}
+
+#[test]
+fn test_route_logs() {
+    let router = make_test_router();
+    let host = router.route(&Workload::Logs);
+    assert!(host.contains("logs"));
+}
+
+#[test]
+fn test_route_endpoints() {
+    let router = make_test_router();
+    let host = router.route(&Workload::Endpoints);
+    assert!(host.contains("endpoints"));
+}
+
+// -- Validation tests --
+
+#[test]
+fn test_validate_readonly_allows_select() {
+    let req = sample_request();
+    assert!(validation::validate_readonly(&req).is_ok());
+}
+
+#[test]
+fn test_validate_readonly_rejects_writes() {
+    let write_statements = vec![
+        "INSERT INTO events VALUES (1)",
+        "CREATE TABLE foo (id UInt64) ENGINE = MergeTree",
+        "DROP TABLE events",
+        "ALTER TABLE events ADD COLUMN x UInt64",
+        "TRUNCATE TABLE events",
+    ];
+
+    for sql in write_statements {
+        let req = QueryRequest {
+            sql: sql.to_string(),
+            read_only: true,
+            ..sample_request()
+        };
+        assert!(
+            validation::validate_readonly(&req).is_err(),
+            "should reject: {sql}"
+        );
+    }
+}
+
+#[test]
+fn test_validate_readonly_allows_writes_when_not_readonly() {
+    let req = QueryRequest {
+        sql: "INSERT INTO events VALUES (1)".to_string(),
+        read_only: false,
+        ..sample_request()
+    };
+    assert!(validation::validate_readonly(&req).is_ok());
+}
+
+// -- Settings ceiling tests --
+
+#[test]
+fn test_settings_ceiling_caps_high_value() {
+    let mut settings = serde_json::json!({"max_execution_time": 999});
+    validation::enforce_settings_ceiling(&mut settings, 30);
+    assert_eq!(settings["max_execution_time"], 30);
+}
+
+#[test]
+fn test_settings_ceiling_preserves_low_value() {
+    let mut settings = serde_json::json!({"max_execution_time": 5});
+    validation::enforce_settings_ceiling(&mut settings, 30);
+    assert_eq!(settings["max_execution_time"], 5);
+}
+
+#[test]
+fn test_settings_ceiling_no_max_execution_time() {
+    let mut settings = serde_json::json!({"some_other_setting": "value"});
+    validation::enforce_settings_ceiling(&mut settings, 30);
+    // Should not add max_execution_time if not present
+    assert!(settings.get("max_execution_time").is_none());
+}
+
+// -- Log comment tests --
+
+#[test]
+fn test_log_comment_construction_basic() {
+    let comment = validation::build_log_comment(42, "APP", &None);
+    let parsed: serde_json::Value = serde_json::from_str(&comment).unwrap();
+    assert_eq!(parsed["team_id"], 42);
+    assert_eq!(parsed["ch_user"], "APP");
+}
+
+#[test]
+fn test_log_comment_construction_with_tags() {
+    let tags = Some(serde_json::json!({
+        "query_id": "test-abc",
+        "source": "insights",
+        "kind": "TrendsQuery"
+    }));
+    let comment = validation::build_log_comment(42, "API", &tags);
+    let parsed: serde_json::Value = serde_json::from_str(&comment).unwrap();
+
+    assert_eq!(parsed["team_id"], 42);
+    assert_eq!(parsed["ch_user"], "API");
+    assert_eq!(parsed["query_id"], "test-abc");
+    assert_eq!(parsed["source"], "insights");
+    assert_eq!(parsed["kind"], "TrendsQuery");
+}
+
+#[test]
+fn test_log_comment_construction_empty_tags() {
+    let tags = Some(serde_json::json!({}));
+    let comment = validation::build_log_comment(1, "BATCH_EXPORT", &tags);
+    let parsed: serde_json::Value = serde_json::from_str(&comment).unwrap();
+    assert_eq!(parsed["team_id"], 1);
+    assert_eq!(parsed["ch_user"], "BATCH_EXPORT");
+}
+
+// -- Workload parsing tests --
+
+#[test]
+fn test_workload_parsing() {
+    assert_eq!(Workload::from_str_value("ONLINE").unwrap(), Workload::Online);
+    assert_eq!(Workload::from_str_value("offline").unwrap(), Workload::Offline);
+    assert_eq!(Workload::from_str_value("Logs").unwrap(), Workload::Logs);
+    assert_eq!(
+        Workload::from_str_value("ENDPOINTS").unwrap(),
+        Workload::Endpoints
+    );
+    assert!(Workload::from_str_value("UNKNOWN").is_err());
+}


### PR DESCRIPTION
## Summary
New Rust service: ClickHouse Query Gateway ([RFC #1044](https://github.com/PostHog/requests-for-comments-internal/pull/1044)).

**Depends on:** #51718 (HTTP default)

- `POST /query`: structured JSON → validate → route by workload → enforce limits → forward to CH
- Workload routing: ONLINE/OFFLINE/LOGS/ENDPOINTS → separate CH host pools
- Per-workload limits: max_concurrent, max_execution_time from config (not overridable)
- Health/readiness probes, Prometheus metrics (port 9090)
- Follows PostHog Rust patterns (envconfig, axum, lifecycle, workspace deps)

## Test plan
- 7 Rust unit tests (config parsing, routing, validation)
- Integration test with mock CH responses
- CI compiles and runs `cargo test`