### PR TITLE
feat(clickhouse): Django gateway client adapter

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -226,7 +226,13 @@ def get_client_from_pool(
     Returns the client for a given workload.
 
     The connection pool for HTTP is managed by a library.
+    When the gateway is enabled, all queries are routed through the ClickHouse Query Gateway.
     """
+
+    if settings.CLICKHOUSE_GATEWAY_ENABLED:
+        from posthog.clickhouse.client.gateway_client import get_gateway_client_ctx
+
+        return get_gateway_client_ctx()
 
     if settings.CLICKHOUSE_USE_HTTP or team_id in settings.CLICKHOUSE_USE_HTTP_PER_TEAM:
         kwargs = get_kwargs_for_client(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user)

--- a/posthog/clickhouse/client/gateway_client.py
+++ b/posthog/clickhouse/client/gateway_client.py
@@ -1,0 +1,143 @@
+"""Gateway client that sends structured JSON to the ClickHouse Query Gateway."""
+
+from contextlib import contextmanager
+from typing import Any, Optional
+
+from django.conf import settings
+
+import requests
+
+
+class GatewayClient:
+    """Sends queries to the ClickHouse Gateway instead of directly to CH.
+
+    Drop-in replacement for ProxyClient — implements the same execute() interface
+    but serializes the query as structured JSON and POSTs it to the gateway service.
+    """
+
+    def __init__(self, gateway_url: str, service_token: str):
+        self.gateway_url = gateway_url.rstrip("/")
+        self.service_token = service_token
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Bearer {service_token}"
+        self.session.headers["Content-Type"] = "application/json"
+
+    def execute(
+        self,
+        query: str,
+        params: Optional[dict[str, Any]] = None,
+        with_column_types: bool = False,
+        external_tables: Any = None,
+        query_id: Optional[str] = None,
+        settings: Optional[dict[str, Any]] = None,
+        types_check: bool = False,
+        columnar: bool = False,
+    ) -> Any:
+        """Execute query via the gateway. Matches ProxyClient.execute() interface."""
+        # Extract structured metadata from the log_comment JSON that sync_execute
+        # packs into settings. The gateway will use these for routing/observability
+        # instead of requiring the caller to parse them back out.
+        query_tags = _extract_query_tags(settings)
+
+        payload: dict[str, Any] = {
+            "sql": query,
+            "params": params,
+            "settings": _clean_settings(settings),
+            "query_tags": query_tags,
+            "query_id": query_id,
+            "columnar": columnar,
+        }
+
+        timeout = _get_timeout()
+        resp = self.session.post(
+            f"{self.gateway_url}/query",
+            json=payload,
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Mirror ProxyClient behavior: INSERT queries return written_rows count
+        written_rows = data.get("written_rows", 0)
+        if written_rows > 0:
+            return written_rows
+
+        if with_column_types:
+            return data.get("data", []), data.get("column_types", [])
+        return data.get("data", [])
+
+    # Context-manager protocol so GatewayClient can be used in all places
+    # a clickhouse_driver.Client or ProxyClient is used (with ... as client).
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def _extract_query_tags(settings_dict: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Pull the log_comment JSON out of settings and parse it back into a dict.
+
+    sync_execute serializes QueryTags into settings["log_comment"] as a JSON string.
+    The gateway wants structured tags, so we deserialize them here.
+    """
+    if not settings_dict or "log_comment" not in settings_dict:
+        return None
+    import json
+
+    log_comment = settings_dict["log_comment"]
+    if isinstance(log_comment, str):
+        try:
+            return json.loads(log_comment)
+        except (json.JSONDecodeError, ValueError):
+            return {"raw": log_comment}
+    return None
+
+
+def _clean_settings(settings_dict: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Return settings with log_comment stripped — the gateway gets tags separately."""
+    if not settings_dict:
+        return settings_dict
+    return {k: v for k, v in settings_dict.items() if k != "log_comment"}
+
+
+def _get_timeout() -> int:
+    """Read gateway timeout from settings, with a sensible default."""
+    return getattr(settings, "CLICKHOUSE_GATEWAY_TIMEOUT", 600)
+
+
+# ---------------------------------------------------------------------------
+# Singleton / cached client
+# ---------------------------------------------------------------------------
+
+_gateway_client: Optional[GatewayClient] = None
+
+
+def get_gateway_client() -> GatewayClient:
+    """Return a cached GatewayClient instance.
+
+    The client holds a requests.Session which manages its own connection pool,
+    so we reuse a single instance for the lifetime of the process.
+    """
+    global _gateway_client
+    if _gateway_client is None:
+        _gateway_client = GatewayClient(
+            gateway_url=settings.CLICKHOUSE_GATEWAY_URL,
+            service_token=settings.CLICKHOUSE_GATEWAY_SERVICE_TOKEN,
+        )
+    return _gateway_client
+
+
+@contextmanager
+def get_gateway_client_ctx():
+    """Context-manager wrapper matching the get_http_client() interface.
+
+    get_client_from_pool() expects a context manager, so we wrap the singleton.
+    """
+    yield get_gateway_client()
+
+
+def reset_gateway_client() -> None:
+    """Reset the cached client — useful for tests."""
+    global _gateway_client
+    _gateway_client = None

--- a/posthog/clickhouse/client/test/test_gateway_client.py
+++ b/posthog/clickhouse/client/test/test_gateway_client.py
@@ -1,0 +1,211 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.clickhouse.client.gateway_client import (
+    GatewayClient,
+    _clean_settings,
+    _extract_query_tags,
+    reset_gateway_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_gateway_client()
+    yield
+    reset_gateway_client()
+
+
+@pytest.fixture
+def mock_session():
+    with patch("posthog.clickhouse.client.gateway_client.requests.Session") as mock_cls:
+        session = MagicMock()
+        mock_cls.return_value = session
+        yield session
+
+
+def _make_client(mock_session: MagicMock) -> GatewayClient:
+    client = GatewayClient(
+        gateway_url="http://gateway:3100",
+        service_token="test-token-123",
+    )
+    # Replace the session that was created in __init__ with our mock
+    client.session = mock_session
+    return client
+
+
+class TestGatewayClientExecute:
+    def test_sends_structured_json(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": [["row1"], ["row2"]], "column_types": []}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        result = client.execute(
+            "SELECT * FROM events WHERE team_id = %(team_id)s",
+            params={"team_id": 1},
+            settings={"max_execution_time": 30, "log_comment": '{"team_id":1,"workload":"ONLINE"}'},
+        )
+
+        assert result == [["row1"], ["row2"]]
+
+        call_args = mock_session.post.call_args
+        assert call_args[0][0] == "http://gateway:3100/query"
+
+        payload = call_args[1]["json"]
+        assert payload["sql"] == "SELECT * FROM events WHERE team_id = %(team_id)s"
+        assert payload["params"] == {"team_id": 1}
+        # log_comment should be stripped from settings and moved to query_tags
+        assert "log_comment" not in (payload["settings"] or {})
+        assert payload["query_tags"] == {"team_id": 1, "workload": "ONLINE"}
+        assert payload["settings"] == {"max_execution_time": 30}
+
+    def test_includes_auth_header(self):
+        client = GatewayClient(
+            gateway_url="http://gateway:3100",
+            service_token="my-secret-token",
+        )
+        assert client.session.headers["Authorization"] == "Bearer my-secret-token"
+        assert client.session.headers["Content-Type"] == "application/json"
+
+    def test_handles_with_column_types(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {
+            "data": [["row1"]],
+            "column_types": [["name", "String"]],
+        }
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        result = client.execute("SELECT name FROM events", with_column_types=True)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        data, col_types = result
+        assert data == [["row1"]]
+        assert col_types == [["name", "String"]]
+
+    def test_returns_written_rows_for_inserts(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": [], "written_rows": 42}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        result = client.execute("INSERT INTO events SELECT ...")
+
+        assert result == 42
+
+    def test_raises_on_http_error(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.raise_for_status.side_effect = Exception("502 Bad Gateway")
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        with pytest.raises(Exception, match="502 Bad Gateway"):
+            client.execute("SELECT 1")
+
+    def test_passes_query_id(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": []}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        client.execute("SELECT 1", query_id="abc-123")
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["query_id"] == "abc-123"
+
+    def test_strips_trailing_slash_from_url(self):
+        client = GatewayClient(gateway_url="http://gateway:3100/", service_token="tok")
+        assert client.gateway_url == "http://gateway:3100"
+
+    def test_context_manager_protocol(self, mock_session: MagicMock):
+        client = _make_client(mock_session)
+        with client as c:
+            assert c is client
+
+    def test_none_settings_passthrough(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": []}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        client.execute("SELECT 1", settings=None)
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["settings"] is None
+        assert payload["query_tags"] is None
+
+
+class TestExtractQueryTags:
+    def test_extracts_json_log_comment(self):
+        settings = {"log_comment": '{"team_id": 5, "workload": "ONLINE"}', "max_threads": 8}
+        tags = _extract_query_tags(settings)
+        assert tags == {"team_id": 5, "workload": "ONLINE"}
+
+    def test_returns_none_when_no_log_comment(self):
+        assert _extract_query_tags({"max_threads": 8}) is None
+        assert _extract_query_tags(None) is None
+        assert _extract_query_tags({}) is None
+
+    def test_handles_invalid_json(self):
+        tags = _extract_query_tags({"log_comment": "not-json{{"})
+        assert tags == {"raw": "not-json{{"}
+
+
+class TestCleanSettings:
+    def test_strips_log_comment(self):
+        settings = {"log_comment": '{"team_id": 1}', "max_threads": 8}
+        cleaned = _clean_settings(settings)
+        assert cleaned == {"max_threads": 8}
+
+    def test_passthrough_none(self):
+        assert _clean_settings(None) is None
+
+    def test_passthrough_empty(self):
+        assert _clean_settings({}) == {}
+
+
+class TestGatewayRouting:
+    def test_gateway_enabled_routes_to_gateway(self, settings):
+        settings.CLICKHOUSE_GATEWAY_ENABLED = True
+        settings.CLICKHOUSE_GATEWAY_URL = "http://gateway:3100"
+        settings.CLICKHOUSE_GATEWAY_SERVICE_TOKEN = "tok"
+
+        from posthog.clickhouse.client.connection import get_client_from_pool
+
+        ctx = get_client_from_pool()
+        # Should be a context manager that yields a GatewayClient
+        with ctx as client:
+            assert isinstance(client, GatewayClient)
+
+    def test_gateway_disabled_routes_to_http(self, settings):
+        settings.CLICKHOUSE_GATEWAY_ENABLED = False
+        settings.CLICKHOUSE_USE_HTTP = True
+
+        from posthog.clickhouse.client.connection import get_client_from_pool
+
+        # Mock get_http_client since there's no CH server in unit tests
+        mock_proxy = MagicMock()
+        with patch("posthog.clickhouse.client.connection.get_http_client", return_value=mock_proxy):
+            ctx = get_client_from_pool()
+            assert ctx is mock_proxy
+            assert not isinstance(ctx, GatewayClient)
+
+    def test_gateway_disabled_falls_through_to_pool(self, settings):
+        settings.CLICKHOUSE_GATEWAY_ENABLED = False
+        settings.CLICKHOUSE_USE_HTTP = False
+        settings.CLICKHOUSE_USE_HTTP_PER_TEAM = set()
+
+        from posthog.clickhouse.client.connection import get_client_from_pool
+
+        # Mock get_pool since there's no CH server in unit tests
+        mock_pool = MagicMock()
+        with patch("posthog.clickhouse.client.connection.get_pool", return_value=mock_pool):
+            result = get_client_from_pool()
+            assert not isinstance(result, GatewayClient)

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -238,6 +238,13 @@ QUERYSERVICE_HOST: str = get_from_env("QUERYSERVICE_HOST", CLICKHOUSE_HOST)
 QUERYSERVICE_SECURE: bool = get_from_env("QUERYSERVICE_SECURE", CLICKHOUSE_SECURE, type_cast=str_to_bool)
 QUERYSERVICE_VERIFY: bool = get_from_env("QUERYSERVICE_VERIFY", CLICKHOUSE_VERIFY, type_cast=str_to_bool)
 
+# ClickHouse Query Gateway — routes queries through a structured JSON gateway
+# instead of sending raw SQL directly to ClickHouse.
+CLICKHOUSE_GATEWAY_ENABLED: bool = get_from_env("CLICKHOUSE_GATEWAY_ENABLED", False, type_cast=str_to_bool)
+CLICKHOUSE_GATEWAY_URL: str = os.getenv("CLICKHOUSE_GATEWAY_URL", "http://clickhouse-gateway:3100")
+CLICKHOUSE_GATEWAY_SERVICE_TOKEN: str = os.getenv("CLICKHOUSE_GATEWAY_SERVICE_TOKEN", "")
+CLICKHOUSE_GATEWAY_TIMEOUT: int = get_from_env("CLICKHOUSE_GATEWAY_TIMEOUT", 600, type_cast=int)
+
 CLICKHOUSE_CONN_POOL_MIN: int = get_from_env("CLICKHOUSE_CONN_POOL_MIN", 20, type_cast=int)
 CLICKHOUSE_CONN_POOL_MAX: int = get_from_env("CLICKHOUSE_CONN_POOL_MAX", 1000, type_cast=int)
 


### PR DESCRIPTION
## Summary
Python client that sends structured JSON to the Query Gateway ([RFC #1044](https://github.com/PostHog/requests-for-comments-internal/pull/1044)).

**Depends on:** gateway scaffold PR

- `GatewayClient`: drop-in replacement for `ProxyClient`, same `execute()` API
- Third branch in `get_client_from_pool()`: `CLICKHOUSE_GATEWAY_ENABLED` → gateway
- Extracts `query_tags` from `log_comment`, strips before forwarding
- Fallback: `CLICKHOUSE_GATEWAY_ENABLED=false` → existing direct HTTP

## Test plan
- 18 unit tests (payload structure, auth, column types, routing, fallback)