### PR TITLE
feat(clickhouse): per-team concurrency limits + query tagging

### DIFF
--- a/rust/clickhouse-gateway/src/error.rs
+++ b/rust/clickhouse-gateway/src/error.rs
@@ -20,6 +20,16 @@ pub enum GatewayError {
     #[error("upstream timeout after {0}s")]
     Timeout(u32),
 
+    #[error("circuit breaker open for workload {0}")]
+    CircuitBreakerOpen(String),
+
+    #[error("team {team_id} ({ch_user}) has reached per-team concurrency limit of {limit}")]
+    TeamConcurrencyLimit {
+        team_id: u64,
+        ch_user: String,
+        limit: u32,
+    },
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -38,6 +48,8 @@ impl GatewayError {
             GatewayError::InvalidRequest(_) => "invalid_request",
             GatewayError::ClickHouseError(_) => "clickhouse_error",
             GatewayError::Timeout(_) => "timeout",
+            GatewayError::CircuitBreakerOpen(_) => "circuit_breaker_open",
+            GatewayError::TeamConcurrencyLimit { .. } => "team_concurrency_limit",
             GatewayError::Internal(_) => "internal_error",
         }
     }
@@ -49,6 +61,8 @@ impl GatewayError {
             GatewayError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             GatewayError::ClickHouseError(_) => StatusCode::BAD_GATEWAY,
             GatewayError::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
+            GatewayError::CircuitBreakerOpen(_) => StatusCode::SERVICE_UNAVAILABLE,
+            GatewayError::TeamConcurrencyLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
             GatewayError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/rust/clickhouse-gateway/src/lib.rs
+++ b/rust/clickhouse-gateway/src/lib.rs
@@ -1,6 +1,10 @@
+pub mod circuit_breaker;
+pub mod circuit_breaker_registry;
 pub mod config;
 pub mod error;
 pub mod query;
 pub mod routing;
 pub mod state;
+pub mod tagging;
+pub mod team_limits;
 pub mod validation;

--- a/rust/clickhouse-gateway/src/query.rs
+++ b/rust/clickhouse-gateway/src/query.rs
@@ -8,6 +8,7 @@ use tracing::{info, warn};
 use crate::error::GatewayError;
 use crate::routing::Workload;
 use crate::state::AppState;
+use crate::tagging;
 use crate::validation;
 
 #[derive(Deserialize, Debug, Clone)]
@@ -70,8 +71,19 @@ pub async fn handle_query(
             .or_insert_with(|| serde_json::Value::Number(max_execution_time.into()));
     }
 
-    // Build log_comment for ClickHouse query attribution
-    let log_comment = validation::build_log_comment(req.team_id, &req.ch_user, &req.query_tags);
+    // Check circuit breaker before forwarding to ClickHouse
+    state.circuit_breakers.get(workload.as_str()).check()?;
+
+    // Acquire per-team concurrency permit (RAII — released on drop)
+    let _team_permit = state.team_limits.try_acquire(req.team_id, &req.ch_user)?;
+
+    // Generate a gateway request ID for tracing
+    let gateway_request_id = uuid::Uuid::new_v4().to_string();
+
+    // Build log_comment for ClickHouse query attribution.
+    // The old validation::build_log_comment is kept for backward compat;
+    // the new tagging module adds gateway-specific fields.
+    let log_comment = tagging::build_log_comment(&req.query_tags, &gateway_request_id);
 
     // Route to the correct cluster host
     let host = state.router.route(&workload);
@@ -85,7 +97,8 @@ pub async fn handle_query(
     );
 
     // Forward to ClickHouse via HTTP POST
-    let response = execute_clickhouse_query(
+    let cb = state.circuit_breakers.get(workload.as_str());
+    let response = match execute_clickhouse_query(
         &state.http_client,
         host,
         &req.sql,
@@ -94,7 +107,17 @@ pub async fn handle_query(
         &log_comment,
         max_execution_time,
     )
-    .await?;
+    .await
+    {
+        Ok(resp) => {
+            cb.record_success();
+            resp
+        }
+        Err(e) => {
+            cb.record_failure();
+            return Err(e);
+        }
+    };
 
     let elapsed_ms = start.elapsed().as_millis() as u64;
 

--- a/rust/clickhouse-gateway/src/state.rs
+++ b/rust/clickhouse-gateway/src/state.rs
@@ -1,19 +1,25 @@
 use std::sync::Arc;
 
+use crate::circuit_breaker_registry::CircuitBreakerRegistry;
 use crate::config::Config;
 use crate::routing::WorkloadRouter;
+use crate::team_limits::TeamLimits;
 
 /// Shared application state accessible from all handlers.
 #[derive(Clone)]
 pub struct AppState {
     pub config: Arc<Config>,
     pub router: Arc<WorkloadRouter>,
+    pub circuit_breakers: Arc<CircuitBreakerRegistry>,
+    pub team_limits: Arc<TeamLimits>,
     pub http_client: reqwest::Client,
 }
 
 impl AppState {
     pub fn new(config: Config) -> Self {
         let router = WorkloadRouter::from_config(&config);
+        let circuit_breakers = CircuitBreakerRegistry::new(&config);
+        let team_limits = TeamLimits::new(&config);
         let http_client = reqwest::Client::builder()
             .pool_max_idle_per_host(10)
             .timeout(std::time::Duration::from_secs(
@@ -25,6 +31,8 @@ impl AppState {
         Self {
             config: Arc::new(config),
             router: Arc::new(router),
+            circuit_breakers: Arc::new(circuit_breakers),
+            team_limits: Arc::new(team_limits),
             http_client,
         }
     }

--- a/rust/clickhouse-gateway/src/tagging.rs
+++ b/rust/clickhouse-gateway/src/tagging.rs
@@ -1,0 +1,106 @@
+use serde_json::{json, Value};
+
+/// Gateway version embedded in every log_comment for traceability.
+const GATEWAY_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Construct a ClickHouse `log_comment` JSON string from the caller-supplied
+/// `query_tags` and gateway-specific fields.
+///
+/// The resulting JSON is passed as a query parameter to ClickHouse and ends up
+/// in `system.query_log.log_comment`, making it easy to attribute queries back
+/// to their originating team, request, and gateway version.
+///
+/// Gateway fields (`gateway_request_id`, `gateway_version`) are always added
+/// and take precedence over any caller-supplied tags with the same keys.
+pub fn build_log_comment(
+    query_tags: &Option<Value>,
+    gateway_request_id: &str,
+) -> String {
+    let mut comment = match query_tags {
+        Some(tags) if tags.is_object() => tags.clone(),
+        _ => json!({}),
+    };
+
+    // Inject gateway-specific fields. These overwrite any caller-supplied
+    // duplicates intentionally — the gateway is the source of truth for
+    // these values.
+    if let Some(obj) = comment.as_object_mut() {
+        obj.insert(
+            "gateway_request_id".to_string(),
+            Value::String(gateway_request_id.to_string()),
+        );
+        obj.insert(
+            "gateway_version".to_string(),
+            Value::String(GATEWAY_VERSION.to_string()),
+        );
+    }
+
+    comment.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_log_comment_no_tags() {
+        let result = build_log_comment(&None, "req-001");
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["gateway_request_id"], "req-001");
+        assert_eq!(parsed["gateway_version"], GATEWAY_VERSION);
+    }
+
+    #[test]
+    fn test_build_log_comment_with_tags() {
+        let tags = Some(json!({
+            "team_id": 42,
+            "query_id": "abc-123",
+            "source": "insights"
+        }));
+        let result = build_log_comment(&tags, "req-002");
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["team_id"], 42);
+        assert_eq!(parsed["query_id"], "abc-123");
+        assert_eq!(parsed["source"], "insights");
+        assert_eq!(parsed["gateway_request_id"], "req-002");
+        assert_eq!(parsed["gateway_version"], GATEWAY_VERSION);
+    }
+
+    #[test]
+    fn test_build_log_comment_gateway_fields_override_tags() {
+        let tags = Some(json!({
+            "gateway_request_id": "caller-supplied-id",
+            "gateway_version": "0.0.0"
+        }));
+        let result = build_log_comment(&tags, "actual-req-id");
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+
+        // Gateway fields always win.
+        assert_eq!(parsed["gateway_request_id"], "actual-req-id");
+        assert_eq!(parsed["gateway_version"], GATEWAY_VERSION);
+    }
+
+    #[test]
+    fn test_build_log_comment_non_object_tags_ignored() {
+        let tags = Some(json!("not an object"));
+        let result = build_log_comment(&tags, "req-003");
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["gateway_request_id"], "req-003");
+        assert_eq!(parsed["gateway_version"], GATEWAY_VERSION);
+        // Should only have gateway fields.
+        assert_eq!(parsed.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_build_log_comment_empty_tags() {
+        let tags = Some(json!({}));
+        let result = build_log_comment(&tags, "req-004");
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed.as_object().unwrap().len(), 2);
+        assert_eq!(parsed["gateway_request_id"], "req-004");
+    }
+}

--- a/rust/clickhouse-gateway/src/team_limits.rs
+++ b/rust/clickhouse-gateway/src/team_limits.rs
@@ -1,0 +1,317 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, RwLock};
+
+use tracing::warn;
+
+use crate::config::Config;
+use crate::error::GatewayError;
+
+/// Default per-team concurrency limits by ClickHouse user (caller identity).
+///
+/// These represent the maximum number of concurrent queries a single team can
+/// run through a given CH user. They exist to prevent a single team from
+/// monopolizing a workload's global concurrency budget.
+const DEFAULT_LIMIT_API: u32 = 3;
+const DEFAULT_LIMIT_APP: u32 = 10;
+const DEFAULT_LIMIT_BATCH_EXPORT: u32 = 2;
+const DEFAULT_LIMIT_MAX_AI: u32 = 5;
+
+/// Fallback limit for any CH user not explicitly configured.
+const DEFAULT_LIMIT_FALLBACK: u32 = 5;
+
+/// In-memory per-team concurrency tracking.
+///
+/// Each (team_id, ch_user) pair has an atomic counter that tracks how many
+/// queries are currently in-flight. `try_acquire` checks the counter against
+/// the configured limit and, if below, atomically increments it and returns
+/// a [`TeamPermit`] RAII guard that decrements the counter on drop.
+pub struct TeamLimits {
+    /// team_id → AtomicU32 counter of current concurrent queries.
+    /// The RwLock is only taken as a write lock when a team is seen for the
+    /// first time; the hot path (existing teams) only needs a read lock.
+    counters: RwLock<HashMap<(u64, String), Arc<AtomicU32>>>,
+
+    /// ch_user (uppercased) → max concurrent queries per team.
+    limits: HashMap<String, u32>,
+}
+
+impl TeamLimits {
+    /// Build a new `TeamLimits` from the gateway config.
+    ///
+    /// Currently the per-user limits are hard-coded defaults. When we add
+    /// env-var overrides to [`Config`] we can wire them through here.
+    pub fn new(_config: &Config) -> Self {
+        let mut limits = HashMap::new();
+        limits.insert("API".to_string(), DEFAULT_LIMIT_API);
+        limits.insert("APP".to_string(), DEFAULT_LIMIT_APP);
+        limits.insert("BATCH_EXPORT".to_string(), DEFAULT_LIMIT_BATCH_EXPORT);
+        limits.insert("MAX_AI".to_string(), DEFAULT_LIMIT_MAX_AI);
+
+        Self {
+            counters: RwLock::new(HashMap::new()),
+            limits,
+        }
+    }
+
+    /// Create a `TeamLimits` with custom per-user limits (for testing).
+    #[cfg(test)]
+    pub fn with_limits(limits: HashMap<String, u32>) -> Self {
+        Self {
+            counters: RwLock::new(HashMap::new()),
+            limits,
+        }
+    }
+
+    /// Look up the concurrency limit for a given CH user.
+    ///
+    /// Returns the configured limit if the user is known, otherwise falls back
+    /// to [`DEFAULT_LIMIT_FALLBACK`].
+    pub fn limit_for_user(&self, ch_user: &str) -> u32 {
+        let key = ch_user.to_uppercase();
+        self.limits.get(&key).copied().unwrap_or(DEFAULT_LIMIT_FALLBACK)
+    }
+
+    /// Attempt to acquire a concurrency slot for `(team_id, ch_user)`.
+    ///
+    /// On success, returns a [`TeamPermit`] that holds the slot and releases
+    /// it on drop. On failure (limit reached), returns a `GatewayError`.
+    ///
+    /// The implementation uses a CAS loop on an `AtomicU32` so the hot path
+    /// is lock-free once the counter exists.
+    pub fn try_acquire(&self, team_id: u64, ch_user: &str) -> Result<TeamPermit, GatewayError> {
+        let limit = self.limit_for_user(ch_user);
+        let key = (team_id, ch_user.to_uppercase());
+
+        let counter = self.get_or_create_counter(&key);
+
+        // CAS loop: try to increment if below limit.
+        loop {
+            let current = counter.load(Ordering::Acquire);
+            if current >= limit {
+                warn!(
+                    team_id = team_id,
+                    ch_user = %ch_user,
+                    current = current,
+                    limit = limit,
+                    "team concurrency limit reached"
+                );
+                return Err(GatewayError::TeamConcurrencyLimit {
+                    team_id,
+                    ch_user: ch_user.to_string(),
+                    limit,
+                });
+            }
+            // Try to atomically move current → current + 1.
+            match counter.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(TeamPermit {
+                        counter: Arc::clone(&counter),
+                        team_id,
+                        ch_user: ch_user.to_uppercase(),
+                    });
+                }
+                Err(_) => {
+                    // Another thread changed the counter; retry.
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// Return the current in-flight count for a (team_id, ch_user) pair.
+    ///
+    /// Useful for metrics and debugging. Returns 0 if the team has never been
+    /// seen.
+    pub fn current_count(&self, team_id: u64, ch_user: &str) -> u32 {
+        let key = (team_id, ch_user.to_uppercase());
+        let counters = self.counters.read().expect("counters lock poisoned");
+        counters
+            .get(&key)
+            .map(|c| c.load(Ordering::Acquire))
+            .unwrap_or(0)
+    }
+
+    /// Get or lazily create the atomic counter for a (team_id, ch_user) pair.
+    ///
+    /// Fast path: read lock only (existing teams). Slow path: write lock to
+    /// insert a new counter.
+    fn get_or_create_counter(&self, key: &(u64, String)) -> Arc<AtomicU32> {
+        // Fast path: read lock.
+        {
+            let counters = self.counters.read().expect("counters lock poisoned");
+            if let Some(counter) = counters.get(key) {
+                return Arc::clone(counter);
+            }
+        }
+
+        // Slow path: write lock to insert.
+        let mut counters = self.counters.write().expect("counters lock poisoned");
+        // Double-check after acquiring write lock.
+        counters
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(AtomicU32::new(0)))
+            .clone()
+    }
+}
+
+/// RAII guard that releases a per-team concurrency slot on drop.
+///
+/// Held by the query handler for the duration of the ClickHouse request.
+/// When the query completes (or the handler is cancelled), the permit is
+/// dropped and the counter is decremented.
+pub struct TeamPermit {
+    counter: Arc<AtomicU32>,
+    /// Stored for logging/debugging only.
+    #[allow(dead_code)]
+    team_id: u64,
+    #[allow(dead_code)]
+    ch_user: String,
+}
+
+impl Drop for TeamPermit {
+    fn drop(&mut self) {
+        let prev = self.counter.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(
+            prev > 0,
+            "TeamPermit drop underflowed counter for team_id={} ch_user={}",
+            self.team_id,
+            self.ch_user,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> Config {
+        Config {
+            host: "0.0.0.0".to_string(),
+            port: 3100,
+            clickhouse_online_hosts: "http://localhost:8123".to_string(),
+            clickhouse_offline_hosts: "http://localhost:8123".to_string(),
+            clickhouse_logs_hosts: "http://localhost:8123".to_string(),
+            clickhouse_endpoints_hosts: "http://localhost:8123".to_string(),
+            online_max_concurrent: 50,
+            online_max_execution_time: 30,
+            offline_max_concurrent: 10,
+            offline_max_execution_time: 600,
+            logs_max_concurrent: 20,
+            logs_max_execution_time: 60,
+            endpoints_max_concurrent: 30,
+            endpoints_max_execution_time: 120,
+            metrics_port: 9090,
+            log_level: "info".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_default_limits() {
+        let tl = TeamLimits::new(&test_config());
+        assert_eq!(tl.limit_for_user("API"), 3);
+        assert_eq!(tl.limit_for_user("APP"), 10);
+        assert_eq!(tl.limit_for_user("BATCH_EXPORT"), 2);
+        assert_eq!(tl.limit_for_user("MAX_AI"), 5);
+        // Case-insensitive lookup
+        assert_eq!(tl.limit_for_user("api"), 3);
+        assert_eq!(tl.limit_for_user("App"), 10);
+        // Unknown user gets fallback
+        assert_eq!(tl.limit_for_user("UNKNOWN"), 5);
+    }
+
+    #[test]
+    fn test_acquire_within_limit() {
+        let mut limits = HashMap::new();
+        limits.insert("API".to_string(), 2);
+        let tl = TeamLimits::with_limits(limits);
+
+        let _p1 = tl.try_acquire(1, "API").expect("first acquire should succeed");
+        let _p2 = tl.try_acquire(1, "API").expect("second acquire should succeed");
+
+        assert_eq!(tl.current_count(1, "API"), 2);
+    }
+
+    #[test]
+    fn test_acquire_exceeds_limit_rejected() {
+        let mut limits = HashMap::new();
+        limits.insert("API".to_string(), 1);
+        let tl = TeamLimits::with_limits(limits);
+
+        let _p1 = tl.try_acquire(1, "API").expect("first acquire should succeed");
+        let result = tl.try_acquire(1, "API");
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GatewayError::TeamConcurrencyLimit {
+                team_id,
+                ch_user,
+                limit,
+            } => {
+                assert_eq!(team_id, 1);
+                assert_eq!(ch_user, "API");
+                assert_eq!(limit, 1);
+            }
+            other => panic!("expected TeamConcurrencyLimit, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_permit_drop_releases_slot() {
+        let mut limits = HashMap::new();
+        limits.insert("API".to_string(), 1);
+        let tl = TeamLimits::with_limits(limits);
+
+        {
+            let _p = tl.try_acquire(1, "API").expect("should succeed");
+            assert_eq!(tl.current_count(1, "API"), 1);
+        }
+        // Permit dropped — slot released.
+        assert_eq!(tl.current_count(1, "API"), 0);
+
+        // Should be able to acquire again.
+        let _p2 = tl.try_acquire(1, "API").expect("should succeed after release");
+        assert_eq!(tl.current_count(1, "API"), 1);
+    }
+
+    #[test]
+    fn test_different_teams_independent() {
+        let mut limits = HashMap::new();
+        limits.insert("API".to_string(), 1);
+        let tl = TeamLimits::with_limits(limits);
+
+        let _p1 = tl.try_acquire(1, "API").expect("team 1 should succeed");
+        let _p2 = tl.try_acquire(2, "API").expect("team 2 should succeed independently");
+
+        assert_eq!(tl.current_count(1, "API"), 1);
+        assert_eq!(tl.current_count(2, "API"), 1);
+    }
+
+    #[test]
+    fn test_different_users_different_limits() {
+        let mut limits = HashMap::new();
+        limits.insert("API".to_string(), 1);
+        limits.insert("APP".to_string(), 2);
+        let tl = TeamLimits::with_limits(limits);
+
+        // API at limit
+        let _p1 = tl.try_acquire(1, "API").expect("API should succeed");
+        assert!(tl.try_acquire(1, "API").is_err());
+
+        // APP still has room for team 1
+        let _p2 = tl.try_acquire(1, "APP").expect("APP should succeed");
+        let _p3 = tl.try_acquire(1, "APP").expect("APP second should succeed");
+        assert!(tl.try_acquire(1, "APP").is_err());
+    }
+
+    #[test]
+    fn test_current_count_unseen_team() {
+        let tl = TeamLimits::new(&test_config());
+        assert_eq!(tl.current_count(999, "API"), 0);
+    }
+}

--- a/rust/clickhouse-gateway/tests/test_team_limits.rs
+++ b/rust/clickhouse-gateway/tests/test_team_limits.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+
+use clickhouse_gateway::error::GatewayError;
+use clickhouse_gateway::tagging;
+use clickhouse_gateway::team_limits::TeamLimits;
+
+// ---------------------------------------------------------------------------
+// TeamLimits tests
+// ---------------------------------------------------------------------------
+
+fn limits_with(user: &str, max: u32) -> TeamLimits {
+    let mut limits = HashMap::new();
+    limits.insert(user.to_string(), max);
+    TeamLimits::with_limits(limits)
+}
+
+fn multi_limits(entries: &[(&str, u32)]) -> TeamLimits {
+    let limits: HashMap<String, u32> = entries
+        .iter()
+        .map(|(k, v)| (k.to_string(), *v))
+        .collect();
+    TeamLimits::with_limits(limits)
+}
+
+#[test]
+fn test_acquire_within_limit() {
+    let tl = limits_with("API", 3);
+
+    let _p1 = tl.try_acquire(1, "API").unwrap();
+    let _p2 = tl.try_acquire(1, "API").unwrap();
+    let _p3 = tl.try_acquire(1, "API").unwrap();
+
+    assert_eq!(tl.current_count(1, "API"), 3);
+}
+
+#[test]
+fn test_acquire_exceeds_limit_rejected() {
+    let tl = limits_with("API", 2);
+
+    let _p1 = tl.try_acquire(1, "API").unwrap();
+    let _p2 = tl.try_acquire(1, "API").unwrap();
+
+    let result = tl.try_acquire(1, "API");
+    assert!(result.is_err());
+
+    match result.unwrap_err() {
+        GatewayError::TeamConcurrencyLimit {
+            team_id,
+            ch_user,
+            limit,
+        } => {
+            assert_eq!(team_id, 1);
+            assert_eq!(ch_user, "API");
+            assert_eq!(limit, 2);
+        }
+        other => panic!("expected TeamConcurrencyLimit, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_permit_drop_releases_slot() {
+    let tl = limits_with("APP", 1);
+
+    // Acquire and then drop.
+    {
+        let _p = tl.try_acquire(10, "APP").unwrap();
+        assert_eq!(tl.current_count(10, "APP"), 1);
+        // _p drops here
+    }
+
+    assert_eq!(tl.current_count(10, "APP"), 0);
+
+    // Can acquire again after release.
+    let _p2 = tl
+        .try_acquire(10, "APP")
+        .expect("should succeed after release");
+    assert_eq!(tl.current_count(10, "APP"), 1);
+}
+
+#[test]
+fn test_different_teams_independent() {
+    let tl = limits_with("API", 1);
+
+    let _p1 = tl.try_acquire(1, "API").unwrap();
+    // Team 1 is at limit — team 2 should still succeed.
+    let _p2 = tl.try_acquire(2, "API").unwrap();
+
+    assert_eq!(tl.current_count(1, "API"), 1);
+    assert_eq!(tl.current_count(2, "API"), 1);
+
+    // Team 1 is still at limit.
+    assert!(tl.try_acquire(1, "API").is_err());
+    // Team 2 is also at limit.
+    assert!(tl.try_acquire(2, "API").is_err());
+    // Team 3 is fine.
+    let _p3 = tl.try_acquire(3, "API").unwrap();
+}
+
+#[test]
+fn test_different_users_different_limits() {
+    let tl = multi_limits(&[("API", 1), ("APP", 3), ("BATCH_EXPORT", 2)]);
+
+    // API: limit 1
+    let _p_api = tl.try_acquire(1, "API").unwrap();
+    assert!(tl.try_acquire(1, "API").is_err());
+
+    // APP: limit 3 — same team, different user
+    let _p_app1 = tl.try_acquire(1, "APP").unwrap();
+    let _p_app2 = tl.try_acquire(1, "APP").unwrap();
+    let _p_app3 = tl.try_acquire(1, "APP").unwrap();
+    assert!(tl.try_acquire(1, "APP").is_err());
+
+    // BATCH_EXPORT: limit 2
+    let _p_be1 = tl.try_acquire(1, "BATCH_EXPORT").unwrap();
+    let _p_be2 = tl.try_acquire(1, "BATCH_EXPORT").unwrap();
+    assert!(tl.try_acquire(1, "BATCH_EXPORT").is_err());
+}
+
+#[test]
+fn test_case_insensitive_ch_user() {
+    let tl = limits_with("API", 1);
+
+    let _p = tl.try_acquire(1, "api").unwrap();
+    // "Api" for the same team should be rejected — same bucket.
+    assert!(tl.try_acquire(1, "Api").is_err());
+}
+
+#[test]
+fn test_unknown_user_gets_fallback_limit() {
+    // No explicit limits — all users get the fallback (5).
+    let tl = TeamLimits::with_limits(HashMap::new());
+
+    let mut permits = Vec::new();
+    for _ in 0..5 {
+        permits.push(tl.try_acquire(1, "UNKNOWN_USER").unwrap());
+    }
+    assert!(tl.try_acquire(1, "UNKNOWN_USER").is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Tagging (build_log_comment) tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_build_log_comment_from_tags() {
+    let tags = Some(serde_json::json!({
+        "team_id": 42,
+        "query_id": "q-001",
+        "source": "trends"
+    }));
+    let result = tagging::build_log_comment(&tags, "gw-req-123");
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+    assert_eq!(parsed["team_id"], 42);
+    assert_eq!(parsed["query_id"], "q-001");
+    assert_eq!(parsed["source"], "trends");
+    assert_eq!(parsed["gateway_request_id"], "gw-req-123");
+}
+
+#[test]
+fn test_log_comment_adds_gateway_fields() {
+    let result = tagging::build_log_comment(&None, "gw-req-456");
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+    assert_eq!(parsed["gateway_request_id"], "gw-req-456");
+    // gateway_version should be the crate version from Cargo.toml.
+    assert!(
+        parsed["gateway_version"].is_string(),
+        "gateway_version should be a string"
+    );
+    assert!(
+        !parsed["gateway_version"]
+            .as_str()
+            .unwrap()
+            .is_empty(),
+        "gateway_version should not be empty"
+    );
+}
+
+#[test]
+fn test_log_comment_gateway_fields_override_caller_tags() {
+    let tags = Some(serde_json::json!({
+        "gateway_request_id": "should-be-overwritten",
+        "gateway_version": "0.0.0",
+        "custom_field": "preserved"
+    }));
+    let result = tagging::build_log_comment(&tags, "actual-id");
+    let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+    assert_eq!(parsed["gateway_request_id"], "actual-id");
+    assert_ne!(parsed["gateway_version"].as_str().unwrap(), "0.0.0");
+    assert_eq!(parsed["custom_field"], "preserved");
+}


### PR DESCRIPTION
## Summary
Per-team rate limiting and structured query tagging for the gateway ([RFC #1044](https://github.com/PostHog/requests-for-comments-internal/pull/1044)).

**Depends on:** #51723 (gateway scaffold)

- `team_limits.rs`: AtomicU32 counters with CAS loop (lock-free), RAII TeamPermit guard
- Per-ch_user limits: API=3, APP=10, BATCH_EXPORT=2, MAX_AI=5
- `tagging.rs`: merge caller query_tags with gateway fields (request_id, version)
- 429 TOO_MANY_REQUESTS on team concurrency exceeded

## Test plan
- 12 Rust unit tests + 10 integration tests