### PR TITLE
feat(clickhouse): per-workload circuit breaker for query gateway

### DIFF
--- a/rust/clickhouse-gateway/src/circuit_breaker.rs
+++ b/rust/clickhouse-gateway/src/circuit_breaker.rs
@@ -1,0 +1,469 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+use tracing::{info, warn};
+
+use crate::error::GatewayError;
+
+/// Circuit breaker states following the standard pattern:
+/// - Closed: requests flow normally, failures are tracked
+/// - Open: requests are rejected immediately to protect ClickHouse
+/// - HalfOpen: a single probe request is allowed through to test recovery
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Normal operation — requests pass through, failures are counted.
+    Closed,
+    /// Circuit is tripped — all requests are rejected until cooldown expires.
+    Open,
+    /// Cooldown expired — one probe request is allowed to test if the backend recovered.
+    HalfOpen,
+}
+
+impl std::fmt::Display for CircuitState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CircuitState::Closed => write!(f, "CLOSED"),
+            CircuitState::Open => write!(f, "OPEN"),
+            CircuitState::HalfOpen => write!(f, "HALF_OPEN"),
+        }
+    }
+}
+
+/// Configuration for a single circuit breaker instance.
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    /// Percentage of failures (0.0–100.0) that triggers the circuit to open.
+    pub error_threshold_percent: f64,
+    /// Sliding window duration in seconds for counting successes and failures.
+    pub window_seconds: u64,
+    /// Minimum number of requests in the window before the threshold is evaluated.
+    /// Prevents the circuit from tripping on a single failure at startup.
+    pub minimum_requests: u64,
+    /// How long to wait in the Open state before transitioning to HalfOpen.
+    pub cooldown: Duration,
+    /// Human-readable name for this breaker (used in logs and metrics).
+    pub workload_name: String,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            error_threshold_percent: 50.0,
+            window_seconds: 30,
+            minimum_requests: 10,
+            cooldown: Duration::from_secs(60),
+            workload_name: "unknown".to_string(),
+        }
+    }
+}
+
+/// Per-workload circuit breaker.
+///
+/// Uses `std::sync` primitives (atomics + RwLock) for the fast path — the check
+/// in the Closed state only reads an atomic, no lock acquisition needed for the
+/// common case. The RwLock is only contended during state transitions.
+pub struct CircuitBreaker {
+    state: RwLock<CircuitState>,
+    /// Total failures recorded in the current window.
+    failure_count: AtomicU64,
+    /// Total successes recorded in the current window.
+    success_count: AtomicU64,
+    /// Timestamp of the last failure — used to determine cooldown expiry.
+    last_failure_time: RwLock<Option<Instant>>,
+    /// Timestamp when the current counting window started.
+    window_start: RwLock<Instant>,
+    config: CircuitBreakerConfig,
+}
+
+impl CircuitBreaker {
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            state: RwLock::new(CircuitState::Closed),
+            failure_count: AtomicU64::new(0),
+            success_count: AtomicU64::new(0),
+            last_failure_time: RwLock::new(None),
+            window_start: RwLock::new(Instant::now()),
+            config,
+        }
+    }
+
+    /// Returns the current circuit state.
+    pub fn state(&self) -> CircuitState {
+        *self.state.read().expect("circuit breaker state lock poisoned")
+    }
+
+    /// Check whether a request should be allowed through.
+    ///
+    /// - **Closed**: always allows.
+    /// - **Open**: rejects unless the cooldown has elapsed, in which case it
+    ///   transitions to HalfOpen and allows the probe.
+    /// - **HalfOpen**: allows (the single probe request).
+    pub fn check(&self) -> Result<(), GatewayError> {
+        let current_state = self.state();
+
+        match current_state {
+            CircuitState::Closed => Ok(()),
+            CircuitState::Open => {
+                // Check whether cooldown has elapsed
+                if self.cooldown_elapsed() {
+                    self.transition_to(CircuitState::HalfOpen);
+                    Ok(())
+                } else {
+                    let workload = &self.config.workload_name;
+                    warn!(
+                        workload = %workload,
+                        "circuit breaker open, rejecting request"
+                    );
+                    metrics::counter!(
+                        "gateway_circuit_breaker_rejected_total",
+                        "workload" => workload.clone()
+                    )
+                    .increment(1);
+                    Err(GatewayError::CircuitBreakerOpen(workload.clone()))
+                }
+            }
+            CircuitState::HalfOpen => {
+                // Allow the probe request through
+                Ok(())
+            }
+        }
+    }
+
+    /// Record a successful request. In HalfOpen state this closes the circuit.
+    pub fn record_success(&self) {
+        self.maybe_reset_window();
+        self.success_count.fetch_add(1, Ordering::Relaxed);
+
+        let current_state = self.state();
+        if current_state == CircuitState::HalfOpen {
+            info!(
+                workload = %self.config.workload_name,
+                "circuit breaker probe succeeded, closing circuit"
+            );
+            self.transition_to(CircuitState::Closed);
+            self.reset_counters();
+        }
+    }
+
+    /// Record a failed request. If the failure rate exceeds the threshold,
+    /// the circuit transitions from Closed to Open (or HalfOpen back to Open).
+    pub fn record_failure(&self) {
+        self.maybe_reset_window();
+        self.failure_count.fetch_add(1, Ordering::Relaxed);
+
+        // Update last failure time
+        {
+            let mut last = self
+                .last_failure_time
+                .write()
+                .expect("last_failure_time lock poisoned");
+            *last = Some(Instant::now());
+        }
+
+        let current_state = self.state();
+
+        match current_state {
+            CircuitState::HalfOpen => {
+                // Probe failed — reopen immediately
+                warn!(
+                    workload = %self.config.workload_name,
+                    "circuit breaker probe failed, reopening circuit"
+                );
+                self.transition_to(CircuitState::Open);
+            }
+            CircuitState::Closed => {
+                if self.threshold_exceeded() {
+                    let failures = self.failure_count.load(Ordering::Relaxed);
+                    let successes = self.success_count.load(Ordering::Relaxed);
+                    let total = failures + successes;
+                    let rate = if total > 0 {
+                        (failures as f64 / total as f64) * 100.0
+                    } else {
+                        0.0
+                    };
+                    warn!(
+                        workload = %self.config.workload_name,
+                        failures,
+                        total,
+                        error_rate = format!("{:.1}%", rate),
+                        threshold = format!("{:.1}%", self.config.error_threshold_percent),
+                        "circuit breaker tripped, opening circuit"
+                    );
+                    self.transition_to(CircuitState::Open);
+                }
+            }
+            CircuitState::Open => {
+                // Already open, nothing to do
+            }
+        }
+    }
+
+    /// Returns the current failure count (useful for tests and metrics).
+    pub fn failure_count(&self) -> u64 {
+        self.failure_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current success count (useful for tests and metrics).
+    pub fn success_count(&self) -> u64 {
+        self.success_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the configured workload name.
+    pub fn workload_name(&self) -> &str {
+        &self.config.workload_name
+    }
+
+    // -- Private helpers --
+
+    /// Check whether the error threshold has been exceeded within the current window.
+    fn threshold_exceeded(&self) -> bool {
+        let failures = self.failure_count.load(Ordering::Relaxed);
+        let successes = self.success_count.load(Ordering::Relaxed);
+        let total = failures + successes;
+
+        // Don't trip on too few samples
+        if total < self.config.minimum_requests {
+            return false;
+        }
+
+        let error_rate = (failures as f64 / total as f64) * 100.0;
+        error_rate >= self.config.error_threshold_percent
+    }
+
+    /// Check whether the cooldown period has elapsed since the last failure.
+    fn cooldown_elapsed(&self) -> bool {
+        let last = self
+            .last_failure_time
+            .read()
+            .expect("last_failure_time lock poisoned");
+        match *last {
+            Some(t) => t.elapsed() >= self.config.cooldown,
+            // No failure recorded — shouldn't be Open, but allow transition
+            None => true,
+        }
+    }
+
+    /// If the current counting window has expired, reset the counters.
+    fn maybe_reset_window(&self) {
+        let window_duration = Duration::from_secs(self.config.window_seconds);
+        let should_reset = {
+            let start = self
+                .window_start
+                .read()
+                .expect("window_start lock poisoned");
+            start.elapsed() >= window_duration
+        };
+
+        if should_reset {
+            let mut start = self
+                .window_start
+                .write()
+                .expect("window_start lock poisoned");
+            // Double-check after acquiring write lock to avoid thundering herd reset
+            if start.elapsed() >= window_duration {
+                *start = Instant::now();
+                self.reset_counters();
+            }
+        }
+    }
+
+    /// Reset success and failure counters to zero.
+    fn reset_counters(&self) {
+        self.failure_count.store(0, Ordering::Relaxed);
+        self.success_count.store(0, Ordering::Relaxed);
+    }
+
+    /// Transition to a new state, emitting a metric.
+    fn transition_to(&self, new_state: CircuitState) {
+        let mut state = self
+            .state
+            .write()
+            .expect("circuit breaker state lock poisoned");
+        let old_state = *state;
+        *state = new_state;
+
+        info!(
+            workload = %self.config.workload_name,
+            from = %old_state,
+            to = %new_state,
+            "circuit breaker state transition"
+        );
+
+        metrics::counter!(
+            "gateway_circuit_breaker_transitions_total",
+            "workload" => self.config.workload_name.clone(),
+            "from" => old_state.to_string(),
+            "to" => new_state.to_string()
+        )
+        .increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> CircuitBreakerConfig {
+        CircuitBreakerConfig {
+            error_threshold_percent: 50.0,
+            window_seconds: 30,
+            minimum_requests: 4,
+            cooldown: Duration::from_millis(50),
+            workload_name: "TEST".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_initial_state_is_closed() {
+        let cb = CircuitBreaker::new(test_config());
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_closed_allows_requests() {
+        let cb = CircuitBreaker::new(test_config());
+        assert!(cb.check().is_ok());
+    }
+
+    #[test]
+    fn test_does_not_trip_below_minimum_requests() {
+        let cb = CircuitBreaker::new(test_config());
+        // 3 failures out of 3 total, but minimum_requests is 4
+        for _ in 0..3 {
+            cb.record_failure();
+        }
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.check().is_ok());
+    }
+
+    #[test]
+    fn test_trips_at_threshold() {
+        let cb = CircuitBreaker::new(test_config());
+        // 2 successes + 2 failures = 50% error rate, threshold is 50%
+        cb.record_success();
+        cb.record_success();
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+    }
+
+    #[test]
+    fn test_open_rejects_requests() {
+        let config = CircuitBreakerConfig {
+            cooldown: Duration::from_secs(3600), // very long cooldown
+            ..test_config()
+        };
+        let cb = CircuitBreaker::new(config);
+        // Trip the circuit
+        cb.record_success();
+        cb.record_success();
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        let result = cb.check();
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            GatewayError::CircuitBreakerOpen(w) => assert_eq!(w, "TEST"),
+            other => panic!("expected CircuitBreakerOpen, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_half_open_after_cooldown() {
+        let cb = CircuitBreaker::new(test_config()); // 50ms cooldown
+        // Trip the circuit
+        cb.record_success();
+        cb.record_success();
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        // Wait for cooldown
+        std::thread::sleep(Duration::from_millis(60));
+
+        // check() should transition to HalfOpen and allow
+        assert!(cb.check().is_ok());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn test_half_open_closes_on_success() {
+        let cb = CircuitBreaker::new(test_config());
+        // Trip the circuit
+        cb.record_success();
+        cb.record_success();
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        // Wait for cooldown and transition to HalfOpen
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(cb.check().is_ok());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        // Probe succeeds
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_half_open_reopens_on_failure() {
+        let cb = CircuitBreaker::new(test_config());
+        // Trip the circuit
+        cb.record_success();
+        cb.record_success();
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        // Wait for cooldown and transition to HalfOpen
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(cb.check().is_ok());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        // Probe fails
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+    }
+
+    #[test]
+    fn test_success_resets_failure_count() {
+        let cb = CircuitBreaker::new(test_config());
+        // Trip the circuit
+        cb.record_success();
+        cb.record_success();
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        // Recover via HalfOpen -> Closed
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(cb.check().is_ok());
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        // Counters should be reset
+        assert_eq!(cb.failure_count(), 0);
+        assert_eq!(cb.success_count(), 0);
+    }
+
+    #[test]
+    fn test_stays_closed_below_threshold() {
+        let cb = CircuitBreaker::new(test_config());
+        // 9 successes + 1 failure = 10% error rate, well below 50%
+        for _ in 0..9 {
+            cb.record_success();
+        }
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_display_circuit_state() {
+        assert_eq!(CircuitState::Closed.to_string(), "CLOSED");
+        assert_eq!(CircuitState::Open.to_string(), "OPEN");
+        assert_eq!(CircuitState::HalfOpen.to_string(), "HALF_OPEN");
+    }
+}

--- a/rust/clickhouse-gateway/src/circuit_breaker_registry.rs
+++ b/rust/clickhouse-gateway/src/circuit_breaker_registry.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
+use crate::config::Config;
+use crate::routing::Workload;
+
+/// Default error threshold percentage for all workloads.
+const DEFAULT_ERROR_THRESHOLD_PERCENT: f64 = 50.0;
+
+/// Default sliding window duration in seconds.
+const DEFAULT_WINDOW_SECONDS: u64 = 30;
+
+/// Default minimum requests before evaluating threshold.
+const DEFAULT_MINIMUM_REQUESTS: u64 = 10;
+
+/// Cooldown for latency-sensitive workloads (ONLINE, ENDPOINTS, LOGS, DEFAULT).
+const ONLINE_COOLDOWN_SECS: u64 = 60;
+
+/// Cooldown for batch workloads (OFFLINE) — longer because these are less urgent.
+const OFFLINE_COOLDOWN_SECS: u64 = 120;
+
+/// Holds one [`CircuitBreaker`] per workload type.
+///
+/// Created once at startup and shared via `Arc` in [`AppState`]. Each workload
+/// has its own independent failure tracking and cooldown duration.
+pub struct CircuitBreakerRegistry {
+    breakers: HashMap<String, CircuitBreaker>,
+}
+
+impl CircuitBreakerRegistry {
+    /// Build a registry from the gateway config, creating one breaker per known workload.
+    pub fn new(_config: &Config) -> Self {
+        let workloads = [
+            Workload::Online,
+            Workload::Offline,
+            Workload::Logs,
+            Workload::Endpoints,
+            Workload::Default,
+        ];
+
+        let mut breakers = HashMap::new();
+
+        for workload in workloads {
+            let name = workload.as_str().to_string();
+            let cooldown = cooldown_for_workload(&workload);
+            let config = CircuitBreakerConfig {
+                error_threshold_percent: DEFAULT_ERROR_THRESHOLD_PERCENT,
+                window_seconds: DEFAULT_WINDOW_SECONDS,
+                minimum_requests: DEFAULT_MINIMUM_REQUESTS,
+                cooldown,
+                workload_name: name.clone(),
+            };
+            breakers.insert(name, CircuitBreaker::new(config));
+        }
+
+        Self { breakers }
+    }
+
+    /// Get the circuit breaker for a workload by its string key (e.g. "ONLINE").
+    ///
+    /// Panics if the workload is not in the registry — this is a programming error
+    /// since the registry is initialized with all known workloads at startup.
+    pub fn get(&self, workload: &str) -> &CircuitBreaker {
+        self.breakers
+            .get(workload)
+            .unwrap_or_else(|| panic!("no circuit breaker registered for workload: {workload}"))
+    }
+
+    /// Returns an iterator over all registered breakers (useful for health/status endpoints).
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &CircuitBreaker)> {
+        self.breakers.iter()
+    }
+}
+
+/// Returns the appropriate cooldown duration for a workload.
+fn cooldown_for_workload(workload: &Workload) -> Duration {
+    match workload {
+        Workload::Offline => Duration::from_secs(OFFLINE_COOLDOWN_SECS),
+        _ => Duration::from_secs(ONLINE_COOLDOWN_SECS),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> Config {
+        Config {
+            host: "0.0.0.0".to_string(),
+            port: 3100,
+            clickhouse_online_hosts: "http://localhost:8123".to_string(),
+            clickhouse_offline_hosts: "http://localhost:8123".to_string(),
+            clickhouse_logs_hosts: "http://localhost:8123".to_string(),
+            clickhouse_endpoints_hosts: "http://localhost:8123".to_string(),
+            online_max_concurrent: 50,
+            online_max_execution_time: 30,
+            offline_max_concurrent: 10,
+            offline_max_execution_time: 600,
+            logs_max_concurrent: 20,
+            logs_max_execution_time: 60,
+            endpoints_max_concurrent: 30,
+            endpoints_max_execution_time: 120,
+            metrics_port: 9090,
+            log_level: "info".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_registry_has_all_workloads() {
+        let registry = CircuitBreakerRegistry::new(&test_config());
+        // Should not panic for any known workload
+        let _ = registry.get("ONLINE");
+        let _ = registry.get("OFFLINE");
+        let _ = registry.get("LOGS");
+        let _ = registry.get("ENDPOINTS");
+        let _ = registry.get("DEFAULT");
+    }
+
+    #[test]
+    #[should_panic(expected = "no circuit breaker registered for workload: BOGUS")]
+    fn test_registry_panics_on_unknown_workload() {
+        let registry = CircuitBreakerRegistry::new(&test_config());
+        let _ = registry.get("BOGUS");
+    }
+
+    #[test]
+    fn test_offline_has_longer_cooldown() {
+        assert_eq!(
+            cooldown_for_workload(&Workload::Offline),
+            Duration::from_secs(OFFLINE_COOLDOWN_SECS)
+        );
+        assert_eq!(
+            cooldown_for_workload(&Workload::Online),
+            Duration::from_secs(ONLINE_COOLDOWN_SECS)
+        );
+        assert!(OFFLINE_COOLDOWN_SECS > ONLINE_COOLDOWN_SECS);
+    }
+
+    #[test]
+    fn test_per_workload_isolation() {
+        let registry = CircuitBreakerRegistry::new(&test_config());
+        let online = registry.get("ONLINE");
+        let offline = registry.get("OFFLINE");
+
+        // Record failures on ONLINE only
+        for _ in 0..20 {
+            online.record_failure();
+        }
+
+        // OFFLINE should still be closed
+        assert!(offline.check().is_ok());
+        assert_eq!(
+            offline.state(),
+            crate::circuit_breaker::CircuitState::Closed
+        );
+    }
+}

--- a/rust/clickhouse-gateway/tests/test_circuit_breaker.rs
+++ b/rust/clickhouse-gateway/tests/test_circuit_breaker.rs
@@ -1,0 +1,304 @@
+use std::time::Duration;
+
+use clickhouse_gateway::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, CircuitState};
+use clickhouse_gateway::circuit_breaker_registry::CircuitBreakerRegistry;
+use clickhouse_gateway::config::Config;
+use clickhouse_gateway::error::GatewayError;
+
+fn make_config(cooldown_ms: u64) -> CircuitBreakerConfig {
+    CircuitBreakerConfig {
+        error_threshold_percent: 50.0,
+        window_seconds: 60,
+        minimum_requests: 4,
+        cooldown: Duration::from_millis(cooldown_ms),
+        workload_name: "TEST".to_string(),
+    }
+}
+
+fn make_gateway_config() -> Config {
+    Config {
+        host: "0.0.0.0".to_string(),
+        port: 3100,
+        clickhouse_online_hosts: "http://localhost:8123".to_string(),
+        clickhouse_offline_hosts: "http://localhost:8123".to_string(),
+        clickhouse_logs_hosts: "http://localhost:8123".to_string(),
+        clickhouse_endpoints_hosts: "http://localhost:8123".to_string(),
+        online_max_concurrent: 50,
+        online_max_execution_time: 30,
+        offline_max_concurrent: 10,
+        offline_max_execution_time: 600,
+        logs_max_concurrent: 20,
+        logs_max_execution_time: 60,
+        endpoints_max_concurrent: 30,
+        endpoints_max_execution_time: 120,
+        metrics_port: 9090,
+        log_level: "info".to_string(),
+    }
+}
+
+// -- Basic state tests --
+
+#[test]
+fn test_closed_allows_requests() {
+    let cb = CircuitBreaker::new(make_config(5000));
+    assert_eq!(cb.state(), CircuitState::Closed);
+    assert!(cb.check().is_ok());
+    // Multiple checks should all pass
+    for _ in 0..100 {
+        assert!(cb.check().is_ok());
+    }
+}
+
+#[test]
+fn test_open_rejects_requests() {
+    let cb = CircuitBreaker::new(make_config(60_000)); // long cooldown
+    // Trip the breaker: 2 successes + 2 failures = 50% error rate at minimum_requests=4
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    cb.record_failure();
+
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    let result = cb.check();
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GatewayError::CircuitBreakerOpen(name) => assert_eq!(name, "TEST"),
+        other => panic!("expected CircuitBreakerOpen, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_transitions_to_open_on_threshold() {
+    let cb = CircuitBreaker::new(make_config(5000));
+
+    // Below minimum_requests — should stay closed
+    cb.record_failure();
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Closed);
+
+    // 4th request (1 success + 3 failures prior isn't enough... let's be explicit)
+    // Reset: new breaker for clean counting
+    let cb = CircuitBreaker::new(make_config(5000));
+
+    // 3 successes, 1 failure = 25% error rate, below 50%
+    cb.record_success();
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Closed);
+
+    // Now push to exactly 50%: 2 successes + 2 failures
+    let cb = CircuitBreaker::new(make_config(5000));
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    // At this point: 2S + 1F = 33%, still Closed, and total=3 < minimum_requests=4
+    assert_eq!(cb.state(), CircuitState::Closed);
+    cb.record_failure();
+    // Now: 2S + 2F = 50%, total=4 >= minimum_requests=4 -> should trip
+    assert_eq!(cb.state(), CircuitState::Open);
+}
+
+#[test]
+fn test_half_open_after_cooldown() {
+    let cb = CircuitBreaker::new(make_config(50)); // 50ms cooldown
+
+    // Trip the breaker
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    // Before cooldown: still rejects
+    let result = cb.check();
+    // Might already be past cooldown on a slow machine, so just check state transitions work
+    if result.is_err() {
+        // Wait for cooldown
+        std::thread::sleep(Duration::from_millis(60));
+    }
+
+    // After cooldown: should transition to HalfOpen
+    let result = cb.check();
+    assert!(result.is_ok());
+    assert_eq!(cb.state(), CircuitState::HalfOpen);
+}
+
+#[test]
+fn test_half_open_closes_on_success() {
+    let cb = CircuitBreaker::new(make_config(50));
+
+    // Trip and wait
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+    std::thread::sleep(Duration::from_millis(60));
+
+    // Transition to HalfOpen
+    assert!(cb.check().is_ok());
+    assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+    // Successful probe closes the circuit
+    cb.record_success();
+    assert_eq!(cb.state(), CircuitState::Closed);
+
+    // Should allow requests again
+    assert!(cb.check().is_ok());
+}
+
+#[test]
+fn test_half_open_reopens_on_failure() {
+    let cb = CircuitBreaker::new(make_config(50));
+
+    // Trip and wait
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+    std::thread::sleep(Duration::from_millis(60));
+
+    // Transition to HalfOpen
+    assert!(cb.check().is_ok());
+    assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+    // Failed probe reopens the circuit
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+}
+
+#[test]
+fn test_per_workload_isolation() {
+    let registry = CircuitBreakerRegistry::new(&make_gateway_config());
+
+    let online = registry.get("ONLINE");
+    let offline = registry.get("OFFLINE");
+    let logs = registry.get("LOGS");
+
+    // Hammer ONLINE with failures — should not affect OFFLINE or LOGS
+    for _ in 0..20 {
+        online.record_failure();
+    }
+
+    // ONLINE is open (20 failures > minimum_requests, 100% error rate)
+    assert_eq!(online.state(), CircuitState::Open);
+
+    // OFFLINE and LOGS remain closed
+    assert_eq!(offline.state(), CircuitState::Closed);
+    assert!(offline.check().is_ok());
+    assert_eq!(logs.state(), CircuitState::Closed);
+    assert!(logs.check().is_ok());
+}
+
+#[test]
+fn test_success_resets_failure_count() {
+    let cb = CircuitBreaker::new(make_config(50));
+
+    // Trip the breaker
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    // Recover
+    std::thread::sleep(Duration::from_millis(60));
+    assert!(cb.check().is_ok()); // -> HalfOpen
+    cb.record_success(); // -> Closed
+
+    // Counters should be reset
+    assert_eq!(cb.failure_count(), 0);
+    assert_eq!(cb.success_count(), 0);
+
+    // Should be able to handle requests normally again
+    assert_eq!(cb.state(), CircuitState::Closed);
+    assert!(cb.check().is_ok());
+}
+
+// -- Registry tests --
+
+#[test]
+fn test_registry_all_workloads_present() {
+    let registry = CircuitBreakerRegistry::new(&make_gateway_config());
+    for wl in &["ONLINE", "OFFLINE", "LOGS", "ENDPOINTS", "DEFAULT"] {
+        let breaker = registry.get(wl);
+        assert_eq!(breaker.state(), CircuitState::Closed);
+        assert_eq!(breaker.workload_name(), *wl);
+    }
+}
+
+#[test]
+#[should_panic(expected = "no circuit breaker registered for workload: NONEXISTENT")]
+fn test_registry_panics_on_unknown() {
+    let registry = CircuitBreakerRegistry::new(&make_gateway_config());
+    let _ = registry.get("NONEXISTENT");
+}
+
+// -- Error type tests --
+
+#[test]
+fn test_circuit_breaker_error_type() {
+    let err = GatewayError::CircuitBreakerOpen("ONLINE".to_string());
+    assert_eq!(err.error_type(), "circuit_breaker_open");
+    assert_eq!(
+        err.status_code(),
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    );
+    assert!(err.to_string().contains("ONLINE"));
+}
+
+// -- Full lifecycle test --
+
+#[test]
+fn test_full_lifecycle_closed_open_halfopen_closed() {
+    let cb = CircuitBreaker::new(make_config(50));
+
+    // Phase 1: Closed — requests work
+    assert_eq!(cb.state(), CircuitState::Closed);
+    assert!(cb.check().is_ok());
+
+    // Phase 2: Accumulate failures to trip
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    // Phase 3: Wait for cooldown, transition to HalfOpen
+    std::thread::sleep(Duration::from_millis(60));
+    assert!(cb.check().is_ok());
+    assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+    // Phase 4: Probe succeeds, back to Closed
+    cb.record_success();
+    assert_eq!(cb.state(), CircuitState::Closed);
+    assert!(cb.check().is_ok());
+}
+
+#[test]
+fn test_full_lifecycle_with_repeated_failures() {
+    let cb = CircuitBreaker::new(make_config(50));
+
+    // Trip the circuit
+    cb.record_success();
+    cb.record_success();
+    cb.record_failure();
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    // First recovery attempt fails
+    std::thread::sleep(Duration::from_millis(60));
+    assert!(cb.check().is_ok()); // -> HalfOpen
+    cb.record_failure(); // -> Open again
+    assert_eq!(cb.state(), CircuitState::Open);
+
+    // Second recovery attempt succeeds
+    std::thread::sleep(Duration::from_millis(60));
+    assert!(cb.check().is_ok()); // -> HalfOpen
+    cb.record_success(); // -> Closed
+    assert_eq!(cb.state(), CircuitState::Closed);
+}


### PR DESCRIPTION
## Summary
Per-workload circuit breaker for the ClickHouse Query Gateway ([RFC #1044](https://github.com/PostHog/requests-for-comments-internal/pull/1044)).

**Depends on:** #51723 (gateway scaffold)

- CLOSED → OPEN on >50% error rate in 30s window (min 10 requests)
- OPEN → HALF_OPEN after cooldown (ONLINE: 60s, OFFLINE: 120s)
- HALF_OPEN → CLOSED on success, → OPEN on failure
- AtomicU64 counters (lock-free), RwLock only for state transitions
- 503 SERVICE_UNAVAILABLE when circuit is open
- Per-workload isolation: OFFLINE circuit tripping doesn't affect ONLINE

## Test plan
- 14 Rust unit tests + 13 integration tests