### PR TITLE
feat(flags): skip PostgreSQL fallback for team token lookups

### DIFF
--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -167,14 +167,19 @@ pub struct HyperCacheConfig {
     pub redis_timeout: Duration,
     pub s3_timeout: Duration,
     pub namespace: String,
-    pub value: String,
+    pub object_name: String,
     pub token_based: bool,
     pub django_cache_version: String,
 }
 
 impl HyperCacheConfig {
     /// Create config with explicit settings (defaults django_cache_version to "1")
-    pub fn new(namespace: String, value: String, s3_region: String, s3_bucket: String) -> Self {
+    pub fn new(
+        namespace: String,
+        object_name: String,
+        s3_region: String,
+        s3_bucket: String,
+    ) -> Self {
         Self {
             s3_bucket,
             s3_region,
@@ -182,7 +187,7 @@ impl HyperCacheConfig {
             redis_timeout: Duration::from_millis(500),
             s3_timeout: Duration::from_secs(3),
             namespace,
-            value,
+            object_name,
             token_based: false,
             django_cache_version: "1".to_string(),
         }
@@ -191,7 +196,7 @@ impl HyperCacheConfig {
     /// Create config with custom django cache version
     pub fn with_django_cache_version(
         namespace: String,
-        value: String,
+        object_name: String,
         s3_region: String,
         s3_bucket: String,
         django_cache_version: String,
@@ -203,7 +208,7 @@ impl HyperCacheConfig {
             redis_timeout: Duration::from_millis(500),
             s3_timeout: Duration::from_secs(3),
             namespace,
-            value,
+            object_name,
             token_based: false,
             django_cache_version,
         }
@@ -239,10 +244,13 @@ impl HyperCacheConfig {
         if self.token_based {
             format!(
                 "cache/team_tokens/{}/{}/{}",
-                key_str, self.namespace, self.value
+                key_str, self.namespace, self.object_name
             )
         } else {
-            format!("cache/teams/{}/{}/{}", key_str, self.namespace, self.value)
+            format!(
+                "cache/teams/{}/{}/{}",
+                key_str, self.namespace, self.object_name
+            )
         }
     }
 }
@@ -319,7 +327,7 @@ impl HyperCacheReader {
                     &[
                         ("result".to_string(), "hit_redis".to_string()),
                         ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.value.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
                     ],
                     1,
                 );
@@ -350,7 +358,7 @@ impl HyperCacheReader {
                     &[
                         ("reason".to_string(), "timeout".to_string()),
                         ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.value.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
                     ],
                     1,
                 );
@@ -371,7 +379,7 @@ impl HyperCacheReader {
                     &[
                         ("result".to_string(), "hit_s3".to_string()),
                         ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.value.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
                     ],
                     1,
                 );
@@ -404,7 +412,7 @@ impl HyperCacheReader {
             &[
                 ("result".to_string(), "missing".to_string()),
                 ("namespace".to_string(), self.config.namespace.clone()),
-                ("value".to_string(), self.config.value.clone()),
+                ("value".to_string(), self.config.object_name.clone()),
             ],
             1,
         );
@@ -462,7 +470,7 @@ impl HyperCacheReader {
                             &[
                                 ("result".to_string(), "hit_fallback".to_string()),
                                 ("namespace".to_string(), self.config.namespace.clone()),
-                                ("value".to_string(), self.config.value.clone()),
+                                ("value".to_string(), self.config.object_name.clone()),
                             ],
                             1,
                         );
@@ -478,7 +486,7 @@ impl HyperCacheReader {
                                     "operation".to_string(),
                                     "hypercache_fallback_miss".to_string(),
                                 ),
-                                ("component".to_string(), self.config.value.clone()),
+                                ("component".to_string(), self.config.object_name.clone()),
                             ],
                             1,
                         );
@@ -522,7 +530,7 @@ impl HyperCacheReader {
                                     &[
                                         ("reason".to_string(), "json_error".to_string()),
                                         ("namespace".to_string(), self.config.namespace.clone()),
-                                        ("value".to_string(), self.config.value.clone()),
+                                        ("value".to_string(), self.config.object_name.clone()),
                                     ],
                                     1,
                                 );
@@ -539,7 +547,7 @@ impl HyperCacheReader {
                             &[
                                 ("reason".to_string(), "pickle_error".to_string()),
                                 ("namespace".to_string(), self.config.namespace.clone()),
-                                ("value".to_string(), self.config.value.clone()),
+                                ("value".to_string(), self.config.object_name.clone()),
                             ],
                             1,
                         );
@@ -556,7 +564,7 @@ impl HyperCacheReader {
                     &[
                         ("reason".to_string(), "get_error".to_string()),
                         ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.value.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
                     ],
                     1,
                 );
@@ -657,7 +665,7 @@ mod tests {
         assert_eq!(config.s3_region, "eu-west-1");
         assert_eq!(config.s3_endpoint, None);
         assert_eq!(config.namespace, "test_namespace");
-        assert_eq!(config.value, "test_value");
+        assert_eq!(config.object_name, "test_value");
         assert_eq!(config.django_cache_version, "1"); // Default value
     }
 

--- a/rust/feature-flags/src/api/flag_definitions.rs
+++ b/rust/feature-flags/src/api/flag_definitions.rs
@@ -287,6 +287,7 @@ async fn fetch_team_by_token(state: &AppState, token: &str) -> Result<Team, Flag
         state.team_hypercache_reader.clone(),
         state.flags_hypercache_reader.clone(),
         state.team_negative_cache.clone(),
+        *state.config.skip_pg_team_fallback,
     );
     flag_service.verify_token_and_get_team(token).await
 }

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -611,7 +611,7 @@ pub struct Config {
     #[envconfig(from = "TEAM_NEGATIVE_CACHE_CAPACITY", default = "10000")]
     pub team_negative_cache_capacity: u64,
 
-    #[envconfig(from = "TEAM_NEGATIVE_CACHE_TTL_SECONDS", default = "300")]
+    #[envconfig(from = "TEAM_NEGATIVE_CACHE_TTL_SECONDS", default = "30")]
     pub team_negative_cache_ttl_seconds: u64,
 
     // TTL for the Redis-backed per-token auth cache (positive hits).
@@ -833,7 +833,7 @@ impl Config {
             skip_writes: FlexBool(false),
             thread_pool_cores: 0,
             team_negative_cache_capacity: 10_000,
-            team_negative_cache_ttl_seconds: 300,
+            team_negative_cache_ttl_seconds: 30,
             skip_pg_team_fallback: FlexBool(false),
             service_mode: ServiceMode::All,
             auth_token_cache_ttl_seconds: 300,

--- a/rust/feature-flags/src/config.rs
+++ b/rust/feature-flags/src/config.rs
@@ -620,6 +620,14 @@ pub struct Config {
     #[envconfig(from = "AUTH_TOKEN_CACHE_TTL_SECONDS", default = "300")]
     pub auth_token_cache_ttl_seconds: u64,
 
+    // When true, skip the PostgreSQL fallback for team token lookups.
+    // HyperCache (Redis/S3) is treated as the source of truth — a cache
+    // miss means the token is invalid. Transient errors (Redis/S3 timeouts)
+    // bypass the fallback entirely and are not negative-cached.
+    // Gated for safe rollout.
+    #[envconfig(from = "SKIP_PG_TEAM_FALLBACK", default = "false")]
+    pub skip_pg_team_fallback: FlexBool,
+
     #[envconfig(from = "SERVICE_MODE", default = "all")]
     pub service_mode: ServiceMode,
 }
@@ -826,6 +834,7 @@ impl Config {
             thread_pool_cores: 0,
             team_negative_cache_capacity: 10_000,
             team_negative_cache_ttl_seconds: 300,
+            skip_pg_team_fallback: FlexBool(false),
             service_mode: ServiceMode::All,
             auth_token_cache_ttl_seconds: 300,
         }

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -601,6 +601,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         match flag_service.verify_token_and_get_team(&token).await {
@@ -631,6 +632,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
         assert!(matches!(
             flag_service.verify_token_and_get_team(&result).await,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -3,8 +3,8 @@ use crate::{
     flags::flag_models::FeatureFlagList,
     handler::canonical_log::with_canonical_log,
     metrics::consts::{
-        DB_TEAM_READS_COUNTER, TEAM_CACHE_HIT_COUNTER, TEAM_NEGATIVE_CACHE_HIT_COUNTER,
-        TOKEN_VALIDATION_ERRORS_COUNTER,
+        DB_TEAM_READS_COUNTER, PG_TEAM_FALLBACK_SKIPPED_COUNTER, TEAM_CACHE_HIT_COUNTER,
+        TEAM_NEGATIVE_CACHE_HIT_COUNTER, TOKEN_VALIDATION_ERRORS_COUNTER,
     },
     team::team_models::Team,
 };
@@ -38,6 +38,8 @@ pub struct FlagService {
     flags_hypercache_reader: Arc<HyperCacheReader>,
     /// In-memory negative cache for invalid API tokens
     team_negative_cache: NegativeCache,
+    /// When true, skip PG fallback for team token lookups
+    skip_pg_team_fallback: bool,
 }
 
 impl FlagService {
@@ -47,6 +49,7 @@ impl FlagService {
         team_hypercache_reader: Arc<HyperCacheReader>,
         flags_hypercache_reader: Arc<HyperCacheReader>,
         team_negative_cache: NegativeCache,
+        skip_pg_team_fallback: bool,
     ) -> Self {
         Self {
             shared_redis_client,
@@ -54,6 +57,7 @@ impl FlagService {
             team_hypercache_reader,
             flags_hypercache_reader,
             team_negative_cache,
+            skip_pg_team_fallback,
         }
     }
 
@@ -104,15 +108,25 @@ impl FlagService {
     /// Fetches the team from HyperCache or the database.
     ///
     /// Uses team_metadata HyperCache (Redis → S3 → PostgreSQL fallback).
+    /// PostgreSQL fallback can be disabled via `skip_pg_team_fallback`.
     /// This is a read-only cache - Django handles cache writes.
     pub async fn get_team_from_cache_or_pg(&self, token: &str) -> Result<Team, FlagError> {
         let key = KeyType::string(token);
+        let skip_pg = self.skip_pg_team_fallback;
         let pg_client = self.pg_client.clone();
         let token_owned = token.to_string();
 
         let (data, source) = self
             .team_hypercache_reader
             .get_with_source_or_fallback(&key, || async move {
+                // This closure only runs on a genuine CacheMiss (key not found
+                // in Redis and S3). Transient errors (timeouts, parse failures)
+                // are propagated directly by HyperCache and never reach here.
+                if skip_pg {
+                    inc(PG_TEAM_FALLBACK_SKIPPED_COUNTER, &[], 1);
+                    return Err(FlagError::TokenValidationError);
+                }
+
                 // Fallback: load from PostgreSQL and convert to JSON Value
                 let team = Team::from_pg(pg_client, &token_owned).await?;
                 inc(DB_TEAM_READS_COUNTER, &[], 1);
@@ -193,6 +207,7 @@ impl FlagService {
 #[cfg(test)]
 mod tests {
     use common_cache::NegativeCache;
+    use rstest::rstest;
     use serde_json::json;
 
     use crate::{
@@ -204,7 +219,8 @@ mod tests {
         utils::test_utils::{
             insert_new_team_in_redis, setup_hypercache_reader,
             setup_hypercache_reader_with_mock_redis, setup_pg_reader_client, setup_redis_client,
-            setup_team_hypercache_reader, TestContext,
+            setup_team_hypercache_reader, setup_team_hypercache_reader_with_mock_redis,
+            TestContext,
         },
     };
 
@@ -226,6 +242,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         // Test valid token returns the team
@@ -258,6 +275,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         // Test fetching from HyperCache
@@ -287,6 +305,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         // Test fetching from PostgreSQL (cache miss)
@@ -415,6 +434,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         // Test fetching from hypercache
@@ -559,6 +579,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -618,6 +639,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         // Should fall back to PostgreSQL and succeed (returns empty list for new team)
@@ -660,6 +682,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -706,6 +729,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -755,6 +779,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             NegativeCache::new(100, 300),
+            false,
         );
 
         let result = flag_service.get_flags_from_cache_or_pg(team.id).await;
@@ -797,6 +822,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             negative_cache,
+            false,
         );
 
         let result = flag_service
@@ -821,6 +847,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             negative_cache.clone(),
+            false,
         );
 
         // First call should fail and populate the negative cache
@@ -849,6 +876,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             negative_cache.clone(),
+            false,
         );
 
         // Valid token should succeed and not be added to negative cache
@@ -880,6 +908,7 @@ mod tests {
             team_hypercache_reader,
             hypercache_reader,
             negative_cache.clone(),
+            false,
         );
 
         // First call: misses cache, hits Redis (mock) + PG fallback, fails, populates negative cache
@@ -900,5 +929,89 @@ mod tests {
             calls_after_first, calls_after_second,
             "Second call should not make additional Redis calls (served from negative cache)"
         );
+    }
+
+    #[tokio::test]
+    async fn test_skip_pg_fallback_still_resolves_token_from_hypercache() {
+        let redis_client = setup_redis_client(None).await;
+        let pg_client = setup_pg_reader_client(None);
+        let team_hypercache_reader = setup_team_hypercache_reader(redis_client.clone()).await;
+        let hypercache_reader = setup_hypercache_reader(redis_client.clone()).await;
+        let team = insert_new_team_in_redis(redis_client.clone())
+            .await
+            .expect("Failed to insert new team in Redis");
+
+        let negative_cache = NegativeCache::new(100, 300);
+
+        let flag_service = FlagService::new(
+            redis_client.clone(),
+            pg_client.clone(),
+            team_hypercache_reader,
+            hypercache_reader,
+            negative_cache.clone(),
+            true, // skip PG fallback
+        );
+
+        // Token is in HyperCache, so lookup should succeed even with PG fallback disabled
+        let result = flag_service
+            .verify_token_and_get_team(&team.api_token)
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().api_token, team.api_token);
+        assert!(
+            !negative_cache.contains(&team.api_token),
+            "Valid token found in HyperCache should not be in negative cache"
+        );
+    }
+
+    #[rstest]
+    #[case::skip_enabled_rejects(true)]
+    #[case::skip_disabled_falls_back_to_pg(false)]
+    #[tokio::test]
+    async fn test_skip_pg_fallback_with_pg_only_token(#[case] skip_pg: bool) {
+        use common_redis::MockRedisClient;
+
+        let mock_client = MockRedisClient::new();
+        let mock_redis: Arc<dyn RedisClient + Send + Sync> = Arc::new(mock_client.clone());
+        let team_hypercache_reader =
+            setup_team_hypercache_reader_with_mock_redis(mock_redis.clone());
+        let hypercache_reader = setup_hypercache_reader_with_mock_redis(mock_redis.clone());
+        let context = TestContext::new(None).await;
+
+        // Team exists in PG but not in HyperCache
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team in PG");
+
+        let negative_cache = NegativeCache::new(100, 300);
+
+        let flag_service = FlagService::new(
+            mock_redis,
+            context.non_persons_reader.clone(),
+            team_hypercache_reader,
+            hypercache_reader,
+            negative_cache.clone(),
+            skip_pg,
+        );
+
+        let result = flag_service
+            .verify_token_and_get_team(&team.api_token)
+            .await;
+
+        if skip_pg {
+            assert!(matches!(result, Err(FlagError::TokenValidationError)));
+            assert!(
+                negative_cache.contains(&team.api_token),
+                "Token should be negative-cached when PG fallback is skipped"
+            );
+        } else {
+            let resolved_team = result.expect("Should resolve via PG fallback");
+            assert_eq!(resolved_team.api_token, team.api_token);
+            assert!(
+                !negative_cache.contains(&team.api_token),
+                "Valid token should not be in negative cache"
+            );
+        }
     }
 }

--- a/rust/feature-flags/src/handler/mod.rs
+++ b/rust/feature-flags/src/handler/mod.rs
@@ -124,6 +124,7 @@ async fn process_request_inner(
             context.state.team_hypercache_reader.clone(),
             context.state.flags_hypercache_reader.clone(),
             context.state.team_negative_cache.clone(),
+            *context.state.config.skip_pg_team_fallback,
         );
 
         let (original_distinct_id, team, request) =

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1304,6 +1304,7 @@ async fn test_fetch_and_filter_flags() {
         team_hypercache_reader,
         hypercache_reader,
         NegativeCache::new(100, 300),
+        false,
     );
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await.unwrap();
@@ -1478,6 +1479,7 @@ async fn test_fetch_and_filter_preserves_evaluation_metadata() {
         team_hypercache_reader,
         hypercache_reader,
         NegativeCache::new(100, 300),
+        false,
     );
     let context = TestContext::new(None).await;
     let team = context.insert_new_team(None).await.unwrap();

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -13,6 +13,7 @@ pub const TEAM_CACHE_HIT_COUNTER: &str = "flags_team_cache_hit_total";
 pub const DB_TEAM_READS_COUNTER: &str = "flags_db_team_reads_total";
 pub const TOKEN_VALIDATION_ERRORS_COUNTER: &str = "flags_token_validation_errors_total";
 pub const TEAM_NEGATIVE_CACHE_HIT_COUNTER: &str = "flags_team_negative_cache_hit_total";
+pub const PG_TEAM_FALLBACK_SKIPPED_COUNTER: &str = "flags_pg_team_fallback_skipped_total";
 pub const DB_COHORT_READS_COUNTER: &str = "flags_db_cohort_reads_total";
 pub const DB_COHORT_ERRORS_COUNTER: &str = "flags_db_cohort_errors_total";
 pub const COHORT_CACHE_HIT_COUNTER: &str = "flags_cohort_cache_hit_total";

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -166,17 +166,18 @@ pub async fn setup_hypercache_reader(
     )
 }
 
-/// Create a HyperCacheReader for tests using a mock Redis client (synchronous).
-/// Uses a dummy S3 client that always returns NotFound.
-/// This is useful for tests that need to control Redis behavior via MockRedisClient.
-/// Returns Arc<HyperCacheReader> to match the production pattern.
+/// Create a HyperCacheReader with a mock Redis client and a dummy S3 client
+/// that always returns NotFound. Parameterized for reuse across different
+/// HyperCache namespaces (feature_flags, team_metadata, etc.).
 #[cfg(test)]
-pub fn setup_hypercache_reader_with_mock_redis(
+fn setup_mock_hypercache_reader(
     redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
+    namespace: &str,
+    object_name: &str,
+    token_based: bool,
 ) -> Arc<HyperCacheReader> {
     use common_s3::{S3Client, S3Error};
 
-    // Create a simple S3 client that always returns NotFound
     struct DummyS3Client;
 
     #[async_trait]
@@ -186,18 +187,27 @@ pub fn setup_hypercache_reader_with_mock_redis(
         }
     }
 
-    let config = HyperCacheConfig::new(
-        "feature_flags".to_string(),
-        "flags.json".to_string(),
+    let mut config = HyperCacheConfig::new(
+        namespace.to_string(),
+        object_name.to_string(),
         "us-east-1".to_string(),
         "posthog".to_string(),
     );
+    config.token_based = token_based;
     let s3_client: Arc<dyn S3Client + Send + Sync> = Arc::new(DummyS3Client);
     Arc::new(HyperCacheReader::new_with_s3_client(
         redis_client,
         s3_client,
         config,
     ))
+}
+
+/// Create a feature_flags HyperCacheReader with a mock Redis client.
+#[cfg(test)]
+pub fn setup_hypercache_reader_with_mock_redis(
+    redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
+) -> Arc<HyperCacheReader> {
+    setup_mock_hypercache_reader(redis_client, "feature_flags", "flags.json", false)
 }
 
 /// Create a HyperCacheReader for team_metadata using the provided Redis client.
@@ -218,6 +228,14 @@ pub async fn setup_team_hypercache_reader(
             .await
             .expect("Failed to create team HyperCacheReader"),
     )
+}
+
+/// Create a team_metadata HyperCacheReader with a mock Redis client.
+#[cfg(test)]
+pub fn setup_team_hypercache_reader_with_mock_redis(
+    redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
+) -> Arc<HyperCacheReader> {
+    setup_mock_hypercache_reader(redis_client, "team_metadata", "full_metadata.json", true)
 }
 
 /// Create a HyperCacheReader for remote config (array/config.json).


### PR DESCRIPTION
## Problem

We're seeing a huge volume of requests for a project token that doesn't exist in our database, putting unnecessary load on PostgreSQL. We have a negative cache for invalid tokens, but it can only do so much — each cache eviction still triggers a PG query for a token that will never resolve. We could enlarge the cache and extend the TTL, but that would only make us more susceptible to cache poisoning.

As HyperCache (Redis/S3) matures as the source of truth for team tokens, we no longer need to fall back to PostgreSQL on cache misses. Skipping the fallback eliminates this database pressure entirely.

## Changes

- Add `SKIP_PG_TEAM_FALLBACK` env var (default `false`) to gate the behavior for safe rollout
- When enabled, HyperCache misses return `TokenValidationError` instead of querying PostgreSQL — this is the same error used for genuinely invalid tokens, which triggers negative caching and a 401 response
- Add `flags_pg_team_fallback_skipped_total` metric to track how often the fallback is skipped
- Thread the new config through `FlagService::new` and both API entry points

## How did you test this code?

Added three new integration tests:
- `test_skip_pg_fallback_still_resolves_token_from_hypercache` — tokens in HyperCache resolve normally
- `test_skip_pg_fallback_rejects_unknown_token_without_pg` — tokens only in PG are rejected when skip is enabled
- `test_skip_pg_fallback_disabled_still_finds_team_in_pg` — confirms default behavior (PG fallback) is unchanged
- Manual test. Made request with valid token, then two requests with invalid token:

<details>

Relevant part of the two log entries

> 2026-03-20T18:19:55.649453Z  INFO  **error_code="invalid_token"**
> 2026-03-20T18:20:14.946661Z  INFO **team_cache_source="negative_cache" error_code="invalid_token"**

</details>

## Publish to changelog?

No