### PR TITLE
feat(dashboard): add indexes and validate constraint for button tiles

### DIFF
--- a/posthog/migrations/1060_add_button_tile_indexes.py
+++ b/posthog/migrations/1060_add_button_tile_indexes.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1059_add_button_tile"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_buttontile_created_by_id_bf09d147"
+                            ON "posthog_buttontile" ("created_by_id");
+                        CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_buttontile_last_modified_by_id_a5860b7a"
+                            ON "posthog_buttontile" ("last_modified_by_id");
+                        CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_buttontile_team_id_a76a940c"
+                            ON "posthog_buttontile" ("team_id");
+                        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_dashboard_button_tile"
+                            ON "posthog_dashboardtile" ("dashboard_id", "button_tile_id")
+                            WHERE "button_tile_id" IS NOT NULL; -- not-null-ignore
+                        ALTER TABLE "posthog_dashboardtile"
+                            VALIDATE CONSTRAINT "dash_tile_exactly_one_related_object";
+                    """,
+                    reverse_sql="""
+                        DROP INDEX IF EXISTS "unique_dashboard_button_tile";
+                        DROP INDEX IF EXISTS "posthog_buttontile_team_id_a76a940c";
+                        DROP INDEX IF EXISTS "posthog_buttontile_last_modified_by_id_a5860b7a";
+                        DROP INDEX IF EXISTS "posthog_buttontile_created_by_id_bf09d147";
+                    """,
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1059_add_button_tile
+1060_add_button_tile_indexes


### PR DESCRIPTION
## Problem

Follow-up to #51524 (button tile for dashboards). That migration added the `posthog_buttontile` table and `posthog_dashboardtile` changes with the check constraint marked `NOT VALID` (to avoid a full table scan on deploy). This migration completes the work:

- Creates the FK indexes on `posthog_buttontile` (`created_by_id`, `last_modified_by_id`, `team_id`) concurrently
- Creates the unique index on `posthog_dashboardtile` (`dashboard_id`, `button_tile_id`) concurrently
- Validates the `dash_tile_exactly_one_related_object` check constraint

All done non-blocking (`CONCURRENTLY`, `atomic=False`, `NOT VALID` → `VALIDATE`).

## How did you test this code?

- [x] Migration safety check passes (`test_migrations_are_safe`)
- [x] Migration risk analysis passes (`analyze_migration_risk --fail-on-blocked`)

## Publish to changelog?

nope

## Docs update
nope
