### PR TITLE
fix(search): fix keyboard navigation skipping items in command search

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -487,7 +487,7 @@ function SearchRoot({
             >
                 <Autocomplete.Root
                     items={orderedItems}
-                    filter={null}
+                    mode="none"
                     itemToStringValue={(item) => item?.name ?? ''}
                     actionsRef={actionsRef}
                     inline


### PR DESCRIPTION
## Problem

Arrow key navigation in the command search (`Search.tsx`) skips items — the keyboard cursor gets "lost" and stops moving at certain points in the list, especially when searching across multiple categories.

This is a follow-up to #51573 which fixed item ordering but didn't fully resolve the issue.

## Root cause

`filter={null}` on `Autocomplete.Root` does **not** disable Base UI's internal filtering.

The chain:
1. `filter={null}` is passed via `...other` in `AutocompleteRoot`
2. `AutocompleteRoot` checks `other.filter` — `null` is falsy, so `baseFilter` falls through to the default `collator.contains`
3. Since `mode='list'` (default), `staticItems=false`, so `resolvedFilter = collator.contains`
4. This `resolvedFilter` **overrides** the original `filter: null` when passed to `AriaCombobox`
5. `AriaCombobox` receives `collator.contains` as its filter — items ARE being filtered internally by name only

Items that matched our custom search (via `searchKeywords`, `category`, etc.) but whose `name` doesn't contain the query get silently removed from Base UI's internal `flatFilteredItems`. Navigation uses `flatFilteredItems` for indexing, but the DOM still renders all items from our `orderedItems`. The index mismatch causes arrow keys to skip items.

## Fix

Replace `filter={null}` with `mode="none"`. This tells `AutocompleteRoot` that items are static (we handle filtering ourselves), which correctly sets the internal filter to `null` → `() => true` in `AriaCombobox`, preventing any internal filtering.

## Test plan

- [ ] Open command search (Cmd+K)
- [ ] Type a search query that returns results across multiple categories
- [ ] Arrow down through all results — should navigate smoothly through every item without getting stuck or jumping
- [ ] Test with no query (recents/apps) — arrow keys should traverse all items