### PR TITLE
fix(startups): refresh form errors after billing upgrade

### DIFF
--- a/frontend/src/scenes/startups/startupProgramLogic.ts
+++ b/frontend/src/scenes/startups/startupProgramLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import posthog from 'posthog-js'
 
@@ -150,14 +150,6 @@ export const startupProgramLogic = kea<startupProgramLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
-        // When billing data refreshes (e.g. after upgrading to paid plan),
-        // touch the form to force error recomputation so the billing check
-        // picks up the new has_active_subscription state
-        [billingLogic.actionTypes.loadBillingSuccess]: () => {
-            actions.setStartupProgramValue('organization_id', values.startupProgram.organization_id)
-        },
-    })),
     forms(({ values, actions, props }) => ({
         startupProgram: {
             defaults: {
@@ -171,22 +163,37 @@ export const startupProgramLogic = kea<startupProgramLogicType>([
                 yc_proof_screenshot_url: undefined,
                 yc_merch_count: values.isYC ? 1 : undefined,
             } as StartupProgramFormValues,
-            errors: ({ organization_id, raised, incorporation_date, yc_batch, yc_proof_screenshot_url }) => {
-                if (!values.billing?.has_active_subscription) {
-                    return {
-                        _form: 'You need to upgrade to a paid plan before submitting your application',
+            // Selector-style errors so that validation recomputes when billing
+            // or isYC change, not only when form values change
+            errors: [
+                (s) => [s.startupProgram, s.billing, s.isYC],
+                (
+                    {
+                        organization_id,
+                        raised,
+                        incorporation_date,
+                        yc_batch,
+                        yc_proof_screenshot_url,
+                    }: StartupProgramFormValues,
+                    billing: BillingType | null,
+                    isYC: boolean
+                ) => {
+                    if (!billing?.has_active_subscription) {
+                        return {
+                            _form: 'You need to upgrade to a paid plan before submitting your application',
+                        }
                     }
-                }
 
-                return {
-                    organization_id: !organization_id ? 'Please select an organization' : undefined,
-                    raised: validateFunding(raised, values.isYC),
-                    incorporation_date: validateIncorporationDate(incorporation_date, values.isYC),
-                    yc_batch: values.isYC && !yc_batch ? 'Please select your YC batch' : undefined,
-                    yc_proof_screenshot_url:
-                        values.isYC && !yc_proof_screenshot_url ? 'Please upload a screenshot' : undefined,
-                }
-            },
+                    return {
+                        organization_id: !organization_id ? 'Please select an organization' : undefined,
+                        raised: validateFunding(raised, isYC),
+                        incorporation_date: validateIncorporationDate(incorporation_date, isYC),
+                        yc_batch: isYC && !yc_batch ? 'Please select your YC batch' : undefined,
+                        yc_proof_screenshot_url:
+                            isYC && !yc_proof_screenshot_url ? 'Please upload a screenshot' : undefined,
+                    }
+                },
+            ],
             submit: async (formValues: StartupProgramFormValues) => {
                 const valuesToSubmit: Record<string, any> = {
                     program: values.isYC ? StartupProgramType.YC : StartupProgramType.Startup,

--- a/frontend/src/scenes/startups/startupProgramLogic.ts
+++ b/frontend/src/scenes/startups/startupProgramLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import posthog from 'posthog-js'
 
@@ -150,6 +150,14 @@ export const startupProgramLogic = kea<startupProgramLogicType>([
             },
         ],
     }),
+    listeners(({ actions, values }) => ({
+        // When billing data refreshes (e.g. after upgrading to paid plan),
+        // touch the form to force error recomputation so the billing check
+        // picks up the new has_active_subscription state
+        [billingLogic.actionTypes.loadBillingSuccess]: () => {
+            actions.setStartupProgramValue('organization_id', values.startupProgram.organization_id)
+        },
+    })),
     forms(({ values, actions, props }) => ({
         startupProgram: {
             defaults: {


### PR DESCRIPTION
## Problem

A couple of users filled in the startup program form, tried to submit (blocked because they weren't on a paid plan), upgraded to paid, and then still couldn't submit - the form kept showing the "you need to upgrade" error.

Sessions:
- https://us.posthog.com/project/2/replay/019d05e6-164a-7550-9157-72345a695fd3?t=97
- https://us.posthog.com/project/2/replay/019d069c-0c02-7ec8-b0ee-4e78d1097b47?t=565

Root cause: kea-forms memoizes the `errors` selector based on form values only. The `billing` check was accessed via a closure (`values.billing?.has_active_subscription`), not as a tracked selector dependency - so when billing refreshed after upgrade, the errors never recomputed (until another form state change, e.g. input edit).

## Changes

Switched from a simple function-style `errors` to kea-forms' selector-style `errors` array, making `billing` and `isYC` explicit reactive dependencies.

## How did you test this code?

Reproduced locally by filling in the form first, then upgrading - confirmed the stale error. After the fix, the form correctly allows submission once billing refreshes.

## Publish to changelog?

No