### PR TITLE
feat(debug): connection dropdown

### DIFF
--- a/frontend/src/scenes/debug/Modifiers.test.tsx
+++ b/frontend/src/scenes/debug/Modifiers.test.tsx
@@ -1,0 +1,140 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { externalDataSourcesLogic } from 'scenes/data-warehouse/externalDataSourcesLogic'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { AccessControlLevel, DataWarehouseSyncInterval, ExternalDataJobStatus, ExternalDataSource } from '~/types'
+
+import { Modifiers } from './Modifiers'
+
+jest.mock('lib/lemon-ui/LemonSelect', () => ({
+    LemonSelect: ({ onChange, options, value }: any): JSX.Element => {
+        const flatOptions = options.flatMap((option: any) => ('options' in option ? option.options : option))
+
+        return (
+            <select
+                value={value === undefined ? '' : String(value)}
+                onChange={(event) => {
+                    const selectedOption = flatOptions.find(
+                        (option: any) => String(option.value) === event.target.value
+                    )
+                    onChange?.(selectedOption?.value)
+                }}
+            >
+                <option value="">Select a value</option>
+                {flatOptions.map((option: any) => (
+                    <option key={String(option.value)} value={String(option.value)} disabled={option.disabled}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        )
+    },
+}))
+
+describe('Modifiers', () => {
+    const mockSourcesResponse = {
+        results: [
+            {
+                id: 'postgres-connection-id',
+                source_id: 'source-1',
+                connection_id: 'conn-1',
+                source_type: 'Postgres',
+                status: ExternalDataJobStatus.Running,
+                schemas: [],
+                prefix: 'analytics-db',
+                description: null,
+                access_method: 'direct',
+                latest_error: null,
+                revenue_analytics_config: {
+                    enabled: false,
+                    include_invoiceless_charges: true,
+                },
+                sync_frequency: '24hour' as DataWarehouseSyncInterval,
+                job_inputs: {},
+                user_access_level: AccessControlLevel.Manager,
+            },
+        ],
+        count: 1,
+        next: null,
+        previous: null,
+    } satisfies {
+        results: ExternalDataSource[]
+        count: number
+        next: string | null
+        previous: string | null
+    }
+
+    beforeEach(() => {
+        initKeaTests()
+        externalDataSourcesLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
+            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: false,
+        })
+    })
+
+    afterEach(() => {
+        externalDataSourcesLogic.unmount()
+        jest.restoreAllMocks()
+        cleanup()
+    })
+
+    it('renders a connection selector for HogQL queries when direct query is enabled', async () => {
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
+            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
+        })
+        jest.spyOn(api.externalDataSources, 'list').mockResolvedValue(mockSourcesResponse)
+
+        const setQuery = jest.fn()
+
+        render(
+            <Provider>
+                <Modifiers
+                    setQuery={setQuery}
+                    query={{ kind: NodeKind.HogQLQuery, query: 'SELECT 1', modifiers: {} }}
+                    response={null}
+                />
+            </Provider>
+        )
+
+        expect(screen.getByText('Connection ID:')).toBeInTheDocument()
+        await screen.findByRole('option', { name: 'analytics-db (Postgres)' })
+
+        await userEvent.selectOptions(screen.getByLabelText('Connection ID:'), 'postgres-connection-id')
+
+        expect(setQuery).toHaveBeenCalledWith({
+            kind: NodeKind.HogQLQuery,
+            query: 'SELECT 1',
+            modifiers: {},
+            connectionId: 'postgres-connection-id',
+        })
+    })
+
+    it('does not render a connection selector for non-HogQL queries', () => {
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
+            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: false,
+        })
+
+        const setQuery = jest.fn()
+
+        render(
+            <Provider>
+                <Modifiers
+                    setQuery={setQuery}
+                    query={{ kind: NodeKind.HogQuery, code: 'return 1', modifiers: {} }}
+                    response={null}
+                />
+            </Provider>
+        )
+
+        expect(screen.queryByText('Connection ID:')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/debug/Modifiers.tsx
+++ b/frontend/src/scenes/debug/Modifiers.tsx
@@ -10,7 +10,6 @@ import { externalDataSourcesLogic } from 'scenes/data-warehouse/externalDataSour
 import { HogQLQueryModifiers, NodeKind } from '~/queries/schema/schema-general'
 
 const POSTHOG_WAREHOUSE = '__posthog_warehouse__'
-const LOADING_CONNECTIONS = '__loading_connections__'
 
 interface QueryWithModifiers {
     connectionId?: string
@@ -66,15 +65,15 @@ function ConnectionIdModifier<Q extends QueryWithModifiers>({
         <LemonLabel className={labelClassName}>
             <div>Connection ID:</div>
             <LemonSelect
+                disabled={dataWarehouseSourcesLoading}
+                disabledReason={dataWarehouseSourcesLoading ? 'Loading connections...' : undefined}
                 fullWidth
                 options={[
                     { value: POSTHOG_WAREHOUSE, label: 'PostHog (ClickHouse)' },
-                    ...(dataWarehouseSourcesLoading
-                        ? [{ value: LOADING_CONNECTIONS, label: 'Loading...', disabled: true }]
-                        : directPostgresSources.map((source) => ({
-                              value: source.id,
-                              label: `${source.prefix ?? source.id} (Postgres)`,
-                          }))),
+                    ...directPostgresSources.map((source) => ({
+                        value: source.id,
+                        label: `${source.prefix ?? source.id} (Postgres)`,
+                    })),
                     ...(!hasSelectedConnection && query.connectionId
                         ? [{ value: query.connectionId, label: `${query.connectionId} (Unavailable)` }]
                         : []),
@@ -82,7 +81,7 @@ function ConnectionIdModifier<Q extends QueryWithModifiers>({
                 onChange={(value) =>
                     setQuery({
                         ...query,
-                        connectionId: value === POSTHOG_WAREHOUSE || value === LOADING_CONNECTIONS ? undefined : value,
+                        connectionId: value === POSTHOG_WAREHOUSE ? undefined : value,
                     })
                 }
                 value={selectedValue}

--- a/frontend/src/scenes/debug/Modifiers.tsx
+++ b/frontend/src/scenes/debug/Modifiers.tsx
@@ -1,15 +1,97 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useMemo } from 'react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { externalDataSourcesLogic } from 'scenes/data-warehouse/externalDataSourcesLogic'
 
-import { HogQLQueryModifiers } from '~/queries/schema/schema-general'
+import { HogQLQueryModifiers, NodeKind } from '~/queries/schema/schema-general'
 
-export interface ModifiersProps<Q extends { response?: Record<string, any>; modifiers?: HogQLQueryModifiers }> {
+const POSTHOG_WAREHOUSE = '__posthog_warehouse__'
+const LOADING_CONNECTIONS = '__loading_connections__'
+
+interface QueryWithModifiers {
+    connectionId?: string
+    kind?: string
+    response?: Record<string, any>
+    modifiers?: HogQLQueryModifiers
+}
+
+export interface ModifiersProps<Q extends QueryWithModifiers> {
     setQuery: (query: Q) => void
     query: Q | null
     response: Required<Q>['response'] | null
 }
 
-export function Modifiers<Q extends { response?: Record<string, any>; modifiers?: HogQLQueryModifiers }>({
+function ConnectionIdModifier<Q extends QueryWithModifiers>({
+    labelClassName,
+    query,
+    setQuery,
+}: {
+    labelClassName: string
+    query: Q
+    setQuery: (query: Q) => void
+}): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { dataWarehouseSources, dataWarehouseSourcesLoading } = useValues(externalDataSourcesLogic)
+    const { loadSources } = useActions(externalDataSourcesLogic)
+    const isDirectQueryEnabled = !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
+    const isHogQLQuery = query.kind === NodeKind.HogQLQuery
+
+    useEffect(() => {
+        if (isHogQLQuery && isDirectQueryEnabled && !dataWarehouseSources) {
+            loadSources()
+        }
+    }, [dataWarehouseSources, isDirectQueryEnabled, isHogQLQuery, loadSources])
+
+    const directPostgresSources = useMemo(
+        () =>
+            (dataWarehouseSources?.results ?? []).filter(
+                (source) => source.access_method === 'direct' && source.source_type.toLowerCase().includes('postgres')
+            ),
+        [dataWarehouseSources]
+    )
+
+    if (!isHogQLQuery || !isDirectQueryEnabled) {
+        return null
+    }
+
+    const selectedValue = query.connectionId ?? POSTHOG_WAREHOUSE
+    const hasSelectedConnection =
+        !!query.connectionId && directPostgresSources.some((source) => source.id === query.connectionId)
+
+    return (
+        <LemonLabel className={labelClassName}>
+            <div>Connection ID:</div>
+            <LemonSelect
+                fullWidth
+                options={[
+                    { value: POSTHOG_WAREHOUSE, label: 'PostHog (ClickHouse)' },
+                    ...(dataWarehouseSourcesLoading
+                        ? [{ value: LOADING_CONNECTIONS, label: 'Loading...', disabled: true }]
+                        : directPostgresSources.map((source) => ({
+                              value: source.id,
+                              label: `${source.prefix ?? source.id} (Postgres)`,
+                          }))),
+                    ...(!hasSelectedConnection && query.connectionId
+                        ? [{ value: query.connectionId, label: `${query.connectionId} (Unavailable)` }]
+                        : []),
+                ]}
+                onChange={(value) =>
+                    setQuery({
+                        ...query,
+                        connectionId: value === POSTHOG_WAREHOUSE || value === LOADING_CONNECTIONS ? undefined : value,
+                    })
+                }
+                value={selectedValue}
+            />
+        </LemonLabel>
+    )
+}
+
+export function Modifiers<Q extends QueryWithModifiers>({
     setQuery,
     query,
     response = null,
@@ -17,195 +99,211 @@ export function Modifiers<Q extends { response?: Record<string, any>; modifiers?
     if (query === null) {
         return null
     }
-    const labelClassName = 'flex flex-col gap-1 items-start'
+    const labelClassName = 'flex min-w-44 flex-1 flex-col items-start gap-1'
+
     return (
-        <div className="flex gap-2">
-            <LemonLabel className={labelClassName}>
-                <div>POE:</div>
-                <LemonSelect
-                    options={[
-                        { value: 'disabled', label: 'Disabled' },
-                        {
-                            value: 'person_id_no_override_properties_on_events',
-                            label: 'Properties: Events, Person ID: Events',
-                        },
-                        {
-                            value: 'person_id_override_properties_on_events',
-                            label: 'Properties: Events, Person ID: Overrides (v2)',
-                        },
-                        {
-                            value: 'person_id_override_properties_joined',
-                            label: 'Properties: Person, Person ID: Overrides (v3)',
-                        },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, personsOnEventsMode: value },
-                        })
-                    }
-                    value={query.modifiers?.personsOnEventsMode ?? response?.modifiers?.personsOnEventsMode}
-                />
-            </LemonLabel>
-            <LemonLabel className={labelClassName}>
-                <div>Persons ArgMax:</div>
-                <LemonSelect
-                    options={[
-                        { value: 'v1', label: 'V1' },
-                        { value: 'v2', label: 'V2' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, personsArgMaxVersion: value },
-                        })
-                    }
-                    value={query.modifiers?.personsArgMaxVersion ?? response?.modifiers?.personsArgMaxVersion}
-                />
-            </LemonLabel>
-            <LemonLabel className={labelClassName}>
-                <div>In Cohort Via:</div>
-                <LemonSelect
-                    options={[
-                        { value: 'auto', label: 'auto' },
-                        { value: 'leftjoin', label: 'leftjoin' },
-                        { value: 'subquery', label: 'subquery' },
-                        { value: 'leftjoin_conjoined', label: 'leftjoin conjoined' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, inCohortVia: value },
-                        })
-                    }
-                    value={query.modifiers?.inCohortVia ?? response?.modifiers?.inCohortVia}
-                />
-            </LemonLabel>
-            <LemonLabel className={labelClassName}>
-                <div>Materialization Mode:</div>
-                <LemonSelect
-                    options={[
-                        { value: 'auto', label: 'auto' },
-                        { value: 'legacy_null_as_string', label: 'legacy_null_as_string' },
-                        { value: 'legacy_null_as_null', label: 'legacy_null_as_null' },
-                        { value: 'disabled', label: 'disabled' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, materializationMode: value },
-                        })
-                    }
-                    value={query.modifiers?.materializationMode ?? response?.modifiers?.materializationMode}
-                />
-            </LemonLabel>
-            <LemonLabel className={labelClassName}>
-                <div>Optimize joined filters:</div>
-                <LemonSelect
-                    options={[
-                        { value: true, label: 'true' },
-                        { value: false, label: 'false' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, optimizeJoinedFilters: value },
-                        })
-                    }
-                    value={query.modifiers?.optimizeJoinedFilters ?? response?.modifiers?.optimizeJoinedFilters}
-                />
-            </LemonLabel>
-            <LemonLabel className={labelClassName}>
-                <div>Projection pushdown:</div>
-                <LemonSelect
-                    options={[
-                        { value: true, label: 'true' },
-                        { value: false, label: 'false' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, optimizeProjections: value },
-                        })
-                    }
-                    value={query.modifiers?.optimizeProjections ?? response?.modifiers?.optimizeProjections}
-                />
-            </LemonLabel>
-            <LemonLabel className={labelClassName}>
-                <div>Use preaggregated intermediate:</div>
-                <LemonSelect
-                    options={[
-                        { value: true, label: 'true' },
-                        { value: false, label: 'false' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, usePreaggregatedIntermediateResults: value },
-                        })
-                    }
-                    value={
-                        query.modifiers?.usePreaggregatedIntermediateResults ??
-                        response?.modifiers?.usePreaggregatedIntermediateResults
-                    }
-                />
-            </LemonLabel>
-            <LemonLabel className={labelClassName}>
-                <div>Property Groups:</div>
-                <LemonSelect
-                    options={[
-                        { value: 'enabled', label: 'Enabled' },
-                        { value: 'disabled', label: 'Disabled' },
-                        { value: 'optimized', label: 'Enabled, with Optimizations' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, propertyGroupsMode: value },
-                        })
-                    }
-                    value={query.modifiers?.propertyGroupsMode ?? response?.modifiers?.propertyGroupsMode}
-                />
-            </LemonLabel>
-
-            <LemonLabel className={labelClassName}>
-                <div>Pre-aggregation transformation:</div>
-                <LemonSelect
-                    options={[
-                        { value: true, label: 'true' },
-                        { value: false, label: 'false' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, usePreaggregatedTableTransforms: value },
-                        })
-                    }
-                    value={
-                        query.modifiers?.usePreaggregatedTableTransforms ??
-                        response?.modifiers?.usePreaggregatedTableTransforms
-                    }
-                />
-            </LemonLabel>
-
-            <LemonLabel className={labelClassName}>
-                <div>Session table version:</div>
-                <LemonSelect<Exclude<HogQLQueryModifiers['sessionTableVersion'], undefined>>
-                    options={[
-                        { value: 'auto', label: 'auto' },
-                        { value: 'v1', label: 'v1' },
-                        { value: 'v2', label: 'v2' },
-                        { value: 'v3', label: 'v3' },
-                    ]}
-                    onChange={(value) =>
-                        setQuery({
-                            ...query,
-                            modifiers: { ...query.modifiers, sessionTableVersion: value },
-                        })
-                    }
-                    value={query.modifiers?.sessionTableVersion ?? response?.modifiers?.sessionTableVersion ?? 'auto'}
-                />
-            </LemonLabel>
+        <div className="deprecated-space-y-2">
+            <div className="flex flex-wrap gap-2">
+                <ConnectionIdModifier labelClassName={labelClassName} query={query} setQuery={setQuery} />
+                <LemonLabel className={labelClassName}>
+                    <div>POE:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: 'disabled', label: 'Disabled' },
+                            {
+                                value: 'person_id_no_override_properties_on_events',
+                                label: 'Properties: Events, Person ID: Events',
+                            },
+                            {
+                                value: 'person_id_override_properties_on_events',
+                                label: 'Properties: Events, Person ID: Overrides (v2)',
+                            },
+                            {
+                                value: 'person_id_override_properties_joined',
+                                label: 'Properties: Person, Person ID: Overrides (v3)',
+                            },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, personsOnEventsMode: value },
+                            })
+                        }
+                        value={query.modifiers?.personsOnEventsMode ?? response?.modifiers?.personsOnEventsMode}
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>Persons ArgMax:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: 'v1', label: 'V1' },
+                            { value: 'v2', label: 'V2' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, personsArgMaxVersion: value },
+                            })
+                        }
+                        value={query.modifiers?.personsArgMaxVersion ?? response?.modifiers?.personsArgMaxVersion}
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>In Cohort Via:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: 'auto', label: 'auto' },
+                            { value: 'leftjoin', label: 'leftjoin' },
+                            { value: 'subquery', label: 'subquery' },
+                            { value: 'leftjoin_conjoined', label: 'leftjoin conjoined' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, inCohortVia: value },
+                            })
+                        }
+                        value={query.modifiers?.inCohortVia ?? response?.modifiers?.inCohortVia}
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>Materialization Mode:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: 'auto', label: 'auto' },
+                            { value: 'legacy_null_as_string', label: 'legacy_null_as_string' },
+                            { value: 'legacy_null_as_null', label: 'legacy_null_as_null' },
+                            { value: 'disabled', label: 'disabled' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, materializationMode: value },
+                            })
+                        }
+                        value={query.modifiers?.materializationMode ?? response?.modifiers?.materializationMode}
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>Optimize joined filters:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: true, label: 'true' },
+                            { value: false, label: 'false' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, optimizeJoinedFilters: value },
+                            })
+                        }
+                        value={query.modifiers?.optimizeJoinedFilters ?? response?.modifiers?.optimizeJoinedFilters}
+                    />
+                </LemonLabel>
+            </div>
+            <div className="flex flex-wrap gap-2">
+                <LemonLabel className={labelClassName}>
+                    <div>Projection pushdown:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: true, label: 'true' },
+                            { value: false, label: 'false' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, optimizeProjections: value },
+                            })
+                        }
+                        value={query.modifiers?.optimizeProjections ?? response?.modifiers?.optimizeProjections}
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>Use preaggregated intermediate:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: true, label: 'true' },
+                            { value: false, label: 'false' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, usePreaggregatedIntermediateResults: value },
+                            })
+                        }
+                        value={
+                            query.modifiers?.usePreaggregatedIntermediateResults ??
+                            response?.modifiers?.usePreaggregatedIntermediateResults
+                        }
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>Property Groups:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: 'enabled', label: 'Enabled' },
+                            { value: 'disabled', label: 'Disabled' },
+                            { value: 'optimized', label: 'Enabled, with Optimizations' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, propertyGroupsMode: value },
+                            })
+                        }
+                        value={query.modifiers?.propertyGroupsMode ?? response?.modifiers?.propertyGroupsMode}
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>Pre-aggregation transformation:</div>
+                    <LemonSelect
+                        fullWidth
+                        options={[
+                            { value: true, label: 'true' },
+                            { value: false, label: 'false' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, usePreaggregatedTableTransforms: value },
+                            })
+                        }
+                        value={
+                            query.modifiers?.usePreaggregatedTableTransforms ??
+                            response?.modifiers?.usePreaggregatedTableTransforms
+                        }
+                    />
+                </LemonLabel>
+                <LemonLabel className={labelClassName}>
+                    <div>Session table version:</div>
+                    <LemonSelect<Exclude<HogQLQueryModifiers['sessionTableVersion'], undefined>>
+                        fullWidth
+                        options={[
+                            { value: 'auto', label: 'auto' },
+                            { value: 'v1', label: 'v1' },
+                            { value: 'v2', label: 'v2' },
+                            { value: 'v3', label: 'v3' },
+                        ]}
+                        onChange={(value) =>
+                            setQuery({
+                                ...query,
+                                modifiers: { ...query.modifiers, sessionTableVersion: value },
+                            })
+                        }
+                        value={
+                            query.modifiers?.sessionTableVersion ?? response?.modifiers?.sessionTableVersion ?? 'auto'
+                        }
+                    />
+                </LemonLabel>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/debug/QueryTabs.test.ts
+++ b/frontend/src/scenes/debug/QueryTabs.test.ts
@@ -1,0 +1,37 @@
+import { NodeKind } from '~/queries/schema/schema-general'
+
+import { getExecutedQueryTabLabel } from './QueryTabs'
+
+describe('getExecutedQueryTabLabel', () => {
+    it('keeps the clickhouse label for regular HogQL queries', () => {
+        expect(
+            getExecutedQueryTabLabel({
+                kind: NodeKind.HogQLQuery,
+                query: 'SELECT 1',
+            })
+        ).toEqual('Clickhouse')
+    })
+
+    it('shows raw sql for direct-source HogQL queries', () => {
+        expect(
+            getExecutedQueryTabLabel({
+                kind: NodeKind.HogQLQuery,
+                query: 'SELECT 1',
+                connectionId: 'postgres-connection-id',
+            })
+        ).toEqual('Raw SQL')
+    })
+
+    it('shows raw sql when a data table wraps a direct-source HogQL query', () => {
+        expect(
+            getExecutedQueryTabLabel({
+                kind: NodeKind.DataTableNode,
+                source: {
+                    kind: NodeKind.HogQLQuery,
+                    query: 'SELECT 1',
+                    connectionId: 'postgres-connection-id',
+                },
+            } as any)
+        ).toEqual('Raw SQL')
+    })
+})

--- a/frontend/src/scenes/debug/QueryTabs.test.ts
+++ b/frontend/src/scenes/debug/QueryTabs.test.ts
@@ -1,37 +1,37 @@
-import { NodeKind } from '~/queries/schema/schema-general'
+import { DataTableNode, HogQLQuery, NodeKind } from '~/queries/schema/schema-general'
 
 import { getExecutedQueryTabLabel } from './QueryTabs'
 
 describe('getExecutedQueryTabLabel', () => {
     it('keeps the clickhouse label for regular HogQL queries', () => {
-        expect(
-            getExecutedQueryTabLabel({
-                kind: NodeKind.HogQLQuery,
-                query: 'SELECT 1',
-            })
-        ).toEqual('Clickhouse')
+        const query: HogQLQuery = {
+            kind: NodeKind.HogQLQuery,
+            query: 'SELECT 1',
+        }
+
+        expect(getExecutedQueryTabLabel(query)).toEqual('Clickhouse')
     })
 
     it('shows raw sql for direct-source HogQL queries', () => {
-        expect(
-            getExecutedQueryTabLabel({
-                kind: NodeKind.HogQLQuery,
-                query: 'SELECT 1',
-                connectionId: 'postgres-connection-id',
-            })
-        ).toEqual('Raw SQL')
+        const query: HogQLQuery = {
+            kind: NodeKind.HogQLQuery,
+            query: 'SELECT 1',
+            connectionId: 'postgres-connection-id',
+        }
+
+        expect(getExecutedQueryTabLabel(query)).toEqual('Raw SQL')
     })
 
     it('shows raw sql when a data table wraps a direct-source HogQL query', () => {
-        expect(
-            getExecutedQueryTabLabel({
-                kind: NodeKind.DataTableNode,
-                source: {
-                    kind: NodeKind.HogQLQuery,
-                    query: 'SELECT 1',
-                    connectionId: 'postgres-connection-id',
-                },
-            } as any)
-        ).toEqual('Raw SQL')
+        const query: DataTableNode = {
+            kind: NodeKind.DataTableNode,
+            source: {
+                kind: NodeKind.HogQLQuery,
+                query: 'SELECT 1',
+                connectionId: 'postgres-connection-id',
+            },
+        }
+
+        expect(getExecutedQueryTabLabel(query)).toEqual('Raw SQL')
     })
 })

--- a/frontend/src/scenes/debug/QueryTabs.tsx
+++ b/frontend/src/scenes/debug/QueryTabs.tsx
@@ -10,7 +10,7 @@ import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { Timings } from '~/queries/nodes/DataNode/ElapsedTime'
 import { Query } from '~/queries/Query/Query'
 import { HogQLMetadataResponse, InsightVizNode, Node, NodeKind, QueryTiming } from '~/queries/schema/schema-general'
-import { isDataTableNode, isInsightQueryNode, isInsightVizNode } from '~/queries/utils'
+import { isDataTableNode, isHogQLQuery, isInsightQueryNode, isInsightVizNode } from '~/queries/utils'
 
 import { QueryLogTable } from './QueryLogTable'
 
@@ -36,6 +36,17 @@ function toLine(hogql: string, position: number): number {
 function toColumn(hogql: string, position: number): number {
     return toLineColumn(hogql, position).column
 }
+
+export function getExecutedQueryTabLabel(query: Node): string {
+    const hogQLQuery = isHogQLQuery(query)
+        ? query
+        : (isDataTableNode(query) || isInsightVizNode(query)) && isHogQLQuery(query.source)
+          ? query.source
+          : null
+
+    return hogQLQuery?.connectionId ? 'Raw SQL' : 'Clickhouse'
+}
+
 interface QueryTabsProps<Q extends Node> {
     query: Q
     queryKey: `new-${string}`
@@ -141,10 +152,10 @@ export function QueryTabs<Q extends Node>({
                   key: 'clickhouse',
                   label: (
                       <>
-                          Clickhouse
-                          {clickHouseTime && (
+                          {getExecutedQueryTabLabel(query)}
+                          {clickHouseTime ? (
                               <LemonTag className="ml-2">{Math.floor(clickHouseTime * 10) / 10}s</LemonTag>
-                          )}
+                          ) : null}
                       </>
                   ),
                   content: (


### PR DESCRIPTION
## Problem

The `/debug` URL only supports clickhouse queries.

## Changes

Add the connection ID dropdown, plus break the modifiers into two rows.
<img width="1334" height="1258" alt="image" src="https://github.com/user-attachments/assets/46b79a95-a1aa-4b45-a5bb-daeb26494f9e" />


## How did you test this code?

👀 

## Publish to changelog?
no
## Docs update
no