### PR TITLE
feat(signals): Signals list API changes for Code inbox

### DIFF
--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -73,7 +73,7 @@ Defined in `backend/temporal/buffer.py`.
 
 - New signals arrive via `@workflow.signal` (`submit_signal`), sent by `SignalEmitterWorkflow` instances.
 - Exposes `@workflow.query` (`get_buffer_size`) so emitters can implement backpressure by polling buffer occupancy before sending.
-- The main loop waits for signals, then waits until either the buffer reaches `BUFFER_MAX_SIZE` (20) or `BUFFER_FLUSH_TIMEOUT_SECONDS` (60s) elapses since the first signal arrived.
+- The main loop waits for signals, then waits until either the buffer reaches `BUFFER_MAX_SIZE` (20) or `BUFFER_FLUSH_TIMEOUT_SECONDS` (5s) elapses since the first signal arrived.
 - On flush: drains the buffer, runs the **safety filter** on all signals in parallel via `safety_filter_activity` (drops signals classified as unsafe — prompt injection, data exfiltration, etc.), then writes the safe signals to S3 at `signals/signal_batches/<uuid>` via `flush_signals_to_s3_activity`, then sends the object key to the grouping v2 workflow via `signal_with_start_grouping_v2_activity` (which creates the grouping workflow if not already running). If the entire batch is unsafe, the flush and grouping steps are skipped.
 - If the buffer is already full again after flushing (signals arrived during the flush activities), loops immediately to flush again rather than `continue_as_new` (avoids losing throughput to workflow restart).
 - Otherwise calls `continue_as_new`, carrying over any signals that arrived between drain and now via `BufferSignalsInput.pending_signals`.
@@ -526,8 +526,8 @@ Signal {index}:
 | `MAX_RESPONSE_TOKENS`          | `4096`                        | Base max tokens for LLM responses (thinking uses 3× for max_tokens, 2× for budget) |
 | Embedding model                | `text-embedding-3-small-1536` | OpenAI embedding model used for signal content                                     |
 | Task queue                     | `VIDEO_EXPORT_TASK_QUEUE`     | Temporal task queue for all workflows                                              |
-| `BUFFER_MAX_SIZE`              | `100`                         | Max signals buffered in memory before flush to S3                                  |
-| `BUFFER_FLUSH_TIMEOUT_SECONDS` | `60`                          | Max seconds to wait for buffer to fill before flushing                             |
+| `BUFFER_MAX_SIZE`              | `20`                          | Max signals buffered in memory before flush to S3                                  |
+| `BUFFER_FLUSH_TIMEOUT_SECONDS` | `5`                           | Max seconds to wait for buffer to fill before flushing                             |
 | S3 prefix                      | `signals/signal_batches/`     | Object storage path for signal batch files (cleaned up by S3 lifecycle policies)   |
 
 ---

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -148,6 +148,8 @@ class SignalReportSerializer(serializers.ModelSerializer):
             data = json.loads(art.content)
         except (json.JSONDecodeError, TypeError, ValueError):
             return None
+        if not isinstance(data, dict):
+            return None
         p = data.get("priority")
         return p if isinstance(p, str) else None
 

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -111,6 +111,9 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
 
 class SignalReportSerializer(serializers.ModelSerializer):
     artefact_count = serializers.IntegerField(read_only=True)
+    priority = serializers.SerializerMethodField(
+        help_text="P0–P4 from the latest actionability judgment artefact (when present).",
+    )
 
     class Meta:
         model = SignalReport
@@ -125,8 +128,28 @@ class SignalReportSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
             "artefact_count",
+            "priority",
         ]
         read_only_fields = fields
+
+    def get_priority(self, obj: SignalReport) -> str | None:
+        prefetched = getattr(obj, "prefetched_actionability_artefacts", None)
+        if prefetched is not None:
+            art = prefetched[0] if prefetched else None
+        else:
+            art = (
+                obj.artefacts.filter(type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT)
+                .order_by("-created_at")
+                .first()
+            )
+        if art is None:
+            return None
+        try:
+            data = json.loads(art.content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        p = data.get("priority")
+        return p if isinstance(p, str) else None
 
 
 class SignalReportArtefactSerializer(serializers.ModelSerializer):

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -133,12 +133,12 @@ class SignalReportSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_priority(self, obj: SignalReport) -> str | None:
-        prefetched = getattr(obj, "prefetched_actionability_artefacts", None)
+        prefetched = getattr(obj, "prefetched_priority_artefacts", None)
         if prefetched is not None:
             art = prefetched[0] if prefetched else None
         else:
             art = (
-                obj.artefacts.filter(type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT)
+                obj.artefacts.filter(type=SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT)
                 .order_by("-created_at")
                 .first()
             )

--- a/products/signals/backend/temporal/buffer.py
+++ b/products/signals/backend/temporal/buffer.py
@@ -24,7 +24,7 @@ logger = structlog.get_logger(__name__)
 
 # TODO: Check if the size of the buffer doesn't overload memory for the Temporal workflow handling the batch
 BUFFER_MAX_SIZE = 20
-BUFFER_FLUSH_TIMEOUT_SECONDS = 60
+BUFFER_FLUSH_TIMEOUT_SECONDS = 5
 
 OBJECT_STORAGE_SIGNALS_PREFIX = "signals/signal_batches"
 

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from urllib.parse import urlencode
 
 from posthog.test.base import APIBaseTest
 
@@ -76,11 +77,14 @@ class TestSignalReportDeleteAPI(APIBaseTest):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-class TestSignalReportPriorityInListAPI(APIBaseTest):
-    """GET list exposes `priority` from the latest ACTIONABILITY_JUDGMENT artefact (see SignalReportSerializer)."""
+class TestSignalReportListAPI(APIBaseTest):
+    """GET list/retrieve: `priority` from actionability artefacts; `ordering` (comma-separated, e.g. `pipeline,-total_weight`)."""
 
-    def _list_url(self) -> str:
-        return f"/api/projects/{self.team.id}/signal_reports/"
+    def _list_url(self, **query) -> str:
+        base = f"/api/projects/{self.team.id}/signal_reports/"
+        if not query:
+            return base
+        return f"{base}?{urlencode(query)}"
 
     def _create_report(self, **kwargs) -> SignalReport:
         defaults = {
@@ -117,6 +121,8 @@ class TestSignalReportPriorityInListAPI(APIBaseTest):
         else:
             art.save()
         return art
+
+    # --- priority ---
 
     def test_list_includes_priority_from_actionability_artefact(self):
         report = self._create_report()
@@ -183,3 +189,78 @@ class TestSignalReportPriorityInListAPI(APIBaseTest):
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["priority"] == "P0"
+
+    # --- ordering ---
+
+    def test_ready_before_candidate_even_if_candidate_has_higher_weight(self):
+        """With `pipeline` first, stage dominates; then `-total_weight`."""
+        low_ready = self._create_report(
+            title="Ready",
+            summary="s",
+            signal_count=1,
+            total_weight=1.0,
+        )
+        high_candidate = self._create_report(
+            status=SignalReport.Status.CANDIDATE,
+            title="Candidate",
+            summary="s",
+            signal_count=1,
+            total_weight=99.0,
+        )
+        response = self.client.get(
+            self._list_url(
+                status="ready,candidate",
+                ordering="pipeline,-total_weight",
+            )
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.json()["results"]]
+        assert ids.index(str(low_ready.id)) < ids.index(str(high_candidate.id))
+
+    def test_secondary_total_weight_within_same_status(self):
+        light = self._create_report(
+            title="A",
+            summary="s",
+            signal_count=1,
+            total_weight=1.0,
+        )
+        heavy = self._create_report(
+            title="B",
+            summary="s",
+            signal_count=1,
+            total_weight=10.0,
+        )
+        response = self.client.get(
+            self._list_url(
+                status="ready",
+                ordering="pipeline,-total_weight",
+            )
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.json()["results"]]
+        assert ids.index(str(heavy.id)) < ids.index(str(light.id))
+
+    def test_ordering_by_total_weight_only_crosses_pipeline(self):
+        """Without `pipeline`, `ordering=-total_weight` is a global sort by weight."""
+        low_ready = self._create_report(
+            title="Ready",
+            summary="s",
+            signal_count=1,
+            total_weight=1.0,
+        )
+        high_candidate = self._create_report(
+            status=SignalReport.Status.CANDIDATE,
+            title="Candidate",
+            summary="s",
+            signal_count=1,
+            total_weight=99.0,
+        )
+        response = self.client.get(
+            self._list_url(
+                status="ready,candidate",
+                ordering="-total_weight",
+            )
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.json()["results"]]
+        assert ids.index(str(high_candidate.id)) < ids.index(str(low_ready.id))

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -78,7 +78,7 @@ class TestSignalReportDeleteAPI(APIBaseTest):
 
 
 class TestSignalReportListAPI(APIBaseTest):
-    """GET list/retrieve: `priority` from actionability artefacts; `ordering` (comma-separated, e.g. `pipeline,-total_weight`)."""
+    """GET list/retrieve: `priority` from actionability artefacts; `ordering` (comma-separated, e.g. `status,-total_weight`)."""
 
     def _list_url(self, **query) -> str:
         base = f"/api/projects/{self.team.id}/signal_reports/"
@@ -193,7 +193,7 @@ class TestSignalReportListAPI(APIBaseTest):
     # --- ordering ---
 
     def test_ready_before_candidate_even_if_candidate_has_higher_weight(self):
-        """With `pipeline` first, stage dominates; then `-total_weight`."""
+        """With `status` first, stage rank dominates; then `-total_weight`."""
         low_ready = self._create_report(
             title="Ready",
             summary="s",
@@ -210,7 +210,7 @@ class TestSignalReportListAPI(APIBaseTest):
         response = self.client.get(
             self._list_url(
                 status="ready,candidate",
-                ordering="pipeline,-total_weight",
+                ordering="status,-total_weight",
             )
         )
         assert response.status_code == status.HTTP_200_OK
@@ -233,15 +233,15 @@ class TestSignalReportListAPI(APIBaseTest):
         response = self.client.get(
             self._list_url(
                 status="ready",
-                ordering="pipeline,-total_weight",
+                ordering="status,-total_weight",
             )
         )
         assert response.status_code == status.HTTP_200_OK
         ids = [r["id"] for r in response.json()["results"]]
         assert ids.index(str(heavy.id)) < ids.index(str(light.id))
 
-    def test_ordering_by_total_weight_only_crosses_pipeline(self):
-        """Without `pipeline`, `ordering=-total_weight` is a global sort by weight."""
+    def test_ordering_by_total_weight_only_crosses_status_rank(self):
+        """Without `status`, `ordering=-total_weight` is a global sort by weight."""
         low_ready = self._create_report(
             title="Ready",
             summary="s",

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -1,11 +1,16 @@
+import json
+from datetime import timedelta
+
 from posthog.test.base import APIBaseTest
+
+from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.team.team import Team
 
-from products.signals.backend.models import SignalReport
+from products.signals.backend.models import SignalReport, SignalReportArtefact
 
 
 class TestSignalReportDeleteAPI(APIBaseTest):
@@ -69,3 +74,112 @@ class TestSignalReportDeleteAPI(APIBaseTest):
         report = self._create_report(report_status=SignalReport.Status.DELETED)
         response = self.client.delete(self._url(str(report.id)))
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestSignalReportPriorityInListAPI(APIBaseTest):
+    """GET list exposes `priority` from the latest ACTIONABILITY_JUDGMENT artefact (see SignalReportSerializer)."""
+
+    def _list_url(self) -> str:
+        return f"/api/projects/{self.team.id}/signal_reports/"
+
+    def _create_report(self, **kwargs) -> SignalReport:
+        defaults = {
+            "team": self.team,
+            "status": SignalReport.Status.READY,
+            "title": "Test report",
+            "summary": "Test summary",
+            "signal_count": 3,
+            "total_weight": 1.5,
+        }
+        defaults.update(kwargs)
+        return SignalReport.objects.create(**defaults)
+
+    def _actionability_artefact(
+        self,
+        report: SignalReport,
+        *,
+        priority: str | None,
+        created_at=None,
+    ) -> SignalReportArtefact:
+        payload = {"choice": "immediately_actionable", "explanation": "x"}
+        if priority is not None:
+            payload["priority"] = priority
+        art = SignalReportArtefact(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+            content=json.dumps(payload),
+        )
+        if created_at is not None:
+            art.save()
+            SignalReportArtefact.objects.filter(pk=art.pk).update(created_at=created_at)
+            art.refresh_from_db()
+        else:
+            art.save()
+        return art
+
+    def test_list_includes_priority_from_actionability_artefact(self):
+        report = self._create_report()
+        self._actionability_artefact(report, priority="P2")
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        rows = response.json()["results"]
+        row = next(r for r in rows if r["id"] == str(report.id))
+        assert row["priority"] == "P2"
+
+    def test_list_uses_latest_actionability_artefact_by_created_at(self):
+        report = self._create_report()
+        now = timezone.now()
+        self._actionability_artefact(report, priority="P3", created_at=now - timedelta(hours=1))
+        self._actionability_artefact(report, priority="P1", created_at=now)
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["priority"] == "P1"
+
+    def test_list_priority_null_without_actionability_artefact(self):
+        report = self._create_report()
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["priority"] is None
+
+    def test_list_priority_null_when_artefact_json_invalid(self):
+        report = self._create_report()
+        SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+            content="not-json{",
+        )
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["priority"] is None
+
+    def test_list_priority_null_when_priority_not_a_string(self):
+        report = self._create_report()
+        SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+            content=json.dumps({"priority": 2}),
+        )
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["priority"] is None
+
+    def test_retrieve_includes_priority(self):
+        report = self._create_report()
+        self._actionability_artefact(report, priority="P0")
+
+        url = f"/api/projects/{self.team.id}/signal_reports/{report.id}/"
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["priority"] == "P0"

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -98,20 +98,20 @@ class TestSignalReportListAPI(APIBaseTest):
         defaults.update(kwargs)
         return SignalReport.objects.create(**defaults)
 
-    def _actionability_artefact(
+    def _priority_artefact(
         self,
         report: SignalReport,
         *,
         priority: str | None,
         created_at=None,
     ) -> SignalReportArtefact:
-        payload = {"choice": "immediately_actionable", "explanation": "x"}
+        payload = {"explanation": "x"}
         if priority is not None:
             payload["priority"] = priority
         art = SignalReportArtefact(
             team=self.team,
             report=report,
-            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+            type=SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT,
             content=json.dumps(payload),
         )
         if created_at is not None:
@@ -124,9 +124,9 @@ class TestSignalReportListAPI(APIBaseTest):
 
     # --- priority ---
 
-    def test_list_includes_priority_from_actionability_artefact(self):
+    def test_list_includes_priority_from_priority_artefact(self):
         report = self._create_report()
-        self._actionability_artefact(report, priority="P2")
+        self._priority_artefact(report, priority="P2")
 
         response = self.client.get(self._list_url())
         assert response.status_code == status.HTTP_200_OK
@@ -134,18 +134,18 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in rows if r["id"] == str(report.id))
         assert row["priority"] == "P2"
 
-    def test_list_uses_latest_actionability_artefact_by_created_at(self):
+    def test_list_uses_latest_priority_artefact_by_created_at(self):
         report = self._create_report()
         now = timezone.now()
-        self._actionability_artefact(report, priority="P3", created_at=now - timedelta(hours=1))
-        self._actionability_artefact(report, priority="P1", created_at=now)
+        self._priority_artefact(report, priority="P3", created_at=now - timedelta(hours=1))
+        self._priority_artefact(report, priority="P1", created_at=now)
 
         response = self.client.get(self._list_url())
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["priority"] == "P1"
 
-    def test_list_priority_null_without_actionability_artefact(self):
+    def test_list_priority_null_without_priority_artefact(self):
         report = self._create_report()
 
         response = self.client.get(self._list_url())
@@ -153,27 +153,22 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["priority"] is None
 
-    def test_list_priority_null_when_artefact_json_invalid(self):
+    @parameterized.expand(
+        [
+            ("invalid_json", "not-json{"),
+            ("json_null", "null"),
+            ("json_array", "[]"),
+            ("non_string_priority", json.dumps({"priority": 2})),
+            ("missing_priority_key", json.dumps({"choice": "immediately_actionable"})),
+        ]
+    )
+    def test_list_priority_null_for_bad_artefact_content(self, _name, content):
         report = self._create_report()
         SignalReportArtefact.objects.create(
             team=self.team,
             report=report,
-            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
-            content="not-json{",
-        )
-
-        response = self.client.get(self._list_url())
-        assert response.status_code == status.HTTP_200_OK
-        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
-        assert row["priority"] is None
-
-    def test_list_priority_null_when_priority_not_a_string(self):
-        report = self._create_report()
-        SignalReportArtefact.objects.create(
-            team=self.team,
-            report=report,
-            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
-            content=json.dumps({"priority": 2}),
+            type=SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT,
+            content=content,
         )
 
         response = self.client.get(self._list_url())
@@ -183,7 +178,7 @@ class TestSignalReportListAPI(APIBaseTest):
 
     def test_retrieve_includes_priority(self):
         report = self._create_report()
-        self._actionability_artefact(report, priority="P0")
+        self._priority_artefact(report, priority="P0")
 
         url = f"/api/projects/{self.team.id}/signal_reports/{report.id}/"
         response = self.client.get(url)

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -254,11 +254,9 @@ class SignalReportViewSet(
     permission_classes = [IsAuthenticated, APIScopePermission]
     scope_object = "task"
     queryset = SignalReport.objects.all()
-    _DEFAULT_SIGNAL_REPORT_ORDERING = "pipeline,-updated_at"
+    _DEFAULT_SIGNAL_REPORT_ORDERING = "status,-updated_at"
     _SIGNAL_REPORT_ORDERING_FIELDS: dict[str, str] = {
-        "pipeline": "pipeline_status_rank",
-        "pipeline_status_rank": "pipeline_status_rank",
-        "stage": "pipeline_status_rank",
+        "status": "pipeline_status_rank",
         "signal_count": "signal_count",
         "total_weight": "total_weight",
         "created_at": "created_at",
@@ -278,7 +276,7 @@ class SignalReportViewSet(
         search = self.request.query_params.get("search")
         if search:
             qs = qs.filter(Q(title__icontains=search) | Q(summary__icontains=search))
-        # `ordering` query param (comma-separated) lists DB columns; use `pipeline` for stage rank (ready first when asc).
+        # `ordering=status` uses semantic stage rank (annotation), not lexicographic `status` column order.
         qs = qs.annotate(
             pipeline_status_rank=Case(
                 When(status=SignalReport.Status.READY, then=Value(0)),

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -6,11 +6,11 @@ from typing import cast
 
 from django.conf import settings
 from django.db import IntegrityError
-from django.db.models import Count, Prefetch, Q
+from django.db.models import Case, Count, IntegerField, Prefetch, Q, Value, When
 
 from asgiref.sync import async_to_sync
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from rest_framework import filters, mixins, serializers, status, viewsets
+from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
@@ -254,9 +254,17 @@ class SignalReportViewSet(
     permission_classes = [IsAuthenticated, APIScopePermission]
     scope_object = "task"
     queryset = SignalReport.objects.all()
-    filter_backends = [filters.OrderingFilter]
-    ordering_fields = ["signal_count", "total_weight", "created_at", "updated_at"]
-    ordering = ["-signal_count"]
+    _DEFAULT_SIGNAL_REPORT_ORDERING = "pipeline,-updated_at"
+    _SIGNAL_REPORT_ORDERING_FIELDS: dict[str, str] = {
+        "pipeline": "pipeline_status_rank",
+        "pipeline_status_rank": "pipeline_status_rank",
+        "stage": "pipeline_status_rank",
+        "signal_count": "signal_count",
+        "total_weight": "total_weight",
+        "created_at": "created_at",
+        "updated_at": "updated_at",
+        "id": "id",
+    }
 
     def safely_get_queryset(self, queryset):
         qs = queryset.filter(team=self.team).annotate(artefact_count=Count("artefacts"))
@@ -270,6 +278,21 @@ class SignalReportViewSet(
         search = self.request.query_params.get("search")
         if search:
             qs = qs.filter(Q(title__icontains=search) | Q(summary__icontains=search))
+        # `ordering` query param (comma-separated) lists DB columns; use `pipeline` for stage rank (ready first when asc).
+        qs = qs.annotate(
+            pipeline_status_rank=Case(
+                When(status=SignalReport.Status.READY, then=Value(0)),
+                When(status=SignalReport.Status.PENDING_INPUT, then=Value(1)),
+                When(status=SignalReport.Status.IN_PROGRESS, then=Value(2)),
+                When(status=SignalReport.Status.CANDIDATE, then=Value(3)),
+                When(status=SignalReport.Status.POTENTIAL, then=Value(4)),
+                When(status=SignalReport.Status.FAILED, then=Value(5)),
+                When(status=SignalReport.Status.SUPPRESSED, then=Value(6)),
+                When(status=SignalReport.Status.DELETED, then=Value(7)),
+                default=Value(50),
+                output_field=IntegerField(),
+            )
+        )
         qs = qs.prefetch_related(
             Prefetch(
                 "artefacts",
@@ -280,6 +303,41 @@ class SignalReportViewSet(
             )
         )
         return qs
+
+    def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        return self._apply_signal_report_ordering(queryset)
+
+    def _parse_ordering_string(self, raw: str) -> list[str]:
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+        clauses: list[str] = []
+        for part in parts:
+            descending = part.startswith("-")
+            name = part[1:] if descending else part
+            db_field = self._SIGNAL_REPORT_ORDERING_FIELDS.get(name)
+            if db_field is None:
+                return self._default_signal_report_ordering_clauses
+            clause = f"-{db_field}" if descending else db_field
+            clauses.append(clause)
+        return clauses
+
+    @property
+    def _default_signal_report_ordering_clauses(self) -> list[str]:
+        return self._parse_ordering_string(self._DEFAULT_SIGNAL_REPORT_ORDERING)
+
+    def _parse_signal_report_ordering(self) -> list[str]:
+        raw = self.request.query_params.get("ordering", self._DEFAULT_SIGNAL_REPORT_ORDERING)
+        if not raw or not str(raw).strip():
+            return self._default_signal_report_ordering_clauses
+        clauses = self._parse_ordering_string(str(raw).strip())
+        return clauses if clauses else self._default_signal_report_ordering_clauses
+
+    def _apply_signal_report_ordering(self, queryset):
+        clauses = self._parse_signal_report_ordering()
+        has_id = any((c[1:] if c.startswith("-") else c) == "id" for c in clauses)
+        if not has_id:
+            clauses = [*clauses, "id"]
+        return queryset.order_by(*clauses)
 
     def get_serializer_context(self):
         return {**super().get_serializer_context(), "team": self.team}

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -6,7 +6,7 @@ from typing import cast
 
 from django.conf import settings
 from django.db import IntegrityError
-from django.db.models import Count, Q
+from django.db.models import Count, Prefetch, Q
 
 from asgiref.sync import async_to_sync
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -270,6 +270,15 @@ class SignalReportViewSet(
         search = self.request.query_params.get("search")
         if search:
             qs = qs.filter(Q(title__icontains=search) | Q(summary__icontains=search))
+        qs = qs.prefetch_related(
+            Prefetch(
+                "artefacts",
+                queryset=SignalReportArtefact.objects.filter(
+                    type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT
+                ).order_by("-created_at"),
+                to_attr="prefetched_actionability_artefacts",
+            )
+        )
         return qs
 
     def get_serializer_context(self):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -295,9 +295,9 @@ class SignalReportViewSet(
             Prefetch(
                 "artefacts",
                 queryset=SignalReportArtefact.objects.filter(
-                    type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT
+                    type=SignalReportArtefact.ArtefactType.PRIORITY_JUDGMENT
                 ).order_by("-created_at"),
-                to_attr="prefetched_actionability_artefacts",
+                to_attr="prefetched_priority_artefacts",
             )
         )
         return qs


### PR DESCRIPTION
## Problem

We're currently saving priority (P0-P4) on the actionability judgement artifact, and PostHog Code needs it on signal reports in list responses without fetching `/artefacts/` per report. Code also needs to fetch the reports not just by creation, but by their status in pipeline.

## Changes

`SignalReportSerializer` gets read-only `priority` field from the latest `ACTIONABILITY_JUDGMENT` artefact + gets more robust ordering, now by `status`.
To avoid N+1 we're doing artefact prefetching in the list endpoint.

Also, decreasing the buffer wait time from 60s to 5s, as discussed with Olly on Slack.

## How did you test this code?

Some new API tests.

## Publish to changelog?

do not publish to changelog