### PR TITLE
fix: guard trackFileSystemLogView against missing team ID during login

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -398,6 +398,10 @@ export class ApiConfig {
         return this._currentTeamId
     }
 
+    static hasCurrentTeamId(): boolean {
+        return !!this._currentTeamId
+    }
+
     static setCurrentTeamId(id: TeamType['id']): void {
         this._currentTeamId = id
     }

--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import api from 'lib/api'
+import api, { ApiConfig } from 'lib/api'
 
 type FileSystemLogViewType =
     | 'experiment'
@@ -25,6 +25,10 @@ interface TrackFileSystemLogViewOptions {
 
 export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileSystemLogViewOptions): void {
     if (!enabled || window.IMPERSONATED_SESSION || ref === null || ref === undefined) {
+        return
+    }
+
+    if (!ApiConfig.hasCurrentTeamId()) {
         return
     }
 

--- a/frontend/src/lib/hooks/useFileSystemLogView.ts
+++ b/frontend/src/lib/hooks/useFileSystemLogView.ts
@@ -24,11 +24,7 @@ interface TrackFileSystemLogViewOptions {
 }
 
 export function trackFileSystemLogView({ type, ref, enabled = true }: TrackFileSystemLogViewOptions): void {
-    if (!enabled || window.IMPERSONATED_SESSION || ref === null || ref === undefined) {
-        return
-    }
-
-    if (!ApiConfig.hasCurrentTeamId()) {
+    if (!enabled || window.IMPERSONATED_SESSION || ref === null || ref === undefined || !ApiConfig.hasCurrentTeamId()) {
         return
     }
 


### PR DESCRIPTION
## Problem

- After Google OAuth or 2FA login, users hit `Error: Team ID is not known.`
- `sceneLogic.setScene` calls `trackFileSystemLogView()` on every scene transition, including login/2FA scenes
- `trackFileSystemLogView` → `ApiRequest.environmentsDetail()` calls `ApiConfig.getCurrentTeamId()` which throws because `teamLogic` hasn't loaded yet
- [Error trace](https://us.posthog.com/project/2/error_tracking?searchQuery=Team%20ID%20is%20not%20known)

## Changes

- Add `ApiConfig.hasCurrentTeamId()` non-throwing check
- Guard `trackFileSystemLogView` to bail when team ID isn't available — fire-and-forget telemetry, safe to skip

## How did you test this code?

Traced from stack trace, verified TS compilation. Guard clause on fire-and-forget call — no behavioral change for authenticated users.

## Publish to changelog?

No