### PR TITLE
chore(llma): Add error trend visualization to LLM Analytics errors tab

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsErrors.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsErrors.tsx
@@ -1,7 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconCopy } from '@posthog/icons'
+import { IconCopy, IconTrends } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
@@ -10,6 +10,7 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
+import { type InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
@@ -21,7 +22,8 @@ export function LLMAnalyticsErrors(): JSX.Element {
     const sharedLogic = useMountedLogic(llmAnalyticsSharedLogic)
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
     const { setErrorsSort } = useActions(llmAnalyticsErrorsLogic)
-    const { errorsQuery, errorsSort } = useValues(llmAnalyticsErrorsLogic)
+    const { errorsQuery, errorsSort, buildErrorTrendQuery, buildAllErrorsTrendQuery } =
+        useValues(llmAnalyticsErrorsLogic)
     const { searchParams } = useValues(router)
 
     const { renderSortableColumnTitle } = useSortableColumns(errorsSort, setErrorsSort)
@@ -45,6 +47,20 @@ export function LLMAnalyticsErrors(): JSX.Element {
                 setPropertyFilters(filters.properties || [])
             }}
             context={{
+                customActions: [
+                    <Tooltip title="View error trends over time" key="trends">
+                        <LemonButton
+                            icon={<IconTrends />}
+                            size="small"
+                            type="secondary"
+                            to={urls.insightNew({ query: buildAllErrorsTrendQuery })}
+                            targetBlank
+                            data-attr="llma-errors-all-trends-click"
+                        >
+                            Error trends
+                        </LemonButton>
+                    </Tooltip>,
+                ],
                 columns: {
                     error: {
                         renderTitle: () => (
@@ -93,6 +109,20 @@ export function LLMAnalyticsErrors(): JSX.Element {
                                         >
                                             {displayValue}
                                         </Link>
+                                    </Tooltip>
+                                    <Tooltip title={`View ${displayValue} trend over time`}>
+                                        <LemonButton
+                                            icon={<IconTrends />}
+                                            size="xsmall"
+                                            to={urls.insightNew({
+                                                query: {
+                                                    kind: NodeKind.InsightVizNode,
+                                                    source: buildErrorTrendQuery(errorString),
+                                                } as InsightVizNode,
+                                            })}
+                                            targetBlank
+                                            data-attr="llma-errors-trend-click"
+                                        />
                                     </Tooltip>
                                     <LemonButton
                                         size="xsmall"

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsErrorsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsErrorsLogic.ts
@@ -3,8 +3,8 @@ import { actions, connect, kea, key, path, props, reducers, selectors } from 'ke
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { groupsModel } from '~/models/groupsModel'
-import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter } from '~/types'
+import { DataTableNode, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
 import errorsQueryTemplate from '../../backend/queries/errors.sql?raw'
 import { SortDirection, SortState, llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
@@ -98,6 +98,98 @@ export const llmAnalyticsErrorsLogic = kea<llmAnalyticsErrorsLogicType>([
                     allowSorting: true,
                 }
             },
+        ],
+        buildErrorTrendQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): ((errorName: string) => TrendsQuery) => {
+                return (errorName: string): TrendsQuery => ({
+                    kind: NodeKind.TrendsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: [
+                        ...propertyFilters,
+                        {
+                            key: '$ai_is_error',
+                            operator: PropertyOperator.Exact,
+                            value: 'true',
+                            type: PropertyFilterType.Event,
+                        },
+                        {
+                            key: '$ai_error_normalized',
+                            operator: PropertyOperator.Exact,
+                            value: errorName,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_generation',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_span',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_embedding',
+                        },
+                    ],
+                })
+            },
+        ],
+        buildAllErrorsTrendQuery: [
+            (s) => [s.dateFilter, s.shouldFilterTestAccounts, s.propertyFilters],
+            (
+                dateFilter: { dateFrom: string | null; dateTo: string | null },
+                shouldFilterTestAccounts: boolean,
+                propertyFilters: AnyPropertyFilter[]
+            ): InsightVizNode => ({
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    dateRange: {
+                        date_from: dateFilter.dateFrom || null,
+                        date_to: dateFilter.dateTo || null,
+                    },
+                    filterTestAccounts: shouldFilterTestAccounts,
+                    properties: [
+                        ...propertyFilters,
+                        {
+                            key: '$ai_is_error',
+                            operator: PropertyOperator.Exact,
+                            value: 'true',
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_generation',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_span',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_embedding',
+                        },
+                    ],
+                    breakdownFilter: {
+                        breakdown: '$ai_error_normalized',
+                        breakdown_type: 'event',
+                        breakdown_limit: 10,
+                    },
+                },
+            }),
         ],
     }),
 ])

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsErrorsLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsErrorsLogic.ts
@@ -139,6 +139,10 @@ export const llmAnalyticsErrorsLogic = kea<llmAnalyticsErrorsLogicType>([
                         },
                         {
                             kind: NodeKind.EventsNode,
+                            event: '$ai_trace',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
                             event: '$ai_embedding',
                         },
                     ],
@@ -177,6 +181,10 @@ export const llmAnalyticsErrorsLogic = kea<llmAnalyticsErrorsLogicType>([
                         {
                             kind: NodeKind.EventsNode,
                             event: '$ai_span',
+                        },
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$ai_trace',
                         },
                         {
                             kind: NodeKind.EventsNode,


### PR DESCRIPTION
## Problem

Users viewing the LLM Analytics errors tab need a way to visualize error trends over time. Currently, the errors table only shows aggregate error counts without temporal context, making it difficult to understand error patterns and trends.

## Changes

Added trend visualization capabilities to the LLM Analytics errors interface:

1. **New query builders in `llmAnalyticsErrorsLogic.ts`**:
   - `buildErrorTrendQuery`: Creates a TrendsQuery for a specific error, filtering by `$ai_is_error=true` and `$ai_error_normalized={errorName}`, tracking three event types ($ai_generation, $ai_span, $ai_embedding)
   - `buildAllErrorsTrendQuery`: Creates an InsightVizNode that visualizes all errors over time with breakdown by `$ai_error_normalized` (limited to top 10)

2. **UI enhancements in `LLMAnalyticsErrors.tsx`**:
   - Added "Error trends" button in the table header that opens a trends visualization for all errors
   - Added trend icon button next to each individual error in the table that opens a trends visualization for that specific error
   - Imported necessary icons (`IconTrends`) and types (`InsightVizNode`)
   - Both buttons open insights in a new tab for non-disruptive exploration

## How did you test this code?

Code review of the implementation:
- Verified query structure matches expected TrendsQuery and InsightVizNode schemas
- Confirmed property filters are correctly applied (error status, error name, test account filtering)
- Validated button placement and navigation URLs are properly constructed
- Checked that all necessary imports and type definitions are in place

https://claude.ai/code/session_01ExNkzCK87T73eTMGEcqwek