### PR TITLE
fix(experiments): Disable test account filters for data warehouse metric previews

### DIFF
--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -828,6 +828,12 @@ export function getEventCountQuery(metric: ExperimentMetric, filterTestAccounts:
         return null
     }
 
+    // Data warehouse tables don't support test account filters — those filters
+    // reference the events table (e.g. events.properties.*), which doesn't exist
+    // on a DW table and causes "Unable to resolve field: events". This matches
+    // product analytics behavior, where the toggle is disabled for DW sources.
+    const isDWQuery = series.some((s) => s.kind === NodeKind.DataWarehouseNode)
+
     return {
         kind: NodeKind.TrendsQuery,
         series,
@@ -841,7 +847,7 @@ export function getEventCountQuery(metric: ExperimentMetric, filterTestAccounts:
             explicitDate: false,
         },
         interval: 'day',
-        filterTestAccounts,
+        filterTestAccounts: isDWQuery ? false : filterTestAccounts,
     }
 }
 


### PR DESCRIPTION
## Problem

When selecting a data warehouse table as an experiment metric, the preview component fails with "Unable to resolve field: events". The metric form's event count preview sends a TrendsQuery with `filterTestAccounts: true`, but test account filters reference `events.properties.*` which doesn't exist on DW tables.

## Changes

Skip test account filters for data warehouse sources in the preview query. Matches product analytics behavior where the toggle is disabled for DW sources.

## How did you test this code?
Didn't test it locally, will test in prod.