### PR TITLE
fix: redirect to login with error instead of 500 on expired OAuth invite

### DIFF
--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -59,6 +59,8 @@ export const ERROR_MESSAGES: Record<string, string | JSX.Element> = {
     // our catch-all case, so the message is generic
     sso_enforced: "Please log in with your organization's required SSO method.",
     oauth_cancelled: "Sign in was cancelled. Please try again when you're ready.",
+    invalid_invite:
+        'This invite link is no longer valid. It may have expired or been revoked. Please ask your administrator for a new invite.',
 }
 
 const LAST_LOGIN_METHOD_COOKIE = 'ph_last_login_method'

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -651,11 +651,7 @@ def process_social_invite_signup(
         try:
             invite = TeamInviteSurrogate(invite_id)
         except Team.DoesNotExist:
-            raise ValidationError(
-                "Team does not exist",
-                code="invalid_invite",
-                params={"source": "social_create_user"},
-            )
+            return redirect("/login?error_code=invalid_invite")
 
     if user:
         invite.validate(user=user, email=email)

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -9,6 +9,7 @@ from django.contrib.auth import login, password_validation
 from django.contrib.sessions.backends.base import SessionBase, UpdateError
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
+from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls.base import reverse
 
@@ -641,7 +642,7 @@ def lookup_invite_for_saml(email: str, organization_domain_id: str) -> Optional[
 
 def process_social_invite_signup(
     strategy: DjangoStrategy, invite_id: str, email: str, full_name: str, user: Optional[User] = None
-) -> User:
+) -> Union[User, HttpResponseRedirect]:
     try:
         # nosemgrep: idor-lookup-without-org (invite UUID from server session serves as auth token)
         invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -641,7 +641,7 @@ def lookup_invite_for_saml(email: str, organization_domain_id: str) -> Optional[
 
 def process_social_invite_signup(
     strategy: DjangoStrategy, invite_id: str, email: str, full_name: str, user: Optional[User] = None
-) -> Union[User, bool]:
+) -> Optional[User]:
     try:
         # nosemgrep: idor-lookup-without-org (invite UUID from server session serves as auth token)
         invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(
@@ -651,7 +651,7 @@ def process_social_invite_signup(
         try:
             invite = TeamInviteSurrogate(invite_id)
         except Team.DoesNotExist:
-            return False
+            return None
 
     if user:
         invite.validate(user=user, email=email)
@@ -807,10 +807,9 @@ def social_create_user(
 
     if invite_id:
         from_invite = True
-        invite_result = process_social_invite_signup(strategy, invite_id, email, full_name)
-        if invite_result is False:
+        user = process_social_invite_signup(strategy, invite_id, email, full_name)
+        if user is None:
             return redirect("/login?error_code=invalid_invite")
-        user = invite_result
 
     else:
         # JIT Provisioning?

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -782,9 +782,7 @@ def social_create_user(
             user.save()
 
         if invite_id:
-            result = process_social_invite_signup(strategy, invite_id, user.email, user.first_name, user)
-            if isinstance(result, HttpResponseRedirect):
-                return result
+            process_social_invite_signup(strategy, invite_id, user.email, user.first_name, user)
         else:
             process_social_domain_jit_provisioning_signup(strategy, user.email, user.first_name, user)
 

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -808,10 +808,9 @@ def social_create_user(
 
     if invite_id:
         from_invite = True
-        result = process_social_invite_signup(strategy, invite_id, email, full_name)
-        if isinstance(result, HttpResponseRedirect):
-            return result
-        user = result
+        user = process_social_invite_signup(strategy, invite_id, email, full_name)
+        if isinstance(user, HttpResponseRedirect):
+            return user
 
     else:
         # JIT Provisioning?

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -9,7 +9,6 @@ from django.contrib.auth import login, password_validation
 from django.contrib.sessions.backends.base import SessionBase, UpdateError
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
-from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls.base import reverse
 
@@ -642,7 +641,7 @@ def lookup_invite_for_saml(email: str, organization_domain_id: str) -> Optional[
 
 def process_social_invite_signup(
     strategy: DjangoStrategy, invite_id: str, email: str, full_name: str, user: Optional[User] = None
-) -> Union[User, HttpResponseRedirect]:
+) -> Union[User, bool]:
     try:
         # nosemgrep: idor-lookup-without-org (invite UUID from server session serves as auth token)
         invite: Union[OrganizationInvite, TeamInviteSurrogate] = OrganizationInvite.objects.select_related(
@@ -652,7 +651,7 @@ def process_social_invite_signup(
         try:
             invite = TeamInviteSurrogate(invite_id)
         except Team.DoesNotExist:
-            return redirect("/login?error_code=invalid_invite")
+            return False
 
     if user:
         invite.validate(user=user, email=email)
@@ -809,8 +808,8 @@ def social_create_user(
     if invite_id:
         from_invite = True
         user = process_social_invite_signup(strategy, invite_id, email, full_name)
-        if isinstance(user, HttpResponseRedirect):
-            return user
+        if user is False:
+            return redirect("/login?error_code=invalid_invite")
 
     else:
         # JIT Provisioning?

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -807,9 +807,10 @@ def social_create_user(
 
     if invite_id:
         from_invite = True
-        user = process_social_invite_signup(strategy, invite_id, email, full_name)
-        if user is False:
+        invite_result = process_social_invite_signup(strategy, invite_id, email, full_name)
+        if invite_result is False:
             return redirect("/login?error_code=invalid_invite")
+        user = invite_result
 
     else:
         # JIT Provisioning?

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -782,7 +782,9 @@ def social_create_user(
             user.save()
 
         if invite_id:
-            process_social_invite_signup(strategy, invite_id, user.email, user.first_name, user)
+            result = process_social_invite_signup(strategy, invite_id, user.email, user.first_name, user)
+            if isinstance(result, HttpResponseRedirect):
+                return result
         else:
             process_social_domain_jit_provisioning_signup(strategy, user.email, user.first_name, user)
 
@@ -808,7 +810,10 @@ def social_create_user(
 
     if invite_id:
         from_invite = True
-        user = process_social_invite_signup(strategy, invite_id, email, full_name)
+        result = process_social_invite_signup(strategy, invite_id, email, full_name)
+        if isinstance(result, HttpResponseRedirect):
+            return result
+        user = result
 
     else:
         # JIT Provisioning?

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -2347,7 +2347,7 @@ class TestInviteSignupAPI(APIBaseTest):
         # AND then
         self.assertEqual(response.json()["detail"], f"/login?next=/signup/{invite.id}")
 
-    def test_process_social_invite_signup_returns_false_for_nonexistent_invite(self):
+    def test_process_social_invite_signup_returns_none_for_nonexistent_invite(self):
         nonexistent_id = str(uuid.uuid4())
         result = process_social_invite_signup(mock.MagicMock(), nonexistent_id, "test@example.com", "Test User")
-        self.assertFalse(result)
+        self.assertIsNone(result)

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -17,7 +17,7 @@ from django.utils import timezone
 
 from rest_framework import status
 
-from posthog.api.signup import _save_session_with_recovery
+from posthog.api.signup import _save_session_with_recovery, process_social_invite_signup
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.constants import AvailableFeature
 from posthog.models import Dashboard, Organization, Team, User
@@ -2346,3 +2346,8 @@ class TestInviteSignupAPI(APIBaseTest):
 
         # AND then
         self.assertEqual(response.json()["detail"], f"/login?next=/signup/{invite.id}")
+
+    def test_process_social_invite_signup_returns_false_for_nonexistent_invite(self):
+        nonexistent_id = str(uuid.uuid4())
+        result = process_social_invite_signup(mock.MagicMock(), nonexistent_id, "test@example.com", "Test User")
+        self.assertFalse(result)


### PR DESCRIPTION
## Problem

- When a user completes Google OAuth with an expired/revoked invite, `process_social_invite_signup` raises `ValidationError` which python-social-auth doesn't handle, resulting in a 500 crash page (~43 occurrences in 48h)

## Changes

- Replace `raise ValidationError` with `return redirect("/login?error_code=invalid_invite")`, matching the existing pattern for other social auth failures
- Add `invalid_invite` error message to the login page

## How did you test this code?

Traced from production logs. Follows the same redirect pattern used by `jit_not_enabled` and `no_new_organizations` error codes.

## Publish to changelog?

No