### PR TITLE
feat: rewrite supporthog name and image

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -622,6 +622,8 @@ export interface ConversationsSettings {
     slack_channel_id?: string | null
     slack_channel_name?: string | null
     slack_ticket_emoji?: string | null
+    slack_bot_icon_url?: string | null
+    slack_bot_display_name?: string | null
     email_enabled?: boolean
 }
 

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -649,6 +649,24 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         # Integration state is managed only by dedicated endpoints, not user input
         for managed_key in ("slack_bot_token", "slack_team_id", "slack_enabled", "email_enabled"):
             value.pop(managed_key, None)
+        icon_url = value.get("slack_bot_icon_url")
+        if icon_url is not None:
+            if not isinstance(icon_url, str):
+                raise serializers.ValidationError({"slack_bot_icon_url": "Must be a string."})
+            icon_url = icon_url.strip()
+            value["slack_bot_icon_url"] = icon_url or None
+            if icon_url and not icon_url.startswith("https://"):
+                raise serializers.ValidationError({"slack_bot_icon_url": "Must be an HTTPS URL."})
+        display_name = value.get("slack_bot_display_name")
+        if display_name is not None:
+            if not isinstance(display_name, str):
+                raise serializers.ValidationError({"slack_bot_display_name": "Must be a string."})
+            display_name = display_name.strip()
+            value["slack_bot_display_name"] = display_name or None
+            if display_name and (len(display_name) > 200 or any(ord(c) < 32 for c in display_name)):
+                raise serializers.ValidationError(
+                    {"slack_bot_display_name": "Must be 200 characters or fewer with no control characters."}
+                )
         return value
 
     def validate_slack_incoming_webhook(self, value: str | None) -> str | None:

--- a/products/conversations/backend/api/slack_oauth.py
+++ b/products/conversations/backend/api/slack_oauth.py
@@ -28,6 +28,7 @@ SUPPORTHOG_SLACK_SCOPE = ",".join(
         "channels:history",
         "channels:read",
         "chat:write",
+        "chat:write.customize",
         "groups:history",
         "groups:read",
         "reactions:read",

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -463,31 +463,39 @@ def create_or_update_slack_ticket(
 
     # Post a confirmation reply in the Slack thread
     ticket_url = f"{settings.SITE_URL}/project/{team_id}/support/tickets/{ticket.id}"
+    support_settings = team.conversations_settings or {}
+    confirmation_kwargs: dict = {
+        "channel": slack_channel_id,
+        "thread_ts": thread_ts,
+        "text": f"Ticket #{ticket.ticket_number} created.",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f":ticket: Ticket #{ticket.ticket_number} created",
+                },
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "View in PostHog", "emoji": True},
+                        "url": ticket_url,
+                    }
+                ],
+            },
+        ],
+    }
+    bot_display_name = support_settings.get("slack_bot_display_name")
+    bot_icon_url = support_settings.get("slack_bot_icon_url")
+    if bot_display_name:
+        confirmation_kwargs["username"] = bot_display_name
+    if bot_icon_url:
+        confirmation_kwargs["icon_url"] = bot_icon_url
     try:
-        client.chat_postMessage(
-            channel=slack_channel_id,
-            thread_ts=thread_ts,
-            text=f"Ticket #{ticket.ticket_number} created.",
-            blocks=[
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f":ticket: Ticket #{ticket.ticket_number} created",
-                    },
-                },
-                {
-                    "type": "actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "View in PostHog", "emoji": True},
-                            "url": ticket_url,
-                        }
-                    ],
-                },
-            ],
-        )
+        client.chat_postMessage(**confirmation_kwargs)
     except Exception:
         logger.warning("slack_support_confirmation_failed", ticket_id=str(ticket.id))
 

--- a/products/conversations/backend/support_slack.py
+++ b/products/conversations/backend/support_slack.py
@@ -137,6 +137,8 @@ def clear_supporthog_slack_token(
 
     settings = team.conversations_settings or {}
     settings["slack_enabled"] = False
+    settings.pop("slack_bot_display_name", None)
+    settings.pop("slack_bot_icon_url", None)
     team.conversations_settings = settings
 
     with transaction.atomic():

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -117,13 +117,18 @@ def post_reply_to_slack(
         image_count=len(rich_images),
     )
 
-    # Build message kwargs with optional avatar
+    support_settings = team.conversations_settings or {}
+    bot_display_name = support_settings.get("slack_bot_display_name")
+    bot_icon_url = support_settings.get("slack_bot_icon_url")
+
     message_kwargs: dict = {
         "channel": slack_channel_id,
         "thread_ts": slack_thread_ts,
         "text": slack_text,
-        "username": author_name or "Support",
+        "username": author_name or bot_display_name or "Support",
     }
+    if bot_icon_url:
+        message_kwargs["icon_url"] = bot_icon_url
     if slack_blocks:
         message_kwargs["blocks"] = slack_blocks
 
@@ -190,12 +195,15 @@ def post_reply_to_slack(
             unique_urls = [url for url in dict.fromkeys(failed_image_urls) if url]
             if unique_urls:
                 fallback_text = "Images:\n" + "\n".join(unique_urls)
-                client.chat_postMessage(
-                    channel=slack_channel_id,
-                    thread_ts=slack_thread_ts,
-                    text=fallback_text,
-                    username=author_name or "Support",
-                )
+                fallback_kwargs: dict = {
+                    "channel": slack_channel_id,
+                    "thread_ts": slack_thread_ts,
+                    "text": fallback_text,
+                    "username": author_name or bot_display_name or "Support",
+                }
+                if bot_icon_url:
+                    fallback_kwargs["icon_url"] = bot_icon_url
+                client.chat_postMessage(**fallback_kwargs)
                 logger.warning(
                     "🖼️ slack_reply_image_upload_fallback_links_posted",
                     ticket_id=ticket_id,

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -127,7 +127,7 @@ def post_reply_to_slack(
         "text": slack_text,
         "username": author_name or bot_display_name or "Support",
     }
-    if bot_icon_url:
+    if not author_name and bot_icon_url:
         message_kwargs["icon_url"] = bot_icon_url
     if slack_blocks:
         message_kwargs["blocks"] = slack_blocks
@@ -201,7 +201,7 @@ def post_reply_to_slack(
                     "text": fallback_text,
                     "username": author_name or bot_display_name or "Support",
                 }
-                if bot_icon_url:
+                if not author_name and bot_icon_url:
                     fallback_kwargs["icon_url"] = bot_icon_url
                 client.chat_postMessage(**fallback_kwargs)
                 logger.warning(

--- a/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
+++ b/products/conversations/frontend/scenes/settings/SupportSettingsScene.tsx
@@ -299,6 +299,10 @@ function SlackChannelSection(): JSX.Element {
         slackChannelsLoading,
         slackTicketEmoji,
         slackTicketEmojiValue,
+        slackBotIconUrl,
+        slackBotIconUrlValue,
+        slackBotDisplayName,
+        slackBotDisplayNameValue,
     } = useValues(supportSettingsLogic)
     const {
         connectSlack,
@@ -306,6 +310,9 @@ function SlackChannelSection(): JSX.Element {
         loadSlackChannelsWithToken,
         setSlackTicketEmojiValue,
         saveSlackTicketEmoji,
+        setSlackBotIconUrlValue,
+        setSlackBotDisplayNameValue,
+        saveSlackBotSettings,
         disconnectSlack,
     } = useActions(supportSettingsLogic)
 
@@ -386,6 +393,47 @@ function SlackChannelSection(): JSX.Element {
                                 size="small"
                                 onClick={saveSlackTicketEmoji}
                                 disabledReason={!slackTicketEmojiValue ? 'Enter an emoji name' : undefined}
+                            >
+                                Save
+                            </LemonButton>
+                        </div>
+                    </div>
+                    <LemonDivider />
+                    <div className="flex flex-col gap-2">
+                        <div>
+                            <label className="font-medium">Bot appearance</label>
+                            <p className="text-xs text-muted-alt">
+                                Override the bot's display name and icon when posting messages. Leave blank to use
+                                defaults. Requires the bot to be re-authorized if it was connected before this feature
+                                was available.
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <LemonInput
+                                value={slackBotDisplayNameValue ?? slackBotDisplayName ?? ''}
+                                onChange={setSlackBotDisplayNameValue}
+                                placeholder="Display name (e.g. SupportHog)"
+                                className="flex-1"
+                            />
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <LemonInput
+                                value={slackBotIconUrlValue ?? slackBotIconUrl ?? ''}
+                                onChange={setSlackBotIconUrlValue}
+                                placeholder="Icon URL (e.g. https://example.com/icon.png)"
+                                className="flex-1"
+                            />
+                        </div>
+                        <div>
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                onClick={saveSlackBotSettings}
+                                disabledReason={
+                                    slackBotDisplayNameValue === null && slackBotIconUrlValue === null
+                                        ? 'No changes to save'
+                                        : undefined
+                                }
                             >
                                 Save
                             </LemonButton>

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -355,17 +355,17 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             }
         },
         saveSlackBotSettings: () => {
-            const iconUrl = values.slackBotIconUrlValue
-            const displayName = values.slackBotDisplayNameValue
+            const iconUrl = values.slackBotIconUrlValue?.trim()
+            const displayName = values.slackBotDisplayNameValue?.trim()
             if (iconUrl && !iconUrl.startsWith('https://')) {
                 lemonToast.error('Icon URL must start with https://')
                 return
             }
             const updates: Record<string, string | null> = {}
-            if (iconUrl !== null) {
+            if (values.slackBotIconUrlValue !== null) {
                 updates.slack_bot_icon_url = iconUrl || null
             }
-            if (displayName !== null) {
+            if (values.slackBotDisplayNameValue !== null) {
                 updates.slack_bot_display_name = displayName || null
             }
             if (Object.keys(updates).length > 0) {

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -44,6 +44,9 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         loadSlackChannelsWithToken: true,
         setSlackTicketEmojiValue: (value: string | null) => ({ value }),
         saveSlackTicketEmoji: true,
+        setSlackBotIconUrlValue: (value: string | null) => ({ value }),
+        setSlackBotDisplayNameValue: (value: string | null) => ({ value }),
+        saveSlackBotSettings: true,
         disconnectSlack: true,
         // Email channel settings
         setEmailFromEmail: (value: string) => ({ value }),
@@ -157,6 +160,18 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 setSlackTicketEmojiValue: (_, { value }) => value,
             },
         ],
+        slackBotIconUrlValue: [
+            null as string | null,
+            {
+                setSlackBotIconUrlValue: (_, { value }) => value,
+            },
+        ],
+        slackBotDisplayNameValue: [
+            null as string | null,
+            {
+                setSlackBotDisplayNameValue: (_, { value }) => value,
+            },
+        ],
     }),
     loaders(({ values }) => ({
         slackChannels: [
@@ -202,6 +217,14 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         slackConnected: [
             (s) => [s.currentTeam],
             (currentTeam): boolean => !!currentTeam?.conversations_settings?.slack_enabled,
+        ],
+        slackBotIconUrl: [
+            (s) => [s.currentTeam],
+            (currentTeam): string | null => currentTeam?.conversations_settings?.slack_bot_icon_url ?? null,
+        ],
+        slackBotDisplayName: [
+            (s) => [s.currentTeam],
+            (currentTeam): string | null => currentTeam?.conversations_settings?.slack_bot_display_name ?? null,
         ],
         emailConnected: [
             (s) => [s.currentTeam],
@@ -331,6 +354,30 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 lemonToast.success('Ticket emoji saved')
             }
         },
+        saveSlackBotSettings: () => {
+            const iconUrl = values.slackBotIconUrlValue
+            const displayName = values.slackBotDisplayNameValue
+            if (iconUrl && !iconUrl.startsWith('https://')) {
+                lemonToast.error('Icon URL must start with https://')
+                return
+            }
+            const updates: Record<string, string | null> = {}
+            if (iconUrl !== null) {
+                updates.slack_bot_icon_url = iconUrl || null
+            }
+            if (displayName !== null) {
+                updates.slack_bot_display_name = displayName || null
+            }
+            if (Object.keys(updates).length > 0) {
+                actions.updateCurrentTeam({
+                    conversations_settings: {
+                        ...values.currentTeam?.conversations_settings,
+                        ...updates,
+                    },
+                })
+                lemonToast.success('Bot settings saved')
+            }
+        },
         loadEmailStatus: async () => {
             try {
                 const response = await api.get('api/conversations/v1/email/status')
@@ -406,6 +453,8 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                     slack_channel_id: null,
                     slack_channel_name: null,
                     slack_ticket_emoji: null,
+                    slack_bot_icon_url: null,
+                    slack_bot_display_name: null,
                 },
             })
             lemonToast.success('Slack disconnected')
@@ -416,6 +465,8 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             actions.setIdentificationFormDescriptionValue(null)
             actions.setPlaceholderTextValue(null)
             actions.setSlackTicketEmojiValue(null)
+            actions.setSlackBotIconUrlValue(null)
+            actions.setSlackBotDisplayNameValue(null)
         },
     })),
     afterMount(({ values, actions }) => {


### PR DESCRIPTION
Let's make SupportHog slack bot name and image configurable