### PR TITLE
fix(error-tracking): use decompressed byte count for cymbal cache memory accounting

### DIFF
--- a/rust/common/symbol_data/src/lib.rs
+++ b/rust/common/symbol_data/src/lib.rs
@@ -8,6 +8,7 @@ pub use error::Error as SymbolDataError;
 
 // The core data type
 pub use symbol_data::read_as as read_symbol_data;
+pub use symbol_data::read_as_with_byte_count as read_symbol_data_with_byte_count;
 pub use symbol_data::write as write_symbol_data;
 pub use symbol_data::write_uncompressed as write_symbol_data_uncompressed;
 

--- a/rust/common/symbol_data/src/symbol_data.rs
+++ b/rust/common/symbol_data/src/symbol_data.rs
@@ -87,13 +87,25 @@ pub fn read_as<T>(data: Vec<u8>) -> Result<T, Error>
 where
     T: SymbolData,
 {
+    read_as_with_byte_count(data).map(|(v, _)| v)
+}
+
+/// Like `read_as`, but also returns the decompressed payload byte count.
+/// This is useful for cache memory accounting when the container uses compression,
+/// since the compressed size can be much smaller than the actual data in memory.
+pub fn read_as_with_byte_count<T>(data: Vec<u8>) -> Result<(T, usize), Error>
+where
+    T: SymbolData,
+{
     let version = read_version(&data)?;
 
     match version {
         V1_VERSION => {
             assert_at_least_as_long_as(v1_header_len(), data.len())?;
             assert_data_type_impl(&data, T::data_type())?;
-            T::from_bytes(data[v1_header_len()..].to_vec())
+            let payload = data[v1_header_len()..].to_vec();
+            let byte_count = payload.len();
+            T::from_bytes(payload).map(|v| (v, byte_count))
         }
         VERSION => {
             assert_at_least_as_long_as(v2_header_len(), data.len())?;
@@ -112,7 +124,8 @@ where
                     out
                 }
             };
-            T::from_bytes(decompressed)
+            let byte_count = decompressed.len();
+            T::from_bytes(decompressed).map(|v| (v, byte_count))
         }
         other => Err(Error::WrongVersion(other, VERSION)),
     }

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -9,11 +9,11 @@ use symbolic::demangle::{Demangle, DemangleOptions};
 use symbolic::symcache::{SymCache, SymCacheConverter};
 use zip::ZipArchive;
 
-use posthog_symbol_data::{read_symbol_data, AppleDsym};
+use posthog_symbol_data::{read_symbol_data_with_byte_count, AppleDsym};
 
 use crate::{
     error::{AppleError, ResolveError},
-    symbol_store::{Fetcher, Parser},
+    symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
 /// Manifest format for source files bundled in the dSYM ZIP under `__source/`
@@ -30,6 +30,14 @@ pub struct ParsedAppleSymbols {
     /// Source file contents indexed by DWARF absolute path.
     /// None if the bundle doesn't contain source files.
     sources: Option<HashMap<String, String>>,
+    /// Decompressed byte count from the symbol_data container, used for cache memory accounting.
+    decompressed_bytes: usize,
+}
+
+impl Countable for ParsedAppleSymbols {
+    fn byte_count(&self) -> usize {
+        self.decompressed_bytes
+    }
 }
 
 pub struct AppleProvider {}
@@ -57,16 +65,23 @@ impl Parser for AppleProvider {
     async fn parse(&self, source: Self::Source) -> Result<ParsedAppleSymbols, ResolveError> {
         // Try to unwrap symbol_data container first (new format),
         // fall back to raw ZIP for backward compatibility with existing uploads
-        let zip_data = match read_symbol_data::<AppleDsym>(source.clone()) {
-            Ok(dsym) => dsym.data,
-            Err(_) => source,
-        };
-        ParsedAppleSymbols::from_dsym_zip(zip_data)
+        let (zip_data, decompressed_bytes) =
+            match read_symbol_data_with_byte_count::<AppleDsym>(source.clone()) {
+                Ok((dsym, bytes)) => (dsym.data, bytes),
+                Err(_) => {
+                    let len = source.len();
+                    (source, len)
+                }
+            };
+        ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
     }
 }
 
 impl ParsedAppleSymbols {
-    pub fn from_dsym_zip(zip_data: Vec<u8>) -> Result<Self, ResolveError> {
+    pub fn from_dsym_zip(
+        zip_data: Vec<u8>,
+        decompressed_bytes: usize,
+    ) -> Result<Self, ResolveError> {
         let cursor = Cursor::new(zip_data);
         let mut archive =
             ZipArchive::new(cursor).map_err(|e| AppleError::ParseError(e.to_string()))?;
@@ -81,6 +96,7 @@ impl ParsedAppleSymbols {
         Ok(Self {
             symcache_data,
             sources,
+            decompressed_bytes,
         })
     }
 

--- a/rust/cymbal/src/symbol_store/caching.rs
+++ b/rust/cymbal/src/symbol_store/caching.rs
@@ -8,7 +8,7 @@ use crate::metric_consts::{
     STORE_CACHE_MISSES,
 };
 
-use super::{saving::Saveable, Fetcher, Parser, Provider};
+use super::{Fetcher, Parser, Provider};
 
 // This is a type-specific symbol provider layer, designed to
 // wrap some inner provider and provide a type-safe caching layer
@@ -24,8 +24,8 @@ impl<P> Caching<P>
 where
     P: Fetcher + Parser<Source = P::Fetched, Err = <P as Fetcher>::Err>,
     P::Ref: ToString + Send,
-    P::Fetched: Countable + Send,
-    P::Set: Any + Send + Sync,
+    P::Fetched: Send,
+    P::Set: Countable + Any + Send + Sync,
 {
     pub fn new(inner: P, cache: Arc<Mutex<SymbolSetCache>>) -> Self {
         Self { inner, cache }
@@ -37,8 +37,8 @@ impl<P> Provider for Caching<P>
 where
     P: Fetcher + Parser<Source = P::Fetched, Err = <P as Fetcher>::Err>,
     P::Ref: ToString + Send,
-    P::Fetched: Countable + Send,
-    P::Set: Any + Send + Sync,
+    P::Fetched: Send,
+    P::Set: Countable + Any + Send + Sync,
 {
     type Ref = P::Ref;
     type Set = P::Set;
@@ -61,8 +61,8 @@ where
         // the outer layer, which is not something the interface
         // guarentees)
         let found = self.inner.fetch(team_id, r).await?;
-        let bytes = found.byte_count();
         let parsed = self.inner.parse(found).await?;
+        let bytes = parsed.byte_count();
 
         let mut cache = self.cache.lock().await; // Re-acquire the cache-wide lock to insert, dropping the ref_lock
 
@@ -167,11 +167,5 @@ pub trait Countable {
 impl Countable for Vec<u8> {
     fn byte_count(&self) -> usize {
         self.len()
-    }
-}
-
-impl Countable for Saveable {
-    fn byte_count(&self) -> usize {
-        self.data.len()
     }
 }

--- a/rust/cymbal/src/symbol_store/hermesmap.rs
+++ b/rust/cymbal/src/symbol_store/hermesmap.rs
@@ -1,14 +1,22 @@
 use async_trait::async_trait;
-use posthog_symbol_data::{read_symbol_data, HermesMap};
+use posthog_symbol_data::{read_symbol_data_with_byte_count, HermesMap};
 
 use crate::{
     error::{HermesError, ResolveError},
     langs::hermes::HermesRef,
-    symbol_store::{Fetcher, Parser},
+    symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
 pub struct ParsedHermesMap {
     pub map: sourcemap::SourceMapHermes,
+    /// Decompressed byte count from the symbol_data container, used for cache memory accounting.
+    decompressed_bytes: usize,
+}
+
+impl Countable for ParsedHermesMap {
+    fn byte_count(&self) -> usize {
+        self.decompressed_bytes
+    }
 }
 
 pub struct HermesMapProvider {}
@@ -31,16 +39,21 @@ impl Parser for HermesMapProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Vec<u8>) -> Result<ParsedHermesMap, Self::Err> {
-        let map: HermesMap = read_symbol_data(source).map_err(HermesError::DataError)?;
-        Ok(ParsedHermesMap::parse(map)?)
+        let (map, decompressed_bytes): (HermesMap, usize) =
+            read_symbol_data_with_byte_count(source).map_err(HermesError::DataError)?;
+        Ok(ParsedHermesMap::parse(map, decompressed_bytes)?)
     }
 }
 
 impl ParsedHermesMap {
-    pub fn parse(map: HermesMap) -> Result<ParsedHermesMap, HermesError> {
+    pub fn parse(
+        map: HermesMap,
+        decompressed_bytes: usize,
+    ) -> Result<ParsedHermesMap, HermesError> {
         Ok(ParsedHermesMap {
             map: sourcemap::SourceMapHermes::from_reader(map.sourcemap.as_bytes())
                 .map_err(|e| HermesError::InvalidMap(e.to_string()))?,
+            decompressed_bytes,
         })
     }
 }

--- a/rust/cymbal/src/symbol_store/proguard.rs
+++ b/rust/cymbal/src/symbol_store/proguard.rs
@@ -1,15 +1,23 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use posthog_symbol_data::{read_symbol_data, ProguardMapping};
+use posthog_symbol_data::{read_symbol_data_with_byte_count, ProguardMapping};
 
 use crate::{
     error::{ProguardError, ResolveError},
-    symbol_store::{Fetcher, Parser},
+    symbol_store::{caching::Countable, Fetcher, Parser},
 };
 
 pub struct FetchedMapping {
     inner: ProguardMapping,
+    /// Decompressed byte count from the symbol_data container, used for cache memory accounting.
+    decompressed_bytes: usize,
+}
+
+impl Countable for FetchedMapping {
+    fn byte_count(&self) -> usize {
+        self.decompressed_bytes
+    }
 }
 
 pub struct ProguardProvider {}
@@ -40,20 +48,24 @@ impl Parser for ProguardProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<FetchedMapping, ResolveError> {
-        let map: ProguardMapping = read_symbol_data(source).map_err(ProguardError::DataError)?;
-        Ok(FetchedMapping::new(map)?)
+        let (map, decompressed_bytes): (ProguardMapping, usize) =
+            read_symbol_data_with_byte_count(source).map_err(ProguardError::DataError)?;
+        Ok(FetchedMapping::new(map, decompressed_bytes)?)
     }
 }
 
 impl FetchedMapping {
-    pub fn new(inner: ProguardMapping) -> Result<Self, ProguardError> {
+    pub fn new(inner: ProguardMapping, decompressed_bytes: usize) -> Result<Self, ProguardError> {
         // Map construction is basically free, so we hold onto the underlying data
         // and re-construct it as needed
         let mapping = proguard::ProguardMapping::new(inner.content.as_bytes());
         if !mapping.is_valid() {
             return Err(ProguardError::InvalidMapping);
         }
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            decompressed_bytes,
+        })
     }
 
     pub fn get_mapper<'a>(&'a self) -> proguard::ProguardMapper<'a> {

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -2,9 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use base64::Engine;
-use posthog_symbol_data::{
-    read_symbol_data_with_byte_count, write_symbol_data, SourceAndMap,
-};
+use posthog_symbol_data::{read_symbol_data_with_byte_count, write_symbol_data, SourceAndMap};
 use reqwest::Url;
 use symbolic::sourcemapcache::{SourceMapCache, SourceMapCacheWriter};
 use tracing::{info, warn};

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -2,7 +2,9 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use base64::Engine;
-use posthog_symbol_data::{read_symbol_data, write_symbol_data, SourceAndMap};
+use posthog_symbol_data::{
+    read_symbol_data_with_byte_count, write_symbol_data, SourceAndMap,
+};
 use reqwest::Url;
 use symbolic::sourcemapcache::{SourceMapCache, SourceMapCacheWriter};
 use tracing::{info, warn};
@@ -16,7 +18,7 @@ use crate::{
     },
 };
 
-use super::{dart_minified_names::parse_dart_minified_names, Fetcher, Parser};
+use super::{caching::Countable, dart_minified_names::parse_dart_minified_names, Fetcher, Parser};
 
 pub struct SourcemapProvider {
     pub client: reqwest::Client,
@@ -31,6 +33,8 @@ pub struct OwnedSourceMapCache {
     /// dart2js minified names mapping (minified -> original) for Flutter Web support.
     /// Parsed from the x_org_dartlang_dart2js.minified_names.global extension.
     dart_minified_names: Option<HashMap<String, String>>,
+    /// Decompressed byte count from the symbol_data container, used for cache memory accounting.
+    decompressed_bytes: usize,
 }
 
 impl OwnedSourceMapCache {
@@ -38,14 +42,17 @@ impl OwnedSourceMapCache {
         // Pass-through parse once to assert we're given valid data, so the unwrap below
         // is safe.
         SourceMapCache::parse(&data)?;
+        let decompressed_bytes = data.len();
         Ok(Self {
             data,
             dart_minified_names: None,
+            decompressed_bytes,
         })
     }
 
     pub fn from_source_and_map(
         sam: SourceAndMap,
+        decompressed_bytes: usize,
     ) -> Result<Self, symbolic::sourcemapcache::SourceMapCacheWriterError> {
         // Parse dart2js minified names before we lose access to the raw JSON
         let dart_minified_names = parse_dart_minified_names(&sam.sourcemap);
@@ -56,6 +63,7 @@ impl OwnedSourceMapCache {
         Ok(Self {
             data,
             dart_minified_names,
+            decompressed_bytes,
         })
     }
 
@@ -68,6 +76,12 @@ impl OwnedSourceMapCache {
     /// Used for remapping Flutter Web minified exception types like "minified:BA".
     pub fn get_dart_minified_names(&self) -> Option<&HashMap<String, String>> {
         self.dart_minified_names.as_ref()
+    }
+}
+
+impl Countable for OwnedSourceMapCache {
+    fn byte_count(&self) -> usize {
+        self.decompressed_bytes
     }
 }
 
@@ -143,8 +157,9 @@ impl Parser for SourcemapProvider {
     type Err = ResolveError;
     async fn parse(&self, data: Vec<u8>) -> Result<Self::Set, Self::Err> {
         let start = common_metrics::timing_guard(SOURCEMAP_PARSE, &[]);
-        let sam: SourceAndMap = read_symbol_data(data).map_err(JsResolveErr::JSDataError)?;
-        let smc = OwnedSourceMapCache::from_source_and_map(sam)
+        let (sam, decompressed_bytes): (SourceAndMap, usize) =
+            read_symbol_data_with_byte_count(data).map_err(JsResolveErr::JSDataError)?;
+        let smc = OwnedSourceMapCache::from_source_and_map(sam, decompressed_bytes)
             .map_err(|_| JsResolveErr::InvalidSourceAndMap)?;
 
         start.label("success", "true").fin();

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -154,8 +154,9 @@ async fn sourcemap_nulls_dont_go_on_frames() {
     let frame: RawFrame = serde_json::from_str(content).unwrap();
 
     let jsdata_bytes = include_bytes!("static/sourcemap_with_nulls.jsdata").to_vec();
-    let data: SourceAndMap = read_symbol_data(jsdata_bytes).unwrap();
-    let smc = OwnedSourceMapCache::from_source_and_map(data).unwrap();
+    let data: SourceAndMap = read_symbol_data(jsdata_bytes.clone()).unwrap();
+    let decompressed_bytes = jsdata_bytes.len();
+    let smc = OwnedSourceMapCache::from_source_and_map(data, decompressed_bytes).unwrap();
     let c = smc.get_smc();
 
     let RawFrame::JavaScriptWeb(frame) = frame else {

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -18,7 +18,7 @@ use cymbal::{
     types::{RawErrProps, Stacktrace},
 };
 use httpmock::MockServer;
-use posthog_symbol_data::{read_symbol_data, SourceAndMap};
+use posthog_symbol_data::{read_symbol_data_with_byte_count, SourceAndMap};
 use symbolic::sourcemapcache::SourcePosition;
 use tokio::sync::Mutex;
 
@@ -154,8 +154,8 @@ async fn sourcemap_nulls_dont_go_on_frames() {
     let frame: RawFrame = serde_json::from_str(content).unwrap();
 
     let jsdata_bytes = include_bytes!("static/sourcemap_with_nulls.jsdata").to_vec();
-    let data: SourceAndMap = read_symbol_data(jsdata_bytes.clone()).unwrap();
-    let decompressed_bytes = jsdata_bytes.len();
+    let (data, decompressed_bytes): (SourceAndMap, usize) =
+        read_symbol_data_with_byte_count(jsdata_bytes).unwrap();
     let smc = OwnedSourceMapCache::from_source_and_map(data, decompressed_bytes).unwrap();
     let c = smc.get_smc();
 


### PR DESCRIPTION
## Problem

After zstd compression was added to the symbol_data container format (#51484), cymbal's symbol set cache started tracking **compressed** byte sizes while storing **decompressed and parsed** objects. This caused the cache to underestimate actual memory usage by 5-20x, preventing eviction from triggering in time and leading to OOM events.

## Changes

- Added `read_symbol_data_with_byte_count` to the `posthog-symbol-data` crate, which returns the decompressed payload size alongside the parsed data
- Changed the `Caching` layer to measure byte count on the **parsed** type (`P::Set: Countable`) instead of the fetched data (`P::Fetched: Countable`)
- Each parsed symbol type now stores the decompressed byte count and implements `Countable`:
  - `OwnedSourceMapCache` (JS sourcemaps)
  - `ParsedAppleSymbols` (dSYM)
  - `ParsedHermesMap` (React Native Hermes)
  - `FetchedMapping` (Proguard)
- Removed the now-unused `Countable` impl for `Saveable`

## How did you test this code?

- All existing cymbal tests pass (19 tests)
- All posthog-symbol-data tests pass (7 tests)

## Publish to changelog?

no