### PR TITLE
feat: add predicate support to PostgresTable

### DIFF
--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -203,6 +203,9 @@ class Table(FieldOrTable):
     def to_printed_hogql(self) -> str:
         raise NotImplementedError("Table.to_printed_hogql not overridden")
 
+    def get_predicates(self) -> list[Expr]:
+        return []
+
     def avoid_asterisk_fields(self) -> list[str]:
         return []
 

--- a/posthog/hogql/database/postgres_table.py
+++ b/posthog/hogql/database/postgres_table.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
 
@@ -8,6 +8,9 @@ from posthog.hogql.escape_sql import escape_hogql_identifier
 
 from posthog.person_db_router import PERSONS_DB_MODELS
 from posthog.scopes import APIScopeObject
+
+if TYPE_CHECKING:
+    from posthog.hogql import ast
 
 
 def build_function_call(postgres_table_name: str, context: Optional[HogQLContext] = None):
@@ -64,6 +67,7 @@ class PostgresTable(FunctionCallTable):
     requires_args: bool = False
     postgres_table_name: str
     access_scope: Optional[APIScopeObject] = None
+    predicates: list["ast.Expr"] = []
 
     def to_printed_hogql(self):
         return escape_hogql_identifier(self.name)

--- a/posthog/hogql/database/postgres_table.py
+++ b/posthog/hogql/database/postgres_table.py
@@ -1,16 +1,14 @@
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from django.conf import settings
 
+from posthog.hogql.base import Expr
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import FunctionCallTable
 from posthog.hogql.escape_sql import escape_hogql_identifier
 
 from posthog.person_db_router import PERSONS_DB_MODELS
 from posthog.scopes import APIScopeObject
-
-if TYPE_CHECKING:
-    from posthog.hogql import ast
 
 
 def build_function_call(postgres_table_name: str, context: Optional[HogQLContext] = None):
@@ -67,7 +65,10 @@ class PostgresTable(FunctionCallTable):
     requires_args: bool = False
     postgres_table_name: str
     access_scope: Optional[APIScopeObject] = None
-    predicates: list["ast.Expr"] = []
+    predicates: list[Expr] = []
+
+    def get_predicates(self) -> list[Expr]:
+        return self.predicates
 
     def to_printed_hogql(self):
         return escape_hogql_identifier(self.name)

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -12,6 +12,7 @@ from posthog.hogql.database.models import (
     TableNode,
 )
 from posthog.hogql.database.postgres_table import PostgresTable
+from posthog.hogql.parser import parse_expr
 
 
 class IngestionWarningsTable(Table):
@@ -472,6 +473,7 @@ notebooks: PostgresTable = PostgresTable(
 data_modeling_jobs: PostgresTable = PostgresTable(
     name="data_modeling_jobs",
     postgres_table_name="posthog_datamodelingjob",
+    predicates=[parse_expr("created_at >= today() - interval 30 day")],
     fields={
         "id": StringDatabaseField(name="id"),
         "team_id": IntegerDatabaseField(name="team_id"),

--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -12,7 +12,6 @@ from posthog.hogql.database.models import (
     TableNode,
 )
 from posthog.hogql.database.postgres_table import PostgresTable
-from posthog.hogql.parser import parse_expr
 
 
 class IngestionWarningsTable(Table):
@@ -473,7 +472,6 @@ notebooks: PostgresTable = PostgresTable(
 data_modeling_jobs: PostgresTable = PostgresTable(
     name="data_modeling_jobs",
     postgres_table_name="posthog_datamodelingjob",
-    predicates=[parse_expr("created_at >= today() - interval 30 day")],
     fields={
         "id": StringDatabaseField(name="id"),
         "team_id": IntegerDatabaseField(name="team_id"),

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -4,9 +4,9 @@ from posthog.test.base import BaseTest
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
-from posthog.hogql.database.models import IntegerDatabaseField, StringDatabaseField, TableNode
+from posthog.hogql.database.models import DateTimeDatabaseField, IntegerDatabaseField, StringDatabaseField, TableNode
 from posthog.hogql.database.postgres_table import PostgresTable
-from posthog.hogql.parser import parse_select
+from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.query import create_default_modifiers_for_team
 
@@ -55,3 +55,65 @@ class TestPostgresTable(BaseTest):
             clickhouse,
             f"SELECT postgres_table.id AS id, postgres_table.team_id AS team_id, postgres_table.name AS name FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE equals(postgres_table.team_id, {self.team.id}) LIMIT 10",
         )
+
+    def _init_database_with_predicates(self, predicates):
+        self.database = Database.create_for(team=self.team)
+
+        self.database.tables.add_child(
+            TableNode(
+                name="postgres_table",
+                table=PostgresTable(
+                    name="postgres_table",
+                    postgres_table_name="some_table_on_postgres",
+                    predicates=predicates,
+                    fields={
+                        "id": IntegerDatabaseField(name="id"),
+                        "team_id": IntegerDatabaseField(name="team_id"),
+                        "name": StringDatabaseField(name="name"),
+                        "created_at": DateTimeDatabaseField(name="created_at"),
+                        "status": StringDatabaseField(name="status"),
+                    },
+                ),
+            )
+        )
+
+        self.context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=self.database,
+            modifiers=create_default_modifiers_for_team(self.team),
+        )
+
+    def test_postgres_table_with_single_predicate(self):
+        self._init_database_with_predicates([parse_expr("created_at >= today() - interval 30 day")])
+
+        clickhouse = self._select(query="SELECT id FROM postgres_table LIMIT 10", dialect="clickhouse")
+
+        self.assertIn(f"equals(postgres_table.team_id, {self.team.id})", clickhouse)
+        self.assertIn(
+            "greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))",
+            clickhouse,
+        )
+
+    def test_postgres_table_with_multiple_predicates(self):
+        self._init_database_with_predicates(
+            [
+                parse_expr("created_at >= today() - interval 30 day"),
+                parse_expr("status != 'deleted'"),
+            ]
+        )
+
+        clickhouse = self._select(query="SELECT id FROM postgres_table LIMIT 10", dialect="clickhouse")
+
+        self.assertIn(
+            "greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))",
+            clickhouse,
+        )
+        self.assertIn("notEquals(postgres_table.status, %(hogql_val_5)s)", clickhouse)
+
+    def test_postgres_table_predicates_transparent_in_hogql(self):
+        self._init_database_with_predicates([parse_expr("created_at >= today() - interval 30 day")])
+
+        hogql = self._select(query="SELECT id FROM postgres_table LIMIT 10", dialect="hogql")
+
+        self.assertEqual(hogql, "SELECT id FROM postgres_table LIMIT 10")

--- a/posthog/hogql/database/test/test_postgres_table.py
+++ b/posthog/hogql/database/test/test_postgres_table.py
@@ -4,7 +4,15 @@ from posthog.test.base import BaseTest
 
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
-from posthog.hogql.database.models import DateTimeDatabaseField, IntegerDatabaseField, StringDatabaseField, TableNode
+from posthog.hogql.database.models import (
+    DateTimeDatabaseField,
+    IntegerDatabaseField,
+    LazyJoin,
+    LazyJoinToAdd,
+    StringDatabaseField,
+    StringJSONDatabaseField,
+    TableNode,
+)
 from posthog.hogql.database.postgres_table import PostgresTable
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import prepare_and_print_ast
@@ -12,8 +20,16 @@ from posthog.hogql.query import create_default_modifiers_for_team
 
 
 class TestPostgresTable(BaseTest):
-    def _init_database(self):
+    def _init_database(self, *, predicates=None, extra_fields=None):
         self.database = Database.create_for(team=self.team)
+
+        fields = {
+            "id": IntegerDatabaseField(name="id"),
+            "team_id": IntegerDatabaseField(name="team_id"),
+            "name": StringDatabaseField(name="name"),
+        }
+        if extra_fields:
+            fields.update(extra_fields)
 
         self.database.tables.add_child(
             TableNode(
@@ -21,11 +37,8 @@ class TestPostgresTable(BaseTest):
                 table=PostgresTable(
                     name="postgres_table",
                     postgres_table_name="some_table_on_postgres",
-                    fields={
-                        "id": IntegerDatabaseField(name="id"),
-                        "team_id": IntegerDatabaseField(name="team_id"),
-                        "name": StringDatabaseField(name="name"),
-                    },
+                    **({} if predicates is None else {"predicates": predicates}),
+                    fields=fields,
                 ),
             )
         )
@@ -35,43 +48,245 @@ class TestPostgresTable(BaseTest):
             enable_select_queries=True,
             database=self.database,
             modifiers=create_default_modifiers_for_team(self.team),
+        )
+
+    def _init_database_for_joins(self, *, predicates=None, extra_fields=None):
+        self._init_database(predicates=predicates, extra_fields=extra_fields)
+        self.database.tables.add_child(
+            TableNode(
+                name="other_table",
+                table=PostgresTable(
+                    name="other_table",
+                    postgres_table_name="some_other_table",
+                    fields={
+                        "id": IntegerDatabaseField(name="id"),
+                        "team_id": IntegerDatabaseField(name="team_id"),
+                        "ref_id": IntegerDatabaseField(name="ref_id"),
+                    },
+                ),
+            )
         )
 
     def _select(self, query: str, dialect: Literal["hogql", "clickhouse"] = "clickhouse") -> str:
         return prepare_and_print_ast(parse_select(query), self.context, dialect=dialect)[0]
 
-    def test_postgres_table_select(self):
+    def test_select(self):
         self._init_database()
-
-        hogql = self._select(query="SELECT * FROM postgres_table LIMIT 10", dialect="hogql")
         self.assertEqual(
-            hogql,
+            self._select("SELECT * FROM postgres_table LIMIT 10", dialect="hogql"),
             "SELECT id, team_id, name FROM postgres_table LIMIT 10",
         )
-
-        clickhouse = self._select(query="SELECT * FROM postgres_table LIMIT 10", dialect="clickhouse")
-
         self.assertEqual(
-            clickhouse,
-            f"SELECT postgres_table.id AS id, postgres_table.team_id AS team_id, postgres_table.name AS name FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE equals(postgres_table.team_id, {self.team.id}) LIMIT 10",
+            self._select("SELECT * FROM postgres_table LIMIT 10"),
+            f"SELECT postgres_table.id AS id, postgres_table.team_id AS team_id, postgres_table.name AS name FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE equals(postgres_table.team_id, {self.team.pk}) LIMIT 10",
         )
 
-    def _init_database_with_predicates(self, predicates):
+    def test_single_predicate(self):
+        self._init_database(
+            predicates=[parse_expr("created_at >= today() - interval 30 day")],
+            extra_fields={"created_at": DateTimeDatabaseField(name="created_at")},
+        )
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table LIMIT 10", dialect="hogql"),
+            "SELECT id FROM postgres_table WHERE greaterOrEquals(created_at, minus(today(), toIntervalDay(30))) LIMIT 10",
+        )
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table LIMIT 10"),
+            f"SELECT postgres_table.id AS id FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE and(equals(postgres_table.team_id, {self.team.pk}), greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))) LIMIT 10",
+        )
+
+    def test_multiple_predicates(self):
+        self._init_database(
+            predicates=[
+                parse_expr("created_at >= today() - interval 30 day"),
+                parse_expr("status != 'deleted'"),
+            ],
+            extra_fields={
+                "created_at": DateTimeDatabaseField(name="created_at"),
+                "status": StringDatabaseField(name="status"),
+            },
+        )
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table LIMIT 10", dialect="hogql"),
+            "SELECT id FROM postgres_table WHERE and(greaterOrEquals(created_at, minus(today(), toIntervalDay(30))), notEquals(status, 'deleted')) LIMIT 10",
+        )
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table LIMIT 10"),
+            f"SELECT postgres_table.id AS id FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE and(and(equals(postgres_table.team_id, {self.team.pk}), greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))), notEquals(postgres_table.status, %(hogql_val_5)s)) LIMIT 10",
+        )
+
+    def test_predicate_combined_with_user_where(self):
+        self._init_database(
+            predicates=[parse_expr("created_at >= today() - interval 30 day")],
+            extra_fields={"created_at": DateTimeDatabaseField(name="created_at")},
+        )
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table where name = 'test' LIMIT 10", dialect="hogql"),
+            "SELECT id FROM postgres_table WHERE and(greaterOrEquals(created_at, minus(today(), toIntervalDay(30))), equals(name, 'test')) LIMIT 10",
+        )
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table where name = 'test' LIMIT 10"),
+            f"SELECT postgres_table.id AS id FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE and(and(equals(postgres_table.team_id, {self.team.pk}), greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))), equals(postgres_table.name, %(hogql_val_5)s)) LIMIT 10",
+        )
+
+    def test_left_join_single_predicate(self):
+        self._init_database_for_joins(
+            predicates=[parse_expr("created_at >= today() - interval 30 day")],
+            extra_fields={"created_at": DateTimeDatabaseField(name="created_at")},
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id, postgres_table.name "
+                "FROM other_table "
+                "LEFT JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "LIMIT 10",
+                dialect="hogql",
+            ),
+            "SELECT other_table.id, postgres_table.name FROM other_table LEFT JOIN postgres_table ON and(greaterOrEquals(created_at, minus(today(), toIntervalDay(30))), equals(other_table.ref_id, postgres_table.id)) LIMIT 10",
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id, postgres_table.name "
+                "FROM other_table "
+                "LEFT JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "LIMIT 10",
+            ),
+            f"SELECT other_table.id AS id, postgres_table.name AS name FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS other_table LEFT JOIN postgresql(%(hogql_val_6_sensitive)s, %(hogql_val_7_sensitive)s, %(hogql_val_5_sensitive)s, %(hogql_val_8_sensitive)s, %(hogql_val_9_sensitive)s) AS postgres_table ON and(and(equals(postgres_table.team_id, {self.team.pk}), greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))), equals(other_table.ref_id, postgres_table.id)) WHERE equals(other_table.team_id, {self.team.pk}) LIMIT 10",
+        )
+
+    def test_left_join_multiple_predicates(self):
+        self._init_database_for_joins(
+            predicates=[
+                parse_expr("created_at >= today() - interval 30 day"),
+                parse_expr("status != 'deleted'"),
+            ],
+            extra_fields={
+                "created_at": DateTimeDatabaseField(name="created_at"),
+                "status": StringDatabaseField(name="status"),
+            },
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id "
+                "FROM other_table "
+                "LEFT JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "LIMIT 10",
+                dialect="hogql",
+            ),
+            "SELECT other_table.id FROM other_table LEFT JOIN postgres_table ON and(and(greaterOrEquals(created_at, minus(today(), toIntervalDay(30))), notEquals(status, 'deleted')), equals(other_table.ref_id, postgres_table.id)) LIMIT 10",
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id "
+                "FROM other_table "
+                "LEFT JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "LIMIT 10",
+            ),
+            f"SELECT other_table.id AS id FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS other_table LEFT JOIN postgresql(%(hogql_val_6_sensitive)s, %(hogql_val_7_sensitive)s, %(hogql_val_5_sensitive)s, %(hogql_val_8_sensitive)s, %(hogql_val_9_sensitive)s) AS postgres_table ON and(and(and(equals(postgres_table.team_id, {self.team.pk}), greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))), notEquals(postgres_table.status, %(hogql_val_10)s)), equals(other_table.ref_id, postgres_table.id)) WHERE equals(other_table.team_id, {self.team.pk}) LIMIT 10",
+        )
+
+    def test_inner_join_predicate(self):
+        self._init_database_for_joins(
+            predicates=[parse_expr("created_at >= today() - interval 30 day")],
+            extra_fields={"created_at": DateTimeDatabaseField(name="created_at")},
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id, postgres_table.name "
+                "FROM other_table "
+                "INNER JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "LIMIT 10",
+                dialect="hogql",
+            ),
+            "SELECT other_table.id, postgres_table.name FROM other_table INNER JOIN postgres_table ON equals(other_table.ref_id, postgres_table.id) WHERE greaterOrEquals(created_at, minus(today(), toIntervalDay(30))) LIMIT 10",
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id, postgres_table.name "
+                "FROM other_table "
+                "INNER JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "LIMIT 10",
+            ),
+            f"SELECT other_table.id AS id, postgres_table.name AS name FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS other_table INNER JOIN postgresql(%(hogql_val_6_sensitive)s, %(hogql_val_7_sensitive)s, %(hogql_val_5_sensitive)s, %(hogql_val_8_sensitive)s, %(hogql_val_9_sensitive)s) AS postgres_table ON equals(other_table.ref_id, postgres_table.id) WHERE and(and(equals(postgres_table.team_id, {self.team.pk}), greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))), equals(other_table.team_id, {self.team.pk})) LIMIT 10",
+        )
+
+    def test_left_join_predicate_with_user_where(self):
+        self._init_database_for_joins(
+            predicates=[parse_expr("created_at >= today() - interval 30 day")],
+            extra_fields={"created_at": DateTimeDatabaseField(name="created_at")},
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id, postgres_table.name "
+                "FROM other_table "
+                "LEFT JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "WHERE other_table.ref_id > 100 "
+                "LIMIT 10",
+                dialect="hogql",
+            ),
+            "SELECT other_table.id, postgres_table.name FROM other_table LEFT JOIN postgres_table ON and(greaterOrEquals(created_at, minus(today(), toIntervalDay(30))), equals(other_table.ref_id, postgres_table.id)) WHERE greater(other_table.ref_id, 100) LIMIT 10",
+        )
+        self.assertEqual(
+            self._select(
+                "SELECT other_table.id, postgres_table.name "
+                "FROM other_table "
+                "LEFT JOIN postgres_table ON other_table.ref_id = postgres_table.id "
+                "WHERE other_table.ref_id > 100 "
+                "LIMIT 10",
+            ),
+            f"SELECT other_table.id AS id, postgres_table.name AS name FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS other_table LEFT JOIN postgresql(%(hogql_val_6_sensitive)s, %(hogql_val_7_sensitive)s, %(hogql_val_5_sensitive)s, %(hogql_val_8_sensitive)s, %(hogql_val_9_sensitive)s) AS postgres_table ON and(and(equals(postgres_table.team_id, {self.team.pk}), greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))), equals(other_table.ref_id, postgres_table.id)) WHERE and(equals(other_table.team_id, {self.team.pk}), greater(other_table.ref_id, 100)) LIMIT 10",
+        )
+
+    def test_lazy_join_with_predicate(self):
+        from posthog.hogql import ast
+
+        def join_fn(join_to_add: LazyJoinToAdd, context: HogQLContext, node: ast.SelectQuery):
+            table = join_to_add.lazy_join.join_table
+            table_name = table if isinstance(table, str) else table.name
+            assert table_name is not None
+            join_expr = ast.JoinExpr(table=ast.Field(chain=[table_name]))
+            join_expr.join_type = "LEFT JOIN"
+            join_expr.alias = join_to_add.to_table
+            join_expr.constraint = ast.JoinConstraint(
+                expr=ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=[join_to_add.from_table, "ref_id"]),
+                    right=ast.Field(chain=[join_to_add.to_table, "id"]),
+                ),
+                constraint_type="ON",
+            )
+            return join_expr
+
         self.database = Database.create_for(team=self.team)
 
+        pg_table = PostgresTable(
+            name="postgres_table",
+            postgres_table_name="some_table_on_postgres",
+            predicates=[parse_expr("created_at >= today() - interval 30 day")],
+            fields={
+                "id": IntegerDatabaseField(name="id"),
+                "team_id": IntegerDatabaseField(name="team_id"),
+                "name": StringDatabaseField(name="name"),
+                "created_at": DateTimeDatabaseField(name="created_at"),
+            },
+        )
+
+        self.database.tables.add_child(TableNode(name="postgres_table", table=pg_table))
         self.database.tables.add_child(
             TableNode(
-                name="postgres_table",
+                name="other_table",
                 table=PostgresTable(
-                    name="postgres_table",
-                    postgres_table_name="some_table_on_postgres",
-                    predicates=predicates,
+                    name="other_table",
+                    postgres_table_name="some_other_table",
                     fields={
                         "id": IntegerDatabaseField(name="id"),
                         "team_id": IntegerDatabaseField(name="team_id"),
-                        "name": StringDatabaseField(name="name"),
-                        "created_at": DateTimeDatabaseField(name="created_at"),
-                        "status": StringDatabaseField(name="status"),
+                        "ref_id": IntegerDatabaseField(name="ref_id"),
+                        "details": LazyJoin(
+                            from_field=["ref_id"],
+                            join_table=pg_table,
+                            join_function=join_fn,
+                        ),
                     },
                 ),
             )
@@ -84,36 +299,25 @@ class TestPostgresTable(BaseTest):
             modifiers=create_default_modifiers_for_team(self.team),
         )
 
-    def test_postgres_table_with_single_predicate(self):
-        self._init_database_with_predicates([parse_expr("created_at >= today() - interval 30 day")])
-
-        clickhouse = self._select(query="SELECT id FROM postgres_table LIMIT 10", dialect="clickhouse")
-
-        self.assertIn(f"equals(postgres_table.team_id, {self.team.id})", clickhouse)
-        self.assertIn(
-            "greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))",
-            clickhouse,
+        self.assertEqual(
+            self._select("SELECT details.name FROM other_table LIMIT 10", dialect="hogql"),
+            "SELECT details.name FROM other_table LIMIT 10",
+        )
+        self.assertEqual(
+            self._select("SELECT details.name FROM other_table LIMIT 10"),
+            f"SELECT other_table__details.name AS name FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS other_table LEFT JOIN postgresql(%(hogql_val_6_sensitive)s, %(hogql_val_7_sensitive)s, %(hogql_val_5_sensitive)s, %(hogql_val_8_sensitive)s, %(hogql_val_9_sensitive)s) AS other_table__details ON and(and(equals(other_table__details.team_id, {self.team.pk}), greaterOrEquals(other_table__details.created_at, minus(today(), toIntervalDay(30)))), equals(other_table.ref_id, other_table__details.id)) WHERE equals(other_table.team_id, {self.team.pk}) LIMIT 10",
         )
 
-    def test_postgres_table_with_multiple_predicates(self):
-        self._init_database_with_predicates(
-            [
-                parse_expr("created_at >= today() - interval 30 day"),
-                parse_expr("status != 'deleted'"),
-            ]
+    def test_predicate_with_nested_property_access(self):
+        self._init_database(
+            predicates=[parse_expr("properties.email != ''")],
+            extra_fields={"properties": StringJSONDatabaseField(name="properties")},
         )
-
-        clickhouse = self._select(query="SELECT id FROM postgres_table LIMIT 10", dialect="clickhouse")
-
-        self.assertIn(
-            "greaterOrEquals(postgres_table.created_at, minus(today(), toIntervalDay(30)))",
-            clickhouse,
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table LIMIT 10", dialect="hogql"),
+            "SELECT id FROM postgres_table WHERE notEquals(properties.email, '') LIMIT 10",
         )
-        self.assertIn("notEquals(postgres_table.status, %(hogql_val_5)s)", clickhouse)
-
-    def test_postgres_table_predicates_transparent_in_hogql(self):
-        self._init_database_with_predicates([parse_expr("created_at >= today() - interval 30 day")])
-
-        hogql = self._select(query="SELECT id FROM postgres_table LIMIT 10", dialect="hogql")
-
-        self.assertEqual(hogql, "SELECT id FROM postgres_table LIMIT 10")
+        self.assertEqual(
+            self._select("SELECT id FROM postgres_table LIMIT 10"),
+            f"SELECT postgres_table.id AS id FROM postgresql(%(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s, %(hogql_val_0_sensitive)s, %(hogql_val_3_sensitive)s, %(hogql_val_4_sensitive)s) AS postgres_table WHERE and(equals(postgres_table.team_id, {self.team.pk}), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(postgres_table.properties, %(hogql_val_15)s), ''), 'null'), '^\"|\"$', ''), %(hogql_val_16)s), 1)) LIMIT 10",
+        )

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -42,6 +42,7 @@ from posthog.hogql.printer.types import (
     PrintableMaterializedColumn,
     PrintableMaterializedPropertyGroupItem,
 )
+from posthog.hogql.resolver import resolve_types
 from posthog.hogql.resolver_utils import lookup_field_by_name
 from posthog.hogql.visitor import Visitor, clone_expr
 
@@ -390,26 +391,13 @@ class HogQLPrinter(Visitor[str]):
         table_type: ast.TableType | ast.LazyTableType,
         node_type: ast.TableOrSelectType | None,
     ) -> list[ast.Expr]:
-        """Return predicate expressions from the table definition, with field types set for proper alias prefixing."""
-        from posthog.hogql.database.postgres_table import PostgresTable
-        from posthog.hogql.visitor import CloningVisitor
-
-        if not isinstance(table_type.table, PostgresTable) or not table_type.table.predicates:
+        """Return predicate expressions from the table definition, resolved against the table's type."""
+        predicates = table_type.table.get_predicates()
+        if not predicates or node_type is None:
             return []
 
-        class _PredicateFieldTypeSetter(CloningVisitor):
-            def __init__(self, ttype: ast.TableOrSelectType | None):
-                super().__init__()
-                self._table_type = ttype
-
-            def visit_field(self, node: ast.Field):
-                cloned = ast.Field(chain=list(node.chain))
-                if len(cloned.chain) == 1 and self._table_type is not None:
-                    cloned.type = ast.FieldType(name=cloned.chain[0], table_type=self._table_type)
-                return cloned
-
-        setter = _PredicateFieldTypeSetter(node_type)
-        return [setter.visit(predicate) for predicate in table_type.table.predicates]
+        scope = ast.SelectQueryType(tables={"t": node_type})
+        return [resolve_types(clone_expr(pred), self.context, self.dialect, [scope]) for pred in predicates]
 
     def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         if self.dialect == "hogql":
@@ -445,12 +433,19 @@ class HogQLPrinter(Visitor[str]):
             else:
                 extra_where = team_id_expr
 
-            # Apply table-level predicates (e.g., date filters on PostgresTable)
-            for pred in self._get_table_predicates(table_type, node.type):
-                if extra_where is None:
-                    extra_where = pred
+            # Apply table-level predicates (e.g., date filters on PostgresTable).
+            predicate_exprs = self._get_table_predicates(table_type, node.type)
+            for pred in predicate_exprs:
+                if is_left_join and node.constraint is not None:
+                    if team_id_for_on_clause is None:
+                        team_id_for_on_clause = pred
+                    else:
+                        team_id_for_on_clause = ast.And(exprs=[team_id_for_on_clause, pred])
                 else:
-                    extra_where = ast.And(exprs=[extra_where, pred])
+                    if extra_where is None:
+                        extra_where = pred
+                    else:
+                        extra_where = ast.And(exprs=[extra_where, pred])
 
             sql = self._print_table_ref(table_type, node)
 

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -385,6 +385,32 @@ class HogQLPrinter(Visitor[str]):
         if self.dialect != "hogql":
             raise NotImplementedError("HogQLPrinter._ensure_team_id_where_clause not overridden")
 
+    def _get_table_predicates(
+        self,
+        table_type: ast.TableType | ast.LazyTableType,
+        node_type: ast.TableOrSelectType | None,
+    ) -> list[ast.Expr]:
+        """Return predicate expressions from the table definition, with field types set for proper alias prefixing."""
+        from posthog.hogql.database.postgres_table import PostgresTable
+        from posthog.hogql.visitor import CloningVisitor
+
+        if not isinstance(table_type.table, PostgresTable) or not table_type.table.predicates:
+            return []
+
+        class _PredicateFieldTypeSetter(CloningVisitor):
+            def __init__(self, ttype: ast.TableOrSelectType | None):
+                super().__init__()
+                self._table_type = ttype
+
+            def visit_field(self, node: ast.Field):
+                cloned = ast.Field(chain=list(node.chain))
+                if len(cloned.chain) == 1 and self._table_type is not None:
+                    cloned.type = ast.FieldType(name=cloned.chain[0], table_type=self._table_type)
+                return cloned
+
+        setter = _PredicateFieldTypeSetter(node_type)
+        return [setter.visit(predicate) for predicate in table_type.table.predicates]
+
     def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         if self.dialect == "hogql":
             return table_type.table.to_printed_hogql()
@@ -418,6 +444,13 @@ class HogQLPrinter(Visitor[str]):
                 team_id_for_on_clause = team_id_expr
             else:
                 extra_where = team_id_expr
+
+            # Apply table-level predicates (e.g., date filters on PostgresTable)
+            for pred in self._get_table_predicates(table_type, node.type):
+                if extra_where is None:
+                    extra_where = pred
+                else:
+                    extra_where = ast.And(exprs=[extra_where, pred])
 
             sql = self._print_table_ref(table_type, node)
 


### PR DESCRIPTION
## Problem

PostgresTable show all the data. We might not want to show everything in the UI (and to AI)

## Changes

- Added `predicates` field to `PostgresTable` class to store a list of filter expressions that should be automatically applied

## How did you test this code?
- unit tests

## Publish to changelog?

no