### PR TITLE
chore: more ai first homepage offramp stuff

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -42,6 +42,8 @@ export const navigationLogic = kea<navigationLogicType>([
         closeProjectNotice: (projectNoticeVariant: ProjectNoticeVariant) => ({ projectNoticeVariant }),
         showConfigurePinnedTabsModal: true,
         hideConfigurePinnedTabsModal: true,
+        showConfigurePinnedTabsTooltip: true,
+        hideConfigurePinnedTabsTooltip: true,
     }),
     loaders(({ values }) => ({
         proxyRecords: {
@@ -84,6 +86,20 @@ export const navigationLogic = kea<navigationLogicType>([
             {
                 showConfigurePinnedTabsModal: () => true,
                 hideConfigurePinnedTabsModal: () => false,
+            },
+        ],
+        isConfigurePinnedTabsTooltipVisible: [
+            false,
+            {
+                showConfigurePinnedTabsTooltip: () => true,
+                hideConfigurePinnedTabsTooltip: () => false,
+            },
+        ],
+        isConfigurePinnedTabsTooltipDismissed: [
+            false,
+            { persist: true },
+            {
+                hideConfigurePinnedTabsTooltip: () => true,
             },
         ],
     }),

--- a/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
@@ -21,7 +21,8 @@ interface NavLinkProps {
 
 export function NavLink({ to, label, icon, isCollapsed, 'data-attr': dataAttr, onClick }: NavLinkProps): JSX.Element {
     const { showConfigurePinnedTabsModal, hideConfigurePinnedTabsTooltip } = useActions(navigationLogic)
-    const { isConfigurePinnedTabsTooltipVisible } = useValues(navigationLogic)
+    const { isConfigurePinnedTabsTooltipVisible, mobileLayout } = useValues(navigationLogic)
+    const { showLayoutNavBar } = useActions(panelLayoutLogic)
     const { pathname } = useValues(panelLayoutLogic)
 
     const isHomePage = to === urls.projectRoot()
@@ -90,6 +91,9 @@ export function NavLink({ to, label, icon, isCollapsed, 'data-attr': dataAttr, o
                                     onClick={(e) => {
                                         e.stopPropagation()
                                         hideConfigurePinnedTabsTooltip()
+                                        if (mobileLayout) {
+                                            showLayoutNavBar(false)
+                                        }
                                     }}
                                 >
                                     Got it

--- a/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
@@ -20,7 +20,8 @@ interface NavLinkProps {
 }
 
 export function NavLink({ to, label, icon, isCollapsed, 'data-attr': dataAttr, onClick }: NavLinkProps): JSX.Element {
-    const { showConfigurePinnedTabsModal } = useActions(navigationLogic)
+    const { showConfigurePinnedTabsModal, hideConfigurePinnedTabsTooltip } = useActions(navigationLogic)
+    const { isConfigurePinnedTabsTooltipVisible } = useValues(navigationLogic)
     const { pathname } = useValues(panelLayoutLogic)
 
     const isHomePage = to === urls.projectRoot()
@@ -67,15 +68,40 @@ export function NavLink({ to, label, icon, isCollapsed, 'data-attr': dataAttr, o
             </Link>
             {isHomePage && !isCollapsed && (
                 <ButtonPrimitive
-                    className="opacity-50 hover:!opacity-100 transition-all duration-50 -outline-offset-2 focus-visible:opacity-100"
+                    className={cn(
+                        'opacity-50 hover:!opacity-100 transition-all duration-50 -outline-offset-2 focus-visible:opacity-100',
+                        isConfigurePinnedTabsTooltipVisible && 'opacity-100 text-primary'
+                    )}
                     iconOnly
+                    variant={isConfigurePinnedTabsTooltipVisible ? 'panel' : 'default'}
                     isSideActionRight
+                    forceVariant={isConfigurePinnedTabsTooltipVisible}
                     onClick={(e) => {
                         e.stopPropagation()
+                        isConfigurePinnedTabsTooltipVisible ? hideConfigurePinnedTabsTooltip() : null
                         showConfigurePinnedTabsModal()
                     }}
-                    tooltip="Configure tabs & home"
+                    tooltip={
+                        isConfigurePinnedTabsTooltipVisible ? (
+                            <div className="flex flex-col gap-1">
+                                <span>Change your homepage settings here.</span>
+                                <ButtonPrimitive
+                                    className="text-primary-inverse border-none cursor-pointer hover:underline px-0 py-0"
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        hideConfigurePinnedTabsTooltip()
+                                    }}
+                                >
+                                    Got it
+                                </ButtonPrimitive>
+                            </div>
+                        ) : (
+                            'Configure tabs & home'
+                        )
+                    }
                     tooltipPlacement="right"
+                    tooltipVisible={isConfigurePinnedTabsTooltipVisible || undefined}
+                    tooltipInteractive={isConfigurePinnedTabsTooltipVisible}
                 >
                     <IconGear className="size-3 text-secondary" />
                 </ButtonPrimitive>

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -283,7 +283,7 @@ function SuggestionMenubar(): JSX.Element {
 }
 
 function HomePageOfframp(): JSX.Element {
-    const { showConfigurePinnedTabsModal } = useActions(navigationLogic)
+    const { showConfigurePinnedTabsModal, showConfigurePinnedTabsTooltip } = useActions(navigationLogic)
     const { revertToPreviousHomepage } = useActions(aiFirstHomepageLogic)
     const { previousHomepage } = useValues(aiFirstHomepageLogic)
 
@@ -295,7 +295,6 @@ function HomePageOfframp(): JSX.Element {
                     posthog.capture('homepage configure home clicked', { source: 'offramp' })
                     showConfigurePinnedTabsModal()
                 }}
-                tooltip="Configure tabs & home"
                 className="text-tertiary hover:text-primary"
             >
                 Configure home <IconGear className="size-4" />
@@ -310,8 +309,9 @@ function HomePageOfframp(): JSX.Element {
                             previous_homepage_title: previousHomepage.title,
                         })
                         revertToPreviousHomepage()
+                        showConfigurePinnedTabsTooltip()
                     }}
-                    tooltip={`Revert to ${previousHomepage.title || 'previous homepage'}`}
+                    tooltip={`Revert to ${previousHomepage.title || 'previous homepage'}, this causes a full page refresh`}
                     className="text-tertiary hover:text-primary"
                 >
                     Put my {(previousHomepage.title || 'previous homepage').toLocaleLowerCase()} back{' '}
@@ -325,6 +325,7 @@ function HomePageOfframp(): JSX.Element {
 export function HomepageInput(): JSX.Element {
     const { mode } = useValues(aiFirstHomepageLogic)
     const { user } = useValues(userLogic)
+    const { isConfigurePinnedTabsTooltipDismissed } = useValues(navigationLogic)
 
     return (
         <div className="w-full max-w-180 mx-auto py-2 ">
@@ -338,7 +339,7 @@ export function HomepageInput(): JSX.Element {
                         PostHog AI can make mistakes. Please double-check responses
                     </p>
 
-                    <HomePageOfframp />
+                    {!isConfigurePinnedTabsTooltipDismissed && <HomePageOfframp />}
                 </div>
             )}
             {mode === 'ai' && <HomepageAiInput />}

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -29,6 +29,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
+import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 
 import { aiFirstHomepageLogic } from './aiFirstHomepageLogic'
 import { HOMEPAGE_TAB_ID } from './constants'
@@ -284,6 +285,8 @@ function SuggestionMenubar(): JSX.Element {
 
 function HomePageOfframp(): JSX.Element {
     const { showConfigurePinnedTabsModal, showConfigurePinnedTabsTooltip } = useActions(navigationLogic)
+    const { mobileLayout } = useValues(navigationLogic)
+    const { showLayoutNavBar } = useActions(panelLayoutLogic)
     const { revertToPreviousHomepage } = useActions(aiFirstHomepageLogic)
     const { previousHomepage } = useValues(aiFirstHomepageLogic)
 
@@ -310,6 +313,9 @@ function HomePageOfframp(): JSX.Element {
                         })
                         revertToPreviousHomepage()
                         showConfigurePinnedTabsTooltip()
+                        if (mobileLayout) {
+                            showLayoutNavBar(true)
+                        }
                     }}
                     tooltip={`Revert to ${previousHomepage.title || 'previous homepage'}, this causes a full page refresh`}
                     className="text-tertiary hover:text-primary"


### PR DESCRIPTION
## Problem
Need to teach users how to configure their home after shoving ai first home page down their throats. 

## Changes
When a user clicks "revert my home page", we then show a tooltip teaching them how to change it again on the gear icon in the nav.

Desktop

![2026-03-20 12 27 59](https://github.com/user-attachments/assets/940b5b17-9b21-4b09-94ac-dfd829c880bc)

Mobile

![2026-03-20 12 29 12](https://github.com/user-attachments/assets/3e424ddb-f345-45a6-94e2-e7fa7cf787dc)


## How did you test this code?
Locally

## Publish to changelog?
No