### PR TITLE
fix(funnels): fix stale preview after hovering another dwh table

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelDataWarehouseStepDefinitionPopover.tsx
@@ -40,7 +40,7 @@ function FunnelDataWarehouseStepDefinitionPopoverContent({
     const table = item as DataWarehouseTableForInsight
 
     // :FIXME: ideally, we'd want to connect() these, but i couldn't make it work
-    const { dataWarehousePopoverFields } = useValues(taxonomicFilterLogic)
+    const { dataWarehousePopoverFields, selectedItemMeta } = useValues(taxonomicFilterLogic)
     const { selectItem } = useActions(taxonomicFilterLogic)
 
     const { insightProps } = useValues(insightLogic)
@@ -49,6 +49,7 @@ function FunnelDataWarehouseStepDefinitionPopoverContent({
         table,
         group,
         dataWarehousePopoverFields,
+        selectedItemMeta,
         onSelectItem: selectItem,
         insightProps,
     })

--- a/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.test.ts
+++ b/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.test.ts
@@ -1,0 +1,91 @@
+import { definitionPopoverLogic } from 'lib/components/DefinitionPopover/definitionPopoverLogic'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { initKeaTests } from '~/test/init'
+
+import { funnelDataWarehouseStepDefinitionPopoverLogic } from './funnelDataWarehouseStepDefinitionPopoverLogic'
+
+describe('funnelDataWarehouseStepDefinitionPopoverLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it('ignores stale field mappings from a previously hovered table', () => {
+        const selectedItemMeta = {
+            id: 'warehouse_table_a',
+            table_name: 'warehouse_table_a',
+            timestamp_field: 'date_day',
+            id_field: 'id',
+            aggregation_target_field: 'person_id',
+        }
+
+        const previouslyHoveredTable = {
+            id: 'table-a-id',
+            name: 'warehouse_table_a',
+            type: 'data_warehouse' as const,
+            format: 'Parquet',
+            url_pattern: '',
+            fields: {
+                id: { name: 'id', hogql_value: 'id', type: 'integer', schema_valid: true },
+                created_at: { name: 'created_at', hogql_value: 'created_at', type: 'datetime', schema_valid: true },
+            },
+        }
+
+        const currentlyHoveredTable = {
+            id: 'table-b-id',
+            name: 'warehouse_table_b',
+            type: 'data_warehouse' as const,
+            format: 'Parquet',
+            url_pattern: '',
+            fields: {
+                id: { name: 'id', hogql_value: 'id', type: 'integer', schema_valid: true },
+                event_timestamp: {
+                    name: 'event_timestamp',
+                    hogql_value: 'event_timestamp',
+                    type: 'datetime',
+                    schema_valid: true,
+                },
+            },
+        }
+
+        const popoverDefinitionLogic = definitionPopoverLogic({
+            type: TaxonomicFilterGroupType.DataWarehouse,
+            selectedItemMeta,
+        })
+        popoverDefinitionLogic.mount()
+        popoverDefinitionLogic.actions.setDefinition(previouslyHoveredTable)
+
+        expect(popoverDefinitionLogic.values.localDefinition.timestamp_field).toEqual('date_day')
+
+        const onSelectItem = jest.fn()
+        const logic = funnelDataWarehouseStepDefinitionPopoverLogic({
+            table: currentlyHoveredTable,
+            group: { type: TaxonomicFilterGroupType.DataWarehouse } as any,
+            dataWarehousePopoverFields: [
+                { key: 'id_field', label: 'Unique ID' },
+                { key: 'timestamp_field', label: 'Timestamp' },
+                { key: 'aggregation_target_field', label: 'Aggregation target', allowHogQL: true },
+            ],
+            selectedItemMeta,
+            onSelectItem,
+            insightProps: { dashboardItemId: undefined } as any,
+        })
+        logic.mount()
+
+        expect(logic.values.previewExpressionColumns).toEqual([])
+        expect(logic.values.activeFieldValue).toBeUndefined()
+
+        logic.actions.setActiveFieldKey('timestamp_field')
+        expect(logic.values.activeFieldValue).toEqual('event_timestamp')
+
+        logic.actions.selectTable()
+        expect(onSelectItem).toHaveBeenCalledWith(
+            expect.objectContaining({ type: TaxonomicFilterGroupType.DataWarehouse }),
+            'warehouse_table_b',
+            expect.objectContaining({
+                id_field: 'id',
+                timestamp_field: 'event_timestamp',
+            })
+        )
+    })
+})

--- a/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.test.ts
+++ b/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.test.ts
@@ -1,9 +1,18 @@
 import { definitionPopoverLogic } from 'lib/components/DefinitionPopover/definitionPopoverLogic'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import type { DataWarehouseTableForInsight } from 'scenes/data-warehouse/types'
 
+import type { DatabaseSchemaField } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
 import { funnelDataWarehouseStepDefinitionPopoverLogic } from './funnelDataWarehouseStepDefinitionPopoverLogic'
+
+const createField = (name: string, type: DatabaseSchemaField['type']): DatabaseSchemaField => ({
+    name,
+    hogql_value: name,
+    type,
+    schema_valid: true,
+})
 
 describe('funnelDataWarehouseStepDefinitionPopoverLogic', () => {
     beforeEach(() => {
@@ -11,7 +20,7 @@ describe('funnelDataWarehouseStepDefinitionPopoverLogic', () => {
     })
 
     it('ignores stale field mappings from a previously hovered table', () => {
-        const selectedItemMeta = {
+        const selectedItemMeta: Partial<DataWarehouseTableForInsight> & { table_name: string } = {
             id: 'warehouse_table_a',
             table_name: 'warehouse_table_a',
             timestamp_field: 'date_day',
@@ -26,10 +35,10 @@ describe('funnelDataWarehouseStepDefinitionPopoverLogic', () => {
             format: 'Parquet',
             url_pattern: '',
             fields: {
-                id: { name: 'id', hogql_value: 'id', type: 'integer', schema_valid: true },
-                created_at: { name: 'created_at', hogql_value: 'created_at', type: 'datetime', schema_valid: true },
+                id: createField('id', 'integer'),
+                created_at: createField('created_at', 'datetime'),
             },
-        }
+        } satisfies DataWarehouseTableForInsight
 
         const currentlyHoveredTable = {
             id: 'table-b-id',
@@ -38,27 +47,24 @@ describe('funnelDataWarehouseStepDefinitionPopoverLogic', () => {
             format: 'Parquet',
             url_pattern: '',
             fields: {
-                id: { name: 'id', hogql_value: 'id', type: 'integer', schema_valid: true },
-                event_timestamp: {
-                    name: 'event_timestamp',
-                    hogql_value: 'event_timestamp',
-                    type: 'datetime',
-                    schema_valid: true,
-                },
+                id: createField('id', 'integer'),
+                event_timestamp: createField('event_timestamp', 'datetime'),
             },
-        }
+        } satisfies DataWarehouseTableForInsight
 
-        const popoverDefinitionLogic = definitionPopoverLogic({
+        const popoverDefinitionLogic = definitionPopoverLogic.build({
             type: TaxonomicFilterGroupType.DataWarehouse,
             selectedItemMeta,
         })
         popoverDefinitionLogic.mount()
         popoverDefinitionLogic.actions.setDefinition(previouslyHoveredTable)
 
-        expect(popoverDefinitionLogic.values.localDefinition.timestamp_field).toEqual('date_day')
+        expect(
+            (popoverDefinitionLogic.values.localDefinition as Partial<DataWarehouseTableForInsight>).timestamp_field
+        ).toEqual('date_day')
 
         const onSelectItem = jest.fn()
-        const logic = funnelDataWarehouseStepDefinitionPopoverLogic({
+        const logic = funnelDataWarehouseStepDefinitionPopoverLogic.build({
             table: currentlyHoveredTable,
             group: { type: TaxonomicFilterGroupType.DataWarehouse } as any,
             dataWarehousePopoverFields: [

--- a/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
@@ -3,6 +3,7 @@ import posthog from 'posthog-js'
 
 import { definitionPopoverLogic } from 'lib/components/DefinitionPopover/definitionPopoverLogic'
 import type { TablePreviewExpressionColumn } from 'lib/components/TablePreview/types'
+import { getDataWarehouseItemWithFieldDefaults } from 'lib/components/TaxonomicFilter/dataWarehouseItemUtils'
 import type {
     DataWarehousePopoverField,
     TaxonomicFilterGroup,
@@ -31,6 +32,7 @@ export interface FunnelDataWarehouseStepDefinitionPopoverLogicProps {
     table: DataWarehouseTableForInsight
     group: TaxonomicFilterGroup
     dataWarehousePopoverFields: DataWarehousePopoverField[]
+    selectedItemMeta?: Record<string, any> | null
     onSelectItem: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue | null, item: any) => void
     insightProps: InsightLogicProps
 }
@@ -40,7 +42,12 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
     key((props) => props.table.name),
     path((key) => ['scenes', 'insights', 'EditorFilters', 'funnelDataWarehouseStepDefinitionPopoverLogic', key]),
     connect((props: FunnelDataWarehouseStepDefinitionPopoverLogicProps) => ({
-        values: [definitionPopoverLogic, ['localDefinition'], funnelDataLogic(props.insightProps), ['querySource']],
+        values: [
+            definitionPopoverLogic,
+            ['definition', 'localDefinition'],
+            funnelDataLogic(props.insightProps),
+            ['querySource'],
+        ],
         actions: [definitionPopoverLogic, ['setLocalDefinition']],
     })),
     actions(() => ({
@@ -88,10 +95,17 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
             (dataWarehousePopoverFields, activeFieldKey) =>
                 dataWarehousePopoverFields.find((f) => f.key === activeFieldKey),
         ],
+        scopedLocalDefinition: [
+            (s, p) => [s.definition, s.localDefinition, p.table, p.selectedItemMeta],
+            (definition, localDefinition, table, selectedItemMeta) =>
+                definition.name === table.name
+                    ? localDefinition
+                    : getDataWarehouseItemWithFieldDefaults(table, selectedItemMeta),
+        ],
         activeFieldValue: [
-            (s) => [s.localDefinition, s.activeFieldKey],
-            (localDefinition, activeFieldKey) =>
-                (localDefinition as Partial<Record<FunnelFieldKey, string | undefined>>)[activeFieldKey],
+            (s) => [s.scopedLocalDefinition, s.activeFieldKey],
+            (scopedLocalDefinition, activeFieldKey) =>
+                (scopedLocalDefinition as Partial<Record<FunnelFieldKey, string | undefined>>)[activeFieldKey],
         ],
         previewTable: [
             (_, p) => [p.table],
@@ -103,14 +117,14 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
             }),
         ],
         previewExpressionColumns: [
-            (s, p) => [p.table, s.dataWarehousePopoverFields, s.localDefinition],
-            (table, dataWarehousePopoverFields, localDefinition): TablePreviewExpressionColumn[] => {
+            (s, p) => [p.table, s.dataWarehousePopoverFields, s.scopedLocalDefinition],
+            (table, dataWarehousePopoverFields, scopedLocalDefinition): TablePreviewExpressionColumn[] => {
                 const tableFieldNames = new Set(Object.values(table.fields).map((field) => field.name))
                 const usedKeys = new Set(tableFieldNames)
                 return EDITABLE_FIELD_ORDER.flatMap((fieldKey) => {
-                    const configuredValue = (localDefinition as Partial<Record<FunnelFieldKey, string | undefined>>)[
-                        fieldKey
-                    ]
+                    const configuredValue = (
+                        scopedLocalDefinition as Partial<Record<FunnelFieldKey, string | undefined>>
+                    )[fieldKey]
                     if (typeof configuredValue !== 'string') {
                         return []
                     }
@@ -180,7 +194,7 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
     }),
     listeners(({ values, props }) => ({
         selectTable: () => {
-            props.onSelectItem(props.group, props.table.name, values.localDefinition)
+            props.onSelectItem(props.group, props.table.name, values.scopedLocalDefinition)
             posthog.capture('funnel data warehouse step selected')
         },
     })),

--- a/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
@@ -58,6 +58,7 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
     })),
     selectors({
         dataWarehousePopoverFields: [(_, props) => [props.dataWarehousePopoverFields], (fields) => fields],
+        selectedItemMeta: [() => [(_, props) => props.selectedItemMeta], (selectedItemMeta) => selectedItemMeta],
     }),
     reducers({
         activeFieldKey: [
@@ -98,7 +99,7 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
                 dataWarehousePopoverFields.find((f) => f.key === activeFieldKey),
         ],
         scopedLocalDefinition: [
-            (s, p) => [s.definition, s.localDefinition, p.table, () => p.selectedItemMeta],
+            (s, p) => [s.definition, s.localDefinition, p.table, s.selectedItemMeta],
             (definition, localDefinition, table, selectedItemMeta) =>
                 definition.name === table.name
                     ? localDefinition

--- a/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
+++ b/frontend/src/scenes/insights/EditorFilters/funnelDataWarehouseStepDefinitionPopoverLogic.ts
@@ -51,7 +51,9 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
         actions: [definitionPopoverLogic, ['setLocalDefinition']],
     })),
     actions(() => ({
-        setActiveFieldKey: (activeFieldKey: FunnelFieldKey) => ({ activeFieldKey }),
+        setActiveFieldKey: (activeFieldKey: FunnelFieldKey) => ({
+            activeFieldKey,
+        }),
         selectTable: true,
     })),
     selectors({
@@ -96,7 +98,7 @@ export const funnelDataWarehouseStepDefinitionPopoverLogic = kea<funnelDataWareh
                 dataWarehousePopoverFields.find((f) => f.key === activeFieldKey),
         ],
         scopedLocalDefinition: [
-            (s, p) => [s.definition, s.localDefinition, p.table, p.selectedItemMeta],
+            (s, p) => [s.definition, s.localDefinition, p.table, () => p.selectedItemMeta],
             (definition, localDefinition, table, selectedItemMeta) =>
                 definition.name === table.name
                     ? localDefinition


### PR DESCRIPTION
## Problem

When you have multiple data warehouse sources, hovering them in the action filter can result in stale data for the preview table.

## Changes

Fixes this.

## How did you test this code?

Added multiple sources locally.