### PR TITLE
fix(insights): preserve sql insight updates after save

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -258,6 +258,28 @@ describe('sqlEditorLogic', () => {
             })
         })
 
+        it('preserves editingInsight when reopening after starting from a new SQL tab', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            logic.actions.createTab('SELECT 1')
+            await expectLogic(logic).toDispatchActions(['createTab', 'updateTab'])
+
+            router.actions.push(urls.sqlEditor(), { open_insight: MOCK_INSIGHT_SHORT_ID })
+
+            await expectLogic(logic)
+                .toDispatchActions(['editInsight', 'createTab', 'updateTab'])
+                .toMatchValues({
+                    editingInsight: partial({
+                        short_id: MOCK_INSIGHT_SHORT_ID,
+                    }),
+                })
+        })
+
         it('does not dispatch syncUrlWithQuery before the API responds', async () => {
             logic = sqlEditorLogic({
                 tabId: TAB_ID,

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1219,7 +1219,9 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 if (!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]) {
                     return undefined
                 }
-                return sourceQuery.source.connectionId
+                return sourceQuery.source && 'connectionId' in sourceQuery.source
+                    ? sourceQuery.source.connectionId
+                    : undefined
             },
         ],
         selectedDirectSource: [

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1602,10 +1602,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
 
                     const queryToOpen = searchParams.open_query ? searchParams.open_query : query
 
-                    actions.editInsight(queryToOpen, insight)
                     if (insight.query) {
                         actions.setSourceQuery(insight.query as DataVisualizationNode)
                     }
+                    actions.editInsight(queryToOpen, insight)
                     actions.setActiveTab(OutputTab.Visualization)
 
                     // Only run the query if the results aren't already cached locally and we're not using the open_query search param


### PR DESCRIPTION
### Motivation
- when a user creates a new SQL insight, saves it, then immediately reopens it for editing, the SQL editor could lose the attached insight context causing only “save as new insight” to be available
- this appears to be a race/ordering issue where the editor tab state can overwrite the reopened insight context during initialization

### Description
- reorder sql editor open-insight initialization to call `setSourceQuery` before `editInsight` in `frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx` to preserve the insight query context
- add a regression test `preserves editingInsight when reopening after starting from a new SQL tab` to `frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts` to cover the new-save-then-reopen flow
- updated files are `frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx` and `frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts`

### Testing
- ran `git diff --check` successfully to validate whitespace and diff checks
- attempted `pnpm --filter=@posthog/frontend jest frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts` but the `build:products` pre-step failed due to a missing `oxfmt` native binding in this environment
- attempted running jest directly but the test run failed in this environment due to a missing `@posthog/hogvm` module required by the frontend test setup
- unit test added locally and committed, tests should pass in CI where native bindings and frontend test dependencies are available

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd43249ba8832f9f0461d0882896b9)