### PR TITLE
feat(lemon-button): ensure disabled reason prevents on click events

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { LemonButton } from './LemonButton'
+
+describe('LemonButton', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    test('does not submit form when disabledReason is set', async () => {
+        const onSubmit = jest.fn((event: React.FormEvent<HTMLFormElement>) => event.preventDefault())
+
+        render(
+            <form onSubmit={onSubmit}>
+                <LemonButton htmlType="submit" disabledReason="Fill required fields">
+                    Save
+                </LemonButton>
+            </form>
+        )
+
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    test('submits form when button is enabled', async () => {
+        const onSubmit = jest.fn((event: React.FormEvent<HTMLFormElement>) => event.preventDefault())
+
+        render(
+            <form onSubmit={onSubmit}>
+                <LemonButton htmlType="submit">Save</LemonButton>
+            </form>
+        )
+
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+})

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -252,16 +252,20 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                         truncate && 'LemonButton--truncate',
                         className
                     )}
-                    onClick={
-                        !disabled
-                            ? (event) => {
-                                  if (stopPropagation) {
-                                      event.stopPropagation()
-                                  }
-                                  onClick?.(event)
-                              }
-                            : undefined
-                    }
+                    onClick={(event) => {
+                        if (disabled || disabledReason) {
+                            // Keep the element focusable/hoverable for tooltip UX, while hard-blocking native actions
+                            // like form submission from `type="submit"` buttons.
+                            event.preventDefault()
+                            event.stopPropagation()
+                            return
+                        }
+
+                        if (stopPropagation) {
+                            event.stopPropagation()
+                        }
+                        onClick?.(event)
+                    }}
                     // We are using the ARIA disabled instead of native HTML because of this:
                     // https://css-tricks.com/making-disabled-buttons-more-inclusive/
                     aria-disabled={disabled}


### PR DESCRIPTION
## Problem

We have deprecated the `disabled` property on the `LemonButton` in favour of `disabledReason`.

We did not update the onClick event to not trigger however if `disabledReason` is passed, only if `disabled` is set.

## Changes

Updates the onClick to also look for `disabledReason`

## How did you test this code?

Locally + a new test.
## Publish to changelog?

No.