### PR TITLE
fix(scim): skip nested group members in SCIM group sync

### DIFF
--- a/ee/api/scim/group.py
+++ b/ee/api/scim/group.py
@@ -137,7 +137,8 @@ class PostHogSCIMGroup(SCIMGroup):
                     RoleMembership.objects.get_or_create(
                         role=role, user=user, defaults={"organization_member": org_membership}
                     )
-            except User.DoesNotExist:
+            except (User.DoesNotExist, ValueError):
+                # Silently skip non-user members (e.g., nested group references from IdPs)
                 continue
 
         # Remove members no longer in the group
@@ -231,7 +232,8 @@ class PostHogSCIMGroup(SCIMGroup):
                         RoleMembership.objects.get_or_create(
                             role=self.obj, user=user, defaults={"organization_member": org_membership}
                         )
-                    except User.DoesNotExist:
+                    except (User.DoesNotExist, ValueError):
+                        # Silently skip non-user members (e.g., nested group references from IdPs)
                         continue
 
     def handle_remove(self, path: AttrPath, value: Union[str, list, dict], operation: dict) -> None:

--- a/ee/api/scim/group.py
+++ b/ee/api/scim/group.py
@@ -137,8 +137,11 @@ class PostHogSCIMGroup(SCIMGroup):
                     RoleMembership.objects.get_or_create(
                         role=role, user=user, defaults={"organization_member": org_membership}
                     )
-            except (User.DoesNotExist, ValueError):
-                # Silently skip non-user members (e.g., nested group references from IdPs)
+            except User.DoesNotExist:
+                continue
+            except ValueError:
+                # Skip non-user members (e.g., nested group references from IdPs)
+                logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": user_id})
                 continue
 
         # Remove members no longer in the group
@@ -232,8 +235,11 @@ class PostHogSCIMGroup(SCIMGroup):
                         RoleMembership.objects.get_or_create(
                             role=self.obj, user=user, defaults={"organization_member": org_membership}
                         )
-                    except (User.DoesNotExist, ValueError):
-                        # Silently skip non-user members (e.g., nested group references from IdPs)
+                    except User.DoesNotExist:
+                        continue
+                    except ValueError:
+                        # Skip non-user members (e.g., nested group references from IdPs)
+                        logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": user_id})
                         continue
 
     def handle_remove(self, path: AttrPath, value: Union[str, list, dict], operation: dict) -> None:

--- a/ee/api/scim/test/test_groups_api.py
+++ b/ee/api/scim/test/test_groups_api.py
@@ -607,6 +607,59 @@ class TestSCIMGroupsAPI(APILicensedTest):
         assert not RoleMembership.objects.filter(role=role, user=user1).exists()
         assert RoleMembership.objects.filter(role=role, user=user2).exists()
 
+    # ── Nested group (non-user member) tests ──
+
+    def test_patch_add_silently_skips_non_user_member_ids(self):
+        """Entra ID sends nested group UUIDs as member values — these should be silently skipped."""
+        user = User.objects.create_user(
+            email="realuser@example.com", password=None, first_name="Real", is_email_verified=True
+        )
+        OrganizationMembership.objects.create(
+            user=user, organization=self.organization, level=OrganizationMembership.Level.MEMBER
+        )
+        role = Role.objects.create(name="TestRole", organization=self.organization)
+        nested_group_id = str(uuid.uuid4())
+
+        patch_data = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [
+                {"op": "add", "path": "members", "value": [{"value": nested_group_id}, {"value": str(user.id)}]}
+            ],
+        }
+
+        response = self.client.patch(
+            f"/scim/v2/{self.domain.id}/Groups/{role.id}", data=patch_data, content_type="application/scim+json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert RoleMembership.objects.filter(role=role, user=user).exists()
+        assert RoleMembership.objects.filter(role=role).count() == 1
+
+    def test_put_silently_skips_non_user_member_ids(self):
+        """PUT with a members list containing a nested group UUID should succeed and only add valid users."""
+        user = User.objects.create_user(
+            email="putuser@example.com", password=None, first_name="Put", is_email_verified=True
+        )
+        OrganizationMembership.objects.create(
+            user=user, organization=self.organization, level=OrganizationMembership.Level.MEMBER
+        )
+        role = Role.objects.create(name="TestRole", organization=self.organization)
+        nested_group_id = str(uuid.uuid4())
+
+        put_data = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Group"],
+            "displayName": "TestRole",
+            "members": [{"value": nested_group_id}, {"value": str(user.id)}],
+        }
+
+        response = self.client.put(
+            f"/scim/v2/{self.domain.id}/Groups/{role.id}", data=put_data, content_type="application/scim+json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert RoleMembership.objects.filter(role=role, user=user).exists()
+        assert RoleMembership.objects.filter(role=role).count() == 1
+
     # ── Pagination tests ──
 
     def _create_groups(self, count: int) -> list[Role]:


### PR DESCRIPTION
## Problem

Customers using Entra ID with nested groups get 400 errors in their provisioning logs. When a parent group contains nested sub-groups, Entra ID sends the nested group's SCIM ID as a member reference. 
The `User.objects.get(id=<uuid>)` throws a `ValueError` (not `User.DoesNotExist`) because user.id is an integer field. 

[More context](https://posthog.slack.com/archives/C09B6HYA6Q5/p1773326607369709?thread_ts=1762279729.310209&cid=C09B6HYA6Q5). 

## Changes

No major SaaS provider supports SCIM nested groups, the spec allows but doesn't require it. So...

Users from nested sub-groups are still provisioned individually and added to their own roles, only the parent-child group relationship is ignored. 

## How did you test this code?
Tests

## Publish to changelog?
No

## Docs update
No