### PR TITLE
fix: change session_id type to str in QueryTags

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -96,7 +96,7 @@ class QueryTags(BaseModel):
     # at this moment: request for HTTP request, celery, dagster and temporal are used, please don't use others.
     kind: Optional[str] = None
     id: Optional[str] = None
-    session_id: Optional[uuid.UUID] = None
+    session_id: Optional[str] = None
 
     # temporalio tags
     temporal: Optional[TemporalTags] = None

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -85,6 +85,13 @@ def test_failure_on_incorrect_type():
     assert get_query_tags() == create_base_tags()
 
 
+def test_session_id_accepts_non_uuid_strings():
+    reset_query_tags()
+    tag_queries(session_id="not-a-uuid-but-valid-string")
+    tags = get_query_tags()
+    assert tags.session_id == "not-a-uuid-but-valid-string"
+
+
 def test_clear_tag():
     reset_query_tags()
     clear_tag("team_id")


### PR DESCRIPTION
## Problem

`POST /login` returns 500 when a request contains a malformed `session_id` query parameter. 

The `QueryTags` model types `session_id` as `Optional[uuid.UUID]` with `validate_assignment=True`, so any non-UUID string causes an unhandled `ValidationError` that crashes the request. This produced 134 Django errors over 48h ([details](https://posthog.slack.com/archives/C0AMG1GR4VA/p1773838721887289?thread_ts=1773838699.486789&cid=C0AMG1GR4VA))

## Changes
 - Change `session_id` to `Optional[str]` in `QueryTags`, matching how the rest of the codebase treats session IDs

## How did you test this code?

Tests

## Publish to changelog?
No

## Docs update
No