### PR TITLE
fix: Several deduplicator fixes

### DIFF
--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -20,6 +20,39 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
+/// Install a panic hook that logs panics through the structured tracing logger.
+///
+/// Without this, panics write to stderr using the default formatter, which
+/// bypasses the JSON log layer and makes them invisible in Loki/Grafana.
+fn install_tracing_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let thread = std::thread::current();
+        let thread_name = thread.name().unwrap_or("<unnamed>");
+        let location = panic_info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "unknown".to_string());
+        let payload = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "unknown panic payload".to_string()
+        };
+
+        error!(
+            thread = %thread_name,
+            location = %location,
+            payload = %payload,
+            "Thread panicked"
+        );
+
+        // Still call the default hook so the process aborts/unwinds as expected
+        default_hook(panic_info);
+    }));
+}
+
 use kafka_deduplicator::{config::Config, service::KafkaDeduplicatorService};
 
 common_alloc::used!();
@@ -218,6 +251,10 @@ async fn main() -> Result<()> {
         .with(log_layer)
         .with(otel_layer)
         .init();
+
+    // Install panic hook after tracing is initialized so panics are logged
+    // through the structured JSON logger, making them visible in Loki/Grafana.
+    install_tracing_panic_hook();
 
     // Create a root span with pod hostname for all logs
     // This adds "pod" field to every log line for Loki/Grafana filtering

--- a/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
+++ b/rust/kafka-deduplicator/src/pipelines/pipeline_builder.rs
@@ -69,6 +69,9 @@ pub struct PipelineBuilder {
     rebalance_cleanup_parallelism: usize,
     local_checkpoint_max_staleness: Duration,
 
+    // Shared offset tracker (injected from service, also used by CheckpointManager)
+    offset_tracker: Option<Arc<OffsetTracker>>,
+
     // Fail-open mode: bypass deduplication and forward events directly
     fail_open: bool,
 
@@ -108,6 +111,7 @@ impl PipelineBuilder {
             local_checkpoint_max_staleness: Duration::from_secs(
                 DEFAULT_LOCAL_CHECKPOINT_MAX_STALENESS_SECS,
             ),
+            offset_tracker: None,
             fail_open,
             dedup_config: None,
             main_producer: None,
@@ -122,6 +126,11 @@ impl PipelineBuilder {
 
     pub fn with_local_checkpoint_staleness(mut self, staleness: Duration) -> Self {
         self.local_checkpoint_max_staleness = staleness;
+        self
+    }
+
+    pub fn with_offset_tracker(mut self, offset_tracker: Arc<OffsetTracker>) -> Self {
+        self.offset_tracker = Some(offset_tracker);
         self
     }
 
@@ -141,7 +150,10 @@ impl PipelineBuilder {
     /// Build a group-based pipeline consumer (uses Kafka's consumer group protocol).
     pub fn build(self, shutdown_rx: oneshot::Receiver<()>) -> Result<PipelineConsumer> {
         let rebalance_tracker = self.store_manager.rebalance_tracker().clone();
-        let offset_tracker = Arc::new(OffsetTracker::new(rebalance_tracker.clone()));
+        let offset_tracker = self
+            .offset_tracker
+            .clone()
+            .unwrap_or_else(|| Arc::new(OffsetTracker::new(rebalance_tracker.clone())));
 
         match self.pipeline_type {
             PipelineType::IngestionEvents => {
@@ -164,7 +176,10 @@ impl PipelineBuilder {
         shutdown_rx: oneshot::Receiver<()>,
     ) -> Result<PipelineConsumer> {
         let rebalance_tracker = self.store_manager.rebalance_tracker().clone();
-        let offset_tracker = Arc::new(OffsetTracker::new(rebalance_tracker));
+        let offset_tracker = self
+            .offset_tracker
+            .clone()
+            .unwrap_or_else(|| Arc::new(OffsetTracker::new(rebalance_tracker)));
 
         match self.pipeline_type {
             PipelineType::IngestionEvents => {

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     checkpoint_manager::CheckpointManager,
     config::Config,
-    kafka::{PartitionRouterConfig, PartitionWorkerConfig},
+    kafka::{OffsetTracker, PartitionRouterConfig, PartitionWorkerConfig},
     rebalance_tracker::RebalanceTracker,
     rocksdb::store::init_shared_resources,
     store::DeduplicationStoreConfig,
@@ -37,6 +37,7 @@ use crate::{
 pub struct KafkaDeduplicatorService {
     config: Config,
     store_manager: Arc<StoreManager>,
+    offset_tracker: Arc<OffsetTracker>,
     checkpoint_manager: Option<CheckpointManager>,
     checkpoint_importer: Option<Arc<CheckpointImporter>>,
     cleanup_task_handle: Option<CleanupTaskHandle>,
@@ -112,20 +113,35 @@ impl KafkaDeduplicatorService {
             rebalance_tracker.clone(),
         ));
 
+        // Create offset tracker — shared between CheckpointManager (for writing offsets
+        // into checkpoint metadata) and PipelineBuilder (for tracking committed offsets)
+        let offset_tracker = Arc::new(OffsetTracker::new(rebalance_tracker));
+
         // In fail-open mode, skip store cleanup and checkpoint infrastructure
         let (cleanup_task_handle, checkpoint_manager, importer) = if config.fail_open {
             info!("Fail-open mode enabled — skipping cleanup task, checkpoint export/import");
             let checkpoint_config = CheckpointConfig::default();
-            let checkpoint_manager =
-                CheckpointManager::new(checkpoint_config, store_manager.clone(), None);
+            let checkpoint_manager = CheckpointManager::new_with_offset_tracker(
+                checkpoint_config,
+                store_manager.clone(),
+                None,
+                offset_tracker.clone(),
+            );
             (None, checkpoint_manager, None)
         } else {
-            Self::create_store_infrastructure(&config, &store_config, &store_manager).await?
+            Self::create_store_infrastructure(
+                &config,
+                &store_config,
+                &store_manager,
+                &offset_tracker,
+            )
+            .await?
         };
 
         Ok(Self {
             config,
             store_manager,
+            offset_tracker,
             checkpoint_manager: Some(checkpoint_manager),
             checkpoint_importer: importer,
             cleanup_task_handle,
@@ -143,6 +159,7 @@ impl KafkaDeduplicatorService {
         config: &Config,
         store_config: &DeduplicationStoreConfig,
         store_manager: &Arc<StoreManager>,
+        offset_tracker: &Arc<OffsetTracker>,
     ) -> Result<(
         Option<CleanupTaskHandle>,
         CheckpointManager,
@@ -238,8 +255,12 @@ impl KafkaDeduplicatorService {
             None
         };
 
-        let checkpoint_manager =
-            CheckpointManager::new(checkpoint_config, store_manager.clone(), exporter);
+        let checkpoint_manager = CheckpointManager::new_with_offset_tracker(
+            checkpoint_config,
+            store_manager.clone(),
+            exporter,
+            offset_tracker.clone(),
+        );
 
         Ok((cleanup_task_handle, checkpoint_manager, importer))
     }
@@ -319,7 +340,8 @@ impl KafkaDeduplicatorService {
             self.config.fail_open,
         )
         .with_checkpoint_importer(self.checkpoint_importer.clone())
-        .with_local_checkpoint_staleness(self.config.local_checkpoint_max_staleness());
+        .with_local_checkpoint_staleness(self.config.local_checkpoint_max_staleness())
+        .with_offset_tracker(self.offset_tracker.clone());
 
         // Configure pipeline-specific options for ingestion events
         if self.config.pipeline_type == PipelineType::IngestionEvents {

--- a/rust/kafka-deduplicator/src/store_manager.rs
+++ b/rust/kafka-deduplicator/src/store_manager.rs
@@ -436,6 +436,13 @@ impl StoreManager {
         consumer_offset: i64,
         producer_offset: i64,
     ) {
+        // Skip if the store has been unregistered (e.g. during rebalance).
+        // The directory may be deleted concurrently by cleanup_store_files,
+        // causing write_to_dir's rename to fail with ENOENT.
+        if self.get(topic, partition).is_none() {
+            return;
+        }
+
         let store_path = format_store_path(&self.store_config.path, topic, partition);
         if !store_path.exists() {
             return;


### PR DESCRIPTION
## Problem

The kafka-deduplicator service had three operational issues in production:

1. WARN log spam ("Failed to update metadata.json after commit") caused by a race condition between `update_metadata_for_partition` and `cleanup_store_files` during Kafka rebalances
2. Pods terminating with `Error` status but no visible error logs, because panics weren't captured by the structured JSON logger
3. Checkpoint metadata.json files always contained `consumer_offset: 0` and `producer_offset: 0` because the `OffsetTracker` was created inside `PipelineBuilder` but never shared with `CheckpointManager`

## Changes

- Add a DashMap registration check in `update_metadata_for_partition` to skip filesystem writes when the store has been unregistered during rebalance
- Install a tracing panic hook after subscriber initialization so panics are logged as structured JSON, making them visible in Loki/Grafana
- Create `OffsetTracker` in `KafkaDeduplicatorService::new()` and share it with both `CheckpointManager` (via `new_with_offset_tracker()`) and `PipelineBuilder` (via new `with_offset_tracker()` builder method), so checkpoint metadata contains real committed offsets


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
