### PR TITLE
fix: Rename 'numeric' type to 'number' for snowflake incremental syncs

### DIFF
--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -31,7 +31,7 @@ def filter_snowflake_incremental_fields(
             results.append((column_name, IncrementalFieldType.Date, nullable))
         elif type == "datetime":
             results.append((column_name, IncrementalFieldType.DateTime, nullable))
-        elif type == "number":
+        elif type in ("number", "numeric"):
             results.append((column_name, IncrementalFieldType.Numeric, nullable))
 
     return results

--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -31,7 +31,7 @@ def filter_snowflake_incremental_fields(
             results.append((column_name, IncrementalFieldType.Date, nullable))
         elif type == "datetime":
             results.append((column_name, IncrementalFieldType.DateTime, nullable))
-        elif type == "numeric":
+        elif type == "number":
             results.append((column_name, IncrementalFieldType.Numeric, nullable))
 
     return results


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/53704 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55018) - we weren't showing number fields as an option for Snowflake incremental syncs.

This is because in Snowflake's information schema, all numeric/number types get reported as `number` for their `DATA_TYPE` - see https://docs.snowflake.com/en/sql-reference/data-types-numeric#decimal-dec-numeric.

## Changes

`numeric` -> `number`

## How did you test this code?

Tested locally + verified with both numeric and number fields that the fix works (empty before, options shown after) - `id` is `number` and `score` is `numeric`:

<img width="456" height="330" alt="CleanShot 2026-03-20 at 15 24 14" src="https://github.com/user-attachments/assets/ff97f920-0660-4ae0-a0d4-904148a5470a" />