### PR TITLE
test(exposures): fixes a flakey test for experiments

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.test.tsx
+++ b/frontend/src/scenes/experiments/Experiment.test.tsx
@@ -8,7 +8,7 @@ import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import type { Experiment as ExperimentType } from '~/types'
+import { ExperimentStatus, type Experiment as ExperimentType } from '~/types'
 
 import { NEW_EXPERIMENT } from './constants'
 import { Experiment } from './Experiment'
@@ -134,29 +134,33 @@ describe('Experiment component', () => {
             description: 'draft',
             expectLaunchButton: true,
             expectWarningBanner: false,
+            tabId: 'test-tab-draft-no-metrics',
         },
         {
-            experimentOverrides: { start_date: '2024-01-01T00:00:00Z' },
+            experimentOverrides: {
+                start_date: '2024-01-01T00:00:00Z',
+                status: ExperimentStatus.Running,
+            },
             description: 'running experiment',
             expectLaunchButton: false,
             expectWarningBanner: true,
+            tabId: 'test-tab-running-no-metrics',
         },
     ])(
         '$description without metrics shows add metric buttons',
-        async ({ experimentOverrides, expectLaunchButton, expectWarningBanner }) => {
+        async ({ experimentOverrides, expectLaunchButton, expectWarningBanner, tabId }) => {
             const experimentData: ExperimentType = { ...DRAFT_EXPERIMENT, ...experimentOverrides }
             localStorage.clear()
             sessionStorage.clear()
             useMocks(mockApiForExperiment(experimentData))
             mountKeaLogics()
 
-            const tabId = 'test-tab-view'
             const { sceneLogic } = renderExperimentViewPage(tabId, experimentData)
 
             await waitFor(() => {
-                expect(screen.getByText('Add primary metric')).toBeInTheDocument()
+                expect(screen.getAllByText('Add primary metric').length).toBeGreaterThan(0)
             })
-            expect(screen.getByText('Add secondary metric')).toBeInTheDocument()
+            expect(screen.getAllByText('Add secondary metric').length).toBeGreaterThan(0)
 
             // No creation form should be shown in view mode
             expect(screen.queryByTestId('experiment-wizard')).not.toBeInTheDocument()
@@ -164,7 +168,8 @@ describe('Experiment component', () => {
             if (expectLaunchButton) {
                 const launchButton = document.querySelector('[data-attr="launch-experiment"]')
                 expect(launchButton).toBeInTheDocument()
-                expect(launchButton).not.toHaveAttribute('aria-disabled')
+                // LemonButton sets aria-disabled={disabled}; React omits the attribute when false, or "false" when present
+                expect(launchButton?.getAttribute('aria-disabled')).not.toBe('true')
             } else {
                 expect(document.querySelector('[data-attr="launch-experiment"]')).not.toBeInTheDocument()
             }

--- a/frontend/src/scenes/experiments/Experiment.test.tsx
+++ b/frontend/src/scenes/experiments/Experiment.test.tsx
@@ -158,9 +158,9 @@ describe('Experiment component', () => {
             const { sceneLogic } = renderExperimentViewPage(tabId, experimentData)
 
             await waitFor(() => {
-                expect(screen.getAllByText('Add primary metric').length).toBeGreaterThan(0)
+                screen.getAllByText('Add primary metric')
             })
-            expect(screen.getAllByText('Add secondary metric').length).toBeGreaterThan(0)
+            screen.getAllByText('Add secondary metric')
 
             // No creation form should be shown in view mode
             expect(screen.queryByTestId('experiment-wizard')).not.toBeInTheDocument()

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -365,7 +365,7 @@ export function Exposures(): JSX.Element {
                                     />
                                 </div>
                             </div>
-                            {exposures?.timeseries.length > 0 && (
+                            {(exposures?.timeseries?.length ?? 0) > 0 && (
                                 <div>
                                     <h3 className="card-secondary">Total exposures</h3>
                                     <LemonTable


### PR DESCRIPTION
## Problem

First noticed here:
https://github.com/PostHog/posthog/actions/runs/23351069986/job/67929681705?pr=51794

<img width="1236" height="684" alt="CleanShot 2026-03-20 at 12 11 57@2x" src="https://github.com/user-attachments/assets/536f6f5c-0c31-419b-aeab-5e6ceaaf8815" />


## How did you test this code?
Locally.

Run 30 times to ensure no flake.

## Publish to changelog?
No.