### PR TITLE
fix(devex): Add missing runs_on to invalid workflow files

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
     call-flags-project:
         timeout-minutes: 5
+        runs_on: ubuntu-latest
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@main
         # Only on PostHog/posthog, as there's no GitHub token on forks
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -621,6 +621,7 @@ jobs:
     # Cleanup preview when hobby-preview label is removed
     cleanup-on-label-removal:
         name: Cleanup preview on label removal
+        runs-on: ubuntu-latest
         needs: changes
         if: needs.changes.outputs.label_removed == 'true'
         timeout-minutes: 5

--- a/.github/workflows/ci-survey-sdk-check.yml
+++ b/.github/workflows/ci-survey-sdk-check.yml
@@ -53,6 +53,7 @@ jobs:
 
     check-docs-generated:
         name: Check SDK docs are up to date
+        runs-on: ubuntu-24.04
         timeout-minutes: 5
         uses: ./.github/workflows/ci-docs-check.yml
         with:

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
     cleanup-hobby-preview:
         name: Cleanup hobby preview deployment
+        runs-on: ubuntu-24.04
         if: contains(github.event.pull_request.labels.*.name, 'hobby-preview')
         timeout-minutes: 5
         uses: ./.github/workflows/pr-cleanup.yml


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Had a bunch of CI jobs fail on master after my [PR](https://github.com/PostHog/posthog/pull/51705) merged:
* https://github.com/PostHog/posthog/actions/runs/23351660947
* https://github.com/PostHog/posthog/actions/runs/23351661497
* https://github.com/PostHog/posthog/actions/runs/23351661795
* https://github.com/PostHog/posthog/actions/runs/23351661185

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

* Add `runs-on` where missing across ☝🏼 CI workflows

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
