### PR TITLE
feat(dashboards): allow toggling insight legend visibility from dashboard

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/DashboardInsightActions.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/DashboardInsightActions.tsx
@@ -1,0 +1,87 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { insightsModel } from '~/models/insightsModel'
+import { InsightLogicProps, QueryBasedInsightModel } from '~/types'
+
+import { toggleDisplayLabelsInInsightQuery } from './displayLabelsToggle'
+import { toggleLegendInInsightQuery } from './legendToggle'
+
+type DashboardInsightActionsProps = {
+    insight: QueryBasedInsightModel
+    insightLogicProps: InsightLogicProps
+    dashboardId: number | undefined
+    canToggleDisplayLabels: boolean
+    canToggleLegend: boolean
+}
+
+/** Quick visualization toggles in the insight card ⋯ menu on dashboard (and similar placements). */
+export function DashboardInsightActions({
+    insight,
+    insightLogicProps,
+    dashboardId,
+    canToggleDisplayLabels,
+    canToggleLegend,
+}: DashboardInsightActionsProps): JSX.Element | null {
+    const {
+        displayLabelsToggleTextForInsight,
+        legendToggleTextForInsight,
+        query: activeQuery,
+    } = useValues(insightLogic(insightLogicProps))
+    const { updateInsightDirect } = useActions(insightsModel)
+    const { reportDashboardInsightValuesOnSeriesToggled, reportDashboardInsightLegendToggled } =
+        useActions(eventUsageLogic)
+
+    if (!canToggleDisplayLabels && !canToggleLegend) {
+        return null
+    }
+
+    return (
+        <>
+            <LemonDivider />
+            {canToggleDisplayLabels && (
+                <LemonButton
+                    onClick={() => {
+                        const currentQuery = activeQuery ?? insight.query
+                        const query = toggleDisplayLabelsInInsightQuery(currentQuery)
+                        if (query !== currentQuery) {
+                            updateInsightDirect(insight, { query })
+                            reportDashboardInsightValuesOnSeriesToggled(
+                                dashboardId,
+                                insight.id,
+                                DashboardEventSource.MoreDropdown
+                            )
+                        }
+                    }}
+                    fullWidth
+                >
+                    {displayLabelsToggleTextForInsight}
+                </LemonButton>
+            )}
+            {canToggleLegend && (
+                <LemonButton
+                    onClick={() => {
+                        const currentQuery = activeQuery ?? insight.query
+                        const query = toggleLegendInInsightQuery(currentQuery)
+                        if (query !== currentQuery) {
+                            updateInsightDirect(insight, { query })
+                            reportDashboardInsightLegendToggled(
+                                dashboardId,
+                                insight.id,
+                                DashboardEventSource.MoreDropdown
+                            )
+                        }
+                    }}
+                    fullWidth
+                >
+                    {legendToggleTextForInsight}
+                </LemonButton>
+            )}
+            <LemonDivider />
+        </>
+    )
+}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -27,7 +27,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
-import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -53,7 +53,7 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
-import { getDisplayLabelsToggleText, toggleDisplayLabelsInInsightQuery } from './displayLabelsToggle'
+import { DashboardInsightActions } from './DashboardInsightActions'
 import { InsightCardProps } from './InsightCard'
 import { InsightDetails } from './InsightDetails'
 import { InsightMoveToDashboardMenu } from './InsightMoveToDashboardMenu'
@@ -127,14 +127,15 @@ export function InsightMeta({
         variablesOverride: variablesOverride ?? null,
         tileFiltersOverride: tile?.filters_overrides ?? null,
     }
-    const { insightFeedback, canToggleDisplayLabelsForInsight } = useValues(insightLogic(insightLogicProps))
+    const { insightFeedback, canToggleDisplayLabelsForInsight, canToggleLegendForInsight } = useValues(
+        insightLogic(insightLogicProps)
+    )
     const { setInsightFeedback } = useActions(insightLogic(insightLogicProps))
     const { exportContext, insightData } = useValues(insightDataLogic(insightLogicProps))
     const { samplingFactor } = useValues(insightVizDataLogic(insightLogicProps))
     const { nameSortedDashboards } = useValues(dashboardsModel)
     const { updateInsightDirect } = useActions(insightsModel)
-    const { reportDashboardInsightMetaUpdated, reportDashboardInsightValuesOnSeriesToggled } =
-        useActions(eventUsageLogic)
+    const { reportDashboardInsightMetaUpdated } = useActions(eventUsageLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const showCompactTile =
@@ -147,7 +148,6 @@ export function InsightMeta({
         placement === DashboardPlacement.Builtin
 
     const isSqlInsight = isDataVisualizationNode(insight.query)
-    const displayLabelsToggleText = getDisplayLabelsToggleText(insight.query)
     const showCompactHeading = !showCompactTile || (!filtersOverride?.date_from && !isSqlInsight)
 
     const topHeadingProps = {
@@ -173,6 +173,7 @@ export function InsightMeta({
               )
             : true
     const canToggleDisplayLabels = isDashboardCardPlacement && canEditInsight && canToggleDisplayLabelsForInsight
+    const canToggleLegend = isDashboardCardPlacement && canEditInsight && canToggleLegendForInsight
 
     // For dashboard-specific actions (remove from dashboard, change tile color), check dashboard permissions
     const currentDashboard = dashboardId ? nameSortedDashboards.find((d) => d.id === dashboardId) : null
@@ -378,33 +379,18 @@ export function InsightMeta({
                     >
                         Duplicate
                     </LemonButton>
-                    {canToggleDisplayLabels && (
-                        <>
-                            <LemonDivider />
-                            <LemonButton
-                                onClick={() => {
-                                    const query = toggleDisplayLabelsInInsightQuery(insight.query)
-                                    if (query !== insight.query) {
-                                        updateInsightDirect(insight, { query })
-                                        reportDashboardInsightValuesOnSeriesToggled(
-                                            dashboardId,
-                                            insight.id,
-                                            DashboardEventSource.MoreDropdown
-                                        )
-                                    }
-                                }}
-                                fullWidth
-                            >
-                                {displayLabelsToggleText}
-                            </LemonButton>
-                            <LemonDivider />
-                        </>
-                    )}
+                    <DashboardInsightActions
+                        insight={insight}
+                        insightLogicProps={insightLogicProps}
+                        dashboardId={dashboardId}
+                        canToggleDisplayLabels={canToggleDisplayLabels}
+                        canToggleLegend={canToggleLegend}
+                    />
 
                     {/* Dashboard related */}
                     {canEditDashboard && (
                         <>
-                            {!canToggleDisplayLabels && <LemonDivider />}
+                            {!canToggleDisplayLabels && !canToggleLegend && <LemonDivider />}
                             {showCompactTile && toggleShowDescription && !!insight.description && (
                                 <LemonButton onClick={toggleShowDescription} fullWidth>
                                     {tile?.show_description === false ? 'Show description' : 'Hide description'}

--- a/frontend/src/lib/components/Cards/InsightCard/legendToggle.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/legendToggle.test.ts
@@ -10,90 +10,100 @@ import {
 
 describe('legendToggle', () => {
     describe('canToggleLegendInInsightQuery', () => {
-        it('returns true for trends line graph', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
+        it.each([
+            {
+                title: 'trends line graph',
+                query: {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
+                    },
                 },
-            } as any
-
-            expect(canToggleLegendInInsightQuery(query)).toBe(true)
-        })
-
-        it('returns false for world map', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    trendsFilter: { display: ChartDisplayType.WorldMap },
+                expected: true,
+            },
+            {
+                title: 'world map',
+                query: {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        trendsFilter: { display: ChartDisplayType.WorldMap },
+                    },
                 },
-            } as any
-
-            expect(canToggleLegendInInsightQuery(query)).toBe(false)
-        })
-
-        it('returns false for funnels', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.FunnelsQuery,
-                    funnelsFilter: { funnelVizType: 'steps' },
+                expected: false,
+            },
+            {
+                title: 'funnels steps',
+                query: {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        funnelsFilter: { funnelVizType: 'steps' },
+                    },
                 },
-            } as any
-
-            expect(canToggleLegendInInsightQuery(query)).toBe(false)
-        })
-
-        it('returns true for lifecycle', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.LifecycleQuery,
+                expected: false,
+            },
+            {
+                title: 'lifecycle',
+                query: {
+                    kind: NodeKind.InsightVizNode,
+                    source: { kind: NodeKind.LifecycleQuery },
                 },
-            } as any
-
-            expect(canToggleLegendInInsightQuery(query)).toBe(true)
-        })
-
-        it('returns false for trends table display', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.TrendsQuery,
-                    trendsFilter: { display: ChartDisplayType.ActionsTable },
+                expected: true,
+            },
+            {
+                title: 'trends table',
+                query: {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        trendsFilter: { display: ChartDisplayType.ActionsTable },
+                    },
                 },
-            } as any
-
-            expect(canToggleLegendInInsightQuery(query)).toBe(false)
-        })
-
-        it('returns false for non-insight-viz query', () => {
-            const query = { kind: NodeKind.DataVisualizationNode } as any
-            expect(canToggleLegendInInsightQuery(query)).toBe(false)
+                expected: false,
+            },
+            {
+                title: 'non-insight-viz (SQL)',
+                query: { kind: NodeKind.DataVisualizationNode },
+                expected: false,
+            },
+        ])('returns $expected for $title', ({ query, expected }) => {
+            expect(canToggleLegendInInsightQuery(query as any)).toBe(expected)
         })
     })
 
     describe('toggleLegendInInsightQuery', () => {
-        it('sets showLegend true when unset', () => {
+        it.each([
+            {
+                kind: NodeKind.TrendsQuery,
+                filterKey: 'trendsFilter',
+                display: ChartDisplayType.ActionsLineGraph,
+            },
+            {
+                kind: NodeKind.StickinessQuery,
+                filterKey: 'stickinessFilter',
+                display: ChartDisplayType.ActionsLineGraph,
+            },
+            {
+                kind: NodeKind.LifecycleQuery,
+                filterKey: 'lifecycleFilter',
+                display: undefined,
+            },
+        ])('sets showLegend true when unset ($kind)', ({ kind, filterKey, display }) => {
             const query = {
                 kind: NodeKind.InsightVizNode,
                 source: {
-                    kind: NodeKind.TrendsQuery,
-                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
+                    kind,
+                    [filterKey]: display ? { display } : {},
                 },
             } as any
 
-            const next = toggleLegendInInsightQuery(query) as InsightVizNode
-            const src = next.source
-            expect(src.kind).toBe(NodeKind.TrendsQuery)
-            if (src.kind === NodeKind.TrendsQuery) {
-                expect(src.trendsFilter?.showLegend).toBe(true)
-            }
+            const next = toggleLegendInInsightQuery(query) as any
+            expect(next.source[filterKey]?.showLegend).toBe(true)
         })
 
-        it('toggles showLegend off', () => {
+        it('toggles showLegend off for trends', () => {
             const query = {
                 kind: NodeKind.InsightVizNode,
                 source: {
@@ -107,40 +117,6 @@ describe('legendToggle', () => {
             expect(src.kind).toBe(NodeKind.TrendsQuery)
             if (src.kind === NodeKind.TrendsQuery) {
                 expect(src.trendsFilter?.showLegend).toBe(false)
-            }
-        })
-
-        it('updates stickiness filter', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.StickinessQuery,
-                    stickinessFilter: { display: ChartDisplayType.ActionsLineGraph },
-                },
-            } as any
-
-            const next = toggleLegendInInsightQuery(query) as InsightVizNode
-            const src = next.source
-            expect(src.kind).toBe(NodeKind.StickinessQuery)
-            if (src.kind === NodeKind.StickinessQuery) {
-                expect(src.stickinessFilter?.showLegend).toBe(true)
-            }
-        })
-
-        it('updates lifecycle filter', () => {
-            const query = {
-                kind: NodeKind.InsightVizNode,
-                source: {
-                    kind: NodeKind.LifecycleQuery,
-                    lifecycleFilter: {},
-                },
-            } as any
-
-            const next = toggleLegendInInsightQuery(query) as InsightVizNode
-            const src = next.source
-            expect(src.kind).toBe(NodeKind.LifecycleQuery)
-            if (src.kind === NodeKind.LifecycleQuery) {
-                expect(src.lifecycleFilter?.showLegend).toBe(true)
             }
         })
     })

--- a/frontend/src/lib/components/Cards/InsightCard/legendToggle.test.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/legendToggle.test.ts
@@ -1,0 +1,187 @@
+import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
+
+import {
+    canToggleLegendInInsightQuery,
+    getLegendToggleText,
+    isLegendEnabledInInsightQuery,
+    toggleLegendInInsightQuery,
+} from './legendToggle'
+
+describe('legendToggle', () => {
+    describe('canToggleLegendInInsightQuery', () => {
+        it('returns true for trends line graph', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
+                },
+            } as any
+
+            expect(canToggleLegendInInsightQuery(query)).toBe(true)
+        })
+
+        it('returns false for world map', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.WorldMap },
+                },
+            } as any
+
+            expect(canToggleLegendInInsightQuery(query)).toBe(false)
+        })
+
+        it('returns false for funnels', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.FunnelsQuery,
+                    funnelsFilter: { funnelVizType: 'steps' },
+                },
+            } as any
+
+            expect(canToggleLegendInInsightQuery(query)).toBe(false)
+        })
+
+        it('returns true for lifecycle', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.LifecycleQuery,
+                },
+            } as any
+
+            expect(canToggleLegendInInsightQuery(query)).toBe(true)
+        })
+
+        it('returns false for trends table display', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsTable },
+                },
+            } as any
+
+            expect(canToggleLegendInInsightQuery(query)).toBe(false)
+        })
+
+        it('returns false for non-insight-viz query', () => {
+            const query = { kind: NodeKind.DataVisualizationNode } as any
+            expect(canToggleLegendInInsightQuery(query)).toBe(false)
+        })
+    })
+
+    describe('toggleLegendInInsightQuery', () => {
+        it('sets showLegend true when unset', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
+                },
+            } as any
+
+            const next = toggleLegendInInsightQuery(query) as InsightVizNode
+            const src = next.source
+            expect(src.kind).toBe(NodeKind.TrendsQuery)
+            if (src.kind === NodeKind.TrendsQuery) {
+                expect(src.trendsFilter?.showLegend).toBe(true)
+            }
+        })
+
+        it('toggles showLegend off', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph, showLegend: true },
+                },
+            } as any
+
+            const next = toggleLegendInInsightQuery(query) as InsightVizNode
+            const src = next.source
+            expect(src.kind).toBe(NodeKind.TrendsQuery)
+            if (src.kind === NodeKind.TrendsQuery) {
+                expect(src.trendsFilter?.showLegend).toBe(false)
+            }
+        })
+
+        it('updates stickiness filter', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.StickinessQuery,
+                    stickinessFilter: { display: ChartDisplayType.ActionsLineGraph },
+                },
+            } as any
+
+            const next = toggleLegendInInsightQuery(query) as InsightVizNode
+            const src = next.source
+            expect(src.kind).toBe(NodeKind.StickinessQuery)
+            if (src.kind === NodeKind.StickinessQuery) {
+                expect(src.stickinessFilter?.showLegend).toBe(true)
+            }
+        })
+
+        it('updates lifecycle filter', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.LifecycleQuery,
+                    lifecycleFilter: {},
+                },
+            } as any
+
+            const next = toggleLegendInInsightQuery(query) as InsightVizNode
+            const src = next.source
+            expect(src.kind).toBe(NodeKind.LifecycleQuery)
+            if (src.kind === NodeKind.LifecycleQuery) {
+                expect(src.lifecycleFilter?.showLegend).toBe(true)
+            }
+        })
+    })
+
+    describe('getLegendToggleText', () => {
+        it('returns hide when legend on', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph, showLegend: true },
+                },
+            } as any
+
+            expect(getLegendToggleText(query)).toBe('Hide legend')
+            expect(isLegendEnabledInInsightQuery(query)).toBe(true)
+        })
+
+        it('returns show when legend off', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph, showLegend: false },
+                },
+            } as any
+
+            expect(getLegendToggleText(query)).toBe('Show legend')
+        })
+
+        it('after toggling unset legend, label reads hide', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    trendsFilter: { display: ChartDisplayType.ActionsLineGraph },
+                },
+            } as any
+
+            const next = toggleLegendInInsightQuery(query)
+            expect(getLegendToggleText(next)).toBe('Hide legend')
+        })
+    })
+})

--- a/frontend/src/lib/components/Cards/InsightCard/legendToggle.ts
+++ b/frontend/src/lib/components/Cards/InsightCard/legendToggle.ts
@@ -1,0 +1,92 @@
+import { DISPLAY_TYPES_WITHOUT_LEGEND } from 'lib/components/InsightLegend/utils'
+
+import { InsightVizNode } from '~/queries/schema/schema-general'
+import { getShowLegend, isInsightVizNode, isLifecycleQuery, isStickinessQuery, isTrendsQuery } from '~/queries/utils'
+import { QueryBasedInsightModel } from '~/types'
+
+// Eligibility matches insightVizDataLogic `hasLegend` (trends / stickiness / lifecycle, excluding DISPLAY_TYPES_WITHOUT_LEGEND).
+
+export function canToggleLegendInInsightQuery(query: QueryBasedInsightModel['query']): boolean {
+    if (!isInsightVizNode(query)) {
+        return false
+    }
+
+    const source = query.source
+    const isTrends = isTrendsQuery(source)
+    const isStickiness = isStickinessQuery(source)
+    const isLifecycle = isLifecycleQuery(source)
+    if (!isTrends && !isStickiness && !isLifecycle) {
+        return false
+    }
+
+    const display = isTrends
+        ? source.trendsFilter?.display
+        : isStickiness
+          ? source.stickinessFilter?.display
+          : undefined
+
+    return !(display && DISPLAY_TYPES_WITHOUT_LEGEND.includes(display))
+}
+
+export function isLegendEnabledInInsightQuery(query: QueryBasedInsightModel['query']): boolean {
+    if (!canToggleLegendInInsightQuery(query) || !isInsightVizNode(query)) {
+        return false
+    }
+
+    return !!getShowLegend(query.source)
+}
+
+export function getLegendToggleText(query: QueryBasedInsightModel['query']): string {
+    return isLegendEnabledInInsightQuery(query) ? 'Hide legend' : 'Show legend'
+}
+
+export function toggleLegendInInsightQuery(query: QueryBasedInsightModel['query']): QueryBasedInsightModel['query'] {
+    if (!isInsightVizNode(query)) {
+        return query
+    }
+
+    const viz: InsightVizNode = query
+    const source = viz.source
+    const nextShowLegend = !getShowLegend(source)
+
+    if (isTrendsQuery(source)) {
+        return {
+            ...viz,
+            source: {
+                ...source,
+                trendsFilter: {
+                    ...source.trendsFilter,
+                    showLegend: nextShowLegend,
+                },
+            },
+        } as QueryBasedInsightModel['query']
+    }
+
+    if (isStickinessQuery(source)) {
+        return {
+            ...viz,
+            source: {
+                ...source,
+                stickinessFilter: {
+                    ...source.stickinessFilter,
+                    showLegend: nextShowLegend,
+                },
+            },
+        } as QueryBasedInsightModel['query']
+    }
+
+    if (isLifecycleQuery(source)) {
+        return {
+            ...viz,
+            source: {
+                ...source,
+                lifecycleFilter: {
+                    ...source.lifecycleFilter,
+                    showLegend: nextShowLegend,
+                },
+            },
+        } as QueryBasedInsightModel['query']
+    }
+
+    return query
+}

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -438,6 +438,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             insightId: number,
             source: DashboardEventSource
         ) => ({ dashboardId, insightId, source }),
+        reportDashboardInsightLegendToggled: (
+            dashboardId: number | undefined,
+            insightId: number,
+            source: DashboardEventSource
+        ) => ({ dashboardId, insightId, source }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
@@ -1292,6 +1297,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportDashboardInsightValuesOnSeriesToggled: async ({ dashboardId, insightId, source }) => {
             posthog.capture('dashboard insight values on series toggled', {
+                dashboard_id: dashboardId,
+                insight_id: insightId,
+                source,
+            })
+        },
+        reportDashboardInsightLegendToggled: async ({ dashboardId, insightId, source }) => {
+            posthog.capture('dashboard insight legend toggled', {
                 dashboard_id: dashboardId,
                 insight_id: insightId,
                 source,

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -12,6 +12,7 @@ import {
     getDisplayLabelsToggleText,
     isDisplayLabelsEnabledInInsightQuery,
 } from 'lib/components/Cards/InsightCard/displayLabelsToggle'
+import { canToggleLegendInInsightQuery, getLegendToggleText } from 'lib/components/Cards/InsightCard/legendToggle'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -447,17 +448,19 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     : true,
         ],
         canToggleDisplayLabelsForInsight: [
-            (s) => [s.insight],
-            (insight) => !!insight.query && canToggleDisplayLabelsInInsightQuery(insight.query),
+            (s) => [s.query],
+            (query) => !!query && canToggleDisplayLabelsInInsightQuery(query),
         ],
+        canToggleLegendForInsight: [(s) => [s.query], (query) => !!query && canToggleLegendInInsightQuery(query)],
         displayLabelsShownForInsight: [
-            (s) => [s.insight],
-            (insight) => !!insight.query && isDisplayLabelsEnabledInInsightQuery(insight.query),
+            (s) => [s.query],
+            (query) => !!query && isDisplayLabelsEnabledInInsightQuery(query),
         ],
         displayLabelsToggleTextForInsight: [
-            (s) => [s.insight],
-            (insight) => (insight.query ? getDisplayLabelsToggleText(insight.query) : 'Show values on series'),
+            (s) => [s.query],
+            (query) => (query ? getDisplayLabelsToggleText(query) : 'Show values on series'),
         ],
+        legendToggleTextForInsight: [(s) => [s.query], (query) => (query ? getLegendToggleText(query) : 'Show legend')],
         insightChanged: [
             (s) => [s.insight, s.savedInsight],
             (insight, savedInsight): boolean => {


### PR DESCRIPTION
## Problem

Recently, we added https://github.com/PostHog/posthog/pull/51610 to toggle visibility of label items on insights directly from dashboards.

Looking at some stats, we see a close second in terms of what people are toggling is legend, so we make that available as well.

<img width="1258" height="844" alt="CleanShot 2026-03-20 at 12 44 30@2x" src="https://github.com/user-attachments/assets/e427feee-9099-43f6-b7f4-c710a7f91317" />


## Changes


https://github.com/user-attachments/assets/4545720b-8d3f-4af1-aed1-173f7c42c38f



## How did you test this code?

Locally + new tests.

## Publish to changelog?

Yes.

