### PR TITLE
fix(experiments): printed hogql respect query configuration.

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -22,7 +22,6 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.modifiers import create_default_modifiers_for_team
-from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.query_tagging import Product, tag_queries
@@ -40,6 +39,7 @@ from posthog.hogql_queries.experiments.exposure_query_logic import (
 from posthog.hogql_queries.experiments.utils import (
     aggregate_variants_across_breakdowns,
     get_bayesian_experiment_result,
+    get_experiment_query_hogql,
     get_experiment_query_sql,
     get_experiment_stats_method,
     get_frequentist_experiment_result,
@@ -244,7 +244,7 @@ class ExperimentQueryRunner(QueryRunner):
         )
 
         experiment_query_ast = self._get_experiment_query()
-        self.hogql = to_printed_hogql(experiment_query_ast, self.team)
+        self.hogql = get_experiment_query_hogql(experiment_query_ast, self.team)
         self.clickhouse_sql = get_experiment_query_sql(experiment_query_ast, self.team)
 
         response = execute_hogql_query(

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -39,8 +39,7 @@ from posthog.hogql_queries.experiments.exposure_query_logic import (
 from posthog.hogql_queries.experiments.utils import (
     aggregate_variants_across_breakdowns,
     get_bayesian_experiment_result,
-    get_experiment_query_hogql,
-    get_experiment_query_sql,
+    get_experiment_query_debug,
     get_experiment_stats_method,
     get_frequentist_experiment_result,
     get_variant_results,
@@ -244,8 +243,9 @@ class ExperimentQueryRunner(QueryRunner):
         )
 
         experiment_query_ast = self._get_experiment_query()
-        self.hogql = get_experiment_query_hogql(experiment_query_ast, self.team)
-        self.clickhouse_sql = get_experiment_query_sql(experiment_query_ast, self.team)
+        experiment_query_debug = get_experiment_query_debug(experiment_query_ast, self.team)
+        self.hogql = experiment_query_debug[0]
+        self.clickhouse_sql = experiment_query_debug[1]
 
         response = execute_hogql_query(
             query_type="ExperimentQuery",

--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -43,27 +43,10 @@ logger = structlog.get_logger(__name__)
 V = TypeVar("V", ExperimentVariantTrendsBaseStats, ExperimentVariantFunnelsBaseStats, ExperimentStatsBase)
 
 
-def get_experiment_query_hogql(experiment_query_ast: ast.SelectQuery, team: Team) -> str:
+def get_experiment_query_debug(experiment_query_ast: ast.SelectQuery, team: Team) -> tuple[str, str]:
     """
-    Generate HogQL for debugging from experiment query AST with proper limit applied
-    """
-    executor = HogQLQueryExecutor(
-        query=experiment_query_ast,
-        team=team,
-        modifiers=create_default_modifiers_for_team(team),
-    )
-    # Generate HogQL - this internally calls _apply_limit() so the limit will match ClickHouse
-    executor._parse_query()
-    executor._process_variables()
-    executor._process_placeholders()
-    executor._apply_limit()
-    executor._generate_hogql()
-    return executor.hogql
-
-
-def get_experiment_query_sql(experiment_query_ast: ast.SelectQuery, team: Team) -> str:
-    """
-    Generate raw SQL for debugging from experiment query AST
+    Generate both HogQL and ClickHouse SQL for debugging from experiment query AST.
+    Returns (hogql, clickhouse_sql) tuple.
     """
     executor = HogQLQueryExecutor(
         query=experiment_query_ast,
@@ -71,9 +54,8 @@ def get_experiment_query_sql(experiment_query_ast: ast.SelectQuery, team: Team) 
         modifiers=create_default_modifiers_for_team(team),
     )
     clickhouse_sql_with_params, clickhouse_context_with_values = executor.generate_clickhouse_sql()
-
-    # Substitute the parameters to get the final executable query
-    return substitute_params(clickhouse_sql_with_params, clickhouse_context_with_values.values)
+    clickhouse_sql = substitute_params(clickhouse_sql_with_params, clickhouse_context_with_values.values)
+    return (executor.hogql, clickhouse_sql)
 
 
 def _parse_enum_config(value: Any, enum_class: type[Enum], default: Any) -> Any:

--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -43,6 +43,24 @@ logger = structlog.get_logger(__name__)
 V = TypeVar("V", ExperimentVariantTrendsBaseStats, ExperimentVariantFunnelsBaseStats, ExperimentStatsBase)
 
 
+def get_experiment_query_hogql(experiment_query_ast: ast.SelectQuery, team: Team) -> str:
+    """
+    Generate HogQL for debugging from experiment query AST with proper limit applied
+    """
+    executor = HogQLQueryExecutor(
+        query=experiment_query_ast,
+        team=team,
+        modifiers=create_default_modifiers_for_team(team),
+    )
+    # Generate HogQL - this internally calls _apply_limit() so the limit will match ClickHouse
+    executor._parse_query()
+    executor._process_variables()
+    executor._process_placeholders()
+    executor._apply_limit()
+    executor._generate_hogql()
+    return executor.hogql
+
+
 def get_experiment_query_sql(experiment_query_ast: ast.SelectQuery, team: Team) -> str:
     """
     Generate raw SQL for debugging from experiment query AST


### PR DESCRIPTION
## Problem

> [!IMPORTANT]
> PR #51771 adds an explicit limit to the query builder, but this future-proofs the code generation.

The HogQL and ClickHouse SQL returned by the experiment query are generated at different stages of the query execution pipeline: while `clickhouse_sql` is created using a `HogQLQueryExecutor` that internally calls `_apply_limit` (before #51771, which only sets the default to `100`), `hogql` is generated using `to_printed_hogql`, which outputs the AST before `_apply_limit` runs. Since the AST lacks an explicit limit, the printer applies `limit_top_select=True` logic, which defaults to the maximum limit of `50000`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

| Clickhouse query settings |
| - |
| <img width="1159" height="102" alt="image" src="https://github.com/user-attachments/assets/514b5e3b-98ed-4b26-b5fe-b6f3a4a5557a" /> |

| before | after |
| - | - |
| <img width="1159" height="105" alt="image" src="https://github.com/user-attachments/assets/7b78cee0-72d1-48db-8944-b66792fda5ec" /> | <img width="1159" height="104" alt="image" src="https://github.com/user-attachments/assets/d528d213-7897-4246-bf78-1ee79dea8999" /> |

Refactored `get_experiment_query_sql` into `get_experiment_query_debug` that now returns a tuple with both HogQL and ClickHouse SQL, making them go through the same query preparation pipeline and show consistent settings.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pytest posthog/hogql_queries/experiments/test/experiment_query_runner -v
```

![cat-type](https://github.com/user-attachments/assets/48763dc8-aa5f-4566-8409-293f3d914ecc)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
