### PR TITLE
fix(messaging): remove kafka key from precalculated person properties backfill

### DIFF
--- a/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
+++ b/posthog/temporal/messaging/backfill_precalculated_person_properties_workflow.py
@@ -311,7 +311,6 @@ async def backfill_precalculated_person_properties_activity(
                                     try:
                                         send_result = kafka_producer.produce(
                                             topic=KAFKA_CDP_CLICKHOUSE_PRECALCULATED_PERSON_PROPERTIES,
-                                            key=event["distinct_id"],
                                             data=event,
                                         )
                                         pending_kafka_messages.append(send_result)


### PR DESCRIPTION
## Problem

Currently, when backfilling precalculated person properties, events are emitted to Kafka with a key set to the distinct_id. This causes all events for a particular distinct_id to be routed to the same partition, which can lead to uneven partition distribution and potential performance issues.

## Changes

- Removed the `key` parameter from the Kafka producer call in the backfill workflow
- Events will now be distributed across partitions in round-robin fashion instead of being partitioned by distinct_id