### PR TITLE
ci: skip migration SQL comment for import-only changes

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -613,7 +613,8 @@ jobs:
                   fi
 
                   if [ -z "$BASE_SHA" ]; then
-                    echo "::warning::BASE_SHA is empty — cannot filter existing migrations, showing all"
+                    echo "::error::BASE_SHA is empty — this should not happen in a pull_request event"
+                    exit 1
                   fi
 
                   # Ensure the base commit is available for comparison

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -604,6 +604,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CHANGED_FILES: ${{ needs.changes.outputs.migrations_files }}
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
               run: |
                   # If no migration files changed, exit
                   if [ -z "$CHANGED_FILES" ]; then
@@ -611,8 +612,12 @@ jobs:
                     exit 0
                   fi
 
+                  # Ensure the base commit is available for comparison
+                  git fetch origin "$BASE_SHA" --depth=1 2>/dev/null || echo "Warning: could not fetch base SHA $BASE_SHA, will treat all migrations as new"
+
                   # Initialize comment body for SQL changes
                   COMMENT_BODY="## Migration SQL Changes\n\nHey 👋, we've detected some migrations on this PR. Here's the SQL output for each migration, make sure they make sense:\n\n"
+                  HAS_NEW_MIGRATIONS=false
 
                   # Process each changed migration file (excluding Rust migrations)
                   for file in $CHANGED_FILES; do
@@ -630,7 +635,15 @@ jobs:
                       else
                         app_name=$(echo $file | sed -E 's|^([^/]+/)*([^/]+)/migrations/.*|\2|')
                       fi
-                        echo "Checking migration $migration_number for app $app_name"
+
+                      # Only show SQL for new migrations, not modifications to existing ones
+                      if git cat-file -e "$BASE_SHA:$file" 2>/dev/null; then
+                        echo "Skipping $file (already exists on base branch)"
+                        continue
+                      fi
+
+                      HAS_NEW_MIGRATIONS=true
+                      echo "Checking migration $migration_number for app $app_name"
 
                       # Get SQL output
                       SQL_OUTPUT=$(python manage.py sqlmigrate $app_name $migration_number)
@@ -640,13 +653,26 @@ jobs:
                     fi
                   done
 
-                  # Get existing comments
+                  # Get existing comments (needed for both update and cleanup)
                   COMMENTS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
                     -H "Accept: application/vnd.github.v3+json" \
                     "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments")
 
                   # Extract comment ID if exists
                   SQL_COMMENT_ID=$(echo "$COMMENTS" | jq -r '.[] | select(.body | startswith("## Migration SQL Changes")) | .id' | head -1)
+
+                  # If no new migrations, clean up any stale comment and exit
+                  if [ "$HAS_NEW_MIGRATIONS" = false ]; then
+                    echo "No new migrations to show (all changed files already exist on base branch)"
+                    if [ -n "$SQL_COMMENT_ID" ]; then
+                      echo "Deleting stale SQL comment $SQL_COMMENT_ID"
+                      curl -X DELETE \
+                        -H "Authorization: token $GITHUB_TOKEN" \
+                        -H "Accept: application/vnd.github.v3+json" \
+                        "https://api.github.com/repos/${{ github.repository }}/issues/comments/$SQL_COMMENT_ID"
+                    fi
+                    exit 0
+                  fi
 
                   # Add timestamp and commit SHA to SQL changes
                   TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -612,8 +612,12 @@ jobs:
                     exit 0
                   fi
 
+                  if [ -z "$BASE_SHA" ]; then
+                    echo "::warning::BASE_SHA is empty — cannot filter existing migrations, showing all"
+                  fi
+
                   # Ensure the base commit is available for comparison
-                  git fetch origin "$BASE_SHA" --depth=1 2>/dev/null || echo "Warning: could not fetch base SHA $BASE_SHA, will treat all migrations as new"
+                  git fetch --no-tags --prune --depth=1 origin "$BASE_SHA" || echo "::warning::Could not fetch base SHA $BASE_SHA — all changed migrations will be shown as new"
 
                   # Initialize comment body for SQL changes
                   COMMENT_BODY="## Migration SQL Changes\n\nHey 👋, we've detected some migrations on this PR. Here's the SQL output for each migration, make sure they make sense:\n\n"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -613,12 +613,11 @@ jobs:
                   fi
 
                   if [ -z "$BASE_SHA" ]; then
-                    echo "::error::BASE_SHA is empty — this should not happen in a pull_request event"
-                    exit 1
+                    echo "::warning::BASE_SHA is empty — all changed migrations will be treated as new"
+                  else
+                    # Ensure the base commit is available for comparison
+                    git fetch --no-tags --prune --depth=1 origin "$BASE_SHA" || echo "::warning::Could not fetch base SHA $BASE_SHA — all changed migrations will be shown as new"
                   fi
-
-                  # Ensure the base commit is available for comparison
-                  git fetch --no-tags --prune --depth=1 origin "$BASE_SHA" || echo "::warning::Could not fetch base SHA $BASE_SHA — all changed migrations will be shown as new"
 
                   # Initialize comment body for SQL changes
                   COMMENT_BODY="## Migration SQL Changes\n\nHey 👋, we've detected some migrations on this PR. Here's the SQL output for each migration, make sure they make sense:\n\n"


### PR DESCRIPTION
## Problem

The CI migration SQL checker posts SQL output for every changed migration file, including modifications to existing migrations (e.g., import path updates, formatting fixes). This creates noise on PRs that don't add new database migrations.

This change was inspired by [this migration change comment on this PR](https://github.com/PostHog/posthog/pull/51513#issuecomment-4084919765)

## Changes

- Compare each changed migration file against the PR's base branch using `git cat-file -e` to determine if it's new or a modification to an existing file
- Only run `sqlmigrate` and post SQL output for genuinely new migrations
- Clean up stale SQL comments when all changed migration files already exist on the base branch (e.g., a previous push added a migration but a force-push removed it)
- Use GitHub Actions `::warning::` annotations instead of plain `echo` for fetch failures, making them visible in the PR checks UI
- Add a defensive guard for empty `BASE_SHA`

## How did you test this code?

Simulated the key logic paths locally:
- `git cat-file -e` correctly identifies existing migrations vs non-existent ones
- Empty `BASE_SHA` guard triggers the warning
- `git fetch` failure fallback works (all migrations treated as new, preserving previous behavior)
- `--no-tags --prune` fetch flags work correctly

No automated tests (inline CI bash script). Will verify end-to-end by observing CI on a PR that touches migration files.

## Publish to changelog?

No