### PR TITLE
fix(insights): Fixes a bug with Line graphs not toggling legend correctly

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -1108,6 +1108,7 @@ export function LineGraph_({
             isArea,
             showTrendLines,
             labels,
+            legend?.display,
             hideTooltip,
             showTooltip,
             getTooltip,


### PR DESCRIPTION
## Problem

When toggling the legend visibility for a lifecycle graph: it would not show correctly, even though it was saved, and you can only see it update by reloading the page. 


## Changes

Before:
https://github.com/user-attachments/assets/bd5f00e1-0b72-4549-a076-0fa0e2c089e4



After:
https://github.com/user-attachments/assets/6937d752-8133-47b9-b706-6ba3931cd747



## How did you test this code?

Locally.

## Publish to changelog?

No.