### PR TITLE
fix(early-access): replace dynamic imports with static imports in earlyAccessFeatureLogic

### DIFF
--- a/products/early_access_features/frontend/earlyAccessFeatureLogic.ts
+++ b/products/early_access_features/frontend/earlyAccessFeatureLogic.ts
@@ -276,7 +276,7 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.CreateEarlyAccessFeature)
             }
         },
-        showGAPromotionConfirmation: async ({ onConfirm }) => {
+        showGAPromotionConfirmation: ({ onConfirm }) => {
             let rolloutToAll = false
             LemonDialog.open({
                 title: 'Promote to General Availability?',

--- a/products/early_access_features/frontend/earlyAccessFeatureLogic.ts
+++ b/products/early_access_features/frontend/earlyAccessFeatureLogic.ts
@@ -2,11 +2,13 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
+import React from 'react'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { identifierToHuman } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -28,6 +30,7 @@ import {
 
 import type { earlyAccessFeatureLogicType } from './earlyAccessFeatureLogicType'
 import { earlyAccessFeaturesLogic } from './earlyAccessFeaturesLogic'
+import { GAPromotionDialogContent } from './GAPromotionDialogContent'
 
 export const NEW_EARLY_ACCESS_FEATURE: NewEarlyAccessFeatureType = {
     name: '',
@@ -274,9 +277,6 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
             }
         },
         showGAPromotionConfirmation: async ({ onConfirm }) => {
-            const { LemonDialog } = await import('lib/lemon-ui/LemonDialog')
-            const React = await import('react')
-            const { GAPromotionDialogContent } = await import('./GAPromotionDialogContent')
             let rolloutToAll = false
             LemonDialog.open({
                 title: 'Promote to General Availability?',


### PR DESCRIPTION
## Problem

Users are experiencing a production error: `TypeError: i.createElement is not a function` in the early access feature promotion dialog. This error occurs because dynamic imports behave differently between development and production environments.

Context: https://posthog.slack.com/archives/C07Q2U4BH4L/p1773957332819619

## Changes

- Replaced dynamic imports with static imports for React, LemonDialog, and GAPromotionDialogContent
- Moved imports to the top of the file following standard practices

## How did you test this code?

- The error doesn't happen locally