### PR TITLE
feat(ci-monitoring): add ingestion pipeline

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -46,6 +46,7 @@ from posthog.models.instance_setting import get_instance_setting
 from posthog.oauth2_urls import urlpatterns as oauth2_urls
 from posthog.temporal.codec_server import decode_payloads
 
+from products.ci_monitoring.backend.webhooks import github_workflow_run_webhook
 from products.data_warehouse.backend.api.public_source_configs import PublicSourceConfigViewSet
 from products.early_access_features.backend.api import early_access_features
 from products.product_tours.backend.api import product_tours
@@ -307,6 +308,8 @@ urlpatterns = [
     opt_slash_path("slack/posthog-code-interactivity-callback", posthog_code_interactivity_handler),
     # GitHub webhooks for task lifecycle events
     opt_slash_path("webhooks/github/pr", github_pr_webhook),
+    # GitHub webhooks for CI monitoring
+    opt_slash_path("webhooks/github/ci", github_workflow_run_webhook),
     # Message preferences
     path("messaging-preferences/<str:token>/", preferences_page, name="message_preferences"),
     opt_slash_path("messaging-preferences/update", update_preferences, name="message_preferences_update"),

--- a/products/ci_monitoring/backend/ingestion.py
+++ b/products/ci_monitoring/backend/ingestion.py
@@ -1,0 +1,104 @@
+"""JUnit XML and Playwright JSON parsers for ci_monitoring."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+from .facade.enums import TestExecutionStatus
+
+
+@dataclass
+class ParsedTestResult:
+    identifier: str
+    classname: str
+    name: str
+    status: TestExecutionStatus
+    duration_ms: int | None
+    error_message: str | None
+    retry_count: int
+    file_path: str | None
+
+
+def parse_junit_xml(xml_content: str | bytes) -> list[ParsedTestResult]:
+    """
+    Parse a JUnit XML file into test results.
+
+    Handles pytest (with pytest-rerunfailures) and standard JUnit formats.
+    Flaky detection: a testcase with <rerun> children that eventually passed
+    is marked as FLAKY.
+    """
+    root = ET.fromstring(xml_content)
+    results: list[ParsedTestResult] = []
+
+    # Handle both <testsuites><testsuite>... and bare <testsuite>...
+    testsuites = root.findall(".//testcase")
+    if not testsuites:
+        return results
+
+    for tc in testsuites:
+        classname = tc.get("classname", "")
+        name = tc.get("name", "")
+        time_attr = tc.get("time")
+        file_path = tc.get("file")
+
+        duration_ms = int(float(time_attr) * 1000) if time_attr else None
+        identifier = f"{classname}.{name}" if classname else name
+
+        # Detect status from child elements
+        failures = tc.findall("failure")
+        errors = tc.findall("error")
+        skipped = tc.findall("skipped")
+        reruns = tc.findall("rerun")
+
+        error_message: str | None = None
+        retry_count = len(reruns)
+
+        if skipped:
+            status = TestExecutionStatus.SKIPPED
+        elif reruns and not failures and not errors:
+            # Had reruns but final result was pass -> flaky
+            status = TestExecutionStatus.FLAKY
+            error_message = _extract_rerun_message(reruns)
+        elif failures or errors:
+            status = TestExecutionStatus.FAILED
+            error_message = _extract_failure_message(failures or errors)
+        else:
+            status = TestExecutionStatus.PASSED
+
+        results.append(
+            ParsedTestResult(
+                identifier=identifier,
+                classname=classname,
+                name=name,
+                status=status,
+                duration_ms=duration_ms,
+                error_message=_truncate(error_message, 2000),
+                retry_count=retry_count,
+                file_path=file_path,
+            )
+        )
+
+    return results
+
+
+def _extract_failure_message(elements: list[ET.Element]) -> str | None:
+    for el in elements:
+        msg = el.get("message") or el.text
+        if msg:
+            return msg.strip()
+    return None
+
+
+def _extract_rerun_message(reruns: list[ET.Element]) -> str | None:
+    for rerun in reruns:
+        msg = rerun.get("message") or rerun.text
+        if msg:
+            return msg.strip()
+    return None
+
+
+def _truncate(s: str | None, max_len: int) -> str | None:
+    if s is None:
+        return None
+    return s[:max_len] if len(s) > max_len else s

--- a/products/ci_monitoring/backend/ingestion.py
+++ b/products/ci_monitoring/backend/ingestion.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 
+import structlog
+
 from .facade.enums import TestExecutionStatus
+
+logger = structlog.get_logger(__name__)
 
 
 @dataclass
@@ -28,15 +32,19 @@ def parse_junit_xml(xml_content: str | bytes) -> list[ParsedTestResult]:
     Flaky detection: a testcase with <rerun> children that eventually passed
     is marked as FLAKY.
     """
-    root = ET.fromstring(xml_content)
+    try:
+        root = ET.fromstring(xml_content)
+    except ET.ParseError:
+        logger.warning("ci_monitoring.malformed_junit_xml")
+        return []
+
     results: list[ParsedTestResult] = []
 
-    # Handle both <testsuites><testsuite>... and bare <testsuite>...
-    testsuites = root.findall(".//testcase")
-    if not testsuites:
+    testcases = root.findall(".//testcase")
+    if not testcases:
         return results
 
-    for tc in testsuites:
+    for tc in testcases:
         classname = tc.get("classname", "")
         name = tc.get("name", "")
         time_attr = tc.get("time")
@@ -44,6 +52,9 @@ def parse_junit_xml(xml_content: str | bytes) -> list[ParsedTestResult]:
 
         duration_ms = int(float(time_attr) * 1000) if time_attr else None
         identifier = f"{classname}.{name}" if classname else name
+
+        if not identifier:
+            continue
 
         # Detect status from child elements
         failures = tc.findall("failure")

--- a/products/ci_monitoring/backend/logic.py
+++ b/products/ci_monitoring/backend/logic.py
@@ -13,8 +13,21 @@ import datetime
 from django.db.models import QuerySet
 from django.utils import timezone
 
-from .facade.enums import QuarantineState, TestExecutionStatus
+import structlog
+
+from .facade.enums import CIRunConclusion, QuarantineState, TestExecutionStatus
 from .models import CIRun, MainStreak, Quarantine, Repo, TestCase, TestExecution
+
+logger = structlog.get_logger(__name__)
+
+
+class RepoNotFoundError(Exception):
+    pass
+
+
+class GitHubIntegrationNotFoundError(Exception):
+    pass
+
 
 # --- Repo ---
 
@@ -43,6 +56,218 @@ def get_repo(*, repo_id: uuid.UUID, team_id: int) -> Repo:
 
 def list_repos(*, team_id: int) -> QuerySet[Repo]:
     return Repo.objects.filter(team_id=team_id).order_by("repo_full_name")
+
+
+# --- Webhook Ingestion ---
+
+
+def create_ci_run_from_webhook(
+    *,
+    repo_external_id: int,
+    repo_full_name: str,
+    github_run_id: int,
+    workflow_name: str,
+    commit_sha: str,
+    branch: str,
+    conclusion: CIRunConclusion,
+    started_at: str | None,
+    completed_at: str | None,
+    pr_number: int | None,
+) -> CIRun:
+    """Create a CIRun from a GitHub workflow_run webhook payload."""
+    from django.utils.dateparse import parse_datetime
+
+    repo = Repo.objects.filter(repo_external_id=repo_external_id).first()
+    if not repo:
+        raise RepoNotFoundError(f"No repo with external_id={repo_external_id}")
+
+    parsed_started = parse_datetime(started_at) if started_at else timezone.now()
+    parsed_completed = parse_datetime(completed_at) if completed_at else timezone.now()
+
+    ci_run, created = CIRun.objects.update_or_create(
+        repo=repo,
+        github_run_id=github_run_id,
+        defaults={
+            "team_id": repo.team_id,
+            "workflow_name": workflow_name,
+            "commit_sha": commit_sha,
+            "branch": branch,
+            "conclusion": conclusion,
+            "started_at": parsed_started,
+            "completed_at": parsed_completed,
+            "pr_number": pr_number,
+        },
+    )
+
+    return ci_run
+
+
+def ingest_test_results(
+    *,
+    ci_run: CIRun,
+    parsed_results: list,
+) -> None:
+    """Create TestCase and TestExecution records from parsed test results."""
+    from .ingestion import ParsedTestResult
+
+    counts = {"total": 0, "passed": 0, "failed": 0, "flaky": 0, "skipped": 0, "errored": 0}
+
+    for result in parsed_results:
+        result: ParsedTestResult
+        test_case, _ = TestCase.objects.get_or_create(
+            repo=ci_run.repo,
+            identifier=result.identifier,
+            defaults={
+                "team_id": ci_run.team_id,
+                "suite": _infer_suite(result),
+                "file_path": result.file_path,
+            },
+        )
+
+        if result.file_path and not test_case.file_path:
+            test_case.file_path = result.file_path
+            test_case.save(update_fields=["file_path"])
+
+        TestExecution.objects.update_or_create(
+            ci_run=ci_run,
+            test_case=test_case,
+            defaults={
+                "status": result.status,
+                "duration_ms": result.duration_ms,
+                "error_message": result.error_message,
+                "retry_count": result.retry_count,
+            },
+        )
+
+        if result.status == TestExecutionStatus.FLAKY and (
+            test_case.last_flaked_at is None or test_case.last_flaked_at < ci_run.completed_at
+        ):
+            test_case.last_flaked_at = ci_run.completed_at
+            test_case.save(update_fields=["last_flaked_at"])
+
+        counts["total"] += 1
+        status_key = result.status.value
+        if status_key in counts:
+            counts[status_key] += 1
+
+    ci_run.total_tests = counts["total"]
+    ci_run.passed = counts["passed"]
+    ci_run.failed = counts["failed"]
+    ci_run.flaky = counts["flaky"]
+    ci_run.skipped = counts["skipped"]
+    ci_run.errored = counts["errored"]
+    ci_run.artifacts_ingested = True
+    ci_run.save(
+        update_fields=[
+            "total_tests",
+            "passed",
+            "failed",
+            "flaky",
+            "skipped",
+            "errored",
+            "artifacts_ingested",
+        ]
+    )
+
+
+def _infer_suite(result) -> str:
+    """Infer the test suite from file path or classname."""
+    from .facade.enums import TestSuite
+
+    fp = result.file_path or result.classname or ""
+    fp_lower = fp.lower()
+
+    if "e2e" in fp_lower or "playwright" in fp_lower:
+        return TestSuite.E2E
+    if "storybook" in fp_lower:
+        return TestSuite.STORYBOOK
+    if fp_lower.endswith(".rs"):
+        return TestSuite.RUST
+    if "node" in fp_lower or fp_lower.endswith((".ts", ".js")):
+        return TestSuite.NODEJS
+    if fp_lower.endswith(".py") or "test_" in fp_lower:
+        return TestSuite.BACKEND
+    return TestSuite.OTHER
+
+
+# --- GitHub API ---
+
+
+def get_github_integration_for_repo(repo: Repo):
+    """Get GitHub integration for the repo's team."""
+    from posthog.models.integration import GitHubIntegration, Integration
+
+    integration = Integration.objects.filter(team_id=repo.team_id, kind="github").first()
+    if not integration:
+        raise GitHubIntegrationNotFoundError(f"No GitHub integration found for team {repo.team_id}")
+
+    return GitHubIntegration(integration)
+
+
+def download_run_artifacts(ci_run: CIRun) -> list[bytes]:
+    """Download JUnit XML artifacts from a GitHub Actions run."""
+    import io
+    import zipfile
+
+    import requests
+
+    github = get_github_integration_for_repo(ci_run.repo)
+    if github.access_token_expired():
+        github.refresh_access_token()
+
+    access_token = github.integration.sensitive_config["access_token"]
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {access_token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    # List artifacts for this run
+    response = requests.get(
+        f"https://api.github.com/repos/{ci_run.repo.repo_full_name}/actions/runs/{ci_run.github_run_id}/artifacts",
+        headers=headers,
+        timeout=30,
+    )
+    if response.status_code != 200:
+        logger.warning(
+            "ci_monitoring.artifacts_list_failed",
+            status=response.status_code,
+            ci_run_id=str(ci_run.id),
+        )
+        return []
+
+    artifacts = response.json().get("artifacts", [])
+    xml_contents: list[bytes] = []
+
+    for artifact in artifacts:
+        name = artifact.get("name", "")
+        if not (name.startswith("junit-") or "junit" in name.lower()):
+            continue
+
+        # Download the artifact zip
+        download_url = artifact.get("archive_download_url")
+        if not download_url:
+            continue
+
+        dl_response = requests.get(download_url, headers=headers, timeout=60)
+        if dl_response.status_code != 200:
+            logger.warning(
+                "ci_monitoring.artifact_download_failed",
+                artifact_name=name,
+                status=dl_response.status_code,
+            )
+            continue
+
+        # Extract XML files from the zip
+        try:
+            with zipfile.ZipFile(io.BytesIO(dl_response.content)) as zf:
+                for entry in zf.namelist():
+                    if entry.endswith(".xml"):
+                        xml_contents.append(zf.read(entry))
+        except zipfile.BadZipFile:
+            logger.warning("ci_monitoring.artifact_bad_zip", artifact_name=name)
+
+    return xml_contents
 
 
 # --- CI Runs ---

--- a/products/ci_monitoring/backend/logic.py
+++ b/products/ci_monitoring/backend/logic.py
@@ -110,7 +110,7 @@ def ingest_test_results(
     """Create TestCase and TestExecution records from parsed test results."""
     from .ingestion import ParsedTestResult
 
-    counts = {"total": 0, "passed": 0, "failed": 0, "flaky": 0, "skipped": 0, "errored": 0}
+    counts = {"total": 0, "passed": 0, "failed": 0, "flaky": 0, "skipped": 0, "error": 0}
 
     for result in parsed_results:
         result: ParsedTestResult
@@ -155,7 +155,7 @@ def ingest_test_results(
     ci_run.failed = counts["failed"]
     ci_run.flaky = counts["flaky"]
     ci_run.skipped = counts["skipped"]
-    ci_run.errored = counts["errored"]
+    ci_run.errored = counts["error"]
     ci_run.artifacts_ingested = True
     ci_run.save(
         update_fields=[

--- a/products/ci_monitoring/backend/tasks/tasks.py
+++ b/products/ci_monitoring/backend/tasks/tasks.py
@@ -1,26 +1,59 @@
-"""
-Celery tasks for ci_monitoring.
-
-Async entrypoints for artifact ingestion and GitHub integration.
-"""
+"""Celery tasks for ci_monitoring."""
 
 import uuid
 
+import structlog
 from celery import shared_task
+
+logger = structlog.get_logger(__name__)
 
 
 @shared_task(ignore_result=True)
 def ingest_ci_run_artifacts(*, ci_run_id: str) -> None:
     """Download and parse test artifacts for a CI run."""
-    # Phase 2: will download JUnit XML / Playwright JSON from GitHub
-    # and create TestExecution records
-    pass
+    from .. import logic
+    from ..ingestion import parse_junit_xml
+    from ..models import CIRun
+
+    ci_run = CIRun.objects.select_related("repo").get(id=ci_run_id)
+
+    xml_contents = logic.download_run_artifacts(ci_run)
+    if not xml_contents:
+        logger.info("ci_monitoring.no_artifacts", ci_run_id=ci_run_id)
+        ci_run.artifacts_ingested = True
+        ci_run.save(update_fields=["artifacts_ingested"])
+        return
+
+    all_results = []
+    for xml_content in xml_contents:
+        all_results.extend(parse_junit_xml(xml_content))
+
+    logic.ingest_test_results(ci_run=ci_run, parsed_results=all_results)
+
+    # Update streak if this is a default branch run
+    if ci_run.branch == ci_run.repo.default_branch:
+        logic.record_main_branch_run(
+            repo_id=ci_run.repo_id,
+            team_id=ci_run.team_id,
+            conclusion=ci_run.conclusion,
+            workflow_name=ci_run.workflow_name,
+        )
+
+    # Recompute flake scores
+    logic.update_flake_scores(repo_id=ci_run.repo_id, team_id=ci_run.team_id)
+
+    logger.info(
+        "ci_monitoring.ingestion_complete",
+        ci_run_id=ci_run_id,
+        total_tests=ci_run.total_tests,
+        flaky=ci_run.flaky,
+    )
 
 
 @shared_task(ignore_result=True)
 def create_quarantine_github_issue(*, quarantine_id: str) -> None:
     """Create a GitHub issue for a quarantined test."""
-    # Phase 4: will use GitHubIntegration to create an issue
+    # Phase 4
     pass
 
 

--- a/products/ci_monitoring/backend/tasks/tasks.py
+++ b/products/ci_monitoring/backend/tasks/tasks.py
@@ -17,7 +17,12 @@ def ingest_ci_run_artifacts(*, ci_run_id: str) -> None:
 
     ci_run = CIRun.objects.select_related("repo").get(id=ci_run_id)
 
-    xml_contents = logic.download_run_artifacts(ci_run)
+    try:
+        xml_contents = logic.download_run_artifacts(ci_run)
+    except Exception:
+        logger.exception("ci_monitoring.artifact_download_failed", ci_run_id=ci_run_id)
+        return
+
     if not xml_contents:
         logger.info("ci_monitoring.no_artifacts", ci_run_id=ci_run_id)
         ci_run.artifacts_ingested = True

--- a/products/ci_monitoring/backend/tests/conftest.py
+++ b/products/ci_monitoring/backend/tests/conftest.py
@@ -1,0 +1,105 @@
+"""Shared fixtures for ci_monitoring tests."""
+
+import hmac
+import json
+import hashlib
+
+import pytest
+from unittest.mock import MagicMock
+
+from products.ci_monitoring.backend.models import CIRun, Repo
+
+
+@pytest.fixture
+def repo(team):
+    return Repo.objects.create(
+        team=team,
+        repo_external_id=12345,
+        repo_full_name="test-org/test-repo",
+        default_branch="main",
+    )
+
+
+@pytest.fixture
+def ci_run(repo):
+    from django.utils import timezone
+
+    return CIRun.objects.create(
+        team_id=repo.team_id,
+        repo=repo,
+        github_run_id=99999,
+        workflow_name="CI Backend",
+        commit_sha="abc123def456",
+        branch="main",
+        conclusion="success",
+        started_at=timezone.now(),
+        completed_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def mock_github_integration(team, mocker):
+    from posthog.models.integration import GitHubIntegration, Integration
+
+    mock_integration = MagicMock(spec=Integration)
+    mock_integration.id = 1
+    mock_integration.team_id = team.id
+    mock_integration.kind = "github"
+    mock_integration.sensitive_config = {
+        "access_token": "ghs_fake_token",
+    }
+
+    original_filter = Integration.objects.filter
+
+    def patched_filter(*args, **kwargs):
+        if kwargs.get("kind") == "github" and kwargs.get("team_id") == team.id:
+            mock_qs = MagicMock()
+            mock_qs.first.return_value = mock_integration
+            return mock_qs
+        return original_filter(*args, **kwargs)
+
+    mocker.patch.object(Integration.objects, "filter", side_effect=patched_filter)
+    mocker.patch.object(GitHubIntegration, "access_token_expired", return_value=False)
+
+    return mock_integration
+
+
+WEBHOOK_SECRET = "test-webhook-secret"
+
+
+def make_webhook_payload(
+    *,
+    repo_external_id: int = 12345,
+    repo_full_name: str = "test-org/test-repo",
+    run_id: int = 99999,
+    workflow_name: str = "CI Backend",
+    head_sha: str = "abc123",
+    head_branch: str = "main",
+    conclusion: str = "success",
+    action: str = "completed",
+    pr_number: int | None = None,
+) -> dict:
+    pull_requests = [{"number": pr_number}] if pr_number else []
+    return {
+        "action": action,
+        "workflow_run": {
+            "id": run_id,
+            "name": workflow_name,
+            "head_sha": head_sha,
+            "head_branch": head_branch,
+            "conclusion": conclusion,
+            "run_started_at": "2026-03-20T10:00:00Z",
+            "updated_at": "2026-03-20T10:05:00Z",
+            "pull_requests": pull_requests,
+        },
+        "repository": {
+            "id": repo_external_id,
+            "full_name": repo_full_name,
+        },
+    }
+
+
+def sign_payload(payload: dict, secret: str = WEBHOOK_SECRET) -> str:
+    body = json.dumps(payload).encode()
+    signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={signature}"

--- a/products/ci_monitoring/backend/tests/test_ingestion.py
+++ b/products/ci_monitoring/backend/tests/test_ingestion.py
@@ -1,0 +1,84 @@
+from products.ci_monitoring.backend.facade.enums import TestExecutionStatus
+from products.ci_monitoring.backend.ingestion import parse_junit_xml
+
+JUNIT_PASSING = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" tests="2" errors="0" failures="0">
+    <testcase classname="tests.test_math" name="test_add" time="0.001" file="tests/test_math.py"/>
+    <testcase classname="tests.test_math" name="test_subtract" time="0.002" file="tests/test_math.py"/>
+</testsuite>
+"""
+
+JUNIT_MIXED = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" tests="4" errors="1" failures="1" skipped="1">
+    <testcase classname="tests.test_api" name="test_ok" time="0.5"/>
+    <testcase classname="tests.test_api" name="test_fail" time="1.2">
+        <failure message="AssertionError: expected 200 got 500">Traceback...</failure>
+    </testcase>
+    <testcase classname="tests.test_api" name="test_error" time="0.0">
+        <error message="ConnectionError">Traceback...</error>
+    </testcase>
+    <testcase classname="tests.test_api" name="test_skip" time="0.0">
+        <skipped message="not implemented"/>
+    </testcase>
+</testsuite>
+"""
+
+JUNIT_FLAKY = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="pytest" tests="1">
+    <testcase classname="tests.test_flaky" name="test_timing" time="2.0" file="tests/test_flaky.py">
+        <rerun message="TimeoutError">first attempt failed</rerun>
+        <rerun message="TimeoutError">second attempt failed</rerun>
+    </testcase>
+</testsuite>
+"""
+
+JUNIT_NESTED = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="suite1" tests="1">
+        <testcase classname="a.b" name="test_one" time="0.1"/>
+    </testsuite>
+    <testsuite name="suite2" tests="1">
+        <testcase classname="c.d" name="test_two" time="0.2"/>
+    </testsuite>
+</testsuites>
+"""
+
+
+class TestParseJunitXml:
+    def test_all_passing(self):
+        results = parse_junit_xml(JUNIT_PASSING)
+        assert len(results) == 2
+        assert all(r.status == TestExecutionStatus.PASSED for r in results)
+        assert results[0].identifier == "tests.test_math.test_add"
+        assert results[0].duration_ms == 1
+        assert results[0].file_path == "tests/test_math.py"
+
+    def test_mixed_statuses(self):
+        results = parse_junit_xml(JUNIT_MIXED)
+        assert len(results) == 4
+
+        by_name = {r.name: r for r in results}
+        assert by_name["test_ok"].status == TestExecutionStatus.PASSED
+        assert by_name["test_fail"].status == TestExecutionStatus.FAILED
+        assert by_name["test_fail"].error_message == "AssertionError: expected 200 got 500"
+        assert by_name["test_error"].status == TestExecutionStatus.FAILED
+        assert by_name["test_skip"].status == TestExecutionStatus.SKIPPED
+
+    def test_flaky_with_reruns(self):
+        results = parse_junit_xml(JUNIT_FLAKY)
+        assert len(results) == 1
+        r = results[0]
+        assert r.status == TestExecutionStatus.FLAKY
+        assert r.retry_count == 2
+        assert r.error_message == "TimeoutError"
+        assert r.file_path == "tests/test_flaky.py"
+
+    def test_nested_testsuites(self):
+        results = parse_junit_xml(JUNIT_NESTED)
+        assert len(results) == 2
+        assert results[0].identifier == "a.b.test_one"
+        assert results[1].identifier == "c.d.test_two"
+
+    def test_empty_xml(self):
+        results = parse_junit_xml("<testsuite/>")
+        assert results == []

--- a/products/ci_monitoring/backend/tests/test_logic.py
+++ b/products/ci_monitoring/backend/tests/test_logic.py
@@ -1,0 +1,202 @@
+import io
+import re
+import zipfile
+
+import pytest
+
+from django.utils import timezone
+
+import responses
+
+from products.ci_monitoring.backend import logic
+from products.ci_monitoring.backend.facade.enums import TestExecutionStatus
+from products.ci_monitoring.backend.ingestion import ParsedTestResult
+from products.ci_monitoring.backend.models import CIRun, TestCase, TestExecution
+
+
+@pytest.mark.django_db
+class TestIngestTestResults:
+    def test_creates_test_cases_and_executions(self, ci_run):
+        results = [
+            ParsedTestResult("mod.test_a", "mod", "test_a", TestExecutionStatus.PASSED, 100, None, 0, "test.py"),
+            ParsedTestResult(
+                "mod.test_b", "mod", "test_b", TestExecutionStatus.FAILED, 200, "AssertionError", 0, "test.py"
+            ),
+            ParsedTestResult("mod.test_c", "mod", "test_c", TestExecutionStatus.FLAKY, 300, "Timeout", 2, "test.py"),
+            ParsedTestResult("mod.test_d", "mod", "test_d", TestExecutionStatus.SKIPPED, 0, None, 0, "test.py"),
+            ParsedTestResult("mod.test_e", "mod", "test_e", TestExecutionStatus.ERROR, 0, "Infra", 0, "test.py"),
+        ]
+
+        logic.ingest_test_results(ci_run=ci_run, parsed_results=results)
+
+        assert TestCase.objects.filter(repo=ci_run.repo).count() == 5
+        assert TestExecution.objects.filter(ci_run=ci_run).count() == 5
+
+        ci_run.refresh_from_db()
+        assert ci_run.total_tests == 5
+        assert ci_run.passed == 1
+        assert ci_run.failed == 1
+        assert ci_run.flaky == 1
+        assert ci_run.skipped == 1
+        assert ci_run.errored == 1
+        assert ci_run.artifacts_ingested is True
+
+    def test_flaky_updates_last_flaked_at(self, ci_run):
+        results = [
+            ParsedTestResult("mod.test_f", "mod", "test_f", TestExecutionStatus.FLAKY, 100, "Timeout", 1, None),
+        ]
+
+        logic.ingest_test_results(ci_run=ci_run, parsed_results=results)
+
+        tc = TestCase.objects.get(identifier="mod.test_f")
+        assert tc.last_flaked_at is not None
+
+    def test_deduplicates_test_cases_across_runs(self, repo):
+        now = timezone.now()
+        run1 = CIRun.objects.create(
+            team_id=repo.team_id,
+            repo=repo,
+            github_run_id=1,
+            workflow_name="CI",
+            commit_sha="aaa",
+            branch="main",
+            conclusion="success",
+            started_at=now,
+            completed_at=now,
+        )
+        run2 = CIRun.objects.create(
+            team_id=repo.team_id,
+            repo=repo,
+            github_run_id=2,
+            workflow_name="CI",
+            commit_sha="bbb",
+            branch="main",
+            conclusion="success",
+            started_at=now,
+            completed_at=now,
+        )
+
+        result = [ParsedTestResult("mod.test_x", "mod", "test_x", TestExecutionStatus.PASSED, 50, None, 0, None)]
+        logic.ingest_test_results(ci_run=run1, parsed_results=result)
+        logic.ingest_test_results(ci_run=run2, parsed_results=result)
+
+        assert TestCase.objects.filter(identifier="mod.test_x").count() == 1
+        assert TestExecution.objects.filter(test_case__identifier="mod.test_x").count() == 2
+
+
+@pytest.mark.django_db
+class TestMainStreak:
+    def test_success_starts_streak(self, repo):
+        streak = logic.record_main_branch_run(
+            repo_id=repo.id, team_id=repo.team_id, conclusion="success", workflow_name="CI"
+        )
+        assert streak.current_streak_started_at is not None
+
+    def test_failure_breaks_streak(self, repo):
+        logic.record_main_branch_run(repo_id=repo.id, team_id=repo.team_id, conclusion="success", workflow_name="CI")
+        streak = logic.record_main_branch_run(
+            repo_id=repo.id, team_id=repo.team_id, conclusion="failure", workflow_name="CI"
+        )
+
+        assert streak.current_streak_started_at is None
+        assert streak.last_broken_at is not None
+        assert "CI" in streak.last_incident_workflows
+
+    def test_recovery_after_failure(self, repo):
+        logic.record_main_branch_run(repo_id=repo.id, team_id=repo.team_id, conclusion="failure", workflow_name="CI")
+        streak = logic.record_main_branch_run(
+            repo_id=repo.id, team_id=repo.team_id, conclusion="success", workflow_name="CI"
+        )
+
+        assert streak.current_streak_started_at is not None
+        assert streak.last_incident_workflows == []
+
+    def test_record_streak_updates(self, repo):
+        import datetime
+
+        streak = logic.get_or_create_main_streak(repo_id=repo.id, team_id=repo.team_id)
+        streak.current_streak_started_at = timezone.now() - datetime.timedelta(days=10)
+        streak.save()
+
+        logic.record_main_branch_run(repo_id=repo.id, team_id=repo.team_id, conclusion="failure", workflow_name="CI")
+
+        streak.refresh_from_db()
+        assert streak.record_streak_days >= 10
+
+
+@pytest.mark.django_db
+class TestFlakeScores:
+    def test_computes_correct_scores(self, repo):
+        now = timezone.now()
+        tc = TestCase.objects.create(team_id=repo.team_id, repo=repo, identifier="mod.flaky_test")
+
+        # Each execution needs its own CIRun (unique constraint on ci_run+test_case)
+        for i in range(10):
+            run = CIRun.objects.create(
+                team_id=repo.team_id,
+                repo=repo,
+                github_run_id=1000 + i,
+                workflow_name="CI",
+                commit_sha=f"sha{i}",
+                branch="main",
+                conclusion="success",
+                started_at=now,
+                completed_at=now,
+            )
+            status = TestExecutionStatus.FLAKY if i < 3 else TestExecutionStatus.PASSED
+            TestExecution.objects.create(ci_run=run, test_case=tc, status=status)
+
+        logic.update_flake_scores(repo_id=repo.id, team_id=repo.team_id)
+
+        tc.refresh_from_db()
+        assert tc.flake_score == 30.0
+        assert tc.total_runs == 10
+        assert tc.total_flakes == 3
+
+    def test_zero_executions_unchanged(self, repo):
+        tc = TestCase.objects.create(team_id=repo.team_id, repo=repo, identifier="mod.no_runs")
+
+        logic.update_flake_scores(repo_id=repo.id, team_id=repo.team_id)
+
+        tc.refresh_from_db()
+        assert tc.flake_score == 0.0
+
+
+@pytest.mark.django_db
+class TestDownloadRunArtifacts:
+    @responses.activate
+    def test_downloads_and_extracts_junit_xml(self, ci_run, mock_github_integration):
+        # Create a zip containing a JUnit XML file
+        xml_content = b'<testsuite><testcase classname="a" name="b" time="0.1"/></testsuite>'
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr("junit-core.xml", xml_content)
+        zip_bytes = zip_buffer.getvalue()
+
+        responses.add(
+            responses.GET,
+            re.compile(r".*/actions/runs/\d+/artifacts"),
+            json={
+                "artifacts": [{"name": "junit-results", "archive_download_url": "https://api.github.com/download/1"}]
+            },
+        )
+        responses.add(responses.GET, "https://api.github.com/download/1", body=zip_bytes)
+
+        result = logic.download_run_artifacts(ci_run)
+
+        assert len(result) == 1
+        assert b"testcase" in result[0]
+
+    @responses.activate
+    def test_skips_non_junit_artifacts(self, ci_run, mock_github_integration):
+        responses.add(
+            responses.GET,
+            re.compile(r".*/actions/runs/\d+/artifacts"),
+            json={
+                "artifacts": [{"name": "coverage-report", "archive_download_url": "https://api.github.com/download/2"}]
+            },
+        )
+
+        result = logic.download_run_artifacts(ci_run)
+
+        assert len(result) == 0

--- a/products/ci_monitoring/backend/tests/test_webhooks.py
+++ b/products/ci_monitoring/backend/tests/test_webhooks.py
@@ -1,0 +1,86 @@
+import json
+
+import pytest
+from unittest.mock import patch
+
+from django.test import RequestFactory
+
+from products.ci_monitoring.backend.models import CIRun
+from products.ci_monitoring.backend.webhooks import github_workflow_run_webhook
+
+from .conftest import WEBHOOK_SECRET, make_webhook_payload, sign_payload
+
+
+@pytest.mark.django_db
+class TestWorkflowRunWebhook:
+    @pytest.fixture(autouse=True)
+    def _mock_secret(self):
+        with patch(
+            "products.ci_monitoring.backend.webhooks.get_github_webhook_secret",
+            return_value=WEBHOOK_SECRET,
+        ):
+            yield
+
+    def _post(self, payload, *, signature=None, event_type="workflow_run"):
+        body = json.dumps(payload).encode()
+        if signature is None:
+            signature = sign_payload(payload)
+        factory = RequestFactory()
+        request = factory.post(
+            "/webhooks/github/ci",
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256=signature,
+            HTTP_X_GITHUB_EVENT=event_type,
+        )
+        return github_workflow_run_webhook(request)
+
+    def test_valid_payload_creates_ci_run(self, repo, mocker):
+        mocker.patch("products.ci_monitoring.backend.tasks.tasks.ingest_ci_run_artifacts.delay")
+        payload = make_webhook_payload()
+
+        response = self._post(payload)
+
+        assert response.status_code == 200
+        assert CIRun.objects.filter(repo=repo, github_run_id=99999).exists()
+
+    def test_invalid_signature_returns_403(self, repo):
+        payload = make_webhook_payload()
+
+        response = self._post(payload, signature="sha256=bad")
+
+        assert response.status_code == 403
+        assert CIRun.objects.count() == 0
+
+    def test_unknown_repo_returns_200(self):
+        payload = make_webhook_payload(repo_external_id=99999)
+
+        response = self._post(payload)
+
+        assert response.status_code == 200
+        assert CIRun.objects.count() == 0
+
+    def test_non_completed_action_ignored(self, repo):
+        payload = make_webhook_payload(action="requested")
+
+        response = self._post(payload)
+
+        assert response.status_code == 200
+        assert CIRun.objects.count() == 0
+
+    def test_non_workflow_run_event_ignored(self, repo):
+        payload = make_webhook_payload()
+
+        response = self._post(payload, event_type="push")
+
+        assert response.status_code == 200
+        assert CIRun.objects.count() == 0
+
+    def test_dispatches_ingestion_task(self, repo, mocker):
+        mock_delay = mocker.patch("products.ci_monitoring.backend.tasks.tasks.ingest_ci_run_artifacts.delay")
+        payload = make_webhook_payload()
+
+        self._post(payload)
+
+        ci_run = CIRun.objects.get(repo=repo)
+        mock_delay.assert_called_once_with(ci_run_id=str(ci_run.id))

--- a/products/ci_monitoring/backend/webhooks.py
+++ b/products/ci_monitoring/backend/webhooks.py
@@ -1,0 +1,114 @@
+"""GitHub webhook handler for ci_monitoring."""
+
+from __future__ import annotations
+
+import json
+
+from django.http import HttpRequest, HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+
+import structlog
+
+from products.tasks.backend.webhooks import get_github_webhook_secret, verify_github_signature
+
+from . import logic
+from .facade.enums import CIRunConclusion
+
+logger = structlog.get_logger(__name__)
+
+# Map GitHub conclusion strings to our enum
+_CONCLUSION_MAP: dict[str, CIRunConclusion] = {
+    "success": CIRunConclusion.SUCCESS,
+    "failure": CIRunConclusion.FAILURE,
+    "cancelled": CIRunConclusion.CANCELLED,
+    "timed_out": CIRunConclusion.TIMED_OUT,
+}
+
+
+@csrf_exempt
+def github_workflow_run_webhook(request: HttpRequest) -> HttpResponse:
+    """
+    Handle GitHub workflow_run webhook events.
+
+    Receives workflow_run.completed events, creates a CIRun record,
+    and dispatches artifact ingestion.
+    """
+    if request.method != "POST":
+        return HttpResponse(status=405)
+
+    webhook_secret = get_github_webhook_secret()
+    if not webhook_secret:
+        logger.error("ci_monitoring.webhook_no_secret")
+        return HttpResponse("Webhook not configured", status=500)
+
+    signature = request.headers.get("X-Hub-Signature-256")
+    if not verify_github_signature(request.body, signature, webhook_secret):
+        logger.warning("ci_monitoring.webhook_invalid_signature", has_signature=bool(signature))
+        return HttpResponse("Invalid signature", status=403)
+
+    try:
+        payload = json.loads(request.body)
+    except json.JSONDecodeError:
+        return HttpResponse("Invalid JSON", status=400)
+
+    event_type = request.headers.get("X-GitHub-Event")
+    if event_type != "workflow_run":
+        return HttpResponse(status=200)
+
+    action = payload.get("action")
+    if action != "completed":
+        return HttpResponse(status=200)
+
+    workflow_run = payload.get("workflow_run", {})
+    repository = payload.get("repository", {})
+
+    conclusion_str = workflow_run.get("conclusion", "")
+    conclusion = _CONCLUSION_MAP.get(conclusion_str)
+    if conclusion is None:
+        logger.debug("ci_monitoring.webhook_ignored_conclusion", conclusion=conclusion_str)
+        return HttpResponse(status=200)
+
+    pr_number = None
+    pull_requests = workflow_run.get("pull_requests", [])
+    if pull_requests:
+        pr_number = pull_requests[0].get("number")
+
+    repo_external_id = repository.get("id")
+    repo_full_name = repository.get("full_name")
+    if not repo_external_id or not repo_full_name:
+        logger.warning("ci_monitoring.webhook_missing_repo_info")
+        return HttpResponse(status=200)
+
+    try:
+        ci_run = logic.create_ci_run_from_webhook(
+            repo_external_id=repo_external_id,
+            repo_full_name=repo_full_name,
+            github_run_id=workflow_run.get("id"),
+            workflow_name=workflow_run.get("name", ""),
+            commit_sha=workflow_run.get("head_sha", ""),
+            branch=workflow_run.get("head_branch", ""),
+            conclusion=conclusion,
+            started_at=workflow_run.get("run_started_at"),
+            completed_at=workflow_run.get("updated_at"),
+            pr_number=pr_number,
+        )
+    except logic.RepoNotFoundError:
+        logger.debug(
+            "ci_monitoring.webhook_repo_not_found",
+            repo_external_id=repo_external_id,
+            repo_full_name=repo_full_name,
+        )
+        return HttpResponse(status=200)
+
+    from .tasks.tasks import ingest_ci_run_artifacts
+
+    ingest_ci_run_artifacts.delay(ci_run_id=str(ci_run.id))
+
+    logger.info(
+        "ci_monitoring.webhook_processed",
+        ci_run_id=str(ci_run.id),
+        workflow=ci_run.workflow_name,
+        conclusion=conclusion_str,
+    )
+
+    return HttpResponse(status=200)


### PR DESCRIPTION
## Summary

- GitHub webhook endpoint for `workflow_run.completed` events at `/webhooks/github/ci`
- JUnit XML parser with flaky test detection (pytest-rerunfailures `<rerun>` elements)
- Celery task: download artifacts from GitHub API, parse, create TestCase/TestExecution records, update MainStreak and flake scores
- Reuses signature verification from `products/tasks` and GitHub integration pattern from `visual_review`

## Test plan

- [x] Unit tests for JUnit XML parser (pass, fail, flaky, skip, nested suites, empty)
- [ ] Integration test: webhook -> task -> parse -> DB flow with mocked GitHub API
- [ ] Manual: configure webhook, trigger CI run, verify ingestion