### PR TITLE
fix: make Vercel installation DELETE idempotent

### DIFF
--- a/ee/api/vercel/test/test_vercel_installation.py
+++ b/ee/api/vercel/test/test_vercel_installation.py
@@ -2,7 +2,7 @@ import json
 
 from unittest.mock import MagicMock, _patch, patch
 
-from rest_framework import status
+from rest_framework import exceptions, status
 
 from ee.api.vercel.test.base import VercelTestBase
 
@@ -93,6 +93,14 @@ class TestVercelInstallationAPI(VercelTestBase):
 
         assert response.status_code == status.HTTP_200_OK
         mock_delete.assert_called_once_with(self.installation_id)
+
+    @patch("ee.vercel.integration.VercelIntegration.delete_installation")
+    def test_destroy_returns_success_when_installation_not_found(self, mock_delete):
+        mock_delete.side_effect = exceptions.NotFound("Installation not found")
+        response = self._request("delete")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"finalized": True}
 
     def test_invalid_installation_id_format(self):
         url = "/api/vercel/v1/installations/invalid-id/"

--- a/ee/api/vercel/vercel_installation.py
+++ b/ee/api/vercel/vercel_installation.py
@@ -138,6 +138,7 @@ class VercelInstallationViewSet(VercelRegionProxyMixin, VercelErrorResponseMixin
         installation_id = validate_installation_id(self.kwargs.get("installation_id"))
         try:
             response_data = VercelIntegration.delete_installation(installation_id)
+            self.invalidate_installation_cache(installation_id)
         except exceptions.NotFound:
             logger.info(
                 "Installation already deleted",

--- a/ee/api/vercel/vercel_installation.py
+++ b/ee/api/vercel/vercel_installation.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any
 
+import structlog
 from rest_framework import decorators, exceptions, serializers, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,6 +14,8 @@ from ee.api.vercel.vercel_error_mixin import VercelErrorResponseMixin
 from ee.api.vercel.vercel_permission import VercelPermission
 from ee.api.vercel.vercel_region_proxy_mixin import VercelRegionProxyMixin
 from ee.vercel.integration import VercelIntegration
+
+logger = structlog.get_logger(__name__)
 
 
 class VercelCredentialsSerializer(serializers.Serializer):
@@ -133,7 +136,15 @@ class VercelInstallationViewSet(VercelRegionProxyMixin, VercelErrorResponseMixin
         Implements: https://vercel.com/docs/integrations/create-integration/marketplace-api#delete-installation
         """
         installation_id = validate_installation_id(self.kwargs.get("installation_id"))
-        response_data = VercelIntegration.delete_installation(installation_id)
+        try:
+            response_data = VercelIntegration.delete_installation(installation_id)
+        except exceptions.NotFound:
+            logger.info(
+                "Installation already deleted",
+                installation_id=installation_id,
+                integration="vercel",
+            )
+            response_data = {"finalized": True}
 
         return Response(response_data, status=200)
 

--- a/ee/api/vercel/vercel_region_proxy_mixin.py
+++ b/ee/api/vercel/vercel_region_proxy_mixin.py
@@ -222,7 +222,7 @@ class VercelRegionProxyMixin:
                 request_path=request.path,
                 integration="vercel",
             )
-            if not is_upsert:
+            if not is_upsert and request.method != "DELETE":
                 self._handle_missing_installation(installation_id)
 
         # If we can't proxy, and the installation exists, we return the response from the current region


### PR DESCRIPTION
## Problem

When a customer's `OrganizationIntegration` record is already deleted (or was never created), Vercel's `DELETE /api/vercel/v1/installations/{id}` call returns 500. This happens because:

1. US doesn't find the installation, proxies to EU
2. EU doesn't find it either, raises `NotFound` from `_handle_missing_installation` inside the region proxy mixin's `dispatch` override
3. Since this runs before `super().dispatch()`, DRF's exception handler never catches it - Django treats it as an unhandled 500
4. Vercel shows "Uninstall Paused" to the customer and retries indefinitely

Reported via Stripe support for integration `icfg_JgQpHxoXoVHr2smafOPXihWH`.

## Changes

- **`vercel_region_proxy_mixin.py`**: Allow DELETE requests through even when installation isn't found (same as PUT/upsert)
- **`vercel_installation.py`**: Catch `NotFound` in `destroy` and return `{"finalized": true}` with 200 - a DELETE for something already gone is success
- **`test_vercel_installation.py`**: Added test for idempotent delete

## How did you test this?

- [x] `pytest ee/api/vercel/test/test_vercel_installation.py -v` - all 8 tests pass including new idempotent delete test
- [ ] Manual: will verify with ngrok once deployed

## Changelog

No - bug fix for existing integration behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)