### PR TITLE
feat(mcp): add query wrapper codegen from schema.json

### DIFF
--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -1,3 +1,23 @@
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from posthog.schema import (
+    AssistantFunnelsQuery,
+    AssistantHogQLQuery,
+    AssistantRetentionQuery,
+    AssistantTrendsQuery,
+    FunnelsQuery,
+    HogQLQuery,
+    RetentionQuery,
+    RevenueAnalyticsGrossRevenueQuery,
+    RevenueAnalyticsMetricsQuery,
+    RevenueAnalyticsMRRQuery,
+    RevenueAnalyticsTopCustomersQuery,
+    TrendsQuery,
+)
+
 from .funnel import FunnelResultsFormatter
 from .retention import RetentionResultsFormatter
 from .revenue_analytics import (
@@ -9,6 +29,45 @@ from .revenue_analytics import (
 from .sql import TRUNCATED_MARKER, SQLResultsFormatter
 from .trends import TrendsResultsFormatter
 
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+
+def format_query_results_for_llm(
+    query: BaseModel,
+    response: dict[str, Any],
+    team: "Team",
+    utc_now: datetime | None = None,
+) -> str | None:
+    """
+    Format query results into LLM-friendly text.
+
+    This is a synchronous function that dispatches to the appropriate formatter
+    based on query type. Returns None if the query type is not supported.
+    """
+    if utc_now is None:
+        utc_now = datetime.now(UTC)
+
+    if isinstance(query, AssistantTrendsQuery | TrendsQuery):
+        return TrendsResultsFormatter(query, response["results"]).format()
+    elif isinstance(query, AssistantFunnelsQuery | FunnelsQuery):
+        return FunnelResultsFormatter(query, response["results"], team, utc_now).format()
+    elif isinstance(query, AssistantRetentionQuery | RetentionQuery):
+        return RetentionResultsFormatter(query, response["results"]).format()
+    elif isinstance(query, AssistantHogQLQuery | HogQLQuery):
+        return SQLResultsFormatter(query, response["results"], response["columns"]).format()
+    elif isinstance(query, RevenueAnalyticsGrossRevenueQuery):
+        return RevenueAnalyticsGrossRevenueResultsFormatter(query, response["results"]).format()
+    elif isinstance(query, RevenueAnalyticsMetricsQuery):
+        return RevenueAnalyticsMetricsResultsFormatter(query, response["results"]).format()
+    elif isinstance(query, RevenueAnalyticsMRRQuery):
+        return RevenueAnalyticsMRRResultsFormatter(query, response["results"]).format()
+    elif isinstance(query, RevenueAnalyticsTopCustomersQuery):
+        return RevenueAnalyticsTopCustomersResultsFormatter(query, response["results"]).format()
+
+    return None
+
+
 __all__ = [
     "FunnelResultsFormatter",
     "RetentionResultsFormatter",
@@ -19,4 +78,5 @@ __all__ = [
     "RevenueAnalyticsMRRResultsFormatter",
     "RevenueAnalyticsTopCustomersResultsFormatter",
     "TRUNCATED_MARKER",
+    "format_query_results_for_llm",
 ]

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -61,6 +61,7 @@ from posthog.rate_limit import (
     HogQLQueryThrottle,
 )
 from posthog.rbac.user_access_control import UserAccessControlError
+from posthog.renderers import MCPRenderer, SafeJSONRenderer
 from posthog.schema_migrations.upgrade import upgrade
 
 from common.hogvm.python.utils import HogVMException
@@ -101,6 +102,7 @@ def _process_query_request(
 
 
 class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
+    renderer_classes = [SafeJSONRenderer, MCPRenderer]
     # NOTE: Do we need to override the scopes for the "create"
     scope_object = "query"
     # Special case for query - these are all essentially read actions
@@ -304,6 +306,15 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 if result.get("query_status") and result["query_status"].get("complete") is False
                 else status.HTTP_200_OK
             )
+
+            if request.accepted_media_type == MCPRenderer.media_type:
+                formatted = self._try_format_for_llm(query, result)
+                if formatted is not None:
+                    return Response(formatted)
+                # Formatting unavailable — override to JSON renderer for this response
+                request.accepted_renderer = SafeJSONRenderer()
+                request.accepted_media_type = SafeJSONRenderer.media_type
+
             return Response(result, status=response_status)
         except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
@@ -435,6 +446,17 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             return
 
         tag_queries(client_query_id=query_id)
+
+    def _try_format_for_llm(self, query: BaseModel, result: dict) -> str | None:
+        """Try to format query results as LLM-friendly text. Returns None on failure."""
+        if not settings.EE_AVAILABLE:
+            return None
+        try:
+            from ee.hogai.context.insight.format import format_query_results_for_llm
+
+            return format_query_results_for_llm(query, result, self.team)
+        except Exception:
+            return None
 
 
 MAX_QUERY_TIMEOUT = 600

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -61,7 +61,6 @@ from posthog.rate_limit import (
     HogQLQueryThrottle,
 )
 from posthog.rbac.user_access_control import UserAccessControlError
-from posthog.renderers import MCPRenderer, SafeJSONRenderer
 from posthog.schema_migrations.upgrade import upgrade
 
 from common.hogvm.python.utils import HogVMException
@@ -102,7 +101,6 @@ def _process_query_request(
 
 
 class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
-    renderer_classes = [SafeJSONRenderer, MCPRenderer]
     # NOTE: Do we need to override the scopes for the "create"
     scope_object = "query"
     # Special case for query - these are all essentially read actions
@@ -307,13 +305,10 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 else status.HTTP_200_OK
             )
 
-            if request.accepted_media_type == MCPRenderer.media_type:
+            if request.META.get("HTTP_X_POSTHOG_CLIENT") == "mcp":
                 formatted = self._try_format_for_llm(query, result)
                 if formatted is not None:
-                    return Response(formatted)
-                # Formatting unavailable — override to JSON renderer for this response
-                request.accepted_renderer = SafeJSONRenderer()
-                request.accepted_media_type = SafeJSONRenderer.media_type
+                    result["formatted_results"] = formatted
 
             return Response(result, status=response_status)
         except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -451,6 +451,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
 
             return format_query_results_for_llm(query, result, self.team)
         except Exception:
+            logger.warning("mcp_llm_format_failed", exc_info=True)
             return None
 
 

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -1232,3 +1232,136 @@ class TestQueryUpgrade(APIBaseTest):
                 }
             },
         )
+
+
+class TestQueryMarkdownFormatting(ClickhouseTestMixin, APIBaseTest):
+    ENDPOINT = "query"
+    ACCEPT_HEADER = "text/markdown"
+
+    @patch("posthog.api.query.process_query_model")
+    def test_trends_query_returns_formatted_markdown(self, mock_process_query_model):
+        mock_process_query_model.return_value = {
+            "results": [
+                {
+                    "data": [100, 200, 150],
+                    "labels": ["2024-01-01", "2024-01-02", "2024-01-03"],
+                    "days": ["2024-01-01", "2024-01-02", "2024-01-03"],
+                    "count": 450,
+                    "label": "$pageview",
+                    "action": {
+                        "days": ["2024-01-01", "2024-01-02", "2024-01-03"],
+                        "id": "$pageview",
+                        "type": "events",
+                    },
+                }
+            ],
+            "is_cached": False,
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/query/",
+            {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
+            HTTP_ACCEPT=self.ACCEPT_HEADER,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
+        content = response.content.decode("utf-8")
+        self.assertIn("$pageview", content)
+        self.assertIn("100", content)
+        self.assertIn("|", content)
+
+    @patch("posthog.api.query.process_query_model")
+    def test_hogql_query_returns_formatted_markdown(self, mock_process_query_model):
+        mock_process_query_model.return_value = {
+            "results": [["sign up", 10], ["sign out", 5]],
+            "columns": ["event", "count"],
+            "is_cached": False,
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/query/",
+            {"query": {"kind": "HogQLQuery", "query": "select event, count() from events group by event"}},
+            HTTP_ACCEPT=self.ACCEPT_HEADER,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
+        content = response.content.decode("utf-8")
+        self.assertIn("sign up", content)
+        self.assertIn("10", content)
+
+    @patch("posthog.api.query.process_query_model")
+    def test_json_returned_without_accept_header(self, mock_process_query_model):
+        mock_process_query_model.return_value = {
+            "results": [
+                {
+                    "data": [100],
+                    "labels": ["2024-01-01"],
+                    "days": ["2024-01-01"],
+                    "count": 100,
+                    "label": "$pageview",
+                    "action": {"days": ["2024-01-01"], "id": "$pageview", "type": "events"},
+                }
+            ],
+            "is_cached": False,
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/query/",
+            {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/json", response["Content-Type"])
+        data = response.json()
+        self.assertIn("results", data)
+
+    @patch("posthog.api.query.process_query_model")
+    def test_unsupported_query_type_falls_back_to_json(self, mock_process_query_model):
+        mock_process_query_model.return_value = {
+            "results": [{"event": "test"}],
+            "columns": ["event"],
+            "is_cached": False,
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/query/",
+            {"query": {"kind": "EventsQuery", "select": ["event"]}},
+            HTTP_ACCEPT=self.ACCEPT_HEADER,
+        )
+
+        # EventsQuery is not supported by formatters, falls back to JSON
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/json", response["Content-Type"])
+
+    @patch("posthog.api.query.settings")
+    @patch("posthog.api.query.process_query_model")
+    def test_ee_unavailable_falls_back_to_json(self, mock_process_query_model, mock_settings):
+        mock_settings.EE_AVAILABLE = False
+        # Forward other settings attributes to the real module
+        for attr in ("TEST", "API_QUERIES_PER_TEAM", "API_QUERIES_ENABLED", "API_QUERIES_LEGACY_TEAM_LIST"):
+            setattr(mock_settings, attr, getattr(__import__("posthog").settings, attr))
+
+        mock_process_query_model.return_value = {
+            "results": [
+                {
+                    "data": [100],
+                    "labels": ["2024-01-01"],
+                    "days": ["2024-01-01"],
+                    "count": 100,
+                    "label": "$pageview",
+                    "action": {"days": ["2024-01-01"], "id": "$pageview", "type": "events"},
+                }
+            ],
+            "is_cached": False,
+        }
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/query/",
+            {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
+            HTTP_ACCEPT=self.ACCEPT_HEADER,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/json", response["Content-Type"])

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -1234,12 +1234,12 @@ class TestQueryUpgrade(APIBaseTest):
         )
 
 
-class TestQueryMarkdownFormatting(ClickhouseTestMixin, APIBaseTest):
+class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
     ENDPOINT = "query"
-    ACCEPT_HEADER = "text/markdown"
+    LLM_FORMAT_HEADER = "HTTP_X_POSTHOG_CLIENT"
 
     @patch("posthog.api.query.process_query_model")
-    def test_trends_query_returns_formatted_markdown(self, mock_process_query_model):
+    def test_trends_query_includes_formatted_results(self, mock_process_query_model):
         mock_process_query_model.return_value = {
             "results": [
                 {
@@ -1261,18 +1261,19 @@ class TestQueryMarkdownFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
-            HTTP_ACCEPT=self.ACCEPT_HEADER,
+            **{self.LLM_FORMAT_HEADER: "mcp"},
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
-        content = response.content.decode("utf-8")
-        self.assertIn("$pageview", content)
-        self.assertIn("100", content)
-        self.assertIn("|", content)
+        data = response.json()
+        self.assertIn("results", data)
+        self.assertIn("formatted_results", data)
+        self.assertIn("$pageview", data["formatted_results"])
+        self.assertIn("100", data["formatted_results"])
+        self.assertIn("|", data["formatted_results"])
 
     @patch("posthog.api.query.process_query_model")
-    def test_hogql_query_returns_formatted_markdown(self, mock_process_query_model):
+    def test_hogql_query_includes_formatted_results(self, mock_process_query_model):
         mock_process_query_model.return_value = {
             "results": [["sign up", 10], ["sign out", 5]],
             "columns": ["event", "count"],
@@ -1282,17 +1283,17 @@ class TestQueryMarkdownFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "HogQLQuery", "query": "select event, count() from events group by event"}},
-            HTTP_ACCEPT=self.ACCEPT_HEADER,
+            **{self.LLM_FORMAT_HEADER: "mcp"},
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "text/markdown; charset=utf-8")
-        content = response.content.decode("utf-8")
-        self.assertIn("sign up", content)
-        self.assertIn("10", content)
+        data = response.json()
+        self.assertIn("formatted_results", data)
+        self.assertIn("sign up", data["formatted_results"])
+        self.assertIn("10", data["formatted_results"])
 
     @patch("posthog.api.query.process_query_model")
-    def test_json_returned_without_accept_header(self, mock_process_query_model):
+    def test_no_formatted_results_without_header(self, mock_process_query_model):
         mock_process_query_model.return_value = {
             "results": [
                 {
@@ -1313,12 +1314,12 @@ class TestQueryMarkdownFormatting(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("application/json", response["Content-Type"])
         data = response.json()
         self.assertIn("results", data)
+        self.assertNotIn("formatted_results", data)
 
     @patch("posthog.api.query.process_query_model")
-    def test_unsupported_query_type_falls_back_to_json(self, mock_process_query_model):
+    def test_unsupported_query_type_omits_formatted_results(self, mock_process_query_model):
         mock_process_query_model.return_value = {
             "results": [{"event": "test"}],
             "columns": ["event"],
@@ -1328,18 +1329,18 @@ class TestQueryMarkdownFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "EventsQuery", "select": ["event"]}},
-            HTTP_ACCEPT=self.ACCEPT_HEADER,
+            **{self.LLM_FORMAT_HEADER: "mcp"},
         )
 
-        # EventsQuery is not supported by formatters, falls back to JSON
         self.assertEqual(response.status_code, 200)
-        self.assertIn("application/json", response["Content-Type"])
+        data = response.json()
+        self.assertIn("results", data)
+        self.assertNotIn("formatted_results", data)
 
     @patch("posthog.api.query.settings")
     @patch("posthog.api.query.process_query_model")
-    def test_ee_unavailable_falls_back_to_json(self, mock_process_query_model, mock_settings):
+    def test_ee_unavailable_omits_formatted_results(self, mock_process_query_model, mock_settings):
         mock_settings.EE_AVAILABLE = False
-        # Forward other settings attributes to the real module
         for attr in ("TEST", "API_QUERIES_PER_TEAM", "API_QUERIES_ENABLED", "API_QUERIES_LEGACY_TEAM_LIST"):
             setattr(mock_settings, attr, getattr(__import__("posthog").settings, attr))
 
@@ -1360,8 +1361,10 @@ class TestQueryMarkdownFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
-            HTTP_ACCEPT=self.ACCEPT_HEADER,
+            **{self.LLM_FORMAT_HEADER: "mcp"},
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("application/json", response["Content-Type"])
+        data = response.json()
+        self.assertIn("results", data)
+        self.assertNotIn("formatted_results", data)

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -1236,7 +1236,6 @@ class TestQueryUpgrade(APIBaseTest):
 
 class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
     ENDPOINT = "query"
-    LLM_FORMAT_HEADER = "HTTP_X_POSTHOG_CLIENT"
 
     @patch("posthog.api.query.process_query_model")
     def test_trends_query_includes_formatted_results(self, mock_process_query_model):
@@ -1261,7 +1260,7 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
-            **{self.LLM_FORMAT_HEADER: "mcp"},
+            HTTP_X_POSTHOG_CLIENT="mcp",
         )
 
         self.assertEqual(response.status_code, 200)
@@ -1283,7 +1282,7 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "HogQLQuery", "query": "select event, count() from events group by event"}},
-            **{self.LLM_FORMAT_HEADER: "mcp"},
+            HTTP_X_POSTHOG_CLIENT="mcp",
         )
 
         self.assertEqual(response.status_code, 200)
@@ -1329,7 +1328,7 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "EventsQuery", "select": ["event"]}},
-            **{self.LLM_FORMAT_HEADER: "mcp"},
+            HTTP_X_POSTHOG_CLIENT="mcp",
         )
 
         self.assertEqual(response.status_code, 200)
@@ -1361,7 +1360,7 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
             {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
-            **{self.LLM_FORMAT_HEADER: "mcp"},
+            HTTP_X_POSTHOG_CLIENT="mcp",
         )
 
         self.assertEqual(response.status_code, 200)

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -24,14 +24,3 @@ class ServerSentEventRenderer(BaseRenderer):
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         return data
-
-
-class MCPRenderer(BaseRenderer):
-    media_type = "text/markdown"
-    format = "md"
-    charset = "utf-8"
-
-    def render(self, data, accepted_media_type=None, renderer_context=None):
-        if isinstance(data, str):
-            return data.encode(self.charset)
-        return str(data).encode(self.charset)

--- a/posthog/renderers.py
+++ b/posthog/renderers.py
@@ -24,3 +24,14 @@ class ServerSentEventRenderer(BaseRenderer):
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         return data
+
+
+class MCPRenderer(BaseRenderer):
+    media_type = "text/markdown"
+    format = "md"
+    charset = "utf-8"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        if isinstance(data, str):
+            return data.encode(self.charset)
+        return str(data).encode(self.charset)

--- a/services/mcp/definitions/query-wrappers.yaml
+++ b/services/mcp/definitions/query-wrappers.yaml
@@ -1,0 +1,79 @@
+# MCP query wrapper tool definitions.
+#
+# Each wrapper generates a typed tool that accepts a single query schema
+# from frontend/src/queries/schema.json and POSTs to /api/environments/{project_id}/query/.
+#
+# schema_ref must match a definition name in schema.json exactly.
+# The Zod input schema is auto-generated from the JSON Schema at build time.
+category: Query wrappers
+feature: insights
+wrappers:
+    query-trends:
+        schema_ref: AssistantTrendsQuery
+        enabled: true
+        scopes:
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        mcp_version: 2
+        title: Run a trends query
+        description: >
+            Run a trends query to analyze metrics over time. Use this to answer questions
+            about event counts, unique users, session counts, or property aggregations
+            with breakdowns and comparisons. Prefer this over raw HogQL for trends analysis.
+            Use 'event-definitions-list' to discover available events, and 'properties-list'
+            to discover available properties for filters and breakdowns.
+        ui_resource_uri: ui://posthog/query-results.html
+        exclude_properties:
+            - kind
+            - response
+            - modifiers
+            - samplingFactor
+
+    query-funnel:
+        schema_ref: AssistantFunnelsQuery
+        enabled: true
+        scopes:
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        mcp_version: 2
+        title: Run a funnel query
+        description: >
+            Run a funnel query to analyze conversion rates through a sequence of steps.
+            Use this to understand how users progress through multi-step flows like
+            sign-up, onboarding, or purchase funnels. Requires at least two series
+            steps. Use 'event-definitions-list' to discover available events.
+        ui_resource_uri: ui://posthog/query-results.html
+        exclude_properties:
+            - kind
+            - response
+            - modifiers
+            - samplingFactor
+
+    query-traces-list:
+        schema_ref: TracesQuery
+        enabled: true
+        scopes:
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        mcp_version: 2
+        title: List LLM traces
+        description: >
+            Query LLM traces to inspect AI/LLM usage. Returns a list of traces
+            with their events, latency, token usage, and other metadata.
+            Use dateRange, properties, and limit to filter results.
+        exclude_properties:
+            - kind
+            - response
+            - modifiers
+            - showColumnConfigurator
+            - tags
+            - version

--- a/services/mcp/definitions/query-wrappers.yaml
+++ b/services/mcp/definitions/query-wrappers.yaml
@@ -27,7 +27,6 @@ wrappers:
             to discover available properties for filters and breakdowns.
         ui_resource_uri: ui://posthog/query-results.html
         exclude_properties:
-            - kind
             - response
             - modifiers
             - samplingFactor
@@ -50,7 +49,6 @@ wrappers:
             steps. Use 'event-definitions-list' to discover available events.
         ui_resource_uri: ui://posthog/query-results.html
         exclude_properties:
-            - kind
             - response
             - modifiers
             - samplingFactor
@@ -72,7 +70,6 @@ wrappers:
             stickiness by cohort. Use 'event-definitions-list' to discover available events.
         ui_resource_uri: ui://posthog/query-results.html
         exclude_properties:
-            - kind
             - response
             - modifiers
             - samplingFactor
@@ -93,7 +90,6 @@ wrappers:
             with their events, latency, token usage, and other metadata.
             Use dateRange, properties, and limit to filter results.
         exclude_properties:
-            - kind
             - response
             - modifiers
             - showColumnConfigurator

--- a/services/mcp/definitions/query-wrappers.yaml
+++ b/services/mcp/definitions/query-wrappers.yaml
@@ -55,6 +55,28 @@ wrappers:
             - modifiers
             - samplingFactor
 
+    query-retention:
+        schema_ref: AssistantRetentionQuery
+        enabled: true
+        scopes:
+            - query:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        mcp_version: 2
+        title: Run a retention query
+        description: >
+            Run a retention query to analyze how many users return over time after
+            performing an initial action. Use this to measure user engagement and
+            stickiness by cohort. Use 'event-definitions-list' to discover available events.
+        ui_resource_uri: ui://posthog/query-results.html
+        exclude_properties:
+            - kind
+            - response
+            - modifiers
+            - samplingFactor
+
     query-traces-list:
         schema_ref: TracesQuery
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1394,6 +1394,21 @@
             "readOnlyHint": true
         }
     },
+    "query-retention": {
+        "description": "Run a retention query to analyze how many users return over time after performing an initial action. Use this to measure user engagement and stickiness by cohort. Use 'event-definitions-list' to discover available events.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a retention query",
+        "title": "Run a retention query",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "query-traces-list": {
         "description": "Query LLM traces to inspect AI/LLM usage. Returns a list of traces with their events, latency, token usage, and other metadata. Use dateRange, properties, and limit to filter results.",
         "category": "Query wrappers",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1363,5 +1363,50 @@
             "openWorldHint": true,
             "readOnlyHint": true
         }
+    },
+    "query-trends": {
+        "description": "Run a trends query to analyze metrics over time. Use this to answer questions about event counts, unique users, session counts, or property aggregations with breakdowns and comparisons. Prefer this over raw HogQL for trends analysis. Use 'event-definitions-list' to discover available events, and 'properties-list' to discover available properties for filters and breakdowns.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a trends query",
+        "title": "Run a trends query",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "query-funnel": {
+        "description": "Run a funnel query to analyze conversion rates through a sequence of steps. Use this to understand how users progress through multi-step flows like sign-up, onboarding, or purchase funnels. Requires at least two series steps. Use 'event-definitions-list' to discover available events.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a funnel query",
+        "title": "Run a funnel query",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "query-traces-list": {
+        "description": "Query LLM traces to inspect AI/LLM usage. Returns a list of traces with their events, latency, token usage, and other metadata. Use dateRange, properties, and limit to filter results.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "List LLM traces",
+        "title": "List LLM traces",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     }
 }

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2023,6 +2023,21 @@
             "readOnlyHint": true
         }
     },
+    "query-retention": {
+        "description": "Run a retention query to analyze how many users return over time after performing an initial action. Use this to measure user engagement and stickiness by cohort. Use 'event-definitions-list' to discover available events.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a retention query",
+        "title": "Run a retention query",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "query-traces-list": {
         "description": "Query LLM traces to inspect AI/LLM usage. Returns a list of traces with their events, latency, token usage, and other metadata. Use dateRange, properties, and limit to filter results.",
         "category": "Query wrappers",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1992,5 +1992,50 @@
             "openWorldHint": true,
             "readOnlyHint": true
         }
+    },
+    "query-trends": {
+        "description": "Run a trends query to analyze metrics over time. Use this to answer questions about event counts, unique users, session counts, or property aggregations with breakdowns and comparisons. Prefer this over raw HogQL for trends analysis. Use 'event-definitions-list' to discover available events, and 'properties-list' to discover available properties for filters and breakdowns.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a trends query",
+        "title": "Run a trends query",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "query-funnel": {
+        "description": "Run a funnel query to analyze conversion rates through a sequence of steps. Use this to understand how users progress through multi-step flows like sign-up, onboarding, or purchase funnels. Requires at least two series steps. Use 'event-definitions-list' to discover available events.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "Run a funnel query",
+        "title": "Run a funnel query",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "query-traces-list": {
+        "description": "Query LLM traces to inspect AI/LLM usage. Returns a list of traces with their events, latency, token usage, and other metadata. Use dateRange, properties, and limit to filter results.",
+        "category": "Query wrappers",
+        "feature": "insights",
+        "summary": "List LLM traces",
+        "title": "List LLM traces",
+        "required_scopes": ["query:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
     }
 }

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -22,10 +22,14 @@ import { fileURLToPath } from 'node:url'
 import { parse as parseYaml } from 'yaml'
 
 import { discoverDefinitions } from './lib/definitions.mjs'
+import { type JsonSchemaRoot, generateZodFromSchemaRef, getEntryVarName } from './lib/json-schema-to-zod'
 import {
     type CategoryConfig,
     CategoryConfigSchema,
     type EnabledToolConfig,
+    type EnabledQueryWrapperToolConfig,
+    type QueryWrappersConfig,
+    QueryWrappersConfigSchema,
     type ToolConfig,
 } from './yaml-config-schema'
 
@@ -39,6 +43,7 @@ const ALL_DEFINITIONS_JSON_PATH = path.resolve(MCP_ROOT, 'schema/tool-definition
 const TOOL_DEFINITIONS_V1_PATH = path.resolve(MCP_ROOT, 'schema/tool-definitions.json')
 const TOOL_DEFINITIONS_V2_PATH = path.resolve(MCP_ROOT, 'schema/tool-definitions-v2.json')
 const OPENAPI_PATH = path.resolve(REPO_ROOT, 'frontend/tmp/openapi.json')
+const SCHEMA_JSON_PATH = path.resolve(REPO_ROOT, 'frontend/src/queries/schema.json')
 
 interface OpenApiParam {
     in: 'path' | 'query' | 'header' | 'cookie'
@@ -821,6 +826,176 @@ function generateDefinitionsJson(
 }
 
 // ------------------------------------------------------------------
+// Query wrapper generation — tools backed by schema.json definitions
+// ------------------------------------------------------------------
+
+function loadQuerySchema(): JsonSchemaRoot {
+    if (!fs.existsSync(SCHEMA_JSON_PATH)) {
+        console.error(`Query schema not found at ${SCHEMA_JSON_PATH}. Run schema:build:json first.`)
+        process.exit(1)
+    }
+    return JSON.parse(fs.readFileSync(SCHEMA_JSON_PATH, 'utf-8')) as JsonSchemaRoot
+}
+
+/**
+ * Returns true if the parsed YAML has the shape of a query wrapper config
+ * (has `wrappers` key instead of `tools`).
+ */
+function isQueryWrappersConfig(parsed: unknown): boolean {
+    return typeof parsed === 'object' && parsed !== null && 'wrappers' in parsed && !('tools' in parsed)
+}
+
+function generateQueryWrapperFile(
+    config: QueryWrappersConfig,
+    fileName: string,
+    querySchema: JsonSchemaRoot
+): {
+    code: string
+    enabledWrappers: [string, EnabledQueryWrapperToolConfig][]
+} {
+    const enabledWrappers: [string, EnabledQueryWrapperToolConfig][] = []
+
+    for (const [name, toolConfig] of Object.entries(config.wrappers)) {
+        if (!toolConfig.enabled) {
+            continue
+        }
+        if (!toolConfig.scopes?.length) {
+            console.error(`Enabled query wrapper "${name}" is missing required "scopes"`)
+            process.exit(1)
+        }
+        if (!toolConfig.annotations) {
+            console.error(`Enabled query wrapper "${name}" is missing required "annotations"`)
+            process.exit(1)
+        }
+        if (!querySchema.definitions[toolConfig.schema_ref]) {
+            console.error(`Query wrapper "${name}": schema_ref "${toolConfig.schema_ref}" not found in schema.json`)
+            process.exit(1)
+        }
+        enabledWrappers.push([name, toolConfig as EnabledQueryWrapperToolConfig])
+    }
+
+    // Generate all Zod schemas first, collecting them to deduplicate shared definitions
+    const allZodBlocks: string[] = []
+    const emittedDefs = new Set<string>()
+
+    for (const [, toolConfig] of enabledWrappers) {
+        const zodCode = generateZodFromSchemaRef(
+            querySchema,
+            toolConfig.schema_ref,
+            toolConfig.exclude_properties ?? []
+        )
+        // Split into individual const declarations and only emit new ones
+        const lines = zodCode.split('\n\nconst ')
+        for (let i = 0; i < lines.length; i++) {
+            const block = i === 0 ? lines[i]! : `const ${lines[i]}`
+            const match = block.match(/^const (\w+) =/)
+            if (match && !emittedDefs.has(match[1]!)) {
+                emittedDefs.add(match[1]!)
+                allZodBlocks.push(block)
+            }
+        }
+    }
+
+    const schemasCode = allZodBlocks.join('\n\n')
+
+    // Generate tool handlers
+    const toolCodes: string[] = []
+
+    for (const [name, toolConfig] of enabledWrappers) {
+        const entryVarName = getEntryVarName(toolConfig.schema_ref)
+        const factoryName = toCamelCase(name)
+        const schemaName = `${toPascalCase(name)}Schema`
+
+        // Build optional _meta block
+        let metaBlock = ''
+        if (toolConfig.ui_resource_uri) {
+            metaBlock = `    _meta: {\n        ui: {\n            resourceUri: '${toolConfig.ui_resource_uri}',\n        },\n    },\n`
+        }
+
+        const code = `
+const ${schemaName} = ${entryVarName}
+
+const ${factoryName} = (): ToolBase<typeof ${schemaName}> => ({
+    name: '${name}',
+    schema: ${schemaName},
+    handler: async (context: Context, params: z.infer<typeof ${schemaName}>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const query = { ...params, kind: '${extractKindFromSchemaRef(querySchema, toolConfig.schema_ref)}' }
+        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
+            method: 'POST',
+            path: \`/api/environments/\${projectId}/query/\`,
+            body: { query },
+        })
+        const queryParam = encodeURIComponent(JSON.stringify(query))
+        const baseUrl = context.api.getProjectBaseUrl(projectId)
+        return {
+            query,
+            results: result,
+            _posthogUrl: \`\${baseUrl}/insights/new?q=\${queryParam}\`,
+        }
+    },
+${metaBlock}})
+`
+        toolCodes.push(code)
+    }
+
+    const mapEntries = enabledWrappers.map(([name]) => `    '${name}': ${toCamelCase(name)},`).join('\n')
+
+    const code = `// AUTO-GENERATED from ${fileName} + schema.json — do not edit
+import { z } from 'zod'
+
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+// --- Shared Zod schemas generated from schema.json ---
+
+${schemasCode}
+
+// --- Tool handlers ---
+${toolCodes.join('')}
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+${mapEntries}
+}
+`
+
+    return { code, enabledWrappers }
+}
+
+/** Extract the `kind` const value from a schema.json definition */
+function extractKindFromSchemaRef(querySchema: JsonSchemaRoot, schemaRef: string): string {
+    const schema = querySchema.definitions[schemaRef]
+    if (schema?.properties?.kind?.const) {
+        return schema.properties.kind.const as string
+    }
+    // Fallback: derive from the schema ref name (e.g. AssistantTrendsQuery → TrendsQuery)
+    return schemaRef.replace(/^Assistant/, '')
+}
+
+function generateQueryWrapperDefinitionsJson(
+    config: QueryWrappersConfig,
+    enabledWrappers: [string, EnabledQueryWrapperToolConfig][]
+): Record<string, unknown> {
+    const definitions: Record<string, unknown> = {}
+    for (const [name, toolConfig] of enabledWrappers) {
+        definitions[name] = {
+            description: toolConfig.description?.trim() || `Run a ${toolConfig.schema_ref} query`,
+            category: config.category,
+            feature: config.feature,
+            summary: toolConfig.title || name,
+            title: toolConfig.title || name,
+            required_scopes: toolConfig.scopes,
+            new_mcp: toolConfig.mcp_version !== undefined ? toolConfig.mcp_version >= 2 : true,
+            annotations: {
+                destructiveHint: toolConfig.annotations.destructive,
+                idempotentHint: toolConfig.annotations.idempotent,
+                openWorldHint: true,
+                readOnlyHint: toolConfig.annotations.readOnly,
+            },
+        }
+    }
+    return definitions
+}
+
+// ------------------------------------------------------------------
 // Main
 // ------------------------------------------------------------------
 
@@ -843,9 +1018,43 @@ function main(): void {
     }[] = []
     const generatedModules: string[] = []
 
+    // Accumulate query wrapper definitions separately
+    const queryWrapperDefinitions: Record<string, unknown> = {}
+    let querySchema: JsonSchemaRoot | undefined
+
     for (const def of definitionSources) {
         const content = fs.readFileSync(def.filePath, 'utf-8')
         const parsed = parseYaml(content)
+
+        // Check if this is a query wrapper config
+        if (isQueryWrappersConfig(parsed)) {
+            const result = QueryWrappersConfigSchema.safeParse(parsed)
+            if (!result.success) {
+                console.error(`Invalid query wrappers YAML in ${def.filePath}:`)
+                for (const issue of result.error.issues) {
+                    console.error(`  ${issue.path.join('.')}: ${issue.message}`)
+                }
+                process.exit(1)
+            }
+
+            // Lazy-load query schema only when needed
+            if (!querySchema) {
+                querySchema = loadQuerySchema()
+            }
+
+            const config = result.data
+            const label = path.relative(REPO_ROOT, def.filePath)
+            const { code, enabledWrappers } = generateQueryWrapperFile(config, label, querySchema)
+
+            if (enabledWrappers.length > 0) {
+                generatedModules.push(def.moduleName)
+                fs.writeFileSync(path.join(GENERATED_DIR, `${def.moduleName}.ts`), code)
+                Object.assign(queryWrapperDefinitions, generateQueryWrapperDefinitionsJson(config, enabledWrappers))
+                process.stdout.write(`Generated ${enabledWrappers.length} query wrapper(s) from ${label}\n`)
+            }
+            continue
+        }
+
         const result = CategoryConfigSchema.safeParse(parsed)
         if (!result.success) {
             console.error(`Invalid YAML config in ${def.filePath}:`)
@@ -881,8 +1090,8 @@ ${spreads}
 `
     fs.writeFileSync(path.join(GENERATED_DIR, 'index.ts'), barrelCode)
 
-    // Tool definitions JSON
-    const definitions = generateDefinitionsJson(allCategories)
+    // Tool definitions JSON (merge OpenAPI-based + query wrapper definitions)
+    const definitions = { ...generateDefinitionsJson(allCategories), ...queryWrapperDefinitions }
     fs.writeFileSync(DEFINITIONS_JSON_PATH, JSON.stringify(definitions, null, 4) + '\n')
 
     // Combined tool definitions for external consumers (docs site)
@@ -892,8 +1101,12 @@ ${spreads}
     fs.writeFileSync(ALL_DEFINITIONS_JSON_PATH, JSON.stringify(allDefinitions, null, 4) + '\n')
 
     const totalTools = allCategories.reduce((sum, c) => sum + c.enabledTools.length, 0)
+    const totalQueryWrappers = Object.keys(queryWrapperDefinitions).length
     const totalAllTools = Object.keys(allDefinitions).length
     process.stdout.write(`Generated ${totalTools} tool(s) from ${allCategories.length} category file(s)\n`)
+    if (totalQueryWrappers > 0) {
+        process.stdout.write(`Generated ${totalQueryWrappers} query wrapper tool(s)\n`)
+    }
     process.stdout.write(`Combined ${totalAllTools} total tool(s) into tool-definitions-all.json\n`)
 
     const generatedTsFiles = [
@@ -908,7 +1121,14 @@ ${spreads}
 }
 
 // Export for testing
-export { composeToolSchema, extractPathParams, generateCategoryFile, generateCustomSchemaToolCode, generateToolCode }
+export {
+    composeToolSchema,
+    extractPathParams,
+    generateCategoryFile,
+    generateCustomSchemaToolCode,
+    generateQueryWrapperFile,
+    generateToolCode,
+}
 export type { OpenApiSpec, ResolvedOperation }
 
 // Run main when executed directly

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -898,61 +898,29 @@ function generateQueryWrapperFile(
 
     const schemasCode = allZodBlocks.join('\n\n')
 
-    // Generate tool handlers
-    const toolCodes: string[] = []
-
-    for (const [name, toolConfig] of enabledWrappers) {
-        const entryVarName = getEntryVarName(toolConfig.schema_ref)
-        const factoryName = toCamelCase(name)
-        const schemaName = `${toPascalCase(name)}Schema`
-
-        // Build optional _meta block
-        let metaBlock = ''
-        if (toolConfig.ui_resource_uri) {
-            metaBlock = `    _meta: {\n        ui: {\n            resourceUri: '${toolConfig.ui_resource_uri}',\n        },\n    },\n`
-        }
-
-        const code = `
-const ${schemaName} = ${entryVarName}
-
-const ${factoryName} = (): ToolBase<typeof ${schemaName}> => ({
-    name: '${name}',
-    schema: ${schemaName},
-    handler: async (context: Context, params: z.infer<typeof ${schemaName}>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const query = { ...params, kind: '${extractKindFromSchemaRef(querySchema, toolConfig.schema_ref)}' }
-        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
-            method: 'POST',
-            path: \`/api/environments/\${projectId}/query/\`,
-            body: { query },
+    // Generate tool registrations using the factory
+    const mapEntries = enabledWrappers
+        .map(([name, toolConfig]) => {
+            const entryVarName = getEntryVarName(toolConfig.schema_ref)
+            const kind = extractKindFromSchemaRef(querySchema, toolConfig.schema_ref)
+            const uiResourceUri = toolConfig.ui_resource_uri ? `, uiResourceUri: '${toolConfig.ui_resource_uri}'` : ''
+            return `    '${name}': createQueryWrapper({ name: '${name}', schema: ${entryVarName}, kind: '${kind}'${uiResourceUri} }),`
         })
-        const queryParam = encodeURIComponent(JSON.stringify(query))
-        const baseUrl = context.api.getProjectBaseUrl(projectId)
-        return {
-            query,
-            results: result,
-            _posthogUrl: \`\${baseUrl}/insights/new?q=\${queryParam}\`,
-        }
-    },
-${metaBlock}})
-`
-        toolCodes.push(code)
-    }
-
-    const mapEntries = enabledWrappers.map(([name]) => `    '${name}': ${toCamelCase(name)},`).join('\n')
+        .join('\n')
 
     const code = `// AUTO-GENERATED from ${fileName} + schema.json — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+import type { ZodObjectAny } from '@/tools/types'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
 
 // --- Shared Zod schemas generated from schema.json ---
 
 ${schemasCode}
 
-// --- Tool handlers ---
-${toolCodes.join('')}
-export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+// --- Tool registrations ---
+
+export const GENERATED_TOOLS: Record<string, ReturnType<typeof createQueryWrapper<ZodObjectAny>>> = {
 ${mapEntries}
 }
 `

--- a/services/mcp/scripts/lib/json-schema-to-zod.ts
+++ b/services/mcp/scripts/lib/json-schema-to-zod.ts
@@ -1,0 +1,347 @@
+/**
+ * Converts JSON Schema definitions from schema.json into Zod source code.
+ *
+ * This is a build-time code generator — it produces static TypeScript strings,
+ * not runtime Zod objects. The output is written into generated tool files.
+ *
+ * Supports the subset of JSON Schema used by PostHog's query schemas:
+ * - $ref, type, const, enum, properties, required, items
+ * - anyOf/oneOf (→ z.union), allOf (→ z.intersection)
+ * - type arrays like ["string", "null"] (→ z.string().nullable())
+ * - additionalProperties, default, description
+ */
+
+export interface JsonSchema {
+    $ref?: string
+    type?: string | string[]
+    const?: unknown
+    enum?: unknown[]
+    properties?: Record<string, JsonSchema>
+    required?: string[]
+    items?: JsonSchema
+    anyOf?: JsonSchema[]
+    oneOf?: JsonSchema[]
+    allOf?: JsonSchema[]
+    additionalProperties?: boolean | JsonSchema
+    default?: unknown
+    description?: string
+    maxLength?: number
+    minimum?: number
+    maximum?: number
+    format?: string
+    nullable?: boolean
+    readOnly?: boolean
+}
+
+export interface JsonSchemaRoot {
+    definitions: Record<string, JsonSchema>
+}
+
+interface ConvertContext {
+    root: JsonSchemaRoot
+    /** Definitions that have been emitted as named variables */
+    emittedDefs: Set<string>
+    /** Definitions we need to emit (discovered via $ref) */
+    pendingDefs: Set<string>
+    /** Properties to exclude from the top-level schema */
+    excludeProperties: Set<string>
+    /** Whether we're at the top-level schema (for exclude_properties) */
+    isTopLevel: boolean
+}
+
+/**
+ * Generate Zod source code for a schema.json definition and all its transitive dependencies.
+ *
+ * Returns a string of TypeScript code that declares Zod schemas as `const` variables.
+ * The entry point schema is the last variable declared, named after `entryDefName`.
+ */
+export function generateZodFromSchemaRef(
+    root: JsonSchemaRoot,
+    entryDefName: string,
+    excludeProperties: string[] = []
+): string {
+    const ctx: ConvertContext = {
+        root,
+        emittedDefs: new Set(),
+        pendingDefs: new Set(),
+        excludeProperties: new Set(excludeProperties),
+        isTopLevel: false,
+    }
+
+    // Collect all transitive refs first so we can emit them in dependency order
+    const ordered = topologicalSort(root, entryDefName, excludeProperties)
+
+    const lines: string[] = []
+    for (const defName of ordered) {
+        if (ctx.emittedDefs.has(defName)) {
+            continue
+        }
+        ctx.emittedDefs.add(defName)
+        const schema = root.definitions[defName]
+        if (!schema) {
+            continue
+        }
+        const isTop = defName === entryDefName
+        ctx.isTopLevel = isTop
+        const varName = sanitizeVarName(defName)
+        const zodExpr = schemaToZod(schema, ctx)
+        lines.push(`const ${varName} = ${zodExpr}`)
+        ctx.isTopLevel = false
+    }
+
+    return lines.join('\n\n')
+}
+
+/**
+ * Get the variable name for the entry definition.
+ */
+export function getEntryVarName(entryDefName: string): string {
+    return sanitizeVarName(entryDefName)
+}
+
+// ------------------------------------------------------------------
+// Core conversion
+// ------------------------------------------------------------------
+
+function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
+    // $ref
+    if (schema.$ref) {
+        const refName = schema.$ref.replace('#/definitions/', '')
+        return sanitizeVarName(refName)
+    }
+
+    // const
+    if (schema.const !== undefined) {
+        return `z.literal(${JSON.stringify(schema.const)})`
+    }
+
+    // enum
+    if (schema.enum) {
+        if (schema.enum.length === 1) {
+            return `z.literal(${JSON.stringify(schema.enum[0])})`
+        }
+        const members = schema.enum.map((v) => JSON.stringify(v)).join(', ')
+        // Check if all enum values are strings
+        if (schema.enum.every((v) => typeof v === 'string')) {
+            return `z.enum([${members}])`
+        }
+        // Mixed types — use union of literals
+        const literals = schema.enum.map((v) => `z.literal(${JSON.stringify(v)})`).join(', ')
+        return `z.union([${literals}])`
+    }
+
+    // anyOf / oneOf → z.union
+    if (schema.anyOf || schema.oneOf) {
+        const variants = (schema.anyOf || schema.oneOf)!
+        if (variants.length === 1) {
+            return schemaToZod(variants[0]!, ctx)
+        }
+        const members = variants.map((v) => schemaToZod(v, ctx)).join(', ')
+        return `z.union([${members}])`
+    }
+
+    // allOf → merge/intersection
+    if (schema.allOf) {
+        if (schema.allOf.length === 1) {
+            return schemaToZod(schema.allOf[0]!, ctx)
+        }
+        const members = schema.allOf.map((v) => schemaToZod(v, ctx))
+        // Use .merge for object schemas, intersection for others
+        return members.reduce((acc, m) => `${acc}.and(${m})`)
+    }
+
+    // type array (e.g. ["string", "null"])
+    if (Array.isArray(schema.type)) {
+        const types = schema.type.filter((t) => t !== 'null')
+        const hasNull = schema.type.includes('null')
+        const base =
+            types.length === 1
+                ? primitiveToZod(types[0]!)
+                : `z.union([${types.map((t) => primitiveToZod(t)).join(', ')}])`
+        return hasNull ? `${base}.nullable()` : base
+    }
+
+    // object
+    if (schema.type === 'object' || schema.properties) {
+        return objectToZod(schema, ctx)
+    }
+
+    // array
+    if (schema.type === 'array') {
+        const itemSchema = schema.items ? schemaToZod(schema.items, ctx) : 'z.unknown()'
+        return `z.array(${itemSchema})`
+    }
+
+    // integer special ref
+    if (schema.type === 'integer') {
+        return 'z.number().int()'
+    }
+
+    // primitives
+    if (schema.type) {
+        return primitiveToZod(schema.type as string)
+    }
+
+    // Fallback
+    return 'z.unknown()'
+}
+
+function primitiveToZod(type: string): string {
+    switch (type) {
+        case 'string':
+            return 'z.string()'
+        case 'number':
+            return 'z.number()'
+        case 'integer':
+            return 'z.number().int()'
+        case 'boolean':
+            return 'z.boolean()'
+        case 'null':
+            return 'z.null()'
+        default:
+            return 'z.unknown()'
+    }
+}
+
+function objectToZod(schema: JsonSchema, ctx: ConvertContext): string {
+    const props = schema.properties ?? {}
+    const required = new Set(schema.required ?? [])
+
+    const fields: string[] = []
+    for (const [name, propSchema] of Object.entries(props)) {
+        // Skip excluded properties at the top level
+        if (ctx.isTopLevel && ctx.excludeProperties.has(name)) {
+            continue
+        }
+        // Skip response/readOnly fields — not relevant for tool input
+        if (name === 'response' || propSchema.readOnly) {
+            continue
+        }
+
+        let zodType = schemaToZod(propSchema, ctx)
+
+        // Add .describe() if there's a description
+        if (propSchema.description) {
+            const escaped = propSchema.description.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n')
+            zodType = `${zodType}.describe('${escaped}')`
+        }
+
+        // Add .default() if there's a default value
+        if (propSchema.default !== undefined) {
+            zodType = `${zodType}.default(${JSON.stringify(propSchema.default)})`
+        }
+
+        // Make optional if not required
+        if (!required.has(name)) {
+            zodType = `${zodType}.optional()`
+        }
+
+        fields.push(`    ${sanitizePropName(name)}: ${zodType},`)
+    }
+
+    const obj = `z.object({\n${fields.join('\n')}\n})`
+    return obj
+}
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+/** Topological sort of schema definitions by dependency order */
+function topologicalSort(root: JsonSchemaRoot, entryDefName: string, excludeProperties: string[] = []): string[] {
+    const visited = new Set<string>()
+    const result: string[] = []
+    const excludeSet = new Set(excludeProperties)
+
+    function visit(defName: string, isEntry: boolean = false): void {
+        if (visited.has(defName)) {
+            return
+        }
+        visited.add(defName)
+        const schema = root.definitions[defName]
+        if (!schema) {
+            return
+        }
+        // For the entry definition, filter out excluded properties before collecting refs
+        const effectiveSchema = isEntry && excludeSet.size > 0 ? filterProperties(schema, excludeSet) : schema
+        for (const ref of collectDirectRefs(effectiveSchema)) {
+            visit(ref)
+        }
+        result.push(defName)
+    }
+
+    visit(entryDefName, true)
+    return result
+}
+
+/** Return a copy of the schema with certain properties removed */
+function filterProperties(schema: JsonSchema, excludeSet: Set<string>): JsonSchema {
+    if (!schema.properties) {
+        return schema
+    }
+    const filtered: Record<string, JsonSchema> = {}
+    for (const [name, prop] of Object.entries(schema.properties)) {
+        if (!excludeSet.has(name) && name !== 'response' && !prop.readOnly) {
+            filtered[name] = prop
+        }
+    }
+    return { ...schema, properties: filtered }
+}
+
+/** Collect $ref names directly referenced by a schema (non-recursive) */
+function collectDirectRefs(schema: JsonSchema): string[] {
+    const refs: string[] = []
+
+    function walk(s: JsonSchema | undefined): void {
+        if (!s) {
+            return
+        }
+        if (s.$ref) {
+            refs.push(s.$ref.replace('#/definitions/', ''))
+            return
+        }
+        if (s.properties) {
+            for (const prop of Object.values(s.properties)) {
+                walk(prop)
+            }
+        }
+        if (s.items) {
+            walk(s.items)
+        }
+        if (s.anyOf) {
+            for (const v of s.anyOf) {
+                walk(v)
+            }
+        }
+        if (s.oneOf) {
+            for (const v of s.oneOf) {
+                walk(v)
+            }
+        }
+        if (s.allOf) {
+            for (const v of s.allOf) {
+                walk(v)
+            }
+        }
+        if (typeof s.additionalProperties === 'object') {
+            walk(s.additionalProperties)
+        }
+    }
+
+    walk(schema)
+    return refs
+}
+
+/** Sanitize a definition name to a valid JS variable name */
+function sanitizeVarName(name: string): string {
+    // Handle names like "AnyEntityNode<DataWarehouseNode>"
+    return name.replace(/[<>]/g, '_').replace(/[^a-zA-Z0-9_$]/g, '_')
+}
+
+/** Sanitize a property name — quote if it contains special chars */
+function sanitizePropName(name: string): string {
+    if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name)) {
+        return name
+    }
+    return `'${name}'`
+}

--- a/services/mcp/scripts/lib/json-schema-to-zod.ts
+++ b/services/mcp/scripts/lib/json-schema-to-zod.ts
@@ -172,9 +172,9 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
         return `z.array(${itemSchema})`
     }
 
-    // integer special ref
+    // integer special ref — use coerce for MCP client compatibility (some clients send numbers as strings)
     if (schema.type === 'integer') {
-        return 'z.number().int()'
+        return 'z.coerce.number().int()'
     }
 
     // primitives
@@ -186,16 +186,17 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
     return 'z.unknown()'
 }
 
+/** Use z.coerce for numbers/booleans — some MCP clients send primitives as strings */
 function primitiveToZod(type: string): string {
     switch (type) {
         case 'string':
             return 'z.string()'
         case 'number':
-            return 'z.number()'
+            return 'z.coerce.number()'
         case 'integer':
-            return 'z.number().int()'
+            return 'z.coerce.number().int()'
         case 'boolean':
-            return 'z.boolean()'
+            return 'z.coerce.boolean()'
         case 'null':
             return 'z.null()'
         default:
@@ -226,9 +227,11 @@ function objectToZod(schema: JsonSchema, ctx: ConvertContext): string {
             zodType = `${zodType}.describe('${escaped}')`
         }
 
-        // Add .default() if there's a default value
+        // Add .default() if there's a default value or a const (const properties auto-fill)
         if (propSchema.default !== undefined) {
             zodType = `${zodType}.default(${JSON.stringify(propSchema.default)})`
+        } else if (propSchema.const !== undefined) {
+            zodType = `${zodType}.default(${JSON.stringify(propSchema.const)})`
         }
 
         // Make optional if not required

--- a/services/mcp/scripts/lint-tool-names.ts
+++ b/services/mcp/scripts/lint-tool-names.ts
@@ -21,7 +21,12 @@ import * as path from 'node:path'
 import { parse as parseYaml } from 'yaml'
 
 import { discoverDefinitions } from './lib/definitions.mjs'
-import { CategoryConfigSchema, MAX_TOOL_NAME_LENGTH, TOOL_NAME_PATTERN } from './yaml-config-schema'
+import {
+    CategoryConfigSchema,
+    MAX_TOOL_NAME_LENGTH,
+    TOOL_NAME_PATTERN,
+    QueryWrappersConfigSchema,
+} from './yaml-config-schema'
 
 const MCP_ROOT = path.resolve(__dirname, '..')
 const REPO_ROOT = path.resolve(MCP_ROOT, '../..')
@@ -55,14 +60,22 @@ function validateYamlDefinitions(violations: Violation[]): boolean {
         const label = path.relative(REPO_ROOT, def.filePath)
         const content = fs.readFileSync(def.filePath, 'utf-8')
         const parsed = parseYaml(content)
-        const result = CategoryConfigSchema.safeParse(parsed)
+        // Try query wrappers config first, then category config
+        const isQueryWrappers =
+            typeof parsed === 'object' && parsed !== null && 'wrappers' in parsed && !('tools' in parsed)
+        const result = isQueryWrappers
+            ? QueryWrappersConfigSchema.safeParse(parsed)
+            : CategoryConfigSchema.safeParse(parsed)
         if (!result.success) {
             process.stderr.write(`Error: ${label} failed schema validation: ${result.error.message}\n`)
             hasErrors = true
             process.exitCode = 1
             continue
         }
-        for (const [name, config] of Object.entries(result.data.tools)) {
+        const tools = isQueryWrappers
+            ? (result.data as { wrappers: Record<string, { enabled: boolean }> }).wrappers
+            : (result.data as { tools: Record<string, { enabled: boolean }> }).tools
+        for (const [name, config] of Object.entries(tools)) {
             if (!config.enabled) {
                 continue
             }

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -368,9 +368,15 @@ function syncAll(spec: OpenApiSpec): void {
             if (!file.endsWith('.yaml') && !file.endsWith('.yml')) {
                 continue
             }
+            // Skip query wrapper configs — they don't map to OpenAPI operations
+            const filePath = path.join(DEFINITIONS_DIR, file)
+            const parsed = parseYaml(fs.readFileSync(filePath, 'utf-8'))
+            if (typeof parsed === 'object' && parsed !== null && 'wrappers' in parsed && !('tools' in parsed)) {
+                continue
+            }
             targets.push({
                 product: file.replace(/\.ya?ml$/, ''),
-                filePath: path.join(DEFINITIONS_DIR, file),
+                filePath,
                 subset: false,
             })
         }

--- a/services/mcp/scripts/yaml-config-schema.ts
+++ b/services/mcp/scripts/yaml-config-schema.ts
@@ -113,3 +113,47 @@ export const CategoryConfigSchema = z
     .strict()
 
 export type CategoryConfig = z.infer<typeof CategoryConfigSchema>
+
+// ------------------------------------------------------------------
+// Query wrapper config — tools generated from frontend/src/queries/schema.json
+// ------------------------------------------------------------------
+
+export const QueryWrapperToolConfigSchema = z
+    .object({
+        /** Name of the definition in schema.json (e.g. "AssistantTrendsQuery") */
+        schema_ref: z.string(),
+        enabled: z.boolean(),
+        scopes: z.array(z.string()).optional(),
+        annotations: z
+            .object({
+                readOnly: z.boolean(),
+                destructive: z.boolean(),
+                idempotent: z.boolean(),
+            })
+            .strict()
+            .optional(),
+        mcp_version: z.number().int().positive().optional(),
+        title: z.string().optional(),
+        description: z.string().optional(),
+        ui_resource_uri: z.string().optional(),
+        /** Properties to exclude from the generated Zod schema */
+        exclude_properties: z.array(z.string()).optional(),
+    })
+    .strict()
+
+export type QueryWrapperToolConfig = z.infer<typeof QueryWrapperToolConfigSchema>
+
+export type EnabledQueryWrapperToolConfig = Omit<QueryWrapperToolConfig, 'scopes' | 'annotations'> & {
+    scopes: string[]
+    annotations: { readOnly: boolean; destructive: boolean; idempotent: boolean }
+}
+
+export const QueryWrappersConfigSchema = z
+    .object({
+        category: z.string(),
+        feature: z.string(),
+        wrappers: z.record(z.string(), QueryWrapperToolConfigSchema),
+    })
+    .strict()
+
+export type QueryWrappersConfig = z.infer<typeof QueryWrappersConfigSchema>

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -135,6 +135,8 @@ export class ApiClient {
         path: string
         body?: Record<string, unknown>
         query?: Record<string, string | number | boolean | (string | number)[] | undefined>
+        headers?: Record<string, string>
+        responseType?: 'json' | 'text'
     }): Promise<T> {
         const searchParams = new URLSearchParams()
         if (opts.query) {
@@ -147,10 +149,24 @@ export class ApiClient {
         const qs = searchParams.toString()
         const url = `${this.baseUrl}${opts.path}${qs ? `?${qs}` : ''}`
 
-        const result = await this.fetchJson<T>(url, {
+        const fetchOptions: RequestInit = {
             method: opts.method,
             ...(opts.body ? { body: JSON.stringify(opts.body) } : {}),
-        })
+            ...(opts.headers ? { headers: opts.headers } : {}),
+        }
+
+        if (opts.responseType === 'text') {
+            const response = await this.fetch(url, fetchOptions)
+            if (!response.ok) {
+                const errorText = await response.text()
+                throw new Error(
+                    `Request failed:\nURL: ${opts.method} ${url}\nStatus Code: ${response.status} (${response.statusText})\nError Message: ${errorText}`
+                )
+            }
+            return (await response.text()) as T
+        }
+
+        const result = await this.fetchJson<T>(url, fetchOptions)
 
         if (!result.success) {
             throw new Error(result.error.message)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30255,99 +30255,10 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type EnvironmentsQueryCreateParams = {
-    format?: EnvironmentsQueryCreateFormat;
-    };
-
-    export type EnvironmentsQueryCreateFormat = typeof EnvironmentsQueryCreateFormat[keyof typeof EnvironmentsQueryCreateFormat];
-
-
-    export const EnvironmentsQueryCreateFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type EnvironmentsQueryRetrieveParams = {
-    format?: EnvironmentsQueryRetrieveFormat;
-    };
-
-    export type EnvironmentsQueryRetrieveFormat = typeof EnvironmentsQueryRetrieveFormat[keyof typeof EnvironmentsQueryRetrieveFormat];
-
-
-    export const EnvironmentsQueryRetrieveFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type EnvironmentsQueryDestroyParams = {
-    format?: EnvironmentsQueryDestroyFormat;
-    };
-
-    export type EnvironmentsQueryDestroyFormat = typeof EnvironmentsQueryDestroyFormat[keyof typeof EnvironmentsQueryDestroyFormat];
-
-
-    export const EnvironmentsQueryDestroyFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type EnvironmentsQueryLogRetrieveParams = {
-    format?: EnvironmentsQueryLogRetrieveFormat;
-    };
-
-    export type EnvironmentsQueryLogRetrieveFormat = typeof EnvironmentsQueryLogRetrieveFormat[keyof typeof EnvironmentsQueryLogRetrieveFormat];
-
-
-    export const EnvironmentsQueryLogRetrieveFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
     /**
      * Unspecified response body
      */
-    export type EnvironmentsQueryLogRetrieve200One = {[key: string]: unknown};
-
-    /**
-     * Unspecified response body
-     */
-    export type EnvironmentsQueryLogRetrieve200Two = {[key: string]: unknown};
-
-    export type EnvironmentsQueryCheckAuthForAsyncCreateParams = {
-    format?: EnvironmentsQueryCheckAuthForAsyncCreateFormat;
-    };
-
-    export type EnvironmentsQueryCheckAuthForAsyncCreateFormat = typeof EnvironmentsQueryCheckAuthForAsyncCreateFormat[keyof typeof EnvironmentsQueryCheckAuthForAsyncCreateFormat];
-
-
-    export const EnvironmentsQueryCheckAuthForAsyncCreateFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type EnvironmentsQueryDraftSqlRetrieveParams = {
-    format?: EnvironmentsQueryDraftSqlRetrieveFormat;
-    };
-
-    export type EnvironmentsQueryDraftSqlRetrieveFormat = typeof EnvironmentsQueryDraftSqlRetrieveFormat[keyof typeof EnvironmentsQueryDraftSqlRetrieveFormat];
-
-
-    export const EnvironmentsQueryDraftSqlRetrieveFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type EnvironmentsQueryUpgradeCreateParams = {
-    format?: EnvironmentsQueryUpgradeCreateFormat;
-    };
-
-    export type EnvironmentsQueryUpgradeCreateFormat = typeof EnvironmentsQueryUpgradeCreateFormat[keyof typeof EnvironmentsQueryUpgradeCreateFormat];
-
-
-    export const EnvironmentsQueryUpgradeCreateFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
+    export type EnvironmentsQueryLogRetrieve200 = {[key: string]: unknown};
 
     export type EnvironmentsSavedListParams = {
     /**
@@ -33359,99 +33270,10 @@ export namespace Schemas {
       Session: 'session',
     } as const;
 
-    export type QueryCreateParams = {
-    format?: QueryCreateFormat;
-    };
-
-    export type QueryCreateFormat = typeof QueryCreateFormat[keyof typeof QueryCreateFormat];
-
-
-    export const QueryCreateFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type QueryRetrieveParams = {
-    format?: QueryRetrieveFormat;
-    };
-
-    export type QueryRetrieveFormat = typeof QueryRetrieveFormat[keyof typeof QueryRetrieveFormat];
-
-
-    export const QueryRetrieveFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type QueryDestroyParams = {
-    format?: QueryDestroyFormat;
-    };
-
-    export type QueryDestroyFormat = typeof QueryDestroyFormat[keyof typeof QueryDestroyFormat];
-
-
-    export const QueryDestroyFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type QueryLogRetrieveParams = {
-    format?: QueryLogRetrieveFormat;
-    };
-
-    export type QueryLogRetrieveFormat = typeof QueryLogRetrieveFormat[keyof typeof QueryLogRetrieveFormat];
-
-
-    export const QueryLogRetrieveFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
     /**
      * Unspecified response body
      */
-    export type QueryLogRetrieve200One = {[key: string]: unknown};
-
-    /**
-     * Unspecified response body
-     */
-    export type QueryLogRetrieve200Two = {[key: string]: unknown};
-
-    export type QueryCheckAuthForAsyncCreateParams = {
-    format?: QueryCheckAuthForAsyncCreateFormat;
-    };
-
-    export type QueryCheckAuthForAsyncCreateFormat = typeof QueryCheckAuthForAsyncCreateFormat[keyof typeof QueryCheckAuthForAsyncCreateFormat];
-
-
-    export const QueryCheckAuthForAsyncCreateFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type QueryDraftSqlRetrieveParams = {
-    format?: QueryDraftSqlRetrieveFormat;
-    };
-
-    export type QueryDraftSqlRetrieveFormat = typeof QueryDraftSqlRetrieveFormat[keyof typeof QueryDraftSqlRetrieveFormat];
-
-
-    export const QueryDraftSqlRetrieveFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
-
-    export type QueryUpgradeCreateParams = {
-    format?: QueryUpgradeCreateFormat;
-    };
-
-    export type QueryUpgradeCreateFormat = typeof QueryUpgradeCreateFormat[keyof typeof QueryUpgradeCreateFormat];
-
-
-    export const QueryUpgradeCreateFormat = {
-      Json: 'json',
-      Md: 'md',
-    } as const;
+    export type QueryLogRetrieve200 = {[key: string]: unknown};
 
     export type QueryTabStateListParams = {
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30255,10 +30255,99 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type EnvironmentsQueryCreateParams = {
+    format?: EnvironmentsQueryCreateFormat;
+    };
+
+    export type EnvironmentsQueryCreateFormat = typeof EnvironmentsQueryCreateFormat[keyof typeof EnvironmentsQueryCreateFormat];
+
+
+    export const EnvironmentsQueryCreateFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type EnvironmentsQueryRetrieveParams = {
+    format?: EnvironmentsQueryRetrieveFormat;
+    };
+
+    export type EnvironmentsQueryRetrieveFormat = typeof EnvironmentsQueryRetrieveFormat[keyof typeof EnvironmentsQueryRetrieveFormat];
+
+
+    export const EnvironmentsQueryRetrieveFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type EnvironmentsQueryDestroyParams = {
+    format?: EnvironmentsQueryDestroyFormat;
+    };
+
+    export type EnvironmentsQueryDestroyFormat = typeof EnvironmentsQueryDestroyFormat[keyof typeof EnvironmentsQueryDestroyFormat];
+
+
+    export const EnvironmentsQueryDestroyFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type EnvironmentsQueryLogRetrieveParams = {
+    format?: EnvironmentsQueryLogRetrieveFormat;
+    };
+
+    export type EnvironmentsQueryLogRetrieveFormat = typeof EnvironmentsQueryLogRetrieveFormat[keyof typeof EnvironmentsQueryLogRetrieveFormat];
+
+
+    export const EnvironmentsQueryLogRetrieveFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
     /**
      * Unspecified response body
      */
-    export type EnvironmentsQueryLogRetrieve200 = {[key: string]: unknown};
+    export type EnvironmentsQueryLogRetrieve200One = {[key: string]: unknown};
+
+    /**
+     * Unspecified response body
+     */
+    export type EnvironmentsQueryLogRetrieve200Two = {[key: string]: unknown};
+
+    export type EnvironmentsQueryCheckAuthForAsyncCreateParams = {
+    format?: EnvironmentsQueryCheckAuthForAsyncCreateFormat;
+    };
+
+    export type EnvironmentsQueryCheckAuthForAsyncCreateFormat = typeof EnvironmentsQueryCheckAuthForAsyncCreateFormat[keyof typeof EnvironmentsQueryCheckAuthForAsyncCreateFormat];
+
+
+    export const EnvironmentsQueryCheckAuthForAsyncCreateFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type EnvironmentsQueryDraftSqlRetrieveParams = {
+    format?: EnvironmentsQueryDraftSqlRetrieveFormat;
+    };
+
+    export type EnvironmentsQueryDraftSqlRetrieveFormat = typeof EnvironmentsQueryDraftSqlRetrieveFormat[keyof typeof EnvironmentsQueryDraftSqlRetrieveFormat];
+
+
+    export const EnvironmentsQueryDraftSqlRetrieveFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type EnvironmentsQueryUpgradeCreateParams = {
+    format?: EnvironmentsQueryUpgradeCreateFormat;
+    };
+
+    export type EnvironmentsQueryUpgradeCreateFormat = typeof EnvironmentsQueryUpgradeCreateFormat[keyof typeof EnvironmentsQueryUpgradeCreateFormat];
+
+
+    export const EnvironmentsQueryUpgradeCreateFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
 
     export type EnvironmentsSavedListParams = {
     /**
@@ -33270,10 +33359,99 @@ export namespace Schemas {
       Session: 'session',
     } as const;
 
+    export type QueryCreateParams = {
+    format?: QueryCreateFormat;
+    };
+
+    export type QueryCreateFormat = typeof QueryCreateFormat[keyof typeof QueryCreateFormat];
+
+
+    export const QueryCreateFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type QueryRetrieveParams = {
+    format?: QueryRetrieveFormat;
+    };
+
+    export type QueryRetrieveFormat = typeof QueryRetrieveFormat[keyof typeof QueryRetrieveFormat];
+
+
+    export const QueryRetrieveFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type QueryDestroyParams = {
+    format?: QueryDestroyFormat;
+    };
+
+    export type QueryDestroyFormat = typeof QueryDestroyFormat[keyof typeof QueryDestroyFormat];
+
+
+    export const QueryDestroyFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type QueryLogRetrieveParams = {
+    format?: QueryLogRetrieveFormat;
+    };
+
+    export type QueryLogRetrieveFormat = typeof QueryLogRetrieveFormat[keyof typeof QueryLogRetrieveFormat];
+
+
+    export const QueryLogRetrieveFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
     /**
      * Unspecified response body
      */
-    export type QueryLogRetrieve200 = {[key: string]: unknown};
+    export type QueryLogRetrieve200One = {[key: string]: unknown};
+
+    /**
+     * Unspecified response body
+     */
+    export type QueryLogRetrieve200Two = {[key: string]: unknown};
+
+    export type QueryCheckAuthForAsyncCreateParams = {
+    format?: QueryCheckAuthForAsyncCreateFormat;
+    };
+
+    export type QueryCheckAuthForAsyncCreateFormat = typeof QueryCheckAuthForAsyncCreateFormat[keyof typeof QueryCheckAuthForAsyncCreateFormat];
+
+
+    export const QueryCheckAuthForAsyncCreateFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type QueryDraftSqlRetrieveParams = {
+    format?: QueryDraftSqlRetrieveFormat;
+    };
+
+    export type QueryDraftSqlRetrieveFormat = typeof QueryDraftSqlRetrieveFormat[keyof typeof QueryDraftSqlRetrieveFormat];
+
+
+    export const QueryDraftSqlRetrieveFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
+
+    export type QueryUpgradeCreateParams = {
+    format?: QueryUpgradeCreateFormat;
+    };
+
+    export type QueryUpgradeCreateFormat = typeof QueryUpgradeCreateFormat[keyof typeof QueryUpgradeCreateFormat];
+
+
+    export const QueryUpgradeCreateFormat = {
+      Json: 'json',
+      Md: 'md',
+    } as const;
 
     export type QueryTabStateListParams = {
     /**

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -274,12 +274,14 @@ export class MCP extends McpAgent<Env> {
                     $ai_is_error: true,
                     ai_product: 'mcp',
                 })
-                return [
-                    {
-                        type: 'text',
-                        text: errorOutput,
-                    },
-                ]
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: errorOutput,
+                        },
+                    ],
+                }
             }
 
             await this.trackEvent(AnalyticsEvent.MCP_TOOL_CALL, {

--- a/services/mcp/src/tools/generated/index.ts
+++ b/services/mcp/src/tools/generated/index.ts
@@ -17,6 +17,7 @@ import { GENERATED_TOOLS as notebooks } from './notebooks'
 import { GENERATED_TOOLS as persons } from './persons'
 import { GENERATED_TOOLS as prompts } from './prompts'
 import { GENERATED_TOOLS as proxyRecords } from './proxy-records'
+import { GENERATED_TOOLS as queryWrappers } from './query-wrappers'
 import { GENERATED_TOOLS as surveys } from './surveys'
 import { GENERATED_TOOLS as workflows } from './workflows'
 
@@ -37,6 +38,7 @@ export const GENERATED_TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = 
     ...persons,
     ...prompts,
     ...proxyRecords,
+    ...queryWrappers,
     ...surveys,
     ...workflows,
 }

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -1,0 +1,835 @@
+// AUTO-GENERATED from services/mcp/definitions/query-wrappers.yaml + schema.json — do not edit
+import { z } from 'zod'
+
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+// --- Shared Zod schemas generated from schema.json ---
+
+const integer = z.number().int()
+
+const AssistantGroupMultipleBreakdownFilter = z.object({
+    group_type_index: z
+        .union([integer, z.null()])
+        .describe('Index of the group type from the group mapping.')
+        .optional(),
+    property: z.string().describe('Property name from the plan to break down by.'),
+    type: z.literal('group'),
+})
+
+const AssistantEventMultipleBreakdownFilterType = z.enum([
+    'cohort',
+    'person',
+    'event',
+    'event_metadata',
+    'session',
+    'hogql',
+    'revenue_analytics',
+])
+
+const AssistantGenericMultipleBreakdownFilter = z.object({
+    property: z.string().describe('Property name from the plan to break down by.'),
+    type: AssistantEventMultipleBreakdownFilterType,
+})
+
+const AssistantMultipleBreakdownFilter = z.union([
+    AssistantGroupMultipleBreakdownFilter,
+    AssistantGenericMultipleBreakdownFilter,
+])
+
+const AssistantTrendsBreakdownFilter = z.object({
+    breakdown_limit: integer.describe('How many distinct values to show.').default(25).optional(),
+    breakdowns: z.array(AssistantMultipleBreakdownFilter).describe('Use this field to define breakdowns.'),
+})
+
+const CompareFilter = z.object({
+    compare: z
+        .boolean()
+        .describe('Whether to compare the current date range to a previous date range.')
+        .default(false)
+        .optional(),
+    compare_to: z
+        .string()
+        .describe(
+            'The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.'
+        )
+        .optional(),
+})
+
+const AssistantDateRange = z.object({
+    date_from: z.string().describe('ISO8601 date string.'),
+    date_to: z.string().nullable().describe('ISO8601 date string.').optional(),
+})
+
+const AssistantDurationRange = z.object({
+    date_from: z
+        .string()
+        .describe(
+            "Duration in the past. Supported units are: `h` (hour), `d` (day), `w` (week), `m` (month), `y` (year), `all` (all time). Use the `Start` suffix to define the exact left date boundary. Examples: `-1d` last day from now, `-180d` last 180 days from now, `mStart` this month start, `-1dStart` yesterday's start."
+        ),
+})
+
+const AssistantDateRangeFilter = z.union([AssistantDateRange, AssistantDurationRange])
+
+const IntervalType = z.enum(['second', 'minute', 'hour', 'day', 'week', 'month'])
+
+const AssistantStringOrBooleanValuePropertyFilterOperator = z.enum([
+    'exact',
+    'is_not',
+    'icontains',
+    'not_icontains',
+    'regex',
+    'not_regex',
+])
+
+const AssistantGenericPropertyFilterType = z.enum(['event', 'person', 'session', 'feature'])
+
+const AssistantNumericValuePropertyFilterOperator = z.enum(['exact', 'gt', 'lt'])
+
+const AssistantArrayPropertyFilterOperator = z.enum(['exact', 'is_not'])
+
+const AssistantDateTimePropertyFilterOperator = z.enum(['is_date_exact', 'is_date_before', 'is_date_after'])
+
+const AssistantSetPropertyFilterOperator = z.enum(['is_set', 'is_not_set'])
+
+const AssistantGenericPropertyFilter = z.union([
+    z.object({
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantStringOrBooleanValuePropertyFilterOperator.describe(
+            '`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.'
+        ),
+        type: AssistantGenericPropertyFilterType,
+        value: z
+            .string()
+            .describe(
+                'Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.'
+            ),
+    }),
+    z.object({
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantNumericValuePropertyFilterOperator,
+        type: AssistantGenericPropertyFilterType,
+        value: z.number(),
+    }),
+    z.object({
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantArrayPropertyFilterOperator.describe(
+            '`exact` - exact match of any of the values. `is_not` - does not match any of the values.'
+        ),
+        type: AssistantGenericPropertyFilterType,
+        value: z
+            .array(z.string())
+            .describe(
+                'Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string "true" or "false".'
+            ),
+    }),
+    z.object({
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantDateTimePropertyFilterOperator,
+        type: AssistantGenericPropertyFilterType,
+        value: z.string().describe('Value must be a date in ISO 8601 format.'),
+    }),
+    z.object({
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantSetPropertyFilterOperator.describe(
+            "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected."
+        ),
+        type: AssistantGenericPropertyFilterType,
+    }),
+])
+
+const AssistantGroupPropertyFilter = z.union([
+    z.object({
+        group_type_index: integer.describe('Index of the group type from the group mapping.'),
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantStringOrBooleanValuePropertyFilterOperator.describe(
+            '`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.'
+        ),
+        type: z.literal('group'),
+        value: z
+            .string()
+            .describe(
+                'Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.'
+            ),
+    }),
+    z.object({
+        group_type_index: integer.describe('Index of the group type from the group mapping.'),
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantNumericValuePropertyFilterOperator,
+        type: z.literal('group'),
+        value: z.number(),
+    }),
+    z.object({
+        group_type_index: integer.describe('Index of the group type from the group mapping.'),
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantArrayPropertyFilterOperator.describe(
+            '`exact` - exact match of any of the values. `is_not` - does not match any of the values.'
+        ),
+        type: z.literal('group'),
+        value: z
+            .array(z.string())
+            .describe(
+                'Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string "true" or "false".'
+            ),
+    }),
+    z.object({
+        group_type_index: integer.describe('Index of the group type from the group mapping.'),
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantDateTimePropertyFilterOperator,
+        type: z.literal('group'),
+        value: z.string().describe('Value must be a date in ISO 8601 format.'),
+    }),
+    z.object({
+        group_type_index: integer.describe('Index of the group type from the group mapping.'),
+        key: z.string().describe('Use one of the properties the user has provided in the plan.'),
+        operator: AssistantSetPropertyFilterOperator.describe(
+            "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected."
+        ),
+        type: z.literal('group'),
+    }),
+])
+
+const AssistantPropertyFilter = z.union([AssistantGenericPropertyFilter, AssistantGroupPropertyFilter])
+
+const BaseMathType = z.enum([
+    'total',
+    'dau',
+    'weekly_active',
+    'monthly_active',
+    'unique_session',
+    'first_time_for_user',
+    'first_matching_event_for_user',
+])
+
+const FunnelMathType = z.enum(['total', 'first_time_for_user', 'first_time_for_user_with_filters'])
+
+const PropertyMathType = z.enum(['avg', 'sum', 'min', 'max', 'median', 'p75', 'p90', 'p95', 'p99'])
+
+const CountPerActorMathType = z.enum([
+    'avg_count_per_actor',
+    'min_count_per_actor',
+    'max_count_per_actor',
+    'median_count_per_actor',
+    'p75_count_per_actor',
+    'p90_count_per_actor',
+    'p95_count_per_actor',
+    'p99_count_per_actor',
+])
+
+const GroupMathType = z.literal('unique_group')
+
+const HogQLMathType = z.literal('hogql')
+
+const ExperimentMetricMathType = z.enum([
+    'total',
+    'sum',
+    'unique_session',
+    'min',
+    'max',
+    'avg',
+    'dau',
+    'unique_group',
+    'hogql',
+])
+
+const CalendarHeatmapMathType = z.enum(['total', 'dau'])
+
+const MathType = z.union([
+    BaseMathType,
+    FunnelMathType,
+    PropertyMathType,
+    CountPerActorMathType,
+    GroupMathType,
+    HogQLMathType,
+    ExperimentMetricMathType,
+    CalendarHeatmapMathType,
+])
+
+const AssistantTrendsEventsNode = z.object({
+    custom_name: z.string().optional(),
+    event: z.string().nullable().describe('The event or `null` for all events.').optional(),
+    kind: z.literal('EventsNode'),
+    math: MathType.optional(),
+    math_group_type_index: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
+    math_multiplier: z.number().optional(),
+    math_property: z.string().optional(),
+    math_property_type: z.string().optional(),
+    name: z.string().optional(),
+    optionalInFunnel: z.boolean().optional(),
+    properties: z.array(AssistantPropertyFilter).optional(),
+    version: z.number().describe('version of the node, used for schema migrations').optional(),
+})
+
+const AssistantTrendsActionsNode = z.object({
+    custom_name: z.string().optional(),
+    id: integer,
+    kind: z.literal('ActionsNode'),
+    math: MathType.optional(),
+    math_group_type_index: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
+    math_multiplier: z.number().optional(),
+    math_property: z.string().optional(),
+    math_property_type: z.string().optional(),
+    name: z.string().describe('Action name from the plan.'),
+    optionalInFunnel: z.boolean().optional(),
+    properties: z.array(AssistantPropertyFilter).optional(),
+    version: z.number().describe('version of the node, used for schema migrations').optional(),
+})
+
+const AggregationAxisFormat = z.enum([
+    'numeric',
+    'duration',
+    'duration_ms',
+    'percentage',
+    'percentage_scaled',
+    'currency',
+    'short',
+])
+
+const AssistantTrendsFilter = z.object({
+    aggregationAxisFormat: AggregationAxisFormat.describe(
+        'Formats the trends value axis. Do not use the formatting unless you are absolutely sure that formatting will match the data. `numeric` - no formatting. Prefer this option by default. `duration` - formats the value in seconds to a human-readable duration, e.g., `132` becomes `2 minutes 12 seconds`. Use this option only if you are sure that the values are in seconds. `duration_ms` - formats the value in miliseconds to a human-readable duration, e.g., `1050` becomes `1 second 50 milliseconds`. Use this option only if you are sure that the values are in miliseconds. `percentage` - adds a percentage sign to the value, e.g., `50` becomes `50%`. `percentage_scaled` - formats the value as a percentage scaled to 0-100, e.g., `0.5` becomes `50%`. `currency` - formats the value as a currency, e.g., `1000` becomes `$1,000`.'
+    )
+        .default('numeric')
+        .optional(),
+    aggregationAxisPostfix: z
+        .string()
+        .describe(
+            'Custom postfix to add to the aggregation axis, e.g., ` clicks` to format 5 as `5 clicks`. You may need to add a space before postfix.'
+        )
+        .optional(),
+    aggregationAxisPrefix: z
+        .string()
+        .describe(
+            'Custom prefix to add to the aggregation axis, e.g., `$` for USD dollars. You may need to add a space after prefix.'
+        )
+        .optional(),
+    decimalPlaces: z
+        .number()
+        .describe(
+            'Number of decimal places to show. Do not add this unless you are sure that values will have a decimal point.'
+        )
+        .optional(),
+    display: z
+        .enum([
+            'Auto',
+            'ActionsLineGraph',
+            'ActionsBar',
+            'ActionsUnstackedBar',
+            'ActionsAreaGraph',
+            'ActionsLineGraphCumulative',
+            'BoldNumber',
+            'ActionsPie',
+            'ActionsBarValue',
+            'ActionsTable',
+            'WorldMap',
+            'CalendarHeatmap',
+            'TwoDimensionalHeatmap',
+            'BoxPlot',
+        ])
+        .describe(
+            'Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.'
+        )
+        .default('ActionsLineGraph')
+        .optional(),
+    formulas: z
+        .array(z.string())
+        .describe(
+            'If the math aggregation is more complex or not listed above, use custom formulas to perform mathematical operations like calculating percentages or metrics. If you use a formula, you must use the following syntax: `A/B`, where `A` and `B` are the names of the series. You can combine math aggregations and formulas. When using a formula, you must:\n- Identify and specify **all** events and actions needed to solve the formula.\n- Carefully review the list of available events and actions to find appropriate entities for each part of the formula.\n- Ensure that you find events and actions corresponding to both the numerator and denominator in ratio calculations. Examples of using math formulas:\n- If you want to calculate the percentage of users who have completed onboarding, you need to find and use events or actions similar to `$identify` and `onboarding complete`, so the formula will be `A / B`, where `A` is `onboarding complete` (unique users) and `B` is `$identify` (unique users).'
+        )
+        .optional(),
+    showLegend: z
+        .boolean()
+        .describe('Whether to show the legend describing series and breakdowns.')
+        .default(false)
+        .optional(),
+    showPercentStackView: z
+        .boolean()
+        .describe('Whether to show a percentage of each series. Use only with')
+        .default(false)
+        .optional(),
+    showValuesOnSeries: z.boolean().describe('Whether to show a value on each data point.').default(false).optional(),
+    yAxisScaleType: z.enum(['log10', 'linear']).describe('Whether to scale the y-axis.').default('linear').optional(),
+})
+
+const AssistantTrendsQuery = z.object({
+    breakdownFilter: AssistantTrendsBreakdownFilter.describe(
+        'Breakdowns are used to segment data by property values of maximum three properties. They divide all defined trends series to multiple subseries based on the values of the property. Include breakdowns **only when they are essential to directly answer the user’s question**. You must not add breakdowns if the question can be addressed without additional segmentation. Always use the minimum set of breakdowns needed to answer the question. When using breakdowns, you must:\n- **Identify the property group** and name for each breakdown.\n- **Provide the property name** for each breakdown.\n- **Validate that the property value accurately reflects the intended criteria**. Examples of using breakdowns:\n- page views trend by country: you need to find a property such as `$geoip_country_code` and set it as a breakdown.\n- number of users who have completed onboarding by an organization: you need to find a property such as `organization name` and set it as a breakdown.'
+    ).optional(),
+    compareFilter: CompareFilter.describe('Compare to date range').optional(),
+    dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
+    filterTestAccounts: z
+        .boolean()
+        .describe('Exclude internal and test users by applying the respective filters')
+        .default(false)
+        .optional(),
+    interval: IntervalType.describe('Granularity of the response. Can be one of `hour`, `day`, `week` or `month`')
+        .default('day')
+        .optional(),
+    properties: z.array(AssistantPropertyFilter).describe('Property filters for all series').default([]).optional(),
+    series: z
+        .array(z.union([AssistantTrendsEventsNode, AssistantTrendsActionsNode]))
+        .describe('Events or actions to include. Prioritize the more popular and fresh events and actions.'),
+    trendsFilter: AssistantTrendsFilter.describe('Properties specific to the trends insight').optional(),
+})
+
+const AssistantFunnelsBreakdownType = z.enum(['person', 'event', 'group', 'session'])
+
+const AssistantFunnelsBreakdownFilter = z.object({
+    breakdown: z.string().describe('The entity property to break down by.'),
+    breakdown_group_type_index: z
+        .union([integer, z.null()])
+        .describe(
+            'If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping.'
+        )
+        .optional(),
+    breakdown_limit: integer.describe('How many distinct values to show.').default(25).optional(),
+    breakdown_type: AssistantFunnelsBreakdownType.describe(
+        'Type of the entity to break down by. If `group` is used, you must also provide `breakdown_group_type_index` from the group mapping.'
+    ).default('event'),
+})
+
+const AssistantFunnelsExclusionEventsNode = z.object({
+    event: z.string(),
+    funnelFromStep: integer,
+    funnelToStep: integer,
+    kind: z.literal('EventsNode'),
+})
+
+const StepOrderValue = z.enum(['strict', 'unordered', 'ordered'])
+
+const FunnelStepReference = z.enum(['total', 'previous'])
+
+const FunnelVizType = z.enum(['steps', 'time_to_convert', 'trends', 'flow'])
+
+const FunnelConversionWindowTimeUnit = z.enum(['second', 'minute', 'hour', 'day', 'week', 'month'])
+
+const FunnelLayout = z.enum(['horizontal', 'vertical'])
+
+const AssistantFunnelsFilter = z.object({
+    binCount: z
+        .number()
+        .int()
+        .describe(
+            'Use this setting only when `funnelVizType` is `time_to_convert`: number of bins to show in histogram.'
+        )
+        .optional(),
+    exclusions: z
+        .array(AssistantFunnelsExclusionEventsNode)
+        .describe(
+            "Users may want to use exclusion events to filter out conversions in which a particular event occurred between specific steps. These events must not be included in the main sequence. This doesn't exclude users who have completed the event before or after the funnel sequence, but often this is what users want. (If not sure, worth clarifying.) You must include start and end indexes for each exclusion where the minimum index is one and the maximum index is the number of steps in the funnel. For example, there is a sequence with three steps: sign up, finish onboarding, purchase. If the user wants to exclude all conversions in which users left the page before finishing the onboarding, the exclusion step would be the event `$pageleave` with start index 2 and end index 3. When exclusion steps appear needed when you're planning the query, make sure to explicitly state this in the plan."
+        )
+        .default([])
+        .optional(),
+    funnelAggregateByHogQL: z
+        .union([z.literal('properties.$session_id'), z.literal(null)])
+        .describe('Use this field only if the user explicitly asks to aggregate the funnel by unique sessions.')
+        .default(null)
+        .optional(),
+    funnelOrderType: StepOrderValue.describe(
+        "Defines the behavior of event matching between steps. Prefer the `strict` option unless explicitly told to use a different one. `ordered` - defines a sequential funnel. Step B must happen after Step A, but any number of events can happen between A and B. `strict` - defines a funnel where all events must happen in order. Step B must happen directly after Step A without any events in between. `any` - order doesn't matter. Steps can be completed in any sequence."
+    )
+        .default('ordered')
+        .optional(),
+    funnelStepReference: FunnelStepReference.describe(
+        'Whether conversion shown in the graph should be across all steps or just relative to the previous step.'
+    )
+        .default('total')
+        .optional(),
+    funnelVizType: FunnelVizType.describe(
+        'Defines the type of visualization to use. The `steps` option is recommended. `steps` - shows a step-by-step funnel. Perfect to show a conversion rate of a sequence of events (default). `time_to_convert` - shows a histogram of the time it took to complete the funnel. `trends` - shows trends of the conversion rate of the whole sequence over time.'
+    )
+        .default('steps')
+        .optional(),
+    funnelWindowInterval: integer
+        .describe(
+            "Controls a time frame value for a conversion to be considered. Select a reasonable value based on the user's query. If needed, this can be practically unlimited by setting a large value, though it's rare to need that. Use in combination with `funnelWindowIntervalUnit`. The default value is 14 days."
+        )
+        .default(14)
+        .optional(),
+    funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.describe(
+        "Controls a time frame interval for a conversion to be considered. Select a reasonable value based on the user's query. Use in combination with `funnelWindowInterval`. The default value is 14 days."
+    )
+        .default('day')
+        .optional(),
+    layout: FunnelLayout.describe('Controls how the funnel chart is displayed: vertically (preferred) or horizontally.')
+        .default('vertical')
+        .optional(),
+})
+
+const AssistantFunnelsMath = z.enum(['first_time_for_user', 'first_time_for_user_with_filters'])
+
+const AssistantFunnelsEventsNode = z.object({
+    custom_name: z.string().describe('Optional custom name for the event if it is needed to be renamed.').optional(),
+    event: z.string().describe('Name of the event.'),
+    kind: z.literal('EventsNode'),
+    math: AssistantFunnelsMath.describe(
+        'Optional math aggregation type for the series. Only specify this math type if the user wants one of these. `first_time_for_user` - counts the number of users who have completed the event for the first time ever. `first_time_for_user_with_filters` - counts the number of users who have completed the event with specified filters for the first time.'
+    ).optional(),
+    properties: z.array(AssistantPropertyFilter).optional(),
+    version: z.number().describe('version of the node, used for schema migrations').optional(),
+})
+
+const AssistantFunnelsActionsNode = z.object({
+    id: z.number().describe('Action ID from the plan.'),
+    kind: z.literal('ActionsNode'),
+    math: AssistantFunnelsMath.describe(
+        'Optional math aggregation type for the series. Only specify this math type if the user wants one of these. `first_time_for_user` - counts the number of users who have completed the event for the first time ever. `first_time_for_user_with_filters` - counts the number of users who have completed the event with specified filters for the first time.'
+    ).optional(),
+    name: z.string().describe('Action name from the plan.'),
+    properties: z.array(AssistantPropertyFilter).optional(),
+    version: z.number().describe('version of the node, used for schema migrations').optional(),
+})
+
+const AssistantFunnelsNode = z.union([AssistantFunnelsEventsNode, AssistantFunnelsActionsNode])
+
+const AssistantFunnelsQuery = z.object({
+    aggregation_group_type_index: integer
+        .describe(
+            'Use this field to define the aggregation by a specific group from the provided group mapping, which is NOT users or sessions.'
+        )
+        .optional(),
+    breakdownFilter: AssistantFunnelsBreakdownFilter.describe(
+        'A breakdown is used to segment data by a single property value. They divide all defined funnel series into multiple subseries based on the values of the property. Include a breakdown **only when it is essential to directly answer the user’s question**. You must not add a breakdown if the question can be addressed without additional segmentation. When using breakdowns, you must:\n- **Identify the property group** and name for a breakdown.\n- **Provide the property name** for a breakdown.\n- **Validate that the property value accurately reflects the intended criteria**. Examples of using a breakdown:\n- page views to sign up funnel by country: you need to find a property such as `$geoip_country_code` and set it as a breakdown.\n- conversion rate of users who have completed onboarding after signing up by an organization: you need to find a property such as `organization name` and set it as a breakdown.'
+    ).optional(),
+    dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
+    filterTestAccounts: z
+        .boolean()
+        .describe('Exclude internal and test users by applying the respective filters')
+        .default(false)
+        .optional(),
+    funnelsFilter: AssistantFunnelsFilter.describe('Properties specific to the funnels insight').optional(),
+    interval: IntervalType.describe(
+        'Granularity of the response. Can be one of `hour`, `day`, `week` or `month`'
+    ).optional(),
+    properties: z.array(AssistantPropertyFilter).describe('Property filters for all series').default([]).optional(),
+    series: z
+        .array(AssistantFunnelsNode)
+        .describe('Events or actions to include. Prioritize the more popular and fresh events and actions.'),
+})
+
+const DateRange = z.object({
+    date_from: z.string().nullable().optional(),
+    date_to: z.string().nullable().optional(),
+    explicitDate: z
+        .boolean()
+        .nullable()
+        .describe(
+            'Whether the date_from and date_to should be used verbatim. Disables rounding to the start and end of period.'
+        )
+        .default(false)
+        .optional(),
+})
+
+const PropertyOperator = z.enum([
+    'exact',
+    'is_not',
+    'icontains',
+    'not_icontains',
+    'regex',
+    'not_regex',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'is_set',
+    'is_not_set',
+    'is_date_exact',
+    'is_date_before',
+    'is_date_after',
+    'between',
+    'not_between',
+    'min',
+    'max',
+    'in',
+    'not_in',
+    'is_cleaned_path_exact',
+    'flag_evaluates_to',
+    'semver_eq',
+    'semver_neq',
+    'semver_gt',
+    'semver_gte',
+    'semver_lt',
+    'semver_lte',
+    'semver_tilde',
+    'semver_caret',
+    'semver_wildcard',
+    'icontains_multi',
+    'not_icontains_multi',
+])
+
+const PropertyFilterBaseValue = z.union([z.string(), z.number(), z.boolean()])
+
+const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
+
+const EventPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator.default('exact'),
+    type: z.literal('event').describe('Event properties'),
+    value: PropertyFilterValue.optional(),
+})
+
+const PersonPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('person').describe('Person properties'),
+    value: PropertyFilterValue.optional(),
+})
+
+const ElementPropertyFilter = z.object({
+    key: z.enum(['tag_name', 'text', 'href', 'selector']),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('element'),
+    value: PropertyFilterValue.optional(),
+})
+
+const EventMetadataPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('event_metadata'),
+    value: PropertyFilterValue.optional(),
+})
+
+const SessionPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('session'),
+    value: PropertyFilterValue.optional(),
+})
+
+const CohortPropertyFilter = z.object({
+    cohort_name: z.string().optional(),
+    key: z.literal('id'),
+    label: z.string().optional(),
+    operator: PropertyOperator.default('in'),
+    type: z.literal('cohort'),
+    value: z.number().int(),
+})
+
+const DurationType = z.enum(['duration', 'active_seconds', 'inactive_seconds'])
+
+const RecordingPropertyFilter = z.object({
+    key: z.union([DurationType, z.literal('snapshot_source'), z.literal('visited_page'), z.literal('comment_text')]),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('recording'),
+    value: PropertyFilterValue.optional(),
+})
+
+const LogEntryPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('log_entry'),
+    value: PropertyFilterValue.optional(),
+})
+
+const GroupPropertyFilter = z.object({
+    group_key_names: z.object({}).optional(),
+    group_type_index: z.union([z.number().int(), z.null()]).optional(),
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('group'),
+    value: PropertyFilterValue.optional(),
+})
+
+const FeaturePropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('feature').describe('Event property with "$feature/" prepended'),
+    value: PropertyFilterValue.optional(),
+})
+
+const FlagPropertyFilter = z.object({
+    key: z.string().describe('The key should be the flag ID'),
+    label: z.string().optional(),
+    operator: z
+        .literal('flag_evaluates_to')
+        .describe('Only flag_evaluates_to operator is allowed for flag dependencies'),
+    type: z.literal('flag').describe('Feature flag dependency'),
+    value: z.union([z.boolean(), z.string()]).describe('The value can be true, false, or a variant name'),
+})
+
+const HogQLPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    type: z.literal('hogql'),
+    value: PropertyFilterValue.optional(),
+})
+
+const EmptyPropertyFilter = z.object({
+    type: z.literal('empty').optional(),
+})
+
+const DataWarehousePropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('data_warehouse'),
+    value: PropertyFilterValue.optional(),
+})
+
+const DataWarehousePersonPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('data_warehouse_person_property'),
+    value: PropertyFilterValue.optional(),
+})
+
+const ErrorTrackingIssueFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('error_tracking_issue'),
+    value: PropertyFilterValue.optional(),
+})
+
+const LogPropertyFilterType = z.enum(['log', 'log_attribute', 'log_resource_attribute'])
+
+const LogPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: LogPropertyFilterType,
+    value: PropertyFilterValue.optional(),
+})
+
+const RevenueAnalyticsPropertyFilter = z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    operator: PropertyOperator,
+    type: z.literal('revenue_analytics'),
+    value: PropertyFilterValue.optional(),
+})
+
+const AnyPropertyFilter = z.union([
+    EventPropertyFilter,
+    PersonPropertyFilter,
+    ElementPropertyFilter,
+    EventMetadataPropertyFilter,
+    SessionPropertyFilter,
+    CohortPropertyFilter,
+    RecordingPropertyFilter,
+    LogEntryPropertyFilter,
+    GroupPropertyFilter,
+    FeaturePropertyFilter,
+    FlagPropertyFilter,
+    HogQLPropertyFilter,
+    EmptyPropertyFilter,
+    DataWarehousePropertyFilter,
+    DataWarehousePersonPropertyFilter,
+    ErrorTrackingIssueFilter,
+    LogPropertyFilter,
+    RevenueAnalyticsPropertyFilter,
+])
+
+const TracesQuery = z.object({
+    dateRange: DateRange.optional(),
+    filterSupportTraces: z.boolean().optional(),
+    filterTestAccounts: z.boolean().optional(),
+    groupKey: z.string().optional(),
+    groupTypeIndex: integer.optional(),
+    limit: integer.optional(),
+    offset: integer.optional(),
+    personId: z.string().describe('Person who performed the event').optional(),
+    properties: z.array(AnyPropertyFilter).describe('Properties configurable in the interface').optional(),
+    randomOrder: z
+        .boolean()
+        .describe(
+            'Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias.'
+        )
+        .optional(),
+})
+
+// --- Tool handlers ---
+
+const QueryTrendsSchema = AssistantTrendsQuery
+
+const queryTrends = (): ToolBase<typeof QueryTrendsSchema> => ({
+    name: 'query-trends',
+    schema: QueryTrendsSchema,
+    handler: async (context: Context, params: z.infer<typeof QueryTrendsSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const query = { ...params, kind: 'TrendsQuery' }
+        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
+            method: 'POST',
+            path: `/api/environments/${projectId}/query/`,
+            body: { query },
+        })
+        const queryParam = encodeURIComponent(JSON.stringify(query))
+        const baseUrl = context.api.getProjectBaseUrl(projectId)
+        return {
+            query,
+            results: result,
+            _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
+        }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/query-results.html',
+        },
+    },
+})
+
+const QueryFunnelSchema = AssistantFunnelsQuery
+
+const queryFunnel = (): ToolBase<typeof QueryFunnelSchema> => ({
+    name: 'query-funnel',
+    schema: QueryFunnelSchema,
+    handler: async (context: Context, params: z.infer<typeof QueryFunnelSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const query = { ...params, kind: 'FunnelsQuery' }
+        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
+            method: 'POST',
+            path: `/api/environments/${projectId}/query/`,
+            body: { query },
+        })
+        const queryParam = encodeURIComponent(JSON.stringify(query))
+        const baseUrl = context.api.getProjectBaseUrl(projectId)
+        return {
+            query,
+            results: result,
+            _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
+        }
+    },
+    _meta: {
+        ui: {
+            resourceUri: 'ui://posthog/query-results.html',
+        },
+    },
+})
+
+const QueryTracesListSchema = TracesQuery
+
+const queryTracesList = (): ToolBase<typeof QueryTracesListSchema> => ({
+    name: 'query-traces-list',
+    schema: QueryTracesListSchema,
+    handler: async (context: Context, params: z.infer<typeof QueryTracesListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const query = { ...params, kind: 'TracesQuery' }
+        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
+            method: 'POST',
+            path: `/api/environments/${projectId}/query/`,
+            body: { query },
+        })
+        const queryParam = encodeURIComponent(JSON.stringify(query))
+        const baseUrl = context.api.getProjectBaseUrl(projectId)
+        return {
+            query,
+            results: result,
+            _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
+        }
+    },
+})
+
+export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'query-trends': queryTrends,
+    'query-funnel': queryFunnel,
+    'query-traces-list': queryTracesList,
+}

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -507,6 +507,70 @@ const AssistantFunnelsQuery = z.object({
         .describe('Events or actions to include. Prioritize the more popular and fresh events and actions.'),
 })
 
+const RetentionPeriod = z.enum(['Hour', 'Day', 'Week', 'Month'])
+
+const RetentionType = z.enum(['retention_recurring', 'retention_first_time', 'retention_first_ever_occurrence'])
+
+const AssistantRetentionEventsNode = z.object({
+    custom_name: z.string().describe('Custom name for the event if it is needed to be renamed.').optional(),
+    name: z.string().describe('Event name from the plan.'),
+    properties: z.array(AssistantPropertyFilter).describe('Property filters for the event.').optional(),
+    type: z.literal('events'),
+})
+
+const AssistantRetentionActionsNode = z.object({
+    id: z.number().describe('Action ID from the plan.'),
+    name: z.string().describe('Action name from the plan.'),
+    properties: z.array(AssistantPropertyFilter).describe('Property filters for the action.').optional(),
+    type: z.literal('actions'),
+})
+
+const AssistantRetentionEntity = z.union([AssistantRetentionEventsNode, AssistantRetentionActionsNode])
+
+const AssistantRetentionFilter = z.object({
+    cumulative: z
+        .boolean()
+        .describe(
+            'Whether retention should be rolling (aka unbounded, cumulative). Rolling retention means that a user coming back in period 5 makes them count towards all the previous periods.'
+        )
+        .optional(),
+    meanRetentionCalculation: z
+        .enum(['simple', 'weighted', 'none'])
+        .describe(
+            'Whether an additional series should be shown, showing the mean conversion for each period across cohorts.'
+        )
+        .optional(),
+    period: RetentionPeriod.describe('Retention period, the interval to track cohorts by.').default('Day').optional(),
+    retentionReference: z
+        .enum(['total', 'previous'])
+        .describe('Whether retention is with regard to initial cohort size, or that of the previous period.')
+        .optional(),
+    retentionType: RetentionType.describe(
+        'Retention type: recurring or first time. Recurring retention counts a user as part of a cohort if they performed the cohort event during that time period, irrespective of it was their first time or not. First time retention only counts a user as part of the cohort if it was their first time performing the cohort event.'
+    ).optional(),
+    returningEntity: AssistantRetentionEntity.describe('Retention event (event marking the user coming back).'),
+    targetEntity: AssistantRetentionEntity.describe(
+        'Activation event (event putting the actor into the initial cohort).'
+    ),
+    totalIntervals: integer
+        .describe(
+            'How many intervals to show in the chart. The default value is 11 (meaning 10 periods after initial cohort).'
+        )
+        .default(11)
+        .optional(),
+})
+
+const AssistantRetentionQuery = z.object({
+    dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
+    filterTestAccounts: z
+        .boolean()
+        .describe('Exclude internal and test users by applying the respective filters')
+        .default(false)
+        .optional(),
+    properties: z.array(AssistantPropertyFilter).describe('Property filters for all series').default([]).optional(),
+    retentionFilter: AssistantRetentionFilter.describe('Properties specific to the retention insight'),
+})
+
 const DateRange = z.object({
     date_from: z.string().nullable().optional(),
     date_to: z.string().nullable().optional(),
@@ -761,6 +825,12 @@ export const GENERATED_TOOLS: Record<string, ReturnType<typeof createQueryWrappe
         name: 'query-funnel',
         schema: AssistantFunnelsQuery,
         kind: 'FunnelsQuery',
+        uiResourceUri: 'ui://posthog/query-results.html',
+    }),
+    'query-retention': createQueryWrapper({
+        name: 'query-retention',
+        schema: AssistantRetentionQuery,
+        kind: 'RetentionQuery',
         uiResourceUri: 'ui://posthog/query-results.html',
     }),
     'query-traces-list': createQueryWrapper({ name: 'query-traces-list', schema: TracesQuery, kind: 'TracesQuery' }),

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -1,7 +1,8 @@
 // AUTO-GENERATED from services/mcp/definitions/query-wrappers.yaml + schema.json — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import type { ZodObjectAny } from '@/tools/types'
 
 // --- Shared Zod schemas generated from schema.json ---
 
@@ -747,89 +748,20 @@ const TracesQuery = z.object({
         .optional(),
 })
 
-// --- Tool handlers ---
+// --- Tool registrations ---
 
-const QueryTrendsSchema = AssistantTrendsQuery
-
-const queryTrends = (): ToolBase<typeof QueryTrendsSchema> => ({
-    name: 'query-trends',
-    schema: QueryTrendsSchema,
-    handler: async (context: Context, params: z.infer<typeof QueryTrendsSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const query = { ...params, kind: 'TrendsQuery' }
-        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
-            method: 'POST',
-            path: `/api/environments/${projectId}/query/`,
-            body: { query },
-        })
-        const queryParam = encodeURIComponent(JSON.stringify(query))
-        const baseUrl = context.api.getProjectBaseUrl(projectId)
-        return {
-            query,
-            results: result,
-            _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
-        }
-    },
-    _meta: {
-        ui: {
-            resourceUri: 'ui://posthog/query-results.html',
-        },
-    },
-})
-
-const QueryFunnelSchema = AssistantFunnelsQuery
-
-const queryFunnel = (): ToolBase<typeof QueryFunnelSchema> => ({
-    name: 'query-funnel',
-    schema: QueryFunnelSchema,
-    handler: async (context: Context, params: z.infer<typeof QueryFunnelSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const query = { ...params, kind: 'FunnelsQuery' }
-        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
-            method: 'POST',
-            path: `/api/environments/${projectId}/query/`,
-            body: { query },
-        })
-        const queryParam = encodeURIComponent(JSON.stringify(query))
-        const baseUrl = context.api.getProjectBaseUrl(projectId)
-        return {
-            query,
-            results: result,
-            _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
-        }
-    },
-    _meta: {
-        ui: {
-            resourceUri: 'ui://posthog/query-results.html',
-        },
-    },
-})
-
-const QueryTracesListSchema = TracesQuery
-
-const queryTracesList = (): ToolBase<typeof QueryTracesListSchema> => ({
-    name: 'query-traces-list',
-    schema: QueryTracesListSchema,
-    handler: async (context: Context, params: z.infer<typeof QueryTracesListSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const query = { ...params, kind: 'TracesQuery' }
-        const result = await context.api.request<{ results: unknown; columns?: unknown }>({
-            method: 'POST',
-            path: `/api/environments/${projectId}/query/`,
-            body: { query },
-        })
-        const queryParam = encodeURIComponent(JSON.stringify(query))
-        const baseUrl = context.api.getProjectBaseUrl(projectId)
-        return {
-            query,
-            results: result,
-            _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
-        }
-    },
-})
-
-export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
-    'query-trends': queryTrends,
-    'query-funnel': queryFunnel,
-    'query-traces-list': queryTracesList,
+export const GENERATED_TOOLS: Record<string, ReturnType<typeof createQueryWrapper<ZodObjectAny>>> = {
+    'query-trends': createQueryWrapper({
+        name: 'query-trends',
+        schema: AssistantTrendsQuery,
+        kind: 'TrendsQuery',
+        uiResourceUri: 'ui://posthog/query-results.html',
+    }),
+    'query-funnel': createQueryWrapper({
+        name: 'query-funnel',
+        schema: AssistantFunnelsQuery,
+        kind: 'FunnelsQuery',
+        uiResourceUri: 'ui://posthog/query-results.html',
+    }),
+    'query-traces-list': createQueryWrapper({ name: 'query-traces-list', schema: TracesQuery, kind: 'TracesQuery' }),
 }

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -6,7 +6,7 @@ import type { ZodObjectAny } from '@/tools/types'
 
 // --- Shared Zod schemas generated from schema.json ---
 
-const integer = z.number().int()
+const integer = z.coerce.number().int()
 
 const AssistantGroupMultipleBreakdownFilter = z.object({
     group_type_index: z
@@ -14,7 +14,7 @@ const AssistantGroupMultipleBreakdownFilter = z.object({
         .describe('Index of the group type from the group mapping.')
         .optional(),
     property: z.string().describe('Property name from the plan to break down by.'),
-    type: z.literal('group'),
+    type: z.literal('group').default('group'),
 })
 
 const AssistantEventMultipleBreakdownFilterType = z.enum([
@@ -43,7 +43,7 @@ const AssistantTrendsBreakdownFilter = z.object({
 })
 
 const CompareFilter = z.object({
-    compare: z
+    compare: z.coerce
         .boolean()
         .describe('Whether to compare the current date range to a previous date range.')
         .default(false)
@@ -109,7 +109,7 @@ const AssistantGenericPropertyFilter = z.union([
         key: z.string().describe('Use one of the properties the user has provided in the plan.'),
         operator: AssistantNumericValuePropertyFilterOperator,
         type: AssistantGenericPropertyFilterType,
-        value: z.number(),
+        value: z.coerce.number(),
     }),
     z.object({
         key: z.string().describe('Use one of the properties the user has provided in the plan.'),
@@ -145,7 +145,7 @@ const AssistantGroupPropertyFilter = z.union([
         operator: AssistantStringOrBooleanValuePropertyFilterOperator.describe(
             '`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.'
         ),
-        type: z.literal('group'),
+        type: z.literal('group').default('group'),
         value: z
             .string()
             .describe(
@@ -156,8 +156,8 @@ const AssistantGroupPropertyFilter = z.union([
         group_type_index: integer.describe('Index of the group type from the group mapping.'),
         key: z.string().describe('Use one of the properties the user has provided in the plan.'),
         operator: AssistantNumericValuePropertyFilterOperator,
-        type: z.literal('group'),
-        value: z.number(),
+        type: z.literal('group').default('group'),
+        value: z.coerce.number(),
     }),
     z.object({
         group_type_index: integer.describe('Index of the group type from the group mapping.'),
@@ -165,7 +165,7 @@ const AssistantGroupPropertyFilter = z.union([
         operator: AssistantArrayPropertyFilterOperator.describe(
             '`exact` - exact match of any of the values. `is_not` - does not match any of the values.'
         ),
-        type: z.literal('group'),
+        type: z.literal('group').default('group'),
         value: z
             .array(z.string())
             .describe(
@@ -176,7 +176,7 @@ const AssistantGroupPropertyFilter = z.union([
         group_type_index: integer.describe('Index of the group type from the group mapping.'),
         key: z.string().describe('Use one of the properties the user has provided in the plan.'),
         operator: AssistantDateTimePropertyFilterOperator,
-        type: z.literal('group'),
+        type: z.literal('group').default('group'),
         value: z.string().describe('Value must be a date in ISO 8601 format.'),
     }),
     z.object({
@@ -185,7 +185,7 @@ const AssistantGroupPropertyFilter = z.union([
         operator: AssistantSetPropertyFilterOperator.describe(
             "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected."
         ),
-        type: z.literal('group'),
+        type: z.literal('group').default('group'),
     }),
 ])
 
@@ -248,31 +248,31 @@ const MathType = z.union([
 const AssistantTrendsEventsNode = z.object({
     custom_name: z.string().optional(),
     event: z.string().nullable().describe('The event or `null` for all events.').optional(),
-    kind: z.literal('EventsNode'),
+    kind: z.literal('EventsNode').default('EventsNode'),
     math: MathType.optional(),
     math_group_type_index: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
-    math_multiplier: z.number().optional(),
+    math_multiplier: z.coerce.number().optional(),
     math_property: z.string().optional(),
     math_property_type: z.string().optional(),
     name: z.string().optional(),
-    optionalInFunnel: z.boolean().optional(),
+    optionalInFunnel: z.coerce.boolean().optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
-    version: z.number().describe('version of the node, used for schema migrations').optional(),
+    version: z.coerce.number().describe('version of the node, used for schema migrations').optional(),
 })
 
 const AssistantTrendsActionsNode = z.object({
     custom_name: z.string().optional(),
     id: integer,
-    kind: z.literal('ActionsNode'),
+    kind: z.literal('ActionsNode').default('ActionsNode'),
     math: MathType.optional(),
     math_group_type_index: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
-    math_multiplier: z.number().optional(),
+    math_multiplier: z.coerce.number().optional(),
     math_property: z.string().optional(),
     math_property_type: z.string().optional(),
     name: z.string().describe('Action name from the plan.'),
-    optionalInFunnel: z.boolean().optional(),
+    optionalInFunnel: z.coerce.boolean().optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
-    version: z.number().describe('version of the node, used for schema migrations').optional(),
+    version: z.coerce.number().describe('version of the node, used for schema migrations').optional(),
 })
 
 const AggregationAxisFormat = z.enum([
@@ -303,7 +303,7 @@ const AssistantTrendsFilter = z.object({
             'Custom prefix to add to the aggregation axis, e.g., `$` for USD dollars. You may need to add a space after prefix.'
         )
         .optional(),
-    decimalPlaces: z
+    decimalPlaces: z.coerce
         .number()
         .describe(
             'Number of decimal places to show. Do not add this unless you are sure that values will have a decimal point.'
@@ -337,17 +337,21 @@ const AssistantTrendsFilter = z.object({
             'If the math aggregation is more complex or not listed above, use custom formulas to perform mathematical operations like calculating percentages or metrics. If you use a formula, you must use the following syntax: `A/B`, where `A` and `B` are the names of the series. You can combine math aggregations and formulas. When using a formula, you must:\n- Identify and specify **all** events and actions needed to solve the formula.\n- Carefully review the list of available events and actions to find appropriate entities for each part of the formula.\n- Ensure that you find events and actions corresponding to both the numerator and denominator in ratio calculations. Examples of using math formulas:\n- If you want to calculate the percentage of users who have completed onboarding, you need to find and use events or actions similar to `$identify` and `onboarding complete`, so the formula will be `A / B`, where `A` is `onboarding complete` (unique users) and `B` is `$identify` (unique users).'
         )
         .optional(),
-    showLegend: z
+    showLegend: z.coerce
         .boolean()
         .describe('Whether to show the legend describing series and breakdowns.')
         .default(false)
         .optional(),
-    showPercentStackView: z
+    showPercentStackView: z.coerce
         .boolean()
         .describe('Whether to show a percentage of each series. Use only with')
         .default(false)
         .optional(),
-    showValuesOnSeries: z.boolean().describe('Whether to show a value on each data point.').default(false).optional(),
+    showValuesOnSeries: z.coerce
+        .boolean()
+        .describe('Whether to show a value on each data point.')
+        .default(false)
+        .optional(),
     yAxisScaleType: z.enum(['log10', 'linear']).describe('Whether to scale the y-axis.').default('linear').optional(),
 })
 
@@ -357,7 +361,7 @@ const AssistantTrendsQuery = z.object({
     ).optional(),
     compareFilter: CompareFilter.describe('Compare to date range').optional(),
     dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
-    filterTestAccounts: z
+    filterTestAccounts: z.coerce
         .boolean()
         .describe('Exclude internal and test users by applying the respective filters')
         .default(false)
@@ -365,6 +369,7 @@ const AssistantTrendsQuery = z.object({
     interval: IntervalType.describe('Granularity of the response. Can be one of `hour`, `day`, `week` or `month`')
         .default('day')
         .optional(),
+    kind: z.literal('TrendsQuery').default('TrendsQuery'),
     properties: z.array(AssistantPropertyFilter).describe('Property filters for all series').default([]).optional(),
     series: z
         .array(z.union([AssistantTrendsEventsNode, AssistantTrendsActionsNode]))
@@ -392,7 +397,7 @@ const AssistantFunnelsExclusionEventsNode = z.object({
     event: z.string(),
     funnelFromStep: integer,
     funnelToStep: integer,
-    kind: z.literal('EventsNode'),
+    kind: z.literal('EventsNode').default('EventsNode'),
 })
 
 const StepOrderValue = z.enum(['strict', 'unordered', 'ordered'])
@@ -406,7 +411,7 @@ const FunnelConversionWindowTimeUnit = z.enum(['second', 'minute', 'hour', 'day'
 const FunnelLayout = z.enum(['horizontal', 'vertical'])
 
 const AssistantFunnelsFilter = z.object({
-    binCount: z
+    binCount: z.coerce
         .number()
         .int()
         .describe(
@@ -461,23 +466,23 @@ const AssistantFunnelsMath = z.enum(['first_time_for_user', 'first_time_for_user
 const AssistantFunnelsEventsNode = z.object({
     custom_name: z.string().describe('Optional custom name for the event if it is needed to be renamed.').optional(),
     event: z.string().describe('Name of the event.'),
-    kind: z.literal('EventsNode'),
+    kind: z.literal('EventsNode').default('EventsNode'),
     math: AssistantFunnelsMath.describe(
         'Optional math aggregation type for the series. Only specify this math type if the user wants one of these. `first_time_for_user` - counts the number of users who have completed the event for the first time ever. `first_time_for_user_with_filters` - counts the number of users who have completed the event with specified filters for the first time.'
     ).optional(),
     properties: z.array(AssistantPropertyFilter).optional(),
-    version: z.number().describe('version of the node, used for schema migrations').optional(),
+    version: z.coerce.number().describe('version of the node, used for schema migrations').optional(),
 })
 
 const AssistantFunnelsActionsNode = z.object({
-    id: z.number().describe('Action ID from the plan.'),
-    kind: z.literal('ActionsNode'),
+    id: z.coerce.number().describe('Action ID from the plan.'),
+    kind: z.literal('ActionsNode').default('ActionsNode'),
     math: AssistantFunnelsMath.describe(
         'Optional math aggregation type for the series. Only specify this math type if the user wants one of these. `first_time_for_user` - counts the number of users who have completed the event for the first time ever. `first_time_for_user_with_filters` - counts the number of users who have completed the event with specified filters for the first time.'
     ).optional(),
     name: z.string().describe('Action name from the plan.'),
     properties: z.array(AssistantPropertyFilter).optional(),
-    version: z.number().describe('version of the node, used for schema migrations').optional(),
+    version: z.coerce.number().describe('version of the node, used for schema migrations').optional(),
 })
 
 const AssistantFunnelsNode = z.union([AssistantFunnelsEventsNode, AssistantFunnelsActionsNode])
@@ -492,7 +497,7 @@ const AssistantFunnelsQuery = z.object({
         'A breakdown is used to segment data by a single property value. They divide all defined funnel series into multiple subseries based on the values of the property. Include a breakdown **only when it is essential to directly answer the user’s question**. You must not add a breakdown if the question can be addressed without additional segmentation. When using breakdowns, you must:\n- **Identify the property group** and name for a breakdown.\n- **Provide the property name** for a breakdown.\n- **Validate that the property value accurately reflects the intended criteria**. Examples of using a breakdown:\n- page views to sign up funnel by country: you need to find a property such as `$geoip_country_code` and set it as a breakdown.\n- conversion rate of users who have completed onboarding after signing up by an organization: you need to find a property such as `organization name` and set it as a breakdown.'
     ).optional(),
     dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
-    filterTestAccounts: z
+    filterTestAccounts: z.coerce
         .boolean()
         .describe('Exclude internal and test users by applying the respective filters')
         .default(false)
@@ -501,6 +506,7 @@ const AssistantFunnelsQuery = z.object({
     interval: IntervalType.describe(
         'Granularity of the response. Can be one of `hour`, `day`, `week` or `month`'
     ).optional(),
+    kind: z.literal('FunnelsQuery').default('FunnelsQuery'),
     properties: z.array(AssistantPropertyFilter).describe('Property filters for all series').default([]).optional(),
     series: z
         .array(AssistantFunnelsNode)
@@ -515,20 +521,20 @@ const AssistantRetentionEventsNode = z.object({
     custom_name: z.string().describe('Custom name for the event if it is needed to be renamed.').optional(),
     name: z.string().describe('Event name from the plan.'),
     properties: z.array(AssistantPropertyFilter).describe('Property filters for the event.').optional(),
-    type: z.literal('events'),
+    type: z.literal('events').default('events'),
 })
 
 const AssistantRetentionActionsNode = z.object({
-    id: z.number().describe('Action ID from the plan.'),
+    id: z.coerce.number().describe('Action ID from the plan.'),
     name: z.string().describe('Action name from the plan.'),
     properties: z.array(AssistantPropertyFilter).describe('Property filters for the action.').optional(),
-    type: z.literal('actions'),
+    type: z.literal('actions').default('actions'),
 })
 
 const AssistantRetentionEntity = z.union([AssistantRetentionEventsNode, AssistantRetentionActionsNode])
 
 const AssistantRetentionFilter = z.object({
-    cumulative: z
+    cumulative: z.coerce
         .boolean()
         .describe(
             'Whether retention should be rolling (aka unbounded, cumulative). Rolling retention means that a user coming back in period 5 makes them count towards all the previous periods.'
@@ -562,11 +568,12 @@ const AssistantRetentionFilter = z.object({
 
 const AssistantRetentionQuery = z.object({
     dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
-    filterTestAccounts: z
+    filterTestAccounts: z.coerce
         .boolean()
         .describe('Exclude internal and test users by applying the respective filters')
         .default(false)
         .optional(),
+    kind: z.literal('RetentionQuery').default('RetentionQuery'),
     properties: z.array(AssistantPropertyFilter).describe('Property filters for all series').default([]).optional(),
     retentionFilter: AssistantRetentionFilter.describe('Properties specific to the retention insight'),
 })
@@ -574,7 +581,7 @@ const AssistantRetentionQuery = z.object({
 const DateRange = z.object({
     date_from: z.string().nullable().optional(),
     date_to: z.string().nullable().optional(),
-    explicitDate: z
+    explicitDate: z.coerce
         .boolean()
         .nullable()
         .describe(
@@ -621,7 +628,7 @@ const PropertyOperator = z.enum([
     'not_icontains_multi',
 ])
 
-const PropertyFilterBaseValue = z.union([z.string(), z.number(), z.boolean()])
+const PropertyFilterBaseValue = z.union([z.string(), z.coerce.number(), z.coerce.boolean()])
 
 const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
 
@@ -629,7 +636,7 @@ const EventPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator.default('exact'),
-    type: z.literal('event').describe('Event properties'),
+    type: z.literal('event').describe('Event properties').default('event'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -637,7 +644,7 @@ const PersonPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('person').describe('Person properties'),
+    type: z.literal('person').describe('Person properties').default('person'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -645,7 +652,7 @@ const ElementPropertyFilter = z.object({
     key: z.enum(['tag_name', 'text', 'href', 'selector']),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('element'),
+    type: z.literal('element').default('element'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -653,7 +660,7 @@ const EventMetadataPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('event_metadata'),
+    type: z.literal('event_metadata').default('event_metadata'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -661,17 +668,17 @@ const SessionPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('session'),
+    type: z.literal('session').default('session'),
     value: PropertyFilterValue.optional(),
 })
 
 const CohortPropertyFilter = z.object({
     cohort_name: z.string().optional(),
-    key: z.literal('id'),
+    key: z.literal('id').default('id'),
     label: z.string().optional(),
     operator: PropertyOperator.default('in'),
-    type: z.literal('cohort'),
-    value: z.number().int(),
+    type: z.literal('cohort').default('cohort'),
+    value: z.coerce.number().int(),
 })
 
 const DurationType = z.enum(['duration', 'active_seconds', 'inactive_seconds'])
@@ -680,7 +687,7 @@ const RecordingPropertyFilter = z.object({
     key: z.union([DurationType, z.literal('snapshot_source'), z.literal('visited_page'), z.literal('comment_text')]),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('recording'),
+    type: z.literal('recording').default('recording'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -688,17 +695,17 @@ const LogEntryPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('log_entry'),
+    type: z.literal('log_entry').default('log_entry'),
     value: PropertyFilterValue.optional(),
 })
 
 const GroupPropertyFilter = z.object({
     group_key_names: z.object({}).optional(),
-    group_type_index: z.union([z.number().int(), z.null()]).optional(),
+    group_type_index: z.union([z.coerce.number().int(), z.null()]).optional(),
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('group'),
+    type: z.literal('group').default('group'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -706,7 +713,7 @@ const FeaturePropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('feature').describe('Event property with "$feature/" prepended'),
+    type: z.literal('feature').describe('Event property with "$feature/" prepended').default('feature'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -715,27 +722,28 @@ const FlagPropertyFilter = z.object({
     label: z.string().optional(),
     operator: z
         .literal('flag_evaluates_to')
-        .describe('Only flag_evaluates_to operator is allowed for flag dependencies'),
-    type: z.literal('flag').describe('Feature flag dependency'),
-    value: z.union([z.boolean(), z.string()]).describe('The value can be true, false, or a variant name'),
+        .describe('Only flag_evaluates_to operator is allowed for flag dependencies')
+        .default('flag_evaluates_to'),
+    type: z.literal('flag').describe('Feature flag dependency').default('flag'),
+    value: z.union([z.coerce.boolean(), z.string()]).describe('The value can be true, false, or a variant name'),
 })
 
 const HogQLPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
-    type: z.literal('hogql'),
+    type: z.literal('hogql').default('hogql'),
     value: PropertyFilterValue.optional(),
 })
 
 const EmptyPropertyFilter = z.object({
-    type: z.literal('empty').optional(),
+    type: z.literal('empty').default('empty').optional(),
 })
 
 const DataWarehousePropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('data_warehouse'),
+    type: z.literal('data_warehouse').default('data_warehouse'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -743,7 +751,7 @@ const DataWarehousePersonPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('data_warehouse_person_property'),
+    type: z.literal('data_warehouse_person_property').default('data_warehouse_person_property'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -751,7 +759,7 @@ const ErrorTrackingIssueFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('error_tracking_issue'),
+    type: z.literal('error_tracking_issue').default('error_tracking_issue'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -769,7 +777,7 @@ const RevenueAnalyticsPropertyFilter = z.object({
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
-    type: z.literal('revenue_analytics'),
+    type: z.literal('revenue_analytics').default('revenue_analytics'),
     value: PropertyFilterValue.optional(),
 })
 
@@ -796,15 +804,16 @@ const AnyPropertyFilter = z.union([
 
 const TracesQuery = z.object({
     dateRange: DateRange.optional(),
-    filterSupportTraces: z.boolean().optional(),
-    filterTestAccounts: z.boolean().optional(),
+    filterSupportTraces: z.coerce.boolean().optional(),
+    filterTestAccounts: z.coerce.boolean().optional(),
     groupKey: z.string().optional(),
     groupTypeIndex: integer.optional(),
+    kind: z.literal('TracesQuery').default('TracesQuery'),
     limit: integer.optional(),
     offset: integer.optional(),
     personId: z.string().describe('Person who performed the event').optional(),
     properties: z.array(AnyPropertyFilter).describe('Properties configurable in the interface').optional(),
-    randomOrder: z
+    randomOrder: z.coerce
         .boolean()
         .describe(
             'Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias.'

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -16,18 +16,21 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
         handler: async (context: Context, params: z.infer<T>) => {
             const projectId = await context.stateManager.getProjectId()
             const query = { ...params, kind: config.kind }
-            const result = await context.api.request<string>({
+            const result = await context.api.request<{
+                results: unknown
+                columns?: unknown
+                formatted_results?: string
+            }>({
                 method: 'POST',
                 path: `/api/environments/${projectId}/query/`,
                 body: { query },
-                headers: { Accept: 'text/markdown' },
-                responseType: 'text',
+                headers: { 'X-PostHog-Client': 'mcp' },
             })
             const queryParam = encodeURIComponent(JSON.stringify(query))
             const baseUrl = context.api.getProjectBaseUrl(projectId)
             return {
                 query,
-                results: result,
+                results: result.formatted_results ?? result,
                 _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
             }
         },

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -29,7 +29,6 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
             const queryParam = encodeURIComponent(JSON.stringify(query))
             const baseUrl = context.api.getProjectBaseUrl(projectId)
             return {
-                query,
                 results: result.formatted_results ?? result,
                 _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
             }

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+interface QueryWrapperConfig<T extends ZodObjectAny> {
+    name: string
+    schema: T
+    kind: string
+    uiResourceUri?: string
+}
+
+export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperConfig<T>): () => ToolBase<T> {
+    return () => ({
+        name: config.name,
+        schema: config.schema,
+        handler: async (context: Context, params: z.infer<T>) => {
+            const projectId = await context.stateManager.getProjectId()
+            const query = { ...params, kind: config.kind }
+            const result = await context.api.request<string>({
+                method: 'POST',
+                path: `/api/environments/${projectId}/query/`,
+                body: { query },
+                headers: { Accept: 'text/markdown' },
+                responseType: 'text',
+            })
+            const queryParam = encodeURIComponent(JSON.stringify(query))
+            const baseUrl = context.api.getProjectBaseUrl(projectId)
+            return {
+                query,
+                results: result,
+                _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
+            }
+        },
+        ...(config.uiResourceUri ? { _meta: { ui: { resourceUri: config.uiResourceUri } } } : {}),
+    })
+}

--- a/services/mcp/src/tools/query-wrapper-factory.ts
+++ b/services/mcp/src/tools/query-wrapper-factory.ts
@@ -29,7 +29,7 @@ export function createQueryWrapper<T extends ZodObjectAny>(config: QueryWrapperC
             const queryParam = encodeURIComponent(JSON.stringify(query))
             const baseUrl = context.api.getProjectBaseUrl(projectId)
             return {
-                results: result.formatted_results ?? result,
+                results: result.formatted_results ?? result.results,
                 _posthogUrl: `${baseUrl}/insights/new?q=${queryParam}`,
             }
         },

--- a/services/mcp/tests/tools/query-wrappers.integration.test.ts
+++ b/services/mcp/tests/tools/query-wrappers.integration.test.ts
@@ -88,6 +88,30 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
         })
     })
 
+    describe('query-retention', () => {
+        it('should execute a basic retention query and return formatted results', async () => {
+            const tool = getToolByName(
+                GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>,
+                'query-retention'
+            )
+            const result = (await tool.handler(context, {
+                retentionFilter: {
+                    targetEntity: { id: '$pageview', type: 'events' },
+                    returningEntity: { id: '$pageview', type: 'events' },
+                    period: 'Day',
+                    totalIntervals: 7,
+                },
+                dateRange: { date_from: '-7d' },
+            })) as any
+
+            expect(result).toHaveProperty('query')
+            expect(result).toHaveProperty('results')
+            expect(result).toHaveProperty('_posthogUrl')
+            expect(result.query.kind).toBe('RetentionQuery')
+            expect(typeof result.results).toBe('string')
+        })
+    })
+
     describe('query-traces-list', () => {
         it('should execute a traces query and return formatted results', async () => {
             const tool = getToolByName(

--- a/services/mcp/tests/tools/query-wrappers.integration.test.ts
+++ b/services/mcp/tests/tools/query-wrappers.integration.test.ts
@@ -33,10 +33,8 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
                 dateRange: { date_from: '-7d' },
             })) as any
 
-            expect(result).toHaveProperty('query')
             expect(result).toHaveProperty('results')
             expect(result).toHaveProperty('_posthogUrl')
-            expect(result.query.kind).toBe('TrendsQuery')
             expect(typeof result.results).toBe('string')
             expect(result._posthogUrl).toMatch(/\/insights\/new\?q=/)
         })
@@ -64,7 +62,6 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
                 },
             })) as any
 
-            expect(result.query.kind).toBe('TrendsQuery')
             expect(typeof result.results).toBe('string')
         })
     })
@@ -80,10 +77,8 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
                 dateRange: { date_from: '-7d' },
             })) as any
 
-            expect(result).toHaveProperty('query')
             expect(result).toHaveProperty('results')
             expect(result).toHaveProperty('_posthogUrl')
-            expect(result.query.kind).toBe('FunnelsQuery')
             expect(typeof result.results).toBe('string')
         })
     })
@@ -104,11 +99,8 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
                 dateRange: { date_from: '-7d' },
             })) as any
 
-            expect(result).toHaveProperty('query')
             expect(result).toHaveProperty('results')
             expect(result).toHaveProperty('_posthogUrl')
-            expect(result.query.kind).toBe('RetentionQuery')
-            expect(typeof result.results).toBe('string')
         })
     })
 
@@ -123,28 +115,15 @@ describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
                 limit: 10,
             })) as any
 
-            expect(result).toHaveProperty('query')
             expect(result).toHaveProperty('results')
             expect(result).toHaveProperty('_posthogUrl')
-            expect(result.query.kind).toBe('TracesQuery')
             // TracesQuery may not have a formatter — result could be string or JSON fallback
             expect(result.results !== undefined).toBe(true)
         })
     })
 
     describe('factory behavior', () => {
-        it('should set the kind field automatically', async () => {
-            const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
-            const result = (await tool.handler(context, {
-                series: [{ kind: 'EventsNode', event: '$pageview' }],
-                dateRange: { date_from: '-7d' },
-            })) as any
-
-            // kind should be set by the factory, not passed in params
-            expect(result.query.kind).toBe('TrendsQuery')
-        })
-
-        it('should generate a valid PostHog URL', async () => {
+        it('should generate a valid PostHog URL with kind', async () => {
             const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
             const result = (await tool.handler(context, {
                 series: [{ kind: 'EventsNode', event: '$pageview' }],

--- a/services/mcp/tests/tools/query-wrappers.integration.test.ts
+++ b/services/mcp/tests/tools/query-wrappers.integration.test.ts
@@ -1,0 +1,139 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import type { ApiClient } from '@/api/client'
+import { GENERATED_TOOLS } from '@/tools/generated/query-wrappers'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+import {
+    TEST_ORG_ID,
+    TEST_PROJECT_ID,
+    createTestClient,
+    createTestContext,
+    getToolByName,
+    setActiveProjectAndOrg,
+    validateEnvironmentVariables,
+} from '../shared/test-utils'
+
+describe('Query Wrapper Integration Tests', { concurrent: false }, () => {
+    let client: ApiClient
+    let context: Context
+
+    beforeAll(async () => {
+        validateEnvironmentVariables()
+        client = createTestClient()
+        context = createTestContext(client)
+        await setActiveProjectAndOrg(context, TEST_PROJECT_ID!, TEST_ORG_ID!)
+    })
+
+    describe('query-trends', () => {
+        it('should execute a basic trends query and return formatted results', async () => {
+            const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
+            const result = (await tool.handler(context, {
+                series: [{ kind: 'EventsNode', event: '$pageview' }],
+                dateRange: { date_from: '-7d' },
+            })) as any
+
+            expect(result).toHaveProperty('query')
+            expect(result).toHaveProperty('results')
+            expect(result).toHaveProperty('_posthogUrl')
+            expect(result.query.kind).toBe('TrendsQuery')
+            expect(typeof result.results).toBe('string')
+            expect(result._posthogUrl).toMatch(/\/insights\/new\?q=/)
+        })
+
+        it('should include pipe-separated table in formatted results', async () => {
+            const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
+            const result = (await tool.handler(context, {
+                series: [{ kind: 'EventsNode', event: '$pageview' }],
+                dateRange: { date_from: '-7d' },
+                interval: 'day',
+            })) as any
+
+            // Formatted results should contain pipe-separated values (the formatter output)
+            expect(typeof result.results).toBe('string')
+            expect(result.results).toContain('|')
+        })
+
+        it('should execute trends with breakdown', async () => {
+            const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
+            const result = (await tool.handler(context, {
+                series: [{ kind: 'EventsNode', event: '$pageview' }],
+                dateRange: { date_from: '-7d' },
+                breakdownFilter: {
+                    breakdowns: [{ property: '$browser', type: 'event' }],
+                },
+            })) as any
+
+            expect(result.query.kind).toBe('TrendsQuery')
+            expect(typeof result.results).toBe('string')
+        })
+    })
+
+    describe('query-funnel', () => {
+        it('should execute a basic funnel query and return formatted results', async () => {
+            const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-funnel')
+            const result = (await tool.handler(context, {
+                series: [
+                    { kind: 'EventsNode', event: '$pageview' },
+                    { kind: 'EventsNode', event: '$pageleave' },
+                ],
+                dateRange: { date_from: '-7d' },
+            })) as any
+
+            expect(result).toHaveProperty('query')
+            expect(result).toHaveProperty('results')
+            expect(result).toHaveProperty('_posthogUrl')
+            expect(result.query.kind).toBe('FunnelsQuery')
+            expect(typeof result.results).toBe('string')
+        })
+    })
+
+    describe('query-traces-list', () => {
+        it('should execute a traces query and return formatted results', async () => {
+            const tool = getToolByName(
+                GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>,
+                'query-traces-list'
+            )
+            const result = (await tool.handler(context, {
+                dateRange: { date_from: '-7d' },
+                limit: 10,
+            })) as any
+
+            expect(result).toHaveProperty('query')
+            expect(result).toHaveProperty('results')
+            expect(result).toHaveProperty('_posthogUrl')
+            expect(result.query.kind).toBe('TracesQuery')
+            // TracesQuery may not have a formatter — result could be string or JSON fallback
+            expect(result.results !== undefined).toBe(true)
+        })
+    })
+
+    describe('factory behavior', () => {
+        it('should set the kind field automatically', async () => {
+            const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
+            const result = (await tool.handler(context, {
+                series: [{ kind: 'EventsNode', event: '$pageview' }],
+                dateRange: { date_from: '-7d' },
+            })) as any
+
+            // kind should be set by the factory, not passed in params
+            expect(result.query.kind).toBe('TrendsQuery')
+        })
+
+        it('should generate a valid PostHog URL', async () => {
+            const tool = getToolByName(GENERATED_TOOLS as Record<string, () => ToolBase<ZodObjectAny>>, 'query-trends')
+            const result = (await tool.handler(context, {
+                series: [{ kind: 'EventsNode', event: '$pageview' }],
+                dateRange: { date_from: '-7d' },
+            })) as any
+
+            expect(result._posthogUrl).toContain('/insights/new?q=')
+            // URL-encoded query should be parseable
+            const url = new URL(result._posthogUrl)
+            const queryParam = url.searchParams.get('q')
+            expect(queryParam).toBeTruthy()
+            const parsed = JSON.parse(decodeURIComponent(queryParam!))
+            expect(parsed.kind).toBe('TrendsQuery')
+        })
+    })
+})

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-funnel.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-funnel.json
@@ -1,0 +1,1144 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "aggregation_group_type_index": {
+            "description": "Use this field to define the aggregation by a specific group from the provided group mapping, which is NOT users or sessions.",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+        },
+        "breakdownFilter": {
+            "description": "A breakdown is used to segment data by a single property value. They divide all defined funnel series into multiple subseries based on the values of the property. Include a breakdown **only when it is essential to directly answer the user’s question**. You must not add a breakdown if the question can be addressed without additional segmentation. When using breakdowns, you must:\n- **Identify the property group** and name for a breakdown.\n- **Provide the property name** for a breakdown.\n- **Validate that the property value accurately reflects the intended criteria**. Examples of using a breakdown:\n- page views to sign up funnel by country: you need to find a property such as `$geoip_country_code` and set it as a breakdown.\n- conversion rate of users who have completed onboarding after signing up by an organization: you need to find a property such as `organization name` and set it as a breakdown.",
+            "properties": {
+                "breakdown": {
+                    "description": "The entity property to break down by.",
+                    "type": "string"
+                },
+                "breakdown_group_type_index": {
+                    "anyOf": [
+                        {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping."
+                },
+                "breakdown_limit": {
+                    "default": 25,
+                    "description": "How many distinct values to show.",
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                },
+                "breakdown_type": {
+                    "default": "event",
+                    "description": "Type of the entity to break down by. If `group` is used, you must also provide `breakdown_group_type_index` from the group mapping.",
+                    "enum": ["person", "event", "group", "session"],
+                    "type": "string"
+                }
+            },
+            "required": ["breakdown"],
+            "type": "object"
+        },
+        "dateRange": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "ISO8601 date string.",
+                            "type": "string"
+                        },
+                        "date_to": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "ISO8601 date string."
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "Duration in the past. Supported units are: `h` (hour), `d` (day), `w` (week), `m` (month), `y` (year), `all` (all time). Use the `Start` suffix to define the exact left date boundary. Examples: `-1d` last day from now, `-180d` last 180 days from now, `mStart` this month start, `-1dStart` yesterday's start.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                }
+            ],
+            "description": "Date range for the query"
+        },
+        "filterTestAccounts": {
+            "default": false,
+            "description": "Exclude internal and test users by applying the respective filters",
+            "type": "boolean"
+        },
+        "funnelsFilter": {
+            "description": "Properties specific to the funnels insight",
+            "properties": {
+                "binCount": {
+                    "description": "Use this setting only when `funnelVizType` is `time_to_convert`: number of bins to show in histogram.",
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                },
+                "exclusions": {
+                    "default": [],
+                    "description": "Users may want to use exclusion events to filter out conversions in which a particular event occurred between specific steps. These events must not be included in the main sequence. This doesn't exclude users who have completed the event before or after the funnel sequence, but often this is what users want. (If not sure, worth clarifying.) You must include start and end indexes for each exclusion where the minimum index is one and the maximum index is the number of steps in the funnel. For example, there is a sequence with three steps: sign up, finish onboarding, purchase. If the user wants to exclude all conversions in which users left the page before finishing the onboarding, the exclusion step would be the event `$pageleave` with start index 2 and end index 3. When exclusion steps appear needed when you're planning the query, make sure to explicitly state this in the plan.",
+                    "items": {
+                        "properties": {
+                            "event": {
+                                "type": "string"
+                            },
+                            "funnelFromStep": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                            },
+                            "funnelToStep": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                            },
+                            "kind": {
+                                "const": "EventsNode",
+                                "type": "string"
+                            }
+                        },
+                        "required": ["event", "funnelFromStep", "funnelToStep", "kind"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "funnelAggregateByHogQL": {
+                    "anyOf": [
+                        {
+                            "const": "properties.$session_id",
+                            "type": "string"
+                        },
+                        {
+                            "const": null,
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Use this field only if the user explicitly asks to aggregate the funnel by unique sessions."
+                },
+                "funnelOrderType": {
+                    "default": "ordered",
+                    "description": "Defines the behavior of event matching between steps. Prefer the `strict` option unless explicitly told to use a different one. `ordered` - defines a sequential funnel. Step B must happen after Step A, but any number of events can happen between A and B. `strict` - defines a funnel where all events must happen in order. Step B must happen directly after Step A without any events in between. `any` - order doesn't matter. Steps can be completed in any sequence.",
+                    "enum": ["strict", "unordered", "ordered"],
+                    "type": "string"
+                },
+                "funnelStepReference": {
+                    "default": "total",
+                    "description": "Whether conversion shown in the graph should be across all steps or just relative to the previous step.",
+                    "enum": ["total", "previous"],
+                    "type": "string"
+                },
+                "funnelVizType": {
+                    "default": "steps",
+                    "description": "Defines the type of visualization to use. The `steps` option is recommended. `steps` - shows a step-by-step funnel. Perfect to show a conversion rate of a sequence of events (default). `time_to_convert` - shows a histogram of the time it took to complete the funnel. `trends` - shows trends of the conversion rate of the whole sequence over time.",
+                    "enum": ["steps", "time_to_convert", "trends", "flow"],
+                    "type": "string"
+                },
+                "funnelWindowInterval": {
+                    "default": 14,
+                    "description": "Controls a time frame value for a conversion to be considered. Select a reasonable value based on the user's query. If needed, this can be practically unlimited by setting a large value, though it's rare to need that. Use in combination with `funnelWindowIntervalUnit`. The default value is 14 days.",
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                },
+                "funnelWindowIntervalUnit": {
+                    "default": "day",
+                    "description": "Controls a time frame interval for a conversion to be considered. Select a reasonable value based on the user's query. Use in combination with `funnelWindowInterval`. The default value is 14 days.",
+                    "enum": ["second", "minute", "hour", "day", "week", "month"],
+                    "type": "string"
+                },
+                "layout": {
+                    "default": "vertical",
+                    "description": "Controls how the funnel chart is displayed: vertically (preferred) or horizontally.",
+                    "enum": ["horizontal", "vertical"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "interval": {
+            "description": "Granularity of the response. Can be one of `hour`, `day`, `week` or `month`",
+            "enum": ["second", "minute", "hour", "day", "week", "month"],
+            "type": "string"
+        },
+        "properties": {
+            "default": [],
+            "description": "Property filters for all series",
+            "items": {
+                "anyOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                        "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["exact", "gt", "lt"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                        "enum": ["exact", "is_not"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value must be a date in ISO 8601 format.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                        "enum": ["is_set", "is_not_set"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                        "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["exact", "gt", "lt"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                        "enum": ["exact", "is_not"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value must be a date in ISO 8601 format.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                        "enum": ["is_set", "is_not_set"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type"],
+                                "type": "object"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "type": "array"
+        },
+        "series": {
+            "description": "Events or actions to include. Prioritize the more popular and fresh events and actions.",
+            "items": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "custom_name": {
+                                "description": "Optional custom name for the event if it is needed to be renamed.",
+                                "type": "string"
+                            },
+                            "event": {
+                                "description": "Name of the event.",
+                                "type": "string"
+                            },
+                            "kind": {
+                                "const": "EventsNode",
+                                "type": "string"
+                            },
+                            "math": {
+                                "description": "Optional math aggregation type for the series. Only specify this math type if the user wants one of these. `first_time_for_user` - counts the number of users who have completed the event for the first time ever. `first_time_for_user_with_filters` - counts the number of users who have completed the event with specified filters for the first time.",
+                                "enum": ["first_time_for_user", "first_time_for_user_with_filters"],
+                                "type": "string"
+                            },
+                            "properties": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            "version": {
+                                "description": "version of the node, used for schema migrations",
+                                "type": "number"
+                            }
+                        },
+                        "required": ["event", "kind"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "id": {
+                                "description": "Action ID from the plan.",
+                                "type": "number"
+                            },
+                            "kind": {
+                                "const": "ActionsNode",
+                                "type": "string"
+                            },
+                            "math": {
+                                "description": "Optional math aggregation type for the series. Only specify this math type if the user wants one of these. `first_time_for_user` - counts the number of users who have completed the event for the first time ever. `first_time_for_user_with_filters` - counts the number of users who have completed the event with specified filters for the first time.",
+                                "enum": ["first_time_for_user", "first_time_for_user_with_filters"],
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "Action name from the plan.",
+                                "type": "string"
+                            },
+                            "properties": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            "version": {
+                                "description": "version of the node, used for schema migrations",
+                                "type": "number"
+                            }
+                        },
+                        "required": ["id", "kind", "name"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array"
+        }
+    },
+    "required": ["series"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-funnel.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-funnel.json
@@ -114,10 +114,11 @@
                             },
                             "kind": {
                                 "const": "EventsNode",
+                                "default": "EventsNode",
                                 "type": "string"
                             }
                         },
-                        "required": ["event", "funnelFromStep", "funnelToStep", "kind"],
+                        "required": ["event", "funnelFromStep", "funnelToStep"],
                         "type": "object"
                     },
                     "type": "array"
@@ -179,6 +180,11 @@
         "interval": {
             "description": "Granularity of the response. Can be one of `hour`, `day`, `week` or `month`",
             "enum": ["second", "minute", "hour", "day", "week", "month"],
+            "type": "string"
+        },
+        "kind": {
+            "const": "FunnelsQuery",
+            "default": "FunnelsQuery",
             "type": "string"
         },
         "properties": {
@@ -322,6 +328,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -329,7 +336,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -350,13 +357,14 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
                                         "type": "number"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -378,6 +386,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -388,7 +397,7 @@
                                         "type": "array"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -409,6 +418,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -416,7 +426,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -438,10 +448,11 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type"],
+                                "required": ["group_type_index", "key", "operator"],
                                 "type": "object"
                             }
                         ]
@@ -466,6 +477,7 @@
                             },
                             "kind": {
                                 "const": "EventsNode",
+                                "default": "EventsNode",
                                 "type": "string"
                             },
                             "math": {
@@ -630,6 +642,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -637,13 +650,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -664,19 +671,14 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
                                                             "type": "number"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -698,6 +700,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -708,13 +711,7 @@
                                                             "type": "array"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -739,6 +736,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -746,13 +744,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -774,10 +766,11 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "required": ["group_type_index", "key", "operator"],
                                                     "type": "object"
                                                 }
                                             ]
@@ -791,7 +784,7 @@
                                 "type": "number"
                             }
                         },
-                        "required": ["event", "kind"],
+                        "required": ["event"],
                         "type": "object"
                     },
                     {
@@ -802,6 +795,7 @@
                             },
                             "kind": {
                                 "const": "ActionsNode",
+                                "default": "ActionsNode",
                                 "type": "string"
                             },
                             "math": {
@@ -970,6 +964,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -977,13 +972,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1004,19 +993,14 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
                                                             "type": "number"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1038,6 +1022,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -1048,13 +1033,7 @@
                                                             "type": "array"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1079,6 +1058,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -1086,13 +1066,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1114,10 +1088,11 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "required": ["group_type_index", "key", "operator"],
                                                     "type": "object"
                                                 }
                                             ]
@@ -1131,7 +1106,7 @@
                                 "type": "number"
                             }
                         },
-                        "required": ["id", "kind", "name"],
+                        "required": ["id", "name"],
                         "type": "object"
                     }
                 ]

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-retention.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-retention.json
@@ -1,0 +1,1694 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "dateRange": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "ISO8601 date string.",
+                            "type": "string"
+                        },
+                        "date_to": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "ISO8601 date string."
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "Duration in the past. Supported units are: `h` (hour), `d` (day), `w` (week), `m` (month), `y` (year), `all` (all time). Use the `Start` suffix to define the exact left date boundary. Examples: `-1d` last day from now, `-180d` last 180 days from now, `mStart` this month start, `-1dStart` yesterday's start.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                }
+            ],
+            "description": "Date range for the query"
+        },
+        "filterTestAccounts": {
+            "default": false,
+            "description": "Exclude internal and test users by applying the respective filters",
+            "type": "boolean"
+        },
+        "properties": {
+            "default": [],
+            "description": "Property filters for all series",
+            "items": {
+                "anyOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                        "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["exact", "gt", "lt"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                        "enum": ["exact", "is_not"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value must be a date in ISO 8601 format.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                        "enum": ["is_set", "is_not_set"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                        "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["exact", "gt", "lt"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                        "enum": ["exact", "is_not"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value must be a date in ISO 8601 format.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                        "enum": ["is_set", "is_not_set"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type"],
+                                "type": "object"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "type": "array"
+        },
+        "retentionFilter": {
+            "description": "Properties specific to the retention insight",
+            "properties": {
+                "cumulative": {
+                    "description": "Whether retention should be rolling (aka unbounded, cumulative). Rolling retention means that a user coming back in period 5 makes them count towards all the previous periods.",
+                    "type": "boolean"
+                },
+                "meanRetentionCalculation": {
+                    "description": "Whether an additional series should be shown, showing the mean conversion for each period across cohorts.",
+                    "enum": ["simple", "weighted", "none"],
+                    "type": "string"
+                },
+                "period": {
+                    "default": "Day",
+                    "description": "Retention period, the interval to track cohorts by.",
+                    "enum": ["Hour", "Day", "Week", "Month"],
+                    "type": "string"
+                },
+                "retentionReference": {
+                    "description": "Whether retention is with regard to initial cohort size, or that of the previous period.",
+                    "enum": ["total", "previous"],
+                    "type": "string"
+                },
+                "retentionType": {
+                    "description": "Retention type: recurring or first time. Recurring retention counts a user as part of a cohort if they performed the cohort event during that time period, irrespective of it was their first time or not. First time retention only counts a user as part of the cohort if it was their first time performing the cohort event.",
+                    "enum": ["retention_recurring", "retention_first_time", "retention_first_ever_occurrence"],
+                    "type": "string"
+                },
+                "returningEntity": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "custom_name": {
+                                    "description": "Custom name for the event if it is needed to be renamed.",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "Event name from the plan.",
+                                    "type": "string"
+                                },
+                                "properties": {
+                                    "description": "Property filters for the event.",
+                                    "items": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "array"
+                                },
+                                "type": {
+                                    "const": "events",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["name", "type"],
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "id": {
+                                    "description": "Action ID from the plan.",
+                                    "type": "number"
+                                },
+                                "name": {
+                                    "description": "Action name from the plan.",
+                                    "type": "string"
+                                },
+                                "properties": {
+                                    "description": "Property filters for the action.",
+                                    "items": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "array"
+                                },
+                                "type": {
+                                    "const": "actions",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["id", "name", "type"],
+                            "type": "object"
+                        }
+                    ],
+                    "description": "Retention event (event marking the user coming back)."
+                },
+                "targetEntity": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "custom_name": {
+                                    "description": "Custom name for the event if it is needed to be renamed.",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "Event name from the plan.",
+                                    "type": "string"
+                                },
+                                "properties": {
+                                    "description": "Property filters for the event.",
+                                    "items": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "array"
+                                },
+                                "type": {
+                                    "const": "events",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["name", "type"],
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "id": {
+                                    "description": "Action ID from the plan.",
+                                    "type": "number"
+                                },
+                                "name": {
+                                    "description": "Action name from the plan.",
+                                    "type": "string"
+                                },
+                                "properties": {
+                                    "description": "Property filters for the action.",
+                                    "items": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type", "value"],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "enum": ["event", "person", "session", "feature"],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                                "enum": [
+                                                                    "exact",
+                                                                    "is_not",
+                                                                    "icontains",
+                                                                    "not_icontains",
+                                                                    "regex",
+                                                                    "not_regex"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": ["exact", "gt", "lt"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                                "enum": ["exact", "is_not"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "enum": [
+                                                                    "is_date_exact",
+                                                                    "is_date_before",
+                                                                    "is_date_after"
+                                                                ],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Value must be a date in ISO 8601 format.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "group_type_index",
+                                                            "key",
+                                                            "operator",
+                                                            "type",
+                                                            "value"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "group_type_index": {
+                                                                "description": "Index of the group type from the group mapping.",
+                                                                "maximum": 9007199254740991,
+                                                                "minimum": -9007199254740991,
+                                                                "type": "integer"
+                                                            },
+                                                            "key": {
+                                                                "description": "Use one of the properties the user has provided in the plan.",
+                                                                "type": "string"
+                                                            },
+                                                            "operator": {
+                                                                "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                                "enum": ["is_set", "is_not_set"],
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "const": "group",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "array"
+                                },
+                                "type": {
+                                    "const": "actions",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["id", "name", "type"],
+                            "type": "object"
+                        }
+                    ],
+                    "description": "Activation event (event putting the actor into the initial cohort)."
+                },
+                "totalIntervals": {
+                    "default": 11,
+                    "description": "How many intervals to show in the chart. The default value is 11 (meaning 10 periods after initial cohort).",
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                }
+            },
+            "required": ["returningEntity", "targetEntity"],
+            "type": "object"
+        }
+    },
+    "required": ["retentionFilter"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-retention.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-retention.json
@@ -42,6 +42,11 @@
             "description": "Exclude internal and test users by applying the respective filters",
             "type": "boolean"
         },
+        "kind": {
+            "const": "RetentionQuery",
+            "default": "RetentionQuery",
+            "type": "string"
+        },
         "properties": {
             "default": [],
             "description": "Property filters for all series",
@@ -183,6 +188,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -190,7 +196,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -211,13 +217,14 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
                                         "type": "number"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -239,6 +246,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -249,7 +257,7 @@
                                         "type": "array"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -270,6 +278,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -277,7 +286,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -299,10 +308,11 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type"],
+                                "required": ["group_type_index", "key", "operator"],
                                 "type": "object"
                             }
                         ]
@@ -509,6 +519,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -516,13 +527,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -543,19 +548,14 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
                                                                 "type": "number"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -577,6 +577,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -587,13 +588,7 @@
                                                                 "type": "array"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -618,6 +613,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -625,13 +621,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -653,10 +643,11 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "required": ["group_type_index", "key", "operator"],
                                                         "type": "object"
                                                     }
                                                 ]
@@ -667,10 +658,11 @@
                                 },
                                 "type": {
                                     "const": "events",
+                                    "default": "events",
                                     "type": "string"
                                 }
                             },
-                            "required": ["name", "type"],
+                            "required": ["name"],
                             "type": "object"
                         },
                         {
@@ -841,6 +833,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -848,13 +841,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -875,19 +862,14 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
                                                                 "type": "number"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -909,6 +891,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -919,13 +902,7 @@
                                                                 "type": "array"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -950,6 +927,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -957,13 +935,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -985,10 +957,11 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "required": ["group_type_index", "key", "operator"],
                                                         "type": "object"
                                                     }
                                                 ]
@@ -999,10 +972,11 @@
                                 },
                                 "type": {
                                     "const": "actions",
+                                    "default": "actions",
                                     "type": "string"
                                 }
                             },
-                            "required": ["id", "name", "type"],
+                            "required": ["id", "name"],
                             "type": "object"
                         }
                     ],
@@ -1178,6 +1152,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -1185,13 +1160,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1212,19 +1181,14 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
                                                                 "type": "number"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1246,6 +1210,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -1256,13 +1221,7 @@
                                                                 "type": "array"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1287,6 +1246,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -1294,13 +1254,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1322,10 +1276,11 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "required": ["group_type_index", "key", "operator"],
                                                         "type": "object"
                                                     }
                                                 ]
@@ -1336,10 +1291,11 @@
                                 },
                                 "type": {
                                     "const": "events",
+                                    "default": "events",
                                     "type": "string"
                                 }
                             },
-                            "required": ["name", "type"],
+                            "required": ["name"],
                             "type": "object"
                         },
                         {
@@ -1510,6 +1466,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -1517,13 +1474,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1544,19 +1495,14 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
                                                                 "type": "number"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1578,6 +1524,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -1588,13 +1535,7 @@
                                                                 "type": "array"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1619,6 +1560,7 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             },
                                                             "value": {
@@ -1626,13 +1568,7 @@
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": [
-                                                            "group_type_index",
-                                                            "key",
-                                                            "operator",
-                                                            "type",
-                                                            "value"
-                                                        ],
+                                                        "required": ["group_type_index", "key", "operator", "value"],
                                                         "type": "object"
                                                     },
                                                     {
@@ -1654,10 +1590,11 @@
                                                             },
                                                             "type": {
                                                                 "const": "group",
+                                                                "default": "group",
                                                                 "type": "string"
                                                             }
                                                         },
-                                                        "required": ["group_type_index", "key", "operator", "type"],
+                                                        "required": ["group_type_index", "key", "operator"],
                                                         "type": "object"
                                                     }
                                                 ]
@@ -1668,10 +1605,11 @@
                                 },
                                 "type": {
                                     "const": "actions",
+                                    "default": "actions",
                                     "type": "string"
                                 }
                             },
-                            "required": ["id", "name", "type"],
+                            "required": ["id", "name"],
                             "type": "object"
                         }
                     ],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-traces-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-traces-list.json
@@ -1,0 +1,1555 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "dateRange": {
+            "properties": {
+                "date_from": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "date_to": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "explicitDate": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": false,
+                    "description": "Whether the date_from and date_to should be used verbatim. Disables rounding to the start and end of period."
+                }
+            },
+            "type": "object"
+        },
+        "filterSupportTraces": {
+            "type": "boolean"
+        },
+        "filterTestAccounts": {
+            "type": "boolean"
+        },
+        "groupKey": {
+            "type": "string"
+        },
+        "groupTypeIndex": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+        },
+        "limit": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+        },
+        "offset": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+        },
+        "personId": {
+            "description": "Person who performed the event",
+            "type": "string"
+        },
+        "properties": {
+            "description": "Properties configurable in the interface",
+            "items": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "default": "exact",
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "event",
+                                "description": "Event properties",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "person",
+                                "description": "Person properties",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "enum": ["tag_name", "text", "href", "selector"],
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "element",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "event_metadata",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "session",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "cohort_name": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "const": "id",
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "default": "in",
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "cohort",
+                                "type": "string"
+                            },
+                            "value": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                            }
+                        },
+                        "required": ["key", "type", "value"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "anyOf": [
+                                    {
+                                        "enum": ["duration", "active_seconds", "inactive_seconds"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "snapshot_source",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "visited_page",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "comment_text",
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "recording",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "log_entry",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "group_key_names": {
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "group_type_index": {
+                                "anyOf": [
+                                    {
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            },
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "group",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "feature",
+                                "description": "Event property with \"$feature/\" prepended",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "description": "The key should be the flag ID",
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "const": "flag_evaluates_to",
+                                "description": "Only flag_evaluates_to operator is allowed for flag dependencies",
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "flag",
+                                "description": "Feature flag dependency",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "description": "The value can be true, false, or a variant name"
+                            }
+                        },
+                        "required": ["key", "operator", "type", "value"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "hogql",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "const": "empty",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "data_warehouse",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "data_warehouse_person_property",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "error_tracking_issue",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "enum": ["log", "log_attribute", "log_resource_attribute"],
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "label": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "is_set",
+                                    "is_not_set",
+                                    "is_date_exact",
+                                    "is_date_before",
+                                    "is_date_after",
+                                    "between",
+                                    "not_between",
+                                    "min",
+                                    "max",
+                                    "in",
+                                    "not_in",
+                                    "is_cleaned_path_exact",
+                                    "flag_evaluates_to",
+                                    "semver_eq",
+                                    "semver_neq",
+                                    "semver_gt",
+                                    "semver_gte",
+                                    "semver_lt",
+                                    "semver_lte",
+                                    "semver_tilde",
+                                    "semver_caret",
+                                    "semver_wildcard",
+                                    "icontains_multi",
+                                    "not_icontains_multi"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "const": "revenue_analytics",
+                                "type": "string"
+                            },
+                            "value": {
+                                "anyOf": [
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "boolean"
+                                                }
+                                            ]
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "required": ["key", "operator", "type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array"
+        },
+        "randomOrder": {
+            "description": "Use random ordering instead of timestamp DESC. Useful for representative sampling to avoid recency bias.",
+            "type": "boolean"
+        }
+    },
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-traces-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-traces-list.json
@@ -52,6 +52,11 @@
             "minimum": -9007199254740991,
             "type": "integer"
         },
+        "kind": {
+            "const": "TracesQuery",
+            "default": "TracesQuery",
+            "type": "string"
+        },
         "limit": {
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
@@ -120,6 +125,7 @@
                             },
                             "type": {
                                 "const": "event",
+                                "default": "event",
                                 "description": "Event properties",
                                 "type": "string"
                             },
@@ -160,7 +166,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "type"],
+                        "required": ["key"],
                         "type": "object"
                     },
                     {
@@ -212,6 +218,7 @@
                             },
                             "type": {
                                 "const": "person",
+                                "default": "person",
                                 "description": "Person properties",
                                 "type": "string"
                             },
@@ -252,7 +259,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -305,6 +312,7 @@
                             },
                             "type": {
                                 "const": "element",
+                                "default": "element",
                                 "type": "string"
                             },
                             "value": {
@@ -344,7 +352,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -396,6 +404,7 @@
                             },
                             "type": {
                                 "const": "event_metadata",
+                                "default": "event_metadata",
                                 "type": "string"
                             },
                             "value": {
@@ -435,7 +444,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -487,6 +496,7 @@
                             },
                             "type": {
                                 "const": "session",
+                                "default": "session",
                                 "type": "string"
                             },
                             "value": {
@@ -526,7 +536,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -536,6 +546,7 @@
                             },
                             "key": {
                                 "const": "id",
+                                "default": "id",
                                 "type": "string"
                             },
                             "label": {
@@ -583,6 +594,7 @@
                             },
                             "type": {
                                 "const": "cohort",
+                                "default": "cohort",
                                 "type": "string"
                             },
                             "value": {
@@ -591,7 +603,7 @@
                                 "type": "integer"
                             }
                         },
-                        "required": ["key", "type", "value"],
+                        "required": ["value"],
                         "type": "object"
                     },
                     {
@@ -660,6 +672,7 @@
                             },
                             "type": {
                                 "const": "recording",
+                                "default": "recording",
                                 "type": "string"
                             },
                             "value": {
@@ -699,7 +712,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -751,6 +764,7 @@
                             },
                             "type": {
                                 "const": "log_entry",
+                                "default": "log_entry",
                                 "type": "string"
                             },
                             "value": {
@@ -790,7 +804,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -858,6 +872,7 @@
                             },
                             "type": {
                                 "const": "group",
+                                "default": "group",
                                 "type": "string"
                             },
                             "value": {
@@ -897,7 +912,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -949,6 +964,7 @@
                             },
                             "type": {
                                 "const": "feature",
+                                "default": "feature",
                                 "description": "Event property with \"$feature/\" prepended",
                                 "type": "string"
                             },
@@ -989,7 +1005,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -1003,11 +1019,13 @@
                             },
                             "operator": {
                                 "const": "flag_evaluates_to",
+                                "default": "flag_evaluates_to",
                                 "description": "Only flag_evaluates_to operator is allowed for flag dependencies",
                                 "type": "string"
                             },
                             "type": {
                                 "const": "flag",
+                                "default": "flag",
                                 "description": "Feature flag dependency",
                                 "type": "string"
                             },
@@ -1023,7 +1041,7 @@
                                 "description": "The value can be true, false, or a variant name"
                             }
                         },
-                        "required": ["key", "operator", "type", "value"],
+                        "required": ["key", "value"],
                         "type": "object"
                     },
                     {
@@ -1036,6 +1054,7 @@
                             },
                             "type": {
                                 "const": "hogql",
+                                "default": "hogql",
                                 "type": "string"
                             },
                             "value": {
@@ -1075,13 +1094,14 @@
                                 ]
                             }
                         },
-                        "required": ["key", "type"],
+                        "required": ["key"],
                         "type": "object"
                     },
                     {
                         "properties": {
                             "type": {
                                 "const": "empty",
+                                "default": "empty",
                                 "type": "string"
                             }
                         },
@@ -1136,6 +1156,7 @@
                             },
                             "type": {
                                 "const": "data_warehouse",
+                                "default": "data_warehouse",
                                 "type": "string"
                             },
                             "value": {
@@ -1175,7 +1196,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -1227,6 +1248,7 @@
                             },
                             "type": {
                                 "const": "data_warehouse_person_property",
+                                "default": "data_warehouse_person_property",
                                 "type": "string"
                             },
                             "value": {
@@ -1266,7 +1288,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -1318,6 +1340,7 @@
                             },
                             "type": {
                                 "const": "error_tracking_issue",
+                                "default": "error_tracking_issue",
                                 "type": "string"
                             },
                             "value": {
@@ -1357,7 +1380,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     },
                     {
@@ -1500,6 +1523,7 @@
                             },
                             "type": {
                                 "const": "revenue_analytics",
+                                "default": "revenue_analytics",
                                 "type": "string"
                             },
                             "value": {
@@ -1539,7 +1563,7 @@
                                 ]
                             }
                         },
-                        "required": ["key", "operator", "type"],
+                        "required": ["key", "operator"],
                         "type": "object"
                     }
                 ]

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-trends.json
@@ -36,10 +36,11 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     }
                                 },
-                                "required": ["property", "type"],
+                                "required": ["property"],
                                 "type": "object"
                             },
                             {
@@ -132,6 +133,11 @@
             "default": "day",
             "description": "Granularity of the response. Can be one of `hour`, `day`, `week` or `month`",
             "enum": ["second", "minute", "hour", "day", "week", "month"],
+            "type": "string"
+        },
+        "kind": {
+            "const": "TrendsQuery",
+            "default": "TrendsQuery",
             "type": "string"
         },
         "properties": {
@@ -275,6 +281,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -282,7 +289,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -303,13 +310,14 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
                                         "type": "number"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -331,6 +339,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -341,7 +350,7 @@
                                         "type": "array"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -362,6 +371,7 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     },
                                     "value": {
@@ -369,7 +379,7 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "required": ["group_type_index", "key", "operator", "value"],
                                 "type": "object"
                             },
                             {
@@ -391,10 +401,11 @@
                                     },
                                     "type": {
                                         "const": "group",
+                                        "default": "group",
                                         "type": "string"
                                     }
                                 },
-                                "required": ["group_type_index", "key", "operator", "type"],
+                                "required": ["group_type_index", "key", "operator"],
                                 "type": "object"
                             }
                         ]
@@ -425,6 +436,7 @@
                             },
                             "kind": {
                                 "const": "EventsNode",
+                                "default": "EventsNode",
                                 "type": "string"
                             },
                             "math": {
@@ -686,6 +698,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -693,13 +706,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -720,19 +727,14 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
                                                             "type": "number"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -754,6 +756,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -764,13 +767,7 @@
                                                             "type": "array"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -795,6 +792,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -802,13 +800,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -830,10 +822,11 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "required": ["group_type_index", "key", "operator"],
                                                     "type": "object"
                                                 }
                                             ]
@@ -847,7 +840,6 @@
                                 "type": "number"
                             }
                         },
-                        "required": ["kind"],
                         "type": "object"
                     },
                     {
@@ -862,6 +854,7 @@
                             },
                             "kind": {
                                 "const": "ActionsNode",
+                                "default": "ActionsNode",
                                 "type": "string"
                             },
                             "math": {
@@ -1124,6 +1117,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -1131,13 +1125,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1158,19 +1146,14 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
                                                             "type": "number"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1192,6 +1175,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -1202,13 +1186,7 @@
                                                             "type": "array"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1233,6 +1211,7 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         },
                                                         "value": {
@@ -1240,13 +1219,7 @@
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": [
-                                                        "group_type_index",
-                                                        "key",
-                                                        "operator",
-                                                        "type",
-                                                        "value"
-                                                    ],
+                                                    "required": ["group_type_index", "key", "operator", "value"],
                                                     "type": "object"
                                                 },
                                                 {
@@ -1268,10 +1241,11 @@
                                                         },
                                                         "type": {
                                                             "const": "group",
+                                                            "default": "group",
                                                             "type": "string"
                                                         }
                                                     },
-                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "required": ["group_type_index", "key", "operator"],
                                                     "type": "object"
                                                 }
                                             ]
@@ -1285,7 +1259,7 @@
                                 "type": "number"
                             }
                         },
-                        "required": ["id", "kind", "name"],
+                        "required": ["id", "name"],
                         "type": "object"
                     }
                 ]

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-trends.json
@@ -1,0 +1,1379 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "breakdownFilter": {
+            "description": "Breakdowns are used to segment data by property values of maximum three properties. They divide all defined trends series to multiple subseries based on the values of the property. Include breakdowns **only when they are essential to directly answer the user’s question**. You must not add breakdowns if the question can be addressed without additional segmentation. Always use the minimum set of breakdowns needed to answer the question. When using breakdowns, you must:\n- **Identify the property group** and name for each breakdown.\n- **Provide the property name** for each breakdown.\n- **Validate that the property value accurately reflects the intended criteria**. Examples of using breakdowns:\n- page views trend by country: you need to find a property such as `$geoip_country_code` and set it as a breakdown.\n- number of users who have completed onboarding by an organization: you need to find a property such as `organization name` and set it as a breakdown.",
+            "properties": {
+                "breakdown_limit": {
+                    "default": 25,
+                    "description": "How many distinct values to show.",
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                },
+                "breakdowns": {
+                    "description": "Use this field to define breakdowns.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "anyOf": [
+                                            {
+                                                "maximum": 9007199254740991,
+                                                "minimum": -9007199254740991,
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Index of the group type from the group mapping."
+                                    },
+                                    "property": {
+                                        "description": "Property name from the plan to break down by.",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["property", "type"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "property": {
+                                        "description": "Property name from the plan to break down by.",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": [
+                                            "cohort",
+                                            "person",
+                                            "event",
+                                            "event_metadata",
+                                            "session",
+                                            "hogql",
+                                            "revenue_analytics"
+                                        ],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["property", "type"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["breakdowns"],
+            "type": "object"
+        },
+        "compareFilter": {
+            "description": "Compare to date range",
+            "properties": {
+                "compare": {
+                    "default": false,
+                    "description": "Whether to compare the current date range to a previous date range.",
+                    "type": "boolean"
+                },
+                "compare_to": {
+                    "description": "The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "dateRange": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "ISO8601 date string.",
+                            "type": "string"
+                        },
+                        "date_to": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "ISO8601 date string."
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "date_from": {
+                            "description": "Duration in the past. Supported units are: `h` (hour), `d` (day), `w` (week), `m` (month), `y` (year), `all` (all time). Use the `Start` suffix to define the exact left date boundary. Examples: `-1d` last day from now, `-180d` last 180 days from now, `mStart` this month start, `-1dStart` yesterday's start.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["date_from"],
+                    "type": "object"
+                }
+            ],
+            "description": "Date range for the query"
+        },
+        "filterTestAccounts": {
+            "default": false,
+            "description": "Exclude internal and test users by applying the respective filters",
+            "type": "boolean"
+        },
+        "interval": {
+            "default": "day",
+            "description": "Granularity of the response. Can be one of `hour`, `day`, `week` or `month`",
+            "enum": ["second", "minute", "hour", "day", "week", "month"],
+            "type": "string"
+        },
+        "properties": {
+            "default": [],
+            "description": "Property filters for all series",
+            "items": {
+                "anyOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                        "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["exact", "gt", "lt"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                        "enum": ["exact", "is_not"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value must be a date in ISO 8601 format.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                        "enum": ["is_set", "is_not_set"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["event", "person", "session", "feature"],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["key", "operator", "type"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                        "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["exact", "gt", "lt"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                        "enum": ["exact", "is_not"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value must be a date in ISO 8601 format.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_type_index": {
+                                        "description": "Index of the group type from the group mapping.",
+                                        "maximum": 9007199254740991,
+                                        "minimum": -9007199254740991,
+                                        "type": "integer"
+                                    },
+                                    "key": {
+                                        "description": "Use one of the properties the user has provided in the plan.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                        "enum": ["is_set", "is_not_set"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "const": "group",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["group_type_index", "key", "operator", "type"],
+                                "type": "object"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "type": "array"
+        },
+        "series": {
+            "description": "Events or actions to include. Prioritize the more popular and fresh events and actions.",
+            "items": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "custom_name": {
+                                "type": "string"
+                            },
+                            "event": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "description": "The event or `null` for all events."
+                            },
+                            "kind": {
+                                "const": "EventsNode",
+                                "type": "string"
+                            },
+                            "math": {
+                                "anyOf": [
+                                    {
+                                        "enum": [
+                                            "total",
+                                            "dau",
+                                            "weekly_active",
+                                            "monthly_active",
+                                            "unique_session",
+                                            "first_time_for_user",
+                                            "first_matching_event_for_user"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": ["total", "first_time_for_user", "first_time_for_user_with_filters"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": ["avg", "sum", "min", "max", "median", "p75", "p90", "p95", "p99"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": [
+                                            "avg_count_per_actor",
+                                            "min_count_per_actor",
+                                            "max_count_per_actor",
+                                            "median_count_per_actor",
+                                            "p75_count_per_actor",
+                                            "p90_count_per_actor",
+                                            "p95_count_per_actor",
+                                            "p99_count_per_actor"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "unique_group",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "hogql",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": [
+                                            "total",
+                                            "sum",
+                                            "unique_session",
+                                            "min",
+                                            "max",
+                                            "avg",
+                                            "dau",
+                                            "unique_group",
+                                            "hogql"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": ["total", "dau"],
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "math_group_type_index": {
+                                "anyOf": [
+                                    {
+                                        "const": 0,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 1,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 2,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 3,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 4,
+                                        "type": "number"
+                                    }
+                                ]
+                            },
+                            "math_multiplier": {
+                                "type": "number"
+                            },
+                            "math_property": {
+                                "type": "string"
+                            },
+                            "math_property_type": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "optionalInFunnel": {
+                                "type": "boolean"
+                            },
+                            "properties": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            "version": {
+                                "description": "version of the node, used for schema migrations",
+                                "type": "number"
+                            }
+                        },
+                        "required": ["kind"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "custom_name": {
+                                "type": "string"
+                            },
+                            "id": {
+                                "maximum": 9007199254740991,
+                                "minimum": -9007199254740991,
+                                "type": "integer"
+                            },
+                            "kind": {
+                                "const": "ActionsNode",
+                                "type": "string"
+                            },
+                            "math": {
+                                "anyOf": [
+                                    {
+                                        "enum": [
+                                            "total",
+                                            "dau",
+                                            "weekly_active",
+                                            "monthly_active",
+                                            "unique_session",
+                                            "first_time_for_user",
+                                            "first_matching_event_for_user"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": ["total", "first_time_for_user", "first_time_for_user_with_filters"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": ["avg", "sum", "min", "max", "median", "p75", "p90", "p95", "p99"],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": [
+                                            "avg_count_per_actor",
+                                            "min_count_per_actor",
+                                            "max_count_per_actor",
+                                            "median_count_per_actor",
+                                            "p75_count_per_actor",
+                                            "p90_count_per_actor",
+                                            "p95_count_per_actor",
+                                            "p99_count_per_actor"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "unique_group",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "hogql",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": [
+                                            "total",
+                                            "sum",
+                                            "unique_session",
+                                            "min",
+                                            "max",
+                                            "avg",
+                                            "dau",
+                                            "unique_group",
+                                            "hogql"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    {
+                                        "enum": ["total", "dau"],
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "math_group_type_index": {
+                                "anyOf": [
+                                    {
+                                        "const": 0,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 1,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 2,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 3,
+                                        "type": "number"
+                                    },
+                                    {
+                                        "const": 4,
+                                        "type": "number"
+                                    }
+                                ]
+                            },
+                            "math_multiplier": {
+                                "type": "number"
+                            },
+                            "math_property": {
+                                "type": "string"
+                            },
+                            "math_property_type": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "Action name from the plan.",
+                                "type": "string"
+                            },
+                            "optionalInFunnel": {
+                                "type": "boolean"
+                            },
+                            "properties": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type", "value"],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "enum": ["event", "person", "session", "feature"],
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "anyOf": [
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern.",
+                                                            "enum": [
+                                                                "exact",
+                                                                "is_not",
+                                                                "icontains",
+                                                                "not_icontains",
+                                                                "regex",
+                                                                "not_regex"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value. Use the string values `true` or `false` for boolean properties.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": ["exact", "gt", "lt"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values.",
+                                                            "enum": ["exact", "is_not"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "enum": [
+                                                                "is_date_exact",
+                                                                "is_date_before",
+                                                                "is_date_after"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Value must be a date in ISO 8601 format.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "group_type_index",
+                                                        "key",
+                                                        "operator",
+                                                        "type",
+                                                        "value"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "group_type_index": {
+                                                            "description": "Index of the group type from the group mapping.",
+                                                            "maximum": 9007199254740991,
+                                                            "minimum": -9007199254740991,
+                                                            "type": "integer"
+                                                        },
+                                                        "key": {
+                                                            "description": "Use one of the properties the user has provided in the plan.",
+                                                            "type": "string"
+                                                        },
+                                                        "operator": {
+                                                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected.",
+                                                            "enum": ["is_set", "is_not_set"],
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "const": "group",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["group_type_index", "key", "operator", "type"],
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            "version": {
+                                "description": "version of the node, used for schema migrations",
+                                "type": "number"
+                            }
+                        },
+                        "required": ["id", "kind", "name"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "type": "array"
+        },
+        "trendsFilter": {
+            "description": "Properties specific to the trends insight",
+            "properties": {
+                "aggregationAxisFormat": {
+                    "default": "numeric",
+                    "description": "Formats the trends value axis. Do not use the formatting unless you are absolutely sure that formatting will match the data. `numeric` - no formatting. Prefer this option by default. `duration` - formats the value in seconds to a human-readable duration, e.g., `132` becomes `2 minutes 12 seconds`. Use this option only if you are sure that the values are in seconds. `duration_ms` - formats the value in miliseconds to a human-readable duration, e.g., `1050` becomes `1 second 50 milliseconds`. Use this option only if you are sure that the values are in miliseconds. `percentage` - adds a percentage sign to the value, e.g., `50` becomes `50%`. `percentage_scaled` - formats the value as a percentage scaled to 0-100, e.g., `0.5` becomes `50%`. `currency` - formats the value as a currency, e.g., `1000` becomes `$1,000`.",
+                    "enum": [
+                        "numeric",
+                        "duration",
+                        "duration_ms",
+                        "percentage",
+                        "percentage_scaled",
+                        "currency",
+                        "short"
+                    ],
+                    "type": "string"
+                },
+                "aggregationAxisPostfix": {
+                    "description": "Custom postfix to add to the aggregation axis, e.g., ` clicks` to format 5 as `5 clicks`. You may need to add a space before postfix.",
+                    "type": "string"
+                },
+                "aggregationAxisPrefix": {
+                    "description": "Custom prefix to add to the aggregation axis, e.g., `$` for USD dollars. You may need to add a space after prefix.",
+                    "type": "string"
+                },
+                "decimalPlaces": {
+                    "description": "Number of decimal places to show. Do not add this unless you are sure that values will have a decimal point.",
+                    "type": "number"
+                },
+                "display": {
+                    "default": "ActionsLineGraph",
+                    "description": "Visualization type. Available values: `ActionsLineGraph` - time-series line chart; most common option, as it shows change over time. `ActionsBar` - time-series bar chart. `ActionsAreaGraph` - time-series area chart. `ActionsLineGraphCumulative` - cumulative time-series line chart; good for cumulative metrics. `BoldNumber` - total value single large number. Use when user explicitly asks for a single output number. You CANNOT use this with breakdown or if the insight has more than one series. `ActionsBarValue` - total value (NOT time-series) bar chart; good for categorical data. `ActionsPie` - total value pie chart; good for visualizing proportions. `ActionsTable` - total value table; good when using breakdown to list users or other entities. `WorldMap` - total value world map; use when breaking down by country name using property `$geoip_country_name`, and only then.",
+                    "enum": [
+                        "Auto",
+                        "ActionsLineGraph",
+                        "ActionsBar",
+                        "ActionsUnstackedBar",
+                        "ActionsAreaGraph",
+                        "ActionsLineGraphCumulative",
+                        "BoldNumber",
+                        "ActionsPie",
+                        "ActionsBarValue",
+                        "ActionsTable",
+                        "WorldMap",
+                        "CalendarHeatmap",
+                        "TwoDimensionalHeatmap",
+                        "BoxPlot"
+                    ],
+                    "type": "string"
+                },
+                "formulas": {
+                    "description": "If the math aggregation is more complex or not listed above, use custom formulas to perform mathematical operations like calculating percentages or metrics. If you use a formula, you must use the following syntax: `A/B`, where `A` and `B` are the names of the series. You can combine math aggregations and formulas. When using a formula, you must:\n- Identify and specify **all** events and actions needed to solve the formula.\n- Carefully review the list of available events and actions to find appropriate entities for each part of the formula.\n- Ensure that you find events and actions corresponding to both the numerator and denominator in ratio calculations. Examples of using math formulas:\n- If you want to calculate the percentage of users who have completed onboarding, you need to find and use events or actions similar to `$identify` and `onboarding complete`, so the formula will be `A / B`, where `A` is `onboarding complete` (unique users) and `B` is `$identify` (unique users).",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "showLegend": {
+                    "default": false,
+                    "description": "Whether to show the legend describing series and breakdowns.",
+                    "type": "boolean"
+                },
+                "showPercentStackView": {
+                    "default": false,
+                    "description": "Whether to show a percentage of each series. Use only with",
+                    "type": "boolean"
+                },
+                "showValuesOnSeries": {
+                    "default": false,
+                    "description": "Whether to show a value on each data point.",
+                    "type": "boolean"
+                },
+                "yAxisScaleType": {
+                    "default": "linear",
+                    "description": "Whether to scale the y-axis.",
+                    "enum": ["log10", "linear"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": ["series"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Adds a new code generation pathway that creates typed MCP tool wrappers for the /query endpoint. Each wrapper targets a single query schema definition from frontend/src/queries/schema.json and POSTs to /api/environments/{project_id}/query/.


## Changes

New components:
- YAML config (definitions/query-wrappers.yaml) to declare which schema definitions to expose as tools (configurable, easy to add more)
- JSON Schema → Zod converter (scripts/lib/json-schema-to-zod.ts) that resolves $ref chains and generates static TypeScript Zod schemas
- Extended generate-tools.ts to detect query wrapper YAML configs and generate deduplicated tool handler files

Initial query wrappers:
- query-trends (AssistantTrendsQuery) — trends analysis
- query-funnel (AssistantFunnelsQuery) — funnel conversion analysis
- query-retention
- query-traces-list (TracesQuery) — LLM trace inspection

All three are version-gated to MCP v2 (new_mcp: true), so v1 clients continue using the existing generic query-run tool.

## How did you test this code?

Integration tests

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
