### PR TITLE
feat(llma): rich empty state experiment for LLM analytics

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -264,6 +264,7 @@ export const FEATURE_FLAGS = {
     DATA_WAREHOUSE_SCENE: 'data-warehouse-scene', // owner: #team-data-modeling
     DEFAULT_EVALUATION_ENVIRONMENTS: 'default-evaluation-environments', // owner: @dmarticus #team-feature-flags
     DROP_PERSON_LIST_ORDER_BY: 'drop-person-list-order-by', // owner: @arthurdedeus #team-customer-analytics
+    LLMA_RICH_EMPTY_STATE: 'llma-rich-empty-state', // owner: #team-growth multivariate=control,test
     LLM_ANALYTICS_TRACE_REVIEW: 'llma-trace-review', // owner: #team-llm-analytics
     DWH_FREE_SYNCS: 'dwh-free-syncs', // owner: @Gilbert09  #team-warehouse-sources
     DWH_POSTGRES_DIRECT_QUERY: 'dwh-postgres-direct-query', // owner: #team-data-tools

--- a/products/llm_analytics/frontend/LLMAnalyticsEmptyStatePage.stories.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsEmptyStatePage.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryFn } from '@storybook/react'
+
+import { LLMAnalyticsEmptyStatePage } from './LLMAnalyticsEmptyStatePage'
+
+const meta: Meta = {
+    title: 'Scenes-App/LLM Analytics/Empty state',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+    },
+}
+
+export default meta
+
+const Template: StoryFn = () => {
+    return (
+        <div className="p-6">
+            <LLMAnalyticsEmptyStatePage />
+        </div>
+    )
+}
+
+export const Default: StoryFn = Template.bind({})
+
+export const WithVideo: StoryFn = () => {
+    return (
+        <div className="p-6">
+            <LLMAnalyticsEmptyStatePage
+                video={{
+                    // Placeholder asset for storybook; experiment can set the real LLMA demo via flag payload.
+                    videoUrl: 'https://res.cloudinary.com/dmukukwp6/video/upload/surveys_overview_2cfc290333.mp4',
+                    posterUrl: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_522e544094.png',
+                }}
+            />
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/LLMAnalyticsEmptyStatePage.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsEmptyStatePage.tsx
@@ -1,0 +1,100 @@
+import { IconLlmAnalytics } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { cn } from 'lib/utils/css-classes'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { OnboardingStepKey } from '~/types'
+
+export type LLMAnalyticsEmptyStateVideoPayload = {
+    videoUrl?: string
+    posterUrl?: string
+}
+
+export interface LLMAnalyticsEmptyStatePageProps {
+    className?: string
+    video?: LLMAnalyticsEmptyStateVideoPayload
+}
+
+export function LLMAnalyticsEmptyStatePage({ className, video }: LLMAnalyticsEmptyStatePageProps): JSX.Element {
+    return (
+        <div className={cn('flex flex-col items-center justify-center max-w-4xl mx-auto py-12 px-6', className)}>
+            <div className="flex items-center gap-2 mb-6">
+                <IconLlmAnalytics className="w-8 h-8 text-[var(--color-product-llm-analytics-light)]" />
+                <h1 className="text-2xl font-bold">LLM analytics</h1>
+            </div>
+
+            <p className="text-center text-lg text-muted mb-2 max-w-2xl">
+                Monitor your AI and LLM application performance (observability, not AI-powered analytics).
+            </p>
+            <p className="text-center text-sm text-muted mb-8 max-w-2xl">
+                Track costs per model, measure latency and error rates, evaluate output quality, debug traces, and
+                understand how users interact with your AI features.
+            </p>
+
+            <div className="w-full max-w-3xl rounded-lg overflow-hidden border border-border bg-bg-light mb-8 shadow-sm">
+                {video?.videoUrl ? (
+                    <video
+                        src={video.videoUrl}
+                        controls
+                        autoPlay
+                        muted
+                        loop
+                        playsInline
+                        preload="metadata"
+                        poster={video.posterUrl}
+                        className="w-full aspect-video"
+                    />
+                ) : (
+                    <div className="w-full aspect-video flex flex-col items-center justify-center gap-2 p-8">
+                        <p className="text-sm text-muted m-0">Demo video loads when enabled for this experiment.</p>
+                        <p className="text-xs text-muted-alt m-0">
+                            (Set a feature flag payload with a `videoUrl` to show the tour.)
+                        </p>
+                    </div>
+                )}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 w-full max-w-3xl mb-8">
+                <div className="border border-border rounded-lg bg-bg-light p-4">
+                    <div className="font-semibold mb-1">Costs and usage</div>
+                    <div className="text-sm text-muted">See spend by model, provider, and prompt.</div>
+                </div>
+                <div className="border border-border rounded-lg bg-bg-light p-4">
+                    <div className="font-semibold mb-1">Latency and reliability</div>
+                    <div className="text-sm text-muted">Track performance over time and catch errors fast.</div>
+                </div>
+                <div className="border border-border rounded-lg bg-bg-light p-4">
+                    <div className="font-semibold mb-1">Quality and evaluations</div>
+                    <div className="text-sm text-muted">Measure output quality and compare prompt changes.</div>
+                </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-6">
+                <LemonButton
+                    type="primary"
+                    size="large"
+                    to={urls.onboarding({
+                        productKey: ProductKey.LLM_ANALYTICS,
+                        stepKey: OnboardingStepKey.INSTALL,
+                    })}
+                    data-attr="llma-empty-state-setup-cta"
+                >
+                    Set up LLM analytics
+                </LemonButton>
+                <LemonButton
+                    type="secondary"
+                    size="large"
+                    to="https://posthog.com/docs/llm-analytics"
+                    targetBlank
+                    data-attr="llma-empty-state-docs-cta"
+                >
+                    Read the docs
+                </LemonButton>
+            </div>
+
+            <p className="text-xs text-muted">Used by 55K+ teams</p>
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/LLMAnalyticsEmptyStatePage.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsEmptyStatePage.tsx
@@ -1,4 +1,4 @@
-import { IconLlmAnalytics } from '@posthog/icons'
+import { IconBolt, IconLlmAnalytics, IconReceipt, IconTarget } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { cn } from 'lib/utils/css-classes'
@@ -20,17 +20,13 @@ export interface LLMAnalyticsEmptyStatePageProps {
 export function LLMAnalyticsEmptyStatePage({ className, video }: LLMAnalyticsEmptyStatePageProps): JSX.Element {
     return (
         <div className={cn('flex flex-col items-center justify-center max-w-4xl mx-auto py-12 px-6', className)}>
-            <div className="flex items-center gap-2 mb-6">
-                <IconLlmAnalytics className="w-8 h-8 text-[var(--color-product-llm-analytics-light)]" />
-                <h1 className="text-2xl font-bold">LLM analytics</h1>
+            <div className="flex items-center gap-3 mb-6">
+                <IconLlmAnalytics className="w-8 h-8 shrink-0 text-[var(--color-product-llm-analytics-light)]" />
+                <h1 className="text-2xl font-bold m-0">LLM analytics</h1>
             </div>
 
-            <p className="text-center text-lg text-muted mb-2 max-w-2xl">
-                Monitor your AI and LLM application performance (observability, not AI-powered analytics).
-            </p>
-            <p className="text-center text-sm text-muted mb-8 max-w-2xl">
-                Track costs per model, measure latency and error rates, evaluate output quality, debug traces, and
-                understand how users interact with your AI features.
+            <p className="text-center text-muted mb-8 max-w-xl">
+                Understand costs, latency, and output quality across every model call your app makes.
             </p>
 
             <div className="w-full max-w-3xl rounded-lg overflow-hidden border border-border bg-bg-light mb-8 shadow-sm">
@@ -57,16 +53,25 @@ export function LLMAnalyticsEmptyStatePage({ className, video }: LLMAnalyticsEmp
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3 w-full max-w-3xl mb-8">
-                <div className="border border-border rounded-lg bg-bg-light p-4">
-                    <div className="font-semibold mb-1">Costs and usage</div>
+                <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 font-semibold mb-1">
+                        <IconReceipt className="w-5 h-5 text-muted" />
+                        Costs and usage
+                    </div>
                     <div className="text-sm text-muted">See spend by model, provider, and prompt.</div>
                 </div>
-                <div className="border border-border rounded-lg bg-bg-light p-4">
-                    <div className="font-semibold mb-1">Latency and reliability</div>
+                <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 font-semibold mb-1">
+                        <IconBolt className="w-5 h-5 text-muted" />
+                        Latency and reliability
+                    </div>
                     <div className="text-sm text-muted">Track performance over time and catch errors fast.</div>
                 </div>
-                <div className="border border-border rounded-lg bg-bg-light p-4">
-                    <div className="font-semibold mb-1">Quality and evaluations</div>
+                <div className="border border-border rounded-lg p-4">
+                    <div className="flex items-center gap-2 font-semibold mb-1">
+                        <IconTarget className="w-5 h-5 text-muted" />
+                        Quality and evaluations
+                    </div>
                     <div className="text-sm text-muted">Measure output quality and compare prompt changes.</div>
                 </div>
             </div>

--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -1,5 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
+import { useFeatureFlagPayload, useFeatureFlagVariantKey } from 'posthog-js/react'
 import React, { useMemo } from 'react'
 
 import { LemonBanner, LemonButton, LemonTab, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
@@ -38,6 +39,7 @@ import { AccessControlLevel, AccessControlResourceType, DashboardPlacement, Even
 
 import { useSortableColumns } from './hooks/useSortableColumns'
 import { llmAnalyticsColumnRenderers } from './llmAnalyticsColumnRenderers'
+import { LLMAnalyticsEmptyStatePage, type LLMAnalyticsEmptyStateVideoPayload } from './LLMAnalyticsEmptyStatePage'
 import { LLMAnalyticsErrors } from './LLMAnalyticsErrors'
 import { LLMAnalyticsReloadAction } from './LLMAnalyticsReloadAction'
 import { LLMAnalyticsSessionsScene } from './LLMAnalyticsSessionsScene'
@@ -436,10 +438,15 @@ export function LLMAnalyticsScene({ tabId }: { tabId?: string }): JSX.Element {
 }
 
 function LLMAnalyticsSceneContent(): JSX.Element {
-    const { activeTab } = useValues(llmAnalyticsSharedLogic)
+    const { activeTab, hasSentAiEvent, hasSentAiEventLoading } = useValues(llmAnalyticsSharedLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { searchParams } = useValues(router)
     const isTraceReviewEnabled = !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_TRACE_REVIEW]
+
+    const richEmptyStateVariant = useFeatureFlagVariantKey(FEATURE_FLAGS.LLMA_RICH_EMPTY_STATE)
+    const richEmptyStatePayload = useFeatureFlagPayload(
+        FEATURE_FLAGS.LLMA_RICH_EMPTY_STATE
+    ) as LLMAnalyticsEmptyStateVideoPayload
 
     const { push } = useActions(router)
     const { toggleProduct, openModal: openEditCustomProductsModal } = useActions(editCustomProductsModalLogic)
@@ -661,8 +668,28 @@ function LLMAnalyticsSceneContent(): JSX.Element {
         ].filter(Boolean) as JSX.Element[]
     }, [featureFlags, isPromptManagementEnabled, searchParams, toggleProduct])
 
+    const showRichEmptyState = !hasSentAiEventLoading && !hasSentAiEvent && richEmptyStateVariant === 'test'
+
     if (activeTab === 'reviews' && !isTraceReviewEnabled) {
         return <NotFound object="page" />
+    }
+
+    if (hasSentAiEventLoading) {
+        return (
+            <SceneContent>
+                <div className="flex justify-center py-12">
+                    <Spinner />
+                </div>
+            </SceneContent>
+        )
+    }
+
+    if (showRichEmptyState) {
+        return (
+            <SceneContent>
+                <LLMAnalyticsEmptyStatePage video={richEmptyStatePayload} />
+            </SceneContent>
+        )
     }
 
     return (

--- a/products/llm_analytics/frontend/LLMAnalyticsSetupPrompt.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsSetupPrompt.tsx
@@ -1,11 +1,14 @@
 import { useValues } from 'kea'
+import { useFeatureFlagPayload, useFeatureFlagVariantKey } from 'posthog-js/react'
 
 import { Spinner } from '@posthog/lemon-ui'
 
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { LLMAnalyticsEmptyStatePage, type LLMAnalyticsEmptyStateVideoPayload } from './LLMAnalyticsEmptyStatePage'
 import { llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
 
 type Thing = 'generation' | 'trace'
@@ -33,6 +36,13 @@ export function LLMAnalyticsSetupPrompt({
 }
 
 function IngestionStatusCheck({ className, thing }: { className?: string; thing: Thing }): JSX.Element {
+    const variant = useFeatureFlagVariantKey(FEATURE_FLAGS.LLMA_RICH_EMPTY_STATE)
+    const payload = useFeatureFlagPayload(FEATURE_FLAGS.LLMA_RICH_EMPTY_STATE) as LLMAnalyticsEmptyStateVideoPayload
+
+    if (variant === 'test') {
+        return <LLMAnalyticsEmptyStatePage className={className} video={payload} />
+    }
+
     return (
         <ProductIntroduction
             productName="LLM analytics"


### PR DESCRIPTION
## Problem

LLM analytics currently shows a minimal “not configured” empty state when no `$ai_*` events are detected, which doesn’t communicate value or clarify the product’s scope.

## Changes

- Add `LLMAnalyticsEmptyStatePage` (rich landing/empty state with value prop, demo slot, and CTAs).
- Gate it behind `FEATURE_FLAGS.LLMA_RICH_EMPTY_STATE` (`llma-rich-empty-state`, multivariate `control,test`).
- Update `LLMAnalyticsSetupPrompt` to render rich variant when flag variant is `test`, otherwise keep the existing `ProductIntroduction` control.
- Add Storybook stories for the empty state (for quick UI review).

<img width="1920" height="993" alt="Screenshot 2026-03-24 at 15 23 48" src="https://github.com/user-attachments/assets/10a7a774-54d4-462b-afb9-80d9fe2816c0" />

## Experiment

The experiment will only run (thus making this screen live) when the demo video is available. 

## How did you test this code?

- Ran `kea-typegen write` and then `tsc --noEmit` (with increased heap) locally in this cloud environment.
- Built `@posthog/hogvm` to satisfy frontend typechecking.
- Manual UI verification: pending (environment can’t run `bin/start` via `mprocs` in this non-interactive runner, so Storybook is used for visual verification).

## Publish to changelog?

no

## Docs update

do not publish to changelog
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POS-28](https://linear.app/posthog-team-growth/issue/POS-28/llma-rich-empty-state-with-demo-video-and-value-prop-pilot-for-product)

<div><a href="https://cursor.com/agents/bc-5dce19d5-a446-49d5-b3d8-9f98569e16e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dce19d5-a446-49d5-b3d8-9f98569e16e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

