### PR TITLE
feat: Expand OAuth COOP middleware to support additional OAuth flows

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -676,26 +676,33 @@ class Fix204Middleware:
         return response
 
 
-class ToolbarOAuthCoopMiddleware:
+class OAuthCoopMiddleware:
     """
-    Override Cross-Origin-Opener-Policy for popup pages that need cross-origin communication.
+    Override Cross-Origin-Opener-Policy for OAuth pages that need cross-origin communication.
 
     Django's SecurityMiddleware sets COOP to "same-origin" by default. This severs
     window.opener when a cross-origin popup navigates to our pages — breaking
-    Vercel's popup monitoring.
+    popup-based OAuth flows that rely on the opener reference to detect completion.
 
-    We set COOP to "unsafe-none" on the specific paths involved in popup flows
-    so the opener reference is preserved.
+    We set COOP to "unsafe-none" on all OAuth-related paths so the opener
+    reference is preserved.
     """
+
+    OAUTH_PATH_PREFIXES = (
+        "/toolbar_oauth/",
+        "/oauth/",
+        "/connect/vercel/",
+        "/login/vercel/",
+        "/api/agentic/authorize",
+        "/api/agentic/oauth/",
+    )
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
-        is_toolbar_flow = request.path.startswith("/toolbar_oauth/")
-        is_vercel_connect = request.path.startswith("/connect/vercel/")
-        if is_toolbar_flow or is_vercel_connect:
+        if any(request.path.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
             response["Cross-Origin-Opener-Policy"] = "unsafe-none"
         return response
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -104,7 +104,7 @@ MIDDLEWARE = [
     "django_structlog.middlewares.RequestMiddleware",
     "posthog.middleware.Fix204Middleware",
     "django.middleware.security.SecurityMiddleware",
-    "posthog.middleware.ToolbarOAuthCoopMiddleware",
+    "posthog.middleware.OAuthCoopMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
     # using dependencies that the healthcheck should be checking. It should be
     # ok below the above middlewares however.


### PR DESCRIPTION
## Problem

OAuth popup flows were failing because Django's SecurityMiddleware sets Cross-Origin-Opener-Policy to "same-origin" by default, which breaks the `window.opener` reference that popup-based authentication flows rely on to communicate completion status back to the parent window.

## Changes

- Renamed `ToolbarOAuthCoopMiddleware` to `OAuthCoopMiddleware` to reflect its broader scope
- Expanded the middleware to handle all OAuth-related paths instead of just toolbar and Vercel flows
- Added support for additional OAuth endpoints: `/oauth/`, `/login/vercel/`, `/api/agentic/authorize`, and `/api/agentic/oauth/`
- Refactored path checking logic to use a centralized list of OAuth path prefixes for better maintainability

## How did you test this code?

As an agent, I have not manually tested this code. The changes maintain the existing middleware pattern and expand coverage to additional OAuth endpoints. Manual testing should verify that popup-based OAuth flows work correctly on all the specified paths and that the Cross-Origin-Opener-Policy header is properly set to "unsafe-none" for these endpoints.

## Publish to changelog?

No

## Docs update

No documentation update needed for this internal middleware change.