### PR TITLE
feat(insights): add Y-axis label to Time to Convert histogram

### DIFF
--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -13,7 +13,7 @@ import { funnelDataLogic } from './funnelDataLogic'
 
 export function FunnelHistogram(): JSX.Element | null {
     const { insightProps, isInDashboardContext } = useValues(insightLogic)
-    const { histogramGraphData } = useValues(funnelDataLogic(insightProps))
+    const { histogramGraphData, aggregationTargetLabel } = useValues(funnelDataLogic(insightProps))
 
     const ref = useRef(null)
     const [width, height] = useSize(ref)
@@ -43,6 +43,7 @@ export function FunnelHistogram(): JSX.Element | null {
                 isDashboardItem={isInDashboardContext}
                 height={height}
                 formatXTickLabel={(v) => humanFriendlyDuration(v, { maxUnits: 2 })}
+                yAxisLabel={aggregationTargetLabel.plural ? `Number of ${aggregationTargetLabel.plural}` : undefined}
             />
         </div>
     )

--- a/frontend/src/scenes/insights/views/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/views/Histogram/Histogram.tsx
@@ -32,6 +32,7 @@ interface HistogramProps {
     height?: number
     formatXTickLabel?: (value: number) => number | string
     formatYTickLabel?: (value: number) => number
+    yAxisLabel?: string
 }
 
 export function Histogram({
@@ -43,6 +44,7 @@ export function Histogram({
     isDashboardItem = false,
     formatXTickLabel = (value: number) => value,
     formatYTickLabel = (value: number) => value,
+    yAxisLabel,
 }: HistogramProps): JSX.Element {
     const { config } = useValues(histogramLogic)
     const { setConfig } = useActions(histogramLogic)
@@ -168,6 +170,19 @@ export function Histogram({
                                     g.selectAll('.tick text').attr('dx', isVertical ? `-${config.spacing.yLabel}` : 0)
                                 )
                     )
+
+                    // y-axis label
+                    if (yAxisLabel) {
+                        const _yAxisLabel = getOrCreateEl(_svg, 'text#y-axis-label', () =>
+                            _svg.append('svg:text').attr('id', 'y-axis-label').classed('y-axis-label', true)
+                        )
+                        _yAxisLabel
+                            .text(yAxisLabel)
+                            .attr('text-anchor', 'middle')
+                            .attr('transform', `translate(12, ${config.height / 2}) rotate(-90)`)
+                            .attr('font-size', '12px')
+                            .attr('fill', 'var(--text-secondary, #666)')
+                    }
 
                     // y-gridlines
                     const _yGridlines = getOrCreateEl(_svg, 'g#y-gridlines', () =>

--- a/frontend/src/scenes/insights/views/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/views/Histogram/Histogram.tsx
@@ -172,16 +172,19 @@ export function Histogram({
                     )
 
                     // y-axis label
+                    const _yAxisLabel = getOrCreateEl(_svg, 'text#y-axis-label', () =>
+                        _svg.append('svg:text').attr('id', 'y-axis-label').classed('y-axis-label', true)
+                    )
                     if (yAxisLabel) {
-                        const _yAxisLabel = getOrCreateEl(_svg, 'text#y-axis-label', () =>
-                            _svg.append('svg:text').attr('id', 'y-axis-label').classed('y-axis-label', true)
-                        )
+                        const plotMidY = (config.margin.top + (config.height - config.margin.bottom)) / 2
                         _yAxisLabel
                             .text(yAxisLabel)
                             .attr('text-anchor', 'middle')
-                            .attr('transform', `translate(12, ${config.height / 2}) rotate(-90)`)
+                            .attr('transform', `translate(${config.margin.left / 3}, ${plotMidY}) rotate(-90)`)
                             .attr('font-size', '12px')
                             .attr('fill', 'var(--text-secondary, #666)')
+                    } else {
+                        _yAxisLabel.text('')
                     }
 
                     // y-gridlines


### PR DESCRIPTION
## Problem

The Time to Convert histogram doesn't label its Y-axis, making it unclear what the bars represent. The Y-axis could show unique users, unique sessions, or other aggregation types depending on funnel configuration, but there's no way to tell at a glance.

Fixes #51505

## Changes

- Added an optional `yAxisLabel` prop to the `Histogram` component (`frontend/src/scenes/insights/views/Histogram/Histogram.tsx`). When provided, it renders a rotated text label to the left of the Y-axis using d3.
- Updated `FunnelHistogram` (`frontend/src/scenes/funnels/FunnelHistogram.tsx`) to pass the aggregation type from `funnelDataLogic.aggregationTargetLabel` as the Y-axis label (e.g., "Number of unique users").

The change is additive - `yAxisLabel` is optional and defaults to `undefined`, so other Histogram usages are unaffected.

## How did you test this code?

Verified formatting with `oxfmt --check`. The Y-axis label uses `aggregationTargetLabel.plural` from `funnelDataLogic`, which is already computed and used elsewhere in the funnel insights UI. The d3 rendering follows the existing pattern of `getOrCreateEl` for idempotent element creation.

## 🤖 LLM context

This PR was developed with AI assistance (Claude Code). The implementation uses the existing `aggregationTargetLabel` selector from `funnelDataLogic` (which handles custom aggregation targets, group types, and HogQL aggregation) to derive the label text, staying consistent with how PostHog labels aggregation types elsewhere.