### PR TITLE
fix(personhog): fixes db url in local dev

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -156,11 +156,11 @@ case "$RS_SVC" in
     ;;
 
   personhog-replica)
-    SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
+    SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-trace}
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL
     export RUST_BACKTRACE=1
     export GRPC_ADDRESS=127.0.0.1:50051
-    export PRIMARY_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export PRIMARY_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_persons
     export METRICS_PORT=9100
     ;;
 


### PR DESCRIPTION
## Problem

The local development db url for personhog-replica was pointing to the wrong database

## Changes

- changes the db url for personhog-replica to point at the persons db in local development
- ups the level of sqlx log config to trace, so that we see sql statements by default in local dev

## How did you test this code?

built this locally and the personhog-replica service started reading from the right db

