### PR TITLE
feat(alerts): enable simulate MCP tool and update descriptions for anomaly detection

### DIFF
--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -573,7 +573,7 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         responses={200: AlertSimulateResponseSerializer},
         description="Simulate a detector on an insight's historical data. Read-only — no AlertCheck records are created.",
     )
-    @action(detail=False, methods=["POST"], url_path="simulate")
+    @action(detail=False, methods=["POST"], url_path="simulate", required_scopes=["alert:read"])
     def simulate(self, request, *args, **kwargs):
         from posthog.tasks.alerts.trends import simulate_detector_on_insight
 

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -20,8 +20,10 @@ tools:
         list: true
         title: List alerts
         description: >
-            List all insight alerts in the project. Returns alerts with their current state, threshold configuration,
-            and timing information. Supports filtering by insight ID via query parameter.
+            List all insight alerts in the project. Returns alerts with their current state, threshold or detector
+            configuration, timing information, and firing check history. Supports filtering by insight ID via query
+            parameter. Alerts can use either threshold-based conditions (absolute_value, relative_increase,
+            relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).
         mcp_version: 1
     alert-get:
         operation: alerts_retrieve
@@ -35,7 +37,8 @@ tools:
         title: Get alert
         description: >
             Get a specific alert by ID. Returns the full alert configuration including the last 5 check results,
-            threshold settings, and subscribed users.
+            threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results
+            include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts.
         mcp_version: 1
     alert-create:
         operation: alerts_create
@@ -48,9 +51,12 @@ tools:
             idempotent: false
         title: Create alert
         description: >
-            Create a new alert on an insight. Alerts monitor insight values and notify subscribed users when thresholds
-            are breached. Requires an insight ID, at least one subscribed user, and a threshold configuration. The alert
-            condition determines how the value is evaluated (absolute_value, relative_increase, or relative_decrease).
+            Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection.
+            For threshold alerts: set condition (absolute_value, relative_increase, relative_decrease) and threshold
+            configuration with bounds. For anomaly detection: set detector_config with a detector type (zscore, mad,
+            iqr, threshold, copod, ecod, hbos, isolation_forest, knn, lof, ocsvm, pca) and parameters like threshold
+            (sensitivity 0-1, default 0.9) and window size. Ensemble detectors combine 2+ sub-detectors with AND/OR
+            logic. Requires an insight ID and at least one subscribed user.
         exclude_params:
             - state
             - last_notified_at
@@ -68,9 +74,10 @@ tools:
             idempotent: true
         title: Update alert
         description: >
-            Update an existing alert by ID. Can update name, threshold, condition, config, subscribed users, enabled
-            state, calculation interval, and weekend skipping. To snooze an alert, set snoozed_until to a relative date
-            string (e.g. '2h', '1d'). To unsnooze, set snoozed_until to null.
+            Update an existing alert by ID. Can update name, threshold, condition, config, detector_config, subscribed
+            users, enabled state, calculation interval, and weekend skipping. Set detector_config to switch to anomaly
+            detection, or set it to null to switch back to threshold mode. To snooze an alert, set snoozed_until to a
+            relative date string (e.g. '2h', '1d'). To unsnooze, set snoozed_until to null.
         exclude_params:
             - state
             - last_notified_at
@@ -93,6 +100,24 @@ tools:
         description: >
             Delete an alert by ID. This permanently removes the alert and all its check history. Subscribed users will
             no longer receive notifications.
+    alert-simulate:
+        operation: alerts_simulate_create
+        enabled: true
+        scopes:
+            - alert:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Simulate detector on insight
+        description: >
+            Run an anomaly detector on an insight's historical data without creating any alert or check records.
+            Use this to preview how a detector configuration would perform before saving it as an alert.
+            Requires an insight ID and a detector_config object with a type (zscore, mad, iqr, copod, ecod, hbos,
+            isolation_forest, knn, lof, ocsvm, pca, or ensemble). Optionally specify date_from (e.g. '-48h', '-30d')
+            to control how far back to simulate, and series_index to pick which series to analyze.
+            Returns data values, anomaly scores per point, triggered indices and dates, and for ensemble detectors,
+            per-sub-detector score breakdowns.
     logs-alerts-list:
         operation: logs_alerts_list
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -90,7 +90,7 @@
         }
     },
     "alerts-list": {
-        "description": "List all insight alerts in the project. Returns alerts with their current state, threshold configuration, and timing information. Supports filtering by insight ID via query parameter.",
+        "description": "List all insight alerts in the project. Returns alerts with their current state, threshold or detector configuration, timing information, and firing check history. Supports filtering by insight ID via query parameter. Alerts can use either threshold-based conditions (absolute_value, relative_increase, relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "List alerts",
@@ -105,7 +105,7 @@
         }
     },
     "alert-get": {
-        "description": "Get a specific alert by ID. Returns the full alert configuration including the last 5 check results, threshold settings, and subscribed users.",
+        "description": "Get a specific alert by ID. Returns the full alert configuration including the last 5 check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Get alert",
@@ -120,7 +120,7 @@
         }
     },
     "alert-create": {
-        "description": "Create a new alert on an insight. Alerts monitor insight values and notify subscribed users when thresholds are breached. Requires an insight ID, at least one subscribed user, and a threshold configuration. The alert condition determines how the value is evaluated (absolute_value, relative_increase, or relative_decrease).",
+        "description": "Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For threshold alerts: set condition (absolute_value, relative_increase, relative_decrease) and threshold configuration with bounds. For anomaly detection: set detector_config with a detector type (zscore, mad, iqr, threshold, copod, ecod, hbos, isolation_forest, knn, lof, ocsvm, pca) and parameters like threshold (sensitivity 0-1, default 0.9) and window size. Ensemble detectors combine 2+ sub-detectors with AND/OR logic. Requires an insight ID and at least one subscribed user.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Create alert",
@@ -135,7 +135,7 @@
         }
     },
     "alert-update": {
-        "description": "Update an existing alert by ID. Can update name, threshold, condition, config, subscribed users, enabled state, calculation interval, and weekend skipping. To snooze an alert, set snoozed_until to a relative date string (e.g. '2h', '1d'). To unsnooze, set snoozed_until to null.",
+        "description": "Update an existing alert by ID. Can update name, threshold, condition, config, detector_config, subscribed users, enabled state, calculation interval, and weekend skipping. Set detector_config to switch to anomaly detection, or set it to null to switch back to threshold mode. To snooze an alert, set snoozed_until to a relative date string (e.g. '2h', '1d'). To unsnooze, set snoozed_until to null.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Update alert",
@@ -162,6 +162,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "alert-simulate": {
+        "description": "Run an anomaly detector on an insight's historical data without creating any alert or check records. Use this to preview how a detector configuration would perform before saving it as an alert. Requires an insight ID and a detector_config object with a type (zscore, mad, iqr, copod, ecod, hbos, isolation_forest, knn, lof, ocsvm, pca, or ensemble). Optionally specify date_from (e.g. '-48h', '-30d') to control how far back to simulate, and series_index to pick which series to analyze. Returns data values, anomaly scores per point, triggered indices and dates, and for ensemble detectors, per-sub-detector score breakdowns.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Simulate detector on insight",
+        "title": "Simulate detector on insight",
+        "required_scopes": ["alert:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "annotations-list": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -824,7 +824,7 @@
         }
     },
     "alerts-list": {
-        "description": "List all insight alerts in the project. Returns alerts with their current state, threshold configuration, and timing information. Supports filtering by insight ID via query parameter.",
+        "description": "List all insight alerts in the project. Returns alerts with their current state, threshold or detector configuration, timing information, and firing check history. Supports filtering by insight ID via query parameter. Alerts can use either threshold-based conditions (absolute_value, relative_increase, relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "List alerts",
@@ -839,7 +839,7 @@
         }
     },
     "alert-get": {
-        "description": "Get a specific alert by ID. Returns the full alert configuration including the last 5 check results, threshold settings, and subscribed users.",
+        "description": "Get a specific alert by ID. Returns the full alert configuration including the last 5 check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Get alert",
@@ -854,7 +854,7 @@
         }
     },
     "alert-create": {
-        "description": "Create a new alert on an insight. Alerts monitor insight values and notify subscribed users when thresholds are breached. Requires an insight ID, at least one subscribed user, and a threshold configuration. The alert condition determines how the value is evaluated (absolute_value, relative_increase, or relative_decrease).",
+        "description": "Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For threshold alerts: set condition (absolute_value, relative_increase, relative_decrease) and threshold configuration with bounds. For anomaly detection: set detector_config with a detector type (zscore, mad, iqr, threshold, copod, ecod, hbos, isolation_forest, knn, lof, ocsvm, pca) and parameters like threshold (sensitivity 0-1, default 0.9) and window size. Ensemble detectors combine 2+ sub-detectors with AND/OR logic. Requires an insight ID and at least one subscribed user.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Create alert",
@@ -869,7 +869,7 @@
         }
     },
     "alert-update": {
-        "description": "Update an existing alert by ID. Can update name, threshold, condition, config, subscribed users, enabled state, calculation interval, and weekend skipping. To snooze an alert, set snoozed_until to a relative date string (e.g. '2h', '1d'). To unsnooze, set snoozed_until to null.",
+        "description": "Update an existing alert by ID. Can update name, threshold, condition, config, detector_config, subscribed users, enabled state, calculation interval, and weekend skipping. Set detector_config to switch to anomaly detection, or set it to null to switch back to threshold mode. To snooze an alert, set snoozed_until to a relative date string (e.g. '2h', '1d'). To unsnooze, set snoozed_until to null.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Update alert",
@@ -896,6 +896,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false
+        }
+    },
+    "alert-simulate": {
+        "description": "Run an anomaly detector on an insight's historical data without creating any alert or check records. Use this to preview how a detector configuration would perform before saving it as an alert. Requires an insight ID and a detector_config object with a type (zscore, mad, iqr, copod, ecod, hbos, isolation_forest, knn, lof, ocsvm, pca, or ensemble). Optionally specify date_from (e.g. '-48h', '-30d') to control how far back to simulate, and series_index to pick which series to analyze. Returns data values, anomaly scores per point, triggered indices and dates, and for ensemble detectors, per-sub-detector score breakdowns.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Simulate detector on insight",
+        "title": "Simulate detector on insight",
+        "required_scopes": ["alert:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
         }
     },
     "annotations-list": {

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 5 enabled ops
+ * PostHog API - MCP 6 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1694,5 +1694,779 @@ export const AlertsDestroyParams = /* @__PURE__ */ zod.object({
         .string()
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Simulate a detector on an insight's historical data. Read-only — no AlertCheck records are created.
+ */
+export const AlertsSimulateCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneTypeDefault = `zscore`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoTypeDefault = `mad`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeTypeDefault = `iqr`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourTypeDefault = `threshold`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault = `ecod`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault = `copod`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault = `isolation_forest`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault = `knn`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault = `hbos`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault = `lof`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault = `ocsvm`
+export const alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault = `pca`
+export const alertsSimulateCreateBodyDetectorConfigOneOneTypeDefault = `ensemble`
+export const alertsSimulateCreateBodyDetectorConfigOneTwoTypeDefault = `zscore`
+export const alertsSimulateCreateBodyDetectorConfigOneThreeTypeDefault = `mad`
+export const alertsSimulateCreateBodyDetectorConfigOneFourTypeDefault = `iqr`
+export const alertsSimulateCreateBodyDetectorConfigOneFiveTypeDefault = `threshold`
+export const alertsSimulateCreateBodyDetectorConfigOneSixTypeDefault = `ecod`
+export const alertsSimulateCreateBodyDetectorConfigOneSevenTypeDefault = `copod`
+export const alertsSimulateCreateBodyDetectorConfigOneEightTypeDefault = `isolation_forest`
+export const alertsSimulateCreateBodyDetectorConfigOneNineTypeDefault = `knn`
+export const alertsSimulateCreateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
+export const alertsSimulateCreateBodyDetectorConfigOneOneoneTypeDefault = `lof`
+export const alertsSimulateCreateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
+export const alertsSimulateCreateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
+export const alertsSimulateCreateBodySeriesIndexDefault = 0
+
+export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
+    insight: zod.number().describe('Insight ID to simulate the detector on.'),
+    detector_config: zod
+        .union([
+            zod.object({
+                detectors: zod
+                    .array(
+                        zod.union([
+                            zod.object({
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
+                                    ),
+                                type: zod
+                                    .enum(['zscore'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Rolling window size for calculating mean/std (default: 30)'),
+                            }),
+                            zod.object({
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
+                                    ),
+                                type: zod
+                                    .enum(['mad'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemTwoTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Rolling window size for calculating median/MAD (default: 30)'),
+                            }),
+                            zod.object({
+                                multiplier: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'
+                                    ),
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                type: zod
+                                    .enum(['iqr'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemThreeTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Rolling window size for calculating quartiles (default: 30)'),
+                            }),
+                            zod.object({
+                                lower_bound: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Lower bound - values below this are anomalies'),
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                type: zod
+                                    .enum(['threshold'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFourTypeDefault),
+                                upper_bound: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Upper bound - values above this are anomalies'),
+                            }),
+                            zod.object({
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['ecod'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault),
+                            }),
+                            zod.object({
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['copod'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault),
+                            }),
+                            zod.object({
+                                n_estimators: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Number of trees in the forest (default: 100)'),
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['isolation_forest'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault),
+                            }),
+                            zod.object({
+                                method: zod.enum(['largest', 'mean', 'median']).nullish(),
+                                n_neighbors: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Number of neighbors to consider (default: 5)'),
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['knn'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault),
+                            }),
+                            zod.object({
+                                n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['hbos'])
+                                    .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault),
+                            }),
+                            zod.object({
+                                n_neighbors: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Number of neighbors for LOF (default: 20)'),
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['lof'])
+                                    .default(
+                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault
+                                    ),
+                            }),
+                            zod.object({
+                                kernel: zod.string().nullish().describe('SVM kernel type (default: "rbf")'),
+                                nu: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Upper bound on training errors fraction (default: 0.1)'),
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['ocsvm'])
+                                    .default(
+                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault
+                                    ),
+                            }),
+                            zod.object({
+                                preprocessing: zod
+                                    .object({
+                                        diffs_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'
+                                            ),
+                                        lags_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'
+                                            ),
+                                        smooth_n: zod
+                                            .number()
+                                            .nullish()
+                                            .describe(
+                                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                                            ),
+                                    })
+                                    .nullish(),
+                                threshold: zod
+                                    .number()
+                                    .nullish()
+                                    .describe('Anomaly probability threshold (default: 0.9)'),
+                                type: zod
+                                    .enum(['pca'])
+                                    .default(
+                                        alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault
+                                    ),
+                            }),
+                        ])
+                    )
+                    .describe('Sub-detector configurations (minimum 2)'),
+                operator: zod.enum(['and', 'or']),
+                type: zod.enum(['ensemble']).default(alertsSimulateCreateBodyDetectorConfigOneOneTypeDefault),
+            }),
+            zod.object({
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
+                    ),
+                type: zod.enum(['zscore']).default(alertsSimulateCreateBodyDetectorConfigOneTwoTypeDefault),
+                window: zod.number().nullish().describe('Rolling window size for calculating mean/std (default: 30)'),
+            }),
+            zod.object({
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)'
+                    ),
+                type: zod.enum(['mad']).default(alertsSimulateCreateBodyDetectorConfigOneThreeTypeDefault),
+                window: zod.number().nullish().describe('Rolling window size for calculating median/MAD (default: 30)'),
+            }),
+            zod.object({
+                multiplier: zod
+                    .number()
+                    .nullish()
+                    .describe('IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)'),
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                type: zod.enum(['iqr']).default(alertsSimulateCreateBodyDetectorConfigOneFourTypeDefault),
+                window: zod.number().nullish().describe('Rolling window size for calculating quartiles (default: 30)'),
+            }),
+            zod.object({
+                lower_bound: zod.number().nullish().describe('Lower bound - values below this are anomalies'),
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                type: zod.enum(['threshold']).default(alertsSimulateCreateBodyDetectorConfigOneFiveTypeDefault),
+                upper_bound: zod.number().nullish().describe('Upper bound - values above this are anomalies'),
+            }),
+            zod.object({
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['ecod']).default(alertsSimulateCreateBodyDetectorConfigOneSixTypeDefault),
+            }),
+            zod.object({
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['copod']).default(alertsSimulateCreateBodyDetectorConfigOneSevenTypeDefault),
+            }),
+            zod.object({
+                n_estimators: zod.number().nullish().describe('Number of trees in the forest (default: 100)'),
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['isolation_forest']).default(alertsSimulateCreateBodyDetectorConfigOneEightTypeDefault),
+            }),
+            zod.object({
+                method: zod.enum(['largest', 'mean', 'median']).nullish(),
+                n_neighbors: zod.number().nullish().describe('Number of neighbors to consider (default: 5)'),
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['knn']).default(alertsSimulateCreateBodyDetectorConfigOneNineTypeDefault),
+            }),
+            zod.object({
+                n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['hbos']).default(alertsSimulateCreateBodyDetectorConfigOneOnezeroTypeDefault),
+            }),
+            zod.object({
+                n_neighbors: zod.number().nullish().describe('Number of neighbors for LOF (default: 20)'),
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['lof']).default(alertsSimulateCreateBodyDetectorConfigOneOneoneTypeDefault),
+            }),
+            zod.object({
+                kernel: zod.string().nullish().describe('SVM kernel type (default: "rbf")'),
+                nu: zod.number().nullish().describe('Upper bound on training errors fraction (default: 0.1)'),
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['ocsvm']).default(alertsSimulateCreateBodyDetectorConfigOneOnetwoTypeDefault),
+            }),
+            zod.object({
+                preprocessing: zod
+                    .object({
+                        diffs_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)'),
+                        lags_n: zod
+                            .number()
+                            .nullish()
+                            .describe('Number of lag features. 0 = none, >0 = include n lagged values (default: 0)'),
+                        smooth_n: zod
+                            .number()
+                            .nullish()
+                            .describe(
+                                'Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)'
+                            ),
+                    })
+                    .nullish(),
+                threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
+                type: zod.enum(['pca']).default(alertsSimulateCreateBodyDetectorConfigOneOnethreeTypeDefault),
+            }),
+        ])
+        .describe('Detector configuration types')
+        .describe('Detector configuration to simulate.'),
+    series_index: zod
+        .number()
+        .default(alertsSimulateCreateBodySeriesIndexDefault)
+        .describe('Zero-based index of the series to analyze.'),
+    date_from: zod
+        .string()
+        .nullish()
+        .describe(
+            "Relative date string for how far back to simulate (e.g. '-24h', '-30d', '-4w'). If not provided, uses the detector's minimum required samples."
         ),
 })

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -9,6 +9,7 @@ import {
     AlertsPartialUpdateBody,
     AlertsPartialUpdateParams,
     AlertsRetrieveParams,
+    AlertsSimulateCreateBody,
 } from '@/generated/alerts/api'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
@@ -164,10 +165,40 @@ const alertDelete = (): ToolBase<typeof AlertDeleteSchema, unknown> => ({
     },
 })
 
+const AlertSimulateSchema = AlertsSimulateCreateBody
+
+const alertSimulate = (): ToolBase<typeof AlertSimulateSchema, Schemas.AlertSimulateResponse> => ({
+    name: 'alert-simulate',
+    schema: AlertSimulateSchema,
+    handler: async (context: Context, params: z.infer<typeof AlertSimulateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.insight !== undefined) {
+            body['insight'] = params.insight
+        }
+        if (params.detector_config !== undefined) {
+            body['detector_config'] = params.detector_config
+        }
+        if (params.series_index !== undefined) {
+            body['series_index'] = params.series_index
+        }
+        if (params.date_from !== undefined) {
+            body['date_from'] = params.date_from
+        }
+        const result = await context.api.request<Schemas.AlertSimulateResponse>({
+            method: 'POST',
+            path: `/api/projects/${projectId}/alerts/simulate/`,
+            body,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'alerts-list': alertsList,
     'alert-get': alertGet,
     'alert-create': alertCreate,
     'alert-update': alertUpdate,
     'alert-delete': alertDelete,
+    'alert-simulate': alertSimulate,
 }

--- a/services/mcp/tests/tools/alerts.integration.test.ts
+++ b/services/mcp/tests/tools/alerts.integration.test.ts
@@ -238,6 +238,108 @@ describe('Alerts', { concurrent: false }, () => {
         })
     })
 
+    describe('anomaly detection alerts', () => {
+        const simulateTool = GENERATED_TOOLS['alert-simulate']!()
+
+        it('should create an alert with detector_config', async () => {
+            const params = makeAlertParams({
+                detector_config: {
+                    type: 'zscore',
+                    threshold: 0.9,
+                    window: 30,
+                },
+            })
+            const result = await createTool.handler(context, params)
+            const alert = parseToolResponse(result)
+            createdAlertIds.push(alert.id)
+
+            expect(alert.id).toBeTruthy()
+            expect(alert.detector_config).toBeTruthy()
+            expect(alert.detector_config.type).toBe('zscore')
+            expect(alert.detector_config.threshold).toBe(0.9)
+            expect(alert.detector_config.window).toBe(30)
+        })
+
+        it('should create an ensemble alert with multiple detectors', async () => {
+            const params = makeAlertParams({
+                detector_config: {
+                    type: 'ensemble',
+                    operator: 'or',
+                    detectors: [
+                        { type: 'zscore', threshold: 0.9, window: 30 },
+                        { type: 'mad', threshold: 0.9, window: 30 },
+                    ],
+                },
+            })
+            const result = await createTool.handler(context, params)
+            const alert = parseToolResponse(result)
+            createdAlertIds.push(alert.id)
+
+            expect(alert.detector_config.type).toBe('ensemble')
+            expect(alert.detector_config.operator).toBe('or')
+            expect(alert.detector_config.detectors).toHaveLength(2)
+        })
+
+        it('should update an alert to add detector_config', async () => {
+            const created = await createTool.handler(context, makeAlertParams())
+            const alert = parseToolResponse(created)
+            createdAlertIds.push(alert.id)
+
+            expect(alert.detector_config).toBeNull()
+
+            const result = await updateTool.handler(context, {
+                id: alert.id,
+                detector_config: {
+                    type: 'mad',
+                    threshold: 0.95,
+                    window: 60,
+                },
+            })
+            const updated = parseToolResponse(result)
+
+            expect(updated.detector_config).toBeTruthy()
+            expect(updated.detector_config.type).toBe('mad')
+        })
+
+        it('should simulate a detector on an insight', async () => {
+            const result = await simulateTool.handler(context, {
+                insight: insightId,
+                detector_config: {
+                    type: 'zscore',
+                    threshold: 0.9,
+                    window: 30,
+                },
+                series_index: 0,
+            })
+            const data = parseToolResponse(result)
+
+            expect(Array.isArray(data.data)).toBe(true)
+            expect(Array.isArray(data.dates)).toBe(true)
+            expect(Array.isArray(data.scores)).toBe(true)
+            expect(Array.isArray(data.triggered_indices)).toBe(true)
+            expect(Array.isArray(data.triggered_dates)).toBe(true)
+            expect(typeof data.total_points).toBe('number')
+            expect(typeof data.anomaly_count).toBe('number')
+            expect(data.total_points).toBeGreaterThan(0)
+            expect(data.scores.length).toBe(data.total_points)
+        })
+
+        it('should simulate with a custom date range', async () => {
+            const result = await simulateTool.handler(context, {
+                insight: insightId,
+                detector_config: {
+                    type: 'zscore',
+                    threshold: 0.9,
+                    window: 30,
+                },
+                date_from: '-7d',
+            })
+            const data = parseToolResponse(result)
+
+            expect(data.total_points).toBeGreaterThan(0)
+        })
+    })
+
     describe('Alerts workflow', () => {
         it('should support a full create → retrieve → update → delete lifecycle', async () => {
             const name = `workflow-alert-${generateUniqueKey('lifecycle')}`

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-simulate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-simulate.json
@@ -1,0 +1,1881 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "date_from": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Relative date string for how far back to simulate (e.g. '-24h', '-30d', '-4w'). If not provided, uses the detector's minimum required samples."
+        },
+        "detector_config": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "detectors": {
+                            "description": "Sub-detector configurations (minimum 2)",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "properties": {
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "zscore",
+                                                "enum": ["zscore"],
+                                                "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size for calculating mean/std (default: 30)"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "mad",
+                                                "enum": ["mad"],
+                                                "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size for calculating median/MAD (default: 30)"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "multiplier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
+                                            },
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "type": {
+                                                "default": "iqr",
+                                                "enum": ["iqr"],
+                                                "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size for calculating quartiles (default: 30)"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "lower_bound": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Lower bound - values below this are anomalies"
+                                            },
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "type": {
+                                                "default": "threshold",
+                                                "enum": ["threshold"],
+                                                "type": "string"
+                                            },
+                                            "upper_bound": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Upper bound - values above this are anomalies"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "ecod",
+                                                "enum": ["ecod"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "copod",
+                                                "enum": ["copod"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "n_estimators": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Number of trees in the forest (default: 100)"
+                                            },
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "isolation_forest",
+                                                "enum": ["isolation_forest"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "method": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": ["largest", "mean", "median"],
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "n_neighbors": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Number of neighbors to consider (default: 5)"
+                                            },
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "knn",
+                                                "enum": ["knn"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "n_bins": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Number of histogram bins (default: 10)"
+                                            },
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "hbos",
+                                                "enum": ["hbos"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "n_neighbors": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Number of neighbors for LOF (default: 20)"
+                                            },
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "lof",
+                                                "enum": ["lof"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "kernel": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "SVM kernel type (default: \"rbf\")"
+                                            },
+                                            "nu": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Upper bound on training errors fraction (default: 0.1)"
+                                            },
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "ocsvm",
+                                                "enum": ["ocsvm"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "properties": {
+                                            "preprocessing": {
+                                                "anyOf": [
+                                                    {
+                                                        "properties": {
+                                                            "diffs_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                                            },
+                                                            "lags_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                                            },
+                                                            "smooth_n": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "number"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            },
+                                            "threshold": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Anomaly probability threshold (default: 0.9)"
+                                            },
+                                            "type": {
+                                                "default": "pca",
+                                                "enum": ["pca"],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        "operator": {
+                            "enum": ["and", "or"],
+                            "type": "string"
+                        },
+                        "type": {
+                            "default": "ensemble",
+                            "enum": ["ensemble"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["detectors", "operator"],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "zscore",
+                            "enum": ["zscore"],
+                            "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size for calculating mean/std (default: 30)"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold [0-1]. Points above this probability are flagged (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "mad",
+                            "enum": ["mad"],
+                            "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size for calculating median/MAD (default: 30)"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "multiplier": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "IQR multiplier for fence calculation (default: 1.5, use 3.0 for far outliers)"
+                        },
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "type": {
+                            "default": "iqr",
+                            "enum": ["iqr"],
+                            "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size for calculating quartiles (default: 30)"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "lower_bound": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Lower bound - values below this are anomalies"
+                        },
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "type": {
+                            "default": "threshold",
+                            "enum": ["threshold"],
+                            "type": "string"
+                        },
+                        "upper_bound": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Upper bound - values above this are anomalies"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "ecod",
+                            "enum": ["ecod"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "copod",
+                            "enum": ["copod"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "n_estimators": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Number of trees in the forest (default: 100)"
+                        },
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "isolation_forest",
+                            "enum": ["isolation_forest"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "method": {
+                            "anyOf": [
+                                {
+                                    "enum": ["largest", "mean", "median"],
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "n_neighbors": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Number of neighbors to consider (default: 5)"
+                        },
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "knn",
+                            "enum": ["knn"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "n_bins": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Number of histogram bins (default: 10)"
+                        },
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "hbos",
+                            "enum": ["hbos"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "n_neighbors": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Number of neighbors for LOF (default: 20)"
+                        },
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "lof",
+                            "enum": ["lof"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "kernel": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "SVM kernel type (default: \"rbf\")"
+                        },
+                        "nu": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Upper bound on training errors fraction (default: 0.1)"
+                        },
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "ocsvm",
+                            "enum": ["ocsvm"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "preprocessing": {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "diffs_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Order of differencing. 0 = raw values, 1 = first-order diffs (default: 0)"
+                                        },
+                                        "lags_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Number of lag features. 0 = none, >0 = include n lagged values (default: 0)"
+                                        },
+                                        "smooth_n": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "number"
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "description": "Moving average window size. 0 = no smoothing, >1 = smooth over n points (default: 0)"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "threshold": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Anomaly probability threshold (default: 0.9)"
+                        },
+                        "type": {
+                            "default": "pca",
+                            "enum": ["pca"],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            ],
+            "description": "Detector configuration to simulate."
+        },
+        "insight": {
+            "description": "Insight ID to simulate the detector on.",
+            "type": "number"
+        },
+        "series_index": {
+            "default": 0,
+            "description": "Zero-based index of the series to analyze.",
+            "type": "number"
+        }
+    },
+    "required": ["insight", "detector_config"],
+    "type": "object"
+}


### PR DESCRIPTION
## Summary

- Enable `alert-simulate` MCP tool so agents can run anomaly detectors on historical insight data
- Update `alerts-list`, `alert-get`, `alert-create`, `alert-update` tool descriptions to mention `detector_config` and anomaly detection capabilities
- Regenerate MCP tool handlers and schemas via `hogli build:openapi`

## Test plan

- [ ] Verify `alert-simulate` tool appears in MCP tool list
- [ ] Test simulate tool with a valid insight + detector config
- [ ] Verify updated descriptions are visible to MCP clients