### PR TITLE
fix(heatmaps): open heatmaps settings section instead of autocapture when configuring

### DIFF
--- a/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapsBrowser.tsx
@@ -332,7 +332,7 @@ function Warnings(): JSX.Element | null {
             action={{
                 type: 'secondary',
                 icon: <IconGear />,
-                onClick: () => openSettingsPanel({ sectionId: 'environment-autocapture', settingId: 'heatmaps' }),
+                onClick: () => openSettingsPanel({ sectionId: 'environment-heatmaps', settingId: 'heatmaps' }),
                 children: 'Configure',
             }}
             dismissKey="heatmaps-might-be-disabled-warning"

--- a/frontend/src/scenes/heatmaps/components/HeatmapsWarnings.tsx
+++ b/frontend/src/scenes/heatmaps/components/HeatmapsWarnings.tsx
@@ -19,7 +19,7 @@ export function HeatmapsWarnings(): JSX.Element | null {
             action={{
                 type: 'secondary',
                 icon: <IconGear />,
-                onClick: () => openSettingsPanel({ sectionId: 'environment-autocapture', settingId: 'heatmaps' }),
+                onClick: () => openSettingsPanel({ sectionId: 'environment-heatmaps', settingId: 'heatmaps' }),
                 children: 'Configure',
             }}
             dismissKey="heatmaps-might-be-disabled-warning"


### PR DESCRIPTION
## Problem

When heatmaps aren't enabled on a project, the heatmaps page shows a warning banner with a "Configure" button. Clicking it opens a settings side panel, but it navigates to the **Autocapture** settings section instead of the **Heatmaps** section. This is because `sectionId` was set to `'environment-autocapture'` instead of `'environment-heatmaps'` in both warning components.

## Changes

- `HeatmapsWarnings.tsx`: Changed `sectionId` from `'environment-autocapture'` to `'environment-heatmaps'`
- `HeatmapsBrowser.tsx` (`Warnings` component): Same fix

## How did you test this code?

🤖 I'm an agent and haven't tested this manually. The fix was verified by:
- Confirming `environment-heatmaps` exists as a valid section in `SettingsMap.tsx` with the `heatmaps` setting ID
- Confirming no other stale references to `environment-autocapture` with `settingId: 'heatmaps'` remain

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Co-authored by Claude Code (Claude Opus 4.6). The fix was identified by tracing the `openSettingsPanel` call from the warning banner through to the settings map, confirming the section ID mismatch.