### PR TITLE
feat(dev-ex): Help claude desktop get set up with flox

### DIFF
--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# SessionStart hook: capture flox environment and write to CLAUDE_ENV_FILE
+# so that all subsequent Bash commands have python, node, pytest, etc. on PATH.
+
+# Skip on Claude web (no flox there) or if CLAUDE_ENV_FILE isn't set
+if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+VENV_DIR="$PROJECT_DIR/.flox/cache/venv"
+
+# Step 1: Capture the flox activation environment (hook.on-activate runs,
+# but [profile] scripts do NOT run in non-interactive `bash -c`).
+FLOX_ENV_SNAPSHOT=$(flox activate --dir "$PROJECT_DIR" -- bash -c 'printenv' 2>/dev/null)
+
+if [ $? -ne 0 ] || [ -z "$FLOX_ENV_SNAPSHOT" ]; then
+  echo "Warning: flox activate failed, skipping env setup" >&2
+  exit 0
+fi
+
+# Step 2: Extract key env vars from flox and write them to CLAUDE_ENV_FILE.
+# We capture PATH and all FLOX_* vars, plus project-specific vars from [vars].
+echo "$FLOX_ENV_SNAPSHOT" | grep -E "^(PATH|FLOX_|UV_PROJECT_ENVIRONMENT|OPENSSL_|LDFLAGS|CPPFLAGS|RUST_|LIBRARY_PATH|MANPATH|DOTENV_FILE|DEBUG|POSTHOG_SKIP_MIGRATION_CHECKS|FLAGS_REDIS_URL|RUSTC_WRAPPER|SCCACHE_)=" | while IFS='=' read -r key value; do
+  echo "export ${key}=\"${value}\""
+done >> "$CLAUDE_ENV_FILE"
+
+# Step 3: The flox [profile] scripts also activate the uv venv, which adds
+# the venv's bin/ to PATH. Since [profile] doesn't run in `bash -c`, we do
+# this manually by prepending the venv bin dir to PATH.
+if [ -d "$VENV_DIR/bin" ]; then
+  echo "export PATH=\"${VENV_DIR}/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  echo "export VIRTUAL_ENV=\"${VENV_DIR}\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -22,7 +22,7 @@ fi
 # Step 2: Extract key env vars from flox and write them to CLAUDE_ENV_FILE.
 # We capture PATH and all FLOX_* vars, plus project-specific vars from [vars].
 echo "$FLOX_ENV_SNAPSHOT" | grep -E "^(PATH|FLOX_|UV_PROJECT_ENVIRONMENT|OPENSSL_|LDFLAGS|CPPFLAGS|RUST_|LIBRARY_PATH|MANPATH|DOTENV_FILE|DEBUG|POSTHOG_SKIP_MIGRATION_CHECKS|FLAGS_REDIS_URL|RUSTC_WRAPPER|SCCACHE_)=" | while IFS='=' read -r key value; do
-  echo "export ${key}=\"${value}\""
+  printf 'export %s=%q\n' "$key" "$value"
 done >> "$CLAUDE_ENV_FILE"
 
 # Step 3: The flox [profile] scripts also activate the uv venv, which adds

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
                     {
                         "type": "command",
                         "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-cloud.sh"
+                    },
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-flox.sh"
                     }
                 ]
             }

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -8,7 +8,12 @@
 [ -f .git ] || exit 0
 
 # Bootstrap husky + lint-staged so pre-commit hooks work in worktrees
-# pnpm is expected to be globally available (corepack, brew, etc.)
+# pnpm may come from flox, corepack, brew, etc. — add flox bin to PATH if available
+MAIN_REPO="$(cd "$(dirname "$0")/.." && pwd)"
+for p in "$MAIN_REPO/.flox/run"/*/bin; do
+    [ -d "$p" ] && export PATH="$p:$PATH"
+done
+
 if [ ! -d node_modules/.pnpm ]; then
     echo "husky: worktree detected, bootstrapping with pnpm install ..."
     pnpm install --frozen-lockfile --filter=.


### PR DESCRIPTION
## Problem

flox works by setting up a bunch of env vars

with claude code CLI, this is fine, as you can activate flox before running claude code, but for claude desktop we need to a little bit more, particularly if trying to use worktrees. Part of the problem is that each bash command in claude desktop is separate, so changes to env vars do not persist.

We could solve this by telling claude to prefix every command with flox activate, but that's pretty noisy and slow, and we can do something much better

## Changes

As a session start hook, run flox, and then copy the relevant env vars to claude's env file.

## How did you test this code?

Created a bunch of new sessions in claude desktop in worktree mode after creating this and make sure that
* `which python`
* `which pnpm`
* `which cargo`

all correctly pointed to the flox env

<img width="736" height="361" alt="Screenshot 2026-03-21 at 12 46 21" src="https://github.com/user-attachments/assets/5b3481d9-3cdc-430f-a2d8-4ba9ccb24f36" />


## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
