### PR TITLE
chore: make setup-flox hook a no-op when flox isn't installed

### DIFF
--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 # SessionStart hook: capture flox environment and write to CLAUDE_ENV_FILE
 # so that all subsequent Bash commands have python, node, pytest, etc. on PATH.
+#
+# CLAUDE_ENV_FILE is only available in SessionStart hooks:
+# https://code.claude.com/docs/en/hooks#sessionstart
 
 # Skip on Claude web (no flox there) or if CLAUDE_ENV_FILE isn't set
 if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then
+  exit 0
+fi
+
+# Skip if flox isn't installed
+if ! command -v flox &>/dev/null; then
   exit 0
 fi
 


### PR DESCRIPTION
## Problem

The `setup-flox.sh` SessionStart hook fails when flox isn't installed on the machine, which can happen for contributors who haven't set up flox yet.

## Changes

- Add a `command -v flox` guard so the hook exits cleanly when flox isn't available
- Add a comment documenting that `CLAUDE_ENV_FILE` is only available in SessionStart hooks, with a link to the docs

## How did you test this code?

I'm an agent — I verified the shell script logic by reading the diff. The change is a simple guard clause addition.

## Publish to changelog?

No

## Docs update

N/A — no docs changes needed.

## 🤖 LLM context

Authored by Claude Code (Claude Opus 4.6).