### PR TITLE
fix(flags): set FLAGS_REDIS_URL in feature-flags service startup

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -135,6 +135,7 @@ case "$RS_SVC" in
     export READ_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
     export MAXMIND_DB_PATH=../share/GeoLite2-City.mmdb
     export REDIS_URL=redis://localhost:6379/
+    export FLAGS_REDIS_URL=${FLAGS_REDIS_URL:-redis://localhost:6379/1}
     export ADDRESS=0.0.0.0:3001
     export DEBUG=1
     export ALLOW_INTERNAL_IPS=${ALLOW_INTERNAL_IPS:-true}


### PR DESCRIPTION
## Problem

The `feature-flags` case in `bin/start-rust-service` explicitly sets every env var the
service needs — except `FLAGS_REDIS_URL`. It works under flox (which sets the var in
`manifest.toml`), but fails when the script is run standalone without flox. Without this
var, local dev doesn't match our prod setup, where a dedicated Redis instance is used for
flags.

## Changes

Add `FLAGS_REDIS_URL` with a default of `redis://localhost:6379/1` to the `feature-flags`
block, matching the value already in the flox manifest and `docker-compose.dev.yml`. Uses
`${FLAGS_REDIS_URL:-…}` so an existing value (e.g., from flox) is preserved.

This better simulates our production setup, where the flags service uses a dedicated Redis
instance separate from the shared one.

## How did you test this code?

Verified the env var is set correctly by reading the script and confirming the default
matches the flox manifest (`.flox/env/manifest.toml`) and `docker-compose.dev.yml`.

## Publish to changelog?

no