### PR TITLE
feat(replay): expiry-aware incremental counting for playlist counters

### DIFF
--- a/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -422,12 +422,11 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
 
             query = convert_playlist_to_recordings_query(playlist)
 
-            # if we already have some data and the query is sorted by start_time,
-            # we can query only new recordings, to (hopefully) reduce load on CH
             has_existing_data = existing_value.get("refreshed_at", None)
             can_query_only_new_recordings = query.order == "start_time"
+            has_versioned_expiry_data = existing_value.get("version") == 2
 
-            if has_existing_data and can_query_only_new_recordings:
+            if has_existing_data and can_query_only_new_recordings and has_versioned_expiry_data:
                 query.date_from = existing_value["refreshed_at"]
 
             (recordings, more_recordings_available, _, _) = list_recordings_from_query(
@@ -435,16 +434,21 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
             )
 
             counted_at_date = timezone.now()
-            new_session_ids = [r.session_id for r in recordings]
+            new_sessions = {r.session_id: r.expiry_time.isoformat() if r.expiry_time else None for r in recordings}
 
-            if has_existing_data and can_query_only_new_recordings:
-                # these results are only used for counting and checking if unwatched
-                # so we can merge them without caring about order
-                new_session_ids = list(set(new_session_ids + existing_value["session_ids"]))
+            if has_existing_data and can_query_only_new_recordings and has_versioned_expiry_data:
+                existing_sessions = existing_value.get("sessions_with_expiry", {})
+                for sid, expiry in existing_sessions.items():
+                    if sid in new_sessions:
+                        continue
+                    if expiry is None or datetime.fromisoformat(expiry) >= counted_at_date:
+                        new_sessions[sid] = expiry
 
             value_to_set = json.dumps(
                 {
-                    "session_ids": new_session_ids,
+                    "version": 2,
+                    "session_ids": list(new_sessions.keys()),
+                    "sessions_with_expiry": new_sessions,
                     "has_more": more_recordings_available,
                     "previous_ids": existing_value.get("session_ids", None),
                     "refreshed_at": counted_at_date.isoformat(),
@@ -466,7 +470,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
                     "team_id": playlist.team.pk,
                     "saved_filters_short_id": playlist.short_id,
                     "saved_filters_name": playlist.name or playlist.derived_name,
-                    "count": len(new_session_ids),
+                    "count": len(new_sessions),
                     "previous_count": len(existing_value.get("session_ids", [])),
                 },
             )

--- a/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -443,11 +443,13 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
 
             query = convert_playlist_to_recordings_query(playlist)
 
-            has_existing_data = existing_value.get("refreshed_at", None)
-            can_query_only_new_recordings = query.order == "start_time"
-            has_versioned_expiry_data = existing_value.get("version") == 2
+            should_query_incrementally = (
+                existing_value.get("refreshed_at", None)
+                and query.order == "start_time"
+                and existing_value.get("version") == 2
+            )
 
-            if has_existing_data and can_query_only_new_recordings and has_versioned_expiry_data:
+            if should_query_incrementally:
                 query.date_from = existing_value["refreshed_at"]
 
             (recordings, more_recordings_available, _, _) = list_recordings_from_query(
@@ -457,7 +459,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
             counted_at_date = timezone.now()
             new_sessions = {r.session_id: r.expiry_time.isoformat() if r.expiry_time else None for r in recordings}
 
-            if has_existing_data and can_query_only_new_recordings and has_versioned_expiry_data:
+            if should_query_incrementally:
                 existing_sessions = existing_value.get("sessions_with_expiry", {})
                 for sid, expiry in existing_sessions.items():
                     if sid in new_sessions:

--- a/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -345,6 +345,27 @@ def try_to_store_error_count(playlist_short_id: str | None) -> None:
         pass
 
 
+def parse_expiry(expiry: str | None) -> datetime | None:
+    if expiry is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(expiry)
+        if parsed.tzinfo is None:
+            parsed = timezone.make_aware(parsed)
+        return parsed
+    except (ValueError, TypeError):
+        return None
+
+
+def is_session_unexpired(expiry: str | None, now: datetime) -> bool:
+    if expiry is None:
+        return True
+    parsed = parse_expiry(expiry)
+    if parsed is None:
+        return False
+    return parsed >= now
+
+
 def safe_seconds_difference(dt1: datetime, dt2: datetime) -> int:
     """
     Returns the difference in seconds between two datetime objects,
@@ -441,7 +462,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
                 for sid, expiry in existing_sessions.items():
                     if sid in new_sessions:
                         continue
-                    if expiry is None or datetime.fromisoformat(expiry) >= counted_at_date:
+                    if is_session_unexpired(expiry, counted_at_date):
                         new_sessions[sid] = expiry
 
             value_to_set = json.dumps(

--- a/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
@@ -1,6 +1,6 @@
 import json
 import random
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries
@@ -8,6 +8,8 @@ from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
 from django.utils import timezone
+
+from parameterized import parameterized
 
 from posthog.schema import (
     FilterLogicalOperator,
@@ -59,7 +61,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
         mock_capture_exception.assert_not_called()
 
         assert self._get_counts_from_redis(playlist) == {
+            "version": 2,
             "session_ids": [],
+            "sessions_with_expiry": {},
             "previous_ids": None,
             "has_more": False,
             "refreshed_at": mock.ANY,
@@ -94,7 +98,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
         mock_capture_exception.assert_not_called()
 
         assert self._get_counts_from_redis(playlist) == {
+            "version": 2,
             "session_ids": ["123"],
+            "sessions_with_expiry": {"123": None},
             "previous_ids": None,
             "has_more": True,
             "refreshed_at": mock.ANY,
@@ -132,7 +138,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
         mock_capture_exception.assert_not_called()
 
         assert self._get_counts_from_redis(playlist) == {
+            "version": 2,
             "session_ids": ["123"],
+            "sessions_with_expiry": {"123": None},
             "has_more": True,
             "previous_ids": ["245"],
             "refreshed_at": mock.ANY,
@@ -419,10 +427,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
     @patch(
         "posthog.session_recordings.playlist_counters.recordings_that_match_playlist_filters.list_recordings_from_query"
     )
-    def test_count_recordings_only_queries_since_last_count(
+    def test_unversioned_cached_data_triggers_full_query(
         self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
     ):
-        # Given a playlist that was previously counted
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
             name="test",
@@ -430,13 +437,12 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
         )
 
         last_count_time = timezone.now() - timedelta(hours=2)
-        existing_sessions = ["session1", "session2"]
 
         self.redis_client.set(
             f"{PLAYLIST_COUNT_REDIS_PREFIX}{playlist.short_id}",
             json.dumps(
                 {
-                    "session_ids": existing_sessions,
+                    "session_ids": ["session1", "session2"],
                     "has_more": False,
                     "refreshed_at": last_count_time.isoformat(),
                     "error_count": 0,
@@ -445,31 +451,95 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
             ),
         )
 
-        # When we run the count task again
-        mock_list_recordings_from_query.return_value = (
-            [
-                SessionRecording.objects.create(
-                    team=self.team,
-                    session_id="session3",
-                )
-            ],
-            False,
-            None,
-            None,
-        )
+        new_recording = SessionRecording(session_id="session3", team=self.team)
+        new_recording.expiry_time = timezone.now() + timedelta(days=10)
+        mock_list_recordings_from_query.return_value = ([new_recording], False, None, None)
 
         count_recordings_that_match_playlist_filters(playlist.id)
 
-        # Then we should only query for recordings since the last count
+        recordings_query = mock_list_recordings_from_query.call_args[0][0]
+        assert recordings_query.date_from == "-21d"
+
+        stored_data = self._get_counts_from_redis(playlist)
+        assert stored_data["session_ids"] == ["session3"]
+        assert stored_data["version"] == 2
+
+        mock_capture_exception.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (
+                "merges_unexpired_cached_sessions_with_new_results",
+                {"session1": (timezone.now() + timedelta(days=10)).isoformat()},
+                "session_new",
+                (timezone.now() + timedelta(days=5)).isoformat(),
+                ["session1", "session_new"],
+            ),
+            (
+                "evicts_expired_cached_sessions",
+                {"session_expired": (timezone.now() - timedelta(days=1)).isoformat()},
+                "session_new",
+                (timezone.now() + timedelta(days=5)).isoformat(),
+                ["session_new"],
+            ),
+            (
+                "keeps_cached_sessions_with_no_expiry",
+                {"session_no_expiry": None},
+                "session_new",
+                (timezone.now() + timedelta(days=5)).isoformat(),
+                ["session_new", "session_no_expiry"],
+            ),
+        ]
+    )
+    @patch("posthoganalytics.capture_exception")
+    @patch(
+        "posthog.session_recordings.playlist_counters.recordings_that_match_playlist_filters.list_recordings_from_query"
+    )
+    def test_incremental_query_with_expiry_awareness(
+        self,
+        _name: str,
+        cached_sessions_with_expiry: dict[str, str | None],
+        new_session_id: str,
+        new_expiry: str | None,
+        expected_session_ids: list[str],
+        mock_list_recordings_from_query: MagicMock,
+        mock_capture_exception: MagicMock,
+    ):
+        playlist = SessionRecordingPlaylist.objects.create(
+            team=self.team,
+            name="test",
+            filters={"date_from": "-21d"},
+        )
+
+        last_count_time = timezone.now() - timedelta(hours=2)
+
+        self.redis_client.set(
+            f"{PLAYLIST_COUNT_REDIS_PREFIX}{playlist.short_id}",
+            json.dumps(
+                {
+                    "version": 2,
+                    "session_ids": list(cached_sessions_with_expiry.keys()),
+                    "sessions_with_expiry": cached_sessions_with_expiry,
+                    "has_more": False,
+                    "refreshed_at": last_count_time.isoformat(),
+                    "error_count": 0,
+                    "errored_at": None,
+                }
+            ),
+        )
+
+        new_recording = SessionRecording(session_id=new_session_id, team=self.team)
+        new_recording.expiry_time = datetime.fromisoformat(new_expiry) if new_expiry else None
+        mock_list_recordings_from_query.return_value = ([new_recording], False, None, None)
+
+        count_recordings_that_match_playlist_filters(playlist.id)
+
         recordings_query = mock_list_recordings_from_query.call_args[0][0]
         assert recordings_query.date_from == last_count_time.isoformat()
-        assert recordings_query.date_to is None
 
-        # And the results should be merged with the existing sessions
         stored_data = self._get_counts_from_redis(playlist)
-        assert sorted(stored_data["session_ids"]) == ["session1", "session2", "session3"]
-        assert stored_data["has_more"] is False
-        assert stored_data["refreshed_at"] > last_count_time.isoformat()
+        assert sorted(stored_data["session_ids"]) == sorted(expected_session_ids)
+        assert stored_data["version"] == 2
 
         mock_capture_exception.assert_not_called()
 

--- a/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
@@ -4,7 +4,10 @@ from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries
-from unittest import mock
+from unittest import (
+    TestCase as UnitTestCase,
+    mock,
+)
 from unittest.mock import MagicMock, call, patch
 
 from django.utils import timezone
@@ -28,6 +31,8 @@ from posthog.session_recordings.playlist_counters.recordings_that_match_playlist
     DEFAULT_RECORDING_FILTERS,
     count_recordings_that_match_playlist_filters,
     enqueue_recordings_that_match_playlist_filters,
+    is_session_unexpired,
+    parse_expiry,
 )
 from posthog.session_recordings.session_recording_playlist_api import PLAYLIST_COUNT_REDIS_PREFIX
 
@@ -489,6 +494,13 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
                 (timezone.now() + timedelta(days=5)).isoformat(),
                 ["session_new", "session_no_expiry"],
             ),
+            (
+                "treats_malformed_expiry_as_expired",
+                {"session_bad": "not-a-date"},
+                "session_new",
+                (timezone.now() + timedelta(days=5)).isoformat(),
+                ["session_new"],
+            ),
         ]
     )
     @patch("posthoganalytics.capture_exception")
@@ -594,3 +606,34 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
         enqueue_recordings_that_match_playlist_filters()
         # Should not be called for playlist with pinned items
         assert playlist.id not in [call_args[0][0] for call_args in mock_count_task.delay.call_args_list]
+
+
+class TestParseExpiry(UnitTestCase):
+    @parameterized.expand(
+        [
+            ("none_returns_none", None, None),
+            ("malformed_returns_none", "not-a-date", None),
+            ("empty_string_returns_none", "", None),
+            ("valid_aware_datetime", "2026-01-15T10:00:00+00:00", datetime(2026, 1, 15, 10, 0, tzinfo=timezone.utc)),
+            (
+                "valid_naive_datetime_becomes_aware",
+                "2026-01-15T10:00:00",
+                datetime(2026, 1, 15, 10, 0, tzinfo=timezone.utc),
+            ),
+        ]
+    )
+    def test_parse_expiry(self, _name: str, expiry: str | None, expected: datetime | None):
+        assert parse_expiry(expiry) == expected
+
+
+class TestIsSessionUnexpired(UnitTestCase):
+    @parameterized.expand(
+        [
+            ("none_expiry_is_unexpired", None, True),
+            ("future_expiry_is_unexpired", (timezone.now() + timedelta(days=1)).isoformat(), True),
+            ("past_expiry_is_expired", (timezone.now() - timedelta(days=1)).isoformat(), False),
+            ("malformed_expiry_is_expired", "garbage", False),
+        ]
+    )
+    def test_is_session_unexpired(self, _name: str, expiry: str | None, expected: bool):
+        assert is_session_unexpired(expiry, timezone.now()) == expected

--- a/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
@@ -1,6 +1,6 @@
 import json
 import random
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries
@@ -621,11 +621,11 @@ class TestParseExpiry(UnitTestCase):
             ("none_returns_none", None, None),
             ("malformed_returns_none", "not-a-date", None),
             ("empty_string_returns_none", "", None),
-            ("valid_aware_datetime", "2026-01-15T10:00:00+00:00", datetime(2026, 1, 15, 10, 0, tzinfo=timezone.utc)),
+            ("valid_aware_datetime", "2026-01-15T10:00:00+00:00", datetime(2026, 1, 15, 10, 0, tzinfo=UTC)),
             (
                 "valid_naive_datetime_becomes_aware",
                 "2026-01-15T10:00:00",
-                datetime(2026, 1, 15, 10, 0, tzinfo=timezone.utc),
+                datetime(2026, 1, 15, 10, 0, tzinfo=UTC),
             ),
         ]
     )

--- a/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/test/test_recordings_that_match_playlist_filters.py
@@ -501,6 +501,13 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
                 (timezone.now() + timedelta(days=5)).isoformat(),
                 ["session_new"],
             ),
+            (
+                "new_result_overwrites_cached_expiry_for_same_session",
+                {"session_shared": (timezone.now() - timedelta(days=1)).isoformat()},
+                "session_shared",
+                (timezone.now() + timedelta(days=5)).isoformat(),
+                ["session_shared"],
+            ),
         ]
     )
     @patch("posthoganalytics.capture_exception")


### PR DESCRIPTION
## Summary

- Playlist counter cache now stores session expiry times alongside IDs in a versioned (v2) format
- When merging cached sessions with new query results, expired sessions are evicted instead of accumulating indefinitely
- Unversioned (v1) cached data triggers a full query to safely migrate to v2, avoiding stale incremental results

## How does this work?

Previously, incremental counting would blindly merge all cached session IDs with new results — sessions that had expired in ClickHouse would remain in the count forever (until the Redis key expired). Now:

1. Each session's `expiry_time` is stored in `sessions_with_expiry`
2. On incremental merge, cached sessions past their expiry are dropped
3. A `version: 2` field gates the incremental path — old v1 cache entries fall through to a full query, which populates the v2 format

## Test plan

- [x] `test_unversioned_cached_data_triggers_full_query` — v1 cached data causes full query instead of incremental
- [x] `test_incremental_query_with_expiry_awareness` (parameterized, 3 cases):
  - Merges unexpired cached sessions with new results
  - Evicts expired cached sessions  
  - Keeps cached sessions with no expiry (null)
- [x] Existing tests updated to assert new v2 format fields (`version`, `sessions_with_expiry`)
- [x] All 17 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)