### PR TITLE
feat: normalize datetime handling with centralized utilities

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -6,6 +6,7 @@ import { IconPlus } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { compareDatetimes } from 'lib/dayjs'
 import { LemonTreeSelectMode, TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
@@ -208,7 +209,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                             return true
                         })
                         .sort((a, b) => {
-                            return new Date(b.created_at ?? '').getTime() - new Date(a.created_at ?? '').getTime()
+                            return -compareDatetimes(a.created_at ?? '', b.created_at ?? '')
                         })
                     if (response.users?.length > 0) {
                         actions.addLoadedUsers(response.users)
@@ -323,7 +324,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                         }
                     } else if (savedItem.created_at && savedItem.type !== 'folder') {
                         const newResults = [...state.results, savedItem].sort((a, b) => {
-                            return new Date(b.created_at ?? '').getTime() - new Date(a.created_at ?? '').getTime()
+                            return -compareDatetimes(a.created_at ?? '', b.created_at ?? '')
                         })
                         return { ...state, results: newResults }
                     }

--- a/frontend/src/lib/charts/utils/format.ts
+++ b/frontend/src/lib/charts/utils/format.ts
@@ -1,3 +1,5 @@
+import { dayjs } from 'lib/dayjs'
+
 import type { AxisFormat } from '../types'
 
 export function formatValue(
@@ -93,17 +95,9 @@ function formatDuration(seconds: number): string {
 }
 
 function formatDate(timestamp: number): string {
-    return new Date(timestamp).toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-    })
+    return dayjs(timestamp).format('MMM D')
 }
 
 function formatDateTime(timestamp: number): string {
-    return new Date(timestamp).toLocaleString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-    })
+    return dayjs(timestamp).format('MMM D, h:mm A')
 }

--- a/frontend/src/lib/components/Errors/errorPropertiesLogic.ts
+++ b/frontend/src/lib/components/Errors/errorPropertiesLogic.ts
@@ -18,7 +18,7 @@ import {
     getSessionId,
     stacktraceHasInAppFrames,
 } from 'lib/components/Errors/utils'
-import { dayjs } from 'lib/dayjs'
+import { compareDatetimes } from 'lib/dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 import type { errorPropertiesLogicType } from './errorPropertiesLogicType'
@@ -120,7 +120,7 @@ export const errorPropertiesLogic = kea<errorPropertiesLogicType>([
                 }
                 // get most recent release
                 const sortedReleases = relatedReleases.sort(
-                    (a, b) => dayjs(b.created_at).unix() - dayjs(a.created_at).unix()
+                    (a, b) => -compareDatetimes(a.created_at, b.created_at)
                 )
                 return sortedReleases[0]
             },

--- a/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdvertisementRecommendedLogic.ts
+++ b/frontend/src/lib/components/NavPanelAdvertisement/navPanelAdvertisementRecommendedLogic.ts
@@ -1,5 +1,7 @@
 import { connect, kea, path, selectors } from 'kea'
 
+import { dayjs } from 'lib/dayjs'
+
 import { customProductsLogic } from '~/layout/panel-layout/ProjectTree/customProductsLogic'
 import { type UserProductListItem, UserProductListReason } from '~/queries/schema/schema-general'
 
@@ -30,7 +32,7 @@ export const navPanelAdvertisementRecommendedLogic = kea<navPanelAdvertisementRe
                     (item) =>
                         RECOMMENDED_PRODUCT_REASONS.includes(item.reason) &&
                         item.enabled &&
-                        new Date(item.created_at) >= createdAtThreshold
+                        dayjs(item.created_at).toDate() >= createdAtThreshold
                 )
             },
         ],

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -4,6 +4,7 @@ import { loaders } from 'kea-loaders'
 import { IconClock, IconDownload } from '@posthog/icons'
 
 import api from 'lib/api'
+import { compareDatetimes } from 'lib/dayjs'
 import { commandLogic } from 'lib/components/Command/commandLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toSentenceCase } from 'lib/utils'
@@ -376,7 +377,7 @@ export const searchLogic = kea<searchLogicType>([
                     if (!b.lastViewedAt) {
                         return -1
                     }
-                    return new Date(b.lastViewedAt).getTime() - new Date(a.lastViewedAt).getTime()
+                    return -compareDatetimes(a.lastViewedAt, b.lastViewedAt)
                 })
             },
         ],
@@ -427,7 +428,7 @@ export const searchLogic = kea<searchLogicType>([
                     if (!b.lastViewedAt) {
                         return -1
                     }
-                    return new Date(b.lastViewedAt).getTime() - new Date(a.lastViewedAt).getTime()
+                    return -compareDatetimes(a.lastViewedAt, b.lastViewedAt)
                 })
             },
         ],

--- a/frontend/src/lib/components/heatmaps/HeatmapEventsPanel.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapEventsPanel.tsx
@@ -6,6 +6,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { compareDatetimes } from 'lib/dayjs'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
@@ -31,7 +32,7 @@ export function HeatmapEventsPanel({ context, exportToken }: HeatmapDataLogicPro
         {
             title: 'Time',
             dataIndex: 'timestamp',
-            sorter: (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+            sorter: (a, b) => compareDatetimes(a.timestamp, b.timestamp),
             render: (_, event) => humanFriendlyDetailedTime(event.timestamp),
         },
         {

--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -30,6 +30,21 @@ const now = (): Dayjs => dayjs()
 
 export { dayjs, isDayjs, now }
 
+/** Convert an ISO datetime string to a Unix timestamp in milliseconds. Use dayjs instead of `new Date()` for consistency. */
+export function toTimestampMs(isoString: string): number {
+    return dayjs(isoString).valueOf()
+}
+
+/** Compare two ISO datetime strings for sorting. Returns negative if a < b (a is older). */
+export function compareDatetimes(a: string, b: string): number {
+    return dayjs(a).valueOf() - dayjs(b).valueOf()
+}
+
+/** Compute duration in milliseconds between two ISO datetime strings. */
+export function durationMs(start: string, end: string): number {
+    return dayjs(end).valueOf() - dayjs(start).valueOf()
+}
+
 /** Parse UTC datetime string using Day.js, taking into account time zone conversion edge cases. */
 export function dayjsUtcToTimezone(
     isoString: string,

--- a/frontend/src/scenes/data-pipelines/legacy-plugins/pipelineNodeLogsLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/legacy-plugins/pipelineNodeLogsLogic.tsx
@@ -5,7 +5,7 @@ import { LemonTableColumns, Link } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { LOGS_PORTION_LIMIT } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
+import { compareDatetimes } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 
 import api from '~/lib/api'
@@ -239,7 +239,7 @@ export const pipelineNodeLogsLogic = kea<pipelineNodeLogsLogicType>([
                         title: 'Timestamp',
                         key: 'timestamp',
                         dataIndex: 'timestamp',
-                        sorter: (a: LogEntry, b: LogEntry) => dayjs(a.timestamp).unix() - dayjs(b.timestamp).unix(),
+                        sorter: (a: LogEntry, b: LogEntry) => compareDatetimes(a.timestamp, b.timestamp),
                         render: (timestamp: string) => <TZLabel time={timestamp} />,
                         width: 0,
                     },

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/QueryInfo.tsx
@@ -4,6 +4,7 @@ import { IconRevert, IconTarget, IconX } from '@posthog/icons'
 import { LemonDialog, LemonTable, Link, Spinner } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { durationMs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
@@ -357,15 +358,13 @@ export function QueryInfo({ tabId }: QueryInfoProps): JSX.Element {
                                         if (job.status === 'Running') {
                                             return 'In progress'
                                         }
-                                        // Convert date strings to timestamps before subtraction
-                                        const start = new Date(job.created_at).getTime()
-                                        const end = new Date(job.last_run_at).getTime()
+                                        const elapsed = durationMs(job.created_at, job.last_run_at)
 
-                                        if (start > end) {
+                                        if (elapsed <= 0) {
                                             return 'N/A'
                                         }
 
-                                        return humanFriendlyDuration((end - start) / 1000)
+                                        return humanFriendlyDuration(elapsed / 1000)
                                     },
                                 },
                             ]}

--- a/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
@@ -6,6 +6,7 @@ import posthog from 'posthog-js'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { compareDatetimes } from 'lib/dayjs'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { availableSourcesDataLogic } from 'scenes/data-warehouse/new/availableSourcesDataLogic'
@@ -149,7 +150,7 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
 
                     // Sort by created_at descending (newest first)
                     return Array.from(jobsById.values()).sort(
-                        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+                        (a, b) => -compareDatetimes(a.created_at, b.created_at)
                     )
                 },
                 loadMoreJobs: async () => {

--- a/frontend/src/scenes/experiments/MetricsView/new/ElapsedTime.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ElapsedTime.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 
+import { dayjs } from 'lib/dayjs'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 
 interface ElapsedTimeProps {
@@ -16,7 +17,7 @@ export function ElapsedTime({ startTime }: ElapsedTimeProps): JSX.Element | null
         }
 
         const updateElapsed = (): void => {
-            const start = new Date(startTime).getTime()
+            const start = dayjs(startTime).valueOf()
             const now = Date.now()
             const elapsed = Math.floor((now - start) / 1000)
             setElapsedSeconds(Math.max(0, elapsed))

--- a/frontend/src/scenes/models/NodeDetailMaterialization.tsx
+++ b/frontend/src/scenes/models/NodeDetailMaterialization.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { LemonButton, LemonTable, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import { durationMs } from 'lib/dayjs'
 import { humanFriendlyDuration } from 'lib/utils'
 
 import { DataModelingJob } from '~/types'
@@ -14,9 +15,8 @@ function computeDuration(job: DataModelingJob): string {
     if (!job.created_at || !job.last_run_at) {
         return '-'
     }
-    const start = new Date(job.created_at).getTime()
-    const end = new Date(job.last_run_at).getTime()
-    const durationSeconds = (end - start) / 1000
+    const elapsed = durationMs(job.created_at, job.last_run_at)
+    const durationSeconds = elapsed / 1000
     if (durationSeconds <= 0) {
         return '-'
     }

--- a/frontend/src/scenes/session-recordings/components/SimpleTimeLabel.tsx
+++ b/frontend/src/scenes/session-recordings/components/SimpleTimeLabel.tsx
@@ -42,7 +42,7 @@ const truncateToSeconds = (time: string | number | Dayjs): number => {
         case 'number':
             return Math.floor(time / 1000) * 1000
         case 'string':
-            return Math.floor(new Date(time).getTime() / 1000) * 1000
+            return Math.floor(dayjs(time).valueOf() / 1000) * 1000
         default:
             return time.startOf('second').valueOf()
     }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
@@ -1,3 +1,5 @@
+import { dayjs, toTimestampMs } from 'lib/dayjs'
+
 import { LiveMetricsSlidingWindow } from './LiveMetricsSlidingWindow'
 
 const MINUTE = 60 * 1000
@@ -8,10 +10,10 @@ const getDeviceCount = (
 ): number | undefined => breakdown.find((d) => d.device === deviceType)?.count
 
 const WALL_CLOCK = '2026-01-16T16:30:00Z'
-const WALL_CLOCK_MS = new Date(WALL_CLOCK).getTime()
+const WALL_CLOCK_MS = toTimestampMs(WALL_CLOCK)
 
-const relativeTime = (offsetMs: number): string => new Date(WALL_CLOCK_MS + offsetMs).toISOString()
-const toUnixSeconds = (isoString: string): number => new Date(isoString).getTime() / 1000
+const relativeTime = (offsetMs: number): string => dayjs(WALL_CLOCK_MS + offsetMs).toISOString()
+const toUnixSeconds = (isoString: string): number => toTimestampMs(isoString) / 1000
 
 describe('LiveMetricsSlidingWindow', () => {
     const WINDOW_SIZE_MINUTES = 30

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -68,7 +68,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 },
                 addEvents: (window, { events, newerThan }) => {
                     for (const event of events) {
-                        const eventTs = new Date(event.timestamp).getTime() / 1000
+                        const eventTs = dayjs(event.timestamp).valueOf() / 1000
                         const newerThanTs = newerThan.getTime() / 1000
 
                         if (eventTs > newerThanTs) {


### PR DESCRIPTION
Add toTimestampMs(), compareDatetimes(), and durationMs() helpers to
lib/dayjs.ts and replace scattered new Date().getTime() and
dayjs().unix() patterns across the frontend with consistent usage.

- Replace new Date(x).getTime() with dayjs(x).valueOf() or helpers
- Replace dayjs(x).unix() sorting with compareDatetimes()
- Replace manual duration calculations with durationMs()
- Use dayjs for chart date/datetime formatting
- Standardize on ISO strings as canonical format, milliseconds internally

https://claude.ai/code/session_019gwErwggmuRJdpVqkDKaqh