### PR TITLE
feat(experiments): add feature flag validation rules to the serializer.

### DIFF
--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -210,10 +210,24 @@ class ExperimentCreateSerializer(serializers.Serializer):
         """Convert validated data to facade DTO."""
         feature_flag_filters_dto = None
         if self.validated_data.get("feature_flag_filters"):
-            # validated_data already contains the deserialized nested dict
-            flag_serializer = CreateFeatureFlagInputSerializer(data=self.validated_data["feature_flag_filters"])
-            flag_serializer.is_valid(raise_exception=True)
-            feature_flag_filters_dto = flag_serializer.to_dto()
+            # Build DTO directly from already-validated data
+            filters_data = self.validated_data["feature_flag_filters"]
+            variant_dtos = [
+                FeatureFlagVariant(
+                    key=v["key"],
+                    split_percent=v["rollout_percentage"],
+                    name=v.get("name") or None,
+                )
+                for v in filters_data["variants"]
+            ]
+            feature_flag_filters_dto = CreateFeatureFlagInput(
+                key=filters_data["key"],
+                name=filters_data.get("name") or None,
+                variants=tuple(variant_dtos),
+                rollout_percentage=filters_data.get("rollout_percentage"),
+                aggregation_group_type_index=filters_data.get("aggregation_group_type_index"),
+                ensure_experience_continuity=filters_data.get("ensure_experience_continuity"),
+            )
 
         return CreateExperimentInput(
             name=self.validated_data["name"],

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -159,14 +159,13 @@ class ExperimentCreateSerializer(serializers.Serializer):
 
         variants = value.get("feature_flag_variants", [])
 
-        if len(variants) >= 21:
-            raise serializers.ValidationError("Feature flag variants must be less than 21")
-
         if len(variants) > 0:
             if len(variants) < 2:
                 raise serializers.ValidationError(
                     "Feature flag must have at least 2 variants (control and at least one test variant)"
                 )
+            if len(variants) >= 21:
+                raise serializers.ValidationError("Feature flag variants must be less than 21")
 
             variant_keys = [variant["key"] for variant in variants]
             if "control" not in variant_keys:

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -167,7 +167,11 @@ class ExperimentCreateSerializer(serializers.Serializer):
             if len(variants) >= 21:
                 raise serializers.ValidationError("Feature flag variants must be less than 21")
 
-            variant_keys = [variant["key"] for variant in variants]
+            try:
+                variant_keys = [variant["key"] for variant in variants]
+            except KeyError:
+                raise serializers.ValidationError("All variants must have a 'key' field")
+
             if "control" not in variant_keys:
                 raise serializers.ValidationError("Feature flag variants must contain a control variant")
 

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -7,6 +7,8 @@ converting between JSON/HTTP and facade DTOs.
 
 from rest_framework import serializers
 
+from posthog.models.feature_flag.feature_flag import FeatureFlag
+
 from products.experiments.backend.facade.contracts import (
     CreateExperimentInput,
     CreateFeatureFlagInput,
@@ -64,6 +66,19 @@ class CreateFeatureFlagInputSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "Feature flag must have at least 2 variants (control and at least one test variant)"
             )
+
+        if len(value) >= 21:
+            raise serializers.ValidationError("Feature flag variants must be less than 21")
+
+        # Check for control variant
+        variant_keys = [variant["key"] for variant in value]
+        if "control" not in variant_keys:
+            raise serializers.ValidationError("Feature flag variants must contain a control variant")
+
+        # Check for duplicate variant keys
+        if len(variant_keys) != len(set(variant_keys)):
+            raise serializers.ValidationError("Feature flag variant keys must be unique")
+
         return value
 
     def to_dto(self) -> CreateFeatureFlagInput:
@@ -111,6 +126,52 @@ class ExperimentCreateSerializer(serializers.Serializer):
     feature_flag_filters = CreateFeatureFlagInputSerializer(
         required=False, allow_null=True, help_text="New format for feature flag configuration"
     )
+
+    def validate_feature_flag_key(self, value):
+        """Validate feature flag key."""
+        if not value:
+            raise serializers.ValidationError("Feature flag key is required")
+
+        # Check if feature flag already exists for this team
+        get_team = self.context.get("get_team")
+        if get_team is None:
+            # If no team context, skip this validation (will fail elsewhere)
+            return value
+
+        team = get_team()
+        if FeatureFlag.objects.filter(key=value, team=team).exists():
+            raise serializers.ValidationError(
+                f"Feature flag with key '{value}' already exists for this team. "
+                "Please use a different key or update the existing flag."
+            )
+
+        return value
+
+    def validate_parameters(self, value):
+        """Validate old format parameters."""
+        if not value:
+            return value
+
+        variants = value.get("feature_flag_variants", [])
+
+        if len(variants) >= 21:
+            raise serializers.ValidationError("Feature flag variants must be less than 21")
+
+        if len(variants) > 0:
+            if len(variants) < 2:
+                raise serializers.ValidationError(
+                    "Feature flag must have at least 2 variants (control and at least one test variant)"
+                )
+
+            variant_keys = [variant["key"] for variant in variants]
+            if "control" not in variant_keys:
+                raise serializers.ValidationError("Feature flag variants must contain a control variant")
+
+            # Check for duplicate variant keys
+            if len(variant_keys) != len(set(variant_keys)):
+                raise serializers.ValidationError("Feature flag variant keys must be unique")
+
+        return value
 
     def validate(self, attrs):
         """Cross-field validation."""

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -79,6 +79,11 @@ class CreateFeatureFlagInputSerializer(serializers.Serializer):
         if len(variant_keys) != len(set(variant_keys)):
             raise serializers.ValidationError("Feature flag variant keys must be unique")
 
+        # Validate rollout percentages sum to 100
+        total_percentage = sum(variant.get("rollout_percentage", 0) for variant in value)
+        if total_percentage != 100:
+            raise serializers.ValidationError(f"Variant rollout percentages must sum to 100, got {total_percentage}")
+
         return value
 
     def to_dto(self) -> CreateFeatureFlagInput:
@@ -171,6 +176,13 @@ class ExperimentCreateSerializer(serializers.Serializer):
             if len(variant_keys) != len(set(variant_keys)):
                 raise serializers.ValidationError("Feature flag variant keys must be unique")
 
+            # Validate rollout percentages sum to 100
+            total_percentage = sum(variant.get("rollout_percentage", 0) for variant in variants)
+            if total_percentage != 100:
+                raise serializers.ValidationError(
+                    f"Variant rollout percentages must sum to 100, got {total_percentage}"
+                )
+
         return value
 
     def validate(self, attrs):
@@ -178,11 +190,16 @@ class ExperimentCreateSerializer(serializers.Serializer):
         has_parameters = attrs.get("parameters") is not None and "feature_flag_variants" in attrs.get("parameters", {})
         has_feature_flag_filters = attrs.get("feature_flag_filters") is not None
 
+        # Cannot provide both formats
         if has_parameters and has_feature_flag_filters:
             raise serializers.ValidationError(
                 "Cannot provide both 'parameters.feature_flag_variants' and 'feature_flag_filters'. "
                 "Please use only one format."
             )
+
+        # Must provide at least one format (for experiments that create new flags)
+        # Note: If neither is provided, the facade will use default variants
+        # This is intentionally permissive to allow minimal experiment creation
 
         return attrs
 

--- a/products/experiments/backend/test/test_presentation_serializers.py
+++ b/products/experiments/backend/test/test_presentation_serializers.py
@@ -6,7 +6,6 @@ request formats and convert them to facade DTOs.
 """
 
 import pytest
-from posthog.test.base import BaseTest
 
 from products.experiments.backend.facade.contracts import CreateExperimentInput, CreateFeatureFlagInput
 from products.experiments.backend.presentation.serializers import ExperimentCreateSerializer
@@ -376,152 +375,140 @@ class TestExperimentCreateSerializer:
         assert dto.feature_flag_filters.variants[1].key == "test_a"
         assert dto.feature_flag_filters.rollout_percentage == 80
 
-    def test_validate_rollout_percentages_sum_to_100(self):
+    @pytest.mark.parametrize(
+        "data,error_message",
+        [
+            (
+                {
+                    "name": "Invalid Percentages",
+                    "feature_flag_key": "invalid-flag",
+                    "feature_flag_filters": {
+                        "key": "invalid-flag",
+                        "variants": [
+                            {"key": "control", "rollout_percentage": 40},
+                            {"key": "test", "rollout_percentage": 40},
+                        ],
+                    },
+                },
+                "sum to 100",
+            ),
+            (
+                {
+                    "name": "Invalid Old Format",
+                    "feature_flag_key": "invalid-old-flag",
+                    "parameters": {
+                        "feature_flag_variants": [
+                            {"key": "control", "rollout_percentage": 60},
+                            {"key": "test", "rollout_percentage": 60},
+                        ],
+                    },
+                },
+                "sum to 100",
+            ),
+        ],
+        ids=["new_format", "old_format"],
+    )
+    def test_validate_rollout_percentages_sum_to_100(self, data, error_message):
         """Test that rollout percentages must sum to 100."""
-        data = {
-            "name": "Invalid Percentages",
-            "feature_flag_key": "invalid-flag",
-            "feature_flag_filters": {
-                "key": "invalid-flag",
-                "variants": [
-                    {"key": "control", "rollout_percentage": 40},
-                    {"key": "test", "rollout_percentage": 40},  # Sum = 80, not 100
-                ],
-            },
-        }
-
         serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
         assert not serializer.is_valid()
-        assert "feature_flag_filters" in serializer.errors
-        assert "sum to 100" in str(serializer.errors).lower()
+        assert error_message in str(serializer.errors).lower()
 
-    def test_validate_rollout_percentages_old_format(self):
-        """Test that rollout percentages must sum to 100 in old format too."""
-        data = {
-            "name": "Invalid Old Format",
-            "feature_flag_key": "invalid-old-flag",
-            "parameters": {
-                "feature_flag_variants": [
-                    {"key": "control", "rollout_percentage": 60},
-                    {"key": "test", "rollout_percentage": 60},  # Sum = 120, not 100
-                ],
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {
+                "name": "No Control Test",
+                "feature_flag_key": "no-control-flag",
+                "feature_flag_filters": {
+                    "key": "no-control-flag",
+                    "variants": [
+                        {"key": "test_a", "rollout_percentage": 50},
+                        {"key": "test_b", "rollout_percentage": 50},
+                    ],
+                },
             },
-        }
-
+            {
+                "name": "No Control Old Format",
+                "feature_flag_key": "no-control-old-flag",
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "test_a", "rollout_percentage": 50},
+                        {"key": "test_b", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        ],
+        ids=["new_format", "old_format"],
+    )
+    def test_validate_control_variant_required(self, data):
+        """Test that control variant is required."""
         serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
         assert not serializer.is_valid()
-        assert "parameters" in serializer.errors
-        assert "sum to 100" in str(serializer.errors).lower()
-
-    def test_validate_control_variant_required(self):
-        """Test that control variant is required in new format."""
-        data = {
-            "name": "No Control Test",
-            "feature_flag_key": "no-control-flag",
-            "feature_flag_filters": {
-                "key": "no-control-flag",
-                "variants": [
-                    {"key": "test_a", "rollout_percentage": 50},
-                    {"key": "test_b", "rollout_percentage": 50},
-                ],
-            },
-        }
-
-        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
-        assert not serializer.is_valid()
-        assert "feature_flag_filters" in serializer.errors
         assert "control" in str(serializer.errors).lower()
 
-    def test_validate_control_variant_required_old_format(self):
-        """Test that control variant is required in old format."""
-        data = {
-            "name": "No Control Old Format",
-            "feature_flag_key": "no-control-old-flag",
-            "parameters": {
-                "feature_flag_variants": [
-                    {"key": "test_a", "rollout_percentage": 50},
-                    {"key": "test_b", "rollout_percentage": 50},
-                ]
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {
+                "name": "Duplicate Keys Test",
+                "feature_flag_key": "duplicate-keys-flag",
+                "feature_flag_filters": {
+                    "key": "duplicate-keys-flag",
+                    "variants": [
+                        {"key": "control", "rollout_percentage": 33},
+                        {"key": "test", "rollout_percentage": 33},
+                        {"key": "test", "rollout_percentage": 34},
+                    ],
+                },
             },
-        }
-
-        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
-        assert not serializer.is_valid()
-        assert "parameters" in serializer.errors
-        assert "control" in str(serializer.errors).lower()
-
-    def test_validate_duplicate_variant_keys(self):
+            {
+                "name": "Duplicate Keys Old",
+                "feature_flag_key": "duplicate-keys-old-flag",
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "control", "rollout_percentage": 33},
+                        {"key": "test", "rollout_percentage": 33},
+                        {"key": "test", "rollout_percentage": 34},
+                    ]
+                },
+            },
+        ],
+        ids=["new_format", "old_format"],
+    )
+    def test_validate_duplicate_variant_keys(self, data):
         """Test that duplicate variant keys are rejected."""
-        data = {
-            "name": "Duplicate Keys Test",
-            "feature_flag_key": "duplicate-keys-flag",
-            "feature_flag_filters": {
-                "key": "duplicate-keys-flag",
-                "variants": [
-                    {"key": "control", "rollout_percentage": 33},
-                    {"key": "test", "rollout_percentage": 33},
-                    {"key": "test", "rollout_percentage": 34},  # Duplicate
-                ],
-            },
-        }
-
         serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
         assert not serializer.is_valid()
-        assert "feature_flag_filters" in serializer.errors
         assert "unique" in str(serializer.errors).lower()
 
-    def test_validate_duplicate_variant_keys_old_format(self):
-        """Test that duplicate variant keys are rejected in old format."""
-        data = {
-            "name": "Duplicate Keys Old",
-            "feature_flag_key": "duplicate-keys-old-flag",
-            "parameters": {
-                "feature_flag_variants": [
-                    {"key": "control", "rollout_percentage": 33},
-                    {"key": "test", "rollout_percentage": 33},
-                    {"key": "test", "rollout_percentage": 34},  # Duplicate
-                ]
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {
+                "name": "Too Many Variants",
+                "feature_flag_key": "too-many-variants-flag",
+                "feature_flag_filters": {
+                    "key": "too-many-variants-flag",
+                    "variants": [{"key": "control", "rollout_percentage": 5}]
+                    + [{"key": f"test_{i}", "rollout_percentage": 5} for i in range(20)],
+                },
             },
-        }
-
-        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
-        assert not serializer.is_valid()
-        assert "parameters" in serializer.errors
-        assert "unique" in str(serializer.errors).lower()
-
-    def test_validate_too_many_variants(self):
+            {
+                "name": "Too Many Variants Old",
+                "feature_flag_key": "too-many-variants-old-flag",
+                "parameters": {
+                    "feature_flag_variants": [{"key": "control", "rollout_percentage": 5}]
+                    + [{"key": f"test_{i}", "rollout_percentage": 5} for i in range(20)]
+                },
+            },
+        ],
+        ids=["new_format", "old_format"],
+    )
+    def test_validate_too_many_variants(self, data):
         """Test that more than 20 variants are rejected."""
-        variants = [{"key": "control", "rollout_percentage": 5}]
-        variants.extend([{"key": f"test_{i}", "rollout_percentage": 5} for i in range(20)])
-
-        data = {
-            "name": "Too Many Variants",
-            "feature_flag_key": "too-many-variants-flag",
-            "feature_flag_filters": {
-                "key": "too-many-variants-flag",
-                "variants": variants,
-            },
-        }
-
         serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
         assert not serializer.is_valid()
-        assert "feature_flag_filters" in serializer.errors
-        assert "21" in str(serializer.errors)
-
-    def test_validate_too_many_variants_old_format(self):
-        """Test that more than 20 variants are rejected in old format."""
-        variants = [{"key": "control", "rollout_percentage": 5}]
-        variants.extend([{"key": f"test_{i}", "rollout_percentage": 5} for i in range(20)])
-
-        data = {
-            "name": "Too Many Variants Old",
-            "feature_flag_key": "too-many-variants-old-flag",
-            "parameters": {"feature_flag_variants": variants},
-        }
-
-        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
-        assert not serializer.is_valid()
-        assert "parameters" in serializer.errors
         assert "21" in str(serializer.errors)
 
     def test_validate_feature_flag_key_already_exists(self):

--- a/products/experiments/backend/test/test_presentation_serializers.py
+++ b/products/experiments/backend/test/test_presentation_serializers.py
@@ -376,6 +376,43 @@ class TestExperimentCreateSerializer:
         assert dto.feature_flag_filters.variants[1].key == "test_a"
         assert dto.feature_flag_filters.rollout_percentage == 80
 
+    def test_validate_rollout_percentages_sum_to_100(self):
+        """Test that rollout percentages must sum to 100."""
+        data = {
+            "name": "Invalid Percentages",
+            "feature_flag_key": "invalid-flag",
+            "feature_flag_filters": {
+                "key": "invalid-flag",
+                "variants": [
+                    {"key": "control", "rollout_percentage": 40},
+                    {"key": "test", "rollout_percentage": 40},  # Sum = 80, not 100
+                ],
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "feature_flag_filters" in serializer.errors
+        assert "sum to 100" in str(serializer.errors).lower()
+
+    def test_validate_rollout_percentages_old_format(self):
+        """Test that rollout percentages must sum to 100 in old format too."""
+        data = {
+            "name": "Invalid Old Format",
+            "feature_flag_key": "invalid-old-flag",
+            "parameters": {
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 60},
+                    {"key": "test", "rollout_percentage": 60},  # Sum = 120, not 100
+                ],
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "parameters" in serializer.errors
+        assert "sum to 100" in str(serializer.errors).lower()
+
     def test_validate_control_variant_required(self):
         """Test that control variant is required in new format."""
         data = {

--- a/products/experiments/backend/test/test_presentation_serializers.py
+++ b/products/experiments/backend/test/test_presentation_serializers.py
@@ -6,6 +6,7 @@ request formats and convert them to facade DTOs.
 """
 
 import pytest
+from posthog.test.base import BaseTest
 
 from products.experiments.backend.facade.contracts import CreateExperimentInput, CreateFeatureFlagInput
 from products.experiments.backend.presentation.serializers import ExperimentCreateSerializer
@@ -14,8 +15,9 @@ from products.experiments.backend.presentation.serializers import ExperimentCrea
 @pytest.mark.django_db
 class TestExperimentCreateSerializer:
     @pytest.fixture(autouse=True)
-    def setup(self, team):
+    def setup(self, team, user):
         self.team = team
+        self.user = user
 
     @pytest.mark.parametrize(
         "data,expected_valid,expected_attrs",
@@ -221,3 +223,290 @@ class TestExperimentCreateSerializer:
         assert not serializer.is_valid()
         if expected_error_field:
             assert expected_error_field in serializer.errors
+
+    def test_validate_old_format_with_parameters(self):
+        """Test validation of old parameters format."""
+        data = {
+            "name": "Old Format Experiment",
+            "feature_flag_key": "old-flag",
+            "parameters": {
+                "feature_flag_variants": [
+                    {"key": "control", "name": "Control", "rollout_percentage": 50},
+                    {"key": "test", "name": "Test", "rollout_percentage": 50},
+                ]
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert serializer.is_valid(), serializer.errors
+
+        dto = serializer.to_facade_dto()
+        assert isinstance(dto, CreateExperimentInput)
+        assert dto.parameters is not None
+        assert "feature_flag_variants" in dto.parameters
+        assert dto.feature_flag_filters is None
+
+    def test_validate_rejects_both_formats(self):
+        """Test that providing both formats raises validation error."""
+        data = {
+            "name": "Both Formats",
+            "feature_flag_key": "both-flag",
+            "parameters": {
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ]
+            },
+            "feature_flag_filters": {
+                "key": "both-flag",
+                "variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ],
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "non_field_errors" in serializer.errors
+        assert "both" in str(serializer.errors).lower()
+
+    def test_validate_minimal_data(self):
+        """Test validation with minimal required fields."""
+        data = {
+            "name": "Minimal Experiment",
+            "feature_flag_key": "minimal-flag",
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert serializer.is_valid(), serializer.errors
+
+        dto = serializer.to_facade_dto()
+        assert dto.name == "Minimal Experiment"
+        assert dto.description == ""
+        assert dto.parameters is None
+        assert dto.feature_flag_filters is None
+
+    def test_validate_feature_flag_filters_nested_structure(self):
+        """Test nested validation of feature_flag_filters."""
+        data = {
+            "name": "Nested Test",
+            "feature_flag_key": "nested-flag",
+            "feature_flag_filters": {
+                "key": "nested-flag",
+                "name": "Nested Flag",
+                "variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ],
+                "rollout_percentage": 100,
+                "aggregation_group_type_index": 0,
+                "ensure_experience_continuity": True,
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert serializer.is_valid(), serializer.errors
+
+        dto = serializer.to_facade_dto()
+        assert dto.feature_flag_filters is not None
+        assert dto.feature_flag_filters.rollout_percentage == 100
+        assert dto.feature_flag_filters.aggregation_group_type_index == 0
+        assert dto.feature_flag_filters.ensure_experience_continuity is True
+
+    def test_validate_feature_flag_filters_requires_variants(self):
+        """Test that feature_flag_filters requires variants."""
+        data = {
+            "name": "No Variants",
+            "feature_flag_key": "no-variants-flag",
+            "feature_flag_filters": {
+                "key": "no-variants-flag",
+                "name": "No Variants Flag",
+                # Missing variants
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "feature_flag_filters" in serializer.errors
+
+    def test_validate_variant_rollout_percentages(self):
+        """Test validation of variant rollout percentages."""
+        data = {
+            "name": "Invalid Percentages",
+            "feature_flag_key": "invalid-flag",
+            "feature_flag_filters": {
+                "key": "invalid-flag",
+                "variants": [
+                    {"key": "control", "rollout_percentage": -10},  # Invalid
+                ],
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+
+    def test_to_facade_dto_preserves_all_fields(self):
+        """Test that to_facade_dto preserves all input fields."""
+        data = {
+            "name": "Complete Test",
+            "feature_flag_key": "complete-flag",
+            "description": "Complete description",
+            "feature_flag_filters": {
+                "key": "complete-flag",
+                "name": "Complete Flag",
+                "variants": [
+                    {"key": "control", "name": "Control", "rollout_percentage": 33},
+                    {"key": "test_a", "name": "Test A", "rollout_percentage": 33},
+                    {"key": "test_b", "name": "Test B", "rollout_percentage": 34},
+                ],
+                "rollout_percentage": 80,
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert serializer.is_valid(), serializer.errors
+
+        dto = serializer.to_facade_dto()
+        assert dto.name == "Complete Test"
+        assert dto.description == "Complete description"
+        assert dto.feature_flag_filters is not None
+        assert len(dto.feature_flag_filters.variants) == 3
+        assert dto.feature_flag_filters.variants[0].name == "Control"
+        assert dto.feature_flag_filters.variants[1].key == "test_a"
+        assert dto.feature_flag_filters.rollout_percentage == 80
+
+    def test_validate_control_variant_required(self):
+        """Test that control variant is required in new format."""
+        data = {
+            "name": "No Control Test",
+            "feature_flag_key": "no-control-flag",
+            "feature_flag_filters": {
+                "key": "no-control-flag",
+                "variants": [
+                    {"key": "test_a", "rollout_percentage": 50},
+                    {"key": "test_b", "rollout_percentage": 50},
+                ],
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "feature_flag_filters" in serializer.errors
+        assert "control" in str(serializer.errors).lower()
+
+    def test_validate_control_variant_required_old_format(self):
+        """Test that control variant is required in old format."""
+        data = {
+            "name": "No Control Old Format",
+            "feature_flag_key": "no-control-old-flag",
+            "parameters": {
+                "feature_flag_variants": [
+                    {"key": "test_a", "rollout_percentage": 50},
+                    {"key": "test_b", "rollout_percentage": 50},
+                ]
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "parameters" in serializer.errors
+        assert "control" in str(serializer.errors).lower()
+
+    def test_validate_duplicate_variant_keys(self):
+        """Test that duplicate variant keys are rejected."""
+        data = {
+            "name": "Duplicate Keys Test",
+            "feature_flag_key": "duplicate-keys-flag",
+            "feature_flag_filters": {
+                "key": "duplicate-keys-flag",
+                "variants": [
+                    {"key": "control", "rollout_percentage": 33},
+                    {"key": "test", "rollout_percentage": 33},
+                    {"key": "test", "rollout_percentage": 34},  # Duplicate
+                ],
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "feature_flag_filters" in serializer.errors
+        assert "unique" in str(serializer.errors).lower()
+
+    def test_validate_duplicate_variant_keys_old_format(self):
+        """Test that duplicate variant keys are rejected in old format."""
+        data = {
+            "name": "Duplicate Keys Old",
+            "feature_flag_key": "duplicate-keys-old-flag",
+            "parameters": {
+                "feature_flag_variants": [
+                    {"key": "control", "rollout_percentage": 33},
+                    {"key": "test", "rollout_percentage": 33},
+                    {"key": "test", "rollout_percentage": 34},  # Duplicate
+                ]
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "parameters" in serializer.errors
+        assert "unique" in str(serializer.errors).lower()
+
+    def test_validate_too_many_variants(self):
+        """Test that more than 20 variants are rejected."""
+        variants = [{"key": "control", "rollout_percentage": 5}]
+        variants.extend([{"key": f"test_{i}", "rollout_percentage": 5} for i in range(20)])
+
+        data = {
+            "name": "Too Many Variants",
+            "feature_flag_key": "too-many-variants-flag",
+            "feature_flag_filters": {
+                "key": "too-many-variants-flag",
+                "variants": variants,
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "feature_flag_filters" in serializer.errors
+        assert "21" in str(serializer.errors)
+
+    def test_validate_too_many_variants_old_format(self):
+        """Test that more than 20 variants are rejected in old format."""
+        variants = [{"key": "control", "rollout_percentage": 5}]
+        variants.extend([{"key": f"test_{i}", "rollout_percentage": 5} for i in range(20)])
+
+        data = {
+            "name": "Too Many Variants Old",
+            "feature_flag_key": "too-many-variants-old-flag",
+            "parameters": {"feature_flag_variants": variants},
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "parameters" in serializer.errors
+        assert "21" in str(serializer.errors)
+
+    def test_validate_feature_flag_key_already_exists(self):
+        """Test that existing feature flag keys are rejected."""
+        from posthog.models.feature_flag.feature_flag import FeatureFlag
+
+        # Create an existing feature flag
+        FeatureFlag.objects.create(team=self.team, key="existing-flag", created_by=self.user)
+
+        data = {
+            "name": "Duplicate Flag Key",
+            "feature_flag_key": "existing-flag",
+            "feature_flag_filters": {
+                "key": "existing-flag",
+                "variants": [
+                    {"key": "control", "rollout_percentage": 50},
+                    {"key": "test", "rollout_percentage": 50},
+                ],
+            },
+        }
+
+        serializer = ExperimentCreateSerializer(data=data, context={"get_team": lambda: self.team})
+        assert not serializer.is_valid()
+        assert "feature_flag_key" in serializer.errors
+        assert "already exists" in str(serializer.errors).lower()


### PR DESCRIPTION
## Problem

The presentation layer serializers accepted experiment creation requests but lacked critical validation rules that are essential for experiments with feature flags.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Enhanced validation logic in `ExperimentCreateSerializer` and `CreateFeatureFlagInputSerializer` to enforce experiment-specific business rules for both old and new formats:

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
