### PR TITLE
fix(flags): align stale filter SQL with FeatureFlagStatusChecker logic

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -2555,15 +2555,20 @@ class FeatureFlagViewSet(
                             """
                             (
                                 (
+                                    -- Boolean flag: fully rolled out (100% with no properties)
+                                    -- A flag is boolean only when multivariate key is absent (NULL).
+                                    -- Flags with multivariate: {"variants": []} are treated as
+                                    -- multivariate by FeatureFlagStatusChecker, not boolean.
                                     EXISTS (
                                         SELECT 1 FROM jsonb_array_elements(posthog_featureflag.filters->'groups') AS elem
                                         WHERE elem->>'rollout_percentage' = '100'
                                         AND (elem->'properties')::text = '[]'::text
                                     )
-                                    AND (posthog_featureflag.filters->>'multivariate' IS NULL OR jsonb_array_length(posthog_featureflag.filters->'multivariate'->'variants') = 0)
+                                    AND posthog_featureflag.filters->>'multivariate' IS NULL
                                 )
                                 OR
                                 (
+                                    -- Multivariate flag: a variant at 100% AND a release condition at 100%
                                     EXISTS (
                                         SELECT 1 FROM jsonb_array_elements(posthog_featureflag.filters->'multivariate'->'variants') AS variant
                                         WHERE variant->>'rollout_percentage' = '100'
@@ -2576,6 +2581,7 @@ class FeatureFlagViewSet(
                                 )
                                 OR
                                 (
+                                    -- Multivariate flag: release condition at 100% with variant override
                                     EXISTS (
                                         SELECT 1 FROM jsonb_array_elements(posthog_featureflag.filters->'groups') AS elem
                                         WHERE elem->>'rollout_percentage' = '100'


### PR DESCRIPTION
## Problem

The stale feature flag filter (`active=STALE`) returns inconsistent results compared to the `FeatureFlagStatusChecker` badges shown in the UI.

Flags with `multivariate: {"variants": []}` are treated differently:
- **SQL filter**: Treats them as boolean (stale if 100% rolled out)
- **FeatureFlagStatusChecker**: Treats them as multivariate (active, since no variant is at 100%)

This causes the filter to show fewer stale flags than actually appear with stale badges in the "All" view.

## Root Cause

In `_apply_filters()`, the boolean branch condition was:
```sql
posthog_featureflag.filters->>'multivariate' IS NULL
OR jsonb_array_length(posthog_featureflag.filters->'multivariate'->'variants') = 0
```

This incorrectly classified flags with empty variant arrays as boolean.

In Python, `FeatureFlagStatusChecker.is_flag_fully_rolled_out()` checks `if multivariate:` which is truthy for `{"variants": []}`, sending it to the multivariate path where no variant has 100% rollout, so the flag is NOT stale.

## Fix

Changed the SQL boolean condition to only match when the `multivariate` key is truly absent (`IS NULL`), not when variants is empty. This aligns with the Python `if multivariate:` check.

## How did you test this code?

Manual verification of the logic alignment between `_apply_filters` SQL and `FeatureFlagStatusChecker.is_flag_fully_rolled_out()`.

Closes #40755