### PR TITLE
fix(cdp): Use truthy check for distinct_id in batch workflow person lookup and postHogCapture

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.consumer.ts
@@ -54,7 +54,7 @@ export class CdpCyclotronWorkerHogFlow extends CdpCyclotronWorker {
 
                 const hogFlowInvocationState = item.state as CyclotronJobInvocationHogFlow['state']
 
-                const personIdOrDistinctId = hogFlowInvocationState.event.distinct_id ?? hogFlowInvocationState.personId
+                const personIdOrDistinctId = hogFlowInvocationState.event.distinct_id || hogFlowInvocationState.personId
                 const kind = hogFlowInvocationState.event.distinct_id ? 'distinct_id' : 'person_id'
 
                 const [person, groups] = await Promise.all([

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-hogflow.test.ts
@@ -250,6 +250,34 @@ describe('CdpCyclotronWorkerHogFlow', () => {
             ])
         })
 
+        it('should resolve person by personId when distinct_id is empty (batch invocations)', async () => {
+            const personUuid = 'dd3d6f80-60ad-45c3-bd61-e2300f2ba7f0'
+            await createPerson(team.id, personUuid, 'distinct_batch_1', {
+                name: 'Batch Person',
+                email: 'batch@posthog.com',
+            })
+
+            // Batch invocations set distinct_id: '' and use personId instead
+            const invocation = createSerializedHogFlowInvocation(hogFlows[0], {
+                event: {
+                    distinct_id: '',
+                    properties: { foo: 'batch' },
+                } as any,
+                personId: personUuid,
+            })
+
+            const results = (await processor.processInvocations([
+                invocation,
+            ])) as CyclotronJobInvocationResult<CyclotronJobInvocationHogFlow>[]
+
+            expect(results).toHaveLength(1)
+            expect(results[0].invocation.person?.properties).toEqual({
+                name: 'Batch Person',
+                email: 'batch@posthog.com',
+            })
+            expect(results[0].invocation.filterGlobals?.person?.id).toBe(personUuid)
+        })
+
         it('should skip invocations when workflow is disabled after being queued', async () => {
             // Scenario: workflow is active, invocations are queued, then workflow is disabled
             // Remaining invocations should be skipped

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -730,6 +730,30 @@ describe('Hog Executor', () => {
             `)
         })
 
+        it('falls back to person.id for distinct_id when event.distinct_id is empty (batch invocations)', async () => {
+            const fn = createHogFunction({
+                ...HOG_EXAMPLES.posthog_capture,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+            })
+
+            const globals = createHogExecutionGlobals({
+                groups: {},
+                event: {
+                    distinct_id: '',
+                } as any,
+                person: {
+                    id: 'person-uuid-123',
+                    name: 'Batch Person',
+                    url: 'http://localhost:8000/persons/1',
+                    properties: { email: 'batch@posthog.com' },
+                },
+            } as any)
+            const result = await executor.execute(createExampleInvocation(fn, globals))
+            expect(result?.capturedPostHogEvents).toHaveLength(1)
+            expect(result?.capturedPostHogEvents[0].distinct_id).toBe('person-uuid-123')
+        })
+
         it('allows events that have already used their postHogCapture a maximum of 10 times', async () => {
             const fn = createHogFunction({
                 ...HOG_EXAMPLES.posthog_capture,

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -472,7 +472,7 @@ export class HogExecutorService {
                                 : null
                         },
                         postHogCapture: (event) => {
-                            const distinctId = event.distinct_id || globals.event?.distinct_id
+                            const distinctId = event.distinct_id || globals.event?.distinct_id || globals.person?.id
                             const eventName = event.event
                             const eventProperties = event.properties || {}
 


### PR DESCRIPTION
## Problem

Batch workflow executions (e.g. sending emails to a matched audience) broke after #49658 (Lazy load persons). Two bugs caused person data to never load for batch invocations.

Batch invocations set `distinct_id: ''` (empty string) because there's no real event - they're triggered for a list of persons. The lazy loading code used `??` (nullish coalescing) which doesn't catch empty strings, only `null`/`undefined`.

Before:
<img width="1726" height="799" alt="Screenshot 2026-03-22 at 17 32 00" src="https://github.com/user-attachments/assets/a66a2ae1-42e4-42a0-97ab-87f6ab14b08d" />

After:
<img width="1591" height="723" alt="Screenshot 2026-03-22 at 17 32 50" src="https://github.com/user-attachments/assets/afbfa4be-2871-4f0d-9ea8-b2120da5624a" />

## Changes

- `cdp-cyclotron-worker-hogflow.consumer.ts`: Changed `??` to `||` so empty `distinct_id` falls through to `personId`. This restores person lookup for batch invocations.
- `hog-executor.service.ts`: Added `globals.person?.id` as a fallback for `postHogCapture` distinct_id resolution. Without this, any workflow step using `postHogCapture` after the email action throws "missing distinct_id".

## How did you test this code?

- Added unit tests for both bug fixes
- Manually triggered batch workflows with an email action - before the fix emails failed, after the fix they sent successfully

## Publish to changelog?
No
