### PR TITLE
fix: resolve conflicting advice on cohort usage in test/internal user filters

### DIFF
--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -436,13 +436,15 @@ export function HogFunctionScene(): JSX.Element {
                 <HogFunctionHeader />
                 {teamHasCohortFilters && (
                     <LemonBanner type="warning" className="mb-4">
-                        <strong>Warning:</strong> This function has "Filter out internal and test users" enabled, but
-                        your team's test account filters include cohorts. Cohorts cannot be used in real-time filters
-                        and may cause this function to fail. Please update your{' '}
+                        <strong>Warning:</strong> This destination has "Filter out internal and test users" enabled, but
+                        your team's test account filters include cohorts. Cohort-based filters are not supported in
+                        real-time CDP destinations and will be skipped, which means internal/test events may still be
+                        sent to this destination. To filter out internal users in destinations, add inline person
+                        property filters (e.g., "email does not contain your-domain.com") to your{' '}
                         <Link to={`/project/${currentProjectId}/settings/project#internal-user-filtering`}>
                             test account filters
-                        </Link>{' '}
-                        to use inline expressions instead of cohorts.
+                        </Link>
+                        .
                     </LemonBanner>
                 )}
                 {templateId ? (

--- a/frontend/src/scenes/settings/environment/TestAccountFiltersConfig.tsx
+++ b/frontend/src/scenes/settings/environment/TestAccountFiltersConfig.tsx
@@ -83,9 +83,16 @@ function TestAccountFiltersConfig(): JSX.Element {
         <div className="mb-4 flex flex-col gap-2">
             <div className="mb-4 flex flex-col gap-2">
                 <LemonBanner type="info">
-                    When filtering out internal users by person properties, like email, we recommend creating a Cohort
-                    with those properties, and then adding that cohort with a "not in" operator in your ‘Filter out
-                    internal and test users’ settings.
+                    <p>
+                        Cohort-based filters work well for analytics queries (Insights, Dashboards) as they properly
+                        account for events received from anonymous users who are later identified.
+                    </p>
+                    <p>
+                        However, cohort-based filters are <strong>not supported</strong> in real-time destinations (CDP
+                        pipelines). If you use CDP destinations and want to filter out internal users there too, use
+                        inline person property filters (e.g., "email does not contain your-domain.com") instead of
+                        cohorts.
+                    </p>
                 </LemonBanner>
                 {!!testAccountFilterWarningLabels && testAccountFilterWarningLabels.length > 0 && (
                     <LemonBanner type="warning" className="m-2">


### PR DESCRIPTION
## Problem

Fixes #41812

The test account filter settings page and CDP destination pages give **contradictory advice** about using cohorts for filtering internal/test users:

- **Settings page** (`TestAccountFiltersConfig.tsx`): *"we recommend creating a Cohort with those properties"*
- **CDP destination page** (`HogFunctionScene.tsx`): *"Cohorts cannot be used in real-time filters... use inline expressions instead of cohorts"*

A user following the recommendation on the settings page would then see a warning on their CDP destinations, with no understanding of why the advice conflicts.

## Changes

### `frontend/src/scenes/settings/environment/TestAccountFiltersConfig.tsx`
- Updated the info banner to explain **both** use cases: cohort-based filters work well for analytics (Insights, Dashboards) but are **not supported** in real-time CDP destinations
- Guides users to use inline person property filters if they use CDP destinations

### `frontend/src/scenes/hog-functions/HogFunctionScene.tsx`  
- Changed "function" → "destination" for clarity
- Made the warning more precise: cohort filters "will be skipped" (not "may cause this function to fail")
- Added a concrete example of an inline filter alternative ("email does not contain your-domain.com")
- Improved overall tone to be helpful rather than alarming

## How did you test this code?

- Verified the banner copy renders correctly by reviewing the JSX structure
- No logic changes — copy-only fix, no new tests needed

## Does this work well for both Cloud and self-hosted?

Yes — this is a frontend-only UX copy change that applies universally.