### PR TITLE
feat(alerts): add checks_date_from and checks_limit params to alert retrieve

### DIFF
--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -571,7 +571,7 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         raw_limit = request.query_params.get("checks_limit")
         if raw_limit is not None:
             try:
-                limit = min(int(raw_limit), self.CHECKS_MAX_LIMIT)
+                limit = max(1, min(int(raw_limit), self.CHECKS_MAX_LIMIT))
             except (ValueError, TypeError):
                 limit = self.CHECKS_DEFAULT_LIMIT
         else:

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -136,7 +136,7 @@ class AlertSerializer(serializers.ModelSerializer):
     checks = AlertCheckSerializer(
         many=True,
         read_only=True,
-        help_text="Alert check results. By default returns the last 5. Use checks_date_from (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). Only populated on retrieve.",
+        help_text="Alert check results. By default returns the last 5. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). Only populated on retrieve.",
     )
     threshold = ThresholdSerializer(
         help_text="Threshold configuration with bounds and type for evaluating the alert.",
@@ -536,7 +536,13 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 name="checks_date_from",
                 type=str,
                 required=False,
-                description="Relative date string to filter checks (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days.",
+                description="Relative date string for the start of the check history window (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days.",
+            ),
+            OpenApiParameter(
+                name="checks_date_to",
+                type=str,
+                required=False,
+                description="Relative date string for the end of the check history window (e.g. '-1h', '-1d'). Defaults to now if not specified.",
             ),
             OpenApiParameter(
                 name="checks_limit",
@@ -556,6 +562,12 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             parsed_date = relative_date_parse(checks_date_from, ZoneInfo("UTC"))
             checks_qs = checks_qs.filter(created_at__gte=parsed_date)
 
+        checks_date_to = request.query_params.get("checks_date_to")
+        if checks_date_to:
+            parsed_date = relative_date_parse(checks_date_to, ZoneInfo("UTC"))
+            checks_qs = checks_qs.filter(created_at__lte=parsed_date)
+
+        has_date_filter = checks_date_from or checks_date_to
         raw_limit = request.query_params.get("checks_limit")
         if raw_limit is not None:
             try:
@@ -563,7 +575,7 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             except (ValueError, TypeError):
                 limit = self.CHECKS_DEFAULT_LIMIT
         else:
-            limit = self.CHECKS_MAX_LIMIT if checks_date_from else self.CHECKS_DEFAULT_LIMIT
+            limit = self.CHECKS_MAX_LIMIT if has_date_filter else self.CHECKS_DEFAULT_LIMIT
 
         instance.checks = checks_qs[:limit]
         serializer = self.get_serializer(instance)

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -6,7 +6,7 @@ from django.db.models import OuterRef, QuerySet, Subquery
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -136,7 +136,7 @@ class AlertSerializer(serializers.ModelSerializer):
     checks = AlertCheckSerializer(
         many=True,
         read_only=True,
-        help_text="The last 5 alert check results (only populated on retrieve).",
+        help_text="Alert check results. By default returns the last 5. Use checks_date_from (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). Only populated on retrieve.",
     )
     threshold = ThresholdSerializer(
         help_text="Threshold configuration with bounds and type for evaluating the alert.",
@@ -527,9 +527,45 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         return queryset
 
+    CHECKS_DEFAULT_LIMIT = 5
+    CHECKS_MAX_LIMIT = 500
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="checks_date_from",
+                type=str,
+                required=False,
+                description="Relative date string to filter checks (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days.",
+            ),
+            OpenApiParameter(
+                name="checks_limit",
+                type=int,
+                required=False,
+                description="Maximum number of check results to return (default 5, max 500). Applied after date filtering.",
+            ),
+        ],
+    )
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
-        instance.checks = instance.alertcheck_set.all().order_by("-created_at")[:5]
+
+        checks_qs = instance.alertcheck_set.all().order_by("-created_at")
+
+        checks_date_from = request.query_params.get("checks_date_from")
+        if checks_date_from:
+            parsed_date = relative_date_parse(checks_date_from, ZoneInfo("UTC"))
+            checks_qs = checks_qs.filter(created_at__gte=parsed_date)
+
+        raw_limit = request.query_params.get("checks_limit")
+        if raw_limit is not None:
+            try:
+                limit = min(int(raw_limit), self.CHECKS_MAX_LIMIT)
+            except (ValueError, TypeError):
+                limit = self.CHECKS_DEFAULT_LIMIT
+        else:
+            limit = self.CHECKS_MAX_LIMIT if checks_date_from else self.CHECKS_DEFAULT_LIMIT
+
+        instance.checks = checks_qs[:limit]
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from posthog.test.base import APIBaseTest, QueryMatchingTest
@@ -140,6 +140,117 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         )
         assert list_for_another_insight.status_code == status.HTTP_200_OK
         assert len(list_for_another_insight.json()["results"]) == 0
+
+    def test_retrieve_checks_default_limit(self) -> None:
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "checks test",
+        }
+        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+
+        for i in range(8):
+            AlertCheck.objects.create(
+                alert_configuration=alert_obj,
+                calculated_value=float(i),
+                state=AlertState.NOT_FIRING,
+            )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["checks"]) == 5
+
+    def test_retrieve_checks_with_limit(self) -> None:
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "checks limit test",
+        }
+        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+
+        for i in range(10):
+            AlertCheck.objects.create(
+                alert_configuration=alert_obj,
+                calculated_value=float(i),
+                state=AlertState.NOT_FIRING,
+            )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}?checks_limit=3")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["checks"]) == 3
+
+    def test_retrieve_checks_with_date_from(self) -> None:
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "checks date test",
+        }
+        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+
+        now = datetime.now(UTC)
+        # Create 3 old checks (2 days ago) and 2 recent checks (now)
+        for i in range(3):
+            check = AlertCheck.objects.create(
+                alert_configuration=alert_obj,
+                calculated_value=float(i),
+                state=AlertState.NOT_FIRING,
+            )
+            AlertCheck.objects.filter(id=check.id).update(created_at=now - timedelta(hours=48 + i))
+
+        for i in range(2):
+            AlertCheck.objects.create(
+                alert_configuration=alert_obj,
+                calculated_value=float(10 + i),
+                state=AlertState.NOT_FIRING,
+            )
+
+        # Without date_from — returns last 5 (all of them)
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}")
+        assert len(response.json()["checks"]) == 5
+
+        # With date_from=-24h — only the 2 recent checks
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}?checks_date_from=-24h")
+        assert response.status_code == status.HTTP_200_OK
+        checks = response.json()["checks"]
+        assert len(checks) == 2
+        for check in checks:
+            assert check["calculated_value"] >= 10.0
+
+    def test_retrieve_checks_limit_capped_at_max(self) -> None:
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "checks cap test",
+        }
+        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+
+        for i in range(3):
+            AlertCheck.objects.create(
+                alert_configuration=alert_obj,
+                calculated_value=float(i),
+                state=AlertState.NOT_FIRING,
+            )
+
+        # Requesting over the max should still work (capped to 500)
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}?checks_limit=9999")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["checks"]) == 3
 
     def test_alert_limit(self) -> None:
         with mock.patch("posthog.api.alert.AlertConfiguration.ALERTS_ALLOWED_ON_FREE_TIER") as alert_limit:

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -141,30 +141,19 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         assert list_for_another_insight.status_code == status.HTTP_200_OK
         assert len(list_for_another_insight.json()["results"]) == 0
 
-    def test_retrieve_checks_default_limit(self) -> None:
-        creation_request = {
-            "insight": self.insight["id"],
-            "subscribed_users": [self.user.id],
-            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
-            "config": {"type": "TrendsAlertConfig", "series_index": 0},
-            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
-            "name": "checks test",
-        }
-        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
-        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
-
-        for i in range(8):
-            AlertCheck.objects.create(
-                alert_configuration=alert_obj,
-                calculated_value=float(i),
-                state=AlertState.NOT_FIRING,
-            )
-
-        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}")
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()["checks"]) == 5
-
-    def test_retrieve_checks_with_limit(self) -> None:
+    @parameterized.expand(
+        [
+            ("default_limit", 8, "", 5),
+            ("explicit_limit", 10, "?checks_limit=3", 3),
+            ("capped_at_max", 3, "?checks_limit=9999", 3),
+            ("negative_clamped_to_1", 5, "?checks_limit=-5", 1),
+            ("zero_clamped_to_1", 5, "?checks_limit=0", 1),
+            ("invalid_falls_back_to_default", 5, "?checks_limit=abc", 5),
+        ]
+    )
+    def test_retrieve_checks_limit_behaviour(
+        self, _name: str, total_checks: int, query_param: str, expected_count: int
+    ) -> None:
         creation_request = {
             "insight": self.insight["id"],
             "subscribed_users": [self.user.id],
@@ -176,16 +165,16 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
         alert_obj = AlertConfiguration.objects.get(id=alert["id"])
 
-        for i in range(10):
+        for i in range(total_checks):
             AlertCheck.objects.create(
                 alert_configuration=alert_obj,
                 calculated_value=float(i),
                 state=AlertState.NOT_FIRING,
             )
 
-        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}?checks_limit=3")
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}{query_param}")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()["checks"]) == 3
+        assert len(response.json()["checks"]) == expected_count
 
     def test_retrieve_checks_with_date_from(self) -> None:
         creation_request = {
@@ -265,30 +254,6 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         assert len(checks) == 3
         values = [c["calculated_value"] for c in checks]
         assert 4.0 not in values
-
-    def test_retrieve_checks_limit_capped_at_max(self) -> None:
-        creation_request = {
-            "insight": self.insight["id"],
-            "subscribed_users": [self.user.id],
-            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
-            "config": {"type": "TrendsAlertConfig", "series_index": 0},
-            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
-            "name": "checks cap test",
-        }
-        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
-        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
-
-        for i in range(3):
-            AlertCheck.objects.create(
-                alert_configuration=alert_obj,
-                calculated_value=float(i),
-                state=AlertState.NOT_FIRING,
-            )
-
-        # Requesting over the max should still work (capped to 500)
-        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}?checks_limit=9999")
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()["checks"]) == 3
 
     def test_alert_limit(self) -> None:
         with mock.patch("posthog.api.alert.AlertConfiguration.ALERTS_ALLOWED_ON_FREE_TIER") as alert_limit:

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -228,6 +228,44 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         for check in checks:
             assert check["calculated_value"] >= 10.0
 
+    def test_retrieve_checks_with_date_from_and_date_to(self) -> None:
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "checks window test",
+        }
+        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+
+        now = datetime.now(UTC)
+        # Create checks at different times: 3 days ago, 2 days ago, 1 day ago, now
+        times_and_values = [
+            (now - timedelta(hours=72), 1.0),
+            (now - timedelta(hours=48), 2.0),
+            (now - timedelta(hours=24), 3.0),
+            (now, 4.0),
+        ]
+        for created_at, value in times_and_values:
+            check = AlertCheck.objects.create(
+                alert_configuration=alert_obj,
+                calculated_value=value,
+                state=AlertState.NOT_FIRING,
+            )
+            AlertCheck.objects.filter(id=check.id).update(created_at=created_at)
+
+        # Window from 4 days ago to 12 hours ago — should get checks with values 1.0, 2.0, 3.0 but not 4.0
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/alerts/{alert['id']}?checks_date_from=-4d&checks_date_to=-12h"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        checks = response.json()["checks"]
+        assert len(checks) == 3
+        values = [c["calculated_value"] for c in checks]
+        assert 4.0 not in values
+
     def test_retrieve_checks_limit_capped_at_max(self) -> None:
         creation_request = {
             "insight": self.insight["id"],

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -535,7 +535,7 @@ export interface AlertApi {
     readonly last_checked_at: string | null
     /** @nullable */
     readonly next_check_at: string | null
-    /** The last 5 alert check results (only populated on retrieve). */
+    /** Alert check results. By default returns the last 5. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). Only populated on retrieve. */
     readonly checks: readonly AlertCheckApi[]
     /** Trends-specific alert configuration. Includes series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). */
     config?: TrendsAlertConfigApi | null
@@ -597,7 +597,7 @@ export interface PatchedAlertApi {
     readonly last_checked_at?: string | null
     /** @nullable */
     readonly next_check_at?: string | null
-    /** The last 5 alert check results (only populated on retrieve). */
+    /** Alert check results. By default returns the last 5. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). Only populated on retrieve. */
     readonly checks?: readonly AlertCheckApi[]
     /** Trends-specific alert configuration. Includes series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). */
     config?: TrendsAlertConfigApi | null
@@ -675,4 +675,19 @@ export type AlertsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+}
+
+export type AlertsRetrieveParams = {
+    /**
+     * Relative date string for the start of the check history window (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days.
+     */
+    checks_date_from?: string
+    /**
+     * Relative date string for the end of the check history window (e.g. '-1h', '-1d'). Defaults to now if not specified.
+     */
+    checks_date_to?: string
+    /**
+     * Maximum number of check results to return (default 5, max 500). Applied after date filtering.
+     */
+    checks_limit?: number
 }

--- a/products/alerts/frontend/generated/api.ts
+++ b/products/alerts/frontend/generated/api.ts
@@ -13,6 +13,7 @@ import type {
     AlertSimulateApi,
     AlertSimulateResponseApi,
     AlertsListParams,
+    AlertsRetrieveParams,
     PaginatedAlertListApi,
     PatchedAlertApi,
 } from './api.schemas'
@@ -78,12 +79,29 @@ export const alertsCreate = async (
     })
 }
 
-export const getAlertsRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/alerts/${id}/`
+export const getAlertsRetrieveUrl = (projectId: string, id: string, params?: AlertsRetrieveParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/alerts/${id}/?${stringifiedParams}`
+        : `/api/projects/${projectId}/alerts/${id}/`
 }
 
-export const alertsRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<AlertApi> => {
-    return apiMutator<AlertApi>(getAlertsRetrieveUrl(projectId, id), {
+export const alertsRetrieve = async (
+    projectId: string,
+    id: string,
+    params?: AlertsRetrieveParams,
+    options?: RequestInit
+): Promise<AlertApi> => {
+    return apiMutator<AlertApi>(getAlertsRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
     })

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -39,9 +39,9 @@ tools:
             Get a specific alert by ID. Returns the full alert configuration including check results,
             threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results
             include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts.
-            By default returns the last 5 checks. Use checks_date_from (e.g. '-24h', '-7d') to get checks
-            within a time window, and checks_limit to control the maximum returned (default 5, max 500).
-            When checks_date_from is provided without checks_limit, up to 500 checks are returned.
+            By default returns the last 5 checks. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d')
+            to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500).
+            When date filters are provided without checks_limit, up to 500 checks are returned.
             Check history is retained for 14 days.
         mcp_version: 1
     alert-create:

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -36,9 +36,13 @@ tools:
             idempotent: true
         title: Get alert
         description: >
-            Get a specific alert by ID. Returns the full alert configuration including the last 5 check results,
+            Get a specific alert by ID. Returns the full alert configuration including check results,
             threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results
             include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts.
+            By default returns the last 5 checks. Use checks_date_from (e.g. '-24h', '-7d') to get checks
+            within a time window, and checks_limit to control the maximum returned (default 5, max 500).
+            When checks_date_from is provided without checks_limit, up to 500 checks are returned.
+            Check history is retained for 14 days.
         mcp_version: 1
     alert-create:
         operation: alerts_create

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -105,7 +105,7 @@
         }
     },
     "alert-get": {
-        "description": "Get a specific alert by ID. Returns the full alert configuration including the last 5 check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts.",
+        "description": "Get a specific alert by ID. Returns the full alert configuration including check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts. By default returns the last 5 checks. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). When date filters are provided without checks_limit, up to 500 checks are returned. Check history is retained for 14 days.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Get alert",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -839,7 +839,7 @@
         }
     },
     "alert-get": {
-        "description": "Get a specific alert by ID. Returns the full alert configuration including the last 5 check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts.",
+        "description": "Get a specific alert by ID. Returns the full alert configuration including check results, threshold settings, detector_config (for anomaly detection alerts), and subscribed users. Check results include anomaly_scores, triggered_points, and triggered_dates for detector-based alerts. By default returns the last 5 checks. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). When date filters are provided without checks_limit, up to 500 checks are returned. Check history is retained for 14 days.",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "Get alert",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4682,7 +4682,7 @@ export namespace Schemas {
       readonly last_checked_at: string | null;
       /** @nullable */
       readonly next_check_at: string | null;
-      /** The last 5 alert check results (only populated on retrieve). */
+      /** Alert check results. By default returns the last 5. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). Only populated on retrieve. */
       readonly checks: readonly AlertCheck[];
       /** Trends-specific alert configuration. Includes series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). */
       config?: TrendsAlertConfig | null;
@@ -20771,7 +20771,7 @@ export namespace Schemas {
       readonly last_checked_at?: string | null;
       /** @nullable */
       readonly next_check_at?: string | null;
-      /** The last 5 alert check results (only populated on retrieve). */
+      /** Alert check results. By default returns the last 5. Use checks_date_from and checks_date_to (e.g. '-24h', '-7d') to get checks within a time window, and checks_limit to control the maximum returned (default 5, max 500). Only populated on retrieve. */
       readonly checks?: readonly AlertCheck[];
       /** Trends-specific alert configuration. Includes series_index (which series to monitor) and check_ongoing_interval (whether to check the current incomplete interval). */
       config?: TrendsAlertConfig | null;
@@ -28398,6 +28398,21 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type EnvironmentsAlertsRetrieveParams = {
+    /**
+     * Relative date string for the start of the check history window (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days.
+     */
+    checks_date_from?: string;
+    /**
+     * Relative date string for the end of the check history window (e.g. '-1h', '-1d'). Defaults to now if not specified.
+     */
+    checks_date_to?: string;
+    /**
+     * Maximum number of check results to return (default 5, max 500). Applied after date filtering.
+     */
+    checks_limit?: number;
+    };
+
     export type EnvironmentsBatchExportsListParams = {
     /**
      * Number of results to return per page.
@@ -30836,6 +30851,21 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    };
+
+    export type AlertsRetrieveParams = {
+    /**
+     * Relative date string for the start of the check history window (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days.
+     */
+    checks_date_from?: string;
+    /**
+     * Relative date string for the end of the check history window (e.g. '-1h', '-1d'). Defaults to now if not specified.
+     */
+    checks_date_to?: string;
+    /**
+     * Maximum number of check results to return (default 5, max 500). Applied after date filtering.
+     */
+    checks_limit?: number;
     };
 
     export type AnnotationsListParams = {

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -856,6 +856,25 @@ export const AlertsRetrieveParams = /* @__PURE__ */ zod.object({
         ),
 })
 
+export const AlertsRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    checks_date_from: zod
+        .string()
+        .optional()
+        .describe(
+            "Relative date string for the start of the check history window (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days."
+        ),
+    checks_date_to: zod
+        .string()
+        .optional()
+        .describe(
+            "Relative date string for the end of the check history window (e.g. '-1h', '-1d'). Defaults to now if not specified."
+        ),
+    checks_limit: zod
+        .number()
+        .optional()
+        .describe('Maximum number of check results to return (default 5, max 500). Applied after date filtering.'),
+})
+
 export const AlertsPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this alert configuration.'),
     project_id: zod

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -9,6 +9,7 @@ import {
     AlertsPartialUpdateBody,
     AlertsPartialUpdateParams,
     AlertsRetrieveParams,
+    AlertsRetrieveQueryParams,
     AlertsSimulateCreateBody,
 } from '@/generated/alerts/api'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -35,7 +36,7 @@ const alertsList = (): ToolBase<typeof AlertsListSchema, Schemas.PaginatedAlertL
     },
 })
 
-const AlertGetSchema = AlertsRetrieveParams.omit({ project_id: true })
+const AlertGetSchema = AlertsRetrieveParams.omit({ project_id: true }).extend(AlertsRetrieveQueryParams.shape)
 
 const alertGet = (): ToolBase<typeof AlertGetSchema, Schemas.Alert> => ({
     name: 'alert-get',
@@ -45,6 +46,11 @@ const alertGet = (): ToolBase<typeof AlertGetSchema, Schemas.Alert> => ({
         const result = await context.api.request<Schemas.Alert>({
             method: 'GET',
             path: `/api/projects/${projectId}/alerts/${params.id}/`,
+            query: {
+                checks_date_from: params.checks_date_from,
+                checks_date_to: params.checks_date_to,
+                checks_limit: params.checks_limit,
+            },
         })
         return result
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/alert-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/v1/alert-get.json
@@ -1,6 +1,18 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "checks_date_from": {
+            "description": "Relative date string for the start of the check history window (e.g. '-24h', '-7d', '-14d'). Returns checks created after this time. Max retention is 14 days.",
+            "type": "string"
+        },
+        "checks_date_to": {
+            "description": "Relative date string for the end of the check history window (e.g. '-1h', '-1d'). Defaults to now if not specified.",
+            "type": "string"
+        },
+        "checks_limit": {
+            "description": "Maximum number of check results to return (default 5, max 500). Applied after date filtering.",
+            "type": "number"
+        },
         "id": {
             "description": "A UUID string identifying this alert configuration.",
             "type": "string"


### PR DESCRIPTION
## Problem

The alert-get API endpoint hardcodes returning only the last 5 check results. This makes it impossible to query alert firing history over a time window (e.g. the last 24 hours) via the API or MCP tools — the only workaround is to re-simulate the detector, which produces approximate rather than actual historical results.

## Changes

Add three optional query parameters to the alert retrieve endpoint:

- `checks_date_from`: relative date string (e.g. `-24h`, `-7d`) for the start of the check history window
- `checks_date_to`: relative date string (e.g. `-1h`, `-1d`) for the end of the window (defaults to now)
- `checks_limit`: max number of check results to return (default 5, max 500)

When date filters are provided without `checks_limit`, up to 500 checks are returned (covering the full time window). Without any params, behavior is unchanged (last 5).

Updated the MCP tool description for `alert-get` to document the new parameters and the 14-day retention window.

## How did you test this code?

5 new unit tests covering:
- Default limit (5) is preserved
- Explicit `checks_limit` param
- `checks_date_from` time-based filtering
- `checks_date_from` + `checks_date_to` window filtering
- `checks_limit` is capped at 500

```
pytest posthog/api/test/test_alert.py::TestAlert::test_retrieve_checks_default_limit
pytest posthog/api/test/test_alert.py::TestAlert::test_retrieve_checks_with_limit
pytest posthog/api/test/test_alert.py::TestAlert::test_retrieve_checks_with_date_from
pytest posthog/api/test/test_alert.py::TestAlert::test_retrieve_checks_with_date_from_and_date_to
pytest posthog/api/test/test_alert.py::TestAlert::test_retrieve_checks_limit_capped_at_max
```

## Publish to changelog?

No

## Docs update

No docs changes needed — the OpenAPI spec and MCP tool descriptions are updated inline.