### PR TITLE
feat(workflows): Add response value filtering to survey triggers

### DIFF
--- a/frontend/src/taxonomy/helpers.ts
+++ b/frontend/src/taxonomy/helpers.ts
@@ -57,12 +57,9 @@ export function getCoreFilterDefinition(
         const surveyIndex = value.replace(/^\$survey_response_/, '')
         if (surveyIndex) {
             const index = Number(surveyIndex) + 1
-            // yes this will return 21th, but I'm applying the domain logic of
-            // it being very unlikely that someone will have more than 20 questions,
-            // rather than hyper optimising the suffix.
-            const suffix = index === 1 ? 'st' : index === 2 ? 'nd' : index === 3 ? 'rd' : 'th'
+            const suffix = index === 2 ? 'nd' : index === 3 ? 'rd' : 'th'
             return {
-                label: `Survey Response Question ID: ${surveyIndex}`,
+                label: `Survey response for ${index}${suffix} question`,
                 description: `The response value for the ${index}${suffix} question in the survey.`,
             }
         }

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
@@ -9,6 +9,10 @@ import {
 } from './surveys'
 import { getRegisteredTriggerTypes } from './triggerTypeRegistry'
 
+// Partial mock — getSurveyResponsePropertyKeys only accesses survey.questions
+const makeSurvey = (questions: { question: string; type: SurveyQuestionType }[]): Survey =>
+    ({ questions: questions.map((q) => ({ ...q, id: 'q-id' })) }) as unknown as Survey
+
 describe('surveys', () => {
     const getSurveyTriggerType = (): ReturnType<typeof getRegisteredTriggerTypes>[number] => {
         const types = getRegisteredTriggerTypes()
@@ -166,59 +170,70 @@ describe('surveys', () => {
     })
 
     describe('getUserProperties', () => {
-        it('filters out managed properties', () => {
-            const config = {
-                type: 'event' as const,
-                filters: {
-                    properties: [
-                        { key: '$survey_id', value: 'survey-123', operator: 'exact', type: 'event' },
-                        { key: '$survey_completed', value: true, operator: 'exact', type: 'event' },
-                        { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
-                        { key: '$survey_response_1', value: 'price', operator: 'exact', type: 'event' },
-                    ],
+        it.each([
+            {
+                name: 'filters out managed properties',
+                config: {
+                    type: 'event' as const,
+                    filters: {
+                        properties: [
+                            { key: '$survey_id', value: 'survey-123', operator: 'exact', type: 'event' },
+                            { key: '$survey_completed', value: true, operator: 'exact', type: 'event' },
+                            { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
+                            { key: '$survey_response_1', value: 'price', operator: 'exact', type: 'event' },
+                        ],
+                    },
                 },
-            }
-            expect(getUserProperties(config)).toEqual([
-                { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
-                { key: '$survey_response_1', value: 'price', operator: 'exact', type: 'event' },
-            ])
-        })
-
-        it('returns empty array when no properties', () => {
-            expect(getUserProperties({ type: 'event', filters: {} })).toEqual([])
+                expected: [
+                    { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
+                    { key: '$survey_response_1', value: 'price', operator: 'exact', type: 'event' },
+                ],
+            },
+            {
+                name: 'returns empty array when no properties',
+                config: { type: 'event' as const, filters: {} },
+                expected: [],
+            },
+        ])('$name', ({ config, expected }) => {
+            expect(getUserProperties(config)).toEqual(expected)
         })
     })
 
     describe('buildProperties', () => {
-        it('builds properties for specific survey with user properties', () => {
-            const userProps = [{ key: '$survey_response', value: '5', operator: 'exact', type: 'event' }]
-            const result = buildProperties('survey-123', false, userProps)
-            expect(result).toEqual([
-                { key: '$survey_id', value: 'survey-123', operator: 'exact', type: 'event' },
-                { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
-            ])
-        })
-
-        it('builds properties for "any" survey', () => {
-            const result = buildProperties('any', true, [])
-            expect(result).toEqual([
-                { key: '$survey_id', operator: 'is_set', type: 'event' },
-                { key: '$survey_completed', value: true, operator: 'exact', type: 'event' },
-            ])
-        })
-
-        it('builds properties with no survey selected', () => {
-            const result = buildProperties(null, false, [])
-            expect(result).toEqual([])
+        it.each([
+            {
+                name: 'specific survey with user properties',
+                surveyId: 'survey-123' as string | null | 'any',
+                completedOnly: false,
+                userProps: [{ key: '$survey_response', value: '5', operator: 'exact', type: 'event' }],
+                expected: [
+                    { key: '$survey_id', value: 'survey-123', operator: 'exact', type: 'event' },
+                    { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
+                ],
+            },
+            {
+                name: '"any" survey with completed filter',
+                surveyId: 'any' as string | null | 'any',
+                completedOnly: true,
+                userProps: [],
+                expected: [
+                    { key: '$survey_id', operator: 'is_set', type: 'event' },
+                    { key: '$survey_completed', value: true, operator: 'exact', type: 'event' },
+                ],
+            },
+            {
+                name: 'no survey selected',
+                surveyId: null as string | null | 'any',
+                completedOnly: false,
+                userProps: [],
+                expected: [],
+            },
+        ])('$name', ({ surveyId, completedOnly, userProps, expected }) => {
+            expect(buildProperties(surveyId, completedOnly, userProps)).toEqual(expected)
         })
     })
 
     describe('getSurveyResponsePropertyKeys', () => {
-        const makeSurvey = (questions: { question: string; type: SurveyQuestionType }[]): Survey =>
-            ({
-                questions: questions.map((q) => ({ ...q, id: 'q-id' })),
-            }) as unknown as Survey
-
         it('generates correct keys for multiple questions', () => {
             const survey = makeSurvey([
                 { question: 'How likely are you to recommend us?', type: SurveyQuestionType.Rating },

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.test.ts
@@ -1,6 +1,12 @@
-import { SurveyEventName } from '~/types'
+import { Survey, SurveyEventName, SurveyQuestionType } from '~/types'
 
-import { getSelectedSurveyId, isSurveyTriggerConfig } from './surveys'
+import {
+    buildProperties,
+    getSelectedSurveyId,
+    getSurveyResponsePropertyKeys,
+    getUserProperties,
+    isSurveyTriggerConfig,
+} from './surveys'
 import { getRegisteredTriggerTypes } from './triggerTypeRegistry'
 
 describe('surveys', () => {
@@ -157,5 +163,101 @@ describe('surveys', () => {
         const surveyType = getSurveyTriggerType()
         const config = surveyType.buildConfig()
         expect(surveyType.matchConfig!(config)).toBe(true)
+    })
+
+    describe('getUserProperties', () => {
+        it('filters out managed properties', () => {
+            const config = {
+                type: 'event' as const,
+                filters: {
+                    properties: [
+                        { key: '$survey_id', value: 'survey-123', operator: 'exact', type: 'event' },
+                        { key: '$survey_completed', value: true, operator: 'exact', type: 'event' },
+                        { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
+                        { key: '$survey_response_1', value: 'price', operator: 'exact', type: 'event' },
+                    ],
+                },
+            }
+            expect(getUserProperties(config)).toEqual([
+                { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
+                { key: '$survey_response_1', value: 'price', operator: 'exact', type: 'event' },
+            ])
+        })
+
+        it('returns empty array when no properties', () => {
+            expect(getUserProperties({ type: 'event', filters: {} })).toEqual([])
+        })
+    })
+
+    describe('buildProperties', () => {
+        it('builds properties for specific survey with user properties', () => {
+            const userProps = [{ key: '$survey_response', value: '5', operator: 'exact', type: 'event' }]
+            const result = buildProperties('survey-123', false, userProps)
+            expect(result).toEqual([
+                { key: '$survey_id', value: 'survey-123', operator: 'exact', type: 'event' },
+                { key: '$survey_response', value: '5', operator: 'exact', type: 'event' },
+            ])
+        })
+
+        it('builds properties for "any" survey', () => {
+            const result = buildProperties('any', true, [])
+            expect(result).toEqual([
+                { key: '$survey_id', operator: 'is_set', type: 'event' },
+                { key: '$survey_completed', value: true, operator: 'exact', type: 'event' },
+            ])
+        })
+
+        it('builds properties with no survey selected', () => {
+            const result = buildProperties(null, false, [])
+            expect(result).toEqual([])
+        })
+    })
+
+    describe('getSurveyResponsePropertyKeys', () => {
+        const makeSurvey = (questions: { question: string; type: SurveyQuestionType }[]): Survey =>
+            ({
+                questions: questions.map((q) => ({ ...q, id: 'q-id' })),
+            }) as unknown as Survey
+
+        it('generates correct keys for multiple questions', () => {
+            const survey = makeSurvey([
+                { question: 'How likely are you to recommend us?', type: SurveyQuestionType.Rating },
+                { question: 'What can we improve?', type: SurveyQuestionType.Open },
+            ])
+            const result = getSurveyResponsePropertyKeys(survey)
+            expect(result).toEqual([
+                {
+                    key: '$survey_response',
+                    buttonLabel: 'How likely are you to recommend us?',
+                    question: 'How likely are you to recommend us?',
+                },
+                { key: '$survey_response_1', buttonLabel: 'What can we improve?', question: 'What can we improve?' },
+            ])
+        })
+
+        it('skips link questions but preserves indices', () => {
+            const survey = makeSurvey([
+                { question: 'Rate us', type: SurveyQuestionType.Rating },
+                { question: 'Visit our site', type: SurveyQuestionType.Link },
+                { question: 'Any feedback?', type: SurveyQuestionType.Open },
+            ])
+            const result = getSurveyResponsePropertyKeys(survey)
+            expect(result).toEqual([
+                { key: '$survey_response', buttonLabel: 'Rate us', question: 'Rate us' },
+                { key: '$survey_response_2', buttonLabel: 'Any feedback?', question: 'Any feedback?' },
+            ])
+        })
+
+        it('truncates long question text', () => {
+            const survey = makeSurvey([
+                {
+                    question: 'This is a very long question that should be truncated at forty characters',
+                    type: SurveyQuestionType.Open,
+                },
+            ])
+            const result = getSurveyResponsePropertyKeys(survey)
+            expect(result[0].buttonLabel).toBe('This is a very long question that shoul...')
+            expect(result[0].question).toBe('This is a very long question that should be truncated at forty characters')
+        })
     })
 })

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
@@ -105,6 +105,21 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
     const userProperties = getUserProperties(config)
     const filterTestAccounts = config.filters?.filter_test_accounts ?? false
 
+    const updateTriggerConfig = (
+        surveyId: string | null | 'any',
+        completedResponsesOnly: boolean,
+        newUserProperties: any[]
+    ): void => {
+        setWorkflowActionConfig(node.data.id, {
+            type: 'event',
+            filters: {
+                events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
+                properties: buildProperties(surveyId, completedResponsesOnly, newUserProperties),
+                filter_test_accounts: filterTestAccounts,
+            },
+        })
+    }
+
     const selectedSurvey =
         selectedSurveyId && selectedSurveyId !== 'any' ? allSurveys.find((s) => s.id === selectedSurveyId) : null
     const selectedSurveyLabel =
@@ -221,14 +236,7 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
                             return
                         }
                         setSearchTerm('')
-                        setWorkflowActionConfig(node.data.id, {
-                            type: 'event',
-                            filters: {
-                                events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
-                                properties: buildProperties(surveyId, completedOnly, userProperties),
-                                filter_test_accounts: filterTestAccounts,
-                            },
-                        })
+                        updateTriggerConfig(surveyId, completedOnly, userProperties)
                     }}
                     placeholder="Select a survey"
                 />
@@ -241,15 +249,7 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
                 <LemonRadio
                     value={completedOnly ? 'completed' : 'any'}
                     onChange={(value) => {
-                        const newCompletedOnly = value === 'completed'
-                        setWorkflowActionConfig(node.data.id, {
-                            type: 'event',
-                            filters: {
-                                events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
-                                properties: buildProperties(selectedSurveyId, newCompletedOnly, userProperties),
-                                filter_test_accounts: filterTestAccounts,
-                            },
-                        })
+                        updateTriggerConfig(selectedSurveyId, value === 'completed', userProperties)
                     }}
                     options={[
                         {
@@ -313,15 +313,7 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
                         filtersKey={`survey-trigger-${node.data.id}`}
                         filters={{ properties: userProperties }}
                         setFilters={(filters) => {
-                            const newUserProperties = filters?.properties ?? []
-                            setWorkflowActionConfig(node.data.id, {
-                                type: 'event',
-                                filters: {
-                                    events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
-                                    properties: buildProperties(selectedSurveyId, completedOnly, newUserProperties),
-                                    filter_test_accounts: filterTestAccounts,
-                                },
-                            })
+                            updateTriggerConfig(selectedSurveyId, completedOnly, filters?.properties ?? [])
                         }}
                     />
                     {selectedSurvey && selectedSurvey.questions.length > 0 && (
@@ -336,25 +328,10 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
                                         icon={<IconPlusSmall />}
                                         tooltip={question}
                                         onClick={() => {
-                                            const newUserProperties = [...userProperties, { key, type: 'event' }]
-                                            setWorkflowActionConfig(node.data.id, {
-                                                type: 'event',
-                                                filters: {
-                                                    events: [
-                                                        {
-                                                            id: SurveyEventName.SENT,
-                                                            type: 'events',
-                                                            name: 'Survey sent',
-                                                        },
-                                                    ],
-                                                    properties: buildProperties(
-                                                        selectedSurveyId,
-                                                        completedOnly,
-                                                        newUserProperties
-                                                    ),
-                                                    filter_test_accounts: filterTestAccounts,
-                                                },
-                                            })
+                                            updateTriggerConfig(selectedSurveyId, completedOnly, [
+                                                ...userProperties,
+                                                { key, type: 'event' },
+                                            ])
                                         }}
                                     >
                                         {buttonLabel}

--- a/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/registry/triggers/surveys.tsx
@@ -1,17 +1,19 @@
 import { useActions, useValues } from 'kea'
 
-import { IconMessage } from '@posthog/icons'
-import { LemonBanner, LemonInput, LemonSelect, Spinner } from '@posthog/lemon-ui'
+import { IconMessage, IconPlusSmall } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonInput, LemonSelect, Spinner } from '@posthog/lemon-ui'
 
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { Link } from 'lib/lemon-ui/Link'
+import { truncate } from 'lib/utils'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter/TestAccountFilter'
 import { urls } from 'scenes/urls'
 
-import { SurveyEventName } from '~/types'
+import { Survey, SurveyEventName, SurveyQuestionType } from '~/types'
 
+import { HogFlowPropertyFilters } from 'products/workflows/frontend/Workflows/hogflows/filters/HogFlowFilters'
 import {
     type EventTriggerConfig,
     registerTriggerType,
@@ -48,7 +50,31 @@ function getCompletedResponsesOnly(config: EventTriggerConfig): boolean {
     return completedProp?.value === true
 }
 
-function buildProperties(surveyId: string | null | 'any', completedResponsesOnly: boolean): any[] {
+export function getSurveyResponsePropertyKeys(
+    survey: Survey
+): { key: string; buttonLabel: string; question: string }[] {
+    return survey.questions
+        .map((q, index) => {
+            if (q.type === SurveyQuestionType.Link) {
+                return null
+            }
+            const key = index === 0 ? '$survey_response' : `$survey_response_${index}`
+            return { key, buttonLabel: truncate(q.question, 40), question: q.question }
+        })
+        .filter(Boolean) as { key: string; buttonLabel: string; question: string }[]
+}
+
+const MANAGED_PROPERTY_KEYS = new Set(['$survey_id', '$survey_completed'])
+
+export function getUserProperties(config: EventTriggerConfig): any[] {
+    return (config.filters?.properties ?? []).filter((p: any) => !MANAGED_PROPERTY_KEYS.has(p.key))
+}
+
+export function buildProperties(
+    surveyId: string | null | 'any',
+    completedResponsesOnly: boolean,
+    userProperties: any[]
+): any[] {
     const properties: any[] = []
     if (surveyId === 'any') {
         properties.push({ key: '$survey_id', operator: 'is_set', type: 'event' })
@@ -58,7 +84,7 @@ function buildProperties(surveyId: string | null | 'any', completedResponsesOnly
     if (completedResponsesOnly) {
         properties.push({ key: '$survey_completed', value: true, operator: 'exact', type: 'event' })
     }
-    return properties
+    return [...properties, ...userProperties]
 }
 
 function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
@@ -76,6 +102,7 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
     const { loadMoreSurveys, setSearchTerm } = useActions(surveyTriggerLogic)
     const selectedSurveyId = getSelectedSurveyId(config)
     const completedOnly = getCompletedResponsesOnly(config)
+    const userProperties = getUserProperties(config)
     const filterTestAccounts = config.filters?.filter_test_accounts ?? false
 
     const selectedSurvey =
@@ -198,7 +225,7 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
                             type: 'event',
                             filters: {
                                 events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
-                                properties: buildProperties(surveyId, completedOnly),
+                                properties: buildProperties(surveyId, completedOnly, userProperties),
                                 filter_test_accounts: filterTestAccounts,
                             },
                         })
@@ -219,7 +246,7 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
                             type: 'event',
                             filters: {
                                 events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
-                                properties: buildProperties(selectedSurveyId, newCompletedOnly),
+                                properties: buildProperties(selectedSurveyId, newCompletedOnly, userProperties),
                                 filter_test_accounts: filterTestAccounts,
                             },
                         })
@@ -279,6 +306,65 @@ function StepTriggerConfigurationSurvey({ node }: { node: any }): JSX.Element {
 
                 return null
             })()}
+
+            <LemonField.Pure label="Only trigger for specific answers">
+                <div className="flex flex-col gap-2">
+                    <HogFlowPropertyFilters
+                        filtersKey={`survey-trigger-${node.data.id}`}
+                        filters={{ properties: userProperties }}
+                        setFilters={(filters) => {
+                            const newUserProperties = filters?.properties ?? []
+                            setWorkflowActionConfig(node.data.id, {
+                                type: 'event',
+                                filters: {
+                                    events: [{ id: SurveyEventName.SENT, type: 'events', name: 'Survey sent' }],
+                                    properties: buildProperties(selectedSurveyId, completedOnly, newUserProperties),
+                                    filter_test_accounts: filterTestAccounts,
+                                },
+                            })
+                        }}
+                    />
+                    {selectedSurvey && selectedSurvey.questions.length > 0 && (
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs text-muted">Add filter for a question:</span>
+                            <div className="flex flex-wrap gap-1">
+                                {getSurveyResponsePropertyKeys(selectedSurvey).map(({ key, buttonLabel, question }) => (
+                                    <LemonButton
+                                        key={key}
+                                        type="secondary"
+                                        size="xsmall"
+                                        icon={<IconPlusSmall />}
+                                        tooltip={question}
+                                        onClick={() => {
+                                            const newUserProperties = [...userProperties, { key, type: 'event' }]
+                                            setWorkflowActionConfig(node.data.id, {
+                                                type: 'event',
+                                                filters: {
+                                                    events: [
+                                                        {
+                                                            id: SurveyEventName.SENT,
+                                                            type: 'events',
+                                                            name: 'Survey sent',
+                                                        },
+                                                    ],
+                                                    properties: buildProperties(
+                                                        selectedSurveyId,
+                                                        completedOnly,
+                                                        newUserProperties
+                                                    ),
+                                                    filter_test_accounts: filterTestAccounts,
+                                                },
+                                            })
+                                        }}
+                                    >
+                                        {buttonLabel}
+                                    </LemonButton>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </LemonField.Pure>
 
             <TestAccountFilter
                 filters={{ filter_test_accounts: filterTestAccounts }}


### PR DESCRIPTION
## Problem

Came from [here](https://posthog.slack.com/archives/C07TQR0V16U/p1774033933885599).

Users want to trigger workflows only for specific survey responses (e.g., NPS score of 6, or a particular answer to a PMF question), but the survey trigger only lets you pick a survey and choose completed vs partial responses. The workaround is to trigger on any response and use conditional branches, but this wastes workflow invocations and adds unnecessary complexity.

## Changes

- Added "Only trigger for specific answers" section to the survey trigger UI with property filters
- Added quick-add buttons showing each survey question - clicking one pre-populates a filter for that question's response property ($survey_response, $survey_response_1, etc.)
- Buttons show truncated question text with full text in a tooltip on hover
- Link-type questions are excluded from the quick-add buttons (they don't produce responses)
- Question indices are preserved correctly even when link questions are skipped
- Improved the taxonomy label for $survey_response_N properties: `Survey Response Question ID: 1` -> `Survey response for 2nd question`
- No backend changes needed - the filter compilation pipeline already supports arbitrary event property filters

<img width="1557" height="905" alt="Screenshot 2026-03-22 at 23 24 19" src="https://github.com/user-attachments/assets/e591cd43-782c-4e69-8885-3abc26cee96b" />

## How did you test this code?

- Added unit tests covering the new changes
- Manually tested by sending survey events via the capture API and verifying trigger match/mismatch behavior with different response values

## Publish to changelog?

No
