### PR TITLE
chore(ux): ai chat streaming = spinner, done = badge in tabs

### DIFF
--- a/frontend/src/layout/scenes/SceneTabs.tsx
+++ b/frontend/src/layout/scenes/SceneTabs.tsx
@@ -326,13 +326,18 @@ function SceneTabComponent({ tab, className, isDragging, containerClassName, ind
                     tooltipPlacement="bottom"
                     aria-label={isPinned ? tab.customTitle || tab.title : undefined}
                 >
-                    {tab.iconType === 'blank' ? (
-                        <></>
-                    ) : tab.iconType === 'loading' ? (
-                        <Spinner />
-                    ) : (
-                        iconForType(tab.iconType as FileSystemIconType)
-                    )}
+                    <span className="relative">
+                        {tab.iconType === 'blank' ? (
+                            <></>
+                        ) : tab.iconType === 'loading' ? (
+                            <Spinner className="-mt-[2px]" />
+                        ) : (
+                            iconForType(tab.iconType as FileSystemIconType)
+                        )}
+                        {tab.badge && tab.iconType !== 'loading' && (
+                            <span className="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-accent" />
+                        )}
+                    </span>
 
                     {isPinned ? (
                         <span className="sr-only">{tab.customTitle || tab.title}</span>

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -10,7 +10,8 @@ import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { objectsEqual, uuid } from 'lib/utils'
-import { Scene } from 'scenes/sceneTypes'
+import { sceneLogic } from 'scenes/sceneLogic'
+import { Scene, SceneTab } from 'scenes/sceneTypes'
 import { maxSettingsLogic } from 'scenes/settings/environment/maxSettingsLogic'
 import { urls } from 'scenes/urls'
 
@@ -114,6 +115,18 @@ function handleCommandString(options: string, actions: maxLogicType['actions']):
 
     if (parsed.question !== '') {
         actions.setQuestion(parsed.question)
+    }
+}
+
+function updateInactiveTab(tabId: string, props: Partial<SceneTab>): void {
+    const scene = sceneLogic.findMounted()
+    if (!scene) {
+        return
+    }
+    const { tabs } = scene.values
+    const tab = tabs.find((t) => t.id === tabId)
+    if (tab && !tab.active) {
+        scene.actions.setTabs(tabs.map((t) => (t.id === tabId ? { ...t, ...props } : t)))
     }
 }
 
@@ -390,7 +403,18 @@ export const maxLogic = kea<maxLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, props }) => ({
+        incrActiveStreamingThreads: () => {
+            updateInactiveTab(props.tabId, { iconType: 'loading', badge: false })
+        },
+        decrActiveStreamingThreads: () => {
+            // Reducer runs before listener, so activeStreamingThreads is already decremented.
+            // If still > 0, other streams are active — don't show badge yet.
+            if (values.activeStreamingThreads > 0) {
+                return
+            }
+            updateInactiveTab(props.tabId, { iconType: 'chat', badge: true })
+        },
         // Listen for when the side panel state changes and check for initial prompt
         [sidePanelStateLogic.actionTypes.openSidePanel]: ({ tab, options }) => {
             if (tab === SidePanelTab.Max && options && typeof options === 'string') {

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -343,8 +343,21 @@ export const maxLogic = kea<maxLogicType>([
         ],
 
         breadcrumbs: [
-            (s) => [s.conversationId, s.chatTitle, s.conversationHistoryVisible, s.searchParams],
-            (conversationId, chatTitle, conversationHistoryVisible, searchParams): Breadcrumb[] => {
+            (s) => [
+                s.conversationId,
+                s.chatTitle,
+                s.conversationHistoryVisible,
+                s.searchParams,
+                s.activeStreamingThreads,
+            ],
+            (
+                conversationId,
+                chatTitle,
+                conversationHistoryVisible,
+                searchParams,
+                activeStreamingThreads
+            ): Breadcrumb[] => {
+                const isStreaming = activeStreamingThreads > 0
                 return [
                     {
                         key: Scene.Max,
@@ -368,7 +381,7 @@ export const maxLogic = kea<maxLogicType>([
                                   key: Scene.Max,
                                   name: chatTitle || 'Chat',
                                   path: urls.ai(conversationId),
-                                  iconType: 'chat' as const,
+                                  iconType: isStreaming ? ('loading' as const) : ('chat' as const),
                               },
                           ]
                         : []),

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -472,7 +472,7 @@ export const sceneLogic = kea<sceneLogicType>([
                     const newState = state.map((t) =>
                         t === tab
                             ? !t.active
-                                ? { ...t, active: true }
+                                ? { ...t, active: true, badge: false }
                                 : t
                             : t.active
                               ? {
@@ -1520,7 +1520,9 @@ export const sceneLogic = kea<sceneLogicType>([
                         // When the tab is loading, don't flicker between the loaded title and the new one
                         return
                     }
-                    const newTabs = values.tabs.map((tab, i) => (i === activeIndex ? { ...tab, title, iconType } : tab))
+                    const newTabs = values.tabs.map((tab, i) =>
+                        i === activeIndex ? { ...tab, title, iconType, badge: false } : tab
+                    )
                     actions.setTabs(newTabs)
                 }
                 if (!process?.env?.STORYBOOK) {

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -225,6 +225,8 @@ export interface SceneTab {
     customTitle?: string
     iconType: FileSystemIconType | 'loading' | 'blank'
     pinned?: boolean
+    /** Show a small badge indicator on the tab icon */
+    badge?: boolean
 
     sceneId?: string
     sceneKey?: string


### PR DESCRIPTION
## Problem
It's hard to know when an ai chat tab is streaming/done making multitasking difficult to grasp

## Changes

Stress test, open multiple ai tabs, multiple streams ✅ 
![2026-03-23 00 03 23](https://github.com/user-attachments/assets/cafb4325-965a-415a-821a-91d20001367e)

Stay on active tab ✅ 
![2026-03-23 00 07 58](https://github.com/user-attachments/assets/b381330b-4a4d-48a0-96df-bd8acaf26be8)


- When a tab with a chat is streaming it get's a loading spinner as a tab icon
- When a tab with chat is done streaming, it gets a badge over the tab sparkles icon

## How did you test this code?
Locally

## Publish to changelog?
Yes

## Docs update
No