### PR TITLE
fix(revenue-analytics): add retry policy for exchange rate jobs

### DIFF
--- a/products/revenue_analytics/dags/exchange_rate.py
+++ b/products/revenue_analytics/dags/exchange_rate.py
@@ -42,14 +42,17 @@ def get_date_partition_from_hourly_partition(hourly_partition: str) -> str:
     return "-".join(hourly_partition.split("-", 3)[0:3])
 
 
-@dagster.op(
-    retry_policy=dagster.RetryPolicy(
-        max_retries=5,
-        delay=0.2,  # 200ms
-        backoff=dagster.Backoff.EXPONENTIAL,
-        jitter=dagster.Jitter.PLUS_MINUS,
-    )
+# Retry policy for transient errors (API timeouts, network issues, etc.)
+# Retries up to 4 times with 2 minute delays (exponential backoff)
+TRANSIENT_ERROR_RETRY_POLICY = dagster.RetryPolicy(
+    max_retries=4,
+    delay=120,  # 2 minutes
+    backoff=dagster.Backoff.EXPONENTIAL,
+    jitter=dagster.Jitter.PLUS_MINUS,
 )
+
+
+@dagster.op(retry_policy=TRANSIENT_ERROR_RETRY_POLICY)
 def fetch_exchange_rates(
     context: dagster.OpExecutionContext, date_str: str, app_id: str, api_base_url: str
 ) -> dict[str, Any]:
@@ -85,7 +88,7 @@ def fetch_exchange_rates(
     return data.get("rates")
 
 
-@dagster.asset(partitions_def=DAILY_PARTITION_DEFINITION)
+@dagster.asset(partitions_def=DAILY_PARTITION_DEFINITION, retry_policy=TRANSIENT_ERROR_RETRY_POLICY)
 def daily_exchange_rates(
     context: dagster.AssetExecutionContext, config: ExchangeRateConfig
 ) -> dagster.Output[dict[str, Any]]:
@@ -114,7 +117,7 @@ def daily_exchange_rates(
     )
 
 
-@dagster.asset(partitions_def=HOURLY_PARTITION_DEFINITION)
+@dagster.asset(partitions_def=HOURLY_PARTITION_DEFINITION, retry_policy=TRANSIENT_ERROR_RETRY_POLICY)
 def hourly_exchange_rates(
     context: dagster.AssetExecutionContext, config: ExchangeRateConfig
 ) -> dagster.Output[dict[str, Any]]:
@@ -213,6 +216,7 @@ def store_exchange_rates_in_clickhouse(
 @dagster.asset(
     partitions_def=DAILY_PARTITION_DEFINITION,
     ins={"exchange_rates": dagster.AssetIn(key=daily_exchange_rates.key)},
+    retry_policy=TRANSIENT_ERROR_RETRY_POLICY,
 )
 def daily_exchange_rates_in_clickhouse(
     context: dagster.AssetExecutionContext,
@@ -254,6 +258,7 @@ def daily_exchange_rates_in_clickhouse(
 @dagster.asset(
     partitions_def=HOURLY_PARTITION_DEFINITION,
     ins={"exchange_rates": dagster.AssetIn(key=hourly_exchange_rates.key)},
+    retry_policy=TRANSIENT_ERROR_RETRY_POLICY,
 )
 def hourly_exchange_rates_in_clickhouse(
     context: dagster.AssetExecutionContext,

--- a/products/revenue_analytics/dags/tests/test_exchange_rate.py
+++ b/products/revenue_analytics/dags/tests/test_exchange_rate.py
@@ -11,6 +11,7 @@ from dagster import build_op_context
 
 from products.revenue_analytics.dags.exchange_rate import (
     OPEN_EXCHANGE_RATES_API_BASE_URL,
+    TRANSIENT_ERROR_RETRY_POLICY,
     ExchangeRateConfig,
     daily_exchange_rates,
     daily_exchange_rates_in_clickhouse,
@@ -31,6 +32,14 @@ SAMPLE_EXCHANGE_RATES = {
     "CAD": 1.25,
     "AUD": 1.35,
 }
+
+
+class TestRetryPolicy:
+    def test_retry_policy_is_configured_for_transient_errors(self):
+        assert TRANSIENT_ERROR_RETRY_POLICY.max_retries == 4
+        assert TRANSIENT_ERROR_RETRY_POLICY.delay == 120  # 2 minutes
+        assert TRANSIENT_ERROR_RETRY_POLICY.backoff == dagster.Backoff.EXPONENTIAL
+        assert TRANSIENT_ERROR_RETRY_POLICY.jitter == dagster.Jitter.PLUS_MINUS
 
 
 class TestExchangeRateUtils:


### PR DESCRIPTION
Add a proper retry mechanism for transient errors in daily and hourly exchange rate jobs. The retry policy retries up to 4 times with exponential backoff starting at 2 minute delays.

https://claude.ai/code/session_01P4HAHpjpq25m42Dc4qYPFS