### PR TITLE
fix(replay): scope ClickHouse TLS skip to client only, revert CA cert approach

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -127,8 +127,6 @@ COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/package.json /code
 COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/assets /code/nodejs/assets
 COPY --from=nodejs-build --chown=posthog:posthog /code/nodejs/bin /code/nodejs/bin
 
-# ClickHouse CA certificate for TLS connections
-COPY --chown=posthog:posthog ee/certs/ch.crt /code/ee/certs/ch.crt
 
 # Setup ENV
 ENV NODE_ENV=production \

--- a/nodejs/src/session-recording/config.ts
+++ b/nodejs/src/session-recording/config.ts
@@ -16,7 +16,6 @@ export type SessionRecordingApiConfig = {
     CLICKHOUSE_USER: string
     CLICKHOUSE_PASSWORD: string | undefined
     CLICKHOUSE_SECURE: boolean
-    CLICKHOUSE_CA: string | undefined
 }
 
 export type SessionRecordingConfig = {
@@ -80,7 +79,6 @@ export function getDefaultSessionRecordingApiConfig(): SessionRecordingApiConfig
         CLICKHOUSE_USER: 'default',
         CLICKHOUSE_PASSWORD: undefined,
         CLICKHOUSE_SECURE: false,
-        CLICKHOUSE_CA: undefined,
     }
 }
 

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -1,6 +1,6 @@
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3'
 import { ClickHouseClient, createClient as createClickHouseClient } from '@clickhouse/client'
-import fs from 'fs'
+import https from 'https'
 import express from 'ultimate-express'
 
 import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS } from '../../config/kafka-topics'
@@ -123,7 +123,6 @@ export class RecordingApi {
         // Initialize ClickHouse client for block listing queries
         const chScheme = this.config.CLICKHOUSE_SECURE ? 'https' : 'http'
         const chPort = this.config.CLICKHOUSE_SECURE ? 8443 : 8123
-        const chCaCert = this.config.CLICKHOUSE_CA ? await fs.promises.readFile(this.config.CLICKHOUSE_CA) : undefined
         this.clickhouseClient = createClickHouseClient({
             url: `${chScheme}://${this.config.CLICKHOUSE_HOST}:${chPort}`,
             username: this.config.CLICKHOUSE_USER,
@@ -131,7 +130,10 @@ export class RecordingApi {
             database: this.config.CLICKHOUSE_DATABASE,
             request_timeout: 30_000,
             max_open_connections: 10,
-            ...(chCaCert ? { tls: { ca_cert: chCaCert } } : {}),
+            // Skip TLS cert verification for internal ClickHouse (self-signed certs
+            // with a hostname mismatch). Scoped to this client only, unlike the
+            // process-wide NODE_TLS_REJECT_UNAUTHORIZED=0.
+            ...(this.config.CLICKHOUSE_SECURE ? { http_agent: new https.Agent({ rejectUnauthorized: false }) } : {}),
         })
 
         // Create the service layer

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -131,6 +131,7 @@ export class RecordingApi {
             request_timeout: 30_000,
             max_open_connections: 10,
             // Internal ClickHouse uses self-signed certs with a hostname mismatch
+            // nosemgrep: problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
             ...(this.config.CLICKHOUSE_SECURE
                 ? { http_agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true, maxSockets: 10 }) }
                 : {}),

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -131,7 +131,9 @@ export class RecordingApi {
             request_timeout: 30_000,
             max_open_connections: 10,
             // Internal ClickHouse uses self-signed certs with a hostname mismatch
-            ...(this.config.CLICKHOUSE_SECURE ? { http_agent: new https.Agent({ rejectUnauthorized: false }) } : {}),
+            ...(this.config.CLICKHOUSE_SECURE
+                ? { http_agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true, maxSockets: 10 }) }
+                : {}),
         })
 
         // Create the service layer

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -130,9 +130,7 @@ export class RecordingApi {
             database: this.config.CLICKHOUSE_DATABASE,
             request_timeout: 30_000,
             max_open_connections: 10,
-            // Skip TLS cert verification for internal ClickHouse (self-signed certs
-            // with a hostname mismatch). Scoped to this client only, unlike the
-            // process-wide NODE_TLS_REJECT_UNAUTHORIZED=0.
+            // Internal ClickHouse uses self-signed certs with a hostname mismatch
             ...(this.config.CLICKHOUSE_SECURE ? { http_agent: new https.Agent({ rejectUnauthorized: false }) } : {}),
         })
 

--- a/nodejs/src/session-replay/recording-api/recording-api.ts
+++ b/nodejs/src/session-replay/recording-api/recording-api.ts
@@ -131,9 +131,8 @@ export class RecordingApi {
             request_timeout: 30_000,
             max_open_connections: 10,
             // Internal ClickHouse uses self-signed certs with a hostname mismatch
-            // nosemgrep: problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
             ...(this.config.CLICKHOUSE_SECURE
-                ? { http_agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true, maxSockets: 10 }) }
+                ? { http_agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true, maxSockets: 10 }) } // nosemgrep: problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
                 : {}),
         })
 

--- a/nodejs/src/session-replay/recording-api/types.ts
+++ b/nodejs/src/session-replay/recording-api/types.ts
@@ -40,7 +40,6 @@ export type RecordingApiConfig = Pick<
         | 'CLICKHOUSE_USER'
         | 'CLICKHOUSE_PASSWORD'
         | 'CLICKHOUSE_SECURE'
-        | 'CLICKHOUSE_CA'
     > &
     Pick<
         SessionRecordingConfig,


### PR DESCRIPTION
## Summary

- Replace process-wide `NODE_TLS_REJECT_UNAUTHORIZED=0` with a scoped `https.Agent({ rejectUnauthorized: false })` passed via `@clickhouse/client`'s `http_agent` option
- This skips TLS verification only for ClickHouse, leaving S3, Kafka, and other connections verified normally
- Revert the `CLICKHOUSE_CA` config and `Dockerfile.node` cert copy from #51222 — `ee/certs/ch.crt` is a dev-only cert (`CN=localhost`, expired 2021), and prod ClickHouse has a hostname mismatch (`*.prod.posthog.dev` cert vs `*.prod-us.posthog.dev` host) that prevents proper cert validation without infra changes

## Follow-up

After this merges and deploys, a charts PR is needed to remove `NODE_TLS_REJECT_UNAUTHORIZED: '0'` and `CLICKHOUSE_CA` from `apps/recording-api/values.yaml`.

## Test plan

- [ ] Verify recording-api connects to ClickHouse and block listings return data
- [ ] Verify other TLS connections (S3, Kafka) are unaffected
- [ ] Remove `NODE_TLS_REJECT_UNAUTHORIZED=0` from charts after deploy