### PR TITLE
feat(experiments): track 'experiment launched' on the backend

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -301,7 +301,7 @@ class EnterpriseExperimentsViewSet(
         """
         experiment: Experiment = self.get_object()
         service = ExperimentService(team=self.team, user=request.user)
-        launched_experiment = service.launch_experiment(experiment)
+        launched_experiment = service.launch_experiment(experiment, request=request)
         return Response(ExperimentSerializer(launched_experiment, context=self.get_serializer_context()).data)
 
     @action(methods=["POST"], detail=True, required_scopes=["experiment:write"])

--- a/frontend/src/lib/posthog-typed.ts
+++ b/frontend/src/lib/posthog-typed.ts
@@ -1249,7 +1249,6 @@ interface EventSchemas {
     'experiment feature flag selected': Record<string, any>
     'experiment holdout assigned': Record<string, any>
     'experiment holdout created': Record<string, any>
-    'experiment launched': Record<string, any>
     'experiment load insight failed': Record<string, any>
     'experiment metric timeout': Record<string, any>
     'experiment_recalculation_time team setting updated': Record<string, any>

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -525,7 +525,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             index,
             isPrimary,
         }),
-        reportExperimentLaunched: (experiment: Experiment, launchDate: Dayjs) => ({ experiment, launchDate }),
         reportExperimentStartDateChange: (experiment: Experiment, newStartDate: string) => ({
             experiment,
             newStartDate,
@@ -1496,12 +1495,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 breakdown_property: breakdown.property,
                 breakdown_index: index,
                 is_primary_metric: isPrimary,
-            })
-        },
-        reportExperimentLaunched: ({ experiment, launchDate }) => {
-            posthog.capture('experiment launched', {
-                ...getEventPropertiesForExperiment(experiment),
-                launch_date: launchDate.toISOString(),
             })
         },
         reportExperimentStartDateChange: ({ experiment, newStartDate }) => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -539,7 +539,6 @@ export const experimentLogic = kea<experimentLogicType>([
             [
                 'reportExperimentCreated',
                 'reportExperimentViewed',
-                'reportExperimentLaunched',
                 'reportExperimentCompleted',
                 'reportExperimentStopped',
                 'reportExperimentArchived',
@@ -1391,7 +1390,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 // Trigger results refresh so the metrics table doesn't get stuck in "loading" state
                 actions.refreshExperimentResults(false, 'manual')
                 actions.setUnmodifiedExperiment(structuredClone(experimentWithMetricOrdering))
-                eventUsageLogic.actions.reportExperimentLaunched(experimentWithMetricOrdering, dayjs())
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.LaunchExperiment)
             } catch (error: any) {
                 lemonToast.error(error.detail || 'Failed to launch experiment')

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -313,6 +313,26 @@ class ExperimentService:
             request=request,
         )
 
+    def _report_experiment_launched(
+        self,
+        experiment: Experiment,
+        *,
+        request: Any | None = None,
+    ) -> None:
+        if request is None:
+            return
+
+        analytics_metadata = experiment.get_analytics_metadata()
+        analytics_metadata["launch_date"] = experiment.start_date.isoformat() if experiment.start_date else None
+
+        report_user_action(
+            self.user,
+            "experiment launched",
+            analytics_metadata,
+            team=experiment.team,
+            request=request,
+        )
+
     def _ensure_feature_flag(
         self,
         feature_flag_key: str,
@@ -544,7 +564,7 @@ class ExperimentService:
     # ------------------------------------------------------------------
 
     @transaction.atomic
-    def launch_experiment(self, experiment: Experiment) -> Experiment:
+    def launch_experiment(self, experiment: Experiment, *, request: Any | None = None) -> Experiment:
         """Launch a draft experiment: validate readiness, set start_date, activate feature flag."""
         if not experiment.is_draft:
             raise ValidationError("Experiment has already been launched.")
@@ -573,6 +593,9 @@ class ExperimentService:
         feature_flag.save()
 
         experiment.save()
+
+        self._report_experiment_launched(experiment, request=request)
+
         return experiment
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

"experiment launched" was tracked client-side via `posthog.capture` in `eventUsageLogic`.

We want to track this on the backend to capture from all sources.

## Changes

- Added `_report_experiment_launched` helper to `ExperimentService` that calls `report_user_action` with analytics metadata + `launch_date`
- Updated `launch_experiment` to accept an optional `request` kwarg and report the event after saving
- Passed `request` from the viewset's `launch` action
- Removed `reportExperimentLaunched` from `eventUsageLogic`, `experimentLogic`, and `posthog-typed.ts`

## Testing

- Tested locally and verified that the "experiment launched" event was being sent via the python SDK