### PR TITLE
chore(funnels): switch to UDF version 11

### DIFF
--- a/funnel-udf/README.md
+++ b/funnel-udf/README.md
@@ -12,24 +12,16 @@
 
 For revertible cloud deploys:
 
-1. Develop using the binary files at the top level of `user_scripts` (see section above),
-   with schema defined in `docker/clickhouse/user_defined_function.xml`
-2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it.
-   This generates versioned binaries and `latest_user_defined_function.xml`
-3. Land a PR with the updated `user_scripts` folder (binaries + XML).
-   **Do not** include the `UDF_VERSION` bump in this PR —
-   that goes in a separate PR (step 6)
-4. Run the `setup_udfs` ansible role in the `posthog-cloud-infra` repo
-   to deploy the binaries and XML config to production ClickHouse.
-   The role pulls directly from the `posthog` repo's master branch,
-   so no manual XML updates are needed in `posthog-cloud-infra` for US/EU
-   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`.
-     An "invalid arguments" error means the function is registered.
-     An "unknown function" error means the deploy hasn't taken effect yet
-   - Verify the UDF works by adapting the version in a CH query for a funnel insight
-5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION`
-   in `posthog/udf_versioner.py` to the new version.
-   This switches the posthog query builder to use the new UDF
+1. Develop using the binary files at the top level of `user_scripts` (see section above), with schema defined in `docker/clickhouse/user_defined_function.xml`
+2. If you've made any changes to UDFs, when ready to deploy, increment the version in `posthog/udf_versioner.py` and run it
+3. Overwrite `user_defined_function.xml` in the `posthog-cloud-infra` repo (us, eu, and dev) with `user_scripts/latest_user_defined_function.xml` and deploy it
+   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`. The error message is different for functions that CH doesn't know about, and for invalid arguments.
+
+4. Land a version of the posthog repo with the updated `user_scripts` folder from the new branch (make sure this PR doesn't include changes to this file with the new version)
+5. Run the `copy_udfs_to_clickhouse` action in the `posthog_cloud_infra` repo to deploy the `user_scripts` folder to clickhouse
+   - Verify that the new UDF works, by adapting the version in a CH query for a funnel insight.
+
+6. After that deploy goes out, it is safe to land and deploy the full changes to the `posthog` repo
 
 ## Design decisions
 

--- a/funnel-udf/README.md
+++ b/funnel-udf/README.md
@@ -12,16 +12,24 @@
 
 For revertible cloud deploys:
 
-1. Develop using the binary files at the top level of `user_scripts` (see section above), with schema defined in `docker/clickhouse/user_defined_function.xml`
-2. If you've made any changes to UDFs, when ready to deploy, increment the version in `posthog/udf_versioner.py` and run it
-3. Overwrite `user_defined_function.xml` in the `posthog-cloud-infra` repo (us, eu, and dev) with `user_scripts/latest_user_defined_function.xml` and deploy it
-   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`. The error message is different for functions that CH doesn't know about, and for invalid arguments.
-
-4. Land a version of the posthog repo with the updated `user_scripts` folder from the new branch (make sure this PR doesn't include changes to this file with the new version)
-5. Run the `copy_udfs_to_clickhouse` action in the `posthog_cloud_infra` repo to deploy the `user_scripts` folder to clickhouse
-   - Verify that the new UDF works, by adapting the version in a CH query for a funnel insight.
-
-6. After that deploy goes out, it is safe to land and deploy the full changes to the `posthog` repo
+1. Develop using the binary files at the top level of `user_scripts` (see section above),
+   with schema defined in `docker/clickhouse/user_defined_function.xml`
+2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it.
+   This generates versioned binaries and `latest_user_defined_function.xml`
+3. Land a PR with the updated `user_scripts` folder (binaries + XML).
+   **Do not** include the `UDF_VERSION` bump in this PR —
+   that goes in a separate PR (step 6)
+4. Run the `setup_udfs` ansible role in the `posthog-cloud-infra` repo
+   to deploy the binaries and XML config to production ClickHouse.
+   The role pulls directly from the `posthog` repo's master branch,
+   so no manual XML updates are needed in `posthog-cloud-infra` for US/EU
+   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`.
+     An "invalid arguments" error means the function is registered.
+     An "unknown function" error means the deploy hasn't taken effect yet
+   - Verify the UDF works by adapting the version in a CH query for a funnel insight
+5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION`
+   in `posthog/udf_versioner.py` to the new version.
+   This switches the posthog query builder to use the new UDF
 
 ## Design decisions
 

--- a/posthog/udf_versioner.py
+++ b/posthog/udf_versioner.py
@@ -9,7 +9,7 @@ from xml.etree.ElementTree import Comment
 
 import defusedxml.ElementTree as ET
 
-UDF_VERSION = 10  # Last modified by: @thmsobrmlr, 2025-12-05
+UDF_VERSION = 11  # Last modified by: @sampennington, 2026-03-23
 
 # Clean up all versions less than this
 EARLIEST_UDF_VERSION = 8


### PR DESCRIPTION
## Problem

We've updated the funnel UDF (v11) to fix integer quoting with `output_format_json_quote_64bit_integers = 0`. The binaries were deployed in #51750 and the ClickHouse has these available now

## Changes

- Bumps `UDF_VERSION` from 10 to 11 in `udf_versioner.py`

## How did you test this code?

This should only be merged **after** the cloud-infra deploy is confirmed and `copy_udfs_to_clickhouse` has been run successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)