### PR TITLE
revert(funnels): revert UDF version back to 10

### DIFF
--- a/posthog/udf_versioner.py
+++ b/posthog/udf_versioner.py
@@ -9,7 +9,7 @@ from xml.etree.ElementTree import Comment
 
 import defusedxml.ElementTree as ET
 
-UDF_VERSION = 10  # Last modified by: @thmsobrmlr, 2025-12-05
+UDF_VERSION = 10  # Reverted from v11 — see #51894
 
 # Clean up all versions less than this
 EARLIEST_UDF_VERSION = 8


### PR DESCRIPTION
## Problem

Emergency revert PR in case UDF v11 causes issues after deploy.

## Changes

- Reverts `UDF_VERSION` from 11 back to 10 in `udf_versioner.py`

## How did you test this code?

This is a pre-prepared revert. Only merge if v11 is causing production issues after #51894 is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)