### PR TITLE
fix(surveys): remove limit from surveys aggregate query

### DIFF
--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -585,7 +585,7 @@ export function buildAggregateQuery(
         return null
     }
 
-    return branches.join('\nUNION ALL\n')
+    return `SELECT question_id, label, cnt FROM (${branches.join('\nUNION ALL\n')})`
 }
 
 export function buildOpenEndedQuery(


### PR DESCRIPTION
## Problem

see https://posthoghelp.zendesk.com/agent/tickets/52678 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56667)

seems hogql puts a `limit 100` on each subquery, which means surveys with >100 distinct responses get capped

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

wraps the query in a select so the default 50k limit is applied instead 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
