### PR TITLE
chore: update funnel UDF deployment docs

### DIFF
--- a/funnel-udf/README.md
+++ b/funnel-udf/README.md
@@ -12,16 +12,24 @@
 
 For revertible cloud deploys:
 
-1. Develop using the binary files at the top level of `user_scripts` (see section above), with schema defined in `docker/clickhouse/user_defined_function.xml`
-2. If you've made any changes to UDFs, when ready to deploy, increment the version in `posthog/udf_versioner.py` and run it
-3. Overwrite `user_defined_function.xml` in the `posthog-cloud-infra` repo (us, eu, and dev) with `user_scripts/latest_user_defined_function.xml` and deploy it
-   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`. The error message is different for functions that CH doesn't know about, and for invalid arguments.
-
-4. Land a version of the posthog repo with the updated `user_scripts` folder from the new branch (make sure this PR doesn't include changes to this file with the new version)
-5. Run the `copy_udfs_to_clickhouse` action in the `posthog_cloud_infra` repo to deploy the `user_scripts` folder to clickhouse
-   - Verify that the new UDF works, by adapting the version in a CH query for a funnel insight.
-
-6. After that deploy goes out, it is safe to land and deploy the full changes to the `posthog` repo
+1. Develop using the binary files at the top level of `user_scripts` (see section above),
+   with schema defined in `docker/clickhouse/user_defined_function.xml`
+2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it.
+   This generates versioned binaries and `latest_user_defined_function.xml`
+3. Land a PR with the updated `user_scripts` folder (binaries + XML).
+   **Do not** include the `UDF_VERSION` bump in this PR —
+   that goes in a separate PR (step 5)
+4. Run the `setup_udfs` ansible role in the `posthog-cloud-infra` repo
+   to deploy the binaries and XML config to production ClickHouse.
+   The role pulls directly from the `posthog` repo's master branch,
+   so no manual XML updates are needed in `posthog-cloud-infra` for US/EU
+   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`.
+     An "invalid arguments" error means the function is registered.
+     An "unknown function" error means the deploy hasn't taken effect yet
+   - Verify the UDF works by adapting the version in a CH query for a funnel insight
+5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION`
+   in `posthog/udf_versioner.py` to the new version.
+   This switches the posthog query builder to use the new UDF
 
 ## Design decisions
 

--- a/funnel-udf/README.md
+++ b/funnel-udf/README.md
@@ -15,10 +15,8 @@ For revertible cloud deploys:
 1. Develop using the binary files at the top level of `user_scripts` (see section above), with schema defined in `docker/clickhouse/user_defined_function.xml`
 2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it. This generates versioned binaries and `latest_user_defined_function.xml`
 3. Land a PR with the updated `user_scripts` folder (binaries + XML). **Do not** include the `UDF_VERSION` bump in this PR — that goes in a separate PR (step 5)
-4. Trigger the ["ClickHouse UDFs configuration"](https://github.com/PostHog/posthog-cloud-infra/actions/workflows/clickhouse-udfs.yml) workflow in the `posthog-cloud-infra` repo (click "Run workflow"). This deploys the binaries and XML config to ClickHouse across dev, eu, and us. The workflow pulls directly from the `posthog` repo's master branch, so no manual XML updates are needed in `posthog-cloud-infra`
-   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`. An "invalid arguments" error means the function is registered. An "unknown function" error means the deploy hasn't taken effect yet
-   - Verify the UDF works by adapting the version in a CH query for a funnel insight
-5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION` in `posthog/udf_versioner.py` to the new version. This switches the posthog query builder to use the new UDF
+4. The binaries should be automatically deployed to Clickhouse, you must verify this in metabase by running `SELECT aggregate_funnel_vXX()`. An "invalid arguments" error means the function is registered. An "unknown function" error means the deploy hasn't taken effect yet. **Make sure to do this for both EU and US**
+6. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION` in `posthog/udf_versioner.py` to the new version. This switches the posthog query builder to use the new UDF
 
 ## Design decisions
 

--- a/funnel-udf/README.md
+++ b/funnel-udf/README.md
@@ -16,7 +16,7 @@ For revertible cloud deploys:
 2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it. This generates versioned binaries and `latest_user_defined_function.xml`
 3. Land a PR with the updated `user_scripts` folder (binaries + XML). **Do not** include the `UDF_VERSION` bump in this PR — that goes in a separate PR (step 5)
 4. The binaries should be automatically deployed to Clickhouse, you must verify this in metabase by running `SELECT aggregate_funnel_vXX()`. An "invalid arguments" error means the function is registered. An "unknown function" error means the deploy hasn't taken effect yet. **Make sure to do this for both EU and US**
-6. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION` in `posthog/udf_versioner.py` to the new version. This switches the posthog query builder to use the new UDF
+5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION` in `posthog/udf_versioner.py` to the new version. This switches the posthog query builder to use the new UDF
 
 ## Design decisions
 

--- a/funnel-udf/README.md
+++ b/funnel-udf/README.md
@@ -15,7 +15,7 @@ For revertible cloud deploys:
 1. Develop using the binary files at the top level of `user_scripts` (see section above), with schema defined in `docker/clickhouse/user_defined_function.xml`
 2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it. This generates versioned binaries and `latest_user_defined_function.xml`
 3. Land a PR with the updated `user_scripts` folder (binaries + XML). **Do not** include the `UDF_VERSION` bump in this PR — that goes in a separate PR (step 5)
-4. Run the `setup_udfs` ansible role in the `posthog-cloud-infra` repo to deploy the binaries and XML config to production ClickHouse. The role pulls directly from the `posthog` repo's master branch, so no manual XML updates are needed in `posthog-cloud-infra` for US/EU
+4. Trigger the ["ClickHouse UDFs configuration"](https://github.com/PostHog/posthog-cloud-infra/actions/workflows/clickhouse-udfs.yml) workflow in the `posthog-cloud-infra` repo (click "Run workflow"). This deploys the binaries and XML config to ClickHouse across dev, eu, and us. The workflow pulls directly from the `posthog` repo's master branch, so no manual XML updates are needed in `posthog-cloud-infra`
    - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`. An "invalid arguments" error means the function is registered. An "unknown function" error means the deploy hasn't taken effect yet
    - Verify the UDF works by adapting the version in a CH query for a funnel insight
 5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION` in `posthog/udf_versioner.py` to the new version. This switches the posthog query builder to use the new UDF

--- a/funnel-udf/README.md
+++ b/funnel-udf/README.md
@@ -12,24 +12,13 @@
 
 For revertible cloud deploys:
 
-1. Develop using the binary files at the top level of `user_scripts` (see section above),
-   with schema defined in `docker/clickhouse/user_defined_function.xml`
-2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it.
-   This generates versioned binaries and `latest_user_defined_function.xml`
-3. Land a PR with the updated `user_scripts` folder (binaries + XML).
-   **Do not** include the `UDF_VERSION` bump in this PR —
-   that goes in a separate PR (step 5)
-4. Run the `setup_udfs` ansible role in the `posthog-cloud-infra` repo
-   to deploy the binaries and XML config to production ClickHouse.
-   The role pulls directly from the `posthog` repo's master branch,
-   so no manual XML updates are needed in `posthog-cloud-infra` for US/EU
-   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`.
-     An "invalid arguments" error means the function is registered.
-     An "unknown function" error means the deploy hasn't taken effect yet
+1. Develop using the binary files at the top level of `user_scripts` (see section above), with schema defined in `docker/clickhouse/user_defined_function.xml`
+2. When ready to deploy, increment the version in `posthog/udf_versioner.py` and run it. This generates versioned binaries and `latest_user_defined_function.xml`
+3. Land a PR with the updated `user_scripts` folder (binaries + XML). **Do not** include the `UDF_VERSION` bump in this PR — that goes in a separate PR (step 5)
+4. Run the `setup_udfs` ansible role in the `posthog-cloud-infra` repo to deploy the binaries and XML config to production ClickHouse. The role pulls directly from the `posthog` repo's master branch, so no manual XML updates are needed in `posthog-cloud-infra` for US/EU
+   - Verify that CH knows about the UDF by running `SELECT aggregate_funnel_vXX()`. An "invalid arguments" error means the function is registered. An "unknown function" error means the deploy hasn't taken effect yet
    - Verify the UDF works by adapting the version in a CH query for a funnel insight
-5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION`
-   in `posthog/udf_versioner.py` to the new version.
-   This switches the posthog query builder to use the new UDF
+5. Once the deploy is confirmed, land a separate PR that bumps `UDF_VERSION` in `posthog/udf_versioner.py` to the new version. This switches the posthog query builder to use the new UDF
 
 ## Design decisions
 


### PR DESCRIPTION
## Problem

The funnel UDF deployment docs were outdated , I've updated them from my recent experience.

## Changes

- Simplified the deployment workflow from 6 steps to 5
- Removed references to manually overwriting XML in cloud-infra for US/EU
- Clarified what each verification step should look like ("invalid arguments" vs "unknown function")

## How did you test this code?
Just docs