### PR TITLE
chore(mcp): normalize feature names

### DIFF
--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -258,24 +258,49 @@ For simpler queries, you can use shorter prompts:
 
 ### Feature Filtering
 
-You can limit which tools are available by adding query parameters to the MCP URL:
+You can limit which tools are available by adding query parameters to the MCP URL. If no features are specified, all tools are available. When features are specified, only tools matching those features are exposed.
 
 ```text
-https://mcp.posthog.com/mcp?features=flags,workspace
+https://mcp.posthog.com/mcp?features=flags,workspace,dashboards
 ```
 
 Available features:
 
-- `workspace` - Organization and project management
-- `error-tracking` - [Error monitoring and debugging](https://posthog.com/docs/errors)
-- `dashboards` - [Dashboard creation and management](https://posthog.com/docs/product-analytics/dashboards)
-- `insights` - [Analytics insights and SQL queries](https://posthog.com/docs/product-analytics/insights)
-- `experiments` - [A/B testing experiments](https://posthog.com/docs/experiments)
-- `flags` - [Feature flag management](https://posthog.com/docs/feature-flags)
-- `llm-analytics` - [LLM usage and cost tracking](https://posthog.com/docs/llm-analytics)
-- `docs` - PostHog documentation search
+| Feature                  | Description                                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `workspace`              | Organization and project management                                                                       |
+| `actions`                | [Action definitions](https://posthog.com/docs/data/actions)                                               |
+| `activity_logs`          | Activity log viewing                                                                                      |
+| `alerts`                 | [Alert management](https://posthog.com/docs/product-analytics/alerts)                                     |
+| `annotations`            | [Annotation management](https://posthog.com/docs/product-analytics/annotations)                           |
+| `cohorts`                | [Cohort management](https://posthog.com/docs/data/cohorts)                                                |
+| `dashboards`             | [Dashboard creation and management](https://posthog.com/docs/product-analytics/dashboards)                |
+| `data_schema`            | Data schema exploration                                                                                   |
+| `data_warehouse`         | [Data warehouse management](https://posthog.com/docs/data-warehouse)                                      |
+| `debug`                  | Debug and diagnostic tools                                                                                |
+| `docs`                   | PostHog documentation search                                                                              |
+| `early_access_features`  | [Early access feature management](https://posthog.com/docs/feature-flags/early-access-feature-management) |
+| `error_tracking`         | [Error monitoring and debugging](https://posthog.com/docs/error-tracking)                                 |
+| `events`                 | Event and property definitions                                                                            |
+| `experiments`            | [A/B testing experiments](https://posthog.com/docs/experiments)                                           |
+| `flags`                  | [Feature flag management](https://posthog.com/docs/feature-flags)                                         |
+| `hog_functions`          | [CDP function management](https://posthog.com/docs/cdp)                                                   |
+| `hog_function_templates` | CDP function template browsing                                                                            |
+| `insights`               | [Analytics insights](https://posthog.com/docs/product-analytics/insights)                                 |
+| `llm_analytics`          | [LLM analytics evaluations](https://posthog.com/docs/ai-engineering)                                      |
+| `prompts`                | [LLM prompt management](https://posthog.com/docs/ai-engineering)                                          |
+| `logs`                   | [Log querying](https://posthog.com/docs/ai-engineering/observability)                                     |
+| `notebooks`              | [Notebook management](https://posthog.com/docs/notebooks)                                                 |
+| `persons`                | [Person and group management](https://posthog.com/docs/data/persons)                                      |
+| `reverse_proxy`          | Reverse proxy record management                                                                           |
+| `search`                 | Entity search across the project                                                                          |
+| `sql`                    | SQL query execution                                                                                       |
+| `surveys`                | [Survey management](https://posthog.com/docs/surveys)                                                     |
+| `workflows`              | [Workflow management](https://posthog.com/docs/cdp)                                                       |
 
-To view which tools are available per feature, see our [documentation](https://posthog.com/docs/model-context-protocol) or alternatively check out `schema/tool-definitions.json`,
+> **Note:** Hyphens and underscores are treated as equivalent in feature names (e.g., `error-tracking` and `error_tracking` both work).
+
+To view which tools are available per feature, see our [documentation](https://posthog.com/docs/model-context-protocol) or check `schema/tool-definitions-all.json`.
 
 ### Data processing
 

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -17,7 +17,7 @@
     "error-details": {
         "description": "Use this tool to get the details of an error in the project.",
         "category": "Error tracking",
-        "feature": "error-tracking",
+        "feature": "error_tracking",
         "summary": "Get the details of an error in the project.",
         "title": "Get error details",
         "required_scopes": ["error_tracking:read"],
@@ -32,7 +32,7 @@
     "list-errors": {
         "description": "Use this tool to list errors in the project.",
         "category": "Error tracking",
-        "feature": "error-tracking",
+        "feature": "error_tracking",
         "summary": "List errors in the project.",
         "title": "List errors",
         "required_scopes": ["error_tracking:read"],
@@ -47,7 +47,7 @@
     "update-issue-status": {
         "description": "Use this tool to update the status of an error tracking issue. Valid statuses are: active, resolved, archived, suppressed, or pending_release.",
         "category": "Error tracking",
-        "feature": "error-tracking",
+        "feature": "error_tracking",
         "summary": "Update the status of an error tracking issue.",
         "title": "Update issue status",
         "required_scopes": ["error_tracking:write"],
@@ -273,7 +273,7 @@
     "evaluations-get": {
         "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status. Evaluation results are stored as '$ai_evaluation' events — to query results, use the execute-sql or query-run tool with a HogQL query filtering on event = '$ai_evaluation'. Key properties: $ai_evaluation_id (evaluation UUID), $ai_evaluation_name, $ai_target_event_id (generation event UUID), $ai_trace_id, $ai_evaluation_result (boolean pass/fail), $ai_evaluation_reasoning (text), $ai_evaluation_applicable (boolean, false = N/A).",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "List LLM analytics evaluations.",
         "title": "List evaluations",
         "required_scopes": ["evaluation:read"],
@@ -288,7 +288,7 @@
     "evaluation-get": {
         "description": "Get a specific LLM analytics evaluation by its UUID. Returns full details including name, type (llm_judge or hog), configuration, conditions, and enabled status.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Get a specific evaluation by ID.",
         "title": "Get evaluation",
         "required_scopes": ["evaluation:read"],
@@ -303,7 +303,7 @@
     "evaluation-create": {
         "description": "Create a new LLM analytics evaluation. Two types are supported: 'llm_judge' uses an LLM to score generations against a prompt you define (for subjective checks like tone, helpfulness, hallucination detection), and 'hog' runs deterministic code against each generation (for rule-based checks like format validation, keyword detection, length limits). For llm_judge evaluations, provide a prompt in evaluation_config and a model_configuration. For hog evaluations, provide source code in evaluation_config.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Create a new evaluation.",
         "title": "Create evaluation",
         "required_scopes": ["evaluation:write"],
@@ -318,7 +318,7 @@
     "evaluation-update": {
         "description": "Update an existing LLM analytics evaluation. You can change the name, description, enabled status, evaluation config (prompt or source code), and output config. Use this to enable/disable evaluations or modify their scoring logic.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Update an evaluation.",
         "title": "Update evaluation",
         "required_scopes": ["evaluation:write"],
@@ -333,7 +333,7 @@
     "evaluation-delete": {
         "description": "Delete an LLM analytics evaluation (soft delete). The evaluation will be marked as deleted and will no longer run.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Delete an evaluation.",
         "title": "Delete evaluation",
         "required_scopes": ["evaluation:write"],
@@ -348,7 +348,7 @@
     "evaluation-run": {
         "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event asynchronously via a background workflow. The run is async — it returns a workflow_id and status 'started'. Results are written as '$ai_evaluation' events once complete. To check results after triggering a run, query events with: SELECT properties.$ai_evaluation_result as result, properties.$ai_evaluation_reasoning as reasoning FROM events WHERE event = '$ai_evaluation' AND properties.$ai_evaluation_id = '<evaluation_uuid>' AND properties.$ai_target_event_id = '<generation_event_uuid>' ORDER BY timestamp DESC LIMIT 1.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Run an evaluation on a specific event.",
         "title": "Run evaluation",
         "required_scopes": ["evaluation:write"],
@@ -363,7 +363,7 @@
     "get-llm-total-costs-for-project": {
         "description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Fetches the total LLM daily costs for each model for a project over a given number of days.",
         "title": "Get LLM costs",
         "required_scopes": ["warehouse_table:read"],
@@ -706,7 +706,7 @@
     "read-data-schema": {
         "description": "Use this tool to explore the user's data schema. The user implements PostHog SDKs to collect events, properties, and property values. They are used by users to create insights with visualizations, SQL queries, watch session recordings, filter data, target particular users or groups by traits or behavior, etc. Each event, action, and entity has its own data schema. You must verify that specific combinations exist before using it anywhere else. Events or properties starting from \"$\" are system properties automatically captured by SDKs. Do not rely on your training data or PostHog defaults for events or properties. Always use this tool to confirm what actually exists in the user's project before referencing any event, property, or property value.",
         "category": "Data schema",
-        "feature": "data-schema",
+        "feature": "data_schema",
         "summary": "Explore the user's events, actions, properties, and property values.",
         "title": "Read data schema",
         "required_scopes": ["event_definition:read", "property_definition:read"],
@@ -721,7 +721,7 @@
     "read-data-warehouse-schema": {
         "description": "Use this tool to retrieve the core data warehouse schemas for PostHog tables (events, groups, persons, sessions) and the available data warehouse tables, views, and system tables. Use this to understand the data model before writing HogQL queries.",
         "category": "Data schema",
-        "feature": "data-schema",
+        "feature": "data_schema",
         "summary": "Read core data warehouse schemas and table lists.",
         "title": "Read data warehouse schema",
         "required_scopes": ["warehouse_table:read", "warehouse_view:read"],

--- a/services/mcp/schema/tool-definitions-v2.json
+++ b/services/mcp/schema/tool-definitions-v2.json
@@ -17,7 +17,7 @@
     "read-data-schema": {
         "description": "Use this tool to explore the user's data schema. The user implements PostHog SDKs to collect events, properties, and property values. They are used by users to create insights with visualizations, SQL queries, watch session recordings, filter data, target particular users or groups by traits or behavior, etc. Each event, action, and entity has its own data schema. You must verify that specific combinations exist before using it anywhere else. Events or properties starting from \"$\" are system properties automatically captured by SDKs. Do not rely on your training data or PostHog defaults for events or properties. Always use this tool to confirm what actually exists in the user's project before referencing any event, property, or property value.",
         "category": "Data schema",
-        "feature": "data-schema",
+        "feature": "data_schema",
         "summary": "Explore the user's events, actions, properties, and property values.",
         "title": "Read data schema",
         "required_scopes": ["event_definition:read", "property_definition:read"],
@@ -32,7 +32,7 @@
     "read-data-warehouse-schema": {
         "description": "Use this tool to retrieve the core data warehouse schemas for PostHog tables (events, groups, persons, sessions) and the available data warehouse tables, views, and system tables. Use this to understand the data model before writing HogQL queries.",
         "category": "Data schema",
-        "feature": "data-schema",
+        "feature": "data_schema",
         "summary": "Read core data warehouse schemas and table lists.",
         "title": "Read data warehouse schema",
         "required_scopes": ["warehouse_table:read", "warehouse_view:read"],

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -17,7 +17,7 @@
     "error-details": {
         "description": "Use this tool to get the details of an error in the project.",
         "category": "Error tracking",
-        "feature": "error-tracking",
+        "feature": "error_tracking",
         "summary": "Get the details of an error in the project.",
         "title": "Get error details",
         "required_scopes": ["error_tracking:read"],
@@ -32,7 +32,7 @@
     "list-errors": {
         "description": "Use this tool to list errors in the project.",
         "category": "Error tracking",
-        "feature": "error-tracking",
+        "feature": "error_tracking",
         "summary": "List errors in the project.",
         "title": "List errors",
         "required_scopes": ["error_tracking:read"],
@@ -47,7 +47,7 @@
     "update-issue-status": {
         "description": "Use this tool to update the status of an error tracking issue. Valid statuses are: active, resolved, archived, suppressed, or pending_release.",
         "category": "Error tracking",
-        "feature": "error-tracking",
+        "feature": "error_tracking",
         "summary": "Update the status of an error tracking issue.",
         "title": "Update issue status",
         "required_scopes": ["error_tracking:write"],
@@ -273,7 +273,7 @@
     "evaluations-get": {
         "description": "List LLM analytics evaluations for the project. Evaluations automatically score AI generations for quality, relevance, safety, and other criteria. Supports optional search by name/description and filtering by enabled status. Evaluation results are stored as '$ai_evaluation' events — to query results, use the execute-sql or query-run tool with a HogQL query filtering on event = '$ai_evaluation'. Key properties: $ai_evaluation_id (evaluation UUID), $ai_evaluation_name, $ai_target_event_id (generation event UUID), $ai_trace_id, $ai_evaluation_result (boolean pass/fail), $ai_evaluation_reasoning (text), $ai_evaluation_applicable (boolean, false = N/A).",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "List LLM analytics evaluations.",
         "title": "List evaluations",
         "required_scopes": ["evaluation:read"],
@@ -288,7 +288,7 @@
     "evaluation-get": {
         "description": "Get a specific LLM analytics evaluation by its UUID. Returns full details including name, type (llm_judge or hog), configuration, conditions, and enabled status.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Get a specific evaluation by ID.",
         "title": "Get evaluation",
         "required_scopes": ["evaluation:read"],
@@ -303,7 +303,7 @@
     "evaluation-create": {
         "description": "Create a new LLM analytics evaluation. Two types are supported: 'llm_judge' uses an LLM to score generations against a prompt you define (for subjective checks like tone, helpfulness, hallucination detection), and 'hog' runs deterministic code against each generation (for rule-based checks like format validation, keyword detection, length limits). For llm_judge evaluations, provide a prompt in evaluation_config and a model_configuration. For hog evaluations, provide source code in evaluation_config.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Create a new evaluation.",
         "title": "Create evaluation",
         "required_scopes": ["evaluation:write"],
@@ -318,7 +318,7 @@
     "evaluation-update": {
         "description": "Update an existing LLM analytics evaluation. You can change the name, description, enabled status, evaluation config (prompt or source code), and output config. Use this to enable/disable evaluations or modify their scoring logic.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Update an evaluation.",
         "title": "Update evaluation",
         "required_scopes": ["evaluation:write"],
@@ -333,7 +333,7 @@
     "evaluation-delete": {
         "description": "Delete an LLM analytics evaluation (soft delete). The evaluation will be marked as deleted and will no longer run.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Delete an evaluation.",
         "title": "Delete evaluation",
         "required_scopes": ["evaluation:write"],
@@ -348,7 +348,7 @@
     "evaluation-run": {
         "description": "Trigger an evaluation run on a specific $ai_generation event. This executes the evaluation (either LLM judge or Hog code) against the target event asynchronously via a background workflow. The run is async — it returns a workflow_id and status 'started'. Results are written as '$ai_evaluation' events once complete. To check results after triggering a run, query events with: SELECT properties.$ai_evaluation_result as result, properties.$ai_evaluation_reasoning as reasoning FROM events WHERE event = '$ai_evaluation' AND properties.$ai_evaluation_id = '<evaluation_uuid>' AND properties.$ai_target_event_id = '<generation_event_uuid>' ORDER BY timestamp DESC LIMIT 1.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Run an evaluation on a specific event.",
         "title": "Run evaluation",
         "required_scopes": ["evaluation:write"],
@@ -363,7 +363,7 @@
     "get-llm-total-costs-for-project": {
         "description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response.",
         "category": "LLM analytics",
-        "feature": "llm-analytics",
+        "feature": "llm_analytics",
         "summary": "Fetches the total LLM daily costs for each model for a project over a given number of days.",
         "title": "Get LLM costs",
         "required_scopes": ["warehouse_table:read"],

--- a/services/mcp/src/tools/toolDefinitions.ts
+++ b/services/mcp/src/tools/toolDefinitions.ts
@@ -76,6 +76,10 @@ export interface ToolFilterOptions {
     aiConsentGiven?: boolean | undefined
 }
 
+function normalizeFeatureName(name: string): string {
+    return name.replace(/-/g, '_')
+}
+
 export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
     const { features, version, readOnly, aiConsentGiven } = options || {}
     const toolDefinitions = getToolDefinitions(version)
@@ -87,9 +91,13 @@ export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
         entries = entries.filter(([_, definition]) => definition.new_mcp !== false)
     }
 
-    // Filter by features if provided
+    // Filter by features if provided. Normalize hyphens to underscores so that
+    // both "error-tracking" and "error_tracking" match regardless of convention.
     if (features && features.length > 0) {
-        entries = entries.filter(([_, definition]) => definition.feature && features.includes(definition.feature))
+        const normalizedFeatures = new Set(features.map(normalizeFeatureName))
+        entries = entries.filter(
+            ([_, definition]) => definition.feature && normalizedFeatures.has(normalizeFeatureName(definition.feature))
+        )
     }
 
     // In read-only mode, only expose tools annotated as read-only

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -46,9 +46,14 @@ describe('Tool Filtering - Features', () => {
             ],
         },
         {
+            features: ['error_tracking'],
+            description: 'error tracking tools (underscore)',
+            expectedTools: ['list-errors', 'error-details', 'update-issue-status', 'error-tracking-issues-list'],
+        },
+        {
             features: ['error-tracking'],
-            description: 'error tracking tools',
-            expectedTools: ['list-errors', 'error-details', 'update-issue-status'],
+            description: 'error tracking tools (hyphen, normalized)',
+            expectedTools: ['list-errors', 'error-details', 'update-issue-status', 'error-tracking-issues-list'],
         },
         {
             features: ['experiments'],
@@ -56,8 +61,13 @@ describe('Tool Filtering - Features', () => {
             expectedTools: ['experiment-get-all'],
         },
         {
+            features: ['llm_analytics'],
+            description: 'LLM analytics tools (underscore)',
+            expectedTools: ['get-llm-total-costs-for-project'],
+        },
+        {
             features: ['llm-analytics'],
-            description: 'LLM analytics tools',
+            description: 'LLM analytics tools (hyphen, normalized)',
             expectedTools: ['get-llm-total-costs-for-project'],
         },
         {


### PR DESCRIPTION
## Problem

  MCP server has inconsistent feature naming — handcoded tools use hyphens (`error-tracking`, `llm-analytics`,
  `data-schema`) while generated tools use underscores (`error_tracking`). This means
  `?features=error-tracking` only matches 3 handcoded tools but misses 3 generated ones for the same product.
  Additionally, only 7 of 28 available features were documented.

  ## Changes

  - Normalize all feature names to underscores in schema files (`error-tracking` → `error_tracking`,
  `llm-analytics` → `llm_analytics`, `data-schema` → `data_schema`)
  - Add `normalizeFeatureName()` to the matching logic so existing URLs with hyphens remain backward compatible
  - Document all 28 available features in the README with descriptions and doc links

  ## How did you test this code?

  - All 249 existing MCP tests pass
  - Added test cases verifying both hyphenated and underscored feature names match the same tools

  ## Publish to changelog?

  No

  ## Docs update

  README updated with complete feature list.