### PR TITLE
fix(hogql): add date_trunc to postgres functions

### DIFF
--- a/posthog/hogql/printer/postgres_functions.py
+++ b/posthog/hogql/printer/postgres_functions.py
@@ -387,6 +387,8 @@ POSTGRES_PASSTHROUGH_FUNCTIONS: frozenset[str] = frozenset(
         # Null
         "coalesce",
         "nullif",
+        # Date/time
+        "date_trunc",
         # Other
         "md5",
     }

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4544,6 +4544,21 @@ class TestPostgresPrinter(BaseTest):
 
     @parameterized.expand(
         [
+            ("date_trunc('second', timestamp)", "date_trunc('second', events.timestamp)"),
+            ("date_trunc('minute', timestamp)", "date_trunc('minute', events.timestamp)"),
+            ("date_trunc('hour', timestamp)", "date_trunc('hour', events.timestamp)"),
+            ("date_trunc('day', timestamp)", "date_trunc('day', events.timestamp)"),
+            ("date_trunc('week', timestamp)", "date_trunc('week', events.timestamp)"),
+            ("date_trunc('month', timestamp)", "date_trunc('month', events.timestamp)"),
+            ("date_trunc('quarter', timestamp)", "date_trunc('quarter', events.timestamp)"),
+            ("date_trunc('year', timestamp)", "date_trunc('year', events.timestamp)"),
+        ]
+    )
+    def test_date_trunc_passthrough_in_postgres(self, expr: str, expected: str):
+        self.assertEqual(self._expr(expr), expected)
+
+    @parameterized.expand(
+        [
             (
                 "toStartOfFiveMinutes(timestamp)",
                 "date_trunc('hour', events.timestamp) + "


### PR DESCRIPTION
## Problem

Trying to use `date_trunc` throws an error

## Changes

Add `date_trunc` to postgres functions

## How did you test this code?

👀 

## Publish to changelog?

No
