### PR TITLE
feat(llma): add engagement and impression tracking to sentiment cards

### DIFF
--- a/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
+++ b/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
@@ -156,7 +156,7 @@ function SentimentCardRow({
 }): JSX.Element {
     const { generation, messageIndex, sentiment } = card
     const { uuid, traceId, aiInput, timestamp } = generation
-    const { toggleCardExpanded } = useActions(llmAnalyticsSentimentLogic)
+    const { toggleCardExpanded, trackTraceClicked } = useActions(llmAnalyticsSentimentLogic)
 
     const targetMessage = getMessageAtIndex(aiInput, messageIndex)
     const fullText = targetMessage ? getTextContent(targetMessage) : ''
@@ -209,7 +209,10 @@ function SentimentCardRow({
                                 })}
                                 className="text-xs ml-1"
                                 data-attr="llma-sentiment-trace-link"
-                                onClick={(e) => e.stopPropagation()}
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    trackTraceClicked(card)
+                                }}
                             >
                                 View trace
                             </Link>

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
@@ -143,6 +143,8 @@ function captureEngagementEvents(
             model_prediction_score: impressedCard.sentiment.score,
             ai_model: impressedCard.generation.model,
             card_position: impressedPosition,
+            sentiment_filter: sentimentFilter,
+            intensity_threshold: intensityThreshold,
             trigger_event: engagementType,
             trigger_generation_uuid: card.generation.uuid,
         })

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
@@ -55,6 +55,8 @@ const MIN_VISIBLE_CARDS = 50
 const MAX_AUTO_LOAD_ROUNDS = 3
 // Match backend MAX_MESSAGE_CHARS (2000) so training data captures the same text window the model classified
 export const CLASSIFIER_WINDOW = 2000
+/** Number of other visible cards to sample as negative (impressed) examples per engagement */
+const IMPRESSION_SAMPLE_SIZE = 5
 
 /** Parse aiInput and return the raw content text for the message at the given index, or '' on failure */
 function getRawMessageText(aiInput: unknown, messageIndex: number): string {
@@ -79,6 +81,72 @@ function getCardMessageText(card: SentimentCard): string {
 
 function getSnippetFromCard(card: SentimentCard): string {
     return getRawMessageText(card.generation.aiInput, card.messageIndex).slice(-CLASSIFIER_WINDOW)
+}
+
+/** Fisher-Yates shuffle on a copy, return first n elements */
+function sampleCards(cards: GroupedSentimentCard[], n: number): GroupedSentimentCard[] {
+    if (cards.length <= n) {
+        return cards
+    }
+    const shuffled = [...cards]
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+    }
+    return shuffled.slice(0, n)
+}
+
+function cardKey(card: SentimentCard): string {
+    return `${card.generation.uuid}:${card.messageIndex}`
+}
+
+function captureEngagementEvents(
+    engagementType: 'expanded' | 'trace_clicked',
+    card: SentimentCard,
+    allVisibleCards: GroupedSentimentCard[],
+    sentimentFilter: SentimentFilterLabel,
+    intensityThreshold: number
+): void {
+    const interactionId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+    const engagedKey = cardKey(card)
+    const cardPosition = allVisibleCards.findIndex((g) => cardKey(g.card) === engagedKey)
+
+    // Positive example: the card the user engaged with
+    posthog.capture('llma sentiment card engaged', {
+        interaction_id: interactionId,
+        engagement_type: engagementType,
+        generation_uuid: card.generation.uuid,
+        trace_id: card.generation.traceId,
+        message_index: card.messageIndex,
+        message_text_snippet: getSnippetFromCard(card),
+        model_prediction_label: card.sentiment.label,
+        model_prediction_score: card.sentiment.score,
+        ai_model: card.generation.model,
+        sentiment_filter: sentimentFilter,
+        intensity_threshold: intensityThreshold,
+        card_position: cardPosition,
+        visible_card_count: allVisibleCards.length,
+    })
+
+    // Negative examples: sample of other visible cards not interacted with
+    const otherCards = allVisibleCards.filter((g) => cardKey(g.card) !== engagedKey)
+    const sampled = sampleCards(otherCards, IMPRESSION_SAMPLE_SIZE)
+    for (const { card: impressedCard } of sampled) {
+        const impressedPosition = allVisibleCards.findIndex((g) => cardKey(g.card) === cardKey(impressedCard))
+        posthog.capture('llma sentiment card impressed', {
+            interaction_id: interactionId,
+            generation_uuid: impressedCard.generation.uuid,
+            trace_id: impressedCard.generation.traceId,
+            message_index: impressedCard.messageIndex,
+            message_text_snippet: getSnippetFromCard(impressedCard),
+            model_prediction_label: impressedCard.sentiment.label,
+            model_prediction_score: impressedCard.sentiment.score,
+            ai_model: impressedCard.generation.model,
+            card_position: impressedPosition,
+            trigger_event: engagementType,
+            trigger_generation_uuid: card.generation.uuid,
+        })
+    }
 }
 
 interface GenerationsQueryValues {
@@ -138,6 +206,7 @@ export const llmAnalyticsSentimentLogic = kea<llmAnalyticsSentimentLogicType>([
         toggleCardExpanded: (cardKey: string) => ({ cardKey }),
         loadMoreGenerations: true,
         setHasMore: (hasMore: boolean) => ({ hasMore }),
+        trackTraceClicked: (card: SentimentCard) => ({ card }),
         submitSentimentFeedback: (cardKey: string, feedbackLabel: SentimentFeedbackLabel, card: SentimentCard) => ({
             cardKey,
             feedbackLabel,
@@ -363,6 +432,32 @@ export const llmAnalyticsSentimentLogic = kea<llmAnalyticsSentimentLogicType>([
                         actions.ensureGenerationSentimentLoaded(gen.uuid, values.dateFilter)
                     }
                 }
+            },
+            toggleCardExpanded: ({ cardKey: key }) => {
+                // Only track when expanding (key is now in the set), not collapsing
+                if (!values.expandedCardIds.has(key)) {
+                    return
+                }
+                const group = values.groupedSentimentCards.find((g) => cardKey(g.card) === key)
+                if (!group) {
+                    return
+                }
+                captureEngagementEvents(
+                    'expanded',
+                    group.card,
+                    values.groupedSentimentCards,
+                    values.sentimentFilter,
+                    values.intensityThreshold
+                )
+            },
+            trackTraceClicked: ({ card }) => {
+                captureEngagementEvents(
+                    'trace_clicked',
+                    card,
+                    values.groupedSentimentCards,
+                    values.sentimentFilter,
+                    values.intensityThreshold
+                )
             },
             submitSentimentFeedback: ({ card, feedbackLabel }) => {
                 posthog.capture('llma sentiment feedback', {


### PR DESCRIPTION
## Problem

We need implicit feedback signals from the sentiment tab to train a `p_interesting` ranking model that will eventually order message cards by relevance.

## Changes

- Capture `llma sentiment card engaged` events when a user expands a card or clicks "View trace" (positive training examples)
- Capture `llma sentiment card impressed` events for a random sample of up to 5 other visible cards per interaction (negative training examples)
- All events from the same interaction share an `interaction_id` for joining in the training pipeline
- Events include `message_text_snippet` (up to 2000 chars) for embedding-based features, plus model predictions, card position, and filter state

## How did you test this code?

Code review of event capture logic. The tracking is additive (new `posthog.capture` calls in existing kea listeners) with no behavioral changes to existing functionality.

## Publish to changelog?

No