### PR TITLE
feat(logs): add saved views modal with list, save, load, and delete

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconGear } from '@posthog/icons'
+import { IconBookmark, IconGear } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTabs } from '@posthog/lemon-ui'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -15,6 +15,8 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
+import { logsViewsListLogic } from 'products/logs/frontend/components/LogsViews/logsViewsListLogic'
+import { SavedViewsModal } from 'products/logs/frontend/components/LogsViews/SavedViewsModal'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 
@@ -87,6 +89,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const { tabId, activeTab } = useValues(logsSceneLogic)
     const { setActiveTab } = useActions(logsSceneLogic)
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
+    const { openModal } = useActions(logsViewsListLogic({ id: tabId }))
 
     return (
         <>
@@ -95,8 +98,16 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 resourceType={{
                     type: sceneConfigurations[Scene.Logs].iconType || 'default_icon_type',
                 }}
-                actions={<>{hasLogs && <LogsSceneFeedbackButton />}</>}
+                actions={
+                    <>
+                        {hasLogs && <LogsSceneFeedbackButton />}
+                        <LemonButton size="small" type="secondary" icon={<IconBookmark />} onClick={openModal}>
+                            Saved views
+                        </LemonButton>
+                    </>
+                }
             />
+            <SavedViewsModal id={tabId} />
             {teamHasLogsCheckFailed && (
                 <LemonBanner
                     type="info"

--- a/products/logs/frontend/components/LogsViewer/Filters/FilterHistoryDropdown.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/FilterHistoryDropdown.tsx
@@ -4,58 +4,17 @@ import { IconClock, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonMenuSection } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
-import { capitalizeFirstLetter } from 'lib/utils'
 
-import { AnyPropertyFilter } from '~/types'
+import { getFiltersSummaryLines } from 'products/logs/frontend/utils'
 
 import { LogsFiltersHistoryEntry } from '../../../types'
 import { logsFilterHistoryLogic } from './logsFilterHistoryLogic'
 
-const formatDateRange = (dateRange: LogsFiltersHistoryEntry['filters']['dateRange']): string => {
-    const from = dateRange.date_from || 'any'
-    const to = dateRange.date_to || 'now'
-    return `${from} → ${to}`
-}
-
-const isPropertyFilter = (v: unknown): v is AnyPropertyFilter => {
-    return typeof v === 'object' && v !== null && 'key' in v
-}
-
-const formatFilterGroupValues = (filterGroup: LogsFiltersHistoryEntry['filters']['filterGroup']): string[] => {
-    const group = filterGroup?.values?.[0]
-    if (!group || !('values' in group)) {
-        return []
-    }
-
-    return group.values.filter(isPropertyFilter).map((filter) => {
-        const key = filter.key || '?'
-        const value = Array.isArray(filter.value) ? filter.value.join(', ') : String(filter.value ?? '')
-        const truncatedValue = value.length > 15 ? `${value.slice(0, 15)}...` : value
-        return `${key}=${truncatedValue}`
-    })
-}
-
 const formatHistoryEntryDetails = (entry: LogsFiltersHistoryEntry): string => {
-    const parts: string[] = []
-    const { filters } = entry
-
-    parts.push(formatDateRange(filters.dateRange))
-
-    if (filters.severityLevels && filters.severityLevels.length > 0) {
-        parts.push(filters.severityLevels.map((l) => capitalizeFirstLetter(l)).join(', '))
-    }
-
-    if (filters.searchTerm) {
-        const truncated = filters.searchTerm.length > 20 ? `${filters.searchTerm.slice(0, 20)}...` : filters.searchTerm
-        parts.push(`"${truncated}"`)
-    }
-
-    const attributeFilters = formatFilterGroupValues(filters.filterGroup)
-    if (attributeFilters.length > 0) {
-        parts.push(attributeFilters.join(', '))
-    }
-
-    return parts.join(' | ')
+    return getFiltersSummaryLines(entry.filters)
+        .filter((line) => line.label !== 'Service' && line.label !== 'Services')
+        .map((line) => line.value)
+        .join(' | ')
 }
 
 const formatServiceNames = (entry: LogsFiltersHistoryEntry): string => {

--- a/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
+++ b/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
@@ -46,7 +46,7 @@ function SaveViewModal({ id }: LogsViewsLogicProps): JSX.Element {
                         onClick={saveView}
                         disabledReason={!viewName.trim() ? 'Enter a name' : undefined}
                     >
-                        Save
+                        Save view
                     </LemonButton>
                 </>
             }

--- a/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
+++ b/products/logs/frontend/components/LogsViews/SavedViewsModal.tsx
@@ -1,0 +1,168 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonButton, LemonDialog, LemonInput, LemonModal, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+
+import { getFiltersSummaryLines } from 'products/logs/frontend/utils'
+
+import { logsViewsListLogic } from './logsViewsListLogic'
+import { LogsView, LogsViewsLogicProps, logsViewsLogic } from './logsViewsLogic'
+
+function FiltersSummaryDisplay({ filters }: { filters: Record<string, any> }): JSX.Element {
+    const lines = getFiltersSummaryLines(filters)
+    if (lines.length === 0) {
+        return <span className="text-muted text-xs">No filters</span>
+    }
+    return (
+        <div className="text-xs text-muted space-y-0.5">
+            {lines.map((line) => (
+                <div key={line.label}>
+                    <span className="font-medium">{line.label}:</span> {line.value}
+                </div>
+            ))}
+        </div>
+    )
+}
+
+function SaveViewModal({ id }: LogsViewsLogicProps): JSX.Element {
+    const { isSaveModalOpen, viewName, filters } = useValues(logsViewsListLogic({ id }))
+    const { closeSaveModal, setViewName, saveView } = useActions(logsViewsListLogic({ id }))
+
+    return (
+        <LemonModal
+            isOpen={isSaveModalOpen}
+            onClose={closeSaveModal}
+            title="Save current view"
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={closeSaveModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={saveView}
+                        disabledReason={!viewName.trim() ? 'Enter a name' : undefined}
+                    >
+                        Save
+                    </LemonButton>
+                </>
+            }
+        >
+            <div className="space-y-2">
+                <LemonInput
+                    placeholder="View name"
+                    value={viewName}
+                    onChange={setViewName}
+                    autoFocus
+                    onPressEnter={saveView}
+                />
+                <FiltersSummaryDisplay filters={filters} />
+            </div>
+        </LemonModal>
+    )
+}
+
+export function SavedViewsModal({ id }: LogsViewsLogicProps): JSX.Element {
+    const { isModalOpen } = useValues(logsViewsListLogic({ id }))
+    const { closeModal, openSaveModal } = useActions(logsViewsListLogic({ id }))
+    const { views, viewsLoading } = useValues(logsViewsLogic({ id }))
+    const { deleteView, loadView } = useActions(logsViewsLogic({ id }))
+
+    const columns: LemonTableColumns<LogsView> = [
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            render: (_, view) => <span className="font-medium">{view.name}</span>,
+        },
+        {
+            title: 'Filters',
+            render: (_, view) => <FiltersSummaryDisplay filters={view.filters ?? {}} />,
+        },
+        {
+            title: 'Created by',
+            dataIndex: 'created_by',
+            render: (_, view) => (
+                <span className="text-muted text-xs">
+                    {view.created_by?.first_name || view.created_by?.email || '\u2014'}
+                </span>
+            ),
+        },
+        {
+            title: 'Created',
+            dataIndex: 'created_at',
+            render: (_, view) => <TZLabel time={view.created_at} />,
+        },
+        {
+            title: '',
+            render: (_, view) => (
+                <div className="flex items-center gap-1">
+                    <LemonButton type="secondary" size="xsmall" onClick={() => loadView(view)}>
+                        Load
+                    </LemonButton>
+                    <More
+                        overlay={
+                            <LemonMenuOverlay
+                                items={[
+                                    {
+                                        label: 'Delete',
+                                        status: 'danger',
+                                        onClick: () => {
+                                            LemonDialog.open({
+                                                title: `Delete "${view.name}"?`,
+                                                description:
+                                                    'This view will be permanently deleted. This action cannot be undone.',
+                                                primaryButton: {
+                                                    children: 'Delete',
+                                                    type: 'primary',
+                                                    status: 'danger',
+                                                    onClick: () => deleteView(view.short_id),
+                                                },
+                                                secondaryButton: {
+                                                    children: 'Cancel',
+                                                },
+                                            })
+                                        },
+                                    },
+                                ]}
+                            />
+                        }
+                    />
+                </div>
+            ),
+        },
+    ]
+
+    return (
+        <>
+            <LemonModal
+                isOpen={isModalOpen}
+                onClose={closeModal}
+                title="Saved views"
+                width={720}
+                footer={
+                    <div className="flex justify-between w-full">
+                        <LemonButton type="primary" onClick={openSaveModal}>
+                            Save current view
+                        </LemonButton>
+                        <LemonButton type="secondary" onClick={closeModal}>
+                            Close
+                        </LemonButton>
+                    </div>
+                }
+            >
+                <LemonTable
+                    columns={columns}
+                    dataSource={views}
+                    rowKey="id"
+                    loading={viewsLoading}
+                    emptyState="No saved views yet."
+                    size="small"
+                />
+            </LemonModal>
+            <SaveViewModal id={id} />
+        </>
+    )
+}

--- a/products/logs/frontend/components/LogsViews/logsViewsListLogic.ts
+++ b/products/logs/frontend/components/LogsViews/logsViewsListLogic.ts
@@ -1,0 +1,66 @@
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+
+import type { logsViewsListLogicType } from './logsViewsListLogicType'
+import { LogsViewsLogicProps, logsViewsLogic } from './logsViewsLogic'
+
+export const logsViewsListLogic = kea<logsViewsListLogicType>([
+    props({} as LogsViewsLogicProps),
+    key((props) => props.id),
+    path((key) => ['products', 'logs', 'frontend', 'components', 'LogsViews', 'logsViewsListLogic', key]),
+
+    connect((props: LogsViewsLogicProps) => ({
+        values: [logsViewerFiltersLogic({ id: props.id }), ['filters']],
+        actions: [logsViewsLogic({ id: props.id }), ['createView', 'createViewSuccess', 'loadView', 'loadViews']],
+    })),
+
+    actions({
+        openModal: true,
+        closeModal: true,
+        openSaveModal: true,
+        closeSaveModal: true,
+        setViewName: (viewName: string) => ({ viewName }),
+        saveView: true,
+    }),
+
+    reducers({
+        isModalOpen: [
+            false,
+            {
+                openModal: () => true,
+                closeModal: () => false,
+                loadView: () => false,
+            },
+        ],
+        isSaveModalOpen: [
+            false,
+            {
+                openSaveModal: () => true,
+                closeSaveModal: () => false,
+                createViewSuccess: () => false,
+            },
+        ],
+        viewName: [
+            '',
+            {
+                setViewName: (_, { viewName }) => viewName,
+                closeSaveModal: () => '',
+                createViewSuccess: () => '',
+            },
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        openModal: () => {
+            actions.loadViews()
+        },
+        saveView: () => {
+            const name = values.viewName.trim()
+            if (!name) {
+                return
+            }
+            actions.createView({ name, filters: { ...values.filters } })
+        },
+    })),
+])

--- a/products/logs/frontend/components/LogsViews/logsViewsLogic.ts
+++ b/products/logs/frontend/components/LogsViews/logsViewsLogic.ts
@@ -1,0 +1,90 @@
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { LogsViewApi, LogsViewApiFilters } from 'products/logs/frontend/generated/api.schemas'
+import { DEFAULT_ACTIVE_TAB, logsSceneLogic } from 'products/logs/frontend/logsSceneLogic'
+
+import type { logsViewsLogicType } from './logsViewsLogicType'
+
+export type LogsView = LogsViewApi
+
+export interface LogsViewsLogicProps {
+    id: string
+}
+
+const logsViewsUrl = (teamId: number | null): string => `api/environments/${teamId}/logs/views`
+
+export const logsViewsLogic = kea<logsViewsLogicType>([
+    props({} as LogsViewsLogicProps),
+    key((props) => props.id),
+    path((key) => ['products', 'logs', 'frontend', 'components', 'LogsViews', 'logsViewsLogic', key]),
+
+    connect((props: LogsViewsLogicProps) => ({
+        values: [teamLogic, ['currentTeamId']],
+        actions: [
+            logsViewerFiltersLogic({ id: props.id }),
+            ['setFilters'],
+            logsSceneLogic({ tabId: props.id }),
+            ['setActiveTab'],
+        ],
+    })),
+
+    actions({
+        deleteView: (shortId: string) => ({ shortId }),
+        loadView: (view: LogsView) => ({ view }),
+    }),
+
+    loaders(({ values }) => ({
+        views: [
+            [] as LogsView[],
+            {
+                loadViews: async () => {
+                    const response = await api.get(`${logsViewsUrl(values.currentTeamId)}/`)
+                    return response.results
+                },
+                createView: async ({ name, filters }: { name: string; filters: LogsViewApiFilters }) => {
+                    const created: LogsView = await api.create(`${logsViewsUrl(values.currentTeamId)}/`, {
+                        name,
+                        filters,
+                    })
+                    lemonToast.success('View saved')
+                    return [created, ...values.views]
+                },
+            },
+        ],
+    })),
+
+    reducers({
+        views: {
+            deleteView: (state, { shortId }) => state.filter((v) => v.short_id !== shortId),
+        },
+    }),
+
+    listeners(({ actions, values }) => ({
+        deleteView: async ({ shortId }) => {
+            try {
+                await api.delete(`${logsViewsUrl(values.currentTeamId)}/${shortId}/`)
+                lemonToast.success('View deleted')
+            } catch {
+                lemonToast.error('Failed to delete view')
+                actions.loadViews()
+            }
+        },
+        loadView: ({ view }) => {
+            actions.setFilters(view.filters || {})
+            actions.setActiveTab(DEFAULT_ACTIVE_TAB)
+        },
+        createViewFailure: () => {
+            lemonToast.error('Failed to save view')
+        },
+        loadViewsFailure: () => {
+            lemonToast.error('Failed to load saved views')
+        },
+    })),
+])

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -38,7 +38,7 @@ import type { logsSceneLogicType } from './logsSceneLogicType'
 
 export type LogsSceneActiveTab = 'viewer' | 'configuration'
 const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'configuration']
-const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
+export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 export interface LogsLogicProps {
     tabId: string

--- a/products/logs/frontend/utils.test.ts
+++ b/products/logs/frontend/utils.test.ts
@@ -1,4 +1,14 @@
-import { getSessionIdFromLogAttributes, isDistinctIdKey, isSessionIdKey } from './utils'
+import {
+    formatFilterGroupValues,
+    getFiltersSummaryLines,
+    getSessionIdFromLogAttributes,
+    isDistinctIdKey,
+    isSessionIdKey,
+} from './utils'
+
+jest.mock('products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/utils', () => ({
+    formatDateRangeLabel: () => '-1h \u2192 now',
+}))
 
 describe('logs utils', () => {
     describe.each([
@@ -81,5 +91,83 @@ describe('logs utils', () => {
                 )
             ).toBe(expected)
         })
+    })
+
+    const filterGroup = (
+        ...filters: Array<{ key: string; value: any; type?: string; operator?: string }>
+    ): Record<string, any> => ({
+        type: 'AND',
+        values: [{ type: 'AND', values: filters.map((f) => ({ type: 'log_entry', operator: 'exact', ...f })) }],
+    })
+
+    describe.each([
+        ['undefined input', undefined, []],
+        ['empty group', { type: 'AND', values: [] }, []],
+        [
+            'simple property filters',
+            filterGroup({ key: 'env', value: 'production' }, { key: 'region', value: 'us-east' }),
+            ['env=production', 'region=us-east'],
+        ],
+        [
+            'truncates long values',
+            filterGroup({ key: 'msg', value: 'this is a very long value that exceeds limit' }),
+            ['msg=this is a very ...'],
+        ],
+        ['joins array values', filterGroup({ key: 'env', value: ['prod', 'staging'] }), ['env=prod, staging']],
+    ])('formatFilterGroupValues – %s', (_, input, expected) => {
+        it(`returns expected output`, () => {
+            expect(formatFilterGroupValues(input as Record<string, any> | undefined)).toEqual(expected)
+        })
+    })
+
+    describe.each([
+        ['empty filters', {}, []],
+        [
+            'date range',
+            { dateRange: { date_from: '-1h', date_to: null } },
+            [{ label: 'Date range', value: expect.any(String) }],
+        ],
+        [
+            'severity levels capitalized',
+            { severityLevels: ['error', 'fatal'] },
+            [{ label: 'Severity', value: 'Error, Fatal' }],
+        ],
+        ['singular service', { serviceNames: ['api'] }, [{ label: 'Service', value: 'api' }]],
+        [
+            'plural services with truncation',
+            { serviceNames: ['api', 'worker', 'scheduler', 'cron'] },
+            [{ label: 'Services', value: 'api, worker, scheduler +1 more' }],
+        ],
+        ['short search term', { searchTerm: 'timeout' }, [{ label: 'Search', value: '"timeout"' }]],
+        [
+            'long search term truncated',
+            { searchTerm: 'a'.repeat(40) },
+            [{ label: 'Search', value: `"${'a'.repeat(30)}..."` }],
+        ],
+        [
+            'single attribute filter',
+            { filterGroup: filterGroup({ key: 'env', value: 'prod' }) },
+            [{ label: 'Filter', value: 'env=prod' }],
+        ],
+        [
+            'multiple attribute filters',
+            { filterGroup: filterGroup({ key: 'env', value: 'prod' }, { key: 'region', value: 'us' }) },
+            [{ label: 'Filters', value: 'env=prod, region=us' }],
+        ],
+    ])('getFiltersSummaryLines – %s', (_, filters, expected) => {
+        it(`returns expected output`, () => {
+            expect(getFiltersSummaryLines(filters as Record<string, any>)).toEqual(expected)
+        })
+    })
+
+    it('getFiltersSummaryLines combines all filter types', () => {
+        const lines = getFiltersSummaryLines({
+            dateRange: { date_from: '-1h', date_to: null },
+            severityLevels: ['error'],
+            serviceNames: ['api'],
+            searchTerm: 'timeout',
+        })
+        expect(lines).toHaveLength(4)
+        expect(lines.map((l) => l.label)).toEqual(['Date range', 'Severity', 'Service', 'Search'])
     })
 })

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -1,3 +1,71 @@
+import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
+import { capitalizeFirstLetter } from 'lib/utils'
+
+import { AnyPropertyFilter } from '~/types'
+
+import { formatDateRangeLabel } from 'products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/utils'
+
+export function formatFilterGroupValues(filterGroup: Record<string, any> | undefined): string[] {
+    const group = filterGroup?.values?.[0]
+    if (!group || !('values' in group)) {
+        return []
+    }
+
+    return group.values.filter(isValidPropertyFilter).map((filter: AnyPropertyFilter) => {
+        const key = filter.key || '?'
+        const value = Array.isArray(filter.value) ? filter.value.join(', ') : String(filter.value ?? '')
+        const truncatedValue = value.length > 15 ? `${value.slice(0, 15)}...` : value
+        return `${key}=${truncatedValue}`
+    })
+}
+
+export interface FiltersSummaryLine {
+    label: string
+    value: string
+}
+
+export function getFiltersSummaryLines(filters: Record<string, any>): FiltersSummaryLine[] {
+    const lines: FiltersSummaryLine[] = []
+
+    if (filters.dateRange) {
+        const label = formatDateRangeLabel(filters.dateRange, Intl.DateTimeFormat().resolvedOptions().timeZone, [])
+        lines.push({ label: 'Date range', value: label })
+    }
+
+    if (filters.severityLevels?.length) {
+        lines.push({
+            label: 'Severity',
+            value: filters.severityLevels.map((l: string) => capitalizeFirstLetter(l)).join(', '),
+        })
+    }
+
+    if (filters.serviceNames?.length) {
+        const maxDisplayed = 3
+        const displayed = filters.serviceNames.slice(0, maxDisplayed)
+        const remaining = filters.serviceNames.length - displayed.length
+        const serviceText = displayed.join(', ')
+        lines.push({
+            label: filters.serviceNames.length === 1 ? 'Service' : 'Services',
+            value: remaining > 0 ? `${serviceText} +${remaining} more` : serviceText,
+        })
+    }
+
+    if (filters.searchTerm) {
+        const truncated = filters.searchTerm.length > 30 ? `${filters.searchTerm.slice(0, 30)}...` : filters.searchTerm
+        lines.push({ label: 'Search', value: `"${truncated}"` })
+    }
+
+    const attributeFilters = formatFilterGroupValues(filters.filterGroup)
+    if (attributeFilters.length > 0) {
+        lines.push({
+            label: attributeFilters.length === 1 ? 'Filter' : 'Filters',
+            value: attributeFilters.join(', '),
+        })
+    }
+
+    return lines
+}
+
 const DISTINCT_ID_KEYS = [
     'distinct.id',
     'distinct_id',


### PR DESCRIPTION
## Problem

Users have no way to save and reuse their logs viewer filter configurations. Filter state is semi-ephemeral, and teams can't share useful filter presets with each other.

## Changes

![2026-03-23 10.56.52.gif](https://app.graphite.com/user-attachments/assets/e8aee3c6-e1bf-4be0-a5eb-877e440f8c6b.gif)



- Add "Saved views" button with bookmark icon to the logs scene header (next to Feedback)
- Add `SavedViewsModal` — lists all saved views with filter summaries, inline "Load" button, and delete via more menu
- Add `SaveViewModal` — secondary modal for naming and saving current filters (opens from "Save current view" in the list modal footer)
- `logsViewsLogic` — kea logic for CRUD (optimistic create/delete, rollback on failure, uses generated `LogsViewApi` type)
- `logsViewsListLogic` — UI state for modal open/close, save form, auto-closes on success
- Deduplicate filter formatting utilities — `FilterHistoryDropdown` now imports shared `getFiltersSummaryLines` from product-level `utils.tsx`
- Export `DEFAULT_ACTIVE_TAB` from `logsSceneLogic` (replaces hardcoded `'viewer'` string)

## How did you test this code?

New unit tests & manual CRUD

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

Yes