### PR TITLE
chore: wire worker_threads var to kafka-deduplicator

### DIFF
--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -206,7 +206,6 @@ fn main() -> Result<()> {
 }
 
 async fn async_main(config: Config) -> Result<()> {
-
     // Initialize tracing with structured output similar to feature-flags
     let log_layer = {
         let base = fmt::layer()

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -191,11 +191,21 @@ fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
     })
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Load configuration first to get OTEL settings
+fn main() -> Result<()> {
+    // Load configuration first (sync) so we can use worker_threads to size the runtime
     let config = Config::init_with_defaults()
         .context("Failed to load configuration from environment variables. Please check your environment setup.")?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(config.worker_threads)
+        .enable_all()
+        .build()
+        .context("Failed to build tokio runtime")?;
+
+    runtime.block_on(async_main(config))
+}
+
+async fn async_main(config: Config) -> Result<()> {
 
     // Initialize tracing with structured output similar to feature-flags
     let log_layer = {

--- a/rust/kafka-deduplicator/src/pipelines/processor.rs
+++ b/rust/kafka-deduplicator/src/pipelines/processor.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tracing::warn;
 
 use crate::metrics::MetricsHelper;
@@ -210,44 +210,58 @@ pub fn get_store_or_drop(
 /// Batch read from RocksDB with metrics.
 ///
 /// Reads multiple keys from the timestamp column family and records the duration.
-pub fn batch_read_timestamp_records(
+/// Runs on a blocking thread to avoid starving the tokio async runtime.
+pub async fn batch_read_timestamp_records(
     store: &DeduplicationStore,
     keys: Vec<&[u8]>,
 ) -> Result<Vec<Option<Vec<u8>>>> {
-    let start = Instant::now();
-    let results = store.multi_get_timestamp_records(keys)?;
-    let duration = start.elapsed();
-    metrics::histogram!(ROCKSDB_MULTI_GET_DURATION_MS, "cf" => "timestamp")
-        .record(duration.as_millis() as f64);
-    Ok(results)
+    let store = store.clone();
+    let owned_keys: Vec<Vec<u8>> = keys.into_iter().map(|k| k.to_vec()).collect();
+    tokio::task::spawn_blocking(move || {
+        let key_refs: Vec<&[u8]> = owned_keys.iter().map(|k| k.as_slice()).collect();
+        let start = Instant::now();
+        let results = store.multi_get_timestamp_records(key_refs)?;
+        let duration = start.elapsed();
+        metrics::histogram!(ROCKSDB_MULTI_GET_DURATION_MS, "cf" => "timestamp")
+            .record(duration.as_millis() as f64);
+        Ok(results)
+    })
+    .await
+    .context("RocksDB batch read task panicked")?
 }
 
 /// Batch write to RocksDB with metrics.
 ///
 /// Writes multiple key-value pairs to the timestamp column family and records the duration.
-pub fn batch_write_timestamp_records(
+/// Runs on a blocking thread to avoid starving the tokio async runtime.
+pub async fn batch_write_timestamp_records(
     store: &DeduplicationStore,
-    writes: &[(Vec<u8>, Vec<u8>)],
+    writes: Vec<(Vec<u8>, Vec<u8>)>,
 ) -> Result<()> {
     if writes.is_empty() {
         return Ok(());
     }
 
-    let entries: Vec<TimestampBatchEntry> = writes
-        .iter()
-        .map(|(key, value)| TimestampBatchEntry {
-            key: key.as_slice(),
-            value: value.as_slice(),
-        })
-        .collect();
+    let store = store.clone();
+    tokio::task::spawn_blocking(move || {
+        let entries: Vec<TimestampBatchEntry> = writes
+            .iter()
+            .map(|(key, value)| TimestampBatchEntry {
+                key: key.as_slice(),
+                value: value.as_slice(),
+            })
+            .collect();
 
-    let start = Instant::now();
-    store.put_timestamp_records_batch(entries)?;
-    let duration = start.elapsed();
-    metrics::histogram!(ROCKSDB_PUT_BATCH_DURATION_MS, "cf" => "timestamp")
-        .record(duration.as_millis() as f64);
+        let start = Instant::now();
+        store.put_timestamp_records_batch(entries)?;
+        let duration = start.elapsed();
+        metrics::histogram!(ROCKSDB_PUT_BATCH_DURATION_MS, "cf" => "timestamp")
+            .record(duration.as_millis() as f64);
 
-    Ok(())
+        Ok(())
+    })
+    .await
+    .context("RocksDB batch write task panicked")?
 }
 
 #[cfg(test)]
@@ -309,11 +323,11 @@ mod tests {
             (b"key1".to_vec(), b"value1".to_vec()),
             (b"key2".to_vec(), b"value2".to_vec()),
         ];
-        batch_write_timestamp_records(&store, &writes).unwrap();
+        batch_write_timestamp_records(&store, writes).await.unwrap();
 
         // Read them back
         let keys: Vec<&[u8]> = vec![b"key1", b"key2", b"key3"];
-        let results = batch_read_timestamp_records(&store, keys).unwrap();
+        let results = batch_read_timestamp_records(&store, keys).await.unwrap();
 
         assert_eq!(results.len(), 3);
         assert_eq!(results[0], Some(b"value1".to_vec()));
@@ -321,9 +335,8 @@ mod tests {
         assert_eq!(results[2], None); // key3 doesn't exist
     }
 
-    #[test]
-    fn test_batch_write_empty() {
-        // Should not panic on empty writes
+    #[tokio::test]
+    async fn test_batch_write_empty() {
         let temp_dir = TempDir::new().unwrap();
         let config = DeduplicationStoreConfig {
             path: temp_dir.path().to_path_buf(),
@@ -332,7 +345,7 @@ mod tests {
         };
         let store = DeduplicationStore::new(config, "test-topic".to_string(), 0).unwrap();
 
-        let result = batch_write_timestamp_records(&store, &[]);
+        let result = batch_write_timestamp_records(&store, vec![]).await;
         assert!(result.is_ok());
     }
 }

--- a/rust/kafka-deduplicator/src/pipelines/timestamp_deduplicator.rs
+++ b/rust/kafka-deduplicator/src/pipelines/timestamp_deduplicator.rs
@@ -145,7 +145,7 @@ impl<E: DeduplicatableEvent> TimestampDeduplicator<E> {
         };
 
         // Run deduplication logic
-        let results = self.deduplicate_events_internal(&store, &events)?;
+        let results = self.deduplicate_events_internal(&store, &events).await?;
 
         // Emit metrics for each result with library info
         for (event, result) in events.iter().zip(results.iter()) {
@@ -169,7 +169,7 @@ impl<E: DeduplicatableEvent> TimestampDeduplicator<E> {
     }
 
     /// Internal deduplication logic operating on the store.
-    fn deduplicate_events_internal(
+    async fn deduplicate_events_internal(
         &self,
         store: &DeduplicationStore,
         events: &[&E],
@@ -188,7 +188,7 @@ impl<E: DeduplicatableEvent> TimestampDeduplicator<E> {
             .iter()
             .map(|e| e.dedup_key_bytes.as_slice())
             .collect();
-        let existing_records = batch_read_timestamp_records(store, keys_refs)?;
+        let existing_records = batch_read_timestamp_records(store, keys_refs).await?;
 
         // Step 3: Process results and prepare writes
         let event_count = enriched_events.len();
@@ -215,7 +215,7 @@ impl<E: DeduplicatableEvent> TimestampDeduplicator<E> {
         }
 
         // Step 4: Batch write to RocksDB
-        batch_write_timestamp_records(store, &writes)?;
+        batch_write_timestamp_records(store, writes).await?;
 
         Ok(dedup_results)
     }


### PR DESCRIPTION
## Problem

The kafka-deduplicator's `worker_threads` config (default: 4) was declared but never wired into the tokio runtime. The `#[tokio::main]` macro defaults to CPU core count, making the config ineffective. Additionally, RocksDB batch read/write operations ran directly on the async runtime, risking tokio worker thread starvation and causing random liveness probe failures.

## Changes

- Replace `#[tokio::main]` with an explicit `tokio::runtime::Builder` that uses `config.worker_threads` to size the runtime
- Wrap `batch_read_timestamp_records` and `batch_write_timestamp_records` in `spawn_blocking` to keep RocksDB I/O off the async worker threads


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
