### PR TITLE
fix(hogql): track used cte aliases

### DIFF
--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -963,7 +963,9 @@ class ClickHousePrinter(HogQLPrinter):
                     found_aliases[alias.alias] = alias
 
         columns_sql = []
+        used_aliases: set[str] = set()
         for column in columns:
+            printed_alias: str | None = None
             if isinstance(column, ast.Alias):
                 # It's either a visible alias, or the last hidden alias with this name.
                 if found_aliases.get(column.alias) == column:
@@ -974,10 +976,20 @@ class ClickHousePrinter(HogQLPrinter):
                     else:
                         # Always print visible aliases.
                         pass
+                    printed_alias = column.alias
                 else:
                     # Non-unique hidden alias. Skip.
                     column = column.expr
-            elif isinstance(column, ast.Call):
+            else:
+                column_type = getattr(column, "type", None)
+                if isinstance(column_type, ast.FieldAliasType):
+                    printed_alias = column_type.alias
+                elif isinstance(column_type, ast.FieldType):
+                    printed_alias = column_type.name
+                elif isinstance(column_type, ast.ExpressionFieldType):
+                    printed_alias = column_type.name
+
+            if isinstance(column, ast.Call):
                 with self.context.timings.measure("printer"):
                     column_alias = safe_identifier(
                         HogQLPrinter(
@@ -985,8 +997,17 @@ class ClickHousePrinter(HogQLPrinter):
                             dialect="hogql",
                         ).visit(column)
                     )
-                column = ast.Alias(alias=column_alias, expr=column)
+                # ClickHouse rejects duplicate aliases for different expressions in the
+                # same SELECT. This can happen after "*" expansion if a subquery already
+                # exposes a generated expression name like `toDate(period_end)`.
+                if column_alias not in used_aliases:
+                    column = ast.Alias(alias=column_alias, expr=column)
+                    printed_alias = column_alias
+                else:
+                    printed_alias = None
             columns_sql.append(self.visit(column))
+            if printed_alias is not None:
+                used_aliases.add(printed_alias)
 
         return columns_sql
 

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -955,6 +955,16 @@ class ClickHousePrinter(HogQLPrinter):
         return sql
 
     def _print_select_columns(self, columns):
+        def _alias_from_column_type(column: ast.Expr) -> str | None:
+            column_type = getattr(column, "type", None)
+            if isinstance(column_type, ast.FieldAliasType):
+                return column_type.alias
+            if isinstance(column_type, ast.FieldType):
+                return column_type.name
+            if isinstance(column_type, ast.ExpressionFieldType):
+                return column_type.name
+            return None
+
         # Gather all visible aliases, and/or the last hidden alias for each unique alias name.
         found_aliases: dict[str, ast.Alias] = {}
         for alias in reversed(columns):
@@ -982,14 +992,9 @@ class ClickHousePrinter(HogQLPrinter):
                     # Non-unique hidden alias. Skip.
                     dropped_hidden_alias = True
                     column = column.expr
-            else:
-                column_type = getattr(column, "type", None)
-                if isinstance(column_type, ast.FieldAliasType):
-                    printed_alias = column_type.alias
-                elif isinstance(column_type, ast.FieldType):
-                    printed_alias = column_type.name
-                elif isinstance(column_type, ast.ExpressionFieldType):
-                    printed_alias = column_type.name
+
+            if printed_alias is None:
+                printed_alias = _alias_from_column_type(column)
 
             if isinstance(column, ast.Call) and not dropped_hidden_alias:
                 with self.context.timings.measure("printer"):

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -966,6 +966,7 @@ class ClickHousePrinter(HogQLPrinter):
         used_aliases: set[str] = set()
         for column in columns:
             printed_alias: str | None = None
+            dropped_hidden_alias = False
             if isinstance(column, ast.Alias):
                 # It's either a visible alias, or the last hidden alias with this name.
                 if found_aliases.get(column.alias) == column:
@@ -979,6 +980,7 @@ class ClickHousePrinter(HogQLPrinter):
                     printed_alias = column.alias
                 else:
                     # Non-unique hidden alias. Skip.
+                    dropped_hidden_alias = True
                     column = column.expr
             else:
                 column_type = getattr(column, "type", None)
@@ -989,7 +991,7 @@ class ClickHousePrinter(HogQLPrinter):
                 elif isinstance(column_type, ast.ExpressionFieldType):
                     printed_alias = column_type.name
 
-            if isinstance(column, ast.Call):
+            if isinstance(column, ast.Call) and not dropped_hidden_alias:
                 with self.context.timings.measure("printer"):
                     column_alias = safe_identifier(
                         HogQLPrinter(

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3064,6 +3064,53 @@ class TestPrinter(BaseTest):
             "SELECT arrayReduce(%(hogql_val_0)s, [1, 2, 3]) AS `arrayReduce('sum', [1, 2, 3])` LIMIT 50000"
         )
 
+    def test_dropped_hidden_alias_still_reserves_type_based_name(self):
+        subquery_type = ast.SelectQueryType(
+            columns={"toDate(period_end)": ast.DateType(), "period_end": ast.DateType()}
+        )
+
+        query = ast.SelectQuery(
+            select=[
+                ast.Alias(
+                    alias="toDate(period_end)",
+                    expr=ast.Field(
+                        chain=["toDate(period_end)"],
+                        type=ast.FieldType(name="toDate(period_end)", table_type=subquery_type),
+                    ),
+                    hidden=True,
+                ),
+                ast.Call(
+                    name="toDate",
+                    args=[
+                        ast.Field(
+                            chain=["period_end"],
+                            type=ast.FieldType(name="period_end", table_type=subquery_type),
+                        )
+                    ],
+                ),
+                ast.Alias(
+                    alias="toDate(period_end)",
+                    expr=ast.Field(
+                        chain=["toDate(period_end)"],
+                        type=ast.FieldType(name="toDate(period_end)", table_type=subquery_type),
+                        from_asterisk=True,
+                    ),
+                    hidden=True,
+                ),
+            ]
+        )
+
+        printed = print_prepared_ast(
+            query,
+            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            dialect="clickhouse",
+        )
+
+        assert (
+            printed
+            == "SELECT `toDate(period_end)`, toDate(period_end), `toDate(period_end)` AS `toDate(period_end)` LIMIT 50000"
+        )
+
     def test_can_call_parametric_function_from_placeholder(self):
         printed = self._print("SELECT arrayReduce({f}, [1, 2, 3])", placeholders={"f": ast.Constant(value="sum")})
         assert printed == (

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -115,6 +115,63 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             assert pretty_print_response_in_tests(response, self.team.pk) == self.snapshot
             self.assertEqual(response.results, [(2, "random event")])
 
+    def test_cte_with_unaliased_expression_and_outer_star(self):
+        response = execute_hogql_query(
+            """
+            WITH blah AS (
+                SELECT
+                    1 AS customer_id,
+                    dateTrunc('month', toDate('2026-08-03')) AS month,
+                    toDate('2026-08-03'),
+                    '2026-08-03' AS period_end
+            )
+            SELECT *, toDate(period_end)
+            FROM blah
+            WHERE month < '2027-01-01'
+            LIMIT 1000
+            """,
+            self.team,
+            pretty=False,
+        )
+
+        self.assertEqual(
+            response.columns,
+            ["customer_id", "month", "toDate('2026-08-03')", "period_end", "toDate(period_end)"],
+        )
+        self.assertEqual(
+            response.results,
+            [(1, datetime.date(2026, 8, 1), datetime.date(2026, 8, 3), "2026-08-03", datetime.date(2026, 8, 3))],
+        )
+
+    def test_cte_with_duplicate_unaliased_expression_names(self):
+        response = execute_hogql_query(
+            """
+            WITH blah AS (
+                SELECT
+                    1 AS customer_id,
+                    dateTrunc('month', toDate(period_end)) AS month,
+                    toDate(period_end),
+                    period_end
+                FROM (SELECT '2026-08-03' AS period_end)
+            )
+            SELECT *, toDate(period_end)
+            FROM blah
+            WHERE month < '2027-01-01'
+            LIMIT 1000
+            """,
+            self.team,
+            pretty=False,
+        )
+
+        self.assertEqual(
+            response.columns,
+            ["customer_id", "month", "toDate(period_end)", "period_end", "toDate(period_end)"],
+        )
+        self.assertEqual(
+            response.results,
+            [(1, datetime.date(2026, 8, 1), datetime.date(2026, 8, 3), "2026-08-03", datetime.date(2026, 8, 3))],
+        )
+
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_query_distinct(self):
         with freeze_time("2020-01-10"):


### PR DESCRIPTION
# Problem

Queries that mixed `SELECT *` with additional unaliased expressions could fail in ClickHouse when the expanded `*` already exposed a generated column name matching the later expression.

In the reported case, a CTE produced an unaliased `toDate(period_end)` column, and the outer query also selected `toDate(period_end)`. Our ClickHouse printer auto-assigned the same synthetic alias to the later expression, which caused ClickHouse to reject the query because two different expressions shared the alias `toDate(period_end)`.

## Changes

Updated the ClickHouse printer to avoid auto-applying a generated alias to an unaliased call when that alias has already been used earlier in the same `SELECT`.

Added HogQL regression coverage for:

- a CTE with an unaliased expression selected through outer `SELECT *`
- the duplicate generated-name case from the bug report, where both the expanded column and a later expression resolve to `toDate(period_end)`

## How did you test this code?

CI tests

## Publish to changelog?

no

## Docs update

no