### PR TITLE
feat: chat title comes in earlier, scene tab title get's updated (when tab inactive)

### DIFF
--- a/ee/hogai/chat_agent/test/test_chat_agent.py
+++ b/ee/hogai/chat_agent/test/test_chat_agent.py
@@ -413,8 +413,8 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
 
         # Separate conversation events from message events
-        conversation_events = [e for e in actual_output if e[0] == "conversation"]
-        message_events = [e for e in actual_output if e[0] == "message"]
+        conversation_events = [e for e in actual_output if e[0] == AssistantEventType.CONVERSATION]
+        message_events = [e for e in actual_output if e[0] == AssistantEventType.MESSAGE]
 
         # Two conversation events: initial + title update
         self.assertEqual(len(conversation_events), 2)
@@ -499,8 +499,8 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
 
         # Separate conversation events from message events
-        conversation_events = [e for e in actual_output if e[0] == "conversation"]
-        message_events = [e for e in actual_output if e[0] == "message"]
+        conversation_events = [e for e in actual_output if e[0] == AssistantEventType.CONVERSATION]
+        message_events = [e for e in actual_output if e[0] == AssistantEventType.MESSAGE]
 
         # Two conversation events: initial + title update
         self.assertEqual(len(conversation_events), 2)
@@ -580,8 +580,8 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
 
         # Separate conversation events from message events
-        conversation_events = [e for e in actual_output if e[0] == "conversation"]
-        message_events = [e for e in actual_output if e[0] == "message"]
+        conversation_events = [e for e in actual_output if e[0] == AssistantEventType.CONVERSATION]
+        message_events = [e for e in actual_output if e[0] == AssistantEventType.MESSAGE]
 
         # Two conversation events: initial + title update
         self.assertEqual(len(conversation_events), 2)
@@ -651,8 +651,8 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True, agent_mode=AgentMode.SQL)
 
         # Separate conversation events from message events
-        conversation_events = [e for e in actual_output if e[0] == "conversation"]
-        message_events = [e for e in actual_output if e[0] == "message"]
+        conversation_events = [e for e in actual_output if e[0] == AssistantEventType.CONVERSATION]
+        message_events = [e for e in actual_output if e[0] == AssistantEventType.MESSAGE]
 
         # Two conversation events: initial + title update
         self.assertEqual(len(conversation_events), 2)

--- a/ee/hogai/chat_agent/test/test_chat_agent.py
+++ b/ee/hogai/chat_agent/test/test_chat_agent.py
@@ -412,27 +412,30 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
 
-        # Verify output length
-        self.assertEqual(len(actual_output), 6)
+        # Separate conversation events from message events
+        conversation_events = [e for e in actual_output if e[0] == "conversation"]
+        message_events = [e for e in actual_output if e[0] == "message"]
 
-        # Check conversation output
-        self.assertEqual(actual_output[0], ("conversation", self.conversation))
+        # Two conversation events: initial + title update
+        self.assertEqual(len(conversation_events), 2)
+        self.assertEqual(conversation_events[0], ("conversation", self.conversation))
+        self.assertEqual(conversation_events[1], ("conversation", self.conversation))
+
+        # Check message events in order
+        self.assertEqual(len(message_events), 5)
 
         # Check human message
-        self.assertEqual(actual_output[1][0], "message")
-        assert isinstance(actual_output[1][1], HumanMessage)
-        self.assertEqual(actual_output[1][1].content, "Hello")
+        assert isinstance(message_events[0][1], HumanMessage)
+        self.assertEqual(message_events[0][1].content, "Hello")
 
         # Check assistant message with tool calls
-        self.assertEqual(actual_output[2][0], "message")
-        self.assertIsInstance(actual_output[2][1], AssistantMessage)
-        assert isinstance(actual_output[2][1], AssistantMessage)
-        assert actual_output[2][1].tool_calls is not None
-        self.assertEqual(actual_output[2][1].tool_calls[0].name, "create_insight")
+        self.assertIsInstance(message_events[1][1], AssistantMessage)
+        assert isinstance(message_events[1][1], AssistantMessage)
+        assert message_events[1][1].tool_calls is not None
+        self.assertEqual(message_events[1][1].tool_calls[0].name, "create_insight")
 
         # Check artifact message - enriched from ArtifactRefMessage
-        self.assertEqual(actual_output[3][0], "message")
-        artifact_msg = actual_output[3][1]
+        artifact_msg = message_events[2][1]
         self.assertIsInstance(artifact_msg, ArtifactMessage)
         assert isinstance(artifact_msg, ArtifactMessage)
         self.assertEqual(artifact_msg.source, ArtifactSource.ARTIFACT)
@@ -440,13 +443,11 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         self.assertEqual(artifact_msg.content.query, query)
 
         # Check tool call message
-        self.assertEqual(actual_output[4][0], "message")
-        self.assertIsInstance(actual_output[4][1], AssistantToolCallMessage)
+        self.assertIsInstance(message_events[3][1], AssistantToolCallMessage)
 
         # Check final assistant message
-        self.assertEqual(actual_output[5][0], "message")
-        assert isinstance(actual_output[5][1], AssistantMessage)
-        self.assertEqual(actual_output[5][1].content, "The results indicate a great future for you.")
+        assert isinstance(message_events[4][1], AssistantMessage)
+        self.assertEqual(message_events[4][1].content, "The results indicate a great future for you.")
 
         # Second run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=False)
@@ -497,41 +498,35 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
 
-        # Verify output length
-        self.assertEqual(len(actual_output), 6)
+        # Separate conversation events from message events
+        conversation_events = [e for e in actual_output if e[0] == "conversation"]
+        message_events = [e for e in actual_output if e[0] == "message"]
 
-        # Check conversation output
-        self.assertEqual(actual_output[0], ("conversation", self.conversation))
+        # Two conversation events: initial + title update
+        self.assertEqual(len(conversation_events), 2)
 
-        # Check human message
-        self.assertEqual(actual_output[1][0], "message")
-        assert isinstance(actual_output[1][1], HumanMessage)
-        self.assertEqual(actual_output[1][1].content, "Hello")
+        # Check message events in order
+        self.assertEqual(len(message_events), 5)
 
-        # Check assistant message with tool calls
-        self.assertEqual(actual_output[2][0], "message")
-        self.assertIsInstance(actual_output[2][1], AssistantMessage)
-        assert isinstance(actual_output[2][1], AssistantMessage)
-        assert actual_output[2][1].tool_calls is not None
-        self.assertEqual(actual_output[2][1].tool_calls[0].name, "create_insight")
+        assert isinstance(message_events[0][1], HumanMessage)
+        self.assertEqual(message_events[0][1].content, "Hello")
 
-        # Check artifact message - enriched from ArtifactRefMessage
-        self.assertEqual(actual_output[3][0], "message")
-        artifact_msg = actual_output[3][1]
+        self.assertIsInstance(message_events[1][1], AssistantMessage)
+        assert isinstance(message_events[1][1], AssistantMessage)
+        assert message_events[1][1].tool_calls is not None
+        self.assertEqual(message_events[1][1].tool_calls[0].name, "create_insight")
+
+        artifact_msg = message_events[2][1]
         self.assertIsInstance(artifact_msg, ArtifactMessage)
         assert isinstance(artifact_msg, ArtifactMessage)
         self.assertEqual(artifact_msg.source, ArtifactSource.ARTIFACT)
         assert isinstance(artifact_msg.content, VisualizationArtifactContent)
         self.assertEqual(artifact_msg.content.query, query)
 
-        # Check tool call message
-        self.assertEqual(actual_output[4][0], "message")
-        self.assertIsInstance(actual_output[4][1], AssistantToolCallMessage)
+        self.assertIsInstance(message_events[3][1], AssistantToolCallMessage)
 
-        # Check final assistant message
-        self.assertEqual(actual_output[5][0], "message")
-        assert isinstance(actual_output[5][1], AssistantMessage)
-        self.assertEqual(actual_output[5][1].content, "The results indicate a great future for you.")
+        assert isinstance(message_events[4][1], AssistantMessage)
+        self.assertEqual(message_events[4][1].content, "The results indicate a great future for you.")
 
         # Second run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=False)
@@ -584,41 +579,35 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True)
 
-        # Verify output length
-        self.assertEqual(len(actual_output), 6)
+        # Separate conversation events from message events
+        conversation_events = [e for e in actual_output if e[0] == "conversation"]
+        message_events = [e for e in actual_output if e[0] == "message"]
 
-        # Check conversation output
-        self.assertEqual(actual_output[0], ("conversation", self.conversation))
+        # Two conversation events: initial + title update
+        self.assertEqual(len(conversation_events), 2)
 
-        # Check human message
-        self.assertEqual(actual_output[1][0], "message")
-        assert isinstance(actual_output[1][1], HumanMessage)
-        self.assertEqual(actual_output[1][1].content, "Hello")
+        # Check message events in order
+        self.assertEqual(len(message_events), 5)
 
-        # Check assistant message with tool calls
-        self.assertEqual(actual_output[2][0], "message")
-        self.assertIsInstance(actual_output[2][1], AssistantMessage)
-        assert isinstance(actual_output[2][1], AssistantMessage)
-        assert actual_output[2][1].tool_calls is not None
-        self.assertEqual(actual_output[2][1].tool_calls[0].name, "create_insight")
+        assert isinstance(message_events[0][1], HumanMessage)
+        self.assertEqual(message_events[0][1].content, "Hello")
 
-        # Check artifact message - enriched from ArtifactRefMessage
-        self.assertEqual(actual_output[3][0], "message")
-        artifact_msg = actual_output[3][1]
+        self.assertIsInstance(message_events[1][1], AssistantMessage)
+        assert isinstance(message_events[1][1], AssistantMessage)
+        assert message_events[1][1].tool_calls is not None
+        self.assertEqual(message_events[1][1].tool_calls[0].name, "create_insight")
+
+        artifact_msg = message_events[2][1]
         self.assertIsInstance(artifact_msg, ArtifactMessage)
         assert isinstance(artifact_msg, ArtifactMessage)
         self.assertEqual(artifact_msg.source, ArtifactSource.ARTIFACT)
         assert isinstance(artifact_msg.content, VisualizationArtifactContent)
         self.assertEqual(artifact_msg.content.query, query)
 
-        # Check tool call message
-        self.assertEqual(actual_output[4][0], "message")
-        self.assertIsInstance(actual_output[4][1], AssistantToolCallMessage)
+        self.assertIsInstance(message_events[3][1], AssistantToolCallMessage)
 
-        # Check final assistant message
-        self.assertEqual(actual_output[5][0], "message")
-        assert isinstance(actual_output[5][1], AssistantMessage)
-        self.assertEqual(actual_output[5][1].content, "The results indicate a great future for you.")
+        assert isinstance(message_events[4][1], AssistantMessage)
+        self.assertEqual(message_events[4][1].content, "The results indicate a great future for you.")
 
         # Second run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=False)
@@ -661,41 +650,35 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
         # First run
         actual_output, _ = await self._run_assistant_graph(is_new_conversation=True, agent_mode=AgentMode.SQL)
 
-        # Verify output length
-        self.assertEqual(len(actual_output), 6)
+        # Separate conversation events from message events
+        conversation_events = [e for e in actual_output if e[0] == "conversation"]
+        message_events = [e for e in actual_output if e[0] == "message"]
 
-        # Check conversation output
-        self.assertEqual(actual_output[0], ("conversation", self.conversation))
+        # Two conversation events: initial + title update
+        self.assertEqual(len(conversation_events), 2)
 
-        # Check human message
-        self.assertEqual(actual_output[1][0], "message")
-        assert isinstance(actual_output[1][1], HumanMessage)
-        self.assertEqual(actual_output[1][1].content, "Hello")
+        # Check message events in order
+        self.assertEqual(len(message_events), 5)
 
-        # Check assistant message with tool calls
-        self.assertEqual(actual_output[2][0], "message")
-        self.assertIsInstance(actual_output[2][1], AssistantMessage)
-        assert isinstance(actual_output[2][1], AssistantMessage)
-        assert actual_output[2][1].tool_calls is not None
-        self.assertEqual(actual_output[2][1].tool_calls[0].name, "execute_sql")
+        assert isinstance(message_events[0][1], HumanMessage)
+        self.assertEqual(message_events[0][1].content, "Hello")
 
-        # Check artifact message - enriched from ArtifactRefMessage
-        self.assertEqual(actual_output[3][0], "message")
-        artifact_msg = actual_output[3][1]
+        self.assertIsInstance(message_events[1][1], AssistantMessage)
+        assert isinstance(message_events[1][1], AssistantMessage)
+        assert message_events[1][1].tool_calls is not None
+        self.assertEqual(message_events[1][1].tool_calls[0].name, "execute_sql")
+
+        artifact_msg = message_events[2][1]
         self.assertIsInstance(artifact_msg, ArtifactMessage)
         assert isinstance(artifact_msg, ArtifactMessage)
         self.assertEqual(artifact_msg.source, ArtifactSource.ARTIFACT)
         assert isinstance(artifact_msg.content, VisualizationArtifactContent)
         self.assertEqual(artifact_msg.content.query, query)
 
-        # Check tool call message
-        self.assertEqual(actual_output[4][0], "message")
-        self.assertIsInstance(actual_output[4][1], AssistantToolCallMessage)
+        self.assertIsInstance(message_events[3][1], AssistantToolCallMessage)
 
-        # Check final assistant message
-        self.assertEqual(actual_output[5][0], "message")
-        assert isinstance(actual_output[5][1], AssistantMessage)
-        self.assertEqual(actual_output[5][1].content, "The results indicate a great future for you.")
+        assert isinstance(message_events[4][1], AssistantMessage)
+        self.assertEqual(message_events[4][1].content, "The results indicate a great future for you.")
 
     @patch("ee.hogai.chat_agent.memory.nodes.MemoryOnboardingFinalizeNode._model")
     @patch("ee.hogai.chat_agent.memory.nodes.MemoryInitializerContextMixin._aretrieve_context")

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -149,6 +149,7 @@ class BaseAgentRunner(ABC):
         self._conversation = conversation
         self._latest_message = new_message.model_copy(deep=True, update={"id": str(uuid4())}) if new_message else None
         self._is_new_conversation = is_new_conversation
+        self._pending_conversation_update = False
         self._state = None
         self._state_type = state_type
         self._partial_state_type = partial_state_type

--- a/ee/hogai/core/runner.py
+++ b/ee/hogai/core/runner.py
@@ -62,6 +62,7 @@ from ee.hogai.utils.types.base import (
     AssistantOutput,
     AssistantResultUnion,
     AssistantStreamedMessageUnion,
+    ConversationTitleAction,
     LangGraphUpdateEvent,
 )
 from ee.hogai.utils.types.composed import AssistantMaxGraphState, AssistantMaxPartialGraphState
@@ -264,6 +265,7 @@ class BaseAgentRunner(ABC):
                 # Send the latest received human message with the initialized id.
                 yield AssistantEventType.MESSAGE, self._latest_message
 
+            self._pending_conversation_update = False
             try:
                 async for update in generator:
                     if messages := await self._process_update(update):
@@ -279,6 +281,13 @@ class BaseAgentRunner(ABC):
                                 yield AssistantEventType.STATUS, message
                             elif isinstance(message, AssistantUpdateEvent | SubagentUpdateEvent):
                                 yield AssistantEventType.UPDATE, message
+
+                    # Re-yield the conversation when the title generator has
+                    # produced a title. Checked after _process_update so the
+                    # flag set by ConversationTitleAction is picked up.
+                    if self._pending_conversation_update:
+                        self._pending_conversation_update = False
+                        yield AssistantEventType.CONVERSATION, self._conversation
             except GraphInterrupt:
                 # GraphInterrupt is raised when interrupt() is called in a tool.
                 # TRICKY: don't reset state. The interrupt handling code
@@ -577,6 +586,11 @@ class BaseAgentRunner(ABC):
 
     async def _process_update(self, update: Any) -> list[AssistantResultUnion] | None:
         update = extract_stream_update(update)
+
+        if isinstance(update, ConversationTitleAction):
+            self._conversation.title = update.title
+            self._pending_conversation_update = True
+            return None
 
         if not isinstance(update, AssistantDispatcherEvent):
             if updates := await self._stream_processor.process_langgraph_update(LangGraphUpdateEvent(update=update)):

--- a/ee/hogai/core/test/test_runner.py
+++ b/ee/hogai/core/test/test_runner.py
@@ -712,7 +712,7 @@ class TestRunnerConversationTitleAction(BaseTest):
         runner._pending_conversation_update = False
 
         # A values update — (namespace, "values", state_dict) format from LangGraph multi-mode streaming
-        other_update = (("some_node",), "values", {})
+        other_update: tuple[tuple[str, ...], str, dict] = (("some_node",), "values", {})
         await runner._process_update(other_update)
 
         self.assertFalse(runner._pending_conversation_update)

--- a/ee/hogai/core/test/test_runner.py
+++ b/ee/hogai/core/test/test_runner.py
@@ -13,7 +13,7 @@ from parameterized import parameterized
 from posthog.schema import AssistantEventType, FailureMessage
 
 from ee.hogai.core.base import BaseAssistantGraph
-from ee.hogai.utils.types.base import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import AssistantState, ConversationTitleAction, PartialAssistantState
 from ee.models.assistant import Conversation
 
 
@@ -645,3 +645,98 @@ class TestRunnerSubagentBehavior(BaseTest):
             self.assertIsInstance(runner._callback_handlers[0], SubagentCallbackHandler)
             handler = cast(SubagentCallbackHandler, runner._callback_handlers[0])
             self.assertEqual(handler._parent_span_id, parent_span_id)
+
+
+class TestRunnerConversationTitleAction(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.conversation = Conversation.objects.create(team=self.team, user=self.user)
+
+    def _create_runner(self, stream_updates=None):
+        from ee.hogai.core.runner import BaseAgentRunner
+
+        async def _fake_astream(*args, **kwargs):
+            for update in stream_updates or []:
+                yield update
+
+        mock_graph = MagicMock()
+        mock_graph.astream = MagicMock(return_value=_fake_astream())
+        mock_graph.aget_state = AsyncMock(return_value=MagicMock(values={}, next=None))
+        mock_graph.aupdate_state = AsyncMock()
+
+        mock_stream_processor = MagicMock()
+        mock_stream_processor.mark_id_as_streamed = MagicMock()
+        mock_stream_processor.process = AsyncMock(return_value=None)
+        mock_stream_processor.process_langgraph_update = AsyncMock(return_value=None)
+
+        mock_graph_class = MagicMock()
+        mock_graph_instance = MagicMock()
+        mock_graph_instance.compile_full_graph = MagicMock(return_value=mock_graph)
+        mock_graph_class.return_value = mock_graph_instance
+
+        class TestRunner(BaseAgentRunner):
+            def get_initial_state(self):
+                return AssistantState(messages=[])
+
+            def get_resumed_state(self):
+                return PartialAssistantState(messages=[])
+
+        runner = TestRunner(
+            team=self.team,
+            conversation=self.conversation,
+            user=self.user,
+            graph_class=cast(type[BaseAssistantGraph], mock_graph_class),
+            state_type=AssistantState,
+            partial_state_type=PartialAssistantState,
+            stream_processor=mock_stream_processor,
+        )
+        runner._graph = mock_graph
+
+        return runner, mock_graph
+
+    async def test_process_update_sets_conversation_title_and_pending_flag(self):
+        runner, _ = self._create_runner()
+        runner._pending_conversation_update = False
+
+        # In the LangGraph custom stream, ConversationTitleAction arrives as (namespace, "custom", action)
+        action = ConversationTitleAction(title="My Generated Title")
+        raw_update = (("title_generator",), "custom", action)
+        result = await runner._process_update(raw_update)
+
+        self.assertIsNone(result)
+        self.assertEqual(runner._conversation.title, "My Generated Title")
+        self.assertTrue(runner._pending_conversation_update)
+
+    async def test_process_update_does_not_set_pending_flag_for_other_updates(self):
+        runner, _ = self._create_runner()
+        runner._pending_conversation_update = False
+
+        # A values update — (namespace, "values", state_dict) format from LangGraph multi-mode streaming
+        other_update = (("some_node",), "values", {})
+        await runner._process_update(other_update)
+
+        self.assertFalse(runner._pending_conversation_update)
+
+    async def test_astream_yields_conversation_event_when_title_action_received(self):
+        title_action = ConversationTitleAction(title="Streamed Title")
+        # Wrap in the LangGraph custom stream tuple format
+        raw_update = (("title_generator",), "custom", title_action)
+
+        runner, mock_graph = self._create_runner(stream_updates=[raw_update])
+
+        with (
+            patch.object(runner, "_init_or_update_state", new_callable=AsyncMock, return_value=None),
+            patch.object(runner, "_lock_conversation", return_value=mock_lock_conversation()),
+        ):
+            results = []
+            async for event_type, payload in runner.astream(
+                stream_message_chunks=False,
+                stream_first_message=False,
+                stream_only_assistant_messages=False,
+            ):
+                results.append((event_type, payload))
+
+        conversation_events = [(et, p) for et, p in results if et == AssistantEventType.CONVERSATION]
+        self.assertEqual(len(conversation_events), 1)
+        _, conversation = conversation_events[0]
+        self.assertEqual(conversation.title, "Streamed Title")

--- a/ee/hogai/core/title_generator/nodes.py
+++ b/ee/hogai/core/title_generator/nodes.py
@@ -1,6 +1,7 @@
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
+from langgraph.config import get_stream_writer
 
 from posthog.schema import HumanMessage
 
@@ -9,6 +10,7 @@ from ee.hogai.core.title_generator.prompts import TITLE_GENERATION_PROMPT
 from ee.hogai.llm import MaxChatOpenAI
 from ee.hogai.utils.helpers import find_last_message_of_type
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
+from ee.hogai.utils.types.base import ConversationTitleAction
 from ee.models.assistant import Conversation
 
 
@@ -32,6 +34,13 @@ class TitleGeneratorNode(AssistantNode):
 
         conversation.title = title[: Conversation.TITLE_MAX_LENGTH].strip()
         conversation.save()
+
+        # Emit the title to the stream so the frontend can display it immediately
+        try:
+            writer = get_stream_writer()
+            writer(ConversationTitleAction(title=conversation.title))
+        except RuntimeError:
+            pass  # Not in a streaming context (e.g. testing)
 
         return None
 

--- a/ee/hogai/core/title_generator/nodes.py
+++ b/ee/hogai/core/title_generator/nodes.py
@@ -38,9 +38,10 @@ class TitleGeneratorNode(AssistantNode):
         # Emit the title to the stream so the frontend can display it immediately
         try:
             writer = get_stream_writer()
-            writer(ConversationTitleAction(title=conversation.title))
         except RuntimeError:
             pass  # Not in a streaming context (e.g. testing)
+        else:
+            writer(ConversationTitleAction(title=conversation.title))
 
         return None
 

--- a/ee/hogai/core/title_generator/test/test_title_generator.py
+++ b/ee/hogai/core/title_generator/test/test_title_generator.py
@@ -8,6 +8,7 @@ from posthog.schema import HumanMessage
 from ee.hogai.core.title_generator.nodes import TitleGeneratorNode
 from ee.hogai.utils.tests import FakeChatOpenAI
 from ee.hogai.utils.types import AssistantState
+from ee.hogai.utils.types.base import ConversationTitleAction
 from ee.models.assistant import Conversation
 
 
@@ -101,6 +102,50 @@ class TestTitleGenerator(BaseTest):
         # Refresh from DB to ensure we get latest value
         self.conversation.refresh_from_db()
         self.assertIsNone(self.conversation.title)
+
+    def test_emits_conversation_title_action_to_stream_writer(self):
+        written = []
+        mock_writer = Mock(side_effect=lambda action: written.append(action))
+
+        with (
+            patch(
+                "ee.hogai.core.title_generator.nodes.TitleGeneratorNode._model",
+                return_value=FakeChatOpenAI(responses=[LangchainAIMessage(content="Stream Title")]),
+            ),
+            patch("ee.hogai.core.title_generator.nodes.get_stream_writer", return_value=mock_writer),
+        ):
+            node = TitleGeneratorNode(self.team, self.user)
+            node.run(
+                AssistantState(messages=[HumanMessage(content="Test Message")]),
+                {"configurable": {"thread_id": self.conversation.id}},
+            )
+
+        self.assertEqual(len(written), 1)
+        action = written[0]
+        self.assertIsInstance(action, ConversationTitleAction)
+        self.assertEqual(action.title, "Stream Title")
+
+    def test_does_not_raise_when_stream_writer_unavailable(self):
+        with (
+            patch(
+                "ee.hogai.core.title_generator.nodes.TitleGeneratorNode._model",
+                return_value=FakeChatOpenAI(responses=[LangchainAIMessage(content="Some Title")]),
+            ),
+            patch(
+                "ee.hogai.core.title_generator.nodes.get_stream_writer",
+                side_effect=RuntimeError("Not in streaming context"),
+            ),
+        ):
+            node = TitleGeneratorNode(self.team, self.user)
+            # Should not raise
+            result = node.run(
+                AssistantState(messages=[HumanMessage(content="Test Message")]),
+                {"configurable": {"thread_id": self.conversation.id}},
+            )
+
+        self.assertIsNone(result)
+        self.conversation.refresh_from_db()
+        self.assertEqual(self.conversation.title, "Some Title")
 
     def test_handles_json_content_without_error(self):
         """Test that title generation works when user message contains JSON with curly braces."""

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -43,7 +43,12 @@ from posthog.models import Team
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
 
 from ee.hogai.utils.anthropic import SUPPORTED_ANTHROPIC_BLOCKS
-from ee.hogai.utils.types.base import ArtifactRefMessage, AssistantDispatcherEvent, AssistantMessageUnion
+from ee.hogai.utils.types.base import (
+    ArtifactRefMessage,
+    AssistantDispatcherEvent,
+    AssistantMessageUnion,
+    ConversationTitleAction,
+)
 
 
 def remove_line_breaks(line: str) -> str:
@@ -391,7 +396,7 @@ def extract_stream_update(update: Any) -> Any:
         # If it's a LangGraph-based chunk, we remove the first two elements, which are "custom" and the parent graph namespace
         update = update[2]
 
-    if isinstance(update, AssistantDispatcherEvent):
+    if isinstance(update, (AssistantDispatcherEvent, ConversationTitleAction)):
         return update
 
     update = update[1:]  # we remove the first element, which is the node/subgraph node name

--- a/ee/hogai/utils/types/base.py
+++ b/ee/hogai/utils/types/base.py
@@ -602,7 +602,14 @@ class UpdateAction(BaseModel):
     content: str | AssistantToolCall
 
 
-AssistantActionUnion = MessageAction | MessageChunkAction | NodeStartAction | NodeEndAction | UpdateAction
+class ConversationTitleAction(BaseModel):
+    type: Literal["CONVERSATION_TITLE"] = "CONVERSATION_TITLE"
+    title: str
+
+
+AssistantActionUnion = (
+    MessageAction | MessageChunkAction | NodeStartAction | NodeEndAction | UpdateAction | ConversationTitleAction
+)
 
 
 class NodePath(BaseModel):

--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -12,7 +12,7 @@ import { SidePanelTab } from '~/types'
 
 import { QUESTION_SUGGESTIONS_DATA, maxLogic } from './maxLogic'
 import { maxThreadLogic } from './maxThreadLogic'
-import { maxMocks } from './testUtils'
+import { MOCK_CONVERSATION, MOCK_CONVERSATION_ID, maxMocks } from './testUtils'
 
 describe('maxLogic', () => {
     let logic: ReturnType<typeof maxLogic.build>
@@ -400,6 +400,99 @@ describe('maxLogic', () => {
             await expectLogic(threadLogic).toMatchValues({
                 agentMode: null,
             })
+        })
+    })
+
+    describe('chatTitle selector', () => {
+        it('returns the conversation title when the conversation has a title', async () => {
+            useMocks({
+                ...maxMocks,
+                get: {
+                    ...maxMocks.get,
+                    '/api/environments/:team_id/conversations/': { results: [MOCK_CONVERSATION] },
+                },
+            })
+
+            logic = maxLogic({ tabId: 'test' })
+            logic.mount()
+
+            // Wait for conversation history to load, then set conversationId
+            await expectLogic(logic).toDispatchActions(['loadConversationHistorySuccess']).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setConversationId(MOCK_CONVERSATION_ID)
+            }).toMatchValues({
+                chatTitle: MOCK_CONVERSATION.title,
+            })
+        })
+
+        it('returns "New chat" when there is a conversationId but no matching conversation in history', async () => {
+            logic = maxLogic({ tabId: 'test' })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setConversationId('unknown-id')
+            }).toMatchValues({
+                chatTitle: 'New chat',
+            })
+        })
+
+        it('returns "Chat history" when conversation history is visible', async () => {
+            logic = maxLogic({ tabId: 'test' })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.toggleConversationHistory(true)
+            }).toMatchValues({
+                chatTitle: 'Chat history',
+            })
+        })
+
+        it('returns null when there is no conversationId and history is not visible', async () => {
+            logic = maxLogic({ tabId: 'test' })
+            logic.mount()
+
+            await expectLogic(logic).toMatchValues({
+                conversationId: null,
+                conversationHistoryVisible: false,
+                chatTitle: null,
+            })
+        })
+    })
+
+    describe('breadcrumbs', () => {
+        it('shows "New chat" as the first breadcrumb name when no conversationId is set', async () => {
+            logic = maxLogic({ tabId: 'test' })
+            logic.mount()
+
+            await expectLogic(logic).toMatchValues({
+                conversationId: null,
+            })
+
+            const breadcrumbs = logic.values.breadcrumbs
+            expect(breadcrumbs[0].name).toBe('New chat')
+        })
+
+        it('shows "AI" as the first breadcrumb name and chat title in second breadcrumb when conversationId is set', async () => {
+            useMocks({
+                ...maxMocks,
+                get: {
+                    ...maxMocks.get,
+                    '/api/environments/:team_id/conversations/': { results: [MOCK_CONVERSATION] },
+                },
+            })
+
+            logic = maxLogic({ tabId: 'test' })
+            logic.mount()
+
+            // Wait for conversation history to load, then set conversationId
+            await expectLogic(logic).toDispatchActions(['loadConversationHistorySuccess']).toFinishAllListeners()
+
+            logic.actions.setConversationId(MOCK_CONVERSATION_ID)
+
+            const breadcrumbs = logic.values.breadcrumbs
+            expect(breadcrumbs[0].name).toBe('AI')
+            expect(breadcrumbs[1].name).toBe(MOCK_CONVERSATION.title)
         })
     })
 })

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -371,10 +371,11 @@ export const maxLogic = kea<maxLogicType>([
                 activeStreamingThreads
             ): Breadcrumb[] => {
                 const isStreaming = activeStreamingThreads > 0
+                const hasConversationBreadcrumb = !conversationHistoryVisible && conversationId
                 return [
                     {
                         key: Scene.Max,
-                        name: 'AI',
+                        name: hasConversationBreadcrumb ? 'AI' : 'New chat',
                         path: urls.ai(),
                         iconType: 'chat',
                     },
@@ -388,7 +389,7 @@ export const maxLogic = kea<maxLogicType>([
                               },
                           ]
                         : []),
-                    ...(!conversationHistoryVisible && conversationId
+                    ...(hasConversationBreadcrumb
                         ? [
                               {
                                   key: Scene.Max,

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -119,6 +119,9 @@ function handleCommandString(options: string, actions: maxLogicType['actions']):
     }
 }
 
+const CHAT_TITLE_NEW = 'New chat'
+const CHAT_TITLE_HISTORY = 'Chat history'
+
 function updateInactiveTab(tabId: string, props: Partial<SceneTab>): void {
     const scene = sceneLogic.findMounted()
     if (!scene) {
@@ -325,12 +328,12 @@ export const maxLogic = kea<maxLogicType>([
             (s) => [s.conversationId, s.conversation, s.conversationHistoryVisible],
             (conversationId, conversation, conversationHistoryVisible) => {
                 if (conversationHistoryVisible) {
-                    return 'Chat history'
+                    return CHAT_TITLE_HISTORY
                 }
 
                 // Existing conversation or the first generation is in progress
                 if (conversationId || conversation) {
-                    return conversation?.title ?? 'New chat'
+                    return conversation?.title ?? CHAT_TITLE_NEW
                 }
 
                 return null
@@ -376,7 +379,7 @@ export const maxLogic = kea<maxLogicType>([
                 return [
                     {
                         key: Scene.Max,
-                        name: hasConversationBreadcrumb ? 'AI' : 'New chat',
+                        name: hasConversationBreadcrumb ? 'AI' : CHAT_TITLE_NEW,
                         path: urls.ai(),
                         iconType: 'chat',
                     },
@@ -384,7 +387,7 @@ export const maxLogic = kea<maxLogicType>([
                         ? [
                               {
                                   key: Scene.Max,
-                                  name: 'Chat history',
+                                  name: CHAT_TITLE_HISTORY,
                                   path: urls.aiHistory(),
                                   iconType: 'chat' as const,
                               },
@@ -540,9 +543,11 @@ export const maxLogic = kea<maxLogicType>([
         },
     })),
 
+    // Active tab titles are updated by sceneLogic's titleAndIcon subscription (reads breadcrumbs).
+    // This subscription covers inactive tabs, which titleAndIcon doesn't reach.
     subscriptions(({ props }) => ({
         chatTitle: (title: string | null) => {
-            if (title && title !== 'New chat' && title !== 'Chat history') {
+            if (title && title !== CHAT_TITLE_NEW && title !== CHAT_TITLE_HISTORY) {
                 updateInactiveTab(props.tabId, { title })
             }
         },
@@ -590,7 +595,7 @@ export const maxLogic = kea<maxLogicType>([
         [urls.ai()]: (_, search) => {
             if (search.ask && !search.chat && !values.question) {
                 // Clear any existing conversation so the tab title updates
-                if (values.conversationId) {
+                if (values.conversationId && values.activeStreamingThreads === 0) {
                     actions.startNewConversation()
                 }
 

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -1,5 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
+import { subscriptions } from 'kea-subscriptions'
 
 import { IconBook } from '@posthog/icons'
 
@@ -539,6 +540,14 @@ export const maxLogic = kea<maxLogicType>([
         },
     })),
 
+    subscriptions(({ props }) => ({
+        chatTitle: (title: string | null) => {
+            if (title && title !== 'New chat' && title !== 'Chat history') {
+                updateInactiveTab(props.tabId, { title })
+            }
+        },
+    })),
+
     afterMount(({ actions, values }) => {
         // Restore pending prompt from sessionStorage (e.g., after OAuth redirect during consent flow)
         if (!values.question) {
@@ -580,6 +589,11 @@ export const maxLogic = kea<maxLogicType>([
         },
         [urls.ai()]: (_, search) => {
             if (search.ask && !search.chat && !values.question) {
+                // Clear any existing conversation so the tab title updates
+                if (values.conversationId) {
+                    actions.startNewConversation()
+                }
+
                 let uiContext: Partial<MaxUIContext> | undefined = undefined
                 try {
                     const stored = sessionStorage.getItem(PENDING_MAX_CONTEXT_KEY)


### PR DESCRIPTION
## Problem
1. Title only appeared after streaming finished — The conversation title (generated by a fast LLM call running in parallel) was only sent to the frontend when loadConversation fired after streaming completed. Users saw "New chat" for the entire duration of a response.
2. Tab showed "AI" instead of "New chat" — When starting a new conversation, the tab/breadcrumb showed "AI" as the scene name, giving no indication it was a fresh chat.
3. Inactive tab titles never updated — The titleAndIcon subscription in sceneLogic only tracks the active scene. If you asked a question and switched tabs, the AI tab would stay "New chat" forever, even after the title was generated.

## Changes
> Image shows the inactive tab getting it's title updated after i switch tabs (it's so fast locally i have to press new tab almost immediately after enter) 
![2026-03-23 11 38 32](https://github.com/user-attachments/assets/6251a901-8ea3-4063-8d4b-37ef117d3f15)

**TLDR**: New chat scene tab title by default, after submitting title comes in super fast.. ai chat titles update on inactive tabs. 

Backend (4 files, +39 lines)

Stream the title as soon as it's generated, rather than waiting for the client to poll after streaming ends:

- ee/hogai/utils/types/base.py — New ConversationTitleAction model added to AssistantActionUnion
- ee/hogai/core/title_generator/nodes.py — After saving the title to DB, emits ConversationTitleAction via LangGraph's custom stream writer
- ee/hogai/utils/helpers.py — extract_stream_update recognizes ConversationTitleAction to prevent tuple-unpacking errors
- ee/hogai/core/runner.py — _process_update detects ConversationTitleAction, sets the title on the in-memory conversation and a _pending_conversation_update flag. The astream loop checks the flag and re-yields a CONVERSATION SSE event with the updated title.

Frontend (1 file, +25 lines)

- Breadcrumbs — Show "New chat" (not "AI") when no conversation is
active; extracted CHAT_TITLE_NEW / CHAT_TITLE_HISTORY constants
- Inactive tab subscription — New chatTitle subscription calls updateInactiveTab when a real title arrives, so background AI tabs get their titles updated
- Search → AI navigation — Calls startNewConversation() (with a streaming guard) when navigating to /ai?ask=... with an existing conversation open, so the old conversation is cleared

Tests (2 files, +141 lines)

- Backend — Title generator emits action to stream writer; runner sets pending flag and yields CONVERSATION event
- Frontend — chatTitle selector returns correct values for all states; breadcrumbs show "New chat" vs "AI" correctly

## How did you test this code?
Locally

## Publish to changelog?
Yes

## Docs update
No