### PR TITLE
chore(devex): validate package.json script content in product lint

### DIFF
--- a/common/hogli/product/checks.py
+++ b/common/hogli/product/checks.py
@@ -153,7 +153,7 @@ def _parse_pytest_paths(script: str) -> list[str]:
             skip_next = False
             continue
         # flags that consume the next token
-        if part in ("-c", "--rootdir", "-k", "-m", "-p", "--override-ini", "-o", "--co"):
+        if part in ("-c", "--rootdir", "-k", "-m", "-p", "--override-ini", "-o"):
             skip_next = True
             continue
         # skip flags
@@ -206,12 +206,12 @@ class PackageJsonScriptsCheck(ProductCheck):
             # strip trailing || true / || exit 0 before further checks
             base_script = test_script.split("||")[0].strip()
 
-            # check: || true swallows failures
+            # check: || true / || exit 0 swallows failures
             if "||" in test_script:
                 tail = test_script.split("||", 1)[1].strip()
                 if tail in ("true", "exit 0"):
-                    result.lines.append("✗ 'backend:test' uses '|| true'")
-                    result.issues.append("'backend:test' script uses '|| true' which swallows test failures in CI")
+                    result.lines.append(f"✗ 'backend:test' uses '|| {tail}'")
+                    result.issues.append(f"'backend:test' script uses '|| {tail}' which swallows test failures in CI")
 
             # check: no-op script but test files exist
             if _is_noop_script(base_script) and _has_test_files(ctx.backend_dir):

--- a/common/hogli/product/checks.py
+++ b/common/hogli/product/checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -119,6 +120,49 @@ class RequiredRootFilesCheck(ProductCheck):
         return CheckResult(lines=["✓ ok"])
 
 
+def _has_test_files(backend_dir: Path) -> bool:
+    """Check if backend/ contains any pytest-discoverable test files."""
+    return any(backend_dir.rglob("test_*.py")) or any(backend_dir.rglob("*_test.py"))
+
+
+def _is_noop_script(script: str) -> bool:
+    """Check if a script is a no-op (echo, true, exit 0, etc.)."""
+    stripped = script.strip()
+    return stripped.startswith("echo ") or stripped in ("true", "exit 0", ":")
+
+
+def _parse_pytest_paths(script: str) -> list[str]:
+    """Extract test path arguments from a pytest command.
+
+    Given something like:
+        pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short
+    Returns:
+        ["backend/tests"]
+    """
+    try:
+        parts = shlex.split(script)
+    except ValueError:
+        parts = script.split()
+    if not parts or parts[0] != "pytest":
+        return []
+
+    paths: list[str] = []
+    skip_next = False
+    for part in parts[1:]:
+        if skip_next:
+            skip_next = False
+            continue
+        # flags that consume the next token
+        if part in ("-c", "--rootdir", "-k", "-m", "-p", "--override-ini", "-o", "--co"):
+            skip_next = True
+            continue
+        # skip flags
+        if part.startswith("-"):
+            continue
+        paths.append(part)
+    return paths
+
+
 class PackageJsonScriptsCheck(ProductCheck):
     label = "package.json scripts"
 
@@ -135,8 +179,10 @@ class PackageJsonScriptsCheck(ProductCheck):
                 issues=["package.json is not valid JSON"],
             )
 
-        required = ["backend:test"] + (["backend:contract-check"] if ctx.is_isolated else [])
         result = CheckResult()
+
+        # --- presence checks ---
+        required = ["backend:test"] + (["backend:contract-check"] if ctx.is_isolated else [])
         for script in required:
             if script not in scripts:
                 result.lines.append(f"✗ missing '{script}'")
@@ -144,6 +190,49 @@ class PackageJsonScriptsCheck(ProductCheck):
                     f"Product has backend/ but package.json is missing '{script}' script — "
                     "turbo cannot discover this product"
                 )
+
+        # --- absence check: non-isolated must NOT have contract-check ---
+        if not ctx.is_isolated and "backend:contract-check" in scripts:
+            result.lines.append("✗ non-isolated product has 'backend:contract-check'")
+            result.issues.append(
+                "Non-isolated product must not have 'backend:contract-check' script — "
+                "turbo-discover uses this to classify products as isolated, which causes "
+                "the full Django test suite to be skipped when this product changes"
+            )
+
+        # --- content checks on backend:test ---
+        test_script = scripts.get("backend:test", "")
+        if test_script:
+            # strip trailing || true / || exit 0 before further checks
+            base_script = test_script.split("||")[0].strip()
+
+            # check: || true swallows failures
+            if "||" in test_script:
+                tail = test_script.split("||", 1)[1].strip()
+                if tail in ("true", "exit 0"):
+                    result.lines.append("✗ 'backend:test' uses '|| true'")
+                    result.issues.append("'backend:test' script uses '|| true' which swallows test failures in CI")
+
+            # check: no-op script but test files exist
+            if _is_noop_script(base_script) and _has_test_files(ctx.backend_dir):
+                result.lines.append("✗ 'backend:test' is a no-op but test files exist")
+                result.issues.append(
+                    "'backend:test' is a no-op (e.g. echo) but backend/ contains test files "
+                    "that will never run — update the script to use pytest"
+                )
+
+            # check: pytest paths exist on disk
+            if base_script.startswith("pytest"):
+                test_paths = _parse_pytest_paths(base_script)
+                for tp in test_paths:
+                    resolved = ctx.product_dir / tp
+                    if not resolved.exists():
+                        result.lines.append(f"✗ test path '{tp}' does not exist")
+                        result.issues.append(
+                            f"'backend:test' references path '{tp}' which does not exist — "
+                            "pytest will fail or silently collect zero tests"
+                        )
+
         if not result.issues:
             result.lines.append("✓ ok")
         return result

--- a/common/hogli/product/lint.py
+++ b/common/hogli/product/lint.py
@@ -69,7 +69,7 @@ def lint_all_products() -> None:
 
     click.echo(f"Linting {len(product_dirs)} products ({len(strict)} strict, {len(lenient)} lenient)")
     click.echo(
-        "Checks: required root files, package.json scripts, misplaced files (strict), "
+        "Checks: required root files, package.json scripts (presence + content), misplaced files (strict), "
         "file/folder conflicts, tach boundaries (+ interfaces for strict), isolation progress (lenient)\n"
     )
 

--- a/common/hogli/tests/test_checks.py
+++ b/common/hogli/tests/test_checks.py
@@ -1,0 +1,369 @@
+"""Tests for product lint checks — focused on PackageJsonScriptsCheck."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hogli.product.checks import (
+    CheckContext,
+    PackageJsonScriptsCheck,
+    _has_test_files,
+    _is_noop_script,
+    _parse_pytest_paths,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_product(
+    tmp_path: Path,
+    *,
+    scripts: dict[str, str] | None = None,
+    has_backend: bool = True,
+    isolated: bool = False,
+    test_files: list[str] | None = None,
+    extra_dirs: list[str] | None = None,
+) -> CheckContext:
+    """Build a minimal product directory and return a CheckContext for it."""
+    product_dir = tmp_path / "my_product"
+    product_dir.mkdir()
+    backend_dir = product_dir / "backend"
+
+    if has_backend:
+        backend_dir.mkdir()
+
+    if isolated:
+        (backend_dir / "facade").mkdir(parents=True, exist_ok=True)
+        (backend_dir / "facade" / "contracts.py").write_text("")
+
+    if scripts is not None:
+        (product_dir / "package.json").write_text(json.dumps({"scripts": scripts}))
+
+    if test_files:
+        for tf in test_files:
+            p = backend_dir / tf
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("")
+
+    if extra_dirs:
+        for d in extra_dirs:
+            (product_dir / d).mkdir(parents=True, exist_ok=True)
+
+    return CheckContext(
+        name="my_product",
+        product_dir=product_dir,
+        backend_dir=backend_dir,
+        is_isolated=isolated,
+        structure={},
+        detailed=False,
+    )
+
+
+check = PackageJsonScriptsCheck()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseHelpers:
+    @pytest.mark.parametrize(
+        "script, expected",
+        [
+            ("pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short", ["backend/tests"]),
+            ("pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short", ["backend/"]),
+            (
+                "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short",
+                ["backend/", "stats/tests"],
+            ),
+            ("pytest backend/test_max_tools.py", ["backend/test_max_tools.py"]),
+            ("echo 'No backend tests'", []),
+            ("pytest -v", []),
+            ("pytest -c ../../pytest.ini --rootdir ../.. -k 'not slow' backend/tests", ["backend/tests"]),
+        ],
+    )
+    def test_parse_pytest_paths(self, script: str, expected: list[str]) -> None:
+        assert _parse_pytest_paths(script) == expected
+
+    @pytest.mark.parametrize(
+        "script, expected",
+        [
+            ("echo 'No backend tests'", True),
+            ("echo skip", True),
+            ("true", True),
+            ("exit 0", True),
+            (":", True),
+            ("pytest backend/tests", False),
+            ("pytest -v", False),
+        ],
+    )
+    def test_is_noop_script(self, script: str, expected: bool) -> None:
+        assert _is_noop_script(script) == expected
+
+    def test_has_test_files_true(self, tmp_path: Path) -> None:
+        (tmp_path / "test_foo.py").write_text("")
+        assert _has_test_files(tmp_path) is True
+
+    def test_has_test_files_nested(self, tmp_path: Path) -> None:
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "test_bar.py").write_text("")
+        assert _has_test_files(tmp_path) is True
+
+    def test_has_test_files_suffix_convention(self, tmp_path: Path) -> None:
+        (tmp_path / "foo_test.py").write_text("")
+        assert _has_test_files(tmp_path) is True
+
+    def test_has_test_files_false(self, tmp_path: Path) -> None:
+        (tmp_path / "models.py").write_text("")
+        assert _has_test_files(tmp_path) is False
+
+    def test_has_test_files_empty_dir(self, tmp_path: Path) -> None:
+        assert _has_test_files(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# Presence checks
+# ---------------------------------------------------------------------------
+
+
+class TestPresenceChecks:
+    def test_skip_when_no_backend_dir(self, tmp_path: Path) -> None:
+        ctx = _make_product(tmp_path, has_backend=False)
+        result = check.run(ctx)
+        assert result.skip is True
+
+    def test_backend_test_required_when_backend_exists(self, tmp_path: Path) -> None:
+        ctx = _make_product(tmp_path, scripts={})
+        result = check.run(ctx)
+        assert any("missing 'backend:test'" in i for i in result.issues)
+
+    def test_backend_test_present_passes(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"},
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+
+    def test_contract_check_required_for_isolated(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"},
+            isolated=True,
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert any("missing 'backend:contract-check'" in i for i in result.issues)
+
+    def test_contract_check_present_for_isolated_passes(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={
+                "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+                "backend:contract-check": "echo 'Contract files unchanged'",
+            },
+            isolated=True,
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+
+    def test_invalid_json_returns_issue(self, tmp_path: Path) -> None:
+        ctx = _make_product(tmp_path, has_backend=True)
+        (ctx.product_dir / "package.json").write_text("{invalid json")
+        result = check.run(ctx)
+        assert any("not valid JSON" in i for i in result.issues)
+
+
+# ---------------------------------------------------------------------------
+# Absence checks
+# ---------------------------------------------------------------------------
+
+
+class TestAbsenceChecks:
+    def test_contract_check_forbidden_for_non_isolated(self, tmp_path: Path) -> None:
+        """Non-isolated product with contract-check causes turbo-discover misclassification."""
+        ctx = _make_product(
+            tmp_path,
+            scripts={
+                "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+                "backend:contract-check": "echo 'Contract files unchanged'",
+            },
+            isolated=False,
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert any("non-isolated product" in i.lower() for i in result.issues)
+        assert any("turbo-discover" in i for i in result.issues)
+
+    def test_no_contract_check_for_non_isolated_passes(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"},
+            isolated=False,
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+
+
+# ---------------------------------------------------------------------------
+# Content checks: pytest path validation
+# ---------------------------------------------------------------------------
+
+
+class TestPytestPathValidation:
+    def test_valid_path_passes(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short"},
+            test_files=["tests/test_foo.py"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+
+    def test_nonexistent_path_fails(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/typo_tests -v --tb=short"},
+        )
+        result = check.run(ctx)
+        assert any("does not exist" in i for i in result.issues)
+        assert any("typo_tests" in i for i in result.issues)
+
+    def test_multiple_paths_one_missing(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ stats/tests -v --tb=short"},
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        # backend/ exists, stats/tests does not
+        assert any("stats/tests" in i for i in result.issues)
+        assert not any("backend/" in i for i in result.issues)
+
+    def test_file_path_passes(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={
+                "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/test_max_tools.py -v --tb=short"
+            },
+            test_files=["test_max_tools.py"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+
+
+# ---------------------------------------------------------------------------
+# Content checks: no-op detection
+# ---------------------------------------------------------------------------
+
+
+class TestNoopDetection:
+    def test_noop_without_test_files_passes(self, tmp_path: Path) -> None:
+        """echo 'No backend tests' is fine when there are genuinely no test files."""
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "echo 'No backend tests'"},
+        )
+        result = check.run(ctx)
+        assert not result.issues
+
+    def test_noop_with_test_files_fails(self, tmp_path: Path) -> None:
+        """echo 'No backend tests' is wrong when test files actually exist."""
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "echo 'No backend tests'"},
+            test_files=["tests/test_something.py"],
+        )
+        result = check.run(ctx)
+        assert any("no-op" in i for i in result.issues)
+        assert any("test files" in i for i in result.issues)
+
+
+# ---------------------------------------------------------------------------
+# Content checks: || true detection
+# ---------------------------------------------------------------------------
+
+
+class TestPipeTrueDetection:
+    def test_pipe_true_fails(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short || true"},
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert any("|| true" in i for i in result.issues)
+        assert any("swallows" in i for i in result.issues)
+
+    def test_pipe_exit_0_fails(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short || exit 0"},
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert any("|| true" in i for i in result.issues)
+
+    def test_no_pipe_true_passes(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"},
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+
+
+# ---------------------------------------------------------------------------
+# Combined scenario: isolated product, all good
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedScenarios:
+    def test_fully_valid_isolated_product(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={
+                "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/tests -v --tb=short",
+                "backend:contract-check": "echo 'Contract files unchanged'",
+            },
+            isolated=True,
+            test_files=["tests/test_api.py"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+        assert any("✓ ok" in line for line in result.lines)
+
+    def test_fully_valid_legacy_product(self, tmp_path: Path) -> None:
+        ctx = _make_product(
+            tmp_path,
+            scripts={"backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"},
+            isolated=False,
+            extra_dirs=["backend"],
+        )
+        result = check.run(ctx)
+        assert not result.issues
+        assert any("✓ ok" in line for line in result.lines)
+
+    def test_multiple_issues_reported(self, tmp_path: Path) -> None:
+        """A product with several problems reports all of them."""
+        ctx = _make_product(
+            tmp_path,
+            scripts={
+                "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/nonexistent -v --tb=short || true",
+                "backend:contract-check": "echo 'Contract files unchanged'",
+            },
+            isolated=False,
+        )
+        result = check.run(ctx)
+        # Should report: contract-check forbidden, || true, nonexistent path
+        assert len(result.issues) >= 3

--- a/common/hogli/tests/test_checks.py
+++ b/common/hogli/tests/test_checks.py
@@ -311,7 +311,8 @@ class TestPipeTrueDetection:
             extra_dirs=["backend"],
         )
         result = check.run(ctx)
-        assert any("|| true" in i for i in result.issues)
+        assert any("|| exit 0" in i for i in result.issues)
+        assert any("swallows" in i for i in result.issues)
 
     def test_no_pipe_true_passes(self, tmp_path: Path) -> None:
         ctx = _make_product(

--- a/products/notifications/package.json
+++ b/products/notifications/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-notifications",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short --no-header -q || true",
+        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
         "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }

--- a/products/notifications/package.json
+++ b/products/notifications/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@posthog/products-notifications",
     "scripts": {
-        "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short",
+        "backend:test": "echo 'No backend tests'",
         "backend:contract-check": "echo 'Contract files unchanged'"
     }
 }


### PR DESCRIPTION
**Problem**

`hogli product:lint` only checked that `backend:test` and `backend:contract-check` keys existed in `package.json` — it never looked at what they contained. This left a few dangerous failure modes undetected:

- A non-isolated product with `backend:contract-check` gets misclassified by `turbo-discover.js` as isolated, silently skipping the full Django test suite when that product changes
- A typo in the pytest path (e.g. `backend/typo_tests`) collects zero tests with no error
- A no-op script like `echo 'No backend tests'` hides the fact that test files actually exist
- `|| true` swallows pytest failures so CI stays green regardless

**Changes**

Four new content validations in `PackageJsonScriptsCheck`, plus 39 tests covering all presence and absence scenarios.

Also removes `|| true` from notifications `backend:test` (no test files exist there anyway — the suffix was unnecessary).