### PR TITLE
feat(sessions): add distinct_id chunking for experimental backfill

### DIFF
--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -116,7 +116,8 @@ class SessionsBackfillConfig(Config):
 
 class ExperimentalSessionsBackfillConfig(Config):
     clickhouse_settings: dict[str, Any] | None = None
-    team_id_chunks: int | None = 64
+    team_id_chunks: int | None = None
+    distinct_id_chunks: int | None = 64
     max_unmerged_parts: int = 100
     parts_check_poll_frequency_seconds: int = 30
     parts_check_max_wait_seconds: int = 3600
@@ -421,6 +422,31 @@ experimental_sessions_backfill_job = define_asset_job(
 )
 
 
+def _get_experimental_chunking(config: ExperimentalSessionsBackfillConfig) -> tuple[int, str]:
+    """Return (num_chunks, chunk_expression) for the experimental backfill.
+
+    Supports two mutually exclusive chunking strategies:
+    - team_id_chunks: splits by team_id % N (can be uneven for large teams)
+    - distinct_id_chunks: splits by cityHash64(distinct_id) % N (more even distribution)
+
+    Raises ValueError if both are specified.
+    """
+    has_team = config.team_id_chunks is not None
+    has_distinct = config.distinct_id_chunks is not None
+
+    if has_team and has_distinct:
+        raise ValueError("Cannot specify both team_id_chunks and distinct_id_chunks — pick one")
+
+    if has_team:
+        num_chunks = max(1, config.team_id_chunks or 1)
+        return num_chunks, "team_id"
+    elif has_distinct:
+        num_chunks = max(1, config.distinct_id_chunks or 1)
+        return num_chunks, "cityHash64(distinct_id)"
+    else:
+        return 1, "team_id"
+
+
 def _do_experimental_backfill(
     sql_template: Callable,
     timestamp_field: str,
@@ -440,11 +466,11 @@ def _do_experimental_backfill(
         merged_settings.update(config.clickhouse_settings)
         context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    team_id_chunks = max(1, config.team_id_chunks or 1)
+    num_chunks, chunk_expr = _get_experimental_chunking(config)
 
     context.log.info(
         f"Running backfill for Dagster partitions {partition_range_str} "
-        f"(where='{where_clause}') "
+        f"(where='{where_clause}', chunking={num_chunks} chunks on {chunk_expr}) "
         f"using commit {get_git_commit_short() or 'unknown'}"
     )
     if debug_url := metabase_debug_query_url(context.run_id):
@@ -460,14 +486,13 @@ def _do_experimental_backfill(
     with get_http_client(**kwargs, **config.client_overrides) as client:
         tags = dagster_tags(context)
         with tags_context(kind="dagster", dagster=tags):
-            # this loop is largely copied from _do_backfill, but not writing per shard
-            for chunk_i in range(team_id_chunks):
+            for chunk_i in range(num_chunks):
                 wait_for_parts_to_merge(context, config, sync_client=client, table=target_table, use_cluster=False)
 
-                if team_id_chunks > 1:
-                    chunk_where_clause = f"({where_clause}) AND team_id % {team_id_chunks} = {chunk_i}"
+                if num_chunks > 1:
+                    chunk_where_clause = f"({where_clause}) AND {chunk_expr} % {num_chunks} = {chunk_i}"
                     context.log.info(
-                        f"Processing chunk {chunk_i + 1}/{team_id_chunks} (team_id % {team_id_chunks} = {chunk_i})"
+                        f"Processing chunk {chunk_i + 1}/{num_chunks} ({chunk_expr} % {num_chunks} = {chunk_i})"
                     )
                 else:
                     chunk_where_clause = where_clause
@@ -480,7 +505,7 @@ def _do_experimental_backfill(
                 context.log.info(backfill_sql)
                 sync_execute(backfill_sql, settings=merged_settings, sync_client=client)
 
-                if team_id_chunks > 1:
-                    context.log.info(f"Completed chunk {chunk_i + 1}/{team_id_chunks}")
+                if num_chunks > 1:
+                    context.log.info(f"Completed chunk {chunk_i + 1}/{num_chunks}")
 
             context.log.info(f"Successfully backfilled sessions_v3 for Dagster partitions {partition_range_str}")

--- a/posthog/dags/tests/__snapshots__/test_sessions.ambr
+++ b/posthog/dags/tests/__snapshots__/test_sessions.ambr
@@ -1,0 +1,21 @@
+# serializer version: 1
+# name: TestExperimentalBackfillChunking.test_chunking_sql[distinct_id_chunks]
+  list([
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 0",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 1",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 2",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 3",
+  ])
+# ---
+# name: TestExperimentalBackfillChunking.test_chunking_sql[no_chunks]
+  list([
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE '2025-06-15' <= timestamp AND timestamp <= '2025-06-16'",
+  ])
+# ---
+# name: TestExperimentalBackfillChunking.test_chunking_sql[team_id_chunks]
+  list([
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND team_id % 3 = 0",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND team_id % 3 = 1",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND team_id % 3 = 2",
+  ])
+# ---

--- a/posthog/dags/tests/test_sessions.py
+++ b/posthog/dags/tests/test_sessions.py
@@ -1,6 +1,16 @@
+from contextlib import contextmanager
+from datetime import datetime
+
+import pytest
+from unittest.mock import MagicMock, patch
+
 from parameterized import parameterized
 
-from posthog.dags.sessions import tags_for_sessions_partition
+from posthog.dags.sessions import (
+    ExperimentalSessionsBackfillConfig,
+    _do_experimental_backfill,
+    tags_for_sessions_partition,
+)
 
 
 class TestTagsForSessionsPartition:
@@ -28,3 +38,73 @@ class TestTagsForSessionsPartition:
             "sessions_db_partition_0": expected_partition_0,
             "sessions_db_partition_1": expected_partition_1,
         }
+
+
+def _make_context(start: str = "2025-06-15", end: str = "2025-06-16") -> MagicMock:
+    context = MagicMock()
+    context.partition_time_window.start = datetime.strptime(start, "%Y-%m-%d")
+    context.partition_time_window.end = datetime.strptime(end, "%Y-%m-%d")
+    context.partition_key_range.start = start
+    context.partition_key_range.end = end
+    context.run_id = "test-run-id"
+    return context
+
+
+@contextmanager
+def _patch_experimental_backfill_deps():
+    """Patch external dependencies so _do_experimental_backfill can run without ClickHouse."""
+    mock_client = MagicMock()
+
+    with (
+        patch("posthog.dags.sessions.get_kwargs_for_client", return_value={}),
+        patch("posthog.dags.sessions.get_http_client") as mock_get_http_client,
+        patch("posthog.dags.sessions.sync_execute") as mock_sync_execute,
+        patch("posthog.dags.sessions.wait_for_parts_to_merge"),
+        patch("posthog.dags.sessions.get_git_commit_short", return_value="abc123"),
+        patch("posthog.dags.sessions.metabase_debug_query_url", return_value=None),
+    ):
+        mock_get_http_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_get_http_client.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_sync_execute
+
+
+def _sql_template_stub(where: str, target_table: str, include_session_timestamp: bool) -> str:
+    return f"INSERT INTO {target_table} SELECT ... WHERE {where}"
+
+
+class TestExperimentalBackfillChunking:
+    @pytest.mark.parametrize(
+        "config_kwargs",
+        [
+            pytest.param({"distinct_id_chunks": 4}, id="distinct_id_chunks"),
+            pytest.param({"team_id_chunks": 3, "distinct_id_chunks": None}, id="team_id_chunks"),
+            pytest.param({"team_id_chunks": None, "distinct_id_chunks": None}, id="no_chunks"),
+        ],
+    )
+    def test_chunking_sql(self, config_kwargs, snapshot):
+        config = ExperimentalSessionsBackfillConfig(**config_kwargs, client_overrides={})
+        context = _make_context()
+
+        with _patch_experimental_backfill_deps() as mock_sync_execute:
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        executed_sqls = [call.args[0] for call in mock_sync_execute.call_args_list]
+        assert executed_sqls == snapshot
+
+    def test_both_chunking_strategies_raises(self):
+        config = ExperimentalSessionsBackfillConfig(team_id_chunks=32, distinct_id_chunks=64, client_overrides={})
+        context = _make_context()
+
+        with _patch_experimental_backfill_deps():
+            with pytest.raises(ValueError, match="Cannot specify both"):
+                _do_experimental_backfill(
+                    sql_template=_sql_template_stub,
+                    timestamp_field="timestamp",
+                    context=context,
+                    config=config,
+                )


### PR DESCRIPTION
## Problem

The experimental sessions backfill splits each run into chunks using `team_id % N`. This produces uneven work distribution because some teams have far more events than others, meaning certain chunks process disproportionately more rows.

## Changes

- Add `distinct_id_chunks` config option that splits by `cityHash64(distinct_id) % N` instead
- This gives a much more even distribution since `cityHash64(distinct_id)` is already materialized in the events table ORDER BY key (so no extra computation cost), and distinct IDs are far more uniformly distributed than team IDs
- Keep `team_id_chunks` as a fallback option, but default to `distinct_id_chunks=64`
- Raise if both chunking strategies are specified simultaneously
- Refactor backfill tests to use parametrized snapshots for SQL verification

## How did you test this code?

Parametrized snapshot tests verify the generated SQL for all three modes (distinct_id chunking, team_id chunking, no chunking) and the mutual-exclusion error case.

I'm an agent — I haven't tested this manually against a real ClickHouse cluster.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code. The `cityHash64(distinct_id)` approach was chosen because:
1. The hash is already stored in the ORDER BY key, so the modulo is just a cheap integer op on already-decompressed data
2. The filter is pushed down to remote shards when querying the distributed events table from the sessions cluster
3. Unlike `_part` based splitting, it gives uniform distribution regardless of merge state