### PR TITLE
refactor(experiments): Move archiving experiments to API

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -304,6 +304,24 @@ class EnterpriseExperimentsViewSet(
         launched_experiment = service.launch_experiment(experiment)
         return Response(ExperimentSerializer(launched_experiment, context=self.get_serializer_context()).data)
 
+    @extend_schema(
+        request=None,
+        responses=ExperimentSerializer,
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["experiment:write"])
+    def archive(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """
+        Archive an ended experiment.
+
+        Hides the experiment from the default list view. The experiment can be
+        restored at any time by updating archived=false. Returns 400 if the
+        experiment is already archived or has not ended yet.
+        """
+        experiment: Experiment = self.get_object()
+        service = ExperimentService(team=self.team, user=request.user)
+        archived_experiment = service.archive_experiment(experiment)
+        return Response(ExperimentSerializer(archived_experiment, context=self.get_serializer_context()).data)
+
     @action(methods=["POST"], detail=True, required_scopes=["experiment:write"])
     def duplicate(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         source_experiment: Experiment = self.get_object()

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -3605,6 +3605,59 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(launch_response.status_code, status.HTTP_200_OK)
         self.assertEqual(launch_response.json()["status"], "running")
 
+    def test_archive_experiment_endpoint(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Archive Endpoint Test",
+                "feature_flag_key": "archive-endpoint-flag",
+                "start_date": "2024-01-01T10:00",
+                "end_date": "2024-01-15T10:00",
+                "metrics": [
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "source": {"kind": "EventsNode", "event": "$pageview"},
+                    }
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+        self.assertFalse(response.json()["archived"])
+
+        archive_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/archive/",
+        )
+        self.assertEqual(archive_response.status_code, status.HTTP_200_OK)
+        self.assertTrue(archive_response.json()["archived"])
+
+    def test_archive_experiment_endpoint_not_ended(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Archive Running Endpoint",
+                "feature_flag_key": "archive-running-endpoint",
+                "start_date": "2024-01-01T10:00",
+                "metrics": [
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "source": {"kind": "EventsNode", "event": "$pageview"},
+                    }
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        archive_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/archive/",
+        )
+        self.assertEqual(archive_response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
     def _generate_experiment(self, start_date="2024-01-01T10:23", extra_parameters=None):

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -716,38 +716,25 @@ describe('experimentLogic', () => {
     })
 
     describe('launchExperiment', () => {
-        it('calls launch endpoint and updates experiment state on success', async () => {
-            const draftExperiment = {
-                ...experiment,
-                start_date: null,
-                status: 'draft',
-            } as unknown as Experiment
+        it('calls launch endpoint and dispatches setExperiment with response', async () => {
+            const launchedResponse = { ...experiment, start_date: '2026-03-17T10:00:00Z', status: 'running' }
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValue(launchedResponse)
 
-            const launchedExperiment = {
-                ...experiment,
-                start_date: '2026-03-17T10:00:00Z',
-                status: 'running',
-            }
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
 
-            useMocks({
-                post: {
-                    '/api/projects/:team/experiments/:id/launch': launchedExperiment,
-                },
-            })
+            const draftExperiment = { ...experiment, start_date: null, status: 'draft' } as unknown as Experiment
+            keyed.actions.setExperiment(draftExperiment)
 
-            logic.actions.setExperiment(draftExperiment)
-
-            expect(logic.values.experiment.start_date).toBeNull()
-            expect(logic.values.experiment.status).toBe('draft')
-
-            await expectLogic(logic, () => {
-                logic.actions.launchExperiment()
+            await expectLogic(keyed, () => {
+                keyed.actions.launchExperiment()
             })
                 .toDispatchActions(['launchExperiment', 'setExperiment'])
                 .toFinishAllListeners()
 
-            expect(logic.values.experiment.start_date).toBe('2026-03-17T10:00:00Z')
-            expect(logic.values.experiment.status).toBe('running')
+            expect(createSpy).toHaveBeenCalledWith(expect.stringContaining(`/experiments/${experiment.id}/launch`))
+            createSpy.mockRestore()
+            keyed.unmount()
         })
 
         it('shows error toast on validation error', async () => {
@@ -799,6 +786,59 @@ describe('experimentLogic', () => {
             }).toFinishAllListeners()
 
             expect(logic.values.experiment.start_date).toBeUndefined()
+            createSpy.mockRestore()
+        })
+    })
+
+    describe('archiveExperiment', () => {
+        it('calls archive endpoint and dispatches setExperiment with response', async () => {
+            const archivedResponse = { ...experiment, archived: true }
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValue(archivedResponse)
+
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(experiment)
+
+            await expectLogic(keyed, () => {
+                keyed.actions.archiveExperiment()
+            })
+                .toDispatchActions(['archiveExperiment', 'setExperiment'])
+                .toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledWith(expect.stringContaining(`/experiments/${experiment.id}/archive`))
+            createSpy.mockRestore()
+            keyed.unmount()
+        })
+
+        it('shows error toast on validation error', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({
+                detail: 'Experiment is already archived.',
+            })
+            const errorMock = lemonToast.error as jest.Mock
+            errorMock.mockClear()
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.archiveExperiment()
+            }).toFinishAllListeners()
+
+            expect(errorMock).toHaveBeenCalledWith('Experiment is already archived.')
+            createSpy.mockRestore()
+        })
+
+        it('shows generic error toast when detail is missing', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue(new Error('Network error'))
+            const errorMock = lemonToast.error as jest.Mock
+            errorMock.mockClear()
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.archiveExperiment()
+            }).toFinishAllListeners()
+
+            expect(errorMock).toHaveBeenCalledWith('Failed to archive experiment')
             createSpy.mockRestore()
         })
     })

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1449,8 +1449,16 @@ export const experimentLogic = kea<experimentLogicType>([
             values.experiment && eventUsageLogic.actions.reportExperimentResumed(values.experiment)
         },
         archiveExperiment: async () => {
-            actions.updateExperiment({ archived: true })
-            values.experiment && actions.reportExperimentArchived(values.experiment)
+            try {
+                const response: Experiment = await api.create(
+                    `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/archive`
+                )
+                actions.setExperiment(response)
+                refreshTreeItem('experiment', String(values.experimentId))
+                eventUsageLogic.actions.reportExperimentArchived(response)
+            } catch (error: any) {
+                lemonToast.error(error.detail || 'Failed to archive experiment')
+            }
         },
         refreshExperimentResults: async ({ forceRefresh, triggeredBy }) => {
             const refreshId = generateRefreshId()

--- a/frontend/src/scenes/experiments/experimentsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.test.ts
@@ -298,7 +298,7 @@ describe('experimentsLogic', () => {
             const initialExperiments = { results: [mockExperiment], count: 1 }
             logic.actions.loadExperimentsSuccess(initialExperiments)
 
-            api.update.mockResolvedValue({})
+            api.create.mockResolvedValue({})
 
             await expectLogic(logic, () => {
                 logic.actions.archiveExperiment(mockExperiment.id as number)
@@ -311,9 +311,9 @@ describe('experimentsLogic', () => {
                     }),
                 })
 
-            expect(api.update).toHaveBeenCalledWith(expect.stringContaining(`/experiments/${mockExperiment.id}`), {
-                archived: true,
-            })
+            expect(api.create).toHaveBeenCalledWith(
+                expect.stringContaining(`/experiments/${mockExperiment.id}/archive`)
+            )
         })
 
         it('duplicates experiment and navigates to it', async () => {

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -16,7 +16,6 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
-import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import {
     ActivityScope,
     Breadcrumb,
@@ -302,7 +301,6 @@ export const experimentsLogic = kea<experimentsLogicType>([
                 archiveExperiment: async (id: number) => {
                     await api.create(`api/projects/${values.currentProjectId}/experiments/${id}/archive`)
                     lemonToast.info('Experiment archived')
-                    refreshTreeItem('experiment', String(id))
                     return {
                         ...values.experiments,
                         results: values.experiments.results.filter((experiment) => experiment.id !== id),

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -16,6 +16,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import {
     ActivityScope,
     Breadcrumb,
@@ -299,8 +300,9 @@ export const experimentsLogic = kea<experimentsLogicType>([
                     }
                 },
                 archiveExperiment: async (id: number) => {
-                    await api.update(`api/projects/${values.currentProjectId}/experiments/${id}`, { archived: true })
+                    await api.create(`api/projects/${values.currentProjectId}/experiments/${id}/archive`)
                     lemonToast.info('Experiment archived')
+                    refreshTreeItem('experiment', String(id))
                     return {
                         ...values.experiments,
                         results: values.experiments.results.filter((experiment) => experiment.id !== id),

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -576,6 +576,21 @@ class ExperimentService:
         return experiment
 
     # ------------------------------------------------------------------
+    # Archive
+    # ------------------------------------------------------------------
+
+    def archive_experiment(self, experiment: Experiment) -> Experiment:
+        """Archive an ended experiment: validate it has ended, set archived=True."""
+        if experiment.archived:
+            raise ValidationError("Experiment is already archived.")
+        if not experiment.end_date:
+            raise ValidationError("Experiment must be ended before it can be archived.")
+
+        experiment.archived = True
+        experiment.save()
+        return experiment
+
+    # ------------------------------------------------------------------
     # Update
     # ------------------------------------------------------------------
 

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -1360,20 +1360,22 @@ class TestExperimentService(APIBaseTest):
 
         assert "already archived" in str(ctx.exception)
 
-    def test_archive_experiment_not_ended_raises(self):
+    @parameterized.expand(
+        [
+            ("draft", True),
+            ("running", False),
+        ]
+    )
+    def test_archive_experiment_not_ended_raises(self, _name: str, is_draft: bool):
         service = self._service()
+        experiment = self._create_launchable_experiment(
+            name=f"Archive {_name}", feature_flag_key=f"archive-{_name}-flag"
+        )
+        if not is_draft:
+            service.launch_experiment(experiment)
 
-        # Draft experiment (never launched)
-        draft = self._create_launchable_experiment(name="Draft Archive", feature_flag_key="draft-archive-flag")
         with self.assertRaises(ValidationError) as ctx:
-            service.archive_experiment(draft)
-        assert "must be ended" in str(ctx.exception)
-
-        # Running experiment (launched but not ended)
-        running = self._create_launchable_experiment(name="Running Archive", feature_flag_key="running-archive-flag")
-        service.launch_experiment(running)
-        with self.assertRaises(ValidationError) as ctx:
-            service.archive_experiment(running)
+            service.archive_experiment(experiment)
         assert "must be ended" in str(ctx.exception)
 
     # ------------------------------------------------------------------

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -1156,6 +1156,18 @@ class TestExperimentService(APIBaseTest):
         kwargs.setdefault("primary_metrics_ordered_uuids", ["m1"])
         return self._service().create_experiment(name=name, feature_flag_key=feature_flag_key, **kwargs)
 
+    def _create_ended_experiment(
+        self,
+        name: str = "Ended",
+        feature_flag_key: str = "ended-flag",
+        **kwargs: Any,
+    ) -> Experiment:
+        experiment = self._create_launchable_experiment(name=name, feature_flag_key=feature_flag_key, **kwargs)
+        service = self._service()
+        service.launch_experiment(experiment)
+        service.update_experiment(experiment, {"end_date": timezone.now()})
+        return experiment
+
     def test_launch_experiment_success(self):
         experiment = self._create_launchable_experiment(name="Launch Test", feature_flag_key="launch-new-flag")
 
@@ -1325,6 +1337,44 @@ class TestExperimentService(APIBaseTest):
             self._service().launch_experiment(experiment)
 
         assert "at least 2 variants" in str(ctx.exception)
+
+    # ------------------------------------------------------------------
+    # Archive
+    # ------------------------------------------------------------------
+
+    def test_archive_experiment_success(self):
+        experiment = self._create_ended_experiment(name="Archive Test", feature_flag_key="archive-flag")
+
+        archived = self._service().archive_experiment(experiment)
+
+        assert archived.archived is True
+        assert archived.status == Experiment.Status.STOPPED
+
+    def test_archive_experiment_already_archived_raises(self):
+        experiment = self._create_ended_experiment(name="Already Archived", feature_flag_key="already-archived-flag")
+        service = self._service()
+        service.archive_experiment(experiment)
+
+        with self.assertRaises(ValidationError) as ctx:
+            service.archive_experiment(experiment)
+
+        assert "already archived" in str(ctx.exception)
+
+    def test_archive_experiment_not_ended_raises(self):
+        service = self._service()
+
+        # Draft experiment (never launched)
+        draft = self._create_launchable_experiment(name="Draft Archive", feature_flag_key="draft-archive-flag")
+        with self.assertRaises(ValidationError) as ctx:
+            service.archive_experiment(draft)
+        assert "must be ended" in str(ctx.exception)
+
+        # Running experiment (launched but not ended)
+        running = self._create_launchable_experiment(name="Running Archive", feature_flag_key="running-archive-flag")
+        service.launch_experiment(running)
+        with self.assertRaises(ValidationError) as ctx:
+            service.archive_experiment(running)
+        assert "must be ended" in str(ctx.exception)
 
     # ------------------------------------------------------------------
     # Exposure cohort

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -369,6 +369,28 @@ export const experimentsDestroy = async (projectId: string, id: number, options?
     })
 }
 
+/**
+ * Archive an ended experiment.
+
+Hides the experiment from the default list view. The experiment can be
+restored at any time by updating archived=false. Returns 400 if the
+experiment is already archived or has not ended yet.
+ */
+export const getExperimentsArchiveCreateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiments/${id}/archive/`
+}
+
+export const experimentsArchiveCreate = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<ExperimentApi> => {
+    return apiMutator<ExperimentApi>(getExperimentsArchiveCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+    })
+}
+
 export const getExperimentsCreateExposureCohortForExperimentCreateUrl = (projectId: string, id: number) => {
     return `/api/projects/${projectId}/experiments/${id}/create_exposure_cohort_for_experiment/`
 }


### PR DESCRIPTION
## Problem

This is one step in the bigger initiative to reduce logic from the client and add it to the API.

In this PR: Move archiving to API, so that frontend does not call PATCH `{ archived: true }`

Note: Just saw Anders moved tracking logic to backend https://github.com/PostHog/posthog/pull/51889, will do this here too in separate PR

## Changes

- Add `POST /api/projects/{team_id}/experiments/{id}/archive/` endpoint
- Add `archive` to service object with same validation as we had before: experiment must be ended and not already archived
- Migrate both frontend archive paths (detail view in `experimentLogic` and list view in `experimentsLogic`) to call the new endpoint
- Add `@extend_schema` annotation for OpenAPI/MCP generation
- Frontend tests now focus on verifying the correct endpoint is called and error handling works, as business logic has moved to backend (this was also changed on the `launch` endpoint)

**Note:** Draft experiments are not archivable — only ended experiments can be archived. This matches the frontend behavior (`canArchiveExperiment` requires `hasEnded()`). This PR moves that guard to the backend but does not change the behavior.

## How did you test this code?

- Manually tested the happy path
- New automated test to test various cases

## Publish to changelog?

No