### PR TITLE
fix(data-warehouse): Refresh token on 401

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/helpers.py
+++ b/posthog/temporal/data_imports/sources/hubspot/helpers.py
@@ -127,6 +127,11 @@ def fetch_data(
     # Make the API request
     try:
         r = requests.get(url, headers=headers, params=params)
+        if r.status_code == 401:
+            # refresh token
+            api_key = hubspot_refresh_access_token(refresh_token)
+            headers = _get_headers(api_key)
+            r = requests.get(url, headers=headers, params=params)
     except requests.exceptions.HTTPError as e:
         if e.response.status_code == 401:
             # refresh token


### PR DESCRIPTION
## Problem
- A change in `requests` (somewhere) has meant that a 401 status code doesnt raise an exception, and so we werent refreshing the hubspot token correctly

## Changes
Fix this

## How did you test this code?
Tested in a pod

## Publish to changelog?
Nope