### PR TITLE
fix: Rust CI

### DIFF
--- a/.github/scripts/check-ci-timeouts.py
+++ b/.github/scripts/check-ci-timeouts.py
@@ -42,6 +42,11 @@ def check_timeouts() -> list[str]:
         for job_name, job_config in jobs.items():
             if not isinstance(job_config, dict):
                 continue
+            # Reusable workflow calls (jobs with `uses:`) don't support
+            # timeout-minutes at the job level — timeouts are set inside
+            # the called workflow.
+            if "uses" in job_config:
+                continue
             if "timeout-minutes" not in job_config:
                 errors.append(f"{workflow_file.name}: job '{job_name}' is missing timeout-minutes")
 

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -19,7 +19,6 @@ on:
 
 jobs:
     build-images:
-        timeout-minutes: 20
         uses: ./.github/workflows/_rust-build-images.yml
         with:
             tag-rules: |


### PR DESCRIPTION
## Problem

Commit da67b547 introduced a `timeout-minutes` property at the job level for the `build-images` reusable workflow call, which is not a supported keyword for reusable workflow jobs. This causes GitHub Actions to misinterpret the job as a regular job, breaking the workflow file validation.

## Changes

- Remove invalid job-level `timeout-minutes` from the `build-images` reusable workflow call in `rust-docker-build.yml`
- The timeout is already handled via the `with.timeout-minutes` input passed to the reusable workflow

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
