### PR TITLE
chore: always add select_account prompt to google oauth

### DIFF
--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -283,12 +283,12 @@ class MultitenantSAMLAuth(SAMLAuth):
 class CustomGoogleOAuth2(GoogleOAuth2):
     def auth_extra_arguments(self):
         extra_args = super().auth_extra_arguments()
-        prompt_tokens = [token for token in str(extra_args.get("prompt", "")).split() if token]
-
-        if "select_account" not in prompt_tokens:
-            prompt_tokens.append("select_account")
-
-        extra_args["prompt"] = " ".join(prompt_tokens)
+        is_reauth = self.strategy.request.GET.get("reauth") == "true"
+        if not is_reauth:
+            prompt_tokens = [token for token in str(extra_args.get("prompt", "")).split() if token]
+            if "select_account" not in prompt_tokens:
+                prompt_tokens.append("select_account")
+            extra_args["prompt"] = " ".join(prompt_tokens)
 
         email = self.strategy.request.GET.get("email")
 

--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -283,6 +283,13 @@ class MultitenantSAMLAuth(SAMLAuth):
 class CustomGoogleOAuth2(GoogleOAuth2):
     def auth_extra_arguments(self):
         extra_args = super().auth_extra_arguments()
+        prompt_tokens = [token for token in str(extra_args.get("prompt", "")).split() if token]
+
+        if "select_account" not in prompt_tokens:
+            prompt_tokens.append("select_account")
+
+        extra_args["prompt"] = " ".join(prompt_tokens)
+
         email = self.strategy.request.GET.get("email")
 
         if email:

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -916,6 +916,21 @@ class TestCustomGoogleOAuth2(APILicensedTest):
         self.assertEqual(extra_args["login_hint"], "test@posthog.com")
         self.assertEqual(extra_args["prompt"], "select_account")
 
+    def test_auth_extra_arguments_reauth_does_not_force_select_account(self):
+        """Test that reauth flow does not force account picker prompt."""
+        mock_request = type("MockRequest", (), {})()
+        mock_request.GET = {"reauth": "true"}
+
+        mock_strategy = type("MockStrategy", (), {})()
+        mock_strategy.request = mock_request
+        mock_strategy.setting = lambda name, default=None, backend=None: default
+
+        self.google_oauth.strategy = mock_strategy
+
+        extra_args = self.google_oauth.auth_extra_arguments()
+
+        self.assertNotIn("prompt", extra_args)
+
     def test_auth_extra_arguments_preserves_existing_prompt(self):
         """Test that auth_extra_arguments appends select_account to existing prompt values."""
         mock_request = type("MockRequest", (), {})()

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -895,6 +895,7 @@ class TestCustomGoogleOAuth2(APILicensedTest):
 
         extra_args = self.google_oauth.auth_extra_arguments()
 
+        self.assertEqual(extra_args["prompt"], "select_account")
         # Should only contain base arguments from parent class, no login_hint
         self.assertNotIn("login_hint", extra_args)
 
@@ -913,6 +914,23 @@ class TestCustomGoogleOAuth2(APILicensedTest):
         extra_args = self.google_oauth.auth_extra_arguments()
 
         self.assertEqual(extra_args["login_hint"], "test@posthog.com")
+        self.assertEqual(extra_args["prompt"], "select_account")
+
+    def test_auth_extra_arguments_preserves_existing_prompt(self):
+        """Test that auth_extra_arguments appends select_account to existing prompt values."""
+        mock_request = type("MockRequest", (), {})()
+        mock_request.GET = {}
+
+        mock_strategy = type("MockStrategy", (), {})()
+        mock_strategy.request = mock_request
+        mock_strategy.setting = lambda name, default=None, backend=None: default
+
+        self.google_oauth.strategy = mock_strategy
+
+        with patch("ee.api.authentication.GoogleOAuth2.auth_extra_arguments", return_value={"prompt": "consent"}):
+            extra_args = self.google_oauth.auth_extra_arguments()
+
+        self.assertEqual(extra_args["prompt"], "consent select_account")
 
     def test_get_user_id_existing_user_with_sub(self):
         """Test that a user with sub as uid continues using that sub."""


### PR DESCRIPTION
## Problem

If you accidentally select the wrong acocunt when logging in via google oauth, then log out and log back in again you are not given the option to select a different account. To fix this we should always prompt the user to select the account they want to login with.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Always add the `select_account` option to the `prompt` parameter during google oauth.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

New tests + manual testing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
