### PR TITLE
fix(alerts): add window param to all PyOD detectors to fix false positive anomaly alerts

### DIFF
--- a/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
@@ -122,12 +122,13 @@ function getDefaultSingleConfigs(window: number): Record<string, SingleDetectorC
         mad: { type: 'mad', threshold: 0.9, window },
         iqr: { type: 'iqr', multiplier: 1.5, window },
         threshold: { type: 'threshold' },
-        ecod: { type: 'ecod', threshold: 0.9 },
-        copod: { type: 'copod', threshold: 0.9 },
+        ecod: { type: 'ecod', threshold: 0.9, window },
+        copod: { type: 'copod', threshold: 0.9, window },
         isolation_forest: {
             type: 'isolation_forest',
             threshold: 0.9,
             n_estimators: 100,
+            window,
             preprocessing: { diffs_n: 1, lags_n: 3 },
         },
         knn: {
@@ -135,12 +136,13 @@ function getDefaultSingleConfigs(window: number): Record<string, SingleDetectorC
             threshold: 0.9,
             n_neighbors: 5,
             method: 'largest',
+            window,
             preprocessing: { diffs_n: 1, lags_n: 3 },
         },
-        lof: { type: 'lof', threshold: 0.9, n_neighbors: 20, preprocessing: { diffs_n: 1, lags_n: 3 } },
-        hbos: { type: 'hbos', threshold: 0.9, n_bins: 10 },
-        ocsvm: { type: 'ocsvm', threshold: 0.9, preprocessing: { diffs_n: 1, lags_n: 3 } },
-        pca: { type: 'pca', threshold: 0.9, preprocessing: { diffs_n: 1, lags_n: 3 } },
+        lof: { type: 'lof', threshold: 0.9, n_neighbors: 20, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
+        hbos: { type: 'hbos', threshold: 0.9, n_bins: 10, window },
+        ocsvm: { type: 'ocsvm', threshold: 0.9, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
+        pca: { type: 'pca', threshold: 0.9, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
     }
 }
 
@@ -370,48 +372,56 @@ function SingleDetectorConfigSection({
                 <ECODConfig
                     config={config as ECODDetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             {config.type === 'copod' && (
                 <COPODConfig
                     config={config as COPODDetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             {config.type === 'isolation_forest' && (
                 <IsolationForestConfig
                     config={config as IsolationForestDetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             {config.type === 'knn' && (
                 <KNNConfig
                     config={config as KNNDetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             {config.type === 'lof' && (
                 <LOFConfig
                     config={config as LOFDetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             {config.type === 'hbos' && (
                 <HBOSConfig
                     config={config as HBOSDetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             {config.type === 'ocsvm' && (
                 <OCSVMConfig
                     config={config as OCSVMDetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             {config.type === 'pca' && (
                 <PCAConfig
                     config={config as PCADetectorConfig}
                     onChange={(updated) => onChange(updated as SingleDetectorConfig)}
+                    calculationInterval={calculationInterval}
                 />
             )}
             <PreprocessingSection config={config} onChange={(updated) => onChange(updated as SingleDetectorConfig)} />
@@ -478,9 +488,11 @@ function IQRConfig({
 function ECODConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: ECODDetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -489,6 +501,7 @@ function ECODConfig({
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">Empirical cumulative distribution — parameter-free and interpretable.</p>
         </div>
     )
@@ -497,9 +510,11 @@ function ECODConfig({
 function COPODConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: COPODDetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -508,6 +523,7 @@ function COPODConfig({
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">Copula-based detection — efficient and parameter-free.</p>
         </div>
     )
@@ -516,9 +532,11 @@ function COPODConfig({
 function IsolationForestConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: IsolationForestDetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -539,6 +557,7 @@ function IsolationForestConfig({
                     fullWidth
                 />
             </div>
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">Isolates anomalies using random forest — good for complex patterns.</p>
         </div>
     )
@@ -547,9 +566,11 @@ function IsolationForestConfig({
 function KNNConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: KNNDetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -589,6 +610,7 @@ function KNNConfig({
                     fullWidth
                 />
             </div>
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">
                 Uses distance to nearest neighbors — points far from others are anomalies.
             </p>
@@ -599,9 +621,11 @@ function KNNConfig({
 function LOFConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: LOFDetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -625,6 +649,7 @@ function LOFConfig({
                     fullWidth
                 />
             </div>
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">
                 Density-based — compares local density of a point to its neighbors. Good for seasonal data.
             </p>
@@ -635,9 +660,11 @@ function LOFConfig({
 function HBOSConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: HBOSDetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -661,6 +688,7 @@ function HBOSConfig({
                     fullWidth
                 />
             </div>
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">Very fast histogram-based detection. Good for high-volume alerting.</p>
         </div>
     )
@@ -669,9 +697,11 @@ function HBOSConfig({
 function OCSVMConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: OCSVMDetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -680,6 +710,7 @@ function OCSVMConfig({
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">
                 One-class SVM — learns a boundary around normal data using a support vector machine.
             </p>
@@ -690,9 +721,11 @@ function OCSVMConfig({
 function PCAConfig({
     config,
     onChange,
+    calculationInterval,
 }: {
     config: PCADetectorConfig
     onChange: (config: DetectorConfig) => void
+    calculationInterval?: AlertCalculationInterval
 }): JSX.Element {
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
@@ -701,6 +734,7 @@ function PCAConfig({
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
+            <WindowSizeInput config={config} onChange={onChange} calculationInterval={calculationInterval} />
             <p className="text-xs text-muted">
                 PCA-based — detects anomalies as points with high reconstruction error.
             </p>

--- a/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
@@ -24,6 +24,9 @@ import {
     ZScoreDetectorConfig,
 } from '~/queries/schema/schema-general'
 
+/** Default anomaly probability threshold for all detectors. Higher = fewer alerts. */
+const DEFAULT_THRESHOLD = 0.95
+
 /** Default window size based on how often the alert checks.
  *  Hourly: 168 (7 days), Daily: 90, Weekly: 26 (6 months), Monthly: 12 (1 year). */
 export function getDefaultWindow(interval?: AlertCalculationInterval): number {
@@ -118,31 +121,37 @@ const SINGLE_DETECTOR_OPTIONS = DETECTOR_OPTIONS.filter((o) => o.value !== 'ense
 
 function getDefaultSingleConfigs(window: number): Record<string, SingleDetectorConfig> {
     return {
-        zscore: { type: 'zscore', threshold: 0.9, window },
-        mad: { type: 'mad', threshold: 0.9, window },
+        zscore: { type: 'zscore', threshold: DEFAULT_THRESHOLD, window },
+        mad: { type: 'mad', threshold: DEFAULT_THRESHOLD, window },
         iqr: { type: 'iqr', multiplier: 1.5, window },
         threshold: { type: 'threshold' },
-        ecod: { type: 'ecod', threshold: 0.9, window },
-        copod: { type: 'copod', threshold: 0.9, window },
+        ecod: { type: 'ecod', threshold: DEFAULT_THRESHOLD, window },
+        copod: { type: 'copod', threshold: DEFAULT_THRESHOLD, window },
         isolation_forest: {
             type: 'isolation_forest',
-            threshold: 0.9,
+            threshold: DEFAULT_THRESHOLD,
             n_estimators: 100,
             window,
             preprocessing: { diffs_n: 1, lags_n: 3 },
         },
         knn: {
             type: 'knn',
-            threshold: 0.9,
+            threshold: DEFAULT_THRESHOLD,
             n_neighbors: 5,
             method: 'largest',
             window,
             preprocessing: { diffs_n: 1, lags_n: 3 },
         },
-        lof: { type: 'lof', threshold: 0.9, n_neighbors: 20, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
-        hbos: { type: 'hbos', threshold: 0.9, n_bins: 10, window },
-        ocsvm: { type: 'ocsvm', threshold: 0.9, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
-        pca: { type: 'pca', threshold: 0.9, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
+        lof: {
+            type: 'lof',
+            threshold: DEFAULT_THRESHOLD,
+            n_neighbors: 20,
+            window,
+            preprocessing: { diffs_n: 1, lags_n: 3 },
+        },
+        hbos: { type: 'hbos', threshold: DEFAULT_THRESHOLD, n_bins: 10, window },
+        ocsvm: { type: 'ocsvm', threshold: DEFAULT_THRESHOLD, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
+        pca: { type: 'pca', threshold: DEFAULT_THRESHOLD, window, preprocessing: { diffs_n: 1, lags_n: 3 } },
     }
 }
 
@@ -151,8 +160,8 @@ function getDefaultEnsemble(window: number): EnsembleDetectorConfig {
         type: 'ensemble',
         operator: EnsembleOperator.AND,
         detectors: [
-            { type: 'zscore', threshold: 0.9, window },
-            { type: 'mad', threshold: 0.9, window },
+            { type: 'zscore', threshold: DEFAULT_THRESHOLD, window },
+            { type: 'mad', threshold: DEFAULT_THRESHOLD, window },
         ],
     }
 }
@@ -347,7 +356,7 @@ function SingleDetectorConfigSection({
             {(config.type === 'zscore' || config.type === 'mad') && (
                 <div className="grid grid-cols-2 gap-3">
                     <SensitivityInput
-                        value={(config as ZScoreDetectorConfig | MADDetectorConfig).threshold ?? 0.9}
+                        value={(config as ZScoreDetectorConfig | MADDetectorConfig).threshold ?? DEFAULT_THRESHOLD}
                         onChange={(val) => onChange({ ...config, threshold: val } as SingleDetectorConfig)}
                         tooltip={
                             config.type === 'zscore'
@@ -447,7 +456,7 @@ function SensitivityInput({
                 max={0.99}
                 step={0.05}
                 value={value}
-                onChange={(val) => onChange(val ? parseFloat(String(val)) : 0.9)}
+                onChange={(val) => onChange(val ? parseFloat(String(val)) : DEFAULT_THRESHOLD)}
             />
         </div>
     )
@@ -497,7 +506,7 @@ function ECODConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
@@ -519,7 +528,7 @@ function COPODConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
@@ -541,7 +550,7 @@ function IsolationForestConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
@@ -575,7 +584,7 @@ function KNNConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
@@ -630,7 +639,7 @@ function LOFConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
@@ -669,7 +678,7 @@ function HBOSConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
@@ -706,7 +715,7 @@ function OCSVMConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />
@@ -730,7 +739,7 @@ function PCAConfig({
     return (
         <div className="space-y-3 pl-4 border-l-2 border-border">
             <SensitivityInput
-                value={config.threshold ?? 0.9}
+                value={config.threshold ?? DEFAULT_THRESHOLD}
                 onChange={(val) => onChange({ ...config, threshold: val })}
                 tooltip="Anomaly probability threshold (0-1). Higher = fewer alerts."
             />

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2833,6 +2833,10 @@
                 "type": {
                     "const": "copod",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],
@@ -12095,6 +12099,10 @@
                 "type": {
                     "const": "ecod",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],
@@ -17671,6 +17679,10 @@
                 "type": {
                     "const": "hbos",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],
@@ -19305,6 +19317,10 @@
                 "type": {
                     "const": "isolation_forest",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],
@@ -19333,6 +19349,10 @@
                 "type": {
                     "const": "knn",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],
@@ -19465,6 +19485,10 @@
                 "type": {
                     "const": "lof",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],
@@ -23488,6 +23512,10 @@
                 "type": {
                     "const": "ocsvm",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],
@@ -23507,6 +23535,10 @@
                 "type": {
                     "const": "pca",
                     "type": "string"
+                },
+                "window": {
+                    "$ref": "#/definitions/integer",
+                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                 }
             },
             "required": ["type"],

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4013,6 +4013,8 @@ export interface ECODDetectorConfig {
     type: 'ecod'
     /** Anomaly probability threshold (default: 0.9) */
     threshold?: number
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }
@@ -4021,6 +4023,8 @@ export interface COPODDetectorConfig {
     type: 'copod'
     /** Anomaly probability threshold (default: 0.9) */
     threshold?: number
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }
@@ -4031,6 +4035,8 @@ export interface IsolationForestDetectorConfig {
     threshold?: number
     /** Number of trees in the forest (default: 100) */
     n_estimators?: integer
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }
@@ -4043,6 +4049,8 @@ export interface KNNDetectorConfig {
     n_neighbors?: integer
     /** Distance method: 'largest', 'mean', 'median' (default: 'largest') */
     method?: 'largest' | 'mean' | 'median'
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }
@@ -4053,6 +4061,8 @@ export interface HBOSDetectorConfig {
     threshold?: number
     /** Number of histogram bins (default: 10) */
     n_bins?: integer
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }
@@ -4063,6 +4073,8 @@ export interface LOFDetectorConfig {
     threshold?: number
     /** Number of neighbors for LOF (default: 20) */
     n_neighbors?: integer
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }
@@ -4075,6 +4087,8 @@ export interface OCSVMDetectorConfig {
     kernel?: string
     /** Upper bound on training errors fraction (default: 0.1) */
     nu?: number
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }
@@ -4083,6 +4097,8 @@ export interface PCADetectorConfig {
     type: 'pca'
     /** Anomaly probability threshold (default: 0.9) */
     threshold?: number
+    /** Rolling window size — how many historical data points to train on (default: based on calculation interval) */
+    window?: integer
     /** Preprocessing transforms applied before detection */
     preprocessing?: PreprocessingConfig
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8199,6 +8199,12 @@ class COPODDetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["copod"] = "copod"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class CacheMissResponse(BaseModel):
@@ -11234,6 +11240,12 @@ class ECODDetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["ecod"] = "ecod"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class EndpointRunRequest(BaseModel):
@@ -12281,6 +12293,12 @@ class HBOSDetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["hbos"] = "hbos"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class HeatMapQuerySource(RootModel[EventsNode]):
@@ -12407,6 +12425,12 @@ class IsolationForestDetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["isolation_forest"] = "isolation_forest"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class KNNDetectorConfig(BaseModel):
@@ -12423,6 +12447,12 @@ class KNNDetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["knn"] = "knn"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class LOFDetectorConfig(BaseModel):
@@ -12435,6 +12465,12 @@ class LOFDetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["lof"] = "lof"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class LifecycleDataWarehouseNode(BaseModel):
@@ -12818,6 +12854,12 @@ class OCSVMDetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["ocsvm"] = "ocsvm"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class PCADetectorConfig(BaseModel):
@@ -12829,6 +12871,12 @@ class PCADetectorConfig(BaseModel):
     )
     threshold: float | None = Field(default=None, description="Anomaly probability threshold (default: 0.9)")
     type: Literal["pca"] = "pca"
+    window: int | None = Field(
+        default=None,
+        description=(
+            "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
+        ),
+    )
 
 
 class PathsQueryResponse(BaseModel):

--- a/posthog/tasks/alerts/detectors/base.py
+++ b/posthog/tasks/alerts/detectors/base.py
@@ -21,6 +21,9 @@ class DetectionResult:
 class BaseDetector(ABC):
     """Abstract base class for all anomaly detectors."""
 
+    # Default anomaly probability threshold. Higher = fewer alerts.
+    DEFAULT_THRESHOLD = 0.95
+
     # Default number of recent points to exclude from training data.
     # Prevents the model from fitting on the points it's about to score.
     # Higher values make the model slower to adapt to recent distribution shifts.

--- a/posthog/tasks/alerts/detectors/pyod_detectors/base_pyod.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/base_pyod.py
@@ -33,7 +33,7 @@ class BasePyODDetector(BaseDetector):
             return DetectionResult(is_anomaly=False)
 
         data = self.preprocess(data)
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
 
         if data.ndim == 1:
             data = data.reshape(-1, 1)
@@ -68,7 +68,7 @@ class BasePyODDetector(BaseDetector):
             return DetectionResult(is_anomaly=False)
 
         data = self.preprocess(data)
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
 
         if data.ndim == 1:
             data = data.reshape(-1, 1)

--- a/posthog/tasks/alerts/detectors/pyod_detectors/copod.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/copod.py
@@ -17,4 +17,4 @@ class COPODDetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.COPOD.value, "threshold": 0.9}
+        return {"type": DetectorType.COPOD.value, "threshold": cls.DEFAULT_THRESHOLD}

--- a/posthog/tasks/alerts/detectors/pyod_detectors/ecod.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/ecod.py
@@ -17,4 +17,4 @@ class ECODDetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.ECOD.value, "threshold": 0.9}
+        return {"type": DetectorType.ECOD.value, "threshold": cls.DEFAULT_THRESHOLD}

--- a/posthog/tasks/alerts/detectors/pyod_detectors/hbos.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/hbos.py
@@ -17,4 +17,4 @@ class HBOSDetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.HBOS.value, "threshold": 0.9, "n_bins": 10}
+        return {"type": DetectorType.HBOS.value, "threshold": cls.DEFAULT_THRESHOLD, "n_bins": 10}

--- a/posthog/tasks/alerts/detectors/pyod_detectors/isolation_forest.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/isolation_forest.py
@@ -20,4 +20,4 @@ class IsolationForestDetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.ISOLATION_FOREST.value, "threshold": 0.9, "n_estimators": 100}
+        return {"type": DetectorType.ISOLATION_FOREST.value, "threshold": cls.DEFAULT_THRESHOLD, "n_estimators": 100}

--- a/posthog/tasks/alerts/detectors/pyod_detectors/knn.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/knn.py
@@ -19,4 +19,9 @@ class KNNDetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.KNN.value, "threshold": 0.9, "n_neighbors": 5, "method": "largest"}
+        return {
+            "type": DetectorType.KNN.value,
+            "threshold": cls.DEFAULT_THRESHOLD,
+            "n_neighbors": 5,
+            "method": "largest",
+        }

--- a/posthog/tasks/alerts/detectors/pyod_detectors/lof.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/lof.py
@@ -20,4 +20,4 @@ class LOFDetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.LOF.value, "threshold": 0.9, "n_neighbors": 20}
+        return {"type": DetectorType.LOF.value, "threshold": cls.DEFAULT_THRESHOLD, "n_neighbors": 20}

--- a/posthog/tasks/alerts/detectors/pyod_detectors/ocsvm.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/ocsvm.py
@@ -20,4 +20,4 @@ class OCSVMDetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.OCSVM.value, "threshold": 0.9, "kernel": "rbf", "nu": 0.1}
+        return {"type": DetectorType.OCSVM.value, "threshold": cls.DEFAULT_THRESHOLD, "kernel": "rbf", "nu": 0.1}

--- a/posthog/tasks/alerts/detectors/pyod_detectors/pca.py
+++ b/posthog/tasks/alerts/detectors/pyod_detectors/pca.py
@@ -17,4 +17,4 @@ class PCADetector(BasePyODDetector):
 
     @classmethod
     def get_default_config(cls) -> dict[str, Any]:
-        return {"type": DetectorType.PCA.value, "threshold": 0.9}
+        return {"type": DetectorType.PCA.value, "threshold": cls.DEFAULT_THRESHOLD}

--- a/posthog/tasks/alerts/detectors/statistical/iqr.py
+++ b/posthog/tasks/alerts/detectors/statistical/iqr.py
@@ -31,13 +31,13 @@ class IQRDetector(BaseDetector):
     function (same approach as pyod's predict_proba).
 
     Config:
-        threshold: float - Anomaly probability threshold (default: 0.9)
+        threshold: float - Anomaly probability threshold (default: 0.95)
         multiplier: float - IQR multiplier for fences (default: 1.5)
         window: int - Rolling window size (default: 30)
     """
 
     def detect(self, data: np.ndarray) -> DetectionResult:
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
         multiplier = self.config.get("multiplier", 1.5)
         window = self.config.get("window", 30)
 
@@ -87,7 +87,7 @@ class IQRDetector(BaseDetector):
         )
 
     def detect_batch(self, data: np.ndarray) -> DetectionResult:
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
         multiplier = self.config.get("multiplier", 1.5)
         window = self.config.get("window", 30)
 
@@ -136,7 +136,7 @@ class IQRDetector(BaseDetector):
     def get_default_config(cls) -> dict[str, Any]:
         return {
             "type": DetectorType.IQR.value,
-            "threshold": 0.9,
+            "threshold": cls.DEFAULT_THRESHOLD,
             "multiplier": 1.5,
             "window": 30,
         }

--- a/posthog/tasks/alerts/detectors/statistical/mad.py
+++ b/posthog/tasks/alerts/detectors/statistical/mad.py
@@ -22,12 +22,12 @@ class MADDetector(BaseDetector):
     predict_proba (erf-based conversion).
 
     Config:
-        threshold: float - Anomaly probability threshold (default: 0.9)
+        threshold: float - Anomaly probability threshold (default: 0.95)
         window: int - Rolling window size (default: 30)
     """
 
     def detect(self, data: np.ndarray) -> DetectionResult:
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
         window = self.config.get("window", 30)
 
         if not self._validate_data(data, min_length=window + 1):
@@ -62,7 +62,7 @@ class MADDetector(BaseDetector):
         )
 
     def detect_batch(self, data: np.ndarray) -> DetectionResult:
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
         window = self.config.get("window", 30)
 
         if not self._validate_data(data, min_length=window + 1):
@@ -100,6 +100,6 @@ class MADDetector(BaseDetector):
     def get_default_config(cls) -> dict:
         return {
             "type": DetectorType.MAD.value,
-            "threshold": 0.9,
+            "threshold": cls.DEFAULT_THRESHOLD,
             "window": 30,
         }

--- a/posthog/tasks/alerts/detectors/statistical/zscore.py
+++ b/posthog/tasks/alerts/detectors/statistical/zscore.py
@@ -28,13 +28,13 @@ class ZScoreDetector(BaseDetector):
     function (same approach as pyod's predict_proba).
 
     Config:
-        threshold: float - Anomaly probability threshold (default: 0.9)
+        threshold: float - Anomaly probability threshold (default: 0.95)
         window: int - Rolling window size (default: 30)
     """
 
     def detect(self, data: np.ndarray) -> DetectionResult:
         """Check if the most recent point is an anomaly based on z-score."""
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
         window = self.config.get("window", 30)
 
         if not self._validate_data(data, min_length=window + 1):
@@ -78,7 +78,7 @@ class ZScoreDetector(BaseDetector):
 
     def detect_batch(self, data: np.ndarray) -> DetectionResult:
         """Check all points for z-score anomalies."""
-        threshold = self.config.get("threshold", 0.9)
+        threshold = self.config.get("threshold", self.DEFAULT_THRESHOLD)
         window = self.config.get("window", 30)
 
         if not self._validate_data(data, min_length=window + 1):
@@ -124,6 +124,6 @@ class ZScoreDetector(BaseDetector):
     def get_default_config(cls) -> dict:
         return {
             "type": DetectorType.ZSCORE.value,
-            "threshold": 0.9,
+            "threshold": cls.DEFAULT_THRESHOLD,
             "window": 30,
         }

--- a/posthog/tasks/alerts/detectors/test/test_detectors.py
+++ b/posthog/tasks/alerts/detectors/test/test_detectors.py
@@ -20,6 +20,7 @@ from posthog.tasks.alerts.detectors.statistical.iqr import IQRDetector
 from posthog.tasks.alerts.detectors.statistical.mad import MADDetector
 from posthog.tasks.alerts.detectors.statistical.zscore import ZScoreDetector
 from posthog.tasks.alerts.detectors.threshold import ThresholdDetector
+from posthog.tasks.alerts.trends import _compute_min_samples_for_detector
 
 # Shared test data
 ANOMALY_DATA = np.array([10, 11, 10, 9, 10, 11, 10, 9, 10, 11, 10, 100])
@@ -514,3 +515,35 @@ class TestEnsembleDetector:
                     ],
                 }
             )
+
+
+class TestComputeMinSamplesForDetector:
+    @parameterized.expand(
+        [
+            ("zscore_default", {"type": "zscore", "window": 30}, 31),
+            ("zscore_custom_window", {"type": "zscore", "window": 168}, 169),
+            (
+                "iforest_with_preprocessing",
+                {"type": "isolation_forest", "window": 168, "preprocessing": {"diffs_n": 1, "lags_n": 3}},
+                173,
+            ),
+            ("iforest_no_window", {"type": "isolation_forest", "preprocessing": {"diffs_n": 1, "lags_n": 3}}, 35),
+            ("threshold", {"type": "threshold"}, 1),
+            ("ecod_no_window", {"type": "ecod"}, 31),
+            ("lof_no_window", {"type": "lof"}, 31),
+            (
+                "ensemble_picks_max",
+                {
+                    "type": "ensemble",
+                    "detectors": [
+                        {"type": "zscore", "window": 30},
+                        {"type": "isolation_forest", "window": 168, "preprocessing": {"diffs_n": 1, "lags_n": 3}},
+                    ],
+                },
+                173,
+            ),
+            ("ensemble_empty", {"type": "ensemble", "detectors": []}, 31),
+        ]
+    )
+    def test_compute_min_samples(self, _name: str, config: dict[str, Any], expected: int) -> None:
+        assert _compute_min_samples_for_detector(config) == expected

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -485,8 +485,8 @@ DETECTOR_MIN_SAMPLES: dict[DetectorType, int] = {
     DetectorType.PCA: 10,
 }
 
-# Default window size per calculation interval, matching frontend defaults.
-# These are used when no explicit window is set in the detector config.
+# Fallback window size used when no explicit window is set in the detector config
+# (e.g. alerts saved before this field was introduced).
 DETECTOR_DEFAULT_WINDOW = 30
 
 

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -485,6 +485,48 @@ DETECTOR_MIN_SAMPLES: dict[DetectorType, int] = {
     DetectorType.PCA: 10,
 }
 
+# Default window size per calculation interval, matching frontend defaults.
+# These are used when no explicit window is set in the detector config.
+DETECTOR_DEFAULT_WINDOW = 30
+
+
+def _compute_min_samples_for_detector(detector_config: dict[str, Any]) -> int:
+    """Compute the number of historical data points needed for a detector.
+
+    Uses the configured ``window`` (falling back to a default) plus headroom
+    for preprocessing (lags, diffs).  The result is floored by the
+    per-detector ``DETECTOR_MIN_SAMPLES`` guard so we never train on fewer
+    points than the algorithm requires.
+    """
+    detector_type_str = detector_config.get("type", "zscore")
+
+    if detector_type_str == "ensemble":
+        sub_detectors = detector_config.get("detectors", [])
+        return max(
+            (_compute_min_samples_for_detector(d) for d in sub_detectors),
+            default=31,
+        )
+
+    detector_type = DetectorType(detector_type_str)
+    guard = DETECTOR_MIN_SAMPLES.get(detector_type, 10)
+
+    # Threshold detector doesn't need a training window
+    if detector_type == DetectorType.THRESHOLD:
+        return guard
+
+    # Use the configured window, falling back to the default
+    window = detector_config.get("window") or DETECTOR_DEFAULT_WINDOW
+
+    # Account for preprocessing that consumes usable data points
+    preprocessing = detector_config.get("preprocessing") or {}
+    lags_n = preprocessing.get("lags_n") or 0
+    diffs_n = preprocessing.get("diffs_n") or 0
+
+    samples_needed = window + 1 + lags_n + diffs_n
+
+    # Never go below the per-detector minimum guard
+    return max(samples_needed, guard)
+
 
 def check_trends_alert_with_detector(
     alert: AlertConfiguration, insight: Insight, query: TrendsQuery, detector_config: dict[str, Any]
@@ -510,19 +552,8 @@ def check_trends_alert_with_detector(
     )
     detector_type_str = detector_config.get("type", "zscore")
 
-    # Calculate minimum samples needed for this detector
-    if detector_type_str == "ensemble":
-        # For ensemble, use the max window across all sub-detectors
-        sub_detectors = detector_config.get("detectors", [])
-        min_samples = max((d.get("window", 30) + 1 for d in sub_detectors), default=31)
-    else:
-        detector_type = DetectorType(detector_type_str)
-        min_samples = DETECTOR_MIN_SAMPLES.get(detector_type, 31)
-        window = detector_config.get("window", 30)
-        if detector_type in (DetectorType.ZSCORE, DetectorType.MAD):
-            min_samples = max(min_samples, window + 1)
-
-    # Calculate date range to fetch enough data
+    # Calculate date range to fetch enough historical data for this detector
+    min_samples = _compute_min_samples_for_detector(detector_config)
     filters_override = _date_range_override_for_detector(query, min_samples)
 
     is_non_time_series = _is_non_time_series_trend(query)
@@ -643,16 +674,8 @@ def simulate_detector_on_insight(
 
     detector_type_str = detector_config.get("type", "zscore")
 
-    # Calculate minimum samples needed
-    if detector_type_str == "ensemble":
-        sub_detectors = detector_config.get("detectors", [])
-        min_samples = max((d.get("window", 30) + 1 for d in sub_detectors), default=31)
-    else:
-        detector_type = DetectorType(detector_type_str)
-        min_samples = DETECTOR_MIN_SAMPLES.get(detector_type, 31)
-        window = detector_config.get("window", 30)
-        if detector_type in (DetectorType.ZSCORE, DetectorType.MAD):
-            min_samples = max(min_samples, window + 1)
+    # Calculate minimum samples needed (same logic as the actual alert check)
+    min_samples = _compute_min_samples_for_detector(detector_config)
 
     # Fetch enough historical data
     is_non_time_series = _is_non_time_series_trend(trends_query)

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -281,6 +281,11 @@ export interface ECODDetectorConfigApi {
      */
     threshold?: number | null
     type?: ECODDetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type COPODDetectorConfigApiType = (typeof COPODDetectorConfigApiType)[keyof typeof COPODDetectorConfigApiType]
@@ -298,6 +303,11 @@ export interface COPODDetectorConfigApi {
      */
     threshold?: number | null
     type?: COPODDetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type IsolationForestDetectorConfigApiType =
@@ -321,6 +331,11 @@ export interface IsolationForestDetectorConfigApi {
      */
     threshold?: number | null
     type?: IsolationForestDetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type MethodApi = (typeof MethodApi)[keyof typeof MethodApi]
@@ -353,6 +368,11 @@ export interface KNNDetectorConfigApi {
      */
     threshold?: number | null
     type?: KNNDetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type HBOSDetectorConfigApiType = (typeof HBOSDetectorConfigApiType)[keyof typeof HBOSDetectorConfigApiType]
@@ -375,6 +395,11 @@ export interface HBOSDetectorConfigApi {
      */
     threshold?: number | null
     type?: HBOSDetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type LOFDetectorConfigApiType = (typeof LOFDetectorConfigApiType)[keyof typeof LOFDetectorConfigApiType]
@@ -397,6 +422,11 @@ export interface LOFDetectorConfigApi {
      */
     threshold?: number | null
     type?: LOFDetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type OCSVMDetectorConfigApiType = (typeof OCSVMDetectorConfigApiType)[keyof typeof OCSVMDetectorConfigApiType]
@@ -424,6 +454,11 @@ export interface OCSVMDetectorConfigApi {
      */
     threshold?: number | null
     type?: OCSVMDetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type PCADetectorConfigApiType = (typeof PCADetectorConfigApiType)[keyof typeof PCADetectorConfigApiType]
@@ -441,6 +476,11 @@ export interface PCADetectorConfigApi {
      */
     threshold?: number | null
     type?: PCADetectorConfigApiType
+    /**
+     * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+     * @nullable
+     */
+    window?: number | null
 }
 
 export type EnsembleOperatorApi = (typeof EnsembleOperatorApi)[keyof typeof EnsembleOperatorApi]

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4445,6 +4445,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: ECODDetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type COPODDetectorConfigType = typeof COPODDetectorConfigType[keyof typeof COPODDetectorConfigType];
@@ -4463,6 +4468,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: COPODDetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type IsolationForestDetectorConfigType = typeof IsolationForestDetectorConfigType[keyof typeof IsolationForestDetectorConfigType];
@@ -4486,6 +4496,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: IsolationForestDetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type Method = typeof Method[keyof typeof Method];
@@ -4520,6 +4535,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: KNNDetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type HBOSDetectorConfigType = typeof HBOSDetectorConfigType[keyof typeof HBOSDetectorConfigType];
@@ -4543,6 +4563,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: HBOSDetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type LOFDetectorConfigType = typeof LOFDetectorConfigType[keyof typeof LOFDetectorConfigType];
@@ -4566,6 +4591,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: LOFDetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type OCSVMDetectorConfigType = typeof OCSVMDetectorConfigType[keyof typeof OCSVMDetectorConfigType];
@@ -4594,6 +4624,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: OCSVMDetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type PCADetectorConfigType = typeof PCADetectorConfigType[keyof typeof PCADetectorConfigType];
@@ -4612,6 +4647,11 @@ export namespace Schemas {
        */
       threshold?: number | null;
       type?: PCADetectorConfigType;
+      /**
+       * Rolling window size — how many historical data points to train on (default: based on calculation interval)
+       * @nullable
+       */
+      window?: number | null;
     }
 
     export type EnsembleOperator = typeof EnsembleOperator[keyof typeof EnsembleOperator];

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -293,6 +293,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['ecod'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 preprocessing: zod
@@ -324,6 +330,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['copod'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_estimators: zod
@@ -359,6 +371,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['isolation_forest'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 method: zod.enum(['largest', 'mean', 'median']).nullish(),
@@ -395,6 +413,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['knn'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
@@ -427,6 +451,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['hbos'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_neighbors: zod
@@ -462,6 +492,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['lof'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 kernel: zod.string().nullish().describe('SVM kernel type (default: "rbf")'),
@@ -498,6 +534,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['ocsvm'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 preprocessing: zod
@@ -529,6 +571,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['pca'])
                                     .default(alertsCreateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                         ])
                     )
@@ -662,6 +710,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['ecod']).default(alertsCreateBodyDetectorConfigOneSixTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 preprocessing: zod
@@ -684,6 +738,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['copod']).default(alertsCreateBodyDetectorConfigOneSevenTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_estimators: zod.number().nullish().describe('Number of trees in the forest (default: 100)'),
@@ -707,6 +767,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['isolation_forest']).default(alertsCreateBodyDetectorConfigOneEightTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 method: zod.enum(['largest', 'mean', 'median']).nullish(),
@@ -731,6 +797,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['knn']).default(alertsCreateBodyDetectorConfigOneNineTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
@@ -754,6 +826,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['hbos']).default(alertsCreateBodyDetectorConfigOneOnezeroTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_neighbors: zod.number().nullish().describe('Number of neighbors for LOF (default: 20)'),
@@ -777,6 +855,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['lof']).default(alertsCreateBodyDetectorConfigOneOneoneTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 kernel: zod.string().nullish().describe('SVM kernel type (default: "rbf")'),
@@ -801,6 +885,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['ocsvm']).default(alertsCreateBodyDetectorConfigOneOnetwoTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 preprocessing: zod
@@ -823,6 +913,12 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['pca']).default(alertsCreateBodyDetectorConfigOneOnethreeTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
         ])
         .describe('Detector configuration types')
@@ -1132,6 +1228,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['ecod'])
                                     .default(alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 preprocessing: zod
@@ -1163,6 +1265,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['copod'])
                                     .default(alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_estimators: zod
@@ -1198,6 +1306,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['isolation_forest'])
                                     .default(alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 method: zod.enum(['largest', 'mean', 'median']).nullish(),
@@ -1234,6 +1348,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['knn'])
                                     .default(alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
@@ -1266,6 +1386,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['hbos'])
                                     .default(alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_neighbors: zod
@@ -1303,6 +1429,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                     .default(
                                         alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault
                                     ),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 kernel: zod.string().nullish().describe('SVM kernel type (default: "rbf")'),
@@ -1339,6 +1471,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['ocsvm'])
                                     .default(alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 preprocessing: zod
@@ -1370,6 +1508,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['pca'])
                                     .default(alertsPartialUpdateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                         ])
                     )
@@ -1503,6 +1647,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['ecod']).default(alertsPartialUpdateBodyDetectorConfigOneSixTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 preprocessing: zod
@@ -1525,6 +1675,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['copod']).default(alertsPartialUpdateBodyDetectorConfigOneSevenTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_estimators: zod.number().nullish().describe('Number of trees in the forest (default: 100)'),
@@ -1548,6 +1704,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['isolation_forest']).default(alertsPartialUpdateBodyDetectorConfigOneEightTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 method: zod.enum(['largest', 'mean', 'median']).nullish(),
@@ -1572,6 +1734,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['knn']).default(alertsPartialUpdateBodyDetectorConfigOneNineTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
@@ -1595,6 +1763,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['hbos']).default(alertsPartialUpdateBodyDetectorConfigOneOnezeroTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_neighbors: zod.number().nullish().describe('Number of neighbors for LOF (default: 20)'),
@@ -1618,6 +1792,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['lof']).default(alertsPartialUpdateBodyDetectorConfigOneOneoneTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 kernel: zod.string().nullish().describe('SVM kernel type (default: "rbf")'),
@@ -1642,6 +1822,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['ocsvm']).default(alertsPartialUpdateBodyDetectorConfigOneOnetwoTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 preprocessing: zod
@@ -1664,6 +1850,12 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['pca']).default(alertsPartialUpdateBodyDetectorConfigOneOnethreeTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
         ])
         .describe('Detector configuration types')
@@ -1919,6 +2111,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['ecod'])
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemFiveTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 preprocessing: zod
@@ -1950,6 +2148,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['copod'])
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSixTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_estimators: zod
@@ -1985,6 +2189,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['isolation_forest'])
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemSevenTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 method: zod.enum(['largest', 'mean', 'median']).nullish(),
@@ -2021,6 +2231,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['knn'])
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemEightTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
@@ -2053,6 +2269,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                 type: zod
                                     .enum(['hbos'])
                                     .default(alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemNineTypeDefault),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 n_neighbors: zod
@@ -2089,6 +2311,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     .enum(['lof'])
                                     .default(
                                         alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnezeroTypeDefault
+                                    ),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
                             }),
                             zod.object({
@@ -2128,6 +2356,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     .default(
                                         alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOneoneTypeDefault
                                     ),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                                    ),
                             }),
                             zod.object({
                                 preprocessing: zod
@@ -2160,6 +2394,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                                     .enum(['pca'])
                                     .default(
                                         alertsSimulateCreateBodyDetectorConfigOneOneDetectorsItemOnetwoTypeDefault
+                                    ),
+                                window: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
                                     ),
                             }),
                         ])
@@ -2294,6 +2534,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['ecod']).default(alertsSimulateCreateBodyDetectorConfigOneSixTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 preprocessing: zod
@@ -2316,6 +2562,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['copod']).default(alertsSimulateCreateBodyDetectorConfigOneSevenTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_estimators: zod.number().nullish().describe('Number of trees in the forest (default: 100)'),
@@ -2339,6 +2591,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['isolation_forest']).default(alertsSimulateCreateBodyDetectorConfigOneEightTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 method: zod.enum(['largest', 'mean', 'median']).nullish(),
@@ -2363,6 +2621,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['knn']).default(alertsSimulateCreateBodyDetectorConfigOneNineTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_bins: zod.number().nullish().describe('Number of histogram bins (default: 10)'),
@@ -2386,6 +2650,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['hbos']).default(alertsSimulateCreateBodyDetectorConfigOneOnezeroTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 n_neighbors: zod.number().nullish().describe('Number of neighbors for LOF (default: 20)'),
@@ -2409,6 +2679,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['lof']).default(alertsSimulateCreateBodyDetectorConfigOneOneoneTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 kernel: zod.string().nullish().describe('SVM kernel type (default: "rbf")'),
@@ -2433,6 +2709,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['ocsvm']).default(alertsSimulateCreateBodyDetectorConfigOneOnetwoTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
             zod.object({
                 preprocessing: zod
@@ -2455,6 +2737,12 @@ export const AlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                     .nullish(),
                 threshold: zod.number().nullish().describe('Anomaly probability threshold (default: 0.9)'),
                 type: zod.enum(['pca']).default(alertsSimulateCreateBodyDetectorConfigOneOnethreeTypeDefault),
+                window: zod
+                    .number()
+                    .nullish()
+                    .describe(
+                        'Rolling window size — how many historical data points to train on (default: based on calculation interval)'
+                    ),
             }),
         ])
         .describe('Detector configuration types')

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
@@ -454,6 +454,17 @@
                                                         "default": "ecod",
                                                         "enum": ["ecod"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -520,6 +531,17 @@
                                                         "default": "copod",
                                                         "enum": ["copod"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -597,6 +619,17 @@
                                                         "default": "isolation_forest",
                                                         "enum": ["isolation_forest"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -685,6 +718,17 @@
                                                         "default": "knn",
                                                         "enum": ["knn"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -762,6 +806,17 @@
                                                         "default": "hbos",
                                                         "enum": ["hbos"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -839,6 +894,17 @@
                                                         "default": "lof",
                                                         "enum": ["lof"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -927,6 +993,17 @@
                                                         "default": "ocsvm",
                                                         "enum": ["ocsvm"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -993,6 +1070,17 @@
                                                         "default": "pca",
                                                         "enum": ["pca"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -1384,6 +1472,17 @@
                                     "default": "ecod",
                                     "enum": ["ecod"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1450,6 +1549,17 @@
                                     "default": "copod",
                                     "enum": ["copod"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1527,6 +1637,17 @@
                                     "default": "isolation_forest",
                                     "enum": ["isolation_forest"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1615,6 +1736,17 @@
                                     "default": "knn",
                                     "enum": ["knn"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1692,6 +1824,17 @@
                                     "default": "hbos",
                                     "enum": ["hbos"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1769,6 +1912,17 @@
                                     "default": "lof",
                                     "enum": ["lof"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1857,6 +2011,17 @@
                                     "default": "ocsvm",
                                     "enum": ["ocsvm"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1923,6 +2088,17 @@
                                     "default": "pca",
                                     "enum": ["pca"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-simulate.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-simulate.json
@@ -390,6 +390,17 @@
                                                 "default": "ecod",
                                                 "enum": ["ecod"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -456,6 +467,17 @@
                                                 "default": "copod",
                                                 "enum": ["copod"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -533,6 +555,17 @@
                                                 "default": "isolation_forest",
                                                 "enum": ["isolation_forest"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -621,6 +654,17 @@
                                                 "default": "knn",
                                                 "enum": ["knn"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -698,6 +742,17 @@
                                                 "default": "hbos",
                                                 "enum": ["hbos"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -775,6 +830,17 @@
                                                 "default": "lof",
                                                 "enum": ["lof"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -863,6 +929,17 @@
                                                 "default": "ocsvm",
                                                 "enum": ["ocsvm"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -929,6 +1006,17 @@
                                                 "default": "pca",
                                                 "enum": ["pca"],
                                                 "type": "string"
+                                            },
+                                            "window": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                             }
                                         },
                                         "type": "object"
@@ -1320,6 +1408,17 @@
                             "default": "ecod",
                             "enum": ["ecod"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"
@@ -1386,6 +1485,17 @@
                             "default": "copod",
                             "enum": ["copod"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"
@@ -1463,6 +1573,17 @@
                             "default": "isolation_forest",
                             "enum": ["isolation_forest"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"
@@ -1551,6 +1672,17 @@
                             "default": "knn",
                             "enum": ["knn"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"
@@ -1628,6 +1760,17 @@
                             "default": "hbos",
                             "enum": ["hbos"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"
@@ -1705,6 +1848,17 @@
                             "default": "lof",
                             "enum": ["lof"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"
@@ -1793,6 +1947,17 @@
                             "default": "ocsvm",
                             "enum": ["ocsvm"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"
@@ -1859,6 +2024,17 @@
                             "default": "pca",
                             "enum": ["pca"],
                             "type": "string"
+                        },
+                        "window": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                         }
                     },
                     "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
@@ -454,6 +454,17 @@
                                                         "default": "ecod",
                                                         "enum": ["ecod"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -520,6 +531,17 @@
                                                         "default": "copod",
                                                         "enum": ["copod"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -597,6 +619,17 @@
                                                         "default": "isolation_forest",
                                                         "enum": ["isolation_forest"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -685,6 +718,17 @@
                                                         "default": "knn",
                                                         "enum": ["knn"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -762,6 +806,17 @@
                                                         "default": "hbos",
                                                         "enum": ["hbos"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -839,6 +894,17 @@
                                                         "default": "lof",
                                                         "enum": ["lof"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -927,6 +993,17 @@
                                                         "default": "ocsvm",
                                                         "enum": ["ocsvm"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -993,6 +1070,17 @@
                                                         "default": "pca",
                                                         "enum": ["pca"],
                                                         "type": "string"
+                                                    },
+                                                    "window": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                                     }
                                                 },
                                                 "type": "object"
@@ -1384,6 +1472,17 @@
                                     "default": "ecod",
                                     "enum": ["ecod"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1450,6 +1549,17 @@
                                     "default": "copod",
                                     "enum": ["copod"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1527,6 +1637,17 @@
                                     "default": "isolation_forest",
                                     "enum": ["isolation_forest"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1615,6 +1736,17 @@
                                     "default": "knn",
                                     "enum": ["knn"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1692,6 +1824,17 @@
                                     "default": "hbos",
                                     "enum": ["hbos"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1769,6 +1912,17 @@
                                     "default": "lof",
                                     "enum": ["lof"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1857,6 +2011,17 @@
                                     "default": "ocsvm",
                                     "enum": ["ocsvm"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"
@@ -1923,6 +2088,17 @@
                                     "default": "pca",
                                     "enum": ["pca"],
                                     "type": "string"
+                                },
+                                "window": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Rolling window size — how many historical data points to train on (default: based on calculation interval)"
                                 }
                             },
                             "type": "object"


### PR DESCRIPTION
## Problem

PyOD-based anomaly detectors (isolation_forest, knn, lof, ocsvm, pca, ecod, copod, hbos) were firing false positive alerts because the alert checker fetched far too little historical data. The `DETECTOR_MIN_SAMPLES` guard (e.g. 10 for isolation forest) was accidentally the *only* thing driving the data fetch size, causing models to train on as few as 9 data points and producing garbage anomaly scores (score=1.0 on perfectly normal data).

Meanwhile, the simulation endpoint used the insight's full date range (e.g. 78 hourly points), producing completely different and correct results. This meant alerts would fire but simulating the same config showed no anomaly.

**Root cause:** Unlike the statistical detectors (zscore, mad, iqr) which have an explicit `window` parameter that drives data fetching, the PyOD detectors had no such parameter. The `min_samples` guard was serving double duty as "how much data to fetch" instead of just being a lower bound.

## Changes

- Add `window` field to all 8 PyOD detector config schemas (TypeScript + Python)
- Add `WindowSizeInput` to all PyOD detector config UI components in `DetectorSelector.tsx`
- Include interval-based defaults matching existing zscore/mad/iqr behavior (hourly=168, daily=90, weekly=26, monthly=12)
- Extract shared `_compute_min_samples_for_detector()` helper used by both the alert checker and simulation endpoint so they always agree
- Factor preprocessing config (`lags_n`, `diffs_n`) into the min_samples calculation since these consume usable training data
- Keep `DETECTOR_MIN_SAMPLES` as a pure lower-bound guard, not the data fetch driver

**Before/After for hourly isolation_forest with preprocessing (diffs=1, lags=3):**
| | min_samples (data points fetched) |
|---|---|
| Before | 10 (trained on 9 points) |
| After (no window set) | 35 (default window 30 + headroom) |
| After (window=168) | 173 (7 days of hourly data + headroom) |

## How did you test this code?

- All 105 existing detector tests pass (`pytest posthog/tasks/alerts/detectors/`)
- Verified `_compute_min_samples_for_detector()` output for isolation_forest, zscore, threshold, ecod, and lof configs
- Regenerated schemas via `hogli build:schema` and `hogli build:openapi`
- I am an agent and have not manually tested the UI changes

## Publish to changelog?

no

## Docs update

no