### PR TITLE
fix(insights): Filter null date rows from SQL insight charts

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -1,6 +1,12 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, selectors } from 'kea'
 
-import { AxisSeries, AxisSeriesSettings, SelectedYAxis, dataVisualizationLogic } from '../dataVisualizationLogic'
+import {
+    AxisSeries,
+    AxisSeriesSettings,
+    filterNullDateRows,
+    SelectedYAxis,
+    dataVisualizationLogic,
+} from '../dataVisualizationLogic'
 import type { seriesBreakdownLogicType } from './seriesBreakdownLogicType'
 
 export interface AxisBreakdownSeries<T> {
@@ -139,11 +145,7 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                           ? response.result
                           : []
 
-                // Filter out rows with null date/datetime x-axis values
-                const data =
-                    xColumn.type.name === 'DATE' || xColumn.type.name === 'DATETIME'
-                        ? allData.filter((n) => n[xColumn.dataIndex] != null)
-                        : allData
+                const data = filterNullDateRows(allData, xColumn)
 
                 // xData is unique x values
                 const xData = Array.from(new Set(data.map((n) => n[xColumn.dataIndex])))

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -139,9 +139,7 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                           ? response.result
                           : []
 
-                // Filter out rows with null date/datetime x-axis values — these are
-                // aggregation artifacts (e.g. from GROUP BY on Nullable columns with
-                // enable_analyzer) that produce outlier values and break chart scaling
+                // Filter out rows with null date/datetime x-axis values
                 const data =
                     xColumn.type.name === 'DATE' || xColumn.type.name === 'DATETIME'
                         ? allData.filter((n) => n[xColumn.dataIndex] != null)

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -132,12 +132,20 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                     return createEmptyBreakdownSeriesWithError('Too many breakdown values (max 50)')
                 }
 
-                const data: any[] =
+                const allData: any[] =
                     'results' in response && Array.isArray(response.results)
                         ? response.results
                         : 'result' in response && Array.isArray(response.result)
                           ? response.result
                           : []
+
+                // Filter out rows with null date/datetime x-axis values — these are
+                // aggregation artifacts (e.g. from GROUP BY on Nullable columns with
+                // enable_analyzer) that produce outlier values and break chart scaling
+                const data =
+                    xColumn.type.name === 'DATE' || xColumn.type.name === 'DATETIME'
+                        ? allData.filter((n) => n[xColumn.dataIndex] != null)
+                        : allData
 
                 // xData is unique x values
                 const xData = Array.from(new Set(data.map((n) => n[xColumn.dataIndex])))

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -317,6 +317,60 @@ describe('dataVisualizationLogic', () => {
             },
         })
     })
+    it('filters out rows with null date x-axis values from chart data', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['created_at', 'succeeded', 'failed'],
+            types: [
+                ['created_at', 'Nullable(Date)'],
+                ['succeeded', 'UInt64'],
+                ['failed', 'UInt64'],
+            ],
+            results: [
+                ['2025-01-01', 100, 5],
+                ['2025-01-02', 200, 10],
+                [null, 300, 15],
+            ],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            xData: {
+                column: expect.objectContaining({ name: 'created_at' }),
+                data: ['2025-01-01', '2025-01-02'],
+            },
+            yData: expect.arrayContaining([
+                expect.objectContaining({
+                    column: expect.objectContaining({ name: 'succeeded' }),
+                    data: [100, 200],
+                }),
+                expect.objectContaining({
+                    column: expect.objectContaining({ name: 'failed' }),
+                    data: [5, 10],
+                }),
+            ]),
+        })
+    })
+
+    it('does not filter null x-axis values for non-date columns', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['category', 'count'],
+            types: [
+                ['category', 'Nullable(String)'],
+                ['count', 'UInt64'],
+            ],
+            results: [
+                ['A', 10],
+                [null, 20],
+            ],
+        })
+
+        await expectLogic(logic).toMatchValues({
+            xData: {
+                column: expect.objectContaining({ name: 'category' }),
+                data: ['A', null],
+            },
+        })
+    })
+
     it('auto-fills 2d heatmap columns when selecting auto on heatmap data', async () => {
         dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
             columns: ['region', 'segment', 'count'],

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -802,9 +802,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                           ? response.result
                           : []
 
-                // Filter out rows with null date/datetime x-axis values — these are
-                // aggregation artifacts (e.g. from GROUP BY on Nullable columns with
-                // enable_analyzer) that produce outlier values and break chart scaling
+                // Filter out rows with null date/datetime x-axis values
                 const xColumn = xSeries !== null ? columns.find((n) => n.name === xSeries) : null
                 const data =
                     xColumn && (xColumn.type.name === 'DATE' || xColumn.type.name === 'DATETIME')
@@ -899,9 +897,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                     return null
                 }
 
-                // Filter out rows with null date/datetime x-axis values — these are
-                // aggregation artifacts (e.g. from GROUP BY on Nullable columns with
-                // enable_analyzer) that produce outlier values and break chart scaling
+                // Filter out rows with null date/datetime x-axis values
                 const filteredData =
                     column.type.name === 'DATE' || column.type.name === 'DATETIME'
                         ? data.filter((n: Record<number, unknown>) => n[column.dataIndex] != null)

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -59,6 +59,14 @@ export interface Column {
     dataIndex: number
 }
 
+/** Filter out rows with null values in a date/datetime column — null dates are not plottable on a time axis */
+export function filterNullDateRows(data: any[], column: Column): any[] {
+    if (column.type.name === 'DATE' || column.type.name === 'DATETIME') {
+        return data.filter((row) => row[column.dataIndex] != null)
+    }
+    return data
+}
+
 export interface TableDataCell<T extends string | number | boolean | Date | null> {
     value: T
     formattedValue: string | object | null
@@ -802,12 +810,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                           ? response.result
                           : []
 
-                // Filter out rows with null date/datetime x-axis values
                 const xColumn = xSeries !== null ? columns.find((n) => n.name === xSeries) : null
-                const data =
-                    xColumn && (xColumn.type.name === 'DATE' || xColumn.type.name === 'DATETIME')
-                        ? allData.filter((row: Record<number, unknown>) => row[xColumn.dataIndex] != null)
-                        : allData
+                const data = xColumn ? filterNullDateRows(allData, xColumn) : allData
 
                 return ySeries
                     .map((series): AxisSeries<number | null> | null => {
@@ -897,15 +901,9 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                     return null
                 }
 
-                // Filter out rows with null date/datetime x-axis values
-                const filteredData =
-                    column.type.name === 'DATE' || column.type.name === 'DATETIME'
-                        ? data.filter((n: Record<number, unknown>) => n[column.dataIndex] != null)
-                        : data
-
                 return {
                     column,
-                    data: filteredData.map((n: any) => n[column.dataIndex]),
+                    data: filterNullDateRows(data, column).map((n: any) => n[column.dataIndex]),
                 }
             },
         ],

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -788,19 +788,28 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             (cachedResults: AnyResponseType | null): boolean => !!cachedResults,
         ],
         yData: [
-            (s) => [s.selectedYAxis, s.response, s.columns, s.chartSettings],
-            (ySeries, response, columns, chartSettings): AxisSeries<number | null>[] => {
+            (s) => [s.selectedYAxis, s.response, s.columns, s.chartSettings, s.selectedXAxis],
+            (ySeries, response, columns, chartSettings, xSeries): AxisSeries<number | null>[] => {
                 if (!response || ySeries === null || ySeries.length === 0) {
                     return [EmptyYAxisSeries]
                 }
 
                 const showNullsAsZero = chartSettings.showNullsAsZero ?? false
-                const data =
+                const allData =
                     'results' in response && Array.isArray(response.results)
                         ? response.results
                         : 'result' in response && Array.isArray(response.result)
                           ? response.result
                           : []
+
+                // Filter out rows with null date/datetime x-axis values — these are
+                // aggregation artifacts (e.g. from GROUP BY on Nullable columns with
+                // enable_analyzer) that produce outlier values and break chart scaling
+                const xColumn = xSeries !== null ? columns.find((n) => n.name === xSeries) : null
+                const data =
+                    xColumn && (xColumn.type.name === 'DATE' || xColumn.type.name === 'DATETIME')
+                        ? allData.filter((row: Record<number, unknown>) => row[xColumn.dataIndex] != null)
+                        : allData
 
                 return ySeries
                     .map((series): AxisSeries<number | null> | null => {
@@ -890,9 +899,17 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                     return null
                 }
 
+                // Filter out rows with null date/datetime x-axis values — these are
+                // aggregation artifacts (e.g. from GROUP BY on Nullable columns with
+                // enable_analyzer) that produce outlier values and break chart scaling
+                const filteredData =
+                    column.type.name === 'DATE' || column.type.name === 'DATETIME'
+                        ? data.filter((n: Record<number, unknown>) => n[column.dataIndex] != null)
+                        : data
+
                 return {
                     column,
-                    data: data.map((n: any) => n[column.dataIndex]),
+                    data: filteredData.map((n: any) => n[column.dataIndex]),
                 }
             },
         ],


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C045L1VEG87/p1774267101185119

We've started to see breakdowns returning some null: huge value's which is blowing up the y-axis and effectivley breaking sql breakdown charts.

## Changes

Filter null: date/times out, so they don't blow up the y-axis

Before:
<img width="1295" height="820" alt="Screenshot 2026-03-23 at 13 31 03" src="https://github.com/user-attachments/assets/48711e4e-d2ce-4384-9be3-27e9a4904302" />

After:
<img width="1280" height="833" alt="Screenshot 2026-03-23 at 13 29 28" src="https://github.com/user-attachments/assets/e3d1ec8c-35ee-4161-bc1c-67c87c732e65" />

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
