### PR TITLE
fix(ci): remove invalid timeout-minutes from reusable workflow call

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -19,7 +19,6 @@ on:
 
 jobs:
     build-images:
-        timeout-minutes: 20
         uses: ./.github/workflows/_rust-build-images.yml
         with:
             tag-rules: |


### PR DESCRIPTION
## Problem

The `rust-docker-build.yml` workflow was failing validation with:

```
(Line: 23, Col: 9): Unexpected value 'uses'
(Line: 24, Col: 9): Unexpected value 'with'
(Line: 32, Col: 9): Unexpected value 'secrets'
(Line: 22, Col: 9): Required property is missing: runs-on
```

## Changes

Removed the job-level `timeout-minutes: 20` from the `build-images` job. This property is not valid on jobs that call reusable workflows via `uses` — its presence caused GitHub's validator to treat the job as a regular job, which then fails because `runs-on` is missing and `uses`/`with`/`secrets` are unexpected.

The timeout is already passed as an input to the reusable workflow via `with: timeout-minutes: 15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)