### PR TITLE
fix(metalytics): fix metalytics 5xxs

### DIFF
--- a/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
+++ b/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
@@ -37,12 +37,11 @@ export const metalyticsLogic = kea<metalyticsLogicType>([
                         WHERE app_source = 'metalytics'
                         AND instance_id = ${values.instanceId}`
 
-                    // NOTE: I think this gets cached heavily - how to correctly invalidate?
                     const currentScene = sceneLogic.findMounted()?.values.activeSceneId ?? 'Metalytics'
                     const response = await api.queryHogQL(
                         query,
                         { scene: currentScene, productKey: 'platform_and_support' },
-                        { refresh: 'force_blocking' }
+                        { refresh: 'async' }
                     )
                     const result = response.results as number[][]
                     return {
@@ -68,7 +67,7 @@ export const metalyticsLogic = kea<metalyticsLogicType>([
                     const response = await api.queryHogQL(
                         query,
                         { scene: currentScene, productKey: 'platform_and_support' },
-                        { refresh: 'force_blocking' }
+                        { refresh: 'async' }
                     )
                     return response.results.map((result) => result[0]) as string[]
                 },
@@ -108,7 +107,7 @@ export const metalyticsLogic = kea<metalyticsLogicType>([
                 actions.loadViewCount()
                 actions.loadUsersLast30days()
 
-                await api.create(`/api/projects/${values.currentProjectId}/metalytics/`, {
+                void api.create(`/api/projects/${values.currentProjectId}/metalytics/`, {
                     metric_name: 'viewed',
                     instance_id: instanceId,
                 })


### PR DESCRIPTION
## Problem

Metalytics endpoint is the single largest source of 504s across platform features endpoints. 

The metalytics frontend fires 3 requests simultaneously per page view:
- A `POST /metalytics/` (viewed metric) — **awaited** despite being fire-and-forget telemetry
- Two HogQL queries with `force_blocking` — each ties up a Django worker until ClickHouse returns

## Changes

- Switch both HogQL queries from `force_blocking` to `async` refresh — returns cached results instantly, refreshes in background
- Make the viewed metric POST fire-and-forget (`void` instead of `await`) — response is unused

## How did you test this code?

Code-only change with no behavioral impact beyond caching strategy. View counts may be a few minutes stale instead of real-time, which is acceptable for internal telemetry.

## Publish to changelog?

no