### PR TITLE
fix: seeing source context in ro impersonation

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -900,6 +900,8 @@ READ_ONLY_IMPERSONATION_ALLOWLISTED_PATHS: list[str | re.Pattern] = [
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/[^/]+/run/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/endpoints/last_execution_times/?$"),
     re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/persons/batch_by_distinct_ids/?$"),
+    # POST but read-only: loads stack frame records (source context) for error tracking UI
+    re.compile(r"^/api/(environments|projects)/([0-9]+|@current)/error_tracking/stack_frames/batch_get/?$"),
     # Allow upgrading from read-only to read-write impersonation
     "/admin/impersonation/upgrade/",
 ]

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -777,6 +777,18 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
         # Should not be blocked by impersonation middleware (might get other errors)
         assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
 
+    def test_read_only_impersonation_allows_error_tracking_stack_frames_batch_get(self):
+        """POST batch_get is read-only; needed for issue stack source context during impersonation."""
+        self.login_as_other_user_read_only()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/error_tracking/stack_frames/batch_get/",
+            data={"raw_ids": []},
+            content_type="application/json",
+        )
+
+        assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
+
     def test_regular_impersonation_allows_write(self):
         """Verify regular (non-read-only) impersonation can still write."""
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -777,18 +777,6 @@ class TestImpersonationReadOnlyMiddleware(APIBaseTest):
         # Should not be blocked by impersonation middleware (might get other errors)
         assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
 
-    def test_read_only_impersonation_allows_error_tracking_stack_frames_batch_get(self):
-        """POST batch_get is read-only; needed for issue stack source context during impersonation."""
-        self.login_as_other_user_read_only()
-
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/error_tracking/stack_frames/batch_get/",
-            data={"raw_ids": []},
-            content_type="application/json",
-        )
-
-        assert response.status_code != 403 or response.json().get("code") != "impersonation_read_only"
-
     def test_regular_impersonation_allows_write(self):
         """Verify regular (non-read-only) impersonation can still write."""
         dashboard = Dashboard.objects.create(team=self.team, name="Test Dashboard")


### PR DESCRIPTION
I've just wasted insane amount of time trying to figure out why I can't see source context while impersonating a user only to find out that RO impersonation blocks POST requests by default...

App handles that very well and displays the correct UI but no stacktraces.

Why not change that to GET? Request might be large given that we might pass a lot of `raw_id`s so yeah it has to be a POST with body