### PR TITLE
fix(ci): remove invalid timeout-minutes from reusable workflow jobs

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
     call-flags-project:
-        timeout-minutes: 5
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@main
         # Only on PostHog/posthog, as there's no GitHub token on forks
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -623,7 +623,6 @@ jobs:
         name: Cleanup preview on label removal
         needs: changes
         if: needs.changes.outputs.label_removed == 'true'
-        timeout-minutes: 5
         uses: ./.github/workflows/pr-cleanup.yml
         # these permissions are required by pr-cleanup.yml
         permissions:

--- a/.github/workflows/ci-survey-sdk-check.yml
+++ b/.github/workflows/ci-survey-sdk-check.yml
@@ -53,7 +53,6 @@ jobs:
 
     check-docs-generated:
         name: Check SDK docs are up to date
-        timeout-minutes: 5
         uses: ./.github/workflows/ci-docs-check.yml
         with:
             source_file: frontend/src/scenes/surveys/surveyVersionRequirements.ts

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -13,7 +13,6 @@ jobs:
     cleanup-hobby-preview:
         name: Cleanup hobby preview deployment
         if: contains(github.event.pull_request.labels.*.name, 'hobby-preview')
-        timeout-minutes: 5
         uses: ./.github/workflows/pr-cleanup.yml
         # these permissions are required by pr-cleanup.yml
         permissions:


### PR DESCRIPTION
## Problem

`timeout-minutes` is not a valid key on jobs that call reusable workflows via `uses:`. GitHub Actions treats these as regular jobs when it sees `timeout-minutes`, then fails because `runs-on` is missing and `uses`/`with`/`secrets` are unexpected.

This is the same class of bug fixed in #51930 and #51832 for the Rust workflows — these four files were also affected.

## Changes

Remove invalid `timeout-minutes` from reusable workflow jobs in:
- `call-flags-project-board.yml`
- `ci-hobby.yml`
- `ci-survey-sdk-check.yml`
- `pr-closed.yml`

Timeouts are handled inside the called workflows themselves.

## Related PRs

- #51930 — same fix for `rust-docker-build.yml` (merged)
- #51832 — same fix for `rust-smoke-test-build.yml` (open)
- #51936 — duplicate of #51930 (closed)