### PR TITLE
feat: add update_service endpoint for Stripe agentic provisioning

### DIFF
--- a/ee/api/agentic_provisioning/test/test_update_service.py
+++ b/ee/api/agentic_provisioning/test/test_update_service.py
@@ -1,0 +1,124 @@
+from django.test import override_settings
+
+from posthog.models.oauth import OAuthAccessToken
+from posthog.models.team.team import Team
+
+from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
+
+
+@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET)
+class TestProvisioningUpdateService(StripeProvisioningTestBase):
+    def test_update_service_returns_complete(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["status"] == "complete"
+        assert data["id"] == str(self.team.id)
+        assert data["service_id"] == "analytics"
+        assert "api_key" in data["complete"]["access_configuration"]
+        assert "host" in data["complete"]["access_configuration"]
+
+    def test_update_service_with_payment_credentials(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={
+                "service_id": "pay_as_you_go",
+                "payment_credentials": {
+                    "type": "stripe_payment_token",
+                    "stripe_payment_token": "spt_test_123",
+                },
+            },
+            token=token,
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["status"] == "complete"
+        assert data["service_id"] == "pay_as_you_go"
+
+    def test_update_service_without_payment_credentials(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["status"] == "complete"
+
+    def test_update_service_missing_bearer_returns_401(self):
+        res = self._post_signed(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={"service_id": "analytics"},
+        )
+        assert res.status_code == 401
+
+    def test_update_service_wrong_team_returns_403(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources/99999/update_service",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert res.status_code == 403
+
+    def test_update_service_deleted_team_returns_404(self):
+        token = self._get_bearer_token()
+        team_id = self.team.id
+        access_token = OAuthAccessToken.objects.get(token=token)
+        access_token.scoped_teams = [team_id]
+        access_token.save(update_fields=["scoped_teams"])
+        Team.objects.filter(id=team_id).delete()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{team_id}/update_service",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert res.status_code == 404
+
+    def test_update_service_invalid_id_returns_400(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources/not-a-number/update_service",
+            data={"service_id": "analytics"},
+            token=token,
+        )
+        assert res.status_code == 400
+
+    def test_update_service_unknown_service_returns_400(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={"service_id": "nonexistent_service"},
+            token=token,
+        )
+        assert res.status_code == 400
+        assert res.json()["error"]["code"] == "unknown_service"
+
+    def test_update_service_defaults_service_id_to_analytics(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={},
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["service_id"] == "analytics"
+
+    def test_update_service_persists_service_id(self):
+        token = self._get_bearer_token()
+        self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={"service_id": "pay_as_you_go"},
+            token=token,
+        )
+        res = self._get_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}",
+            token=token,
+        )
+        assert res.json()["service_id"] == "pay_as_you_go"

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -674,6 +674,85 @@ def provisioning_resources_create(request: Request) -> Response:
 
 
 # ---------------------------------------------------------------------------
+# POST /provisioning/resources/:id/update_service
+# ---------------------------------------------------------------------------
+
+
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+def provisioning_update_service(request: Request, resource_id: str) -> Response:
+    auth_error, user, access_token = _authenticate_bearer(request)
+    if auth_error:
+        return auth_error
+
+    error = verify_stripe_signature(request)
+    if error:
+        return error
+    if error := verify_api_version(request):
+        return error
+
+    scoped_teams = access_token.scoped_teams or []
+
+    try:
+        team_id = int(resource_id)
+    except (ValueError, TypeError):
+        return _error_response("invalid_resource_id", "Invalid resource ID", resource_id=resource_id)
+
+    if team_id not in scoped_teams:
+        return _error_response(
+            "forbidden", "Resource not accessible with this token", resource_id=resource_id, status=403
+        )
+
+    try:
+        team = Team.objects.get(id=team_id)
+    except Team.DoesNotExist:
+        return _error_response("not_found", "Resource not found", resource_id=resource_id, status=404)
+
+    service_id = request.data.get("service_id", "")
+    if service_id and service_id not in VALID_SERVICE_IDS:
+        return _error_response("unknown_service", f"Unknown service_id: {service_id}", resource_id=resource_id)
+
+    resolved_service_id = service_id or ANALYTICS_SERVICE_ID
+    cache.set(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}", resolved_service_id, timeout=None)
+
+    payment_credentials = request.data.get("payment_credentials")
+    if payment_credentials:
+        logger.info(
+            "agentic_provisioning.update_service.payment_credentials_received",
+            team_id=team_id,
+            credential_type=payment_credentials.get("type"),
+            has_token=bool(payment_credentials.get("stripe_payment_token")),
+        )
+        posthoganalytics.capture(
+            "agentic_provisioning update_service payment credentials",
+            distinct_id="agentic_provisioning_system",
+            properties={
+                "team_id": team_id,
+                "credential_type": payment_credentials.get("type"),
+                "has_token": bool(payment_credentials.get("stripe_payment_token")),
+            },
+        )
+
+    region = get_instance_region() or "US"
+    host = _region_to_host(region)
+
+    return Response(
+        {
+            "status": "complete",
+            "id": resource_id,
+            "service_id": resolved_service_id,
+            "complete": {
+                "access_configuration": {
+                    "api_key": team.api_token,
+                    "host": host,
+                },
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # GET /provisioning/resources/:id
 # ---------------------------------------------------------------------------
 

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -295,6 +295,11 @@ urlpatterns: list[Any] = [
         name="agentic_provisioning_rotate_credentials",
     ),
     path(
+        "api/agentic/provisioning/resources/<str:resource_id>/update_service",
+        csrf_exempt(agentic_provisioning_views.provisioning_update_service),
+        name="agentic_provisioning_update_service",
+    ),
+    path(
         "api/agentic/provisioning/resources/<str:resource_id>",
         csrf_exempt(agentic_provisioning_views.provisioning_resource_detail),
         name="agentic_provisioning_resource_detail",


### PR DESCRIPTION
## Problem

When users run `stripe projects upgrade posthog/analytics`, Stripe collects payment and then calls `POST /provisioning/resources/:id/update_service` back to PostHog. This endpoint didn't exist, causing the upgrade flow to fail with a 404 (`updateService failed with status 404`).

## Changes

- Add `provisioning_update_service` view handling `POST /provisioning/resources/:id/update_service`
- Register URL route in `ee/urls.py`
- Add test coverage (10 test cases)

The endpoint follows the same auth/validation patterns as existing provisioning endpoints. It accepts `service_id` and `payment_credentials` (SPT token). The SPT is logged for now - billing service integration to actually use the `default_shared_payment_token` on Stripe subscriptions will follow.

## How did you test this code?

- Unit tests in `ee/api/agentic_provisioning/test/test_update_service.py`
- Tests couldn't run locally due to missing `sqlx` binary (environment issue affecting all agentic provisioning tests), but syntax and lint pass
- Will need to test with `stripe projects upgrade posthog/analytics` end-to-end once deployed

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code. Based on the APP 0.1d spec for `update_service` and existing endpoint patterns in the codebase.