### PR TITLE
chore: simplify Stripe service catalog to free-only

### DIFF
--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -66,14 +66,14 @@ class TestProvisioningResources(StripeProvisioningTestBase):
         token = self._get_bearer_token()
         self._post_signed_with_bearer(
             "/api/agentic/provisioning/resources",
-            data={"service_id": "pay_as_you_go"},
+            data={"service_id": "analytics"},
             token=token,
         )
         res = self._get_signed_with_bearer(
             f"/api/agentic/provisioning/resources/{self.team.id}",
             token=token,
         )
-        assert res.json()["service_id"] == "pay_as_you_go"
+        assert res.json()["service_id"] == "analytics"
 
     def test_get_resource_defaults_service_id_without_create(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_rotate_credentials.py
+++ b/ee/api/agentic_provisioning/test/test_rotate_credentials.py
@@ -66,14 +66,14 @@ class TestProvisioningRotateCredentials(StripeProvisioningTestBase):
         token = self._get_bearer_token()
         self._post_signed_with_bearer(
             "/api/agentic/provisioning/resources",
-            data={"service_id": "pay_as_you_go"},
+            data={"service_id": "analytics"},
             token=token,
         )
         res = self._post_signed_with_bearer(
             f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
             token=token,
         )
-        assert res.json()["service_id"] == "pay_as_you_go"
+        assert res.json()["service_id"] == "analytics"
 
     def test_rotate_defaults_service_id_to_posthog(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_services.py
+++ b/ee/api/agentic_provisioning/test/test_services.py
@@ -65,37 +65,19 @@ def _mock_cache_fresh(services):
 class TestProvisioningServices(StripeProvisioningTestBase):
     @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
-    def test_returns_three_services(self, mock_cache, mock_get):
+    def test_returns_single_service(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         data = res.json()
         services = data["data"]
-        assert len(services) == 3
+        assert len(services) == 1
         assert data["next_cursor"] == ""
-
-    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
-    def test_free_plan(self, mock_cache, mock_get):
-        res = self._get_signed("/api/agentic/provisioning/services")
-        free = res.json()["data"][0]
-        assert free["id"] == "free"
-        assert free["kind"] == "plan"
-        assert free["pricing"]["type"] == "free"
-
-    @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
-    @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
-    def test_pay_as_you_go_plan(self, mock_cache, mock_get):
-        res = self._get_signed("/api/agentic/provisioning/services")
-        paid = res.json()["data"][1]
-        assert paid["id"] == "pay_as_you_go"
-        assert paid["kind"] == "plan"
-        assert paid["pricing"]["type"] == "paid"
 
     @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
     def test_analytics_deployable_description_from_billing(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
-        analytics = res.json()["data"][2]
+        analytics = res.json()["data"][0]
         assert analytics["id"] == "analytics"
         assert analytics["kind"] == "deployable"
         assert "product analytics" in analytics["description"]
@@ -104,16 +86,10 @@ class TestProvisioningServices(StripeProvisioningTestBase):
 
     @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
-    def test_analytics_deployable_structure(self, mock_cache, mock_get):
+    def test_analytics_deployable_is_free(self, mock_cache, mock_get):
         res = self._get_signed("/api/agentic/provisioning/services")
-        analytics = res.json()["data"][2]
-        assert analytics["pricing"]["type"] == "component"
-        options = analytics["pricing"]["component"]["options"]
-        assert len(options) == 2
-        assert options[0]["parent_service_ids"] == ["free"]
-        assert options[0]["type"] == "free"
-        assert options[1]["parent_service_ids"] == ["pay_as_you_go"]
-        assert options[1]["type"] == "paid"
+        analytics = res.json()["data"][0]
+        assert analytics["pricing"]["type"] == "free"
 
     @patch("ee.api.agentic_provisioning.views.requests.get")
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)
@@ -122,10 +98,9 @@ class TestProvisioningServices(StripeProvisioningTestBase):
         res = self._get_signed("/api/agentic/provisioning/services")
         assert res.status_code == 200
         data = res.json()["data"]
-        assert len(data) == 3
-        assert data[0]["id"] == "free"
-        assert data[2]["id"] == "analytics"
-        assert "PostHog" in data[2]["description"]
+        assert len(data) == 1
+        assert data[0]["id"] == "analytics"
+        assert "PostHog" in data[0]["description"]
 
     @patch("ee.api.agentic_provisioning.views.requests.get", return_value=_mock_billing_response())
     @patch("ee.api.agentic_provisioning.views.cache", new_callable=_mock_cache_empty)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -58,15 +58,11 @@ ACCESS_TOKEN_EXPIRY_SECONDS = 365 * 24 * 3600
 
 
 # ---------------------------------------------------------------------------
-# Service catalog — two plans (free + pay_as_you_go) and one deployable
-# (analytics). The deployable provisions a PostHog project and defaults to the
-# free plan. When pay_as_you_go is selected, Stripe collects SPT for
-# usage-based billing across all products.
+# Service catalog — a single free deployable (analytics) that provisions a
+# PostHog project. Paid plan (pay_as_you_go with SPT) will be re-added once
+# billing integration is complete.
 # ---------------------------------------------------------------------------
 
-FREE_PLAN_ID = "free"
-PAY_AS_YOU_GO_PLAN_ID = "pay_as_you_go"
-USAGE_BASED_PRICING = {"type": "freeform", "freeform": "Usage-based pricing"}
 ANALYTICS_SERVICE_ID = "analytics"
 
 ALL_CATEGORIES: list[str] = ["analytics", "feature_flags", "ai"]
@@ -79,26 +75,7 @@ SERVICES_CACHE_STORE_TTL = 86400
 
 _EXCLUDED_PRODUCT_TYPES = {"platform_and_support", "integrations"}
 
-FREE_PLAN_SERVICE: dict[str, Any] = {
-    "id": FREE_PLAN_ID,
-    "description": "Free — generous free tier across all PostHog products, no credit card required.",
-    "categories": ALL_CATEGORIES,
-    "pricing": {"type": "free"},
-    "kind": "plan",
-}
-
-PAY_AS_YOU_GO_PLAN_SERVICE: dict[str, Any] = {
-    "id": PAY_AS_YOU_GO_PLAN_ID,
-    "description": "Pay-as-you-go — usage-based pricing across all PostHog products with no minimum commitment.",
-    "categories": ALL_CATEGORIES,
-    "pricing": {
-        "type": "paid",
-        "paid": USAGE_BASED_PRICING,
-    },
-    "kind": "plan",
-}
-
-_FALLBACK_DESCRIPTION = "PostHog — product analytics, session replay, feature flags, A/B testing, surveys, and more."
+_FALLBACK_DESCRIPTION = "PostHog — product analytics, session replay, realtime destinations, feature flags & experiments, surveys, data warehouse, error tracking, llm analytics, logs, posthog ai, emails, and more."
 
 
 def _build_analytics_service(description: str) -> dict[str, Any]:
@@ -106,22 +83,7 @@ def _build_analytics_service(description: str) -> dict[str, Any]:
         "id": ANALYTICS_SERVICE_ID,
         "description": description,
         "categories": ALL_CATEGORIES,
-        "pricing": {
-            "type": "component",
-            "component": {
-                "options": [
-                    {
-                        "parent_service_ids": [FREE_PLAN_ID],
-                        "type": "free",
-                    },
-                    {
-                        "parent_service_ids": [PAY_AS_YOU_GO_PLAN_ID],
-                        "type": "paid",
-                        "paid": USAGE_BASED_PRICING,
-                    },
-                ]
-            },
-        },
+        "pricing": {"type": "free"},
         "kind": "deployable",
     }
 
@@ -146,11 +108,7 @@ def _fetch_services_from_billing() -> list[dict[str, Any]] | None:
     ]
     description = f"PostHog — {', '.join(n for n in product_names if n).lower()}, and more."
 
-    return [
-        FREE_PLAN_SERVICE,
-        PAY_AS_YOU_GO_PLAN_SERVICE,
-        _build_analytics_service(description),
-    ]
+    return [_build_analytics_service(description)]
 
 
 def _get_services() -> list[dict[str, Any]]:
@@ -173,13 +131,13 @@ def _get_services() -> list[dict[str, Any]]:
         return cached
 
     logger.warning("agentic_provisioning.services.no_cache_fallback")
-    fallback = [FREE_PLAN_SERVICE, PAY_AS_YOU_GO_PLAN_SERVICE, _build_analytics_service(_FALLBACK_DESCRIPTION)]
+    fallback = [_build_analytics_service(_FALLBACK_DESCRIPTION)]
     cache.set(SERVICES_CACHE_KEY, fallback, SERVICES_CACHE_RETRY_TTL)
     cache.set(SERVICES_CACHE_EXPIRES_KEY, now + SERVICES_CACHE_RETRY_TTL, SERVICES_CACHE_RETRY_TTL)
     return fallback
 
 
-VALID_SERVICE_IDS: set[str] = {FREE_PLAN_ID, PAY_AS_YOU_GO_PLAN_ID, ANALYTICS_SERVICE_ID}
+VALID_SERVICE_IDS: set[str] = {ANALYTICS_SERVICE_ID}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Stripe Projects service catalog currently includes a `pay_as_you_go` paid plan and a `free` plan, with the `analytics` deployable as a component of both. When users run `stripe projects upgrade posthog/analytics`, Stripe collects payment and tries to call `update_service` - but the SPT billing integration isn't complete yet, so the upgrade fails.

## Changes

- Remove `free` and `pay_as_you_go` plan services from the catalog
- Simplify `analytics` deployable from a component (with free/paid options) to a simple free service
- Update `VALID_SERVICE_IDS` to only include `analytics`
- Update tests to reflect simplified catalog

The catalog now returns a single service:
```json
{
  "id": "analytics",
  "description": "PostHog - ...",
  "categories": ["analytics", "feature_flags", "ai"],
  "pricing": {"type": "free"},
  "kind": "deployable"
}
```

Plans will be re-added once SPT billing integration is complete (see #51946).

## How did you test this code?

- Updated unit tests in `test_services.py`, `test_resources.py`, `test_rotate_credentials.py`
- Verified syntax and linting pass

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code.