### PR TITLE
fix(dashboard): fixes how overrides are determined on the dashboard for insights

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.test.ts
@@ -1,0 +1,42 @@
+import { DashboardFilter, TileFilters } from '~/queries/schema/schema-general'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
+
+describe('isDashboardFilterEmpty', () => {
+    const emptyCases: Array<[string, DashboardFilter | TileFilters | null | undefined]> = [
+        ['null', null],
+        ['undefined', undefined],
+        ['empty object', {}],
+        ['only explicitDate false', { explicitDate: false }],
+        ['null date fields + explicitDate false', { date_from: null, date_to: null, explicitDate: false }],
+        ['empty properties array', { properties: [] }],
+    ]
+
+    test.each(emptyCases)('returns true for %s', (_, filter) => {
+        expect(isDashboardFilterEmpty(filter)).toBe(true)
+    })
+
+    const nonEmptyCases: Array<[string, DashboardFilter | TileFilters]> = [
+        ['date_from set', { date_from: '-7d' }],
+        ['date_to set', { date_to: '2024-01-01' }],
+        [
+            'non-empty properties',
+            {
+                properties: [
+                    {
+                        key: 'email',
+                        type: PropertyFilterType.Person,
+                        value: 'foo',
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+        ],
+        ['breakdown_filter set', { breakdown_filter: { breakdown: 'browser' } }],
+    ]
+
+    test.each(nonEmptyCases)('returns false for %s', (_, filter) => {
+        expect(isDashboardFilterEmpty(filter)).toBe(false)
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
+++ b/frontend/src/scenes/dashboard/dashboardFilterEmpty.ts
@@ -1,0 +1,12 @@
+import { DashboardFilter, TileFilters } from '~/queries/schema/schema-general'
+
+/** True when the filter carries no meaningful constraint (dashboard / tile override payloads). */
+export function isDashboardFilterEmpty(filter: DashboardFilter | TileFilters | null | undefined): boolean {
+    return (
+        !filter ||
+        (filter.date_from == null &&
+            filter.date_to == null &&
+            (filter.properties == null || (Array.isArray(filter.properties) && filter.properties.length === 0)) &&
+            filter.breakdown_filter == null)
+    )
+}

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -21,6 +21,7 @@ import { isEmptyObject, isObject, objectsEqual } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { InsightEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { isDashboardFilterEmpty } from 'scenes/dashboard/dashboardFilterEmpty'
 import { DashboardLoadAction, dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -507,9 +508,9 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 tileFiltersOverride: TileFilters | null
             ) => {
                 return (
-                    (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
+                    !isDashboardFilterEmpty(filtersOverride) ||
                     (isObject(variablesOverride) && !isEmptyObject(variablesOverride)) ||
-                    (isObject(tileFiltersOverride) && !isEmptyObject(tileFiltersOverride))
+                    !isDashboardFilterEmpty(tileFiltersOverride)
                 )
             },
         ],

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -9,6 +9,7 @@ import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { isEmptyObject, isObject } from 'lib/utils'
 import { InsightEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { isDashboardFilterEmpty } from 'scenes/dashboard/dashboardFilterEmpty'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { createEmptyInsight, insightLogic } from 'scenes/insights/insightLogic'
 import { insightLogicType } from 'scenes/insights/insightLogicType'
@@ -49,16 +50,6 @@ export type InsightId = InsightShortId | typeof NEW_INSIGHT | null
 
 export interface InsightSceneLogicProps {
     tabId?: string
-}
-
-function isDashboardFilterEmpty(filter: DashboardFilter | null): boolean {
-    return (
-        !filter ||
-        (filter.date_from == null &&
-            filter.date_to == null &&
-            (filter.properties == null || (Array.isArray(filter.properties) && filter.properties.length === 0)) &&
-            filter.breakdown_filter == null)
-    )
 }
 
 function normalizeItemId(itemId: string | undefined): string | number | null {
@@ -376,9 +367,9 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
         hasOverrides: [
             (s) => [s.filtersOverride, s.variablesOverride, s.tileFiltersOverride],
             (filtersOverride, variablesOverride, tileFiltersOverride) =>
-                (isObject(filtersOverride) && !isEmptyObject(filtersOverride)) ||
+                !isDashboardFilterEmpty(filtersOverride) ||
                 (isObject(variablesOverride) && !isEmptyObject(variablesOverride)) ||
-                (isObject(tileFiltersOverride) && !isEmptyObject(tileFiltersOverride)),
+                !isDashboardFilterEmpty(tileFiltersOverride),
         ],
     }),
     sharedListeners(({ actions, values }) => ({


### PR DESCRIPTION
## Problem
Insight tiles on dashboards could show **“Discard overrides to edit the insight”** (e.g. on the legend) even when the dashboard date control looked like there was **no meaningful override**. That was confusing next to copy like **“No date range override.”**

### Root cause
`hasOverrides` in `insightLogic` (and the matching logic in `insightSceneLogic`) treated any non-`{}` filter object as an override using **`!isEmptyObject()`**. Tile/dashboard filter payloads can still carry keys with **no real constraint** (e.g. `{ explicitDate: false }`, or null-ish date fields). Those objects are **semantically empty** but not `Object.keys`-empty, so we incorrectly set `hasOverrides` and blocked editing affordances.

## Changes

- Add `isDashboardFilterEmpty` in `frontend/src/scenes/dashboard/dashboardFilterEmpty.ts`, matching how insight URL state already defines “empty” filters.
- Use it for `hasOverrides` in `insightLogic` and for `hasOverrides` + URL `setSceneState` normalization in `insightSceneLogic`.
- Keep the helper under **dashboard** (filter payload semantics), with insights importing it where needed.


Before:
Visit local url `http://localhost:8010/project/1/dashboard/1?query_filters=%7B%22date_from%22%3Anull%2C%22date_to%22%3Anull%2C%22explicitDate%22%3Afalse%7D%20`

- Create query filters by setting a date range override for the page, and then removing them. 
- Observe that after removing the query filters, we "null" the fields in the query filters
- Observe that even with no overrides for the dashboard or tile set, the tooltips still are indicating that theres filters enabled, and we cant update the legend status
<img width="2670" height="1126" alt="CleanShot 2026-03-23 at 11 08 27@2x" src="https://github.com/user-attachments/assets/5b49e242-df02-44dd-9694-558d9ae063cd" />


After:
With "null" filters enabled, we dont see the tooltip.
<img width="2370" height="1578" alt="CleanShot 2026-03-23 at 11 10 05@2x" src="https://github.com/user-attachments/assets/c6371807-112a-48f4-8d4b-57ee0e5d2d9e" />

Observe when dashboard filters are enabled, its shows disabled correctly
<img width="2772" height="1428" alt="CleanShot 2026-03-23 at 11 10 25@2x" src="https://github.com/user-attachments/assets/98d539ee-97e3-4f0c-827f-1c86834cfc27" />

Observe when insight overrides are enabled, it shows disabled correctly
<img width="2860" height="1088" alt="CleanShot 2026-03-23 at 11 10 50@2x" src="https://github.com/user-attachments/assets/7a3f10cd-fde1-47cd-96a9-5ce52d5c051d" />



## How did you test this code?

Locally.

## Publish to changelog?

No.