### PR TITLE
chore(mcp): enabled insights create saved property

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -808,7 +808,7 @@ export class ApiClient {
 
                 return this.fetchJson<Schemas.Insight>(`${this.baseUrl}/api/projects/${projectId}/insights/`, {
                     method: 'POST',
-                    body: JSON.stringify(validatedInput),
+                    body: JSON.stringify({ ...validatedInput, saved: true }),
                 })
             },
 

--- a/services/mcp/tests/tools/insights.integration.test.ts
+++ b/services/mcp/tests/tools/insights.integration.test.ts
@@ -62,6 +62,7 @@ describe('Insights', { concurrent: false }, () => {
             const insightData = parseToolResponse(result)
             expect(insightData.id).toBeTruthy()
             expect(insightData.name).toBe(params.data.name)
+            expect(insightData.saved).toBe(true)
             expect(insightData.url).toContain('/insights/')
 
             createdResources.insights.push(insightData.id)


### PR DESCRIPTION
## Problem

  Insights created or updated via the MCP server don't appear in the default Insights list view because the
  `saved` field is not exposed in the MCP tool schemas. The Django API defaults `saved` to `false`, and since
  the MCP create/update schemas don't include the field, there's no way for the LLM to set it. Users have to
  manually click "Save" in the UI for the insight to appear in the list.

  Closes [#41089](https://github.com/PostHog/posthog/issues/41089)

  ## Changes

  Added `saved` field to the MCP insight Zod schemas in `services/mcp/src/schema/insights.ts`:

  - `CreateInsightInputSchema`: `saved: z.boolean().default(true)` — insights created via MCP are saved by
  default, matching UI behavior
  - `UpdateInsightInputSchema`: `saved: z.boolean().optional()` — allows explicitly toggling the saved state

  No backend changes needed — the Django `InsightSerializer` already accepts `saved` as a writable field.

  ## How did you test this code?

  Manual verification: create an insight via the MCP `insight-create-from-query` tool and confirm `saved: true`
   in the response and the insight appears in the UI Insights list.

  ## Publish to changelog?

  No

  ## Docs update

  No docs update needed.