### PR TITLE
fix(ux): better nav tabs, nav collapsible chevron now visible

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -209,8 +209,8 @@ export function Nav(): JSX.Element {
                     orientation={isLayoutNavCollapsed ? 'vertical' : 'horizontal'}
                 >
                     {!isLayoutNavCollapsed && (
-                        <>
-                            <Tabs.List className="relative flex items-center gap-1 shrink-0 z-0 pb-2 pt-1 px-2">
+                        <div className="p-1">
+                            <Tabs.List className="relative flex items-center gap-1 shrink-0 z-0 p-1 rounded-lg bg-(--color-bg-fill-highlight-50) dark:bg-surface-primary">
                                 {TAB_CONFIG.map((tab) => (
                                     <Tabs.Tab
                                         key={tab.id}
@@ -218,7 +218,7 @@ export function Nav(): JSX.Element {
                                         render={(props) => (
                                             <ButtonPrimitive
                                                 {...props}
-                                                className="group data-[composite-item-active]:bg-fill-button-tertiary-active w-1/2 justify-center"
+                                                className="group data-[composite-item-active]:bg-surface-tertiary w-1/2 justify-center"
                                                 data-attr={`nav-tab-${tab.id}`}
                                             >
                                                 <span
@@ -246,11 +246,7 @@ export function Nav(): JSX.Element {
                                     />
                                 ))}
                             </Tabs.List>
-
-                            <div className="px-2">
-                                <div className="h-px bg-border-primary " />
-                            </div>
-                        </>
+                        </div>
                     )}
 
                     <div className="flex-1 overflow-hidden relative">

--- a/frontend/src/lib/ui/Collapsible/Collapsible.tsx
+++ b/frontend/src/lib/ui/Collapsible/Collapsible.tsx
@@ -81,7 +81,10 @@ const CollapsibleTrigger = forwardRef<HTMLButtonElement, CollapsibleTriggerProps
                         {children}
                     </Label>
                     {!hideChevron && (
-                        <IconChevronRight className="size-3 text-tertiary opacity-0 group-hover:opacity-100 transition-all duration-150 group-data-[panel-open]:rotate-90" />
+                        <IconChevronRight
+                            aria-hidden={true}
+                            className="size-3 text-tertiary opacity-50 group-hover:opacity-100 transition-all duration-150 group-data-[panel-open]:rotate-90"
+                        />
                     )}
                 </CollapsiblePrimitiveTrigger>
             )


### PR DESCRIPTION
## Problem
![2026-03-23 15 10 51](https://github.com/user-attachments/assets/f38440af-9393-4e69-8207-5d3b1664da44)


* Nav tabs were hard to distinguish as two clickable options IMO
* Nav collapsible triggers chevrons were hidden until hovered, which made it ambiguous that these were clickable.

## Changes

![2026-03-23 15 09 53](https://github.com/user-attachments/assets/00273d81-17b1-4b4f-aec5-fe133bc1c1a8)

* New nav tab design
* nav collapsible triggers are not hidden, but sit at 50% opacity + aria label added to icon

## How did you test this code?
Locally

## Publish to changelog?
No