### PR TITLE
feat: New result for BigQuery destination tests (SKIPPED)

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportConfiguration.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
-import { IconCheckCircle, IconPlus, IconX } from '@posthog/icons'
+import { IconCheckCircle, IconPlus, IconX, IconInfo } from '@posthog/icons'
 import { LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { EventSelect } from 'lib/components/EventSelect/EventSelect'
@@ -437,6 +437,8 @@ export function BatchExportConfigurationTests({
 
         return step.result.status === 'Passed' ? (
             <IconCheckCircle className="text-green-500 shrink-0" />
+        ) : step.result.status === 'Skipped' ? (
+            <IconInfo className="text-yellow-500 shrink-0" />
         ) : (
             <IconX className="text-red-500 shrink-0" />
         )
@@ -494,7 +496,15 @@ export function BatchExportConfigurationTests({
                                     </LemonLabel>
                                     {step.result && (
                                         <div className="mt-2">
-                                            <LemonBanner type={step.result.status === 'Passed' ? 'success' : 'error'}>
+                                            <LemonBanner
+                                                type={
+                                                    step.result.status === 'Passed'
+                                                        ? 'success'
+                                                        : step.result.status === 'Skipped'
+                                                          ? 'info'
+                                                          : 'error'
+                                                }
+                                            >
                                                 {step.result.status === 'Passed' ? 'Success' : `${step.result.message}`}
                                             </LemonBanner>
                                         </div>

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigurationLogic.tsx
@@ -1111,7 +1111,7 @@ export const batchExportConfigurationLogic = kea<batchExportConfigurationLogicTy
 
                 if (
                     step.result &&
-                    step.result.status === 'Passed' &&
+                    (step.result.status === 'Passed' || step.result.status === 'Skipped') &&
                     index < values.batchExportConfigTest.steps.length - 1
                 ) {
                     actions.runBatchExportConfigTestStep(index + 1)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5774,7 +5774,7 @@ export type BatchExportConfiguration = {
     latest_runs?: BatchExportRun[]
 }
 
-export type BatchExportConfigurationTestStepStatus = 'Passed' | 'Failed'
+export type BatchExportConfigurationTestStepStatus = 'Passed' | 'Failed' | 'Skipped'
 
 export type BatchExportConfigurationTestStepResult = {
     status: BatchExportConfigurationTestStepStatus

--- a/products/batch_exports/backend/api/destination_tests/base.py
+++ b/products/batch_exports/backend/api/destination_tests/base.py
@@ -9,6 +9,7 @@ from asgiref.sync import async_to_sync
 class Status(enum.StrEnum):
     PASSED = "Passed"
     FAILED = "Failed"
+    SKIPPED = "Skipped"
 
 
 DestinationTestStepResultDict = dict[str, str | None]

--- a/products/batch_exports/backend/api/destination_tests/bigquery.py
+++ b/products/batch_exports/backend/api/destination_tests/bigquery.py
@@ -130,8 +130,13 @@ class BigQueryVerifyServiceAccountOwnershipTestStep(DestinationTestStep):
 
     def _is_configured(self) -> bool:
         """Ensure required configuration parameters are set."""
-        if self.project_id is None or self.organization_id is None:
+        if self.project_id is None:
             return False
+
+        if self.integration is not None and not self.integration.has_key() and self.organization_id is None:
+            # Only when we actually need to verify ownership is organization_id required
+            return False
+
         return True
 
     async def _run_step(self) -> DestinationTestStepResult:

--- a/products/batch_exports/backend/api/destination_tests/bigquery.py
+++ b/products/batch_exports/backend/api/destination_tests/bigquery.py
@@ -67,13 +67,16 @@ class BigQueryImpersonateServiceAccountTestStep(DestinationTestStep):
 
     def _is_configured(self) -> bool:
         """Ensure required configuration parameters are set."""
-        if self.project_id is None or self.integration is None:
+        if self.project_id is None:
             return False
         return True
 
     async def _run_step(self) -> DestinationTestStepResult:
         """Run this test step."""
-        assert self.integration is not None
+        if self.integration is None or self.integration.has_key():
+            return DestinationTestStepResult(
+                status=Status.SKIPPED, message="Using credentials without impersonation, skipping test"
+            )
 
         try:
             their_credentials = impersonate_service_account(self.integration)
@@ -130,13 +133,16 @@ class BigQueryVerifyServiceAccountOwnershipTestStep(DestinationTestStep):
 
     def _is_configured(self) -> bool:
         """Ensure required configuration parameters are set."""
-        if self.project_id is None or self.integration is None or self.organization_id is None:
+        if self.project_id is None or self.organization_id is None:
             return False
         return True
 
     async def _run_step(self) -> DestinationTestStepResult:
         """Run this test step."""
-        assert self.integration is not None
+        if self.integration is None or self.integration.has_key():
+            return DestinationTestStepResult(
+                status=Status.SKIPPED, message="Using credentials without impersonation, ownership is assumed"
+            )
 
         service_account_email = self.integration.service_account_email
 
@@ -446,23 +452,13 @@ class BigQueryDestinationTest(DestinationTest):
     @property
     def steps(self) -> collections.abc.Sequence[DestinationTestStep]:
         """Sequence of test steps that make up this destination test."""
-        if self.integration is not None and self.service_account_info is None:
-            # If no service account information is set, then that's the same as
-            # asserting the integration has no keys, so we can check impersonation and
-            # ownership.
-            base_steps: tuple[DestinationTestStep, ...] = (
-                BigQueryImpersonateServiceAccountTestStep(project_id=self.project_id, integration=self.integration),
-                BigQueryVerifyServiceAccountOwnershipTestStep(
-                    project_id=self.project_id,
-                    integration=self.integration,
-                    organization_id=str(self.integration.integration.team.organization_id),
-                ),
-            )
-        else:
-            base_steps = ()
-
         return [
-            *base_steps,
+            BigQueryImpersonateServiceAccountTestStep(project_id=self.project_id, integration=self.integration),
+            BigQueryVerifyServiceAccountOwnershipTestStep(
+                project_id=self.project_id,
+                integration=self.integration,
+                organization_id=str(self.integration.integration.team.organization_id) if self.integration else None,
+            ),
             BigQueryProjectTestStep(
                 project_id=self.project_id,
                 integration=self.integration,

--- a/products/batch_exports/backend/api/destination_tests/bigquery.py
+++ b/products/batch_exports/backend/api/destination_tests/bigquery.py
@@ -1,6 +1,7 @@
 import typing
 import collections.abc
 
+import google.auth.transport.requests
 from google.api_core.exceptions import NotFound, PermissionDenied
 from google.cloud import bigquery, iam_admin_v1
 
@@ -80,12 +81,8 @@ class BigQueryImpersonateServiceAccountTestStep(DestinationTestStep):
 
         try:
             their_credentials = impersonate_service_account(self.integration)
-            client = bigquery.Client(
-                project=self.integration.project_id,
-                credentials=their_credentials,
-            )
             # This triggers an actual credential refresh
-            list(client.query("SELECT 1").result())
+            their_credentials.refresh(google.auth.transport.requests.Request())
 
         except NotFound:
             service_account_email = self.integration.service_account_email
@@ -353,7 +350,6 @@ class BigQueryTableTestStep(DestinationTestStep):
     async def _run_step(self) -> DestinationTestStepResult:
         """Run this test step."""
         from google.api_core.exceptions import BadRequest
-        from google.cloud import bigquery
         from google.cloud.exceptions import NotFound
 
         client = get_client(self.project_id, self.integration, self.service_account_info)

--- a/products/batch_exports/backend/tests/api/destination_tests/test_bigquery_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_bigquery_destination_tests.py
@@ -272,6 +272,19 @@ async def test_bigquery_impersonate_service_account_test_step_with_unknown_accou
     assert result.message is not None
 
 
+@pytest.mark.parametrize("integration", ["key_file", None], indirect=True)
+async def test_bigquery_impersonate_service_account_test_step_with_no_impersonation(project_id, integration):
+    test_step = BigQueryImpersonateServiceAccountTestStep(
+        project_id=project_id,
+        integration=integration,
+    )
+    result = await test_step.run()
+
+    assert result.status == Status.SKIPPED
+    assert result.message is not None
+    assert "Using credentials without impersonation" in result.message
+
+
 @pytest.mark.parametrize("integration", ["impersonated"], indirect=True)
 async def test_bigquery_verify_service_account_ownership_test_step(project_id, integration, aorganization):
     test_step = BigQueryVerifyServiceAccountOwnershipTestStep(
@@ -299,6 +312,22 @@ async def test_bigquery_verify_service_account_ownership_test_step_with_garbage_
 
     assert result.status == Status.FAILED
     assert result.message is not None
+
+
+@pytest.mark.parametrize("integration", ["key_file", None], indirect=True)
+async def test_bigquery_verify_service_account_ownership_test_step_with_no_impersonation(
+    project_id, integration, aorganization
+):
+    test_step = BigQueryVerifyServiceAccountOwnershipTestStep(
+        project_id=project_id,
+        integration=integration,
+        organization_id=str(aorganization.id),
+    )
+    result = await test_step.run()
+
+    assert result.status == Status.SKIPPED, result.message
+    assert result.message is not None
+    assert "Using credentials without impersonation" in result.message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

BigQuery destination steps contain a couple of tests that only make sense when impersonating an account. The problem is that it doesn't make sense to fail these when not impersonating, as nothing has gone wrong. But excluding them causes the frontend to not display them, which looks confusing. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Include all bigquery destination steps, regardless of integration status
* Skip tests that require impersonation when impersonation is not configured

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

New unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
