### PR TITLE
fix(llma): fix trace-not-found when clicking view trace from sentiment tab

### DIFF
--- a/products/llm_analytics/backend/queries/sentiment_generations.sql
+++ b/products/llm_analytics/backend/queries/sentiment_generations.sql
@@ -16,7 +16,8 @@ SELECT
     argMax(ai_input, ts) as ai_input,
     argMax(model, ts) as model,
     argMax(did, ts) as distinct_id,
-    max(ts) as timestamp
+    max(ts) as timestamp,
+    min(ts) as created_at
 FROM (
     SELECT
         uuid,

--- a/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
+++ b/products/llm_analytics/frontend/tabs/LLMAnalyticsSentiment.tsx
@@ -15,7 +15,7 @@ import { llmAnalyticsSharedLogic } from '../llmAnalyticsSharedLogic'
 import { extractContentText, formatScore } from '../sentimentUtils'
 import type { SentimentLabel } from '../sentimentUtils'
 import type { CompatMessage } from '../types'
-import { normalizeMessages } from '../utils'
+import { getTraceTimestamp, normalizeMessages } from '../utils'
 import type { GroupedSentimentCard, SentimentCard, SentimentFeedbackLabel } from './llmAnalyticsSentimentLogic'
 import { CLASSIFIER_WINDOW, llmAnalyticsSentimentLogic, SentimentFilterLabel } from './llmAnalyticsSentimentLogic'
 
@@ -155,7 +155,7 @@ function SentimentCardRow({
     traceCount: number
 }): JSX.Element {
     const { generation, messageIndex, sentiment } = card
-    const { uuid, traceId, aiInput, timestamp } = generation
+    const { uuid, traceId, aiInput, timestamp, createdAt } = generation
     const { toggleCardExpanded, trackTraceClicked } = useActions(llmAnalyticsSentimentLogic)
 
     const targetMessage = getMessageAtIndex(aiInput, messageIndex)
@@ -204,7 +204,7 @@ function SentimentCardRow({
                             <Link
                                 to={urls.llmAnalyticsTrace(traceId, {
                                     event: uuid,
-                                    timestamp,
+                                    timestamp: getTraceTimestamp(createdAt),
                                     msg: String(messageIndex),
                                 })}
                                 className="text-xs ml-1"

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsSentimentLogic.ts
@@ -26,6 +26,8 @@ export interface SentimentGeneration {
     model: string | null
     distinctId: string
     timestamp: string
+    /** Earliest event in the trace — used for trace deep-links (matches trace createdAt) */
+    createdAt: string
 }
 
 /** A generation paired with the index of the best matching message for display */
@@ -182,6 +184,7 @@ async function fetchGenerations(values: GenerationsQueryValues, cursor: string |
         model: row[3] as string | null,
         distinctId: row[4] as string,
         timestamp: row[5] as string,
+        createdAt: row[6] as string,
     }))
 }
 


### PR DESCRIPTION
## Problem

Clicking "View trace" from the sentiment tab frequently shows "Trace not found." Removing the `timestamp` URL parameter makes the trace load correctly.

Two issues in how the sentiment tab constructs the trace deep-link:

1. **Timezone mismatch**: The raw ClickHouse timestamp (UTC, no timezone indicator) was passed directly. `dayjs()` treated it as local time and the backend's `relative_date_parse` treated it as project timezone, shifting the lookup window by the timezone offset.
2. **Wrong timestamp reference**: The sentiment query used `max(ts)` (latest event in trace) for the link, but the trace query's `_map_results` filter checks `first_timestamp >= date_from`. Since `first_timestamp` (earliest event) is always before `max(ts)`, the trace was filtered out.

## Changes

- Added `min(ts) as created_at` to the sentiment generations SQL query to capture the trace's first event timestamp
- Changed the "View trace" link to use `getTraceTimestamp(createdAt)` instead of the raw `timestamp`
- This matches the pattern used by the traces table, sessions scene, and all other trace link callers in LLM analytics

## How did you test this code?

Verified the fix aligns with the existing `getTraceTimestamp` pattern used across all other trace link callers (traces table, sessions scene, trace scene tree navigation). The function properly converts to UTC with "Z" suffix and subtracts a 5-minute buffer.

## Publish to changelog?

No