### PR TITLE
fix(tracing): add assumeNotNull to trace_id filter

### DIFF
--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -178,7 +178,7 @@ class TraceSpansQueryRunner(AnalyticsQueryRunner[TraceSpansQueryResponse]):
         if self.query.traceId:
             exprs.append(
                 parse_expr(
-                    "trace_id = base64Encode(unhex({traceId}))",
+                    "trace_id = assumeNotNull(base64Encode(unhex({traceId})))",
                     placeholders={
                         "traceId": ast.Constant(value=self.query.traceId),
                     },


### PR DESCRIPTION

## Problem
the nullability was breaking the trace_id index - add assumeNotNull here

## Changes

assumeNotNull here assured that the comparison isn't wrapped in "ifNull" which breaks clickhouse's fragile query analyser

## How did you test this code?
locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
