### PR TITLE
chore(billing): migrate Salesforce to OAuth

### DIFF
--- a/ee/billing/salesforce_enrichment/salesforce_client.py
+++ b/ee/billing/salesforce_enrichment/salesforce_client.py
@@ -1,23 +1,67 @@
 from django.conf import settings
 
+import requests
+from requests.adapters import HTTPAdapter
 from simple_salesforce import Salesforce
+from urllib3.util.retry import Retry
+
+
+def _build_retry_session() -> requests.Session:
+    """Build a requests session with retry on transient errors."""
+    retry = Retry(
+        total=3,
+        backoff_factor=2,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET", "POST", "PATCH", "PUT", "DELETE"],
+    )
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _get_client_credentials_token() -> tuple[str, str]:
+    """Exchange OAuth client credentials for an access token.
+
+    Returns (access_token, instance_url) from the Salesforce token endpoint.
+    """
+    response = requests.post(
+        f"https://{settings.SALESFORCE_INTERNAL_DOMAIN}/services/oauth2/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": settings.SALESFORCE_INTERNAL_CONSUMER_KEY,
+            "client_secret": settings.SALESFORCE_INTERNAL_CONSUMER_SECRET,
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload["access_token"], payload["instance_url"]
 
 
 def get_salesforce_client() -> Salesforce:
-    """Create and return a Salesforce client with validated credentials."""
-    username = settings.SALESFORCE_USERNAME
-    password = settings.SALESFORCE_PASSWORD
-    security_token = settings.SALESFORCE_SECURITY_TOKEN
+    """Create and return a Salesforce client.
 
-    missing = []
-    if not username:
-        missing.append("SALESFORCE_USERNAME")
-    if not password:
-        missing.append("SALESFORCE_PASSWORD")
-    if not security_token:
-        missing.append("SALESFORCE_SECURITY_TOKEN")
+    Prefers OAuth Client Credentials flow when SF_INTERNAL_CONSUMER_KEY and
+    SF_INTERNAL_CONSUMER_SECRET are set, falling back to legacy username/password
+    auth for backward compatibility during migration.
+    """
+    session = _build_retry_session()
 
-    if missing:
-        raise ValueError(f"Missing Salesforce credentials: {', '.join(missing)}")
+    if settings.SALESFORCE_INTERNAL_CONSUMER_KEY and settings.SALESFORCE_INTERNAL_CONSUMER_SECRET:
+        access_token, instance_url = _get_client_credentials_token()
+        return Salesforce(session_id=access_token, instance_url=instance_url, session=session)
 
-    return Salesforce(username=username, password=password, security_token=security_token)
+    if settings.SALESFORCE_USERNAME and settings.SALESFORCE_PASSWORD and settings.SALESFORCE_SECURITY_TOKEN:
+        return Salesforce(
+            username=settings.SALESFORCE_USERNAME,
+            password=settings.SALESFORCE_PASSWORD,
+            security_token=settings.SALESFORCE_SECURITY_TOKEN,
+            session=session,
+        )
+
+    raise ValueError(
+        "Missing Salesforce credentials. Configure either OAuth client credentials "
+        "(SF_INTERNAL_CONSUMER_KEY, SF_INTERNAL_CONSUMER_SECRET) or legacy auth "
+        "(SF_USERNAME, SF_PASSWORD, SF_SECURITY_TOKEN)."
+    )

--- a/ee/billing/salesforce_enrichment/salesforce_client.py
+++ b/ee/billing/salesforce_enrichment/salesforce_client.py
@@ -21,18 +21,20 @@ def _build_retry_session() -> requests.Session:
     return session
 
 
-def _get_client_credentials_token() -> tuple[str, str]:
+def _get_client_credentials_token(session: requests.Session | None = None) -> tuple[str, str]:
     """Exchange OAuth client credentials for an access token.
 
     Returns (access_token, instance_url) from the Salesforce token endpoint.
     """
-    response = requests.post(
+    _session = session or requests.Session()
+    response = _session.post(
         f"https://{settings.SALESFORCE_INTERNAL_DOMAIN}/services/oauth2/token",
         data={
             "grant_type": "client_credentials",
             "client_id": settings.SALESFORCE_INTERNAL_CONSUMER_KEY,
             "client_secret": settings.SALESFORCE_INTERNAL_CONSUMER_SECRET,
         },
+        timeout=30,
     )
     response.raise_for_status()
     payload = response.json()
@@ -49,7 +51,7 @@ def get_salesforce_client() -> Salesforce:
     session = _build_retry_session()
 
     if settings.SALESFORCE_INTERNAL_CONSUMER_KEY and settings.SALESFORCE_INTERNAL_CONSUMER_SECRET:
-        access_token, instance_url = _get_client_credentials_token()
+        access_token, instance_url = _get_client_credentials_token(session)
         return Salesforce(session_id=access_token, instance_url=instance_url, session=session)
 
     if settings.SALESFORCE_USERNAME and settings.SALESFORCE_PASSWORD and settings.SALESFORCE_SECURITY_TOKEN:

--- a/ee/billing/salesforce_enrichment/salesforce_client.py
+++ b/ee/billing/salesforce_enrichment/salesforce_client.py
@@ -60,8 +60,16 @@ def get_salesforce_client() -> Salesforce:
             session=session,
         )
 
-    raise ValueError(
-        "Missing Salesforce credentials. Configure either OAuth client credentials "
-        "(SF_INTERNAL_CONSUMER_KEY, SF_INTERNAL_CONSUMER_SECRET) or legacy auth "
-        "(SF_USERNAME, SF_PASSWORD, SF_SECURITY_TOKEN)."
-    )
+    missing = []
+    if not settings.SALESFORCE_INTERNAL_CONSUMER_KEY:
+        missing.append("SF_INTERNAL_CONSUMER_KEY")
+    if not settings.SALESFORCE_INTERNAL_CONSUMER_SECRET:
+        missing.append("SF_INTERNAL_CONSUMER_SECRET")
+    if not settings.SALESFORCE_USERNAME:
+        missing.append("SF_USERNAME")
+    if not settings.SALESFORCE_PASSWORD:
+        missing.append("SF_PASSWORD")
+    if not settings.SALESFORCE_SECURITY_TOKEN:
+        missing.append("SF_SECURITY_TOKEN")
+
+    raise ValueError(f"Missing Salesforce credentials: {', '.join(missing)}")

--- a/ee/billing/test/test_salesforce_client.py
+++ b/ee/billing/test/test_salesforce_client.py
@@ -117,7 +117,7 @@ class TestGetSalesforceClient:
     def test_raises_on_token_exchange_failure(self, mock_post, mock_sf):
         response = MagicMock(spec=requests.Response)
         response.status_code = 401
-        response.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized")
+        response.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized", response=response)
         mock_post.return_value = response
 
         with pytest.raises(requests.HTTPError):

--- a/ee/billing/test/test_salesforce_client.py
+++ b/ee/billing/test/test_salesforce_client.py
@@ -20,6 +20,14 @@ def _mock_token_response():
     return response
 
 
+def _mock_retry_session(token_response=None):
+    """Build a mock session that returns the given token response on post()."""
+    session = MagicMock(spec=requests.Session)
+    if token_response is not None:
+        session.post.return_value = token_response
+    return session
+
+
 class TestGetSalesforceClient:
     @override_settings(
         SALESFORCE_INTERNAL_CONSUMER_KEY="test-consumer-key",
@@ -27,14 +35,15 @@ class TestGetSalesforceClient:
         SALESFORCE_INTERNAL_DOMAIN="test.my.salesforce.com",
     )
     @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
-    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
-    def test_uses_oauth_when_client_credentials_set(self, mock_post, mock_sf):
-        mock_post.return_value = _mock_token_response()
+    @patch("ee.billing.salesforce_enrichment.salesforce_client._build_retry_session")
+    def test_uses_oauth_when_client_credentials_set(self, mock_build_session, mock_sf):
+        mock_session = _mock_retry_session(_mock_token_response())
+        mock_build_session.return_value = mock_session
 
         get_salesforce_client()
 
-        mock_post.assert_called_once()
-        call_data = mock_post.call_args[1]["data"]
+        mock_session.post.assert_called_once()
+        call_data = mock_session.post.call_args[1]["data"]
         assert call_data["grant_type"] == "client_credentials"
         assert call_data["client_id"] == "test-consumer-key"
         assert call_data["client_secret"] == "test-consumer-secret"
@@ -43,7 +52,7 @@ class TestGetSalesforceClient:
         sf_kwargs = mock_sf.call_args[1]
         assert sf_kwargs["session_id"] == "oauth-access-token-xyz"
         assert sf_kwargs["instance_url"] == "https://test.my.salesforce.com"
-        assert mock_post.call_args[0][0] == "https://test.my.salesforce.com/services/oauth2/token"
+        assert mock_session.post.call_args[0][0] == "https://test.my.salesforce.com/services/oauth2/token"
 
     @override_settings(
         SALESFORCE_INTERNAL_CONSUMER_KEY="",
@@ -72,13 +81,14 @@ class TestGetSalesforceClient:
         SALESFORCE_SECURITY_TOKEN="token456",
     )
     @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
-    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
-    def test_prefers_oauth_when_both_credentials_set(self, mock_post, mock_sf):
-        mock_post.return_value = _mock_token_response()
+    @patch("ee.billing.salesforce_enrichment.salesforce_client._build_retry_session")
+    def test_prefers_oauth_when_both_credentials_set(self, mock_build_session, mock_sf):
+        mock_session = _mock_retry_session(_mock_token_response())
+        mock_build_session.return_value = mock_session
 
         get_salesforce_client()
 
-        mock_post.assert_called_once()
+        mock_session.post.assert_called_once()
         sf_kwargs = mock_sf.call_args[1]
         assert "session_id" in sf_kwargs
         assert "password" not in sf_kwargs
@@ -100,12 +110,13 @@ class TestGetSalesforceClient:
         SALESFORCE_INTERNAL_DOMAIN="test.my.salesforce.com",
     )
     @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
-    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
-    def test_raises_on_token_exchange_failure(self, mock_post, mock_sf):
+    @patch("ee.billing.salesforce_enrichment.salesforce_client._build_retry_session")
+    def test_raises_on_token_exchange_failure(self, mock_build_session, mock_sf):
         response = MagicMock(spec=requests.Response)
         response.status_code = 401
         response.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized", response=response)
-        mock_post.return_value = response
+        mock_session = _mock_retry_session(response)
+        mock_build_session.return_value = mock_session
 
         with pytest.raises(requests.HTTPError):
             get_salesforce_client()

--- a/ee/billing/test/test_salesforce_client.py
+++ b/ee/billing/test/test_salesforce_client.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+import requests
+
+from ee.billing.salesforce_enrichment.salesforce_client import get_salesforce_client
+
+
+def _mock_token_response():
+    response = MagicMock(spec=requests.Response)
+    response.status_code = 200
+    response.json.return_value = {
+        "access_token": "oauth-access-token-xyz",
+        "instance_url": "https://test.my.salesforce.com",
+        "token_type": "Bearer",
+    }
+    response.raise_for_status = MagicMock()
+    return response
+
+
+class TestGetSalesforceClient:
+    @override_settings(
+        SALESFORCE_INTERNAL_CONSUMER_KEY="test-consumer-key",
+        SALESFORCE_INTERNAL_CONSUMER_SECRET="test-consumer-secret",
+        SALESFORCE_INTERNAL_DOMAIN="test.my.salesforce.com",
+    )
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
+    def test_uses_oauth_when_client_credentials_set(self, mock_post, mock_sf):
+        mock_post.return_value = _mock_token_response()
+
+        get_salesforce_client()
+
+        mock_post.assert_called_once()
+        call_data = mock_post.call_args[1]["data"]
+        assert call_data["grant_type"] == "client_credentials"
+        assert call_data["client_id"] == "test-consumer-key"
+        assert call_data["client_secret"] == "test-consumer-secret"
+
+        mock_sf.assert_called_once()
+        sf_kwargs = mock_sf.call_args[1]
+        assert sf_kwargs["session_id"] == "oauth-access-token-xyz"
+        assert sf_kwargs["instance_url"] == "https://test.my.salesforce.com"
+
+    @override_settings(
+        SALESFORCE_INTERNAL_CONSUMER_KEY="test-consumer-key",
+        SALESFORCE_INTERNAL_CONSUMER_SECRET="test-consumer-secret",
+        SALESFORCE_INTERNAL_DOMAIN="test.my.salesforce.com",
+    )
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
+    def test_posts_to_correct_token_endpoint(self, mock_post, mock_sf):
+        mock_post.return_value = _mock_token_response()
+
+        get_salesforce_client()
+
+        assert mock_post.call_args[0][0] == "https://test.my.salesforce.com/services/oauth2/token"
+
+    @override_settings(
+        SALESFORCE_INTERNAL_CONSUMER_KEY="",
+        SALESFORCE_INTERNAL_CONSUMER_SECRET="",
+        SALESFORCE_USERNAME="user@example.com",
+        SALESFORCE_PASSWORD="password123",
+        SALESFORCE_SECURITY_TOKEN="token456",
+    )
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
+    def test_falls_back_to_legacy_when_no_oauth_credentials(self, mock_sf):
+        get_salesforce_client()
+
+        mock_sf.assert_called_once()
+        sf_kwargs = mock_sf.call_args[1]
+        assert sf_kwargs["username"] == "user@example.com"
+        assert sf_kwargs["password"] == "password123"
+        assert sf_kwargs["security_token"] == "token456"
+        assert "session_id" not in sf_kwargs
+
+    @override_settings(
+        SALESFORCE_INTERNAL_CONSUMER_KEY="test-consumer-key",
+        SALESFORCE_INTERNAL_CONSUMER_SECRET="test-consumer-secret",
+        SALESFORCE_INTERNAL_DOMAIN="test.my.salesforce.com",
+        SALESFORCE_USERNAME="user@example.com",
+        SALESFORCE_PASSWORD="password123",
+        SALESFORCE_SECURITY_TOKEN="token456",
+    )
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
+    def test_prefers_oauth_when_both_credentials_set(self, mock_post, mock_sf):
+        mock_post.return_value = _mock_token_response()
+
+        get_salesforce_client()
+
+        mock_post.assert_called_once()
+        sf_kwargs = mock_sf.call_args[1]
+        assert "session_id" in sf_kwargs
+        assert "password" not in sf_kwargs
+
+    @override_settings(
+        SALESFORCE_INTERNAL_CONSUMER_KEY="",
+        SALESFORCE_INTERNAL_CONSUMER_SECRET="",
+        SALESFORCE_USERNAME="",
+        SALESFORCE_PASSWORD="",
+        SALESFORCE_SECURITY_TOKEN="",
+    )
+    def test_raises_value_error_when_no_credentials(self):
+        with pytest.raises(ValueError, match="Missing Salesforce credentials"):
+            get_salesforce_client()
+
+    @override_settings(
+        SALESFORCE_INTERNAL_CONSUMER_KEY="test-consumer-key",
+        SALESFORCE_INTERNAL_CONSUMER_SECRET="test-consumer-secret",
+        SALESFORCE_INTERNAL_DOMAIN="test.my.salesforce.com",
+    )
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
+    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
+    def test_raises_on_token_exchange_failure(self, mock_post, mock_sf):
+        response = MagicMock(spec=requests.Response)
+        response.status_code = 401
+        response.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized")
+        mock_post.return_value = response
+
+        with pytest.raises(requests.HTTPError):
+            get_salesforce_client()
+
+        mock_sf.assert_not_called()

--- a/ee/billing/test/test_salesforce_client.py
+++ b/ee/billing/test/test_salesforce_client.py
@@ -43,19 +43,6 @@ class TestGetSalesforceClient:
         sf_kwargs = mock_sf.call_args[1]
         assert sf_kwargs["session_id"] == "oauth-access-token-xyz"
         assert sf_kwargs["instance_url"] == "https://test.my.salesforce.com"
-
-    @override_settings(
-        SALESFORCE_INTERNAL_CONSUMER_KEY="test-consumer-key",
-        SALESFORCE_INTERNAL_CONSUMER_SECRET="test-consumer-secret",
-        SALESFORCE_INTERNAL_DOMAIN="test.my.salesforce.com",
-    )
-    @patch("ee.billing.salesforce_enrichment.salesforce_client.Salesforce")
-    @patch("ee.billing.salesforce_enrichment.salesforce_client.requests.post")
-    def test_posts_to_correct_token_endpoint(self, mock_post, mock_sf):
-        mock_post.return_value = _mock_token_response()
-
-        get_salesforce_client()
-
         assert mock_post.call_args[0][0] == "https://test.my.salesforce.com/services/oauth2/token"
 
     @override_settings(

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -123,7 +123,12 @@ SQS_QUEUES = {
     },
 }
 
-# Salesforce API credentials
+# Salesforce OAuth Client Credentials for internal enrichment (preferred over username/password auth)
+SALESFORCE_INTERNAL_CONSUMER_KEY = get_from_env("SF_INTERNAL_CONSUMER_KEY", "", type_cast=str)
+SALESFORCE_INTERNAL_CONSUMER_SECRET = get_from_env("SF_INTERNAL_CONSUMER_SECRET", "", type_cast=str)
+SALESFORCE_INTERNAL_DOMAIN = get_from_env("SF_INTERNAL_DOMAIN", "posthog.my.salesforce.com", type_cast=str)
+
+# Salesforce legacy API credentials (fallback)
 SALESFORCE_USERNAME = get_from_env("SF_USERNAME", "", type_cast=str)
 SALESFORCE_PASSWORD = get_from_env("SF_PASSWORD", "", type_cast=str)
 SALESFORCE_SECURITY_TOKEN = get_from_env("SF_SECURITY_TOKEN", "", type_cast=str)


### PR DESCRIPTION
The enrichment client used username/password/security_token auth which breaks when the password expires. Switch to OAuth Client Credentials flow using a dedicated Salesforce Connected App, which authenticates via consumer key/secret with no password expiration.

The new auth is preferred when SF_INTERNAL_CONSUMER_KEY and SF_INTERNAL_CONSUMER_SECRET are set, with automatic fallback to legacy auth for backward compatibility during rollout.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
We're currently using personal access tokens as credentials for enrichment jobs. I'm migrating this to use an OAuth External App I created

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Migrate to:
`SALESFORCE_INTERNAL_CONSUMER_KEY` and `SALESFORCE_INTERNAL_CONSUMER_SECRET` SFDC credentials

## ⚠️ 
need to deploy: https://github.com/PostHog/charts/pull/9264 first

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

I ran the temporal job locally and updated Infinex:
<img width="625" height="346" alt="image" src="https://github.com/user-attachments/assets/deabe20b-618a-4555-a777-1e83892a1ffb" />


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
