### PR TITLE
perf: Related groups query optimization

### DIFF
--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -41,16 +41,28 @@ class RelatedActorsQuery:
         self.group_type_index = validate_group_type_index("group_type_index", group_type_index)
         self.id = id
 
-    def run(self) -> list[SerializedActor]:
-        results: list[SerializedActor] = []
-        results.extend(self._query_related_people())
-        for group_type_mapping in GroupTypeMapping.objects.filter(project_id=self.team.project_id):
-            results.extend(self._query_related_groups(group_type_mapping.group_type_index))
-        return results
-
     @property
     def is_aggregating_by_groups(self) -> bool:
         return self.group_type_index is not None
+
+    def run(self, variant: str = "control") -> list[SerializedActor]:
+        results: list[SerializedActor] = []
+        results.extend(self._query_related_people())
+
+        group_type_indexes = list(
+            GroupTypeMapping.objects.filter(project_id=self.team.project_id)
+            .exclude(group_type_index=self.group_type_index)
+            .values_list("group_type_index", flat=True)
+        )
+
+        if variant == "test":
+            tag_queries(name="optimized-related-groups-test")
+            results.extend(self._query_related_groups_optimized(group_type_indexes=group_type_indexes))
+        else:
+            tag_queries(name="optimized-related-groups-control")
+            for index in group_type_indexes:
+                results.extend(self._query_related_groups_control(index))
+        return results
 
     def _is_test_variant(self) -> bool:
         flag_result = posthoganalytics.get_feature_flag(
@@ -114,10 +126,7 @@ class RelatedActorsQuery:
             )
         )
 
-    def _query_related_groups(self, group_type_index: GroupTypeIndex) -> list[SerializedGroup]:
-        if group_type_index == self.group_type_index:
-            return []
-
+    def _query_related_groups_control(self, group_type_index: GroupTypeIndex) -> list:
         group_ids = self._take_first(
             # nosemgrep: clickhouse-injection-taint, clickhouse-fstring-param-audit - internal SQL fragments, values parameterized
             sync_execute(
@@ -141,9 +150,42 @@ class RelatedActorsQuery:
                 {**self._params, "group_type_index": group_type_index},
             )
         )
+        _, serialized_groups = get_groups(self.team.pk, group_type_index, group_ids)
+        return serialized_groups
 
-        _, serialize_groups = get_groups(self.team.pk, group_type_index, group_ids)
-        return serialize_groups
+    def _query_related_groups_optimized(self, group_type_indexes: list[int]) -> list:
+        if not list(group_type_indexes):
+            return []
+
+        array_join_tuples = ", ".join(f"(toUInt8({index}), e.$group_{index})" for index in group_type_indexes)
+        query = f"""
+                SELECT DISTINCT group_type_index, group_key
+                FROM groups
+                WHERE team_id = %(team_id)s
+                  AND group_type_index IN {list(group_type_indexes)}
+                  AND (group_type_index, group_key) IN (
+                      SELECT tuples.1 AS group_type_index, tuples.2 AS group_key
+                      FROM events e
+                      ARRAY JOIN arrayFilter(x -> x.2 != '', [{array_join_tuples}]) AS tuples
+                      WHERE team_id = %(team_id)s
+                        AND e.timestamp > %(after)s
+                        AND e.timestamp < %(before)s
+                        AND {f"e.$group_{self.group_type_index} = %(id)s" if self.is_aggregating_by_groups else f"e.person_id = %(id)s"}
+                  )
+                ORDER BY group_type_index, group_key
+                """
+        # nosemgrep: clickhouse-injection-taint - group_type_indexes are ints from DB, values parameterized
+        results = sync_execute(query, self._params)
+        if not results:
+            return []
+
+        serialized_results: list[SerializedGroup] = []
+        for index in group_type_indexes:
+            group_keys = [result[1] for result in results if result[0] == index]
+            _, serialized_groups = get_groups(self.team.pk, index, group_keys)
+            serialized_results.extend(serialized_groups)
+
+        return serialized_results
 
     def _take_first(self, rows: list) -> list:
         return [row[0] for row in rows]

--- a/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
@@ -1,5 +1,79 @@
 # serializer version: 1
-# name: TestRelatedActorsQuery.test_query_related_people_control
+# name: TestRelatedGroupsQuery.test_control_query
+  '''
+  
+  SELECT DISTINCT $group_0 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 0
+     GROUP BY group_key) groups ON $group_0 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2024-12-01T12:00:00.000000'
+    AND timestamp < '2025-03-01T12:00:00.000000'
+    AND group_key != ''
+    AND pdi.person_id = '00000000-0000-4000-8000-000000000000'
+  ORDER BY group_key
+  '''
+# ---
+# name: TestRelatedGroupsQuery.test_control_query.1
+  '''
+  
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2024-12-01T12:00:00.000000'
+    AND timestamp < '2025-03-01T12:00:00.000000'
+    AND group_key != ''
+    AND pdi.person_id = '00000000-0000-4000-8000-000000000000'
+  ORDER BY group_key
+  '''
+# ---
+# name: TestRelatedGroupsQuery.test_optimized_query
+  '''
+  
+  SELECT DISTINCT group_type_index,
+                  group_key
+  FROM groups
+  WHERE team_id = 99999
+    AND group_type_index IN [0, 1]
+    AND (group_type_index,
+         group_key) IN
+      (SELECT tuples.1 AS group_type_index,
+              tuples.2 AS group_key
+       FROM events e ARRAY
+       JOIN arrayFilter(x -> x.2 != '', [(toUInt8(0), e.$group_0), (toUInt8(1), e.$group_1)]) AS tuples
+       WHERE team_id = 99999
+         AND e.timestamp > '2024-12-01T12:00:00.000000'
+         AND e.timestamp < '2025-03-01T12:00:00.000000'
+         AND e.person_id = '00000000-0000-4000-8000-000000000000' )
+  ORDER BY group_type_index,
+           group_key
+  '''
+# ---
+# name: TestRelatedPersonsQuery.test_query_related_people_control
   '''
   
   SELECT DISTINCT pdi.person_id
@@ -17,7 +91,26 @@
     AND $group_0 = 'org:1'
   '''
 # ---
-# name: TestRelatedActorsQuery.test_query_related_people_optimized
+# name: TestRelatedPersonsQuery.test_query_related_people_control.1
+  '''
+  
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2024-12-01T12:00:00.000000'
+    AND timestamp < '2025-03-01T12:00:00.000000'
+    AND group_key != ''
+    AND $group_0 = 'org:1'
+  ORDER BY group_key
+  '''
+# ---
+# name: TestRelatedPersonsQuery.test_query_related_people_optimized
   '''
   
   SELECT DISTINCT argMax(person_id, version) AS person_id
@@ -32,5 +125,24 @@
          AND $group_0 = 'org:1' )
   GROUP BY distinct_id
   HAVING argMax(is_deleted, version) = 0
+  '''
+# ---
+# name: TestRelatedPersonsQuery.test_query_related_people_optimized.1
+  '''
+  
+  SELECT DISTINCT $group_1 AS group_key
+  FROM events e
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 1
+     GROUP BY group_key) groups ON $group_1 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2024-12-01T12:00:00.000000'
+    AND timestamp < '2025-03-01T12:00:00.000000'
+    AND group_key != ''
+    AND $group_0 = 'org:1'
+  ORDER BY group_key
   '''
 # ---

--- a/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
@@ -2,32 +2,6 @@
 # name: TestRelatedGroupsQuery.test_control_query
   '''
   
-  SELECT DISTINCT $group_0 AS group_key
-  FROM events e
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 99999
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
-  JOIN
-    (SELECT group_key
-     FROM groups
-     WHERE team_id = 99999
-       AND group_type_index = 0
-     GROUP BY group_key) groups ON $group_0 = groups.group_key
-  WHERE team_id = 99999
-    AND timestamp > '2024-12-01T12:00:00.000000'
-    AND timestamp < '2025-03-01T12:00:00.000000'
-    AND group_key != ''
-    AND pdi.person_id = '00000000-0000-4000-8000-000000000000'
-  ORDER BY group_key
-  '''
-# ---
-# name: TestRelatedGroupsQuery.test_control_query.1
-  '''
-  
   SELECT DISTINCT $group_1 AS group_key
   FROM events e
   JOIN
@@ -51,6 +25,32 @@
   ORDER BY group_key
   '''
 # ---
+# name: TestRelatedGroupsQuery.test_control_query.1
+  '''
+  
+  SELECT DISTINCT $group_0 AS group_key
+  FROM events e
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 99999
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  JOIN
+    (SELECT group_key
+     FROM groups
+     WHERE team_id = 99999
+       AND group_type_index = 0
+     GROUP BY group_key) groups ON $group_0 = groups.group_key
+  WHERE team_id = 99999
+    AND timestamp > '2024-12-01T12:00:00.000000'
+    AND timestamp < '2025-03-01T12:00:00.000000'
+    AND group_key != ''
+    AND pdi.person_id = '00000000-0000-4000-8000-000000000000'
+  ORDER BY group_key
+  '''
+# ---
 # name: TestRelatedGroupsQuery.test_optimized_query
   '''
   
@@ -58,13 +58,13 @@
                   group_key
   FROM groups
   WHERE team_id = 99999
-    AND group_type_index IN [0, 1]
+    AND group_type_index IN [1, 0]
     AND (group_type_index,
          group_key) IN
       (SELECT tuples.1 AS group_type_index,
               tuples.2 AS group_key
        FROM events e ARRAY
-       JOIN arrayFilter(x -> x.2 != '', [(toUInt8(0), e.$group_0), (toUInt8(1), e.$group_1)]) AS tuples
+       JOIN arrayFilter(x -> x.2 != '', [(toUInt8(1), e.$group_1), (toUInt8(0), e.$group_0)]) AS tuples
        WHERE team_id = 99999
          AND e.timestamp > '2024-12-01T12:00:00.000000'
          AND e.timestamp < '2025-03-01T12:00:00.000000'

--- a/ee/clickhouse/queries/test/test_related_actors_query.py
+++ b/ee/clickhouse/queries/test/test_related_actors_query.py
@@ -1,4 +1,6 @@
-from datetime import datetime
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+from typing import cast
 from uuid import uuid4
 
 from freezegun import freeze_time
@@ -15,33 +17,69 @@ from unittest.mock import patch
 from parameterized import parameterized
 
 from posthog.clickhouse.client import sync_execute
+from posthog.models import Group, GroupTypeMapping
+from posthog.models.filters.utils import GroupTypeIndex
+from posthog.models.group.util import create_group
 
 from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
 
 PATH = "ee.clickhouse.queries.related_actors_query"
+RECENT_DATE = datetime(2025, 2, 15, 12, 0, 0)
 
 
-@freeze_time("2025-03-01T12:00:00Z")
-class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
+class BaseRelatedActorsTest(ABC, ClickhouseTestMixin, APIBaseTest):
     def setUp(self):
         super().setUp()
         self.person = _create_person(distinct_ids=["user1"], team=self.team)
         self.another_person = _create_person(distinct_ids=["user2"], team=self.team)
         self.unrelated_person = _create_person(distinct_ids=["user3"], team=self.team)
         self.old_related_person = _create_person(distinct_ids=["user4"], team=self.team)
-        self._create_group_event("user1", "org:1", datetime(2025, 2, 15, 12, 0, 0))
-        self._create_group_event("user2", "org:1", datetime(2025, 2, 15, 12, 0, 0))
-        self._create_group_event("user3", "another-org", datetime(2025, 2, 15, 12, 0, 0))
-        self._create_group_event("user4", "org:1", datetime(2024, 2, 15, 12, 0, 0))
+
+        self.org_group_type = GroupTypeMapping.objects.create(
+            group_type_index=0, team=self.team, project=self.project, group_type="org"
+        )
+        self.instance_group_type = GroupTypeMapping.objects.create(
+            group_type_index=1, team=self.team, project=self.project, group_type="instance"
+        )
+        org_type_index = cast(GroupTypeIndex, self.org_group_type.group_type_index)
+        instance_type_index = cast(GroupTypeIndex, self.instance_group_type.group_type_index)
+
+        self.org1 = create_group(
+            team_id=self.team.id,
+            group_type_index=org_type_index,
+            group_key="org:1",
+            properties={"name": "org 1"},
+            sync=True,
+        )
+        self.another_org = create_group(
+            team_id=self.team.id,
+            group_type_index=org_type_index,
+            group_key="another-org",
+            properties={"name": "another org"},
+            sync=True,
+        )
+        self.instance = create_group(
+            team_id=self.team.id,
+            group_type_index=instance_type_index,
+            group_key="instance:1",
+            properties={"name": "instance 1"},
+            sync=True,
+        )
+
+        self._create_group_event("user1", RECENT_DATE, self.org1)
+        self._create_group_event("user1", RECENT_DATE, self.instance)
+        self._create_group_event("user2", RECENT_DATE, self.org1)
+        self._create_group_event("user3", RECENT_DATE, self.another_org)
+        self._create_group_event("user4", RECENT_DATE - timedelta(days=100), self.org1)
         flush_persons_and_events()
 
-    def _create_group_event(self, distinct_id: str, group_key: str, timestamp: datetime) -> None:
+    def _create_group_event(self, distinct_id: str, timestamp: datetime, group: Group) -> None:
         _create_event(
             team=self.team,
             event="$pageview",
             distinct_id=distinct_id,
             timestamp=timestamp,
-            properties={"$group_0": group_key},
+            properties={f"$group_{group.group_type_index}": group.group_key},
         )
 
     def _insert_pdi2_row(self, distinct_id: str, person_id: str, version: int, is_deleted: int = 0) -> None:
@@ -50,30 +88,37 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
             [(self.team.pk, distinct_id, person_id, is_deleted, version)],
         )
 
-    def _query(self) -> list:
-        return RelatedActorsQuery(team=self.team, group_type_index=0, id="org:1").run()
-
     @staticmethod
-    def _get_person_ids(results: list) -> set[str]:
-        return {r["id"] for r in results if r["type"] == "person"}
+    def get_ids_from_results(results: list) -> set[str]:
+        return {r["id"] for r in results}
+
+    @abstractmethod
+    def run_query(self) -> list:
+        raise NotImplementedError()
+
+
+@freeze_time("2025-03-01T12:00:00Z")
+class TestRelatedPersonsQuery(BaseRelatedActorsTest):
+    def run_query(self) -> list:
+        return RelatedActorsQuery(team=self.team, group_type_index=0, id="org:1").run()
 
     @snapshot_clickhouse_queries
     @patch(f"{PATH}.posthoganalytics.get_feature_flag", return_value="control")
     def test_query_related_people_control(self, _):
-        results = self._query()
+        results = self.run_query()
 
         assert len(results) == 2
-        ids = self._get_person_ids(results)
+        ids = self.get_ids_from_results(results)
         assert str(self.person.uuid) in ids
         assert str(self.another_person.uuid) in ids
 
     @snapshot_clickhouse_queries
     @patch(f"{PATH}.posthoganalytics.get_feature_flag", return_value="test")
     def test_query_related_people_optimized(self, _):
-        results = self._query()
+        results = self.run_query()
 
         assert len(results) == 2
-        ids = self._get_person_ids(results)
+        ids = self.get_ids_from_results(results)
         assert str(self.person.uuid) in ids
         assert str(self.another_person.uuid) in ids
 
@@ -82,10 +127,10 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
     def test_returns_related_people(self, variant, mock_flag):
         mock_flag.return_value = variant
 
-        results = self._query()
+        results = self.run_query()
 
         assert len(results) == 2
-        ids = self._get_person_ids(results)
+        ids = self.get_ids_from_results(results)
         assert str(self.person.uuid) in ids
         assert str(self.another_person.uuid) in ids
         assert str(self.unrelated_person.uuid) not in ids
@@ -97,9 +142,9 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         mock_flag.return_value = variant
         self._insert_pdi2_row("user2", str(self.another_person.uuid), version=100, is_deleted=1)
 
-        results = self._query()
+        results = self.run_query()
 
-        ids = self._get_person_ids(results)
+        ids = self.get_ids_from_results(results)
         assert str(self.another_person.uuid) not in ids
 
     @parameterized.expand(["control", "test"])
@@ -110,9 +155,9 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
         self._insert_pdi2_row("user1", str(new_person.uuid), version=100)
 
-        results = self._query()
+        results = self.run_query()
 
-        ids = self._get_person_ids(results)
+        ids = self.get_ids_from_results(results)
         assert str(new_person.uuid) in ids
         assert str(self.person.uuid) not in ids
 
@@ -122,8 +167,83 @@ class TestRelatedActorsQuery(ClickhouseTestMixin, APIBaseTest):
         mock_flag.return_value = variant
         self._insert_pdi2_row("user2", str(self.person.uuid), version=100)
 
-        results = self._query()
+        results = self.run_query()
 
-        ids = self._get_person_ids(results)
+        ids = self.get_ids_from_results(results)
         assert str(self.person.uuid) in ids
         assert len(ids) == 1
+
+
+@freeze_time("2025-03-01T12:00:00Z")
+class TestRelatedGroupsQuery(BaseRelatedActorsTest):
+    def run_query(self, variant: str = "control") -> list:
+        return RelatedActorsQuery(team=self.team, group_type_index=None, id=str(self.person.uuid)).run(variant=variant)
+
+    @snapshot_clickhouse_queries
+    def test_control_query(self):
+        results = self.run_query(variant="control")
+
+        assert len(results) == 2
+        ids = self.get_ids_from_results(results)
+        assert ids == {"org:1", "instance:1"}
+
+    @snapshot_clickhouse_queries
+    def test_optimized_query(self):
+        results = self.run_query(variant="test")
+
+        assert len(results) == 2
+        ids = self.get_ids_from_results(results)
+        assert ids == {"org:1", "instance:1"}
+
+    @parameterized.expand(["control", "test"])
+    def test_returns_related_groups(self, variant):
+        results = self.run_query(variant=variant)
+
+        ids = self.get_ids_from_results(results)
+        assert "org:1" in ids
+        assert "instance:1" in ids
+
+    @parameterized.expand(["control", "test"])
+    def test_excludes_unrelated_groups(self, variant):
+        results = self.run_query(variant=variant)
+
+        ids = self.get_ids_from_results(results)
+        assert "another-org" not in ids
+
+    @parameterized.expand(["control", "test"])
+    def test_excludes_old_groups(self, variant):
+        results = self.run_query(variant=variant)
+
+        ids = self.get_ids_from_results(results)
+        assert str(self.old_related_person.uuid) not in ids
+
+    @parameterized.expand(["control", "test"])
+    def test_returns_all_groups_of_same_type(self, variant):
+        extra_org = create_group(
+            team_id=self.team.id,
+            group_type_index=cast(GroupTypeIndex, self.org_group_type.group_type_index),
+            group_key="org:2",
+            properties={"name": "org 2"},
+            sync=True,
+        )
+        self._create_group_event("user1", RECENT_DATE, extra_org)
+        flush_persons_and_events()
+
+        results = self.run_query(variant=variant)
+
+        ids = self.get_ids_from_results(results)
+        assert "org:1" in ids
+        assert "org:2" in ids
+        assert "instance:1" in ids
+
+    @parameterized.expand(["control", "test"])
+    def test_no_groups_when_no_mappings(self, variant):
+        another_team = self.create_team_with_organization(self.organization)
+        another_person = _create_person(team=another_team, uuid=uuid4())
+
+        results = RelatedActorsQuery(team=another_team, group_type_index=None, id=str(another_person.uuid)).run(
+            variant=variant
+        )
+
+        group_results = [r for r in results if r.get("type") == "group"]
+        assert len(group_results) == 0

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -691,10 +691,11 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
     def related(self, request: request.Request, pk=None, **kw) -> response.Response:
         group_type_index = request.GET.get("group_type_index")
         actor_id = request.GET.get("id")
+        variant = request.GET.get("variant", "control")
         if not actor_id:
             raise ValidationError({"id": ["This query parameter is required."]})
 
-        results = RelatedActorsQuery(self.team, group_type_index, actor_id).run()
+        results = RelatedActorsQuery(self.team, group_type_index, actor_id).run(variant=variant)
         return response.Response(results)
 
     @action(methods=["GET"], detail=False, required_scopes=["group:read"])

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -378,6 +378,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_SIMPLIFIED_PRODUCT_SELECTION: 'onboarding-simplified-product-selection', // owner: @fercgomes #team-growth multivariate=control,test
     ONBOARDING_SOCIAL_PROOF_INFO: 'onboarding-social-proof-info', // owner: @fercgomes #team-growth, payload overrides social proof strings per product
     ONBOARDING_SKIP_INSTALL_STEP: 'onboarding-skip-install-step', // owner: @rafaeelaudibert #team-growth multivariate=true
+    OPTIMIZED_RELATED_GROUPS_QUERY: 'optimized-related-groups-query', // owner: @arthurdedeus #team-customer-analytics
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics

--- a/frontend/src/scenes/groups/relatedGroupsLogic.ts
+++ b/frontend/src/scenes/groups/relatedGroupsLogic.ts
@@ -1,7 +1,10 @@
-import { actions, connect, events, kea, key, path, props, selectors } from 'kea'
+import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toParams } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -19,10 +22,18 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
     ),
     key((props) => `${props.groupTypeIndex ?? 'person'}-${props.id}`),
     path(['scenes', 'groups', 'relatedGroupsLogic']),
-    connect(() => ({ values: [teamLogic, ['currentTeamId']] })),
+    connect(() => ({ values: [teamLogic, ['currentTeamId'], featureFlagLogic, ['featureFlags']] })),
     actions(() => ({
         loadRelatedActors: true,
     })),
+    reducers({
+        loadStartTime: [
+            null as number | null,
+            {
+                loadRelatedActors: () => performance.now(),
+            },
+        ],
+    }),
     loaders(({ values, props }) => ({
         relatedActors: [
             [] as ActorType[],
@@ -31,6 +42,7 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
                     const url = `api/environments/${values.currentTeamId}/groups/related?${toParams({
                         group_type_index: props.groupTypeIndex,
                         id: props.id,
+                        variant: values.variant,
                     })}`
                     return await api.get(url)
                 },
@@ -43,6 +55,28 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
             () => [selectors.relatedActors],
             (relatedActors: ActorType[]) => relatedActors.filter((actor) => actor.type === 'person'),
         ],
+        variant: [
+            (s) => [s.featureFlags],
+            (featureFlags) => {
+                return featureFlags[FEATURE_FLAGS.OPTIMIZED_RELATED_GROUPS_QUERY]
+            },
+        ],
+    })),
+    listeners(({ values, props }) => ({
+        loadRelatedActorsSuccess: () => {
+            const durationMs =
+                values.loadStartTime !== null ? Math.round(performance.now() - values.loadStartTime) : null
+
+            posthog.capture('related actors loaded', {
+                duration_ms: durationMs,
+                variant: values.variant,
+                group_type_index: props.groupTypeIndex,
+                id: props.id,
+                type: props.type ?? 'group',
+                team_id: values.currentTeamId,
+                result_count: values.relatedActors.length,
+            })
+        },
     })),
     events(({ actions }) => ({
         afterMount: actions.loadRelatedActors,

--- a/products/customer_analytics/frontend/customerProfileLogic.ts
+++ b/products/customer_analytics/frontend/customerProfileLogic.ts
@@ -366,6 +366,7 @@ export function addGroupAttrsToNode({ attrs, node, children = [] }: AddAttrsToNo
                     ...node.attrs,
                     nodeId,
                     id: groupKey,
+                    type: 'person',
                     groupTypeIndex,
                     children,
                 },


### PR DESCRIPTION
## Problem

The related actors query for groups needs optimization to improve performance when querying multiple group types. The current implementation makes separate database queries for each group type, which can be inefficient for teams with many group type mappings.

Part of https://github.com/PostHog/posthog/issues/40472

## Changes

- Added a new feature flag `optimized-related-groups-query` to A/B test the optimization
- Implemented `_query_related_groups_optimized()` method that uses a single query with `ARRAY JOIN` to fetch all related groups at once, instead of separate queries per group type
- Evaluate experiment's feature flag in the client and pass variant via request, so that we can target persons instead of orgs (reasoning [here](https://posthog.slack.com/archives/C09BDQLM8KA/p1773930970041059))
- Fire `related actors loaded` event with request timings to be used in the experiment
- Added query tagging for monitoring test vs control performance

The optimized query uses ClickHouse's `ARRAY JOIN` with `arrayFilter` to process multiple group types in a single database round-trip, reducing the number of queries from N (number of group types) to 1.

## How did you test this code?

Added comprehensive test coverage for both control and optimized query paths:
- `TestRelatedPersonsQuery` tests the person-related functionality with both variants
- `TestRelatedGroupsQuery` tests the group-related functionality with both variants  
- Tests verify correct results, exclusion of unrelated/old data, and edge cases like teams with no group mappings
- Snapshot tests capture the actual SQL queries generated by both implementations
- Parameterized tests ensure both control and test variants produce identical results

Also tested manually in the UI locally, making sure the events were being fired as expected

## Publish to changelog?

No - this is an internal performance optimization behind a feature flag.

## Docs update

No documentation changes needed as this is an internal optimization.