### PR TITLE
fix(insights): use filled heart icon for active favorites filter

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.test.tsx
@@ -1,4 +1,5 @@
 import { MOCK_DEFAULT_BASIC_USER, MOCK_SECOND_BASIC_USER } from 'lib/api.mock'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import '@testing-library/jest-dom'
 
@@ -12,7 +13,14 @@ import { initKeaTests } from '~/test/init'
 import { SavedInsightsFilters } from './SavedInsightsFilters'
 import { SavedInsightFilters, cleanFilters } from './savedInsightsLogic'
 
+jest.mock('lib/hooks/useFeatureFlag', () => ({
+    useFeatureFlag: jest.fn(),
+}))
+
 const DEFAULT_FILTERS: SavedInsightFilters = cleanFilters({})
+const mockedUseFeatureFlag = useFeatureFlag as jest.MockedFunction<typeof useFeatureFlag>
+const OUTLINE_HEART_PATH_PREFIX = 'M16.925 4.6'
+const FILLED_HEART_PATH_PREFIX = 'M12.367 21.404'
 
 describe('SavedInsightsFilters Created by dropdown', () => {
     let setFilters: jest.Mock
@@ -48,6 +56,7 @@ describe('SavedInsightsFilters Created by dropdown', () => {
         })
         initKeaTests()
         setFilters = jest.fn()
+        mockedUseFeatureFlag.mockReturnValue(true)
     })
 
     afterEach(() => {
@@ -118,5 +127,21 @@ describe('SavedInsightsFilters Created by dropdown', () => {
         await userEvent.click(screen.getByText('Rose'))
 
         expect(setFilters).toHaveBeenCalledWith({ createdBy: [MOCK_SECOND_BASIC_USER.id] })
+    })
+
+    it('renders the outlined heart icon when favorites filter is disabled', () => {
+        renderFilters({ favorited: false })
+
+        const favoritesIconPath = screen.getByRole('button', { name: 'Favorites' }).querySelector('svg path')
+
+        expect(favoritesIconPath?.getAttribute('d')).toContain(OUTLINE_HEART_PATH_PREFIX)
+    })
+
+    it('renders the filled heart icon when favorites filter is enabled', () => {
+        renderFilters({ favorited: true })
+
+        const favoritesIconPath = screen.getByRole('button', { name: 'Favorites' }).querySelector('svg path')
+
+        expect(favoritesIconPath?.getAttribute('d')).toContain(FILLED_HEART_PATH_PREFIX)
     })
 })

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconFlag, IconHeart, IconStar } from '@posthog/icons'
+import { IconFlag, IconHeart, IconHeartFilled, IconStar, IconStarFilled } from '@posthog/icons'
 import { LemonDropdown, ProfilePicture } from '@posthog/lemon-ui'
 
 import { TagSelect } from 'lib/components/TagSelect'
@@ -205,7 +205,19 @@ export function SavedInsightsFilters({
                             active={favorited || false}
                             onClick={() => setFilters({ favorited: !favorited })}
                             size="small"
-                            icon={isAIFirst ? <IconHeart /> : <IconStar />}
+                            icon={
+                                isAIFirst ? (
+                                    favorited ? (
+                                        <IconHeartFilled />
+                                    ) : (
+                                        <IconHeart />
+                                    )
+                                ) : favorited ? (
+                                    <IconStarFilled />
+                                ) : (
+                                    <IconStar />
+                                )
+                            }
                         >
                             Favorites
                         </LemonButton>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the saved insights list, the Favorites quick filter always showed the outlined heart icon even when the filter was enabled, making the active state less clear.

## Changes

- Updated `SavedInsightsFilters` so the Favorites quick filter icon switches to a filled variant when active.
- In AI-first mode, the icon now toggles between `IconHeart` and `IconHeartFilled`.
- In non-AI-first mode, the icon now toggles between `IconStar` and `IconStarFilled`.
- Added focused frontend tests in `SavedInsightsFilters.test.tsx` to assert outlined vs filled heart rendering based on Favorites filter state.

## How did you test this code?

Automated checks attempted:
- `pnpm --filter=@posthog/frontend jest src/scenes/saved-insights/SavedInsightsFilters.test.tsx --runInBand` ❌ (blocked: missing `oxfmt` tool in this environment)
- `pnpm --filter=@posthog/frontend exec jest src/scenes/saved-insights/SavedInsightsFilters.test.tsx --runInBand` ❌ (blocked: missing frontend deps/modules in this environment)
- `pnpm --filter=@posthog/frontend exec jest src/scenes/saved-insights/SavedInsightsFilters.test.tsx --runInBand --setupFiles=fake-indexeddb/auto` ❌ (blocked: missing frontend deps/modules in this environment)
- `pnpm --filter=@posthog/frontend exec oxlint src/scenes/saved-insights/SavedInsightsFilters.tsx src/scenes/saved-insights/SavedInsightsFilters.test.tsx` ✅ (no errors; warnings are existing linter behavior around async `expect` usage in this file)

Manual UI check:
- Attempted to start local app for GUI verification, but startup is blocked in this environment by missing binary dependencies (`brotli`) and could not be completed here.

## Publish to changelog?

no

## Docs update

No docs changes required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e972447e-f0b7-407b-b9d1-c35e60710681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e972447e-f0b7-407b-b9d1-c35e60710681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

