### PR TITLE
feat(paths): default showFullUrls and pathReplacements to true

### DIFF
--- a/frontend/src/queries/nodes/InsightQuery/defaults.ts
+++ b/frontend/src/queries/nodes/InsightQuery/defaults.ts
@@ -106,7 +106,6 @@ function getPathsQueryDefault(): PathsQuery {
         pathsFilter: {
             includeEventTypes: [pathType],
             showFullUrls: true,
-            pathReplacements: true,
         },
     }
 }

--- a/frontend/src/queries/nodes/InsightQuery/defaults.ts
+++ b/frontend/src/queries/nodes/InsightQuery/defaults.ts
@@ -105,6 +105,8 @@ function getPathsQueryDefault(): PathsQuery {
         kind: NodeKind.PathsQuery,
         pathsFilter: {
             includeEventTypes: [pathType],
+            showFullUrls: true,
+            pathReplacements: true,
         },
     }
 }


### PR DESCRIPTION
i was using the user paths insight and it's really hard to read

i can't think why i wouldn't want to show full URLs instead of truncated
and I can't think why i wouldn't want to apply path cleaning if i had it configured

so let's default them both on in the UI when creating an insight