### PR TITLE
fix(workflows): Show error toast instead of onboarding screen when workflow list fails to load

### DIFF
--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -99,6 +99,7 @@ export function WorkflowsTable(props: WorkflowsSceneProps): JSX.Element {
         draftWorkflows,
         archivedWorkflows,
         workflowsLoading,
+        hasLoadedWorkflows,
         filters,
         visibleStatuses,
         selectedArchivedWorkflowIds,
@@ -282,6 +283,7 @@ export function WorkflowsTable(props: WorkflowsSceneProps): JSX.Element {
     ]
 
     const showProductIntroduction =
+        hasLoadedWorkflows &&
         !workflowsLoading &&
         activeWorkflows.length === 0 &&
         draftWorkflows.length === 0 &&

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -70,6 +70,12 @@ export const workflowsLogic = kea<workflowsLogicType>([
                 loadWorkflowsSuccess: () => new Set<string>(),
             },
         ],
+        hasLoadedWorkflows: [
+            false as boolean,
+            {
+                loadWorkflowsSuccess: () => true,
+            },
+        ],
     }),
     loaders(({ actions, values }) => ({
         workflows: [
@@ -244,6 +250,9 @@ export const workflowsLogic = kea<workflowsLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
+        loadWorkflowsFailure: () => {
+            lemonToast.error('Failed to load workflows')
+        },
         deleteSelectedWorkflows: () => {
             const ids = Array.from(values.selectedArchivedWorkflowIds)
             if (ids.length === 0) {

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -73,6 +73,7 @@ export const workflowsLogic = kea<workflowsLogicType>([
         hasLoadedWorkflows: [
             false as boolean,
             {
+                loadWorkflows: () => false,
                 loadWorkflowsSuccess: () => true,
             },
         ],
@@ -250,8 +251,8 @@ export const workflowsLogic = kea<workflowsLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
-        loadWorkflowsFailure: () => {
-            lemonToast.error('Failed to load workflows')
+        loadWorkflowsFailure: ({ error }) => {
+            lemonToast.error(`Failed to load workflows: ${error || 'Unknown error'}`)
         },
         deleteSelectedWorkflows: () => {
             const ids = Array.from(values.selectedArchivedWorkflowIds)


### PR DESCRIPTION
## Problem

When the API call to load workflows fails (network blip, timeout, etc.), the page silently shows the "Create your first workflow" onboarding screen, making it look like the user has no workflows. A customer reported this: on refresh they'd see the empty onboarding state, and only on a second refresh would their workflows appear. This is more in line with existing behavior when we fail to load.

## Changes

- Added `hasLoadedWorkflows` reducer that only becomes `true` after a successful load. The "Create your first workflow" onboarding screen now requires a confirmed successful empty response, not just "not loading and no data"
- Added `lemonToast.error` on `loadWorkflowsFailure` so the user knows something went wrong

### Screenshots

**Before:**
<img width="1575" height="1063" alt="Screenshot 2026-03-23 at 21 01 27" src="https://github.com/user-attachments/assets/c55aab51-e29d-4407-b171-f285d8e249dd" />

**After:**
<img width="1581" height="1072" alt="Screenshot 2026-03-23 at 20 56 51" src="https://github.com/user-attachments/assets/544c945a-97cf-4e98-88b7-463c7824a575" />

## How did you test this code?

Reproduced by blocking the `hog_flows` API request in Chrome DevTools Network tab. Before: shows misleading "Create your first workflow" onboarding screen. After: shows empty table layout with error toast.

## Publish to changelog?

No