### PR TITLE
fix(error-tracking): flush invocation results

### DIFF
--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -334,6 +334,24 @@ describe('ErrorTrackingConsumer', () => {
             expect(properties.$geoip_country_code).toBe('SE')
             expect(properties.$geoip_city_name).toBe('Linköping')
         })
+
+        it('should flush invocation results after batch processing', async () => {
+            const messages = createKafkaMessages([createEvent()])
+            await consumer.handleKafkaBatch(messages)
+
+            expect(mockHogTransformer.processInvocationResults).toHaveBeenCalledTimes(1)
+        })
+
+        it('should flush invocation results even when batch processing fails', async () => {
+            // Make the pipeline throw an error
+            mockHogTransformer.transformEventAndProduceMessages.mockRejectedValueOnce(new Error('Test error'))
+
+            const messages = createKafkaMessages([createEvent()])
+            await expect(consumer.handleKafkaBatch(messages)).rejects.toThrow('Test error')
+
+            // processInvocationResults should still be called via finally block
+            expect(mockHogTransformer.processInvocationResults).toHaveBeenCalledTimes(1)
+        })
     })
 
     describe('error handling', () => {

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -98,6 +98,7 @@ const createMockHogTransformer = (): jest.Mocked<ErrorTrackingHogTransformer> =>
     transformEventAndProduceMessages: jest
         .fn()
         .mockImplementation((event) => Promise.resolve({ event, invocationResults: [] })),
+    processInvocationResults: jest.fn().mockResolvedValue(undefined),
 })
 
 let offsetIncrementer = 0

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -59,6 +59,7 @@ export interface ErrorTrackingHogTransformer {
     start(): Promise<void>
     stop(): Promise<void>
     transformEventAndProduceMessages(event: PluginEvent): Promise<TransformationResult>
+    processInvocationResults(): Promise<void>
 }
 
 /**
@@ -269,5 +270,8 @@ export class ErrorTrackingConsumer {
             })
             throw error
         }
+
+        // Flush scheduled work and invocation results to prevent memory accumulation
+        await Promise.all([this.promiseScheduler.waitForAll(), this.deps.hogTransformer.processInvocationResults()])
     }
 }

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -269,9 +269,9 @@ export class ErrorTrackingConsumer {
                 size: messages.length,
             })
             throw error
+        } finally {
+            // Flush scheduled work and invocation results to prevent memory accumulation
+            await Promise.all([this.promiseScheduler.waitForAll(), this.deps.hogTransformer.processInvocationResults()])
         }
-
-        // Flush scheduled work and invocation results to prevent memory accumulation
-        await Promise.all([this.promiseScheduler.waitForAll(), this.deps.hogTransformer.processInvocationResults()])
     }
 }

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
@@ -242,6 +242,7 @@ describe('ErrorTrackingPipeline', () => {
             transformEventAndProduceMessages: jest
                 .fn()
                 .mockImplementation((event) => Promise.resolve({ event, invocationResults: [] })),
+            processInvocationResults: jest.fn().mockResolvedValue(undefined),
         }
 
         mockCymbalClient = {


### PR DESCRIPTION
## Problem

we're not flushing invocation events in the error tracking service - causing a linear growth in mem usage until we oom.

## Changes

add the flush