### PR TITLE
chore(tests): edgecase tests for DateRange + InsightVariables

### DIFF
--- a/posthog/api/test/test_insight_variable.py
+++ b/posthog/api/test/test_insight_variable.py
@@ -149,7 +149,7 @@ class TestInsightVariable(APIBaseTest):
 
 
 class TestMapStaleToLatest(TestCase):
-    def _make_variable(self, code_name: str) -> MagicMock:
+    def _make_variable(self, code_name: str) -> InsightVariable:
         var = MagicMock(spec=InsightVariable)
         var.id = uuid4()
         var.code_name = code_name

--- a/posthog/api/test/test_insight_variable.py
+++ b/posthog/api/test/test_insight_variable.py
@@ -1,5 +1,11 @@
-from posthog.test.base import APIBaseTest
+from uuid import uuid4
 
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+
+from posthog.api.insight_variable import map_stale_to_latest
 from posthog.models.insight_variable import InsightVariable
 
 
@@ -63,3 +69,130 @@ class TestInsightVariable(APIBaseTest):
         response = self.client.get(f"/api/environments/{self.team.pk}/insight_variables/")
         assert response.status_code == 200
         assert len(response.json()["results"]) == 500
+
+    @parameterized.expand(
+        [
+            ("preserves_underscores", "my_var", "my_var"),
+            ("strips_special_chars", "Test @#$ Var!", "test__var"),
+            ("multiple_spaces", "foo  bar", "foo__bar"),
+            (
+                "leading_trailing_spaces",
+                " spaced ",
+                "spaced",
+            ),  # DRF CharField strips whitespace before code_name generation
+            ("mixed_alphanumeric", "abc123", "abc123"),
+        ]
+    )
+    def test_code_name_generation(self, _name, input_name, expected_code_name):
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/insight_variables/",
+            data={"name": input_name, "type": "String"},
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        assert response.json()["code_name"] == expected_code_name
+
+    def test_sharing_token_auth_denied(self):
+        from unittest.mock import patch
+
+        from rest_framework.exceptions import PermissionDenied
+
+        from posthog.api.insight_variable import InsightVariableViewSet
+        from posthog.auth import SharingAccessTokenAuthentication
+
+        request = MagicMock()
+        request.successful_authenticator = SharingAccessTokenAuthentication()
+
+        viewset = InsightVariableViewSet()
+        viewset.request = request
+        viewset.kwargs = {}
+        viewset.format_kwarg = None
+
+        with patch("rest_framework.viewsets.ModelViewSet.initial"):
+            with self.assertRaises(PermissionDenied) as ctx:
+                viewset.initial(request)
+
+        assert "sharing authentication" in str(ctx.exception.detail)
+
+    def test_update_variable_name(self):
+        variable = InsightVariable.objects.create(team=self.team, name="Original", type="String", code_name="original")
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/insight_variables/{variable.id}/",
+            data={"name": "Updated"},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "Updated"
+
+    def test_update_list_variable_values(self):
+        variable = InsightVariable.objects.create(
+            team=self.team, name="List Var", type="List", code_name="list_var", values=["a"]
+        )
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/insight_variables/{variable.id}/",
+            data={"values": ["a", "b", "c"]},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["values"] == ["a", "b", "c"]
+
+    def test_update_type_to_list_coerces_null_values(self):
+        variable = InsightVariable.objects.create(team=self.team, name="Str Var", type="String", code_name="str_var")
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/insight_variables/{variable.id}/",
+            data={"type": "List"},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["values"] == []
+
+
+class TestMapStaleToLatest(APIBaseTest):
+    def _make_variable(self, code_name: str) -> MagicMock:
+        var = MagicMock(spec=InsightVariable)
+        var.id = uuid4()
+        var.code_name = code_name
+        return var
+
+    @parameterized.expand(
+        [
+            (
+                "empty_stale_returns_empty",
+                {},
+                ["var_a", "var_b"],
+                [],
+            ),
+            (
+                "matching_code_names_update_ids",
+                {"old-id-1": {"code_name": "var_a", "value": 1}},
+                ["var_a"],
+                ["var_a"],
+            ),
+            (
+                "unmatched_code_names_dropped",
+                {"old-id-1": {"code_name": "no_match", "value": 1}},
+                ["var_a"],
+                [],
+            ),
+            (
+                "mixed_match_and_no_match",
+                {
+                    "old-id-1": {"code_name": "var_a", "value": 1},
+                    "old-id-2": {"code_name": "no_match", "value": 2},
+                },
+                ["var_a", "var_b"],
+                ["var_a"],
+            ),
+        ]
+    )
+    def test_map_stale_to_latest(self, _name, stale, latest_code_names, expected_matched_code_names):
+        latest_vars = [self._make_variable(cn) for cn in latest_code_names]
+        result = map_stale_to_latest(stale, latest_vars)
+
+        result_code_names = [v["code_name"] for v in result.values()]
+        self.assertEqual(sorted(result_code_names), sorted(expected_matched_code_names))
+
+        for v in result.values():
+            code_name = v["code_name"]
+            matched_var = next(lv for lv in latest_vars if lv.code_name == code_name)
+            self.assertEqual(v["variableId"], str(matched_var.id))

--- a/posthog/api/test/test_insight_variable.py
+++ b/posthog/api/test/test_insight_variable.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 from posthog.test.base import APIBaseTest
+from unittest import TestCase
 from unittest.mock import MagicMock
 
 from parameterized import parameterized
@@ -147,7 +148,7 @@ class TestInsightVariable(APIBaseTest):
         assert response.json()["values"] == []
 
 
-class TestMapStaleToLatest(APIBaseTest):
+class TestMapStaleToLatest(TestCase):
     def _make_variable(self, code_name: str) -> MagicMock:
         var = MagicMock(spec=InsightVariable)
         var.id = uuid4()
@@ -190,9 +191,14 @@ class TestMapStaleToLatest(APIBaseTest):
         result = map_stale_to_latest(stale, latest_vars)
 
         result_code_names = [v["code_name"] for v in result.values()]
-        self.assertEqual(sorted(result_code_names), sorted(expected_matched_code_names))
+        assert sorted(result_code_names) == sorted(expected_matched_code_names)
 
         for v in result.values():
             code_name = v["code_name"]
             matched_var = next(lv for lv in latest_vars if lv.code_name == code_name)
-            self.assertEqual(v["variableId"], str(matched_var.id))
+            assert v["variableId"] == str(matched_var.id)
+
+            # original stale values are preserved via spread
+            original = next(sv for sv in stale.values() if sv.get("code_name") == code_name)
+            for key, val in original.items():
+                assert v[key] == val

--- a/posthog/api/test/test_insight_variable.py
+++ b/posthog/api/test/test_insight_variable.py
@@ -2,11 +2,13 @@ from uuid import uuid4
 
 from posthog.test.base import APIBaseTest
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
+from rest_framework.exceptions import PermissionDenied
 
-from posthog.api.insight_variable import map_stale_to_latest
+from posthog.api.insight_variable import InsightVariableViewSet, map_stale_to_latest
+from posthog.auth import SharingAccessTokenAuthentication
 from posthog.models.insight_variable import InsightVariable
 
 
@@ -94,13 +96,6 @@ class TestInsightVariable(APIBaseTest):
         assert response.json()["code_name"] == expected_code_name
 
     def test_sharing_token_auth_denied(self):
-        from unittest.mock import patch
-
-        from rest_framework.exceptions import PermissionDenied
-
-        from posthog.api.insight_variable import InsightVariableViewSet
-        from posthog.auth import SharingAccessTokenAuthentication
-
         request = MagicMock()
         request.successful_authenticator = SharingAccessTokenAuthentication()
 

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 from posthog.test.base import APIBaseTest
 
 from dateutil import parser
+from parameterized import parameterized
 
 from posthog.schema import DateRange, IntervalType
 
@@ -257,6 +258,199 @@ class TestQueryDateRange(APIBaseTest):
         query_date_range = QueryDateRange(team=self.team, date_range=date_range, interval=IntervalType.DAY, now=now)
         self.assertEqual(query_date_range.date_from(), parser.isoparse("2025-09-21T00:00:00Z"))
         self.assertEqual(query_date_range.date_to(), parser.isoparse("2025-09-27T23:59:59.999999Z"))
+
+
+class TestExactTimerange(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("day", IntervalType.DAY),
+            ("hour", IntervalType.HOUR),
+            ("minute", IntervalType.MINUTE),
+        ]
+    )
+    def test_date_to_returns_now_directly_when_exact_timerange_true_and_no_date_to(self, _name, interval):
+        now = parser.isoparse("2021-08-25T14:30:45.123456Z")
+        qdr = QueryDateRange(
+            team=self.team, date_range=DateRange(date_from="-7d"), interval=interval, now=now, exact_timerange=True
+        )
+        result = qdr.date_to()
+        self.assertEqual(result, qdr.now_with_timezone)
+
+    @parameterized.expand(
+        [
+            ("day", IntervalType.DAY),
+            ("hour", IntervalType.HOUR),
+            ("minute", IntervalType.MINUTE),
+        ]
+    )
+    def test_date_to_rounds_when_exact_timerange_false_and_no_date_to(self, _name, interval):
+        now = parser.isoparse("2021-08-25T14:30:45.123456Z")
+        qdr = QueryDateRange(
+            team=self.team, date_range=DateRange(date_from="-7d"), interval=interval, now=now, exact_timerange=False
+        )
+        result = qdr.date_to()
+        self.assertNotEqual(result, qdr.now_with_timezone)
+
+    def test_date_from_does_not_truncate_when_exact_timerange_true(self):
+        now = parser.isoparse("2021-08-25T14:30:45.000Z")
+        qdr_exact = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="-48h"),
+            interval=IntervalType.DAY,
+            now=now,
+            exact_timerange=True,
+        )
+        qdr_normal = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="-48h"),
+            interval=IntervalType.DAY,
+            now=now,
+            exact_timerange=False,
+        )
+        # exact_timerange=True passes always_truncate=False, preserving minutes/seconds
+        self.assertEqual(qdr_exact.date_from(), parser.isoparse("2021-08-23T14:30:45Z"))
+        # Without exact_timerange, always_truncate=True rounds to the hour boundary
+        self.assertEqual(qdr_normal.date_from(), parser.isoparse("2021-08-23T14:00:00Z"))
+
+    @parameterized.expand(
+        [
+            ("day", IntervalType.DAY),
+            ("hour", IntervalType.HOUR),
+            ("minute", IntervalType.MINUTE),
+        ]
+    )
+    def test_use_start_of_interval_false_when_exact_timerange_true(self, _name, interval):
+        now = parser.isoparse("2021-08-25T14:30:45.000Z")
+        qdr = QueryDateRange(
+            team=self.team, date_range=DateRange(date_from="-7d"), interval=interval, now=now, exact_timerange=True
+        )
+        self.assertFalse(qdr.use_start_of_interval())
+
+
+class TestUseStartOfInterval(APIBaseTest):
+    @parameterized.expand(
+        [
+            (
+                "explicit_date_returns_false",
+                DateRange(date_from="2021-08-20T00:00:00Z", date_to="2021-08-25T00:00:00Z", explicitDate=True),
+                IntervalType.DAY,
+                False,
+            ),
+            (
+                "none_date_range_returns_true",
+                None,
+                IntervalType.DAY,
+                True,
+            ),
+            (
+                "none_date_from_returns_true",
+                DateRange(date_from=None),
+                IntervalType.DAY,
+                True,
+            ),
+            (
+                "hour_interval_relative_returns_false",
+                DateRange(date_from="-3h"),
+                IntervalType.HOUR,
+                False,
+            ),
+            (
+                "minute_interval_relative_returns_false",
+                DateRange(date_from="-30M"),
+                IntervalType.MINUTE,
+                False,
+            ),
+            (
+                "day_interval_with_hour_delta_returns_false",
+                DateRange(date_from="-48h"),
+                IntervalType.DAY,
+                False,
+            ),
+            (
+                "day_interval_with_day_delta_returns_true",
+                DateRange(date_from="-7d"),
+                IntervalType.DAY,
+                True,
+            ),
+        ]
+    )
+    def test_use_start_of_interval(self, _name, date_range, interval, expected):
+        now = parser.isoparse("2021-08-25T14:30:00.000Z")
+        qdr = QueryDateRange(team=self.team, date_range=date_range, interval=interval, now=now)
+        self.assertEqual(qdr.use_start_of_interval(), expected)
+
+
+class TestMultiHourIntervalConversion(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("count_1_stays_hour", 1, "hour", 1),
+            ("count_2_converts_to_minute_120", 2, "minute", 120),
+            ("count_3_converts_to_minute_180", 3, "minute", 180),
+            ("count_4_converts_to_minute_240", 4, "minute", 240),
+        ]
+    )
+    def test_multi_hour_interval_conversion(self, _name, interval_count, expected_interval_name, expected_count):
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        qdr = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="-7d"),
+            interval=IntervalType.HOUR,
+            now=now,
+            interval_count=interval_count,
+        )
+        self.assertEqual(qdr.interval_name, expected_interval_name)
+        self.assertEqual(qdr.interval_count, expected_count)
+
+
+class TestPreviousPeriodDateFrom(APIBaseTest):
+    @parameterized.expand(
+        [
+            (
+                "7d_range",
+                DateRange(date_from="-7d"),
+                IntervalType.DAY,
+                # date_from = 2021-08-18 00:00:00, date_to = 2021-08-25 23:59:59.999999
+                # previous = 2021-08-18 - (2021-08-25T23:59:59.999999 - 2021-08-18) = 2021-08-10 00:00:00.000001
+                "2021-08-10T00:00:00.000001Z",
+            ),
+            (
+                "custom_explicit",
+                DateRange(
+                    date_from="2021-08-10T00:00:00Z",
+                    date_to="2021-08-20T00:00:00Z",
+                    explicitDate=True,
+                ),
+                IntervalType.DAY,
+                # date_from = 2021-08-10, date_to = 2021-08-20, delta = 10 days
+                # previous = 2021-08-10 - 10 days = 2021-07-31
+                "2021-07-31T00:00:00Z",
+            ),
+        ]
+    )
+    def test_previous_period_date_from(self, _name, date_range, interval, expected_str):
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        qdr = QueryDateRange(team=self.team, date_range=date_range, interval=interval, now=now)
+        self.assertEqual(qdr.previous_period_date_from, parser.isoparse(expected_str))
+
+
+class TestDateFromAll(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("day_interval", IntervalType.DAY),
+            ("hour_interval", IntervalType.HOUR),
+        ]
+    )
+    def test_date_from_all_uses_earliest_timestamp_fallback(self, _name, interval):
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        fallback = parser.isoparse("2020-01-01T00:00:00.000Z")
+        qdr = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="all"),
+            interval=interval,
+            now=now,
+            earliest_timestamp_fallback=fallback,
+        )
+        self.assertEqual(qdr.date_from(), fallback)
 
 
 class TestQueryDateRangeWithIntervals(APIBaseTest):

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -261,13 +261,13 @@ class TestQueryDateRange(APIBaseTest):
 
 
 class TestExactTimerange(APIBaseTest):
-    @parameterized.expand(
-        [
-            ("day", IntervalType.DAY),
-            ("hour", IntervalType.HOUR),
-            ("minute", IntervalType.MINUTE),
-        ]
-    )
+    INTERVALS = [
+        ("day", IntervalType.DAY),
+        ("hour", IntervalType.HOUR),
+        ("minute", IntervalType.MINUTE),
+    ]
+
+    @parameterized.expand(INTERVALS)
     def test_date_to_returns_now_directly_when_exact_timerange_true_and_no_date_to(self, _name, interval):
         now = parser.isoparse("2021-08-25T14:30:45.123456Z")
         qdr = QueryDateRange(
@@ -278,18 +278,17 @@ class TestExactTimerange(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("day", IntervalType.DAY),
-            ("hour", IntervalType.HOUR),
-            ("minute", IntervalType.MINUTE),
+            ("day", IntervalType.DAY, "2021-08-25T23:59:59.999999Z"),
+            ("hour", IntervalType.HOUR, "2021-08-25T14:59:59.999999Z"),
+            ("minute", IntervalType.MINUTE, "2021-08-25T14:30:59.999999Z"),
         ]
     )
-    def test_date_to_rounds_when_exact_timerange_false_and_no_date_to(self, _name, interval):
+    def test_date_to_rounds_when_exact_timerange_false_and_no_date_to(self, _name, interval, expected_str):
         now = parser.isoparse("2021-08-25T14:30:45.123456Z")
         qdr = QueryDateRange(
             team=self.team, date_range=DateRange(date_from="-7d"), interval=interval, now=now, exact_timerange=False
         )
-        result = qdr.date_to()
-        self.assertNotEqual(result, qdr.now_with_timezone)
+        self.assertEqual(qdr.date_to(), parser.isoparse(expected_str))
 
     def test_date_from_does_not_truncate_when_exact_timerange_true(self):
         now = parser.isoparse("2021-08-25T14:30:45.000Z")
@@ -312,13 +311,7 @@ class TestExactTimerange(APIBaseTest):
         # Without exact_timerange, always_truncate=True rounds to the hour boundary
         self.assertEqual(qdr_normal.date_from(), parser.isoparse("2021-08-23T14:00:00Z"))
 
-    @parameterized.expand(
-        [
-            ("day", IntervalType.DAY),
-            ("hour", IntervalType.HOUR),
-            ("minute", IntervalType.MINUTE),
-        ]
-    )
+    @parameterized.expand(INTERVALS)
     def test_use_start_of_interval_false_when_exact_timerange_true(self, _name, interval):
         now = parser.isoparse("2021-08-25T14:30:45.000Z")
         qdr = QueryDateRange(


### PR DESCRIPTION
## Problem

🐛  There were 6 bugs in last 6 months around these, these tests would've caught them.

## Changes

Adds tests to:
- insight variables
- query date range
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
