### PR TITLE
chore(dwh): add extended person properties to demo data

### DIFF
--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -4,7 +4,7 @@ import datetime as dt
 from collections.abc import Callable
 from dataclasses import dataclass
 from io import StringIO
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
@@ -1563,8 +1563,9 @@ class HedgeboxMatrix(Matrix):
             raise ValueError("Demo data warehouse tables require a completed simulation.")
 
         rows: list[tuple[Any, ...]] = []
+        people = cast(list[HedgeboxPerson], self.people)
 
-        for person in sorted(self.people, key=lambda current_person: current_person.in_product_id):
+        for person in sorted(people, key=lambda current_person: current_person.in_product_id):
             if not hasattr(person, "properties_at_now"):
                 person.take_snapshot_at_now()
 

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -55,6 +55,7 @@ from posthog.models.oauth import OAuthApplication
 from posthog.storage import object_storage
 
 from products.data_warehouse.backend.models.credential import get_or_create_datawarehouse_credential
+from products.data_warehouse.backend.models.join import DataWarehouseJoin
 from products.data_warehouse.backend.models.table import DataWarehouseTable
 from products.endpoints.backend.models import Endpoint, EndpointVersion
 from products.event_definitions.backend.models.event_definition import EventDefinition
@@ -1461,6 +1462,11 @@ class HedgeboxMatrix(Matrix):
             except Exception as err:
                 capture_exception(err)
 
+        try:
+            self._upsert_demo_extended_person_properties_table(team, user, credential)
+        except Exception as err:
+            capture_exception(err)
+
     def _demo_data_warehouse_table_specs(self) -> tuple[DemoDataWarehouseTableSpec, ...]:
         return (
             DemoDataWarehouseTableSpec(
@@ -1530,6 +1536,120 @@ class HedgeboxMatrix(Matrix):
         )
         return [table_spec.row_builder(event, row_id) for row_id, event in enumerate(matching_events, start=1)]
 
+    @staticmethod
+    def _demo_extended_person_properties_columns() -> dict[str, str]:
+        return {
+            "id": "Int64",
+            "email": "String",
+            "hedgebox_user_id": "String",
+            "company_name": "String",
+            "industry": "String",
+            "account_kind": "String",
+            "current_plan": "String",
+            "team_size": "Int64",
+            "file_count": "Int64",
+            "used_mb": "Float64",
+            "allocation_used_fraction": "Float64",
+            "monthly_bill_usd": "Float64",
+            "lifecycle_stage": "String",
+            "onboarding_variant": "String",
+            "file_engagement_variant": "String",
+            "watches_marius_tech_tips": "Bool",
+            "is_invitable": "Bool",
+        }
+
+    def _collect_demo_extended_person_rows(self) -> list[tuple[Any, ...]]:
+        if not self.is_complete:
+            raise ValueError("Demo data warehouse tables require a completed simulation.")
+
+        rows: list[tuple[Any, ...]] = []
+
+        for person in sorted(self.people, key=lambda current_person: current_person.in_product_id):
+            if not hasattr(person, "properties_at_now"):
+                person.take_snapshot_at_now()
+
+            email = person.properties_at_now.get("email")
+            if not email:
+                continue
+
+            account = person.account
+            team_size = len(account.team_members) if account else 0
+            file_count = len(account.files) if account else 0
+
+            if file_count >= 5:
+                lifecycle_stage = "power_user"
+            elif file_count > 0:
+                lifecycle_stage = "activated"
+            else:
+                lifecycle_stage = "signed_up"
+
+            rows.append(
+                (
+                    len(rows) + 1,
+                    str(email),
+                    person.in_product_id,
+                    person.cluster.company.name if person.cluster.company else person.name,
+                    str(person.cluster.company.industry) if person.cluster.company else "consumer",
+                    "business" if person.cluster.company else "personal",
+                    str(account.plan) if account else "",
+                    team_size,
+                    file_count,
+                    float(account.current_used_mb) if account else 0.0,
+                    float(account.allocation_used_fraction) if account else 0.0,
+                    float(account.current_monthly_bill_usd) if account else 0.0,
+                    lifecycle_stage,
+                    person.onboarding_variant,
+                    person.file_engagement_variant,
+                    person.watches_marius_tech_tips,
+                    person.is_invitable,
+                )
+            )
+
+        return rows
+
+    def _upsert_demo_extended_person_properties_table(self, team: "Team", user: "User", credential) -> None:
+        table_name = "extended_properties"
+        rows = self._collect_demo_extended_person_rows()
+        self._upsert_demo_data_warehouse_table_contents(
+            team=team,
+            user=user,
+            credential=credential,
+            table_name=table_name,
+            columns=self._demo_extended_person_properties_columns(),
+            rows=rows,
+        )
+        self._upsert_demo_extended_person_properties_join(team, table_name)
+
+    @staticmethod
+    def _upsert_demo_extended_person_properties_join(team: "Team", table_name: str) -> None:
+        existing_join = (
+            DataWarehouseJoin.objects.filter(
+                team=team,
+                source_table_name="persons",
+                source_table_key="properties.email",
+                joining_table_name=table_name,
+                joining_table_key="email",
+                field_name=table_name,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+        if existing_join:
+            existing_join.deleted = False
+            existing_join.deleted_at = None
+            existing_join.save()
+            return
+
+        DataWarehouseJoin.objects.create(
+            team=team,
+            source_table_name="persons",
+            source_table_key="properties.email",
+            joining_table_name=table_name,
+            joining_table_key="email",
+            field_name=table_name,
+        )
+
     def _upsert_demo_data_warehouse_table(
         self,
         team: "Team",
@@ -1538,19 +1658,38 @@ class HedgeboxMatrix(Matrix):
         table_spec: DemoDataWarehouseTableSpec,
         rows: list[tuple[Any, ...]],
     ) -> None:
-        s3_prefix = f"data-warehouse/demo_{table_spec.name}/team_{team.pk}"
-        object_key = f"{s3_prefix}/{table_spec.name}.csv"
-        object_storage.write(object_key, self._warehouse_rows_to_csv(rows, headers=tuple(table_spec.columns.keys())))
+        self._upsert_demo_data_warehouse_table_contents(
+            team=team,
+            user=user,
+            credential=credential,
+            table_name=table_spec.name,
+            columns=table_spec.columns,
+            rows=rows,
+        )
+
+    def _upsert_demo_data_warehouse_table_contents(
+        self,
+        team: "Team",
+        user: "User",
+        credential,
+        table_name: str,
+        columns: dict[str, str],
+        rows: list[tuple[Any, ...]],
+    ) -> None:
+        s3_prefix = f"data-warehouse/demo_{table_name}/team_{team.pk}"
+        object_key = f"{s3_prefix}/{table_name}.csv"
+        object_storage.write(object_key, self._warehouse_rows_to_csv(rows, headers=tuple(columns.keys())))
 
         url_pattern = f"{self._warehouse_endpoint()}/{settings.OBJECT_STORAGE_BUCKET}/{s3_prefix}/*.csv"
-        existing_table = DataWarehouseTable.objects.filter(team=team, name=table_spec.name).first()
+        existing_table = DataWarehouseTable.objects.filter(team=team, name=table_name).first()
         if existing_table:
             if existing_table.external_data_source is not None:
                 return
             existing_table.format = DataWarehouseTable.TableFormat.CSVWithNames
             existing_table.url_pattern = url_pattern
             existing_table.credential = credential
-            existing_table.columns = table_spec.columns
+            existing_table.columns = columns
+            existing_table.options = {**(existing_table.options or {}), "csv_allow_double_quotes": True}
             existing_table.deleted = False
             existing_table.deleted_at = None
             if existing_table.created_by_id is None:
@@ -1560,11 +1699,12 @@ class HedgeboxMatrix(Matrix):
 
         DataWarehouseTable.objects.create(
             team=team,
-            name=table_spec.name,
+            name=table_name,
             format=DataWarehouseTable.TableFormat.CSVWithNames,
             url_pattern=url_pattern,
             credential=credential,
-            columns=table_spec.columns,
+            columns=columns,
+            options={"csv_allow_double_quotes": True},
             created_by=user,
         )
 

--- a/posthog/demo/test/test_hedgebox_matrix.py
+++ b/posthog/demo/test/test_hedgebox_matrix.py
@@ -1,6 +1,7 @@
 import uuid
 import datetime as dt
 from types import SimpleNamespace
+from typing import Any, cast
 
 from unittest.mock import MagicMock, patch
 
@@ -185,8 +186,8 @@ class TestHedgeboxMatrixDemoWarehouseTables(SimpleTestCase):
         self, mock_filter, mock_create, _mock_write
     ):
         matrix = HedgeboxMatrix(seed="warehouse-test", n_clusters=0)
-        team = SimpleNamespace(pk=1)
-        user = SimpleNamespace()
+        team = cast(Any, SimpleNamespace(pk=1))
+        user = cast(Any, SimpleNamespace())
         credential = object()
 
         mock_filter.return_value.first.return_value = None
@@ -207,8 +208,8 @@ class TestHedgeboxMatrixDemoWarehouseTables(SimpleTestCase):
     @patch("posthog.demo.products.hedgebox.matrix.DataWarehouseTable.objects.filter")
     def test_upsert_demo_data_warehouse_table_sets_csv_double_quotes_on_update(self, mock_filter, _mock_write):
         matrix = HedgeboxMatrix(seed="warehouse-test", n_clusters=0)
-        team = SimpleNamespace(pk=1)
-        user = SimpleNamespace()
+        team = cast(Any, SimpleNamespace(pk=1))
+        user = cast(Any, SimpleNamespace())
         credential = object()
         existing_table = SimpleNamespace(
             external_data_source=None,

--- a/posthog/demo/test/test_hedgebox_matrix.py
+++ b/posthog/demo/test/test_hedgebox_matrix.py
@@ -2,6 +2,8 @@ import uuid
 import datetime as dt
 from types import SimpleNamespace
 
+from unittest.mock import MagicMock, patch
+
 from django.test import SimpleTestCase
 
 from posthog.demo.matrix.models import SimEvent
@@ -76,6 +78,158 @@ class TestHedgeboxMatrixDemoWarehouseTables(SimpleTestCase):
             (1, "person-4", "2025-01-03 11:00:00", "upgrade", "personal_free", "business_standard"),
             (2, "person-4", "2025-01-05 13:00:00", "downgrade", "business_pro", "business_standard"),
         ]
+
+    def test_collect_demo_extended_person_rows(self):
+        matrix = HedgeboxMatrix(seed="warehouse-test", n_clusters=0)
+        matrix.is_complete = True
+
+        matrix.clusters = [
+            SimpleNamespace(
+                people=[
+                    SimpleNamespace(
+                        in_product_id="biz-user",
+                        properties_at_now={"email": "owner@acme.test"},
+                        account=SimpleNamespace(
+                            team_members={"biz-user", "coworker-user"},
+                            files={"a", "b", "c", "d", "e"},
+                            current_used_mb=512.0,
+                            allocation_used_fraction=0.64,
+                            current_monthly_bill_usd=40.0,
+                            plan="business/standard",
+                        ),
+                        cluster=SimpleNamespace(company=SimpleNamespace(name="Acme", industry="technology")),
+                        name="Owner Name",
+                        onboarding_variant="blue",
+                        file_engagement_variant="red",
+                        watches_marius_tech_tips=True,
+                        is_invitable=False,
+                    ),
+                    SimpleNamespace(
+                        in_product_id="solo-user",
+                        properties_at_now={"email": "solo@example.test"},
+                        account=SimpleNamespace(
+                            team_members={"solo-user"},
+                            files=set(),
+                            current_used_mb=0.0,
+                            allocation_used_fraction=0.0,
+                            current_monthly_bill_usd=0.0,
+                            plan="personal/free",
+                        ),
+                        cluster=SimpleNamespace(company=None),
+                        name="Solo User",
+                        onboarding_variant="control",
+                        file_engagement_variant="blue",
+                        watches_marius_tech_tips=False,
+                        is_invitable=True,
+                    ),
+                    SimpleNamespace(
+                        in_product_id="visitor-user",
+                        properties_at_now={},
+                        account=None,
+                        cluster=SimpleNamespace(company=None),
+                        name="Visitor User",
+                        onboarding_variant="red",
+                        file_engagement_variant="control",
+                        watches_marius_tech_tips=False,
+                        is_invitable=True,
+                    ),
+                ]
+            )  # type: ignore[list-item]
+        ]
+
+        assert matrix._collect_demo_extended_person_rows() == [
+            (
+                1,
+                "owner@acme.test",
+                "biz-user",
+                "Acme",
+                "technology",
+                "business",
+                "business/standard",
+                2,
+                5,
+                512.0,
+                0.64,
+                40.0,
+                "power_user",
+                "blue",
+                "red",
+                True,
+                False,
+            ),
+            (
+                2,
+                "solo@example.test",
+                "solo-user",
+                "Solo User",
+                "consumer",
+                "personal",
+                "personal/free",
+                1,
+                0,
+                0.0,
+                0.0,
+                0.0,
+                "signed_up",
+                "control",
+                "blue",
+                False,
+                True,
+            ),
+        ]
+
+    @patch("posthog.demo.products.hedgebox.matrix.object_storage.write")
+    @patch("posthog.demo.products.hedgebox.matrix.DataWarehouseTable.objects.create")
+    @patch("posthog.demo.products.hedgebox.matrix.DataWarehouseTable.objects.filter")
+    def test_upsert_demo_data_warehouse_table_sets_csv_double_quotes_on_create(
+        self, mock_filter, mock_create, _mock_write
+    ):
+        matrix = HedgeboxMatrix(seed="warehouse-test", n_clusters=0)
+        team = SimpleNamespace(pk=1)
+        user = SimpleNamespace()
+        credential = object()
+
+        mock_filter.return_value.first.return_value = None
+
+        matrix._upsert_demo_data_warehouse_table_contents(
+            team=team,
+            user=user,
+            credential=credential,
+            table_name="extended_properties",
+            columns={"email": "String", "company_name": "String"},
+            rows=[("owner@acme.test", "Acme, Inc.")],
+        )
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["options"] == {"csv_allow_double_quotes": True}
+
+    @patch("posthog.demo.products.hedgebox.matrix.object_storage.write")
+    @patch("posthog.demo.products.hedgebox.matrix.DataWarehouseTable.objects.filter")
+    def test_upsert_demo_data_warehouse_table_sets_csv_double_quotes_on_update(self, mock_filter, _mock_write):
+        matrix = HedgeboxMatrix(seed="warehouse-test", n_clusters=0)
+        team = SimpleNamespace(pk=1)
+        user = SimpleNamespace()
+        credential = object()
+        existing_table = SimpleNamespace(
+            external_data_source=None,
+            options={},
+            created_by_id=None,
+            save=MagicMock(),
+        )
+
+        mock_filter.return_value.first.return_value = existing_table
+
+        matrix._upsert_demo_data_warehouse_table_contents(
+            team=team,
+            user=user,
+            credential=credential,
+            table_name="extended_properties",
+            columns={"email": "String", "company_name": "String"},
+            rows=[("owner@acme.test", "Acme, Inc.")],
+        )
+
+        assert existing_table.options == {"csv_allow_double_quotes": True}
+        existing_table.save.assert_called_once()
 
     @staticmethod
     def _make_event(event: str, distinct_id: str, timestamp: dt.datetime, properties: dict) -> SimEvent:


### PR DESCRIPTION
## Problem

We don't have extended person properties available in the demo data by default.

## Changes

Adds an `extended_properties` data warehouse table and joins it onto persons, to serve as extended person properties in the demo data.

Each row is generated from the simulated person and their account state at simulation "now", and includes fields such as:

- `email`, `hedgebox_user_id`
- `company_name`, `industry`, `account_kind`
- `current_plan`, `team_size`, `file_count`
- `used_mb`, `allocation_used_fraction`, `monthly_bill_usd`
- `lifecycle_stage`
- `onboarding_variant`, `file_engagement_variant`
- `watches_marius_tech_tips`, `is_invitable`

The table is written as CSV into object storage, registered as a `DataWarehouseTable`, and joined onto `persons` by `properties.email`.

## How did you test this code?

Used it in a trends insight after resetting the dev environment
