### PR TITLE
fix(logs): display empty string for empty attribute values

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
@@ -122,6 +122,9 @@ export function LogAttributes({ attributes, type, logUuid, title }: LogAttribute
                         key: 'value',
                         dataIndex: 'value',
                         render: (_, record) => {
+                            if (record.value === '') {
+                                return <span className="font-mono text-xs text-muted italic">empty</span>
+                            }
                             return (
                                 <CopyToClipboardInline
                                     explicitValue={record.value}

--- a/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogAttributes.tsx
@@ -123,7 +123,7 @@ export function LogAttributes({ attributes, type, logUuid, title }: LogAttribute
                         dataIndex: 'value',
                         render: (_, record) => {
                             if (record.value === '') {
-                                return <span className="font-mono text-xs text-muted italic">empty</span>
+                                return <span className="font-mono text-xs text-muted italic">(empty)</span>
                             }
                             return (
                                 <CopyToClipboardInline


### PR DESCRIPTION
## Problem                                                                                                                                
                  
When viewing log attributes with empty string values, the copy button would glitch and the UI would attempt to copy or display nothing,  providing a poor user experience.

We now explicitly indicate when an attribute value is empty, making it clear that the attribute exists but has an empty value rather than being missing                                   
                
## Changes

Added a check in the `LogAttributes` component's value renderer to display "empty" in italic gray text when an attribute value is an empty string                                                                                                                                     
                  
### Before and After

  <table>
    <tr>
      <th align="center">Before</th>
      <th align="center">After</th>                                                                                                         
    </tr>
    <tr>
  <td><img src="https://github.com/user-attachments/assets/439186ac-2a40-4b6b-90fd-9a7d7b1ca67e" width="100%" alt="After - empty values
  now display clearly" /></td>                                                                                                                                          
      <td><img src="https://github.com/user-attachments/assets/4a5fd1ca-d9cd-4150-9421-ac5b07f6414c" width="100%" alt="Before - glitchy copy
   button on empty values" /></td>                                                                                                                                                                                                                  
    </tr>         
  </table>           

## How did you test this code?                                                                                                            
                
Manual testing: Generated some logs with empty attribute values and checked if they were displayed as "empty" without the copy to clipboard button.
                                                                                                                                          
## Publish to changelog?

no
