### PR TITLE
feat(flags): add skill for cleaning up stale feature flags

### DIFF
--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -55,6 +55,13 @@ and describe the desired outcome for the customer.
 This separation matters because agents are good at composing simple tools
 but need guidance on _which_ tools to use, in _what order_, with _what constraints_.
 
+### Referencing MCP tools in skills
+
+When a skill references an MCP tool, use the `posthog:` namespace prefix
+(e.g. `posthog:execute-sql`, `posthog:feature-flag-get-all`).
+This matches how tools appear to agents consuming the PostHog MCP server
+and helps agents resolve tool names unambiguously.
+
 ## Skill structure
 
 Skills live in `products/*/skills/` and come in two forms.

--- a/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
+++ b/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
@@ -27,7 +27,7 @@ Disabled flags (`active: false`) are not considered stale — they were intentio
 
 ### 1. List stale flags
 
-Call `feature-flag-get-all` with `active: "STALE"`. This returns all stale flags in a single request — PostHog handles the staleness detection server-side using the criteria described above.
+Call `posthog:feature-flag-get-all` with `active: "STALE"`. This returns all stale flags in a single request — PostHog handles the staleness detection server-side using the criteria described above.
 
 ### 2. Assess each candidate
 
@@ -35,7 +35,7 @@ For each stale flag, gather context before recommending action:
 
 **Check if it's tied to an experiment:**
 
-The `feature-flag-get-definition` tool returns an `experiment_set` field. If non-empty, the flag is used by an experiment — check the experiment status before touching it.
+The `posthog:feature-flag-get-definition` tool returns an `experiment_set` field. If non-empty, the flag is used by an experiment — check the experiment status before touching it.
 
 **Check if other flags depend on it:**
 
@@ -63,8 +63,8 @@ For each stale flag, present:
 
 The safest approach is a two-phase cleanup:
 
-1. **Disable** the flag (`active: false`) using `update-feature-flag`. This stops it from being evaluated but keeps the configuration intact. If something breaks, re-enabling is instant.
-2. **Delete** the flag using `delete-feature-flag` after the user confirms no issues. This is a soft-delete — the flag is marked as deleted but not physically removed.
+1. **Disable** the flag (`active: false`) using `posthog:update-feature-flag`. This stops it from being evaluated but keeps the configuration intact. If something breaks, re-enabling is instant.
+2. **Delete** the flag using `posthog:delete-feature-flag` after the user confirms no issues. This is a soft-delete — the flag is marked as deleted but not physically removed.
 
 When disabling or deleting multiple flags, process them one at a time and confirm each action. This makes it easy to stop if something goes wrong.
 
@@ -124,8 +124,8 @@ Present the full cleanup prompt in a copyable format so the user can paste it di
 User: "Can you help me clean up our stale feature flags?"
 
 Agent steps:
-- Call feature-flag-get-all with active: "STALE" to get all stale flags in one request
-- For each stale flag, call feature-flag-get-definition to check experiment_set and dependencies
+- Call posthog:feature-flag-get-all with active: "STALE" to get all stale flags in one request
+- For each stale flag, call posthog:feature-flag-get-definition to check experiment_set and dependencies
 - Present findings:
 
    "I found 7 stale feature flags in your project:
@@ -142,8 +142,8 @@ Agent steps:
    and beta-dashboard-v2 since they have no dependencies."
 
 - User confirms: "Yes, remove those two"
-- Disable each flag first using update-feature-flag (active: false), then confirm with the user before deleting
-- After user confirms no issues, call delete-feature-flag for each
+- Disable each flag first using posthog:update-feature-flag (active: false), then confirm with the user before deleting
+- After user confirms no issues, call posthog:delete-feature-flag for each
 - Classify rollout states from the flag definitions:
    - old-checkout-flow: fully_rolled_out (boolean, 100% rollout, no conditions)
    - beta-dashboard-v2: fully_rolled_out (boolean, 100% rollout, no conditions)
@@ -179,8 +179,8 @@ Agent steps:
 
 ## Related tools
 
-- `feature-flag-get-all`: List and search feature flags (supports `active: "STALE"` filter)
-- `feature-flag-get-definition`: Get full flag details including experiment associations
-- `feature-flags-status-retrieve`: Get the status and reason for a single flag
-- `update-feature-flag`: Disable a flag by setting `active: false`
-- `delete-feature-flag`: Soft-delete a flag
+- `posthog:feature-flag-get-all`: List and search feature flags (supports `active: "STALE"` filter)
+- `posthog:feature-flag-get-definition`: Get full flag details including experiment associations
+- `posthog:feature-flags-status-retrieve`: Get the status and reason for a single flag
+- `posthog:update-feature-flag`: Disable a flag by setting `active: false`
+- `posthog:delete-feature-flag`: Soft-delete a flag

--- a/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
+++ b/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
@@ -27,34 +27,7 @@ Disabled flags (`active: false`) are not considered stale — they were intentio
 
 ### 1. List stale flags
 
-Use the `feature-flag-get-all` tool with the search parameter to find flags, or query via HogQL for a comprehensive view.
-
-**Option A: Use the `feature-flag-get-all` MCP tool (simpler, recommended first)**
-
-Call `feature-flag-get-all` to list all flags. The response includes `last_called_at`, `active`, `created_at`, and `status` fields. Look for flags where `status` is `stale`.
-
-**Option B: Use the `execute_sql` MCP tool (more powerful, for detailed analysis)**
-
-Query the `feature_flags` system table for a richer view:
-
-```sql
-SELECT
-    id,
-    key,
-    name,
-    active,
-    created_at,
-    updated_at,
-    last_called_at,
-    created_by_id
-FROM system.feature_flags
-WHERE deleted = false
-  AND active = true
-ORDER BY last_called_at ASC NULLS FIRST
-LIMIT 100
-```
-
-Flags at the top of this list (null or oldest `last_called_at`) are the best candidates.
+Call `feature-flag-get-all` with `active: "STALE"`. This returns all stale flags in a single request — PostHog handles the staleness detection server-side using the criteria described above.
 
 ### 2. Assess each candidate
 
@@ -151,9 +124,8 @@ Present the full cleanup prompt in a copyable format so the user can paste it di
 User: "Can you help me clean up our stale feature flags?"
 
 Agent steps:
-1. Call feature-flag-get-all to list all flags
-2. Identify flags with status "stale" or where last_called_at is >30 days ago
-3. For each stale flag, call feature-flag-get-definition to check experiment_set and dependencies
+1. Call feature-flag-get-all with active: "STALE" to get all stale flags in one request
+2. For each stale flag, call feature-flag-get-definition to check experiment_set and dependencies
 4. Present findings:
 
    "I found 7 stale feature flags in your project:
@@ -206,8 +178,8 @@ Agent steps:
 
 ## Related tools
 
-- `feature-flag-get-all`: List and search feature flags
+- `feature-flag-get-all`: List and search feature flags (supports `active: "STALE"` filter)
 - `feature-flag-get-definition`: Get full flag details including experiment associations
+- `feature-flags-status-retrieve`: Get the status and reason for a single flag
 - `update-feature-flag`: Disable a flag by setting `active: false`
 - `delete-feature-flag`: Soft-delete a flag
-- `execute_sql`: Query the feature_flags system table via HogQL for advanced analysis

--- a/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
+++ b/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
@@ -75,7 +75,7 @@ After disabling or deleting flags, generate a cleanup prompt the user can run in
 Classify each deleted/disabled flag into one of three rollout states based on its definition:
 
 - **`fully_rolled_out`**: A boolean flag with a release condition at 100% rollout and no property filters, or a multivariate flag where one variant is at 100%. Record which variant was active (for multivariate flags).
-- **`not_rolled_out`**: The flag was never called (`last_called_at` is null and it's not fully rolled out), or all release conditions are at 0%.
+- **`not_rolled_out`**: All release conditions are at 0%, or the flag has no release conditions at all.
 - **`partial`**: Everything else — the flag had some targeting but wasn't fully rolled out or fully off.
 
 Then generate instructions following this structure:
@@ -124,9 +124,9 @@ Present the full cleanup prompt in a copyable format so the user can paste it di
 User: "Can you help me clean up our stale feature flags?"
 
 Agent steps:
-1. Call feature-flag-get-all with active: "STALE" to get all stale flags in one request
-2. For each stale flag, call feature-flag-get-definition to check experiment_set and dependencies
-4. Present findings:
+- Call feature-flag-get-all with active: "STALE" to get all stale flags in one request
+- For each stale flag, call feature-flag-get-definition to check experiment_set and dependencies
+- Present findings:
 
    "I found 7 stale feature flags in your project:
 
@@ -141,12 +141,13 @@ Agent steps:
    Want me to disable any of these? I'd recommend starting with old-checkout-flow
    and beta-dashboard-v2 since they have no dependencies."
 
-5. User confirms: "Yes, delete those two"
-6. Call delete-feature-flag for each
-7. Classify rollout states from the flag definitions:
+- User confirms: "Yes, remove those two"
+- Disable each flag first using update-feature-flag (active: false), then confirm with the user before deleting
+- After user confirms no issues, call delete-feature-flag for each
+- Classify rollout states from the flag definitions:
    - old-checkout-flow: fully_rolled_out (boolean, 100% rollout, no conditions)
    - beta-dashboard-v2: fully_rolled_out (boolean, 100% rollout, no conditions)
-8. Generate and present cleanup prompt:
+- Generate and present cleanup prompt:
 
    "Both flags are deleted. Here's a cleanup prompt you can paste into your
    code editor:

--- a/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
+++ b/products/feature_flags/skills/cleaning-up-stale-feature-flags/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: cleaning-up-stale-feature-flags
+description: 'Identify and clean up stale feature flags in a PostHog project. Use when the user wants to find unused, fully rolled out, or abandoned feature flags, review them for safety, and then disable or delete them. Covers staleness detection, dependency checking, and safe removal workflows.'
+---
+
+# Cleaning up stale feature flags
+
+This skill guides you through finding feature flags that are no longer serving a purpose and safely removing them.
+
+## When to use this skill
+
+- The user asks to clean up, audit, or review their feature flags
+- The user wants to find flags that are stale, unused, or fully rolled out
+- The user asks "which feature flags can I remove?" or similar
+- The user wants to reduce tech debt from old feature flags
+
+## What makes a flag stale
+
+A feature flag is considered stale when it's no longer doing useful work. PostHog tracks this with two signals:
+
+1. **Usage-based staleness**: The flag has `last_called_at` data, but hasn't been evaluated in 30+ days. This is the strongest signal — the SDKs are no longer checking this flag.
+2. **Configuration-based staleness**: The flag has no usage data (`last_called_at` is null), is 30+ days old, and is 100% rolled out (boolean at 100% with no property filters, or a multivariate flag with one variant at 100%). A fully rolled out flag with no conditions is equivalent to a hardcoded value — it can be replaced by removing the flag check from code.
+
+Disabled flags (`active: false`) are not considered stale — they were intentionally turned off and may be kept for reactivation.
+
+## Workflow
+
+### 1. List stale flags
+
+Use the `feature-flag-get-all` tool with the search parameter to find flags, or query via HogQL for a comprehensive view.
+
+**Option A: Use the `feature-flag-get-all` MCP tool (simpler, recommended first)**
+
+Call `feature-flag-get-all` to list all flags. The response includes `last_called_at`, `active`, `created_at`, and `status` fields. Look for flags where `status` is `stale`.
+
+**Option B: Use the `execute_sql` MCP tool (more powerful, for detailed analysis)**
+
+Query the `feature_flags` system table for a richer view:
+
+```sql
+SELECT
+    id,
+    key,
+    name,
+    active,
+    created_at,
+    updated_at,
+    last_called_at,
+    created_by_id
+FROM system.feature_flags
+WHERE deleted = false
+  AND active = true
+ORDER BY last_called_at ASC NULLS FIRST
+LIMIT 100
+```
+
+Flags at the top of this list (null or oldest `last_called_at`) are the best candidates.
+
+### 2. Assess each candidate
+
+For each stale flag, gather context before recommending action:
+
+**Check if it's tied to an experiment:**
+
+The `feature-flag-get-definition` tool returns an `experiment_set` field. If non-empty, the flag is used by an experiment — check the experiment status before touching it.
+
+**Check if other flags depend on it:**
+
+Feature flags can have dependencies (flag B only evaluates when flag A is true). The flag definition includes dependency information in its `filters`. Look for `flag_key` references in other flags' filter groups.
+
+**Check when it was last modified:**
+
+A flag last updated years ago with no recent calls is a stronger removal candidate than one updated last month with no calls (it might be newly deployed and waiting for a release).
+
+**Summarize for the user:**
+
+For each stale flag, present:
+
+- Flag key and description
+- Why it's considered stale (no calls in N days, or fully rolled out for N days)
+- Whether it's tied to experiments
+- When it was created and last modified
+- A recommended action (disable, delete, or keep with explanation)
+
+### 3. Take action (with user confirmation)
+
+**Never delete or disable flags without explicit user approval.** Always present the list and recommendations first, then ask which flags to act on.
+
+**Disable first, delete later:**
+
+The safest approach is a two-phase cleanup:
+
+1. **Disable** the flag (`active: false`) using `update-feature-flag`. This stops it from being evaluated but keeps the configuration intact. If something breaks, re-enabling is instant.
+2. **Delete** the flag using `delete-feature-flag` after the user confirms no issues. This is a soft-delete — the flag is marked as deleted but not physically removed.
+
+When disabling or deleting multiple flags, process them one at a time and confirm each action. This makes it easy to stop if something goes wrong.
+
+### 4. Generate code cleanup instructions
+
+After disabling or deleting flags, generate a cleanup prompt the user can run in their code editor or coding agent. The cleanup instructions must be tailored to each flag's rollout state, because the rollout state determines which code path to keep.
+
+Classify each deleted/disabled flag into one of three rollout states based on its definition:
+
+- **`fully_rolled_out`**: A boolean flag with a release condition at 100% rollout and no property filters, or a multivariate flag where one variant is at 100%. Record which variant was active (for multivariate flags).
+- **`not_rolled_out`**: The flag was never called (`last_called_at` is null and it's not fully rolled out), or all release conditions are at 0%.
+- **`partial`**: Everything else — the flag had some targeting but wasn't fully rolled out or fully off.
+
+Then generate instructions following this structure:
+
+**For fully rolled out boolean flags** — remove the flag check but keep the enabled code path:
+
+```text
+Search for: isFeatureEnabled, useFeatureFlag, getFeatureFlag, posthog.isFeatureEnabled, posthog.getFeatureFlag
+
+For flag "example-flag":
+- Remove the if-check, keep the body
+- If there is an else branch, remove the else branch entirely
+```
+
+**For fully rolled out multivariate flags** — keep only the winning variant's code:
+
+```text
+For flag "example-flag" (keep variant: "winning-variant"):
+- For if/else chains: keep only the branch matching "winning-variant", remove the flag check
+- For switch statements: keep only the winning variant's case, remove the switch
+```
+
+**For not-rolled-out flags** — remove the entire flag check AND the enabled code path:
+
+```text
+For flag "example-flag":
+- Remove the if-check AND its body (the feature was never active)
+- If there is an else branch, keep only the else body
+```
+
+**For partial rollout flags** — flag these for manual review:
+
+```text
+For flag "example-flag":
+- This flag had a partial rollout — check the flag's intent to determine which code path to keep
+- Then remove the flag check
+```
+
+End the instructions with: "After cleanup, remove any dead code branches and unused imports."
+
+Present the full cleanup prompt in a copyable format so the user can paste it directly into Claude Code, Cursor, Copilot, or any other AI code editor. This is the same approach used in the PostHog UI's bulk delete flow.
+
+## Example interaction
+
+```text
+User: "Can you help me clean up our stale feature flags?"
+
+Agent steps:
+1. Call feature-flag-get-all to list all flags
+2. Identify flags with status "stale" or where last_called_at is >30 days ago
+3. For each stale flag, call feature-flag-get-definition to check experiment_set and dependencies
+4. Present findings:
+
+   "I found 7 stale feature flags in your project:
+
+   | Flag | Last called | Reason | Recommendation |
+   |------|-------------|--------|----------------|
+   | old-checkout-flow | 45 days ago | No evaluations in 45 days | Disable then delete |
+   | beta-dashboard-v2 | Never | 100% rolled out, created 3 months ago | Disable then delete |
+   | holiday-promo-2024 | 90 days ago | No evaluations in 90 days | Delete (seasonal, won't reuse) |
+   | new-pricing-page | 60 days ago | No evaluations in 60 days, tied to experiment #42 | Check experiment first |
+   ...
+
+   Want me to disable any of these? I'd recommend starting with old-checkout-flow
+   and beta-dashboard-v2 since they have no dependencies."
+
+5. User confirms: "Yes, delete those two"
+6. Call delete-feature-flag for each
+7. Classify rollout states from the flag definitions:
+   - old-checkout-flow: fully_rolled_out (boolean, 100% rollout, no conditions)
+   - beta-dashboard-v2: fully_rolled_out (boolean, 100% rollout, no conditions)
+8. Generate and present cleanup prompt:
+
+   "Both flags are deleted. Here's a cleanup prompt you can paste into your
+   code editor:
+
+   ---
+   Find and remove all references to these deleted feature flags in the codebase.
+   For each flag, search for all usages: isFeatureEnabled, useFeatureFlag,
+   getFeatureFlag, posthog.isFeatureEnabled, posthog.getFeatureFlag, etc.
+
+   ## Flags that were rolled out to 100%
+   These flags were fully rolled out. Remove the flag check but KEEP the enabled code path.
+
+   Boolean flags (remove the if-check, keep the body):
+   - old-checkout-flow
+   - beta-dashboard-v2
+
+   If there is an else branch, remove the else branch entirely.
+   After cleanup, remove any dead code branches and unused imports.
+   ---"
+```
+
+## Important notes
+
+- **Always confirm before acting.** This skill involves disabling and deleting flags, which can affect production behavior.
+- **Disabled flags are not stale.** Don't recommend deleting flags that are intentionally disabled — they may be kept for emergency reactivation.
+- **Experiment flags need extra care.** If a flag is tied to an active or recently completed experiment, the user likely wants to keep it until they've analyzed results.
+- **Seasonal flags may return.** Flags like "black-friday-sale" might look stale but are intentionally reused. Ask the user before removing these.
+- **Code cleanup is the real win.** Removing the flag from PostHog is the easy part. The value comes from removing the dead code paths.
+
+## Related tools
+
+- `feature-flag-get-all`: List and search feature flags
+- `feature-flag-get-definition`: Get full flag details including experiment associations
+- `update-feature-flag`: Disable a flag by setting `active: false`
+- `delete-feature-flag`: Soft-delete a flag
+- `execute_sql`: Query the feature_flags system table via HogQL for advanced analysis


### PR DESCRIPTION
## Problem

Feature flags accumulate over time — flags that are fully rolled out, never evaluated, or tied to completed experiments become tech debt. Users need a way to identify and safely clean these up, both in PostHog and in their codebase.

## Changes

Adds a new agent skill (`cleaning-up-stale-feature-flags`) in `products/feature_flags/skills/` that teaches agents how to:

- Identify stale flags using MCP tools (usage-based and configuration-based staleness)
- Assess each flag for experiment dependencies and other flag dependencies
- Present findings with recommendations (disable, delete, or keep)
- Safely disable/delete flags with user confirmation
- Generate tailored code cleanup instructions based on each flag's rollout state (fully rolled out, not rolled out, partial)

The skill uses PostHog MCP tools (`feature-flag-get-all`, `feature-flag-get-definition`, `update-feature-flag`, `delete-feature-flag`, `execute_sql`) rather than direct API calls, so it works across all distribution channels (PostHog Code, Claude Code, Cursor, etc.).

## How did you test this code?

- Synced the skill locally via `hogli sync:skill -- --name cleaning-up-stale-feature-flags` against a local PostHog instance with the MCP server running
- Verified the skill activates correctly and walks through the full workflow
- Ran `hogli build:skills` and `hogli lint:skills` to confirm the skill passes validation

## Publish to changelog?

No

## Docs update

No docs changes needed — the skill is distributed automatically via CI after merge.

## 🤖 LLM context

Co-authored with Claude Code. The skill content was written iteratively — started from the existing code cleanup AI configuration used in the feature flags UI delete flow, then expanded into a full agent workflow.