### PR TITLE
feat(insights): use favourite icon for filter

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconFlag, IconHeart, IconStar } from '@posthog/icons'
+import { IconFlag, IconHeart, IconHeartFilled, IconStar, IconStarFilled } from '@posthog/icons'
 import { LemonDropdown, ProfilePicture } from '@posthog/lemon-ui'
 
 import { TagSelect } from 'lib/components/TagSelect'
@@ -205,7 +205,19 @@ export function SavedInsightsFilters({
                             active={favorited || false}
                             onClick={() => setFilters({ favorited: !favorited })}
                             size="small"
-                            icon={isAIFirst ? <IconHeart /> : <IconStar />}
+                            icon={
+                                favorited ? (
+                                    isAIFirst ? (
+                                        <IconHeartFilled className="text-danger" />
+                                    ) : (
+                                        <IconStarFilled className="text-warning" />
+                                    )
+                                ) : isAIFirst ? (
+                                    <IconHeart className="text-secondary" />
+                                ) : (
+                                    <IconStar className="text-secondary" />
+                                )
+                            }
                         >
                             Favorites
                         </LemonButton>

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -206,14 +206,14 @@ export function SavedInsightsFilters({
                             onClick={() => setFilters({ favorited: !favorited })}
                             size="small"
                             icon={
-                                favorited ? (
-                                    isAIFirst ? (
+                                isAIFirst ? (
+                                    favorited ? (
                                         <IconHeartFilled className="text-danger" />
                                     ) : (
-                                        <IconStarFilled className="text-warning" />
+                                        <IconHeart className="text-secondary" />
                                     )
-                                ) : isAIFirst ? (
-                                    <IconHeart className="text-secondary" />
+                                ) : favorited ? (
+                                    <IconStarFilled className="text-warning" />
                                 ) : (
                                     <IconStar className="text-secondary" />
                                 )


### PR DESCRIPTION
## Problem

Use nicer icon when favourites filter is selected.

## Changes

<img width="2112" height="684" alt="CleanShot 2026-03-23 at 17 33 42@2x" src="https://github.com/user-attachments/assets/7bf6756b-e3f1-4a4a-b1f3-b1b50b679750" />

## How did you test this code?

Locally.

## Publish to changelog?

No.