### PR TITLE
chore(replay): use INTERNAL_API_SECRET for rasterizer recording-api auth

### DIFF
--- a/nodejs/src/session-replay/recording-rasterizer/config.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/config.ts
@@ -27,7 +27,7 @@ export const config = {
 
     // Recording API
     recordingApiBaseUrl: process.env.RECORDING_API_BASE_URL || 'http://localhost:6738',
-    recordingApiSecret: process.env.RECORDING_API_SECRET || '',
+    recordingApiSecret: process.env.INTERNAL_API_SECRET || '',
 
     // Player
     siteUrl: process.env.SITE_URL || 'http://localhost:8000',


### PR DESCRIPTION
## Summary

- Use `INTERNAL_API_SECRET` env var consistently for recording-api authentication in the rasterizer, matching the charts config (`secret_env: INTERNAL_API_SECRET: INTERNAL_API_SECRET`)
- Removes the old `RECORDING_API_SECRET` reference — a single consistent name across all services

## Test plan

- [ ] Verify rasterizer pods start without `CreateContainerConfigError` after charts PR #9271 is merged
- [ ] Run a `rasterize-recording` workflow and confirm it no longer fails with `[INIT_FAILED] Failed to fetch`