### PR TITLE
chore(flags): add management command to invalidate team flags auth cache

### DIFF
--- a/posthog/management/commands/invalidate_flags_auth_cache.py
+++ b/posthog/management/commands/invalidate_flags_auth_cache.py
@@ -1,0 +1,72 @@
+"""
+Invalidate flags-service auth cache entries for a team.
+
+Clears cached token entries in Redis so the Rust feature-flags service
+re-validates against Postgres on the next request. Does NOT revoke the
+tokens themselves. Covers team secret tokens, project secret API keys,
+and personal API keys that have access to the team.
+
+Usage:
+    python manage.py invalidate_flags_auth_cache --team-id 12345
+    python manage.py invalidate_flags_auth_cache --team-id 12345 --dry-run
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+
+from posthog.models.team.team import Team
+from posthog.storage.team_access_cache import token_auth_cache
+
+
+class Command(BaseCommand):
+    help = (
+        "Invalidate flags-service auth cache entries for a team. "
+        "Clears Redis cache so the Rust service re-fetches from Postgres; does not revoke tokens."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            required=True,
+            help="Team ID whose flags auth cache entries to invalidate.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be invalidated without deleting.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        team_id: int = options["team_id"]
+        dry_run: bool = options["dry_run"]
+
+        if not dry_run and not token_auth_cache.is_configured:
+            raise CommandError("FLAGS_REDIS_URL is not configured. No cache to invalidate.")
+
+        try:
+            counts = token_auth_cache.invalidate_team_tokens(team_id, dry_run=dry_run)
+        except Team.DoesNotExist:
+            raise CommandError(f"Team {team_id} not found.")
+
+        self._print_counts(team_id, counts, dry_run)
+
+    def _print_counts(self, team_id: int, counts: dict[str, int], dry_run: bool) -> None:
+        header = (
+            f"[DRY RUN] Flags auth cache entries for team {team_id}:"
+            if dry_run
+            else f"Invalidated flags auth cache entries for team {team_id}:"
+        )
+        self.stdout.write(header)
+        self.stdout.write(f"  Secret tokens:       {counts['secret_tokens']}")
+        self.stdout.write(f"  Project secret keys: {counts['project_secret_keys']}")
+        self.stdout.write(f"  Personal keys:       {counts['personal_keys']}")
+
+        if dry_run:
+            self.stdout.write(f"  Total:               {counts['total']}")
+            self.stdout.write(self.style.WARNING("No entries were deleted (dry run)."))
+        else:
+            self.stdout.write(self.style.SUCCESS(f"  Total invalidated:   {counts['total']}"))

--- a/posthog/management/commands/test/test_invalidate_flags_auth_cache.py
+++ b/posthog/management/commands/test/test_invalidate_flags_auth_cache.py
@@ -8,6 +8,7 @@ from django.core.management.base import CommandError
 from django.test import override_settings
 
 import redis as redis_lib
+from parameterized import parameterized
 
 from posthog.models.organization import Organization
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
@@ -91,31 +92,25 @@ class TestInvalidateFlagsAuthCacheCommand(BaseTest):
         assert not self._cache_exists(pak_hash)
         assert "Personal keys:       1" in output
 
-    def test_skips_pak_scoped_to_different_team(self):
-        other_team = Team.objects.create(organization=self.organization, name="Other Team")
-        pak_hash = hash_key_value("test_cmd_pak_other_team")
-        PersonalAPIKey.objects.create(
-            user=self.user,
-            label="Other Scoped PAK",
-            secure_value=pak_hash,
-            scoped_teams=[other_team.id],
-        )
-        self._seed_cache(pak_hash, {"type": "personal", "user_id": self.user.id})
+    @parameterized.expand(
+        [
+            ("scoped_to_different_team", "other_team", None),
+            ("scoped_to_different_org", None, "other_org"),
+        ]
+    )
+    def test_skips_pak_scoped_to_different(self, _name, scope_team, scope_org):
+        pak_hash = hash_key_value("test_cmd_pak_scoped")
+        pak_kwargs: dict = {"user": self.user, "label": "Scoped PAK", "secure_value": pak_hash}
 
-        output = self._call("--team-id", str(self.team.id))
+        if scope_team == "other_team":
+            other_team = Team.objects.create(organization=self.organization, name="Other Team")
+            pak_kwargs["scoped_teams"] = [other_team.id]
 
-        assert self._cache_exists(pak_hash)
-        assert "Personal keys:       0" in output
+        if scope_org == "other_org":
+            other_org = Organization.objects.create(name="Other Org")
+            pak_kwargs["scoped_organizations"] = [str(other_org.id)]
 
-    def test_skips_pak_scoped_to_different_org(self):
-        other_org = Organization.objects.create(name="Other Org")
-        pak_hash = hash_key_value("test_cmd_pak_other_org")
-        PersonalAPIKey.objects.create(
-            user=self.user,
-            label="Other Org PAK",
-            secure_value=pak_hash,
-            scoped_organizations=[str(other_org.id)],
-        )
+        PersonalAPIKey.objects.create(**pak_kwargs)
         self._seed_cache(pak_hash, {"type": "personal", "user_id": self.user.id})
 
         output = self._call("--team-id", str(self.team.id))

--- a/posthog/management/commands/test/test_invalidate_flags_auth_cache.py
+++ b/posthog/management/commands/test/test_invalidate_flags_auth_cache.py
@@ -1,0 +1,189 @@
+import json
+from io import StringIO
+
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import override_settings
+
+import redis as redis_lib
+
+from posthog.models.organization import Organization
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+from posthog.models.project_secret_api_key import ProjectSecretAPIKey
+from posthog.models.team.team import Team
+from posthog.models.utils import generate_random_token_secret
+from posthog.storage.team_access_cache import TOKEN_CACHE_PREFIX, token_auth_cache
+
+DEFAULT_CACHE_TTL = 300
+
+
+class TestInvalidateFlagsAuthCacheCommand(BaseTest):
+    def setUp(self):
+        super().setUp()
+        from posthog.redis import get_client
+
+        self.redis: redis_lib.Redis = get_client()
+        self.stdout = StringIO()
+        self.stderr = StringIO()
+
+        # Point the global token_auth_cache at the test Redis so seeded entries
+        # and deletions use the same database.
+        self._original_redis_client = token_auth_cache._redis_client
+        token_auth_cache._redis_client = self.redis
+
+        # BaseTest's team doesn't have secret tokens set
+        self.team.secret_api_token = generate_random_token_secret()
+        self.team.secret_api_token_backup = generate_random_token_secret()
+        self.team.save(update_fields=["secret_api_token", "secret_api_token_backup"])
+
+    def tearDown(self):
+        token_auth_cache._redis_client = self._original_redis_client
+        super().tearDown()
+
+    def _seed_cache(self, token_hash: str, data: dict) -> None:
+        self.redis.setex(f"{TOKEN_CACHE_PREFIX}{token_hash}", DEFAULT_CACHE_TTL, json.dumps(data))
+
+    def _cache_exists(self, token_hash: str) -> bool:
+        return bool(self.redis.exists(f"{TOKEN_CACHE_PREFIX}{token_hash}"))
+
+    def _call(self, *args: str) -> str:
+        self.stdout = StringIO()
+        call_command("invalidate_flags_auth_cache", *args, stdout=self.stdout, stderr=self.stderr)
+        return self.stdout.getvalue()
+
+    def test_invalidates_team_secret_tokens(self):
+        assert self.team.secret_api_token is not None
+        assert self.team.secret_api_token_backup is not None
+        primary_hash = hash_key_value(self.team.secret_api_token, mode="sha256")
+        backup_hash = hash_key_value(self.team.secret_api_token_backup, mode="sha256")
+        self._seed_cache(primary_hash, {"type": "secret", "team_id": self.team.id})
+        self._seed_cache(backup_hash, {"type": "secret", "team_id": self.team.id})
+
+        output = self._call("--team-id", str(self.team.id))
+
+        assert not self._cache_exists(primary_hash)
+        assert not self._cache_exists(backup_hash)
+        assert "Secret tokens:       2" in output
+
+    def test_invalidates_psaks(self):
+        psak = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Test PSAK",
+            secure_value=hash_key_value("test_cmd_psak"),
+        )
+        assert psak.secure_value is not None
+        self._seed_cache(psak.secure_value, {"type": "project_secret", "team_id": self.team.id})
+
+        output = self._call("--team-id", str(self.team.id))
+
+        assert not self._cache_exists(psak.secure_value)
+        assert "Project secret keys: 1" in output
+
+    def test_invalidates_personal_keys(self):
+        pak_hash = hash_key_value("test_cmd_pak")
+        PersonalAPIKey.objects.create(user=self.user, label="Test PAK", secure_value=pak_hash)
+        self._seed_cache(pak_hash, {"type": "personal", "user_id": self.user.id})
+
+        output = self._call("--team-id", str(self.team.id))
+
+        assert not self._cache_exists(pak_hash)
+        assert "Personal keys:       1" in output
+
+    def test_skips_pak_scoped_to_different_team(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        pak_hash = hash_key_value("test_cmd_pak_other_team")
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="Other Scoped PAK",
+            secure_value=pak_hash,
+            scoped_teams=[other_team.id],
+        )
+        self._seed_cache(pak_hash, {"type": "personal", "user_id": self.user.id})
+
+        output = self._call("--team-id", str(self.team.id))
+
+        assert self._cache_exists(pak_hash)
+        assert "Personal keys:       0" in output
+
+    def test_skips_pak_scoped_to_different_org(self):
+        other_org = Organization.objects.create(name="Other Org")
+        pak_hash = hash_key_value("test_cmd_pak_other_org")
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="Other Org PAK",
+            secure_value=pak_hash,
+            scoped_organizations=[str(other_org.id)],
+        )
+        self._seed_cache(pak_hash, {"type": "personal", "user_id": self.user.id})
+
+        output = self._call("--team-id", str(self.team.id))
+
+        assert self._cache_exists(pak_hash)
+        assert "Personal keys:       0" in output
+
+    def test_dry_run_does_not_delete(self):
+        assert self.team.secret_api_token is not None
+        primary_hash = hash_key_value(self.team.secret_api_token, mode="sha256")
+        self._seed_cache(primary_hash, {"type": "secret", "team_id": self.team.id})
+
+        output = self._call("--team-id", str(self.team.id), "--dry-run")
+
+        assert self._cache_exists(primary_hash)
+        assert "DRY RUN" in output
+        assert "No entries were deleted" in output
+
+    def test_nonexistent_team_raises_error(self):
+        with self.assertRaises(CommandError) as cm:
+            self._call("--team-id", "999999")
+        assert "Team 999999 not found" in str(cm.exception)
+
+    @override_settings(FLAGS_REDIS_URL=None)
+    def test_not_configured_raises_error(self):
+        # Temporarily clear the injected client so is_configured checks the setting
+        token_auth_cache._redis_client = None
+        try:
+            with self.assertRaises(CommandError) as cm:
+                self._call("--team-id", str(self.team.id))
+            assert "FLAGS_REDIS_URL is not configured" in str(cm.exception)
+        finally:
+            token_auth_cache._redis_client = self.redis
+
+    @override_settings(FLAGS_REDIS_URL=None)
+    def test_dry_run_works_without_redis(self):
+        # Temporarily clear the injected client so is_configured checks the setting
+        token_auth_cache._redis_client = None
+        try:
+            output = self._call("--team-id", str(self.team.id), "--dry-run")
+            assert "DRY RUN" in output
+            assert "No entries were deleted" in output
+        finally:
+            token_auth_cache._redis_client = self.redis
+
+    def test_dry_run_counts_match_actual_invalidation(self):
+        psak = ProjectSecretAPIKey.objects.create(
+            team=self.team,
+            label="Count Test PSAK",
+            secure_value=hash_key_value("test_cmd_count_psak"),
+        )
+        assert psak.secure_value is not None
+        self._seed_cache(psak.secure_value, {"type": "project_secret", "team_id": self.team.id})
+
+        pak_hash = hash_key_value("test_cmd_count_pak")
+        PersonalAPIKey.objects.create(user=self.user, label="Count PAK", secure_value=pak_hash)
+        self._seed_cache(pak_hash, {"type": "personal", "user_id": self.user.id})
+
+        args = ["--team-id", str(self.team.id)]
+
+        dry_output = self._call(*args, "--dry-run")
+        actual_output = self._call(*args)
+
+        # Extract total lines
+        dry_total = next(line for line in dry_output.splitlines() if "Total" in line)
+        actual_total = next(line for line in actual_output.splitlines() if "Total" in line)
+
+        # Both should report the same count
+        dry_count = int(dry_total.split()[-1])
+        actual_count = int(actual_total.split()[-1])
+        assert dry_count == actual_count

--- a/posthog/storage/team_access_cache.py
+++ b/posthog/storage/team_access_cache.py
@@ -1,5 +1,5 @@
 """
-Per-token auth cache with targeted invalidation.
+Per-token auth cache for the /flags/definitions service with targeted invalidation.
 
 Rust populates cache entries on first use (lazy). Python signal handlers
 perform targeted invalidation when cached tokens become invalid.
@@ -8,14 +8,20 @@ Cache keys (Rust writes, Python only deletes):
   posthog:auth_token:{token_hash}        → token metadata
 """
 
+from __future__ import annotations
+
+from django.db.models import Q
+
 import redis as redis_lib
 import structlog
 
-from posthog.models.personal_api_key import SHA256_HASH_PREFIX, PersonalAPIKey
+from posthog.models.personal_api_key import SHA256_HASH_PREFIX, PersonalAPIKey, hash_key_value
+from posthog.models.project_secret_api_key import ProjectSecretAPIKey
+from posthog.models.team.team import Team
 
 logger = structlog.get_logger(__name__)
 
-# Cache key prefix — must match the prefix used by the Rust feature-flags service
+# Cache key prefix — must match the prefix used by the Rust /flags/definitions service
 TOKEN_CACHE_PREFIX = "posthog:auth_token:"
 
 
@@ -29,7 +35,7 @@ def _get_redis_client() -> redis_lib.Redis:
 
 
 class TokenAuthCache:
-    """Per-token auth cache with targeted invalidation."""
+    """Per-token auth cache for the /flags/definitions service with targeted invalidation."""
 
     def __init__(self, redis_client: redis_lib.Redis | None = None):
         self._redis_client = redis_client
@@ -95,6 +101,76 @@ class TokenAuthCache:
 
         self.invalidate_tokens(secure_values)
         logger.info("Invalidated tokens for user via DB", user_id=user_id, tokens_invalidated=len(secure_values))
+
+    def invalidate_team_tokens(
+        self,
+        team_id: int,
+        dry_run: bool = False,
+    ) -> dict[str, int]:
+        """Invalidate all cached flags-service auth tokens for a team.
+
+        Clears Redis cache entries so the Rust /flags/definitions service re-validates
+        against Postgres on the next request. Does not revoke the tokens themselves.
+        Covers team secret tokens, project secret API keys, and personal API keys
+        that have access to the team.
+
+        When dry_run=True, collects and counts tokens but skips Redis deletion.
+
+        Returns counts of tokens found per category.
+        """
+        # Guard here (not just in invalidate_tokens) to skip the DB queries
+        if not dry_run and not self.is_configured:
+            return {"secret_tokens": 0, "project_secret_keys": 0, "personal_keys": 0, "total": 0}
+
+        team = Team.objects.only("id", "secret_api_token", "secret_api_token_backup", "organization_id").get(id=team_id)
+
+        all_hashes: list[str] = []
+
+        # 1. Team secret tokens
+        secret_token_hashes = [
+            hash_key_value(token, mode="sha256")
+            for token in (team.secret_api_token, team.secret_api_token_backup)
+            if token
+        ]
+        all_hashes.extend(secret_token_hashes)
+
+        # 2. Project Secret API Keys
+        psak_secure_values: list[str] = list(
+            ProjectSecretAPIKey.objects.filter(team_id=team_id, secure_value__isnull=False).values_list(
+                "secure_value", flat=True
+            )  # type: ignore[arg-type]  # filter guarantees non-null
+        )
+        all_hashes.extend(psak_secure_values)
+
+        # 3. Personal API Keys that could access this team
+        org_id = str(team.organization_id)
+        pak_secure_values: list[str] = list(
+            PersonalAPIKey.objects.filter(
+                user__organization_membership__organization_id=team.organization_id,
+                secure_value__startswith=SHA256_HASH_PREFIX,
+            )
+            .filter(
+                Q(scoped_teams__isnull=True) | Q(scoped_teams=[]) | Q(scoped_teams__contains=[team_id]),
+                Q(scoped_organizations__isnull=True)
+                | Q(scoped_organizations=[])
+                | Q(scoped_organizations__contains=[org_id]),
+            )
+            .values_list("secure_value", flat=True)  # type: ignore[arg-type]  # startswith filter guarantees non-null
+        )
+        all_hashes.extend(pak_secure_values)
+
+        if all_hashes and not dry_run:
+            self.invalidate_tokens(all_hashes)
+
+        counts = {
+            "secret_tokens": len(secret_token_hashes),
+            "project_secret_keys": len(psak_secure_values),
+            "personal_keys": len(pak_secure_values),
+            "total": len(all_hashes),
+        }
+        if not dry_run:
+            logger.info("Invalidated team tokens", team_id=team_id, **counts)
+        return counts
 
 
 # Global instance

--- a/posthog/storage/test/test_team_access_cache.py
+++ b/posthog/storage/test/test_team_access_cache.py
@@ -31,6 +31,10 @@ class TestTokenAuthCacheNotConfigured(TestCase):
         self.cache.invalidate_user_tokens(42)
         mock_pak.objects.filter.assert_not_called()
 
+    def test_invalidate_team_tokens_skips_when_not_configured(self):
+        counts = self.cache.invalidate_team_tokens(team_id=99999)
+        assert counts == {"secret_tokens": 0, "project_secret_keys": 0, "personal_keys": 0, "total": 0}
+
 
 class TestTokenAuthCache(TestCase):
     BATCH_TOKEN_HASHES = ["sha256$token_a", "sha256$token_b", "sha256$token_c"]
@@ -66,6 +70,12 @@ class TestTokenAuthCache(TestCase):
             "test_my_token",
             "test_other_token",
             "test_fallback_key",
+            "test_psak_token",
+            "test_pak_include_token",
+            "test_pak_scoped_token",
+            "test_pak_org_scoped_token",
+            "test_pak_scoped_to_target",
+            "test_pak_empty_scope",
         ]
         keys_to_delete = [
             f"{TOKEN_CACHE_PREFIX}{self.token_hash}",
@@ -159,6 +169,193 @@ class TestTokenAuthCache(TestCase):
 
     def test_invalidate_tokens_noop_on_empty_list(self):
         self.cache.invalidate_tokens([])  # should not raise
+
+    def test_invalidate_team_tokens_deletes_secret_tokens(self):
+        from posthog.models.personal_api_key import hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.utils import generate_random_token_secret
+
+        team = Team.objects.create(
+            organization=self._get_or_create_org(),
+            name="Secret Token Test Team",
+            secret_api_token=generate_random_token_secret(),
+            secret_api_token_backup=generate_random_token_secret(),
+        )
+        primary_hash = hash_key_value(team.secret_api_token, mode="sha256")
+        backup_hash = hash_key_value(team.secret_api_token_backup, mode="sha256")
+        self._seed_token_cache(primary_hash, {"type": "secret", "team_id": team.id})
+        self._seed_token_cache(backup_hash, {"type": "secret", "team_id": team.id})
+
+        counts = self.cache.invalidate_team_tokens(team.id)
+
+        assert counts["secret_tokens"] == 2
+        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{primary_hash}")
+        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{backup_hash}")
+
+    def test_invalidate_team_tokens_deletes_psak_entries(self):
+        from posthog.models.personal_api_key import hash_key_value
+        from posthog.models.project_secret_api_key import ProjectSecretAPIKey
+        from posthog.models.team.team import Team
+        from posthog.models.utils import generate_random_token_secret
+
+        team = Team.objects.create(
+            organization=self._get_or_create_org(),
+            name="PSAK Test Team",
+            secret_api_token=generate_random_token_secret(),
+        )
+        psak = ProjectSecretAPIKey.objects.create(
+            team=team,
+            label="Test PSAK",
+            secure_value=hash_key_value("test_psak_token"),
+        )
+        assert psak.secure_value is not None
+        self._seed_token_cache(psak.secure_value, {"type": "project_secret", "team_id": team.id})
+
+        counts = self.cache.invalidate_team_tokens(team.id)
+
+        assert counts["project_secret_keys"] == 1
+        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{psak.secure_value}")
+
+    def test_invalidate_team_tokens_includes_personal_keys(self):
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_secret
+
+        org = self._get_or_create_org()
+        team = Team.objects.create(
+            organization=org, name="PAK Include Test Team", secret_api_token=generate_random_token_secret()
+        )
+        user = User.objects.create(email="pak_include_test@example.com", is_active=True)
+        user.join(organization=org)
+
+        pak_hash = hash_key_value("test_pak_include_token")
+        PersonalAPIKey.objects.create(user=user, label="Include Key", secure_value=pak_hash)
+        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
+
+        counts = self.cache.invalidate_team_tokens(team.id)
+
+        assert counts["personal_keys"] == 1
+        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
+
+    def test_invalidate_team_tokens_skips_pak_scoped_to_different_team(self):
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_secret
+
+        org = self._get_or_create_org()
+        team = Team.objects.create(
+            organization=org, name="PAK Scope Team Test", secret_api_token=generate_random_token_secret()
+        )
+        other_team = Team.objects.create(
+            organization=org, name="Other Team", secret_api_token=generate_random_token_secret()
+        )
+        user = User.objects.create(email="pak_scope_test@example.com", is_active=True)
+        user.join(organization=org)
+
+        pak_hash = hash_key_value("test_pak_scoped_token")
+        PersonalAPIKey.objects.create(
+            user=user,
+            label="Scoped Key",
+            secure_value=pak_hash,
+            scoped_teams=[other_team.id],
+        )
+        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
+
+        counts = self.cache.invalidate_team_tokens(team.id)
+
+        assert counts["personal_keys"] == 0
+        assert self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
+
+    def test_invalidate_team_tokens_skips_pak_scoped_to_different_org(self):
+        from posthog.models.organization import Organization
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_secret
+
+        org = self._get_or_create_org()
+        other_org = Organization.objects.create(name="Other Org")
+        team = Team.objects.create(
+            organization=org, name="PAK Org Scope Team", secret_api_token=generate_random_token_secret()
+        )
+        user = User.objects.create(email="pak_org_scope_test@example.com", is_active=True)
+        user.join(organization=org)
+
+        pak_hash = hash_key_value("test_pak_org_scoped_token")
+        PersonalAPIKey.objects.create(
+            user=user,
+            label="Org Scoped Key",
+            secure_value=pak_hash,
+            scoped_organizations=[str(other_org.id)],
+        )
+        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
+
+        counts = self.cache.invalidate_team_tokens(team.id)
+
+        assert counts["personal_keys"] == 0
+        assert self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
+
+    def test_invalidate_team_tokens_includes_pak_scoped_to_target_team(self):
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_secret
+
+        org = self._get_or_create_org()
+        team = Team.objects.create(
+            organization=org, name="PAK Scoped Target Test", secret_api_token=generate_random_token_secret()
+        )
+        user = User.objects.create(email="pak_scoped_target@example.com", is_active=True)
+        user.join(organization=org)
+
+        pak_hash = hash_key_value("test_pak_scoped_to_target")
+        PersonalAPIKey.objects.create(
+            user=user,
+            label="Scoped to Target Key",
+            secure_value=pak_hash,
+            scoped_teams=[team.id],
+        )
+        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
+
+        counts = self.cache.invalidate_team_tokens(team.id)
+
+        assert counts["personal_keys"] == 1
+        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
+
+    def test_invalidate_team_tokens_includes_pak_with_empty_scope_arrays(self):
+        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
+        from posthog.models.team.team import Team
+        from posthog.models.user import User
+        from posthog.models.utils import generate_random_token_secret
+
+        org = self._get_or_create_org()
+        team = Team.objects.create(
+            organization=org, name="PAK Empty Scope Test", secret_api_token=generate_random_token_secret()
+        )
+        user = User.objects.create(email="pak_empty_scope@example.com", is_active=True)
+        user.join(organization=org)
+
+        pak_hash = hash_key_value("test_pak_empty_scope")
+        PersonalAPIKey.objects.create(
+            user=user,
+            label="Empty Scope Key",
+            secure_value=pak_hash,
+            scoped_teams=[],
+            scoped_organizations=[],
+        )
+        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
+
+        counts = self.cache.invalidate_team_tokens(team.id)
+
+        assert counts["personal_keys"] == 1
+        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
+
+    def _get_or_create_org(self):
+        from posthog.models.organization import Organization
+
+        return Organization.objects.get_or_create(name="Test Org for Auth Cache")[0]
 
     def test_invalidate_preserves_other_users_tokens(self):
         from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value

--- a/posthog/storage/test/test_team_access_cache.py
+++ b/posthog/storage/test/test_team_access_cache.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.test import TestCase, override_settings
 
 import redis as redis_lib
+from parameterized import parameterized
 
 from posthog.storage.team_access_cache import TOKEN_CACHE_PREFIX, TokenAuthCache
 
@@ -73,9 +74,6 @@ class TestTokenAuthCache(TestCase):
             "test_psak_token",
             "test_pak_include_token",
             "test_pak_scoped_token",
-            "test_pak_org_scoped_token",
-            "test_pak_scoped_to_target",
-            "test_pak_empty_scope",
         ]
         keys_to_delete = [
             f"{TOKEN_CACHE_PREFIX}{self.token_hash}",
@@ -238,37 +236,15 @@ class TestTokenAuthCache(TestCase):
         assert counts["personal_keys"] == 1
         assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
 
-    def test_invalidate_team_tokens_skips_pak_scoped_to_different_team(self):
-        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
-        from posthog.models.team.team import Team
-        from posthog.models.user import User
-        from posthog.models.utils import generate_random_token_secret
-
-        org = self._get_or_create_org()
-        team = Team.objects.create(
-            organization=org, name="PAK Scope Team Test", secret_api_token=generate_random_token_secret()
-        )
-        other_team = Team.objects.create(
-            organization=org, name="Other Team", secret_api_token=generate_random_token_secret()
-        )
-        user = User.objects.create(email="pak_scope_test@example.com", is_active=True)
-        user.join(organization=org)
-
-        pak_hash = hash_key_value("test_pak_scoped_token")
-        PersonalAPIKey.objects.create(
-            user=user,
-            label="Scoped Key",
-            secure_value=pak_hash,
-            scoped_teams=[other_team.id],
-        )
-        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
-
-        counts = self.cache.invalidate_team_tokens(team.id)
-
-        assert counts["personal_keys"] == 0
-        assert self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
-
-    def test_invalidate_team_tokens_skips_pak_scoped_to_different_org(self):
+    @parameterized.expand(
+        [
+            ("scoped_to_different_team", "other_team", None, 0),
+            ("scoped_to_different_org", None, "other_org", 0),
+            ("scoped_to_target_team", "target_team", None, 1),
+            ("empty_scope_arrays", [], [], 1),
+        ]
+    )
+    def test_invalidate_team_tokens_pak_scoping(self, _name, scoped_teams, scoped_organizations, expected_count):
         from posthog.models.organization import Organization
         from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
         from posthog.models.team.team import Team
@@ -276,81 +252,39 @@ class TestTokenAuthCache(TestCase):
         from posthog.models.utils import generate_random_token_secret
 
         org = self._get_or_create_org()
-        other_org = Organization.objects.create(name="Other Org")
         team = Team.objects.create(
-            organization=org, name="PAK Org Scope Team", secret_api_token=generate_random_token_secret()
+            organization=org, name="PAK Scope Test", secret_api_token=generate_random_token_secret()
         )
-        user = User.objects.create(email="pak_org_scope_test@example.com", is_active=True)
+        user = User.objects.create(email="pak_scope_test@example.com", is_active=True)
         user.join(organization=org)
 
-        pak_hash = hash_key_value("test_pak_org_scoped_token")
-        PersonalAPIKey.objects.create(
-            user=user,
-            label="Org Scoped Key",
-            secure_value=pak_hash,
-            scoped_organizations=[str(other_org.id)],
-        )
+        # Resolve sentinel values to real IDs
+        if scoped_teams == "other_team":
+            other_team = Team.objects.create(
+                organization=org, name="Other Team", secret_api_token=generate_random_token_secret()
+            )
+            scoped_teams = [other_team.id]
+        elif scoped_teams == "target_team":
+            scoped_teams = [team.id]
+
+        if scoped_organizations == "other_org":
+            other_org = Organization.objects.create(name="Other Org")
+            scoped_organizations = [str(other_org.id)]
+
+        pak_hash = hash_key_value("test_pak_scoped_token")
+        pak_kwargs: dict = {"user": user, "label": "Scoped Key", "secure_value": pak_hash}
+        if scoped_teams is not None:
+            pak_kwargs["scoped_teams"] = scoped_teams
+        if scoped_organizations is not None:
+            pak_kwargs["scoped_organizations"] = scoped_organizations
+        PersonalAPIKey.objects.create(**pak_kwargs)
         self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
 
         counts = self.cache.invalidate_team_tokens(team.id)
 
-        assert counts["personal_keys"] == 0
-        assert self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
-
-    def test_invalidate_team_tokens_includes_pak_scoped_to_target_team(self):
-        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
-        from posthog.models.team.team import Team
-        from posthog.models.user import User
-        from posthog.models.utils import generate_random_token_secret
-
-        org = self._get_or_create_org()
-        team = Team.objects.create(
-            organization=org, name="PAK Scoped Target Test", secret_api_token=generate_random_token_secret()
-        )
-        user = User.objects.create(email="pak_scoped_target@example.com", is_active=True)
-        user.join(organization=org)
-
-        pak_hash = hash_key_value("test_pak_scoped_to_target")
-        PersonalAPIKey.objects.create(
-            user=user,
-            label="Scoped to Target Key",
-            secure_value=pak_hash,
-            scoped_teams=[team.id],
-        )
-        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
-
-        counts = self.cache.invalidate_team_tokens(team.id)
-
-        assert counts["personal_keys"] == 1
-        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
-
-    def test_invalidate_team_tokens_includes_pak_with_empty_scope_arrays(self):
-        from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
-        from posthog.models.team.team import Team
-        from posthog.models.user import User
-        from posthog.models.utils import generate_random_token_secret
-
-        org = self._get_or_create_org()
-        team = Team.objects.create(
-            organization=org, name="PAK Empty Scope Test", secret_api_token=generate_random_token_secret()
-        )
-        user = User.objects.create(email="pak_empty_scope@example.com", is_active=True)
-        user.join(organization=org)
-
-        pak_hash = hash_key_value("test_pak_empty_scope")
-        PersonalAPIKey.objects.create(
-            user=user,
-            label="Empty Scope Key",
-            secure_value=pak_hash,
-            scoped_teams=[],
-            scoped_organizations=[],
-        )
-        self._seed_token_cache(pak_hash, {"type": "personal", "user_id": user.id})
-
-        counts = self.cache.invalidate_team_tokens(team.id)
-
-        assert counts["personal_keys"] == 1
-        assert not self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}")
+        assert counts["personal_keys"] == expected_count
+        should_exist = expected_count == 0
+        assert self.redis.exists(f"{TOKEN_CACHE_PREFIX}{pak_hash}") == should_exist
 
     def _get_or_create_org(self):
         from posthog.models.organization import Organization


### PR DESCRIPTION
## Problem

When a team's auth tokens need to be re-validated by the Rust feature-flags service (e.g., after a security incident, token rotation, or debugging cache staleness), there is no way to force cache invalidation for all token types associated with a team. The signal handlers handle individual token changes, but bulk invalidation requires manual Redis operations.

## Changes

Adds a `invalidate_flags_auth_cache` Django management command and the underlying `invalidate_team_tokens()` method on `TokenAuthCache`.

- Collects token hashes from three sources: team secret tokens, project secret API keys, and personal API keys that have access to the team (scoped by team and org membership)
- Batch-deletes the corresponding Redis cache entries so the Rust service re-validates against Postgres on the next request
- Supports `--dry-run` to preview what would be invalidated without deleting
- Does not revoke tokens, only clears cache entries

```
python manage.py invalidate_flags_auth_cache --team-id 12345
python manage.py invalidate_flags_auth_cache --team-id 12345 --dry-run
```

## How did you test this code?

- 20 unit and integration tests across two test files covering all token types, PAK scope filtering (different team, different org, target team, empty scopes), dry-run behavior, error conditions, and count parity between dry-run and actual invalidation
- Manually ran the command against a local dev environment

no