### PR TITLE
feat: (flags): optimize is_condition_match with zero-copy filtering

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -366,11 +367,12 @@ pub fn evaluate_dynamic_cohorts(
 /// 1. Checking each filter's cohort ID
 /// 2. Looking up the match result in the cohort_matches map
 /// 3. Applying the appropriate operator (IN/NOT_IN)
-pub fn apply_cohort_membership_logic(
-    cohort_filters: &[PropertyFilter],
+pub fn apply_cohort_membership_logic<F: Borrow<PropertyFilter>>(
+    cohort_filters: &[F],
     cohort_matches: &HashMap<CohortId, bool>,
 ) -> Result<bool, FlagError> {
     for filter in cohort_filters {
+        let filter = filter.borrow();
         let cohort_id = filter
             .get_cohort_id()
             .ok_or(FlagError::CohortFiltersParsingError)?;

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1431,9 +1431,9 @@ impl FeatureFlagMatcher {
                 );
             }
 
-            // Single-pass evaluation, cheapest-first: flag-value → property → cohort.
-            // Flag-value and property filters short-circuit immediately on mismatch.
-            // Cohort filters are collected and batch-evaluated after the loop.
+            // Single-pass evaluation: flag-value and property filters are evaluated in Vec order
+            // and short-circuit immediately on mismatch. Cohort filters (the most expensive)
+            // are deferred and batch-evaluated after the loop to avoid unnecessary work.
             let mut cohort_filters: Vec<&PropertyFilter> = Vec::new();
             for filter in flag_property_filters {
                 if filter.depends_on_feature_flag() {

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1431,35 +1431,25 @@ impl FeatureFlagMatcher {
                 );
             }
 
-            // Evaluate filters by type without cloning, ordered cheapest-first:
-            // 1. Flag-value filters (hash lookups against already-evaluated flags)
-            for filter in flag_property_filters
-                .iter()
-                .filter(|f| f.depends_on_feature_flag())
-            {
-                if !match_flag_value_to_flag_filter(
-                    filter,
-                    &self.flag_evaluation_state.flag_evaluation_results,
-                ) {
+            // Single-pass evaluation, cheapest-first: flag-value → property → cohort.
+            // Flag-value and property filters short-circuit immediately on mismatch.
+            // Cohort filters are collected and batch-evaluated after the loop.
+            let mut cohort_filters: Vec<&PropertyFilter> = Vec::new();
+            for filter in flag_property_filters {
+                if filter.depends_on_feature_flag() {
+                    if !match_flag_value_to_flag_filter(
+                        filter,
+                        &self.flag_evaluation_state.flag_evaluation_results,
+                    ) {
+                        return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                    }
+                } else if filter.is_cohort() {
+                    cohort_filters.push(filter);
+                } else if !match_property(filter, merged_properties, false).unwrap_or(false) {
                     return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
                 }
             }
 
-            // 2. Non-cohort property filters (person/group property lookups)
-            for filter in flag_property_filters
-                .iter()
-                .filter(|f| !f.depends_on_feature_flag() && !f.is_cohort())
-            {
-                if !match_property(filter, merged_properties, false).unwrap_or(false) {
-                    return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
-                }
-            }
-
-            // 3. Cohort filters (most expensive, deferred to last)
-            let cohort_filters: Vec<&PropertyFilter> = flag_property_filters
-                .iter()
-                .filter(|f| f.is_cohort())
-                .collect();
             if !cohort_filters.is_empty() {
                 let cohorts = match &self.flag_evaluation_state.cohorts {
                     Some(cohorts) => cohorts.clone(),

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1450,6 +1450,7 @@ impl FeatureFlagMatcher {
                 }
             }
 
+            // Evaluate cohort filters, if any.
             if !cohort_filters.is_empty() {
                 let cohorts = match &self.flag_evaluation_state.cohorts {
                     Some(cohorts) => cohorts.clone(),

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -10,8 +10,8 @@ use crate::flags::flag_group_type_mapping::{
 };
 use crate::flags::flag_match_reason::FeatureFlagMatchReason;
 use crate::flags::flag_matching_utils::{
-    all_flag_condition_properties_match, all_properties_match, calculate_hash,
-    fetch_and_locally_cache_all_relevant_properties, get_feature_flag_hash_key_overrides,
+    calculate_hash, fetch_and_locally_cache_all_relevant_properties,
+    get_feature_flag_hash_key_overrides, match_flag_value_to_flag_filter,
     populate_missing_initial_properties, set_feature_flag_hash_key_overrides,
     should_write_hash_key_override,
 };
@@ -31,6 +31,7 @@ use crate::metrics::consts::{
     FLAG_REALTIME_COHORT_QUERY_ERROR_COUNTER, FLAG_REALTIME_COHORT_QUERY_TIME,
     PROPERTY_CACHE_HITS_COUNTER, PROPERTY_CACHE_MISSES_COUNTER,
 };
+use crate::properties::property_matching::match_property;
 use crate::properties::property_models::PropertyFilter;
 use crate::rayon_dispatcher::RayonDispatcher;
 use crate::utils::graph_utils::PrecomputedDependencyGraph;
@@ -629,7 +630,7 @@ impl FeatureFlagMatcher {
     /// and evaluates dynamic cohorts based on the provided properties.
     pub fn evaluate_cohort_filters(
         &self,
-        cohort_property_filters: &[PropertyFilter],
+        cohort_property_filters: &[&PropertyFilter],
         target_properties: &HashMap<String, Value>,
         cohorts: Vec<Cohort>,
     ) -> Result<bool, FlagError> {
@@ -1430,35 +1431,35 @@ impl FeatureFlagMatcher {
                 );
             }
 
-            // Separate flag value filters from other filters
-            let (flag_value_filters, other_filters): (Vec<PropertyFilter>, Vec<PropertyFilter>) =
-                flag_property_filters
-                    .iter()
-                    .cloned()
-                    .partition(|prop| prop.depends_on_feature_flag());
-
-            if !flag_value_filters.is_empty()
-                && !all_flag_condition_properties_match(
-                    &flag_value_filters,
-                    &self.flag_evaluation_state.flag_evaluation_results,
-                )
+            // Evaluate filters by type without cloning, ordered cheapest-first:
+            // 1. Flag-value filters (hash lookups against already-evaluated flags)
+            for filter in flag_property_filters
+                .iter()
+                .filter(|f| f.depends_on_feature_flag())
             {
-                return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                if !match_flag_value_to_flag_filter(
+                    filter,
+                    &self.flag_evaluation_state.flag_evaluation_results,
+                ) {
+                    return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                }
             }
 
-            // Separate cohort and non-cohort filters
-            let (cohort_filters, non_cohort_filters): (Vec<PropertyFilter>, Vec<PropertyFilter>) =
-                other_filters
-                    .iter()
-                    .cloned()
-                    .partition(|prop| prop.is_cohort());
-
-            // Evaluate non-cohort filters first, since they're cheaper to evaluate and we can return early if they don't match
-            if !all_properties_match(&non_cohort_filters, merged_properties) {
-                return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+            // 2. Non-cohort property filters (person/group property lookups)
+            for filter in flag_property_filters
+                .iter()
+                .filter(|f| !f.depends_on_feature_flag() && !f.is_cohort())
+            {
+                if !match_property(filter, merged_properties, false).unwrap_or(false) {
+                    return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                }
             }
 
-            // Evaluate cohort filters, if any.
+            // 3. Cohort filters (most expensive, deferred to last)
+            let cohort_filters: Vec<&PropertyFilter> = flag_property_filters
+                .iter()
+                .filter(|f| f.is_cohort())
+                .collect();
             if !cohort_filters.is_empty() {
                 let cohorts = match &self.flag_evaluation_state.cohorts {
                     Some(cohorts) => cohorts.clone(),

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -526,7 +526,6 @@ fn classify_and_track_error(error: &FlagError, operation: &str, will_retry: bool
     common_metrics::inc(FLAG_DATABASE_ERROR_COUNTER, &labels, 1);
 }
 
-
 // Attempts to match a flag condition filter that depends on another flag
 // evaluation result to a flag evaluation result
 pub fn match_flag_value_to_flag_filter(

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -33,10 +33,7 @@ use crate::{
         FLAG_HASH_KEY_QUERY_RESULT, FLAG_HASH_KEY_RETRIES_COUNTER, FLAG_PERSON_PROCESSING_TIME,
         FLAG_PERSON_QUERY_TIME,
     },
-    properties::{
-        property_matching::match_property,
-        property_models::{OperatorType, PropertyFilter},
-    },
+    properties::property_models::{OperatorType, PropertyFilter},
 };
 
 use super::{flag_group_type_mapping::GroupTypeIndex, flag_matching::FlagEvaluationState};
@@ -529,24 +526,6 @@ fn classify_and_track_error(error: &FlagError, operation: &str, will_retry: bool
     common_metrics::inc(FLAG_DATABASE_ERROR_COUNTER, &labels, 1);
 }
 
-/// Check if all properties match the given filters
-pub fn all_properties_match(
-    flag_condition_properties: &[PropertyFilter],
-    matching_property_values: &HashMap<String, Value>,
-) -> bool {
-    flag_condition_properties
-        .iter()
-        .all(|property| match_property(property, matching_property_values, false).unwrap_or(false))
-}
-
-pub fn all_flag_condition_properties_match(
-    flag_condition_properties: &[PropertyFilter],
-    flag_evaluation_results: &HashMap<FeatureFlagId, FlagValue>,
-) -> bool {
-    flag_condition_properties
-        .iter()
-        .all(|property| match_flag_value_to_flag_filter(property, flag_evaluation_results))
-}
 
 // Attempts to match a flag condition filter that depends on another flag
 // evaluation result to a flag evaluation result

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -1501,6 +1501,146 @@ mod tests {
         assert_eq!(reason, FeatureFlagMatchReason::ConditionMatch);
     }
 
+    /// Verifies that interleaved filter types within a single condition (e.g., a Person
+    /// property filter followed by a Flag filter) are evaluated correctly in Vec order.
+    #[tokio::test]
+    async fn test_is_condition_match_interleaved_filter_types() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+
+        // Dependent flag id used in the flag-value filter
+        let dependent_flag_id = 42;
+
+        let flag = create_test_flag(
+            Some(1),
+            None,
+            None,
+            None,
+            Some(FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                    ..Default::default()
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+                holdout: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        // Interleaved: Person filter, then Flag filter, then another Person filter.
+        let condition = FlagPropertyGroup {
+            variant: None,
+            properties: Some(vec![
+                PropertyFilter {
+                    key: "email".to_string(),
+                    value: Some(json!("test@example.com")),
+                    operator: Some(OperatorType::Exact),
+                    prop_type: PropertyType::Person,
+                    group_type_index: None,
+                    negation: None,
+                },
+                PropertyFilter {
+                    key: dependent_flag_id.to_string(),
+                    value: Some(json!(true)),
+                    operator: Some(OperatorType::FlagEvaluatesTo),
+                    prop_type: PropertyType::Flag,
+                    group_type_index: None,
+                    negation: None,
+                },
+                PropertyFilter {
+                    key: "age".to_string(),
+                    value: Some(json!(25)),
+                    operator: Some(OperatorType::Gte),
+                    prop_type: PropertyType::Person,
+                    group_type_index: None,
+                    negation: None,
+                },
+            ]),
+            rollout_percentage: Some(100.0),
+            ..Default::default()
+        };
+
+        let mut person_properties = HashMap::new();
+        person_properties.insert("email".to_string(), json!("test@example.com"));
+        person_properties.insert("age".to_string(), json!(30));
+
+        let mut matcher = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            1,
+            context.create_postgres_router(),
+            cohort_cache.clone(),
+            empty_group_type_cache(),
+            None,
+        );
+        matcher
+            .flag_evaluation_state
+            .add_flag_evaluation_result(dependent_flag_id, FlagValue::Boolean(true));
+
+        // All filters match: should pass
+        let (is_match, reason) = matcher
+            .is_condition_match(&flag, &condition, &person_properties, None, &None)
+            .unwrap();
+        assert!(is_match);
+        assert_eq!(reason, FeatureFlagMatchReason::ConditionMatch);
+
+        // Now make the person property filter (first in Vec) fail.
+        // The loop should short-circuit on the first filter without evaluating the flag filter.
+        let mut mismatched_properties = HashMap::new();
+        mismatched_properties.insert("email".to_string(), json!("other@example.com"));
+        mismatched_properties.insert("age".to_string(), json!(30));
+
+        let mut matcher2 = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            1,
+            context.create_postgres_router(),
+            cohort_cache.clone(),
+            empty_group_type_cache(),
+            None,
+        );
+        matcher2
+            .flag_evaluation_state
+            .add_flag_evaluation_result(dependent_flag_id, FlagValue::Boolean(true));
+
+        let (is_match, reason) = matcher2
+            .is_condition_match(&flag, &condition, &mismatched_properties, None, &None)
+            .unwrap();
+        assert!(!is_match);
+        assert_eq!(reason, FeatureFlagMatchReason::NoConditionMatch);
+
+        // Make the flag-value filter (middle of Vec) fail while person filters match.
+        let mut matcher3 = FeatureFlagMatcher::new(
+            "test_user".to_string(),
+            None,
+            1,
+            context.create_postgres_router(),
+            cohort_cache,
+            empty_group_type_cache(),
+            None,
+        );
+        matcher3
+            .flag_evaluation_state
+            .add_flag_evaluation_result(dependent_flag_id, FlagValue::Boolean(false));
+
+        let (is_match, reason) = matcher3
+            .is_condition_match(&flag, &condition, &person_properties, None, &None)
+            .unwrap();
+        assert!(!is_match);
+        assert_eq!(reason, FeatureFlagMatchReason::NoConditionMatch);
+    }
+
     fn create_test_flag_with_variants(team_id: TeamId) -> FeatureFlag {
         FeatureFlag {
             id: 1,


### PR DESCRIPTION
## Problem

`is_condition_match()` performs two `iter().cloned().partition()` calls on every condition of every flag, cloning every `PropertyFilter` (which contains heap-allocated `String` and `serde_json::Value`) unnecessarily. All downstream consumers only need borrowed references.

_Note: see https://github.com/PostHog/posthog/issues/52017_

## Changes

Replace the clone-partition pattern with zero-copy filtered iteration. Filters are now evaluated in a single pass by branching on `prop_type` (a cheap `Clone + PartialEq` enum compared by value). Flag-value and property filters short-circuit immediately on mismatch (in Vec order); cohort filters are deferred and batch-evaluated after the loop. The only allocation is a `Vec<&PropertyFilter>` for cohort filters when present.

- Make `apply_cohort_membership_logic` generic over `Borrow<PropertyFilter>` so it accepts both owned and borrowed filter slices
- Change `evaluate_cohort_filters` to take `&[&PropertyFilter]`
- Inline `match_flag_value_to_flag_filter` and `match_property` calls directly in the evaluation loop

## How did you test this code?

- All previous tests pass
- Clippy clean
- Criterion benchmark (see below)

### Criterion benchmarks (original vs optimized)

Per-flag `get_match` with varying filter counts:

| Filters per condition | Original | Optimized | Change |
|-----------------------|----------|-----------|--------|
| 1 | 747 ns | 587 ns | **-21%** |
| 3 | 1.16 us | 896 ns | **-23%** |
| 5 | 1.66 us | 1.19 us | **-28%** |
| 10 | 2.78 us | 1.90 us | **-32%** |
| 20 | 4.95 us | 3.32 us | **-33%** |

Per-flag `get_match` with varying condition counts (worst-case: only last condition matches):

| Conditions per flag | Original | Optimized | Change |
|---------------------|----------|-----------|--------|
| 1 | 1.19 us | 875 ns | **-26%** |
| 3 | 1.80 us | 915 ns | **-49%** |
| 5 | 2.37 us | 955 ns | **-60%** |
| 10 | 3.79 us | 1.03 us | **-73%** |
| 20 | 6.58 us | 1.17 us | **-82%** |

Rollout-only (no filters, baseline): 375 ns -> 375 ns (no change, as expected).

Realistic `/flags` request (mixed flag types):

| Flags | Original | Optimized | Change |
|-------|----------|-----------|--------|
| 10 | 16.2 us | 13.2 us | **-18%** |
| 50 | 282 us | 264 us | **-6%** |
| 100 | 1.065 ms | 1.032 ms | **-3%** |
| 200 | 4.34 ms | 4.27 ms | **-2%** |

The many_flags improvement diminishes at higher counts because 25% of those flags use regex operators (~70us each), which dominate total time and are unaffected by this change (follow up optimization).

### Production data validation

Queried `posthog_featureflag` to validate benchmark parameters against real usage:

**Filters per condition**: 55% of conditions are rollout-only (0 filters), 35% have 1 filter, ~10% have 2-3. Our benchmark covers the full range, though the dominant case is 0-1 filters.

**Conditions per flag**: 86% of flags have exactly 1 condition, 95% have at most 2. The dramatic multi-condition improvements (49-82%) apply to a long tail of ~5% of flags.

**Top teams by total filters**: Heaviest teams have 300-700 total filters evaluated per request (600-1,400 clones eliminated). PostHog's own team: 966 flags, 1,126 filters, 2,252 clones eliminated per request.

**Estimated real-world impact**: Weighted by production distribution, the improvement should be ~10-15% of total per-request flag evaluation CPU time (and ~35-40% of the property-matching portion specifically). The benefit is most significant on the SDK `/flags` hot path where properties are provided inline as overrides and no DB round-trip occurs.
