### PR TITLE
feat(flags): preload referenced cohorts in flags hypercache

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -112,6 +112,10 @@ _COHORT_RECALCULATION_FIELDS = frozenset(
         "last_calculation_duration_ms",
         "errors_calculating",
         "last_error_at",
+        # NOTE: `groups` is the legacy cohort-condition field (deprecated in favour of
+        # `filters`).  calculate_people_ch() always saves it in update_fields even when
+        # unchanged (see cohort.py:347).  Real definition changes go through a full save
+        # (update_fields=None), so they still trigger invalidation.
         "groups",
         "cohort_type",
     ]

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -125,8 +125,8 @@ def _extract_cohort_ids_from_flag_filters(flags_data: list[dict[str, Any]]) -> s
     properties:
     - ``super_groups`` are early-access enrollment gates that only use person
       properties (``$feature_enrollment/*``).
-    - ``holdout_groups`` use a different schema (``{"id": N,
-      "exclusion_percentage": N}``) with no property filters at all.
+    - ``holdout`` uses a different schema for configuring experiment holdouts
+      with no property filters at all.
     """
     cohort_ids: set[int] = set()
     for flag in flags_data:

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -3,13 +3,15 @@ Flags HyperCache for feature-flags service.
 
 This module provides a HyperCache that stores feature flags for the feature-flags service.
 Unlike the local_evaluation.py cache which provides rich data for SDKs (including cohorts
-and group type mappings), this cache provides just the raw flag data.
+and group type mappings), this cache provides flag data plus the cohort definitions that
+those flags actually reference.
 
 The cache is automatically invalidated when:
 - FeatureFlag models are created, updated, or deleted
 - Team models are created or deleted (to ensure flag caches are cleaned up)
 - FeatureFlagEvaluationTag models are created or deleted
 - Tag models are updated (since tag names are cached in evaluation_tags)
+- Cohort definitions are created, updated, or deleted (not recalculation-only saves)
 - Hourly refresh job detects expiring entries (TTL < 24h)
 
 Cache Key Pattern:
@@ -44,6 +46,8 @@ import structlog
 
 from posthog.caching.flags_redis_cache import FLAGS_DEDICATED_CACHE_ALIAS
 from posthog.metrics import TOMBSTONE_COUNTER
+from posthog.models.cohort.cohort import Cohort
+from posthog.models.cohort.dependencies import extract_cohort_dependencies
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.feature_flag.feature_flag import (
     FeatureFlagEvaluationTag,
@@ -90,6 +94,134 @@ def _extract_direct_dependency_ids(flag_data: dict[str, Any]) -> set[int]:
                 except (ValueError, KeyError, TypeError):
                     continue
     return dep_ids
+
+
+# Cohort model fields that change only during recalculation, not definition edits.
+# Used by the post_save signal to avoid rebuilding the flags cache on every
+# static cohort recalculation or count update.
+# NOTE: cohort_type is included because calculate_people_ch() always saves it in
+# update_fields even when unchanged. The rare actual cohort_type change (realtime
+# exceeding person limit) uses Cohort.objects.filter().update() which bypasses signals.
+_COHORT_RECALCULATION_FIELDS = frozenset(
+    [
+        "count",
+        "version",
+        "pending_version",
+        "is_calculating",
+        "last_calculation",
+        "last_calculation_duration_ms",
+        "errors_calculating",
+        "last_error_at",
+        "groups",
+        "cohort_type",
+    ]
+)
+
+
+def _extract_cohort_ids_from_flag_filters(flags_data: list[dict[str, Any]]) -> set[int]:
+    """Extract cohort IDs directly referenced in active flag filters.
+
+    Only scans ``groups`` — the other filter sections cannot contain cohort
+    properties:
+    - ``super_groups`` are early-access enrollment gates that only use person
+      properties (``$feature_enrollment/*``).
+    - ``holdout_groups`` use a different schema (``{"id": N,
+      "exclusion_percentage": N}``) with no property filters at all.
+    """
+    cohort_ids: set[int] = set()
+    for flag in flags_data:
+        if not flag.get("active", True) or flag.get("deleted", False):
+            continue
+        for group in flag.get("filters", {}).get("groups") or []:
+            for prop in group.get("properties") or []:
+                if prop.get("type") == "cohort":
+                    try:
+                        cohort_ids.add(int(prop["value"]))
+                    except (ValueError, KeyError, TypeError):
+                        continue
+    return cohort_ids
+
+
+_MAX_COHORT_DEPENDENCY_DEPTH = 20
+
+
+def _load_cohorts_with_deps(seed_ids: set[int], **team_filter: Any) -> dict[int, Cohort]:
+    """BFS-load cohorts by seed IDs, resolving transitive cohort-on-cohort deps.
+
+    Args:
+        seed_ids: Initial cohort IDs to load.
+        **team_filter: Passed to Cohort.objects.filter() for team scoping,
+            e.g. team_id=5 or team_id__in={5, 6}.
+
+    Returns:
+        Dict mapping cohort PK to loaded Cohort instance.
+    """
+    if not seed_ids:
+        return {}
+
+    all_ids = set(seed_ids)
+    ids_to_load = set(seed_ids)
+    loaded: dict[int, Cohort] = {}
+    depth = 0
+
+    while ids_to_load:
+        if depth >= _MAX_COHORT_DEPENDENCY_DEPTH:
+            logger.warning(
+                "Cohort dependency depth limit reached",
+                depth=depth,
+                remaining_ids=ids_to_load,
+            )
+            break
+        depth += 1
+        newly_loaded: list[Cohort] = []
+        for cohort in Cohort.objects.filter(pk__in=ids_to_load, deleted=False, **team_filter):
+            loaded[cohort.pk] = cohort
+            newly_loaded.append(cohort)
+
+        ids_to_load_next: set[int] = set()
+        for cohort in newly_loaded:
+            for dep_id in extract_cohort_dependencies(cohort):
+                if dep_id not in all_ids:
+                    all_ids.add(dep_id)
+                    ids_to_load_next.add(dep_id)
+        ids_to_load = ids_to_load_next
+
+    return loaded
+
+
+def _get_referenced_cohorts(team_id: int, flags_data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fetch cohort definitions referenced by flags, including transitive cohort-on-cohort deps."""
+    direct_ids = _extract_cohort_ids_from_flag_filters(flags_data)
+    loaded = _load_cohorts_with_deps(direct_ids, team_id=team_id)
+    return [_serialize_cohort(c) for c in loaded.values()]
+
+
+def _serialize_cohort(cohort: Cohort) -> dict[str, Any]:
+    """Serialize a Cohort to a dict matching the Rust Cohort struct field names.
+
+    Keep in sync with rust/feature-flags/src/cohorts/cohort_models.rs::Cohort.
+    The Rust struct has no serde(default) on required fields (deleted, is_calculating,
+    is_static, errors_calculating, groups), so omitting any of these causes a
+    deserialization failure.
+    """
+    return {
+        "id": cohort.id,
+        "name": cohort.name,
+        "description": cohort.description,
+        "team_id": cohort.team_id,
+        "deleted": cohort.deleted,
+        "filters": cohort.filters,
+        "query": cohort.query,
+        "version": cohort.version,
+        "pending_version": cohort.pending_version,
+        "count": cohort.count,
+        "is_calculating": cohort.is_calculating,
+        "is_static": cohort.is_static,
+        "errors_calculating": cohort.errors_calculating,
+        "groups": cohort.groups,
+        "created_by_id": cohort.created_by_id,
+        "cohort_type": cohort.cohort_type,
+    }
 
 
 def _compute_flag_dependencies(flags_data: list[dict[str, Any]]) -> dict[str, Any]:
@@ -185,24 +317,28 @@ def _get_feature_flags_for_service(team: Team) -> dict[str, Any]:
     in /flags would return unusable encrypted ciphertext.
 
     Returns:
-        dict: {"flags": [...], "evaluation_metadata": {...}} where flags is a list
-        of flag dictionaries and evaluation_metadata contains pre-computed dependency
-        metadata (stages, missing deps, transitive deps).
+        dict: {"flags": [...], "evaluation_metadata": {...}, "cohorts": [...]} where
+        flags is a list of flag dictionaries, evaluation_metadata contains pre-computed
+        dependency metadata (stages, missing deps, transitive deps), and cohorts contains
+        serialized cohort definitions referenced by the flags (including transitive deps).
     """
     # Exclude encrypted remote config flags at DB level for efficiency
     flags = get_feature_flags(team=team, exclude_encrypted_remote_config=True)
     flags_data = serialize_feature_flags(flags)
     evaluation_metadata = _compute_flag_dependencies(flags_data)
 
+    cohorts = _get_referenced_cohorts(team.id, flags_data)
+
     logger.info(
         "Loaded feature flags for service cache",
         team_id=team.id,
         project_id=team.project_id,
         flag_count=len(flags_data),
+        cohort_count=len(cohorts),
     )
 
     # Wrap in dict for HyperCache compatibility
-    return {"flags": flags_data, "evaluation_metadata": evaluation_metadata}
+    return {"flags": flags_data, "evaluation_metadata": evaluation_metadata, "cohorts": cohorts}
 
 
 def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str, Any]]:
@@ -220,7 +356,7 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
         teams: List of Team objects to load flags for
 
     Returns:
-        Dict mapping team_id to {"flags": [...], "evaluation_metadata": {...}} for each team
+        Dict mapping team_id to {"flags": [...], "evaluation_metadata": {...}, "cohorts": [...]} for each team
     """
     if not teams:
         return {}
@@ -255,21 +391,44 @@ def _get_feature_flags_for_teams_batch(teams: list[Team]) -> dict[int, dict[str,
     for flag in all_flags:
         flags_by_team_id[flag.team_id].append(flag)
 
-    # Serialize flags for each team
-    result: dict[int, dict[str, Any]] = {}
+    # Serialize flags for each team and collect all referenced cohort IDs
+    flags_data_by_team: dict[int, list[dict[str, Any]]] = {}
+    all_cohort_ids: set[int] = set()
     for team in teams:
         team_flags = flags_by_team_id.get(team.id, [])
         flags_data = serialize_feature_flags(team_flags)
+        flags_data_by_team[team.id] = flags_data
+        all_cohort_ids.update(_extract_cohort_ids_from_flag_filters(flags_data))
+
+    # Batch-load all referenced cohorts across all teams (including transitive deps)
+    team_ids = {t.id for t in teams}
+    loaded_cohorts = _load_cohorts_with_deps(all_cohort_ids, team_id__in=team_ids)
+
+    # Group loaded cohorts by team_id
+    cohorts_by_team: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for cohort in loaded_cohorts.values():
+        cohorts_by_team[cohort.team_id].append(_serialize_cohort(cohort))
+
+    # Build result for each team
+    result: dict[int, dict[str, Any]] = {}
+    for team in teams:
+        flags_data = flags_data_by_team[team.id]
         evaluation_metadata = _compute_flag_dependencies(flags_data)
 
+        team_cohorts = cohorts_by_team.get(team.id, [])
         logger.info(
             "Loaded feature flags for service cache (batch)",
             team_id=team.id,
             project_id=team.project_id,
             flag_count=len(flags_data),
+            cohort_count=len(team_cohorts),
         )
 
-        result[team.id] = {"flags": flags_data, "evaluation_metadata": evaluation_metadata}
+        result[team.id] = {
+            "flags": flags_data,
+            "evaluation_metadata": evaluation_metadata,
+            "cohorts": team_cohorts,
+        }
 
     return result
 
@@ -735,3 +894,25 @@ def tag_changed_flags_cache(sender, instance: "Tag", created: bool, **kwargs):
     for team_id in FeatureFlagEvaluationTag.get_team_ids_using_tag(instance):
         # Capture team_id in closure to avoid late binding issues
         transaction.on_commit(lambda tid=team_id: update_team_service_flags_cache.delay(tid))  # type: ignore[misc]
+
+
+@receiver(post_save, sender=Cohort)
+@receiver(post_delete, sender=Cohort)
+def cohort_changed_flags_cache(sender, instance: "Cohort", **kwargs):
+    """
+    Invalidate flags cache when a cohort definition changes.
+
+    Skips recalculation-only saves (count, version, is_calculating, etc.) to avoid
+    rebuilding the flags cache on every static cohort recalculation.
+    Only operates when FLAGS_REDIS_URL is configured.
+    """
+    if not settings.FLAGS_REDIS_URL:
+        return
+
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and frozenset(update_fields) <= _COHORT_RECALCULATION_FIELDS:
+        return
+
+    from posthog.tasks.feature_flags import update_team_service_flags_cache
+
+    transaction.on_commit(lambda: update_team_service_flags_cache.delay(instance.team_id))

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -8,6 +8,8 @@ Tests cover:
 - Data format compatibility with service
 """
 
+from typing import Any
+
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
@@ -17,13 +19,17 @@ from django.test import override_settings
 from parameterized import parameterized
 
 from posthog.models import FeatureFlag, Tag, Team
+from posthog.models.cohort.cohort import Cohort
 from posthog.models.feature_flag.feature_flag import FeatureFlagEvaluationTag
 from posthog.models.feature_flag.flags_cache import (
     _compute_flag_dependencies,
+    _extract_cohort_ids_from_flag_filters,
     _extract_direct_dependency_ids,
     _get_feature_flags_for_service,
     _get_feature_flags_for_teams_batch,
+    _get_referenced_cohorts,
     _get_team_ids_with_recently_updated_flags,
+    _serialize_cohort,
     clear_flags_cache,
     flags_hypercache,
     get_flags_from_cache,
@@ -57,6 +63,7 @@ class TestServiceFlagsCache(BaseTest):
                 "flags_with_missing_deps": [],
                 "transitive_deps": {},
             },
+            "cohorts": [],
         }
 
     def test_get_feature_flags_for_service_with_flags(self):
@@ -402,6 +409,70 @@ class TestServiceFlagsCache(BaseTest):
         # Cache should now load from DB (source will be "db")
         flags, source = flags_hypercache.get_from_cache_with_source(self.team)
         assert source == "db"
+
+    def test_get_feature_flags_for_service_includes_referenced_cohorts(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="cohort-flag",
+            created_by=self.user,
+            filters={
+                "groups": [{"properties": [{"type": "cohort", "value": cohort.id}], "rollout_percentage": 100}],
+            },
+        )
+        result = _get_feature_flags_for_service(self.team)
+        assert len(result["cohorts"]) == 1
+        assert result["cohorts"][0]["id"] == cohort.id
+        assert result["cohorts"][0]["name"] == "Test Cohort"
+
+    def test_get_feature_flags_for_teams_batch_isolates_cohorts_per_team(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        cohort_a = Cohort.objects.create(
+            team=self.team,
+            name="Cohort A",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+        )
+        cohort_b = Cohort.objects.create(
+            team=other_team,
+            name="Cohort B",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "b@b.com", "type": "person"}]}],
+                }
+            },
+        )
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="flag-a",
+            created_by=self.user,
+            filters={"groups": [{"properties": [{"type": "cohort", "value": cohort_a.id}], "rollout_percentage": 100}]},
+        )
+        FeatureFlag.objects.create(
+            team=other_team,
+            key="flag-b",
+            created_by=self.user,
+            filters={"groups": [{"properties": [{"type": "cohort", "value": cohort_b.id}], "rollout_percentage": 100}]},
+        )
+        result = _get_feature_flags_for_teams_batch([self.team, other_team])
+        assert len(result[self.team.id]["cohorts"]) == 1
+        assert result[self.team.id]["cohorts"][0]["id"] == cohort_a.id
+        assert len(result[other_team.id]["cohorts"]) == 1
+        assert result[other_team.id]["cohorts"][0]["id"] == cohort_b.id
 
 
 @override_settings(FLAGS_REDIS_URL="redis://test")
@@ -2530,3 +2601,385 @@ class TestComputeFlagDependenciesIntegration(BaseTest):
         assert ctx["transitive_deps"][str(flag_b.id)] == [flag_c.id]
         assert ctx["transitive_deps"][str(flag_c.id)] == []
         assert ctx["dependency_stages"] == [[flag_c.id], [flag_b.id], [flag_a.id]]
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestExtractCohortIdsFromFlagFilters(BaseTest):
+    def test_extracts_cohort_ids_from_active_flag(self):
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": 42}]}],
+                },
+            }
+        ]
+        assert _extract_cohort_ids_from_flag_filters(flags_data) == {42}
+
+    @parameterized.expand(
+        [
+            ("inactive", {"active": False}),
+            ("deleted", {"active": True, "deleted": True}),
+        ]
+    )
+    def test_skips_excluded_flag(self, _name, flag_overrides):
+        flags_data = [
+            {
+                **flag_overrides,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": 42}]}],
+                },
+            }
+        ]
+        assert _extract_cohort_ids_from_flag_filters(flags_data) == set()
+
+    def test_handles_string_cohort_value(self):
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": "42"}]}],
+                },
+            }
+        ]
+        assert _extract_cohort_ids_from_flag_filters(flags_data) == {42}
+
+    def test_skips_non_cohort_properties(self):
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {"type": "person", "key": "email", "value": "test@test.com"},
+                                {"type": "cohort", "value": 5},
+                            ]
+                        }
+                    ],
+                },
+            }
+        ]
+        assert _extract_cohort_ids_from_flag_filters(flags_data) == {5}
+
+    def test_handles_malformed_value(self):
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": "not_a_number"}]}],
+                },
+            }
+        ]
+        assert _extract_cohort_ids_from_flag_filters(flags_data) == set()
+
+    def test_returns_empty_for_no_flags(self):
+        assert _extract_cohort_ids_from_flag_filters([]) == set()
+
+    def test_deduplicates_cohort_ids(self):
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [
+                        {"properties": [{"type": "cohort", "value": 42}]},
+                        {"properties": [{"type": "cohort", "value": 42}]},
+                    ],
+                },
+            },
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": 42}]}],
+                },
+            },
+        ]
+        assert _extract_cohort_ids_from_flag_filters(flags_data) == {42}
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestGetReferencedCohorts(BaseTest):
+    def test_returns_empty_when_no_cohorts_referenced(self):
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "person", "key": "email", "value": "x"}]}],
+                },
+            }
+        ]
+        assert _get_referenced_cohorts(self.team.id, flags_data) == []
+
+    def test_returns_referenced_cohort(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+        )
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": cohort.id}]}],
+                },
+            }
+        ]
+        result = _get_referenced_cohorts(self.team.id, flags_data)
+        assert len(result) == 1
+        assert result[0]["id"] == cohort.id
+        assert result[0]["name"] == "Test Cohort"
+
+    def test_includes_transitive_cohort_deps(self):
+        cohort_b = Cohort.objects.create(
+            team=self.team,
+            name="Leaf Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "b@b.com", "type": "person"}]}],
+                }
+            },
+        )
+        cohort_a = Cohort.objects.create(
+            team=self.team,
+            name="Parent Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "id", "value": cohort_b.id, "type": "cohort"}]}],
+                }
+            },
+        )
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": cohort_a.id}]}],
+                },
+            }
+        ]
+        result = _get_referenced_cohorts(self.team.id, flags_data)
+        result_ids = {c["id"] for c in result}
+        assert cohort_a.id in result_ids
+        assert cohort_b.id in result_ids
+
+    def test_excludes_deleted_cohorts(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Deleted",
+            deleted=True,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+        )
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": cohort.id}]}],
+                },
+            }
+        ]
+        assert _get_referenced_cohorts(self.team.id, flags_data) == []
+
+    def test_excludes_other_team_cohorts(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        cohort = Cohort.objects.create(
+            team=other_team,
+            name="Other Team Cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+        )
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": cohort.id}]}],
+                },
+            }
+        ]
+        assert _get_referenced_cohorts(self.team.id, flags_data) == []
+
+    def test_handles_circular_cohort_deps(self):
+        cohort_a = Cohort.objects.create(
+            team=self.team,
+            name="A",
+            filters={"properties": {"type": "OR", "values": []}},
+        )
+        cohort_b = Cohort.objects.create(
+            team=self.team,
+            name="B",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "id", "value": cohort_a.id, "type": "cohort"}]}],
+                }
+            },
+        )
+        # Update A to reference B (creating a cycle)
+        cohort_a.filters = {
+            "properties": {
+                "type": "OR",
+                "values": [{"type": "OR", "values": [{"key": "id", "value": cohort_b.id, "type": "cohort"}]}],
+            }
+        }
+        cohort_a.save()
+
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": cohort_a.id}]}],
+                },
+            }
+        ]
+        # Should terminate without infinite loop
+        result = _get_referenced_cohorts(self.team.id, flags_data)
+        result_ids = {c["id"] for c in result}
+        assert cohort_a.id in result_ids
+        assert cohort_b.id in result_ids
+
+    def test_terminates_at_depth_limit(self):
+        chain: list[Cohort] = []
+        for i in range(25):
+            filters: dict[str, Any] = {"properties": {"type": "OR", "values": []}}
+            if chain:
+                filters["properties"]["values"] = [
+                    {"type": "OR", "values": [{"key": "id", "value": chain[-1].id, "type": "cohort"}]}
+                ]
+            cohort = Cohort.objects.create(team=self.team, name=f"chain-{i}", filters=filters)
+            chain.append(cohort)
+
+        flags_data = [
+            {
+                "active": True,
+                "filters": {
+                    "groups": [{"properties": [{"type": "cohort", "value": chain[-1].id}]}],
+                },
+            }
+        ]
+        result = _get_referenced_cohorts(self.team.id, flags_data)
+        # BFS should stop at depth 20, returning fewer than all 25 cohorts
+        assert len(result) <= 21  # root + 20 levels
+        assert len(result) < 25
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestSerializeCohort(BaseTest):
+    def test_serializes_all_required_fields(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test",
+            description="A test cohort",
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+        )
+        result = _serialize_cohort(cohort)
+
+        # All 16 fields required by the Rust Cohort struct must be present
+        expected_fields = {
+            "id",
+            "name",
+            "description",
+            "team_id",
+            "deleted",
+            "filters",
+            "query",
+            "version",
+            "pending_version",
+            "count",
+            "is_calculating",
+            "is_static",
+            "errors_calculating",
+            "groups",
+            "created_by_id",
+            "cohort_type",
+        }
+        assert set(result.keys()) == expected_fields
+        assert result["id"] == cohort.id
+        assert result["team_id"] == self.team.id
+        assert result["name"] == "Test"
+        assert result["deleted"] is False
+        assert result["is_static"] is False
+        assert result["is_calculating"] is False
+
+
+@override_settings(FLAGS_REDIS_URL="redis://test")
+class TestCohortChangedFlagsCacheSignal(BaseTest):
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    def test_fires_on_cohort_definition_change(self, mock_task):
+        cohort = Cohort.objects.create(team=self.team, name="test")
+        mock_task.reset_mock()
+        cohort.name = "updated"
+        cohort.save()
+        mock_task.delay.assert_called_with(self.team.id)
+
+    @parameterized.expand(
+        [
+            ("is_calculating", "is_calculating", True),
+            ("count", "count", 100),
+            ("version", "version", 2),
+        ]
+    )
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    def test_skips_recalculation_only_save(self, _name, field, value, mock_task):
+        cohort = Cohort.objects.create(team=self.team, name="test")
+        mock_task.reset_mock()
+        setattr(cohort, field, value)
+        cohort.save(update_fields=[field])
+        mock_task.delay.assert_not_called()
+
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    def test_skips_cohort_type_only_save(self, mock_task):
+        cohort = Cohort.objects.create(team=self.team, name="test")
+        mock_task.reset_mock()
+        cohort.cohort_type = "behavioral"
+        cohort.save(update_fields=["cohort_type"])
+        mock_task.delay.assert_not_called()
+
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    def test_fires_on_mixed_recalculation_and_definition_fields(self, mock_task):
+        cohort = Cohort.objects.create(team=self.team, name="test")
+        mock_task.reset_mock()
+        cohort.name = "updated"
+        cohort.count = 50
+        cohort.save(update_fields=["name", "count"])
+        mock_task.delay.assert_called_with(self.team.id)
+
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    def test_fires_on_cohort_delete(self, mock_task):
+        cohort = Cohort.objects.create(team=self.team, name="test")
+        mock_task.reset_mock()
+        cohort.delete()
+        mock_task.delay.assert_called_with(self.team.id)
+
+    @override_settings(FLAGS_REDIS_URL=None)
+    @patch("django.db.transaction.on_commit", lambda fn: fn())
+    @patch("posthog.tasks.feature_flags.update_team_service_flags_cache")
+    def test_skips_when_no_flags_redis_url(self, mock_task):
+        cohort = Cohort.objects.create(team=self.team, name="test")
+        mock_task.reset_mock()
+        cohort.name = "updated"
+        cohort.save()
+        mock_task.delay.assert_not_called()

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -2872,7 +2872,7 @@ class TestGetReferencedCohorts(BaseTest):
         ]
         result = _get_referenced_cohorts(self.team.id, flags_data)
         # BFS should stop at depth 20, returning fewer than all 25 cohorts
-        assert len(result) <= 21  # root + 20 levels
+        assert len(result) <= 20  # BFS loads at most 20 cohorts
         assert len(result) < 25
 
 

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,4 +1,5 @@
 use crate::api::errors::{simplify_serde_error, FlagError};
+use crate::cohorts::cohort_models::Cohort;
 use crate::database::get_connection_with_metrics;
 use crate::flags::flag_models::{
     EvaluationMetadata, FeatureFlag, FeatureFlagList, FeatureFlagRow, HypercacheFlagsWrapper,
@@ -9,6 +10,13 @@ use common_hypercache::HYPER_CACHE_EMPTY_VALUE;
 use common_types::TeamId;
 use metrics::counter;
 
+/// Parsed hypercache result: flags, optional evaluation metadata, optional preloaded cohorts.
+type HypercacheParseResult = (
+    Vec<FeatureFlag>,
+    Option<EvaluationMetadata>,
+    Option<Vec<Cohort>>,
+);
+
 impl FeatureFlagList {
     pub fn new(flags: Vec<FeatureFlag>) -> Self {
         Self {
@@ -17,25 +25,26 @@ impl FeatureFlagList {
         }
     }
 
-    /// Parses a JSON Value from hypercache into flags and optional evaluation metadata.
+    /// Parses a JSON Value from hypercache into flags, optional evaluation metadata,
+    /// and optional preloaded cohort definitions.
     ///
     /// Handles:
     /// - Null values (returns empty vec)
     /// - Sentinel "__missing__" value (returns empty vec)
-    /// - Standard hypercache format `{"flags": [...], "evaluation_metadata": {...}}`
+    /// - Standard hypercache format `{"flags": [...], "evaluation_metadata": {...}, "cohorts": [...]}`
     pub fn parse_hypercache_value(
         data: serde_json::Value,
         team_id: TeamId,
-    ) -> Result<(Vec<FeatureFlag>, Option<EvaluationMetadata>), FlagError> {
+    ) -> Result<HypercacheParseResult, FlagError> {
         // Handle null (can happen when hypercache returns empty)
         if data.is_null() {
-            return Ok((vec![], None));
+            return Ok((vec![], None, None));
         }
 
         // Check for the sentinel value indicating no flags for this team
         if data.as_str() == Some(HYPER_CACHE_EMPTY_VALUE) {
             tracing::debug!("Hypercache sentinel (no flags) for team {}", team_id);
-            return Ok((vec![], None));
+            return Ok((vec![], None, None));
         }
 
         // Parse the hypercache format: {"flags": [...], "evaluation_metadata": {...}}
@@ -57,9 +66,14 @@ impl FeatureFlagList {
             ))
         })?;
 
-        tracing::debug!("Parsed {} flags for team {}", wrapper.flags.len(), team_id);
+        tracing::debug!(
+            "Parsed {} flags and {} cohorts for team {}",
+            wrapper.flags.len(),
+            wrapper.cohorts.as_ref().map_or(0, |c| c.len()),
+            team_id,
+        );
 
-        Ok((wrapper.flags, wrapper.evaluation_metadata))
+        Ok((wrapper.flags, wrapper.evaluation_metadata, wrapper.cohorts))
     }
 
     /// Returns feature flags from postgres given a team_id
@@ -644,7 +658,7 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let (flags, metadata) = result.unwrap();
+        let (flags, metadata, _cohorts) = result.unwrap();
         assert!(metadata.is_none());
         assert_eq!(flags.len(), 2);
         assert_eq!(flags[0].key, "test_flag");
@@ -803,7 +817,7 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let (flags, evaluation_metadata) = result.unwrap();
+        let (flags, evaluation_metadata, _cohorts) = result.unwrap();
         let meta = evaluation_metadata.unwrap();
         assert_eq!(meta.dependency_stages.len(), 2);
         assert_eq!(meta.dependency_stages[0], vec![766, 768, 769]);
@@ -831,7 +845,7 @@ mod tests {
         let data = serde_json::Value::Null;
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let (flags, metadata) = result.unwrap();
+        let (flags, metadata, _cohorts) = result.unwrap();
         assert!(flags.is_empty());
         assert!(metadata.is_none());
     }
@@ -841,7 +855,7 @@ mod tests {
         let data = json!("__missing__");
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let (flags, metadata) = result.unwrap();
+        let (flags, metadata, _cohorts) = result.unwrap();
         assert!(flags.is_empty());
         assert!(metadata.is_none());
     }
@@ -851,7 +865,7 @@ mod tests {
         let data = json!({"flags": []});
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let (flags, metadata) = result.unwrap();
+        let (flags, metadata, _cohorts) = result.unwrap();
         assert!(flags.is_empty());
         assert!(metadata.is_none());
     }
@@ -927,7 +941,7 @@ mod tests {
 
         let result = FeatureFlagList::parse_hypercache_value(data, 123);
         assert!(result.is_ok());
-        let (flags, metadata) = result.unwrap();
+        let (flags, metadata, _cohorts) = result.unwrap();
         assert!(metadata.is_none());
         assert_eq!(flags.len(), 1);
         let flag = &flags[0];
@@ -939,6 +953,57 @@ mod tests {
         assert_eq!(flag.evaluation_runtime, Some("frontend".to_string()));
         assert_eq!(flag.filters.groups.len(), 1);
         assert_eq!(flag.filters.groups[0].rollout_percentage, Some(50.0));
+    }
+
+    #[test]
+    fn test_parse_hypercache_value_with_cohorts() {
+        let data = json!({
+            "flags": [],
+            "cohorts": [{
+                "id": 42,
+                "name": "Test Cohort",
+                "description": null,
+                "team_id": 123,
+                "deleted": false,
+                "filters": {"properties": {"type": "AND", "values": []}},
+                "query": null,
+                "version": 1,
+                "pending_version": null,
+                "count": 100,
+                "is_calculating": false,
+                "is_static": false,
+                "errors_calculating": 0,
+                "groups": [],
+                "created_by_id": null,
+                "cohort_type": null
+            }]
+        });
+        let result = FeatureFlagList::parse_hypercache_value(data, 123);
+        assert!(result.is_ok());
+        let (_flags, _metadata, cohorts) = result.unwrap();
+        let cohorts = cohorts.expect("cohorts should be Some");
+        assert_eq!(cohorts.len(), 1);
+        assert_eq!(cohorts[0].id, 42);
+        assert_eq!(cohorts[0].name, Some("Test Cohort".to_string()));
+        assert_eq!(cohorts[0].team_id, 123);
+        assert!(!cohorts[0].deleted);
+    }
+
+    #[test]
+    fn test_parse_hypercache_value_without_cohorts_defaults_to_none() {
+        let data = json!({
+            "flags": [{
+                "id": 1,
+                "team_id": 123,
+                "name": "flag",
+                "key": "flag-key",
+                "filters": {"groups": []}
+            }]
+        });
+        let result = FeatureFlagList::parse_hypercache_value(data, 123);
+        assert!(result.is_ok());
+        let (_flags, _metadata, cohorts) = result.unwrap();
+        assert!(cohorts.is_none());
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -269,6 +269,11 @@ pub struct FeatureFlagMatcher {
     /// Whether to enable realtime cohort evaluation.
     /// When false, realtime cohorts are treated as non-members.
     enable_realtime_cohort_evaluation: bool,
+    /// Cohort definitions preloaded from the flags hypercache.
+    /// When present, scoped to only the cohorts referenced by flags (including transitive deps),
+    /// so the matcher skips the CohortCacheManager PG query entirely.
+    /// `None` means no preloaded data (PG fallback or old cache) — use CohortCacheManager.
+    preloaded_cohorts: Option<Vec<Cohort>>,
 }
 
 /// Lightweight snapshot of a flag's identity fields, saved before moving
@@ -317,6 +322,7 @@ impl FeatureFlagMatcher {
             skip_writes: false,
             filtered_out_flag_ids: HashSet::new(),
             enable_realtime_cohort_evaluation: false,
+            preloaded_cohorts: None,
         }
     }
 
@@ -388,6 +394,7 @@ impl FeatureFlagMatcher {
         };
 
         self.filtered_out_flag_ids = feature_flags.filtered_out_flag_ids;
+        self.preloaded_cohorts = feature_flags.cohorts;
 
         // Extract global stats before potential consuming filter call
         let error_count = precomputed.error_count;
@@ -1803,8 +1810,20 @@ impl FeatureFlagMatcher {
         &mut self,
         flags: &[&FeatureFlag],
     ) -> Result<(), FlagError> {
-        // Get cohorts first since we need the IDs
-        let cohorts = self.cohort_cache.get_cohorts(self.team_id).await?;
+        // Use preloaded cohorts from the flags cache when available (already scoped
+        // to only referenced cohorts). Fall back to CohortCacheManager which fetches
+        // ALL cohorts for the team.
+        let cohorts = match self.preloaded_cohorts.take() {
+            Some(preloaded) => {
+                tracing::debug!(
+                    "Using {} preloaded cohorts for team {}",
+                    preloaded.len(),
+                    self.team_id,
+                );
+                preloaded
+            }
+            None => self.cohort_cache.get_cohorts(self.team_id).await?,
+        };
         self.flag_evaluation_state.set_cohorts(cohorts.clone());
 
         // Get static cohort IDs

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -23,11 +23,11 @@ use crate::handler::canonical_log::{install_rayon_canonical_log, take_rayon_cano
 use crate::handler::with_canonical_log;
 use crate::metrics::consts::{
     DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER, FLAG_BATCH_EVALUATION_COUNTER,
-    FLAG_BATCH_EVALUATION_TIME, FLAG_BATCH_SIZE, FLAG_DB_PROPERTIES_FETCH_TIME,
-    FLAG_EVALUATE_ALL_CONDITIONS_TIME, FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME,
-    FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED, FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER,
-    FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME, FLAG_GROUP_DB_FETCH_TIME,
-    FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER,
+    FLAG_BATCH_EVALUATION_TIME, FLAG_BATCH_SIZE, FLAG_COHORT_SOURCE_COUNTER,
+    FLAG_DB_PROPERTIES_FETCH_TIME, FLAG_EVALUATE_ALL_CONDITIONS_TIME,
+    FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME, FLAG_EXPERIENCE_CONTINUITY_OPTIMIZED,
+    FLAG_EXPERIENCE_CONTINUITY_REQUESTS_COUNTER, FLAG_GET_MATCH_TIME, FLAG_GROUP_CACHE_FETCH_TIME,
+    FLAG_GROUP_DB_FETCH_TIME, FLAG_HASH_KEY_PROCESSING_TIME, FLAG_HASH_KEY_WRITES_COUNTER,
     FLAG_REALTIME_COHORT_QUERY_ERROR_COUNTER, FLAG_REALTIME_COHORT_QUERY_TIME,
     PROPERTY_CACHE_HITS_COUNTER, PROPERTY_CACHE_MISSES_COUNTER,
 };
@@ -1815,14 +1815,21 @@ impl FeatureFlagMatcher {
         // ALL cohorts for the team.
         let cohorts = match self.preloaded_cohorts.take() {
             Some(preloaded) => {
-                tracing::debug!(
-                    "Using {} preloaded cohorts for team {}",
-                    preloaded.len(),
-                    self.team_id,
+                inc(
+                    FLAG_COHORT_SOURCE_COUNTER,
+                    &[("source".to_string(), "preloaded".to_string())],
+                    1,
                 );
                 preloaded
             }
-            None => self.cohort_cache.get_cohorts(self.team_id).await?,
+            None => {
+                inc(
+                    FLAG_COHORT_SOURCE_COUNTER,
+                    &[("source".to_string(), "cache_manager".to_string())],
+                    1,
+                );
+                self.cohort_cache.get_cohorts(self.team_id).await?
+            }
         };
         self.flag_evaluation_state.set_cohorts(cohorts.clone());
 

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -3,6 +3,7 @@ use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
+use crate::cohorts::cohort_models::Cohort;
 use crate::properties::property_models::PropertyFilter;
 
 /// Deserializes a JSON object with string keys into `HashMap<i32, HashSet<i32>>`.
@@ -47,7 +48,7 @@ where
 
 /// Pre-computed dependency metadata, built by Django at cache-write time.
 /// Shipped as a top-level field alongside the flags array in the hypercache.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct EvaluationMetadata {
     /// Flag IDs grouped by evaluation stage. Stage 0 (no deps) first.
     pub dependency_stages: Vec<Vec<i32>>,
@@ -61,12 +62,17 @@ pub struct EvaluationMetadata {
     pub transitive_deps: HashMap<i32, HashSet<i32>>,
 }
 
-/// Wrapper struct for deserializing hypercache format: {"flags": [...]}
+/// Wrapper struct for deserializing hypercache format: {"flags": [...], "cohorts": [...]}
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HypercacheFlagsWrapper {
     pub flags: Vec<FeatureFlag>,
     #[serde(default)]
     pub evaluation_metadata: Option<EvaluationMetadata>,
+    /// Cohort definitions referenced by flags (including transitive deps).
+    /// Precomputed by Django at cache-write time so the Rust service can skip
+    /// the separate CohortCacheManager PG query.
+    #[serde(default)]
+    pub cohorts: Option<Vec<Cohort>>,
 }
 
 /// New holdout format: `{"id": 42, "exclusion_percentage": 10}`.
@@ -223,4 +229,9 @@ pub struct FeatureFlagList {
     /// or old cache entries.
     #[serde(skip)]
     pub evaluation_metadata: Option<EvaluationMetadata>,
+    /// Cohort definitions referenced by flags (including transitive deps),
+    /// precomputed by Django at cache-write time.
+    /// When present, the matcher uses these instead of querying CohortCacheManager.
+    #[serde(skip)]
+    pub cohorts: Option<Vec<Cohort>>,
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -177,6 +177,7 @@ impl FlagService {
                 let wrapper = crate::flags::flag_models::HypercacheFlagsWrapper {
                     flags,
                     evaluation_metadata: None,
+                    cohorts: None,
                 };
                 let value = serde_json::to_value(&wrapper).map_err(|e| {
                     tracing::error!(
@@ -191,12 +192,14 @@ impl FlagService {
             .await?;
 
         // Parse the result (from cache or fallback)
-        let (flags, evaluation_metadata) = FeatureFlagList::parse_hypercache_value(data, team_id)?;
+        let (flags, evaluation_metadata, cohorts) =
+            FeatureFlagList::parse_hypercache_value(data, team_id)?;
 
         Ok(FlagResult {
             flag_list: FeatureFlagList {
                 flags,
                 evaluation_metadata,
+                cohorts,
                 ..Default::default()
             },
             cache_source: source,
@@ -549,6 +552,7 @@ mod tests {
         let wrapper = HypercacheFlagsWrapper {
             flags: large_flags.flags.clone(),
             evaluation_metadata: None,
+            cohorts: None,
         };
         let json_string = serde_json::to_string(&wrapper).expect("Failed to serialize to JSON");
 

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -6720,6 +6720,7 @@ mod tests {
             flags: vec![filtered_continuity_flag, active_normal_flag],
             filtered_out_flag_ids: filtered_out.clone(),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
@@ -6914,6 +6915,7 @@ mod tests {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
@@ -7011,6 +7013,7 @@ mod tests {
             flags: vec![flag_a, flag_b],
             filtered_out_flag_ids: filtered_out.clone(),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)
@@ -7206,6 +7209,7 @@ mod tests {
             flags: vec![flag_a, flag_b, flag_c],
             filtered_out_flag_ids: filtered_out.clone(),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&flags, team.id, None)

--- a/rust/feature-flags/src/flags/test_helpers.rs
+++ b/rust/feature-flags/src/flags/test_helpers.rs
@@ -133,6 +133,8 @@ pub async fn get_flags_from_redis(
 
     Ok(FeatureFlagList {
         flags: wrapper.flags,
+        evaluation_metadata: wrapper.evaluation_metadata,
+        cohorts: wrapper.cohorts,
         ..Default::default()
     })
 }
@@ -154,6 +156,7 @@ pub async fn update_flags_in_hypercache(
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.flags.clone(),
         evaluation_metadata: flags.evaluation_metadata.clone(),
+        cohorts: flags.cohorts.clone(),
     };
 
     // Match Django's format: JSON string -> Pickle

--- a/rust/feature-flags/src/handler/billing.rs
+++ b/rust/feature-flags/src/handler/billing.rs
@@ -211,6 +211,7 @@ mod tests {
             flags: vec![disabled_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         // Should NOT record usage when only filtered-out flags are present
@@ -226,6 +227,7 @@ mod tests {
             flags: vec![disabled_flag.clone(), active_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         // Should record usage when at least one non-filtered, non-survey flag is present
@@ -241,6 +243,7 @@ mod tests {
             flags: vec![disabled_survey_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_survey_flag.id]),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         // Should NOT record usage for filtered-out survey flags
@@ -256,6 +259,7 @@ mod tests {
             flags: vec![disabled_flag.clone(), survey_flag],
             filtered_out_flag_ids: HashSet::from([disabled_flag.id]),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         // Should NOT record usage when only filtered-out and survey flags are present
@@ -299,6 +303,7 @@ mod tests {
             flags: vec![disabled_tour_flag.clone()],
             filtered_out_flag_ids: HashSet::from([disabled_tour_flag.id]),
             evaluation_metadata: None,
+            cohorts: None,
         };
 
         // Should NOT record usage for filtered-out product tour flags

--- a/rust/feature-flags/src/handler/flags.rs
+++ b/rust/feature-flags/src/handler/flags.rs
@@ -145,6 +145,7 @@ pub async fn fetch_and_filter(
 
     let flags = flag_result.flag_list.flags;
     let evaluation_metadata = flag_result.flag_list.evaluation_metadata;
+    let cohorts = flag_result.flag_list.cohorts;
 
     // Build the filtered-out set: user-disabled, deleted, survey filter, runtime/tag mismatches.
     // This is the single source of truth for "should this flag be skipped during evaluation."
@@ -182,6 +183,7 @@ pub async fn fetch_and_filter(
         flags,
         filtered_out_flag_ids,
         evaluation_metadata,
+        cohorts,
     })
 }
 

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -1524,6 +1524,7 @@ async fn test_fetch_and_filter_preserves_evaluation_metadata() {
     let wrapper = HypercacheFlagsWrapper {
         flags: flags.clone(),
         evaluation_metadata: Some(eval_metadata),
+        cohorts: None,
     };
     let json_string = serde_json::to_string(&wrapper).unwrap();
     let pickled_bytes = serde_pickle::to_vec(&json_string, Default::default()).unwrap();
@@ -1788,6 +1789,7 @@ async fn test_parallel_path_matches_sequential_results() {
             flags: flags.clone(),
             filtered_out_flag_ids: filtered_out_flag_ids.clone(),
             evaluation_metadata: None,
+            cohorts: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),
@@ -1820,6 +1822,7 @@ async fn test_parallel_path_matches_sequential_results() {
             flags,
             filtered_out_flag_ids,
             evaluation_metadata: None,
+            cohorts: None,
         },
         persons_reader: reader.clone(),
         persons_writer: writer.clone(),

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -20,6 +20,9 @@ pub const COHORT_CACHE_HIT_COUNTER: &str = "flags_cohort_cache_hit_total";
 pub const COHORT_CACHE_MISS_COUNTER: &str = "flags_cohort_cache_miss_total";
 pub const COHORT_CACHE_SIZE_BYTES_GAUGE: &str = "flags_cohort_cache_size_bytes";
 pub const COHORT_CACHE_ENTRIES_GAUGE: &str = "flags_cohort_cache_entries";
+// Cohort source for flag evaluation
+// Labels: source="preloaded" (from flags hypercache) | source="cache_manager" (CohortCacheManager fallback)
+pub const FLAG_COHORT_SOURCE_COUNTER: &str = "flags_cohort_source_total";
 pub const PROPERTY_CACHE_HITS_COUNTER: &str = "flags_property_cache_hits_total";
 pub const PROPERTY_CACHE_MISSES_COUNTER: &str = "flags_property_cache_misses_total";
 pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -1386,6 +1386,7 @@ fn make_flag_list(
         flags,
         filtered_out_flag_ids,
         evaluation_metadata: None,
+        cohorts: None,
     }
 }
 
@@ -2850,6 +2851,7 @@ mod precomputed_dependency_graph_tests {
                 flags_with_missing_deps: vec![],
                 transitive_deps: HashMap::from([(1, HashSet::new()), (2, HashSet::new())]),
             }),
+            cohorts: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();
@@ -2878,6 +2880,7 @@ mod precomputed_dependency_graph_tests {
                     (3, HashSet::new()),
                 ]),
             }),
+            cohorts: None,
         };
 
         let precomputed = PrecomputedDependencyGraph::build(&feature_flags, 1, None).unwrap();


### PR DESCRIPTION
## Problem

The Rust feature-flags service queries PostgreSQL via `CohortCacheManager` for every team's cohorts on each `/flags` request, even though the cohort definitions rarely change. This adds unnecessary latency and PG load, especially for teams with many cohort-based flags.

## Changes

Preloads cohort definitions (including transitive dependencies) into the flags hypercache at cache-write time so the Rust service can skip the separate PG query.

**Python (cache write path):**
- Extracts cohort IDs from active flag filters (`groups` only — `super_groups` and `holdout_groups` cannot contain cohort properties)
- BFS-loads referenced cohorts with transitive cohort-on-cohort dependency resolution (depth limit 20, cycle-safe)
- Serializes cohorts into the hypercache payload alongside flags and evaluation metadata
- Batch path collects all cohort IDs across teams and loads in a single BFS pass
- Adds `post_save`/`post_delete` signal on `Cohort` to invalidate the flags cache on definition changes (skips recalculation-only saves via `_COHORT_RECALCULATION_FIELDS` subset check)

**Rust (cache read path):**
- `HypercacheFlagsWrapper` gains optional `cohorts` field with `#[serde(default)]` for backwards compatibility
- `FeatureFlagMatcher` consumes preloaded cohorts via `Option::take()`, falls back to `CohortCacheManager` when absent
- `EvaluationMetadata` gains `Default` and `PartialEq` derives

**Rolling deploy safety:**
- Old Rust ignores the unknown `cohorts` key (no `deny_unknown_fields`)
- New Rust reading old cache entries defaults `cohorts` to `None` and falls back to PG

## How did you test this code?

- 20 new Python tests across 4 test classes: cohort extraction, BFS loading (transitive deps, circular deps, depth limit), serialization (all 16 fields), signal handler filtering
- 2 new Rust tests for hypercache cohort deserialization
- Rust test helper updated to propagate cohorts through round-trip

### Test plan

The automated unit tests cover extraction, BFS loading, serialization, and signal handler logic. This plan focuses on end-to-end scenarios that exercise the full Python → Redis → Rust pipeline.

#### Prerequisites

- [x] PostHog dev environment running (`hogli start`)
- [x] Rust feature-flags service running and connected to the same Redis and Postgres
- [x] Test team created with cohorts (direct, transitive, circular, unreferenced) and flags referencing them

#### 1. Python: cache write path

- [x] `_get_feature_flags_for_service` returns `flags`, `evaluation_metadata`, and `cohorts`
- [x] Only referenced cohorts included (unreferenced cohort excluded)
- [x] Transitive deps loaded (flag → cohort B → cohort A loads both)
- [x] Circular cohort dependencies (D ↔ E) terminate without infinite loop
- [x] BFS depth limit enforced (chain of 25 cohorts, loader returned only 20)
- [x] Batch path isolates cohorts per team (no cross-team leakage)
- [x] Log messages include `flag_count` and `cohort_count`

#### 2. Python: signal handler (cache invalidation)

- [x] Recalculation-only saves (`is_calculating`) do NOT trigger cache invalidation
- [x] Definition changes (`name`) DO trigger cache invalidation
- [x] Mixed fields (`count` + `name`) DO trigger invalidation
- [x] Cohort deletion triggers invalidation via `post_delete`
- [x] Signal uses `transaction.on_commit`, not direct task call
- [x] No-op when `FLAGS_REDIS_URL` is not configured

#### 3. Rust: flag evaluation with preloaded cohorts

- [x] Preloaded cohort path: `/flags` with cohorts in cache evaluates correctly (cohort flags: `no_condition_match`, circular: `dependency_cycle_cohort`, plain: `condition_match`)
- [x] Fallback path: cache without `cohorts` key falls back to `CohortCacheManager`, identical results

#### 4. Rolling deploy safety

- [x] Old Rust (master) reads new cache (with `cohorts`): silently ignores unknown key, correct results
- [x] New Rust (branch) reads old cache (without `cohorts`): falls back to PG, correct results

## Publish to changelog?

no