### PR TITLE
fix(cohorts): add update_fields guard to all cohort post_save signal handlers

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -839,10 +839,12 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
 
     def _safe_save_cohort_state(self, *, team_id: int, processing_error=None) -> None:
         """
-        Safely save cohort state with fallback to save only critical fields.
+        Save only the cohort's calculation-state fields with a single retry on failure.
 
-        This prevents cohorts from getting stuck in calculating state when
-        database issues occur during cleanup operations.
+        Only updates `is_calculating`, `count`, and either success fields
+        (`last_calculation`, `errors_calculating`) or error fields
+        (`errors_calculating`, `last_error_at`) — never the full model — so
+        concurrent edits to other cohort fields are not overwritten.
 
         Args:
             team_id: Team ID for logging context

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -103,6 +103,20 @@ class CohortManager(RootTeamManager):
         return cohort
 
 
+# Fields that are updated during cohort recalculation. The save_fields lists
+# in _safe_save_cohort_state must remain subsets of this set, otherwise the
+# is_cohort_recalculation_only_save guard will incorrectly allow signal handlers to fire.
+COHORT_RECALCULATION_FIELDS = frozenset(
+    {"is_calculating", "last_calculation", "errors_calculating", "last_error_at", "count"}
+)
+
+
+def is_cohort_recalculation_only_save(kwargs: dict) -> bool:
+    """Return True when a post_save signal was triggered only by recalculation bookkeeping fields."""
+    update_fields = kwargs.get("update_fields")
+    return update_fields is not None and COHORT_RECALCULATION_FIELDS.issuperset(update_fields)
+
+
 class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
     name = models.CharField(max_length=400, null=True, blank=True)
     description = models.CharField(max_length=1000, blank=True)
@@ -839,11 +853,13 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         if processing_error is None:
             self.last_calculation = timezone.now()
             self.errors_calculating = 0
+            save_fields = ["is_calculating", "last_calculation", "errors_calculating", "count"]
         else:
             self.errors_calculating = F("errors_calculating") + 1
             self.last_error_at = timezone.now()
+            save_fields = ["is_calculating", "errors_calculating", "last_error_at", "count"]
         try:
-            self.save()
+            self.save(update_fields=save_fields)
         except Exception as save_err:
             logger.exception("Failed to save cohort state", cohort_id=self.id, team_id=team_id)
             capture_exception(
@@ -853,7 +869,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
 
             # Single retry for transient issues
             try:
-                self.save()
+                self.save(update_fields=save_fields)
             except Exception:
                 logger.exception(
                     "Failed to save cohort state on retry",

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -7,7 +7,7 @@ from prometheus_client import Counter
 from rest_framework.exceptions import ValidationError
 from structlog import get_logger
 
-from posthog.models.cohort.cohort import Cohort
+from posthog.models.cohort.cohort import Cohort, is_cohort_recalculation_only_save
 from posthog.models.team.team import Team
 
 logger = get_logger(__name__)
@@ -153,6 +153,8 @@ def cohort_changed(sender, instance, **kwargs):
     """
     Clear and rebuild dependency caches when cohort changes.
     """
+    if is_cohort_recalculation_only_save(kwargs):
+        return
 
     transaction.on_commit(lambda: _on_cohort_changed(instance))
 

--- a/posthog/models/feature_flag/local_evaluation.py
+++ b/posthog/models/feature_flag/local_evaluation.py
@@ -36,7 +36,7 @@ import structlog
 from posthoganalytics import capture_exception
 from prometheus_client import Counter
 
-from posthog.models.cohort.cohort import Cohort, CohortOrEmpty
+from posthog.models.cohort.cohort import Cohort, CohortOrEmpty, is_cohort_recalculation_only_save
 from posthog.models.cohort.util import get_nested_cohort_ids
 from posthog.models.evaluation_context import EvaluationContext, FeatureFlagEvaluationContext
 from posthog.models.feature_flag import FeatureFlag
@@ -862,6 +862,9 @@ def feature_flag_changed(sender, instance: "FeatureFlag", **kwargs):
 @receiver(post_save, sender=Cohort)
 @receiver(post_delete, sender=Cohort)
 def cohort_changed(sender, instance: "Cohort", **kwargs):
+    if is_cohort_recalculation_only_save(kwargs):
+        return
+
     from posthog.tasks.feature_flags import update_team_flags_cache
 
     transaction.on_commit(lambda: update_team_flags_cache.delay(instance.team_id))

--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -13,6 +13,7 @@ from prometheus_client import Counter
 
 from posthog.helpers.encrypted_fields import EncryptedJSONStringField
 from posthog.models.action.action import Action
+from posthog.models.cohort.cohort import is_cohort_recalculation_only_save
 from posthog.models.file_system.file_system_mixin import FileSystemSyncMixin
 from posthog.models.file_system.file_system_representation import FileSystemRepresentation
 from posthog.models.hog_function_template import HogFunctionTemplate
@@ -271,6 +272,9 @@ def team_saved(sender, instance: Team, created, **kwargs):
 
 @receiver(post_save, sender="posthog.Cohort")
 def cohort_saved(sender, instance, **kwargs):
+    if is_cohort_recalculation_only_save(kwargs):
+        return
+
     # When a cohort changes, recompile hog functions for any team that uses
     # this cohort in their test_account_filters (cohorts are inlined into bytecode).
     # Deletion is handled separately: the cohort API prevents deleting cohorts

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -865,7 +865,9 @@ class TestCohortCalculationTasks(APIBaseTest):
             ),
         ]
     )
-    def test_safe_save_cohort_state_passes_update_fields(self, _name, processing_error, expected_update_fields) -> None:
+    def test_safe_save_cohort_state_passes_update_fields(
+        self, _name: str, processing_error: Exception | None, expected_update_fields: list[str]
+    ) -> None:
         cohort = Cohort.objects.create(
             team_id=self.team.pk,
             name="test_cohort",

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from dateutil.relativedelta import relativedelta
+from parameterized import parameterized
 
 from posthog.models.cohort import Cohort
 from posthog.models.person import Person
@@ -835,127 +836,151 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             mock_chain.assert_called_once_with(mock_task, mock_task, mock_task)
             mock_chain_instance.apply_async.assert_called_once()
 
-        def test_safe_save_cohort_state_handles_errors(self) -> None:
-            """Test that _safe_save_cohort_state handles database errors gracefully"""
-            from unittest.mock import patch
-
-            # Create a static cohort
-            cohort = Cohort.objects.create(
-                team_id=self.team.pk,
-                name="test_cohort",
-                is_static=True,
-                count=0,
-            )
-
-            # Mock save to throw an exception
-            with patch.object(cohort, "save", side_effect=Exception("Database error")):
-                # This should not raise an exception - it should handle the error gracefully
-                cohort._safe_save_cohort_state(team_id=self.team.pk, processing_error=None)
-
-            # Verify cohort state is still set correctly in memory even though save failed
-            self.assertFalse(cohort.is_calculating)
-            self.assertEqual(cohort.errors_calculating, 0)  # Should be reset for successful processing
-
-        def test_insert_cohort_from_query_count_updated_on_exception(self) -> None:
-            """Test that insert_cohort_from_query updates count even when processing fails"""
-            from unittest.mock import patch
-
-            from posthog.tasks.calculate_cohort import insert_cohort_from_query
-
-            # Create a static cohort
-            cohort = Cohort.objects.create(
-                team_id=self.team.pk,
-                name="test_query_cohort",
-                is_static=True,
-                count=0,
-                query={"kind": "HogQLQuery", "query": "SELECT person_id FROM persons LIMIT 10"},
-            )
-
-            # Mock the query processing to fail
-            with (
-                patch("posthog.api.cohort.insert_cohort_query_actors_into_ch") as mock_insert_ch,
-                patch("posthog.api.cohort.insert_cohort_people_into_pg") as mock_insert_pg,
-            ):
-                # Make the processing functions throw an exception
-                mock_insert_ch.side_effect = Exception("Simulated query processing error")
-                mock_insert_pg.side_effect = Exception("Simulated pg insert error")
-
-                # This should not raise an exception and should update the count using PostgreSQL
-                insert_cohort_from_query(cohort.id, self.team.pk)
-
-                # Verify count was updated despite processing errors (should be 0 since no people were inserted due to mocked failures)
-                cohort.refresh_from_db()
-                self.assertEqual(
-                    cohort.count, 0, "Count should be updated using PostgreSQL even when query processing fails"
-                )
-                self.assertFalse(cohort.is_calculating, "Cohort should not be in calculating state")
-                self.assertGreater(cohort.errors_calculating, 0, "Should have recorded the processing error")
-
-        @patch("posthog.tasks.calculate_cohort.chain")
-        @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.si")
-        def test_increment_version_and_enqueue_calculate_cohort_with_referencing_cohorts(
-            self, mock_calculate_cohort_ch_si: MagicMock, mock_chain: MagicMock
-        ) -> None:
-            # Create cohort A (base cohort)
-            cohort_a = Cohort.objects.create(
-                team=self.team,
-                name="Cohort A",
-                filters={
-                    "properties": {"type": "AND", "values": [{"key": "$browser", "value": "Chrome", "type": "person"}]}
-                },
-                is_static=False,
-            )
-
-            # Create cohort B that references A
-            cohort_b = Cohort.objects.create(
-                team=self.team,
-                name="Cohort B (references A)",
-                filters={
-                    "properties": {
-                        "type": "AND",
-                        "values": [
-                            {"key": "id", "value": cohort_a.id, "type": "cohort"},
-                            {"key": "$os", "value": "Windows", "type": "person"},
-                        ],
-                    }
-                },
-                is_static=False,
-            )
-
-            # Create cohort C that references B
-            cohort_c = Cohort.objects.create(
-                team=self.team,
-                name="Cohort C (references B)",
-                filters={
-                    "properties": {
-                        "type": "AND",
-                        "values": [
-                            {"key": "id", "value": cohort_b.id, "type": "cohort"},
-                            {"key": "$country", "value": "US", "type": "person"},
-                        ],
-                    }
-                },
-                is_static=False,
-            )
-
-            mock_chain_instance = MagicMock()
-            mock_chain.return_value = mock_chain_instance
-            mock_task = MagicMock()
-            mock_calculate_cohort_ch_si.return_value = mock_task
-
-            # Update cohort A - should trigger recalculation of A, B, then C
-            increment_version_and_enqueue_calculate_cohort(cohort_a, initiating_user=None)
-
-            # Should call calculate_cohort_ch.si for all 3 cohorts (A, B, C)
-            self.assertEqual(mock_calculate_cohort_ch_si.call_count, 3)
-
-            # Verify all cohorts are included
-            actual_calls = mock_calculate_cohort_ch_si.call_args_list
-            actual_cohort_ids = {call[0][0] for call in actual_calls}
-            expected_cohort_ids = {cohort_a.id, cohort_b.id, cohort_c.id}
-            self.assertEqual(actual_cohort_ids, expected_cohort_ids)
-
-            mock_chain.assert_called_once()
-            mock_chain_instance.apply_async.assert_called_once()
-
     return TestCalculateCohort
+
+
+class TestCohortCalculationTasks(APIBaseTest):
+    def test_safe_save_cohort_state_handles_errors(self) -> None:
+        cohort = Cohort.objects.create(
+            team_id=self.team.pk,
+            name="test_cohort",
+            is_static=True,
+            count=0,
+        )
+
+        with patch.object(cohort, "save", side_effect=Exception("Database error")) as mock_save:
+            cohort._safe_save_cohort_state(team_id=self.team.pk, processing_error=None)
+
+        self.assertFalse(cohort.is_calculating)
+        self.assertEqual(cohort.errors_calculating, 0)
+        self.assertEqual(mock_save.call_count, 2)
+
+    @parameterized.expand(
+        [
+            ("success", None, ["is_calculating", "last_calculation", "errors_calculating", "count"]),
+            (
+                "error",
+                Exception("processing failed"),
+                ["is_calculating", "errors_calculating", "last_error_at", "count"],
+            ),
+        ]
+    )
+    def test_safe_save_cohort_state_passes_update_fields(self, _name, processing_error, expected_update_fields) -> None:
+        cohort = Cohort.objects.create(
+            team_id=self.team.pk,
+            name="test_cohort",
+            is_static=True,
+            count=0,
+        )
+
+        with patch.object(cohort, "save") as mock_save:
+            cohort._safe_save_cohort_state(team_id=self.team.pk, processing_error=processing_error)
+
+        mock_save.assert_called_once_with(update_fields=expected_update_fields)
+
+    def test_safe_save_cohort_state_does_not_trigger_downstream_signals(self) -> None:
+        cohort = Cohort.objects.create(
+            team_id=self.team.pk,
+            name="test_cohort",
+            is_static=True,
+            count=0,
+        )
+
+        with (
+            patch("posthog.models.cohort.dependencies._on_cohort_changed") as mock_dep_cache,
+            patch("posthog.tasks.feature_flags.update_team_flags_cache") as mock_flags_cache,
+            patch("posthog.tasks.hog_functions.refresh_affected_hog_functions") as mock_hog_refresh,
+        ):
+            cohort._safe_save_cohort_state(team_id=self.team.pk, processing_error=None)
+
+        mock_dep_cache.assert_not_called()
+        mock_flags_cache.delay.assert_not_called()
+        mock_hog_refresh.delay.assert_not_called()
+
+    def test_insert_cohort_from_query_count_updated_on_exception(self) -> None:
+        from posthog.tasks.calculate_cohort import insert_cohort_from_query
+
+        cohort = Cohort.objects.create(
+            team_id=self.team.pk,
+            name="test_query_cohort",
+            is_static=True,
+            count=0,
+            query={"kind": "HogQLQuery", "query": "SELECT person_id FROM persons LIMIT 10"},
+        )
+
+        with (
+            patch("posthog.api.cohort.insert_cohort_query_actors_into_ch") as mock_insert_ch,
+            patch("posthog.api.cohort.insert_cohort_people_into_pg") as mock_insert_pg,
+        ):
+            mock_insert_ch.side_effect = Exception("Simulated query processing error")
+            mock_insert_pg.side_effect = Exception("Simulated pg insert error")
+
+            insert_cohort_from_query(cohort.id, self.team.pk)
+
+            cohort.refresh_from_db()
+            self.assertEqual(
+                cohort.count, 0, "Count should be updated using PostgreSQL even when query processing fails"
+            )
+            self.assertFalse(cohort.is_calculating, "Cohort should not be in calculating state")
+            self.assertGreater(cohort.errors_calculating, 0, "Should have recorded the processing error")
+
+    @patch("posthog.tasks.calculate_cohort.chain")
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.si")
+    def test_increment_version_and_enqueue_calculate_cohort_with_referencing_cohorts(
+        self, mock_calculate_cohort_ch_si: MagicMock, mock_chain: MagicMock
+    ) -> None:
+        cohort_a = Cohort.objects.create(
+            team=self.team,
+            name="Cohort A",
+            filters={
+                "properties": {"type": "AND", "values": [{"key": "$browser", "value": "Chrome", "type": "person"}]}
+            },
+            is_static=False,
+        )
+
+        cohort_b = Cohort.objects.create(
+            team=self.team,
+            name="Cohort B (references A)",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"key": "id", "value": cohort_a.id, "type": "cohort"},
+                        {"key": "$os", "value": "Windows", "type": "person"},
+                    ],
+                }
+            },
+            is_static=False,
+        )
+
+        cohort_c = Cohort.objects.create(
+            team=self.team,
+            name="Cohort C (references B)",
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"key": "id", "value": cohort_b.id, "type": "cohort"},
+                        {"key": "$country", "value": "US", "type": "person"},
+                    ],
+                }
+            },
+            is_static=False,
+        )
+
+        mock_chain_instance = MagicMock()
+        mock_chain.return_value = mock_chain_instance
+        mock_task = MagicMock()
+        mock_calculate_cohort_ch_si.return_value = mock_task
+
+        increment_version_and_enqueue_calculate_cohort(cohort_a, initiating_user=None)
+
+        self.assertEqual(mock_calculate_cohort_ch_si.call_count, 3)
+
+        actual_calls = mock_calculate_cohort_ch_si.call_args_list
+        actual_cohort_ids = {call[0][0] for call in actual_calls}
+        expected_cohort_ids = {cohort_a.id, cohort_b.id, cohort_c.id}
+        self.assertEqual(actual_cohort_ids, expected_cohort_ids)
+
+        mock_chain.assert_called_once()
+        mock_chain_instance.apply_async.assert_called_once()


### PR DESCRIPTION
## Problem

When a cohort recalculates, `_safe_save_cohort_state` calls `self.save()` without `update_fields`, triggering every `post_save` signal handler. This causes unnecessary cache invalidations (feature flag cache, dependency cache, hog function recompilation) on every recalculation cycle, even though only bookkeeping fields like `is_calculating` and `last_calculation` changed.

## Changes

- Define `COHORT_RECALCULATION_FIELDS` frozenset (`is_calculating`, `last_calculation`, `errors_calculating`, `last_error_at`) as the set of fields touched during recalculation
- Pass `update_fields` to `self.save()` in `_safe_save_cohort_state` so Django's `post_save` signal includes the field list
- Add an early-return guard to all three `post_save` signal handlers (`dependencies.cohort_changed`, `local_evaluation.cohort_changed`, `hog_function.cohort_saved`) that skips processing when only recalculation fields were updated
- Refactor tests out of the factory class and add assertions verifying `update_fields` is passed correctly on both success and error paths

## How did you test this code?

Unit tests verify `update_fields` is passed to `save()` on both the success path and the error path. Existing tests for cohort dependency tracking, feature flag cache invalidation, and hog function recompilation continue to pass.

## Publish to changelog?

No