### PR TITLE
fix(replay): search inspector by feature flag name

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -862,6 +862,26 @@ describe('lib/utils', () => {
             ).toEqual('clicked "hello"')
         })
 
+        it('handles feature flag called events', () => {
+            expect(
+                eventToDescription({
+                    ...baseEvent,
+                    event: '$feature_flag_called',
+                    properties: { $feature_flag: 'my-flag-key' },
+                })
+            ).toEqual('my-flag-key')
+        })
+
+        it('handles feature flag called events without flag name', () => {
+            expect(
+                eventToDescription({
+                    ...baseEvent,
+                    event: '$feature_flag_called',
+                    properties: {},
+                })
+            ).toEqual('$feature_flag_called')
+        })
+
         it('handles unknown event/action', () => {
             expect(
                 eventToDescription({

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -862,24 +862,17 @@ describe('lib/utils', () => {
             ).toEqual('clicked "hello"')
         })
 
-        it('handles feature flag called events', () => {
+        it.each([
+            ['with a flag key', { $feature_flag: 'my-flag-key' }, 'my-flag-key'],
+            ['without the flag key property', {}, '$feature_flag_called'],
+        ])('handles feature flag called events %s', (_, properties, expected) => {
             expect(
                 eventToDescription({
                     ...baseEvent,
                     event: '$feature_flag_called',
-                    properties: { $feature_flag: 'my-flag-key' },
+                    properties,
                 })
-            ).toEqual('my-flag-key')
-        })
-
-        it('handles feature flag called events without flag name', () => {
-            expect(
-                eventToDescription({
-                    ...baseEvent,
-                    event: '$feature_flag_called',
-                    properties: {},
-                })
-            ).toEqual('$feature_flag_called')
+            ).toEqual(expected)
         })
 
         it('handles unknown event/action', () => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1034,6 +1034,9 @@ export function eventToDescription(
     if (event.event === '$autocapture') {
         return autoCaptureEventToDescription(event, shortForm)
     }
+    if (event.event === '$feature_flag_called') {
+        return event.properties.$feature_flag ?? event.event
+    }
     // All other events and actions
     return event.event
 }


### PR DESCRIPTION
## Problem

When searching in the session replay inspector, typing a feature flag name (key) doesn't surface `$feature_flag_called` events that contain that flag. The search only matches against the event label ("Feature flag called") and the raw event name, not the actual flag key stored in properties.

Closes #52027

## Changes

Added a `$feature_flag_called` case to `eventToDescription()` in `lib/utils.tsx` that returns the `$feature_flag` property value (the flag key). This makes the flag key both searchable in the inspector and visible as the event description.

Searching for "feature flag called" still works — the search string is composed of the taxonomy label + description, so both match.

## How did you test this code?

Added unit tests for `eventToDescription` covering:
- Feature flag called event with a flag key
- Feature flag called event without the `$feature_flag` property (falls back to event name)

## Publish to changelog?

no