### PR TITLE
feat(experiments): Add browser notifications for long-running metric queries

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -58,6 +58,7 @@ import { Info } from './Info'
 import { LegacyExperimentHeader } from './LegacyExperimentHeader'
 import { Overview } from './Overview'
 import { ReleaseConditionsModal, ReleaseConditionsTable } from './ReleaseConditionsTable'
+import { ResultsNotificationBanner } from './ResultsNotificationBanner'
 import { SettingsTab } from './SettingsTab'
 import { SummaryTable } from './SummaryTable'
 
@@ -122,6 +123,7 @@ const MetricsTab = (): JSX.Element => {
 
     return (
         <>
+            <ResultsNotificationBanner />
             {usesNewQueryRunner && !isAiAnalysisTabEnabled && (
                 <div className="mt-1 mb-4 flex justify-start gap-2">
                     <SummarizeExperimentButton

--- a/frontend/src/scenes/experiments/ExperimentView/ResultsNotificationBanner.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ResultsNotificationBanner.tsx
@@ -1,0 +1,53 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconClock } from '@posthog/icons'
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+
+import { experimentLogic } from '../experimentLogic'
+
+export function ResultsNotificationBanner(): JSX.Element | null {
+    const {
+        showNotificationOffer,
+        notifyWhenResultsReady,
+        primaryMetricsResultsLoading,
+        secondaryMetricsResultsLoading,
+    } = useValues(experimentLogic)
+    const { subscribeToResultsNotification, dismissNotificationOffer } = useActions(experimentLogic)
+
+    const isLoading = primaryMetricsResultsLoading || secondaryMetricsResultsLoading
+
+    useEffect(() => {
+        if (!notifyWhenResultsReady || !isLoading) {
+            return
+        }
+
+        const handler = (e: BeforeUnloadEvent): void => {
+            e.preventDefault()
+        }
+        window.addEventListener('beforeunload', handler)
+        return () => window.removeEventListener('beforeunload', handler)
+    }, [notifyWhenResultsReady, isLoading])
+
+    if (!showNotificationOffer && !notifyWhenResultsReady) {
+        return null
+    }
+    if (!isLoading) {
+        return null
+    }
+
+    return (
+        <LemonBanner type="info" className="mb-4" icon={<IconClock />} onClose={dismissNotificationOffer}>
+            {notifyWhenResultsReady ? (
+                "We'll notify you when results are ready. Keep this tab open."
+            ) : (
+                <div className="flex items-center gap-2">
+                    <span>Results are taking a while.</span>
+                    <LemonButton type="secondary" size="xsmall" onClick={subscribeToResultsNotification}>
+                        Notify me when ready
+                    </LemonButton>
+                </div>
+            )}
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/experiments/ExperimentView/ResultsNotificationBanner.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ResultsNotificationBanner.tsx
@@ -37,7 +37,12 @@ export function ResultsNotificationBanner(): JSX.Element | null {
     }
 
     return (
-        <LemonBanner type="info" className="mb-4" icon={<IconClock />} onClose={dismissNotificationOffer}>
+        <LemonBanner
+            type="info"
+            className="mb-4"
+            icon={<IconClock />}
+            onClose={notifyWhenResultsReady ? undefined : dismissNotificationOffer}
+        >
             {notifyWhenResultsReady ? (
                 "We'll notify you when results are ready. Keep this tab open."
             ) : (

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -742,6 +742,10 @@ export const experimentLogic = kea<experimentLogicType>([
         resetAutoRefreshInterval: true,
         stopAutoRefreshInterval: true,
         setPageVisibility: (visible: boolean) => ({ visible }),
+        subscribeToResultsNotification: true,
+        dismissNotificationOffer: true,
+        setShowNotificationOffer: (show: boolean) => ({ show }),
+        setNotifyWhenResultsReady: (notify: boolean) => ({ notify }),
     }),
     reducers({
         experiment: [
@@ -1221,10 +1225,44 @@ export const experimentLogic = kea<experimentLogicType>([
                 setPageVisibility: (_, { visible }) => visible,
             },
         ],
+        showNotificationOffer: [
+            false,
+            {
+                setShowNotificationOffer: (_, { show }) => show,
+                dismissNotificationOffer: () => false,
+            },
+        ],
+        notifyWhenResultsReady: [
+            false,
+            {
+                setNotifyWhenResultsReady: (_, { notify }) => notify,
+                dismissNotificationOffer: () => false,
+            },
+        ],
     }),
     listeners(({ values, actions, asyncActions, cache }) => ({
         beforeUnmount: () => {
             actions.stopAutoRefreshInterval()
+            clearTimeout(cache.notificationOfferTimer)
+        },
+        subscribeToResultsNotification: async () => {
+            if (!('Notification' in window)) {
+                lemonToast.error('Your browser does not support notifications.')
+                return
+            }
+
+            let permission = Notification.permission
+            if (permission === 'default') {
+                permission = await Notification.requestPermission()
+            }
+
+            if (permission === 'granted') {
+                actions.setNotifyWhenResultsReady(true)
+            } else if (permission === 'denied') {
+                lemonToast.info(
+                    'Notifications are blocked. Enable them in your browser address bar or system settings.'
+                )
+            }
         },
         setFeatureFlagActive: async ({ isActive }) => {
             if (!values.experiment.feature_flag) {
@@ -1464,6 +1502,13 @@ export const experimentLogic = kea<experimentLogicType>([
             const summaries: MetricLoadingSummary[] = []
             cache.refreshSummariesById = cache.refreshSummariesById ?? {}
             cache.refreshSummariesById[refreshId] = summaries
+
+            // Start 30s timer to offer browser notifications
+            clearTimeout(cache.notificationOfferTimer)
+            cache.notificationOfferTimer = setTimeout(() => {
+                actions.setShowNotificationOffer(true)
+            }, 10_000)
+
             try {
                 await Promise.all([
                     asyncActions.loadPrimaryMetricsResults(forceRefresh, refreshId),
@@ -1513,6 +1558,30 @@ export const experimentLogic = kea<experimentLogicType>([
                         total_metrics_count: primaryCount + secondaryCount,
                     }
                 )
+
+                // Clear notification offer timer
+                clearTimeout(cache.notificationOfferTimer)
+
+                // Fire browser notification if user subscribed
+                if (
+                    values.notifyWhenResultsReady &&
+                    'Notification' in window &&
+                    Notification.permission === 'granted'
+                ) {
+                    const notification = new Notification('Experiment results ready', {
+                        body: `Results for "${values.experiment.name}" are now available.`,
+                        icon: '/static/posthog-icon.svg',
+                        tag: `experiment-results-${values.experimentId}`,
+                    })
+                    notification.onclick = () => {
+                        window.focus()
+                        notification.close()
+                    }
+                }
+
+                // Reset notification state
+                actions.setShowNotificationOffer(false)
+                actions.setNotifyWhenResultsReady(false)
 
                 // Only set up auto-refresh if enabled AND page is visible
                 // This prevents the interval from restarting when async operations complete after the page becomes invisible

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1503,7 +1503,7 @@ export const experimentLogic = kea<experimentLogicType>([
             cache.refreshSummariesById = cache.refreshSummariesById ?? {}
             cache.refreshSummariesById[refreshId] = summaries
 
-            // Start 30s timer to offer browser notifications
+            // Start 10s timer to offer browser notifications
             clearTimeout(cache.notificationOfferTimer)
             cache.notificationOfferTimer = setTimeout(() => {
                 actions.setShowNotificationOffer(true)


### PR DESCRIPTION
## Problem

Experiment metric queries can take a long time.

## Changes

Added a "Notify me when ready" banner that appears after 10s of loading. Uses the browser Notification API to alert the user when results finish. Tab must remain open.

<img width="1511" height="1032" alt="image" src="https://github.com/user-attachments/assets/61acedb7-930a-4a4f-b34c-254fc070fd83" />

<img width="1511" height="1029" alt="image" src="https://github.com/user-attachments/assets/a12aa870-59c9-4c58-a851-41c02b7c8b02" />

## How did you test this code?

Manually tested the full flow: banner appearance, permission prompt, notification delivery, tab focus on click, dismiss behavior, beforeunload warning, and auto-refresh interaction.