### PR TITLE
chore: Removed sessions tables from backup dag

### DIFF
--- a/posthog/dags/backups.py
+++ b/posthog/dags/backups.py
@@ -33,10 +33,8 @@ SHARDED_TABLES = [
     "sharded_heatmaps",
     "sharded_ingestion_warnings",
     "sharded_performance_events",
-    "sharded_raw_sessions",
     "sharded_session_replay_embeddings",
     "sharded_session_replay_events",
-    "sharded_sessions",
 ]
 
 NON_SHARDED_TABLES = [


### PR DESCRIPTION
After moving sessions and raw_sessions to a new cluster, backups are failing. We can remove these for now from the backup so the backup works again and then work on a proper solution