### PR TITLE
feat: Add more logging to deduplicator failure states

### DIFF
--- a/rust/kafka-deduplicator/src/checkpoint/metadata.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/metadata.rs
@@ -11,9 +11,10 @@ use crate::utils::format_store_path;
 
 /// Deterministic 8-hex-char prefix for spreading S3 object keys across internal partitions.
 /// Applied ONLY to checkpoint object file paths, NEVER to metadata.json paths.
-pub fn hash_prefix_for_partition(topic: &str, partition: i32) -> String {
-    let input = format!("{topic}/{partition}");
-    let hash = Sha256::digest(input.as_bytes());
+/// Derived from topic name only so all partitions of the same topic share a prefix,
+/// simplifying S3 listing and lifecycle operations.
+pub fn hash_prefix_for_partition(topic: &str, _partition: i32) -> String {
+    let hash = Sha256::digest(topic.as_bytes());
     format!(
         "{:02x}{:02x}{:02x}{:02x}",
         hash[0], hash[1], hash[2], hash[3]
@@ -498,13 +499,20 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_prefix_different_partitions() {
+    fn test_hash_prefix_same_topic_same_hash() {
+        // All partitions of the same topic share a hash prefix
         let h0 = hash_prefix_for_partition("events", 0);
         let h1 = hash_prefix_for_partition("events", 1);
-        let h2 = hash_prefix_for_partition("other-topic", 0);
+        let h2 = hash_prefix_for_partition("events", 42);
+        assert_eq!(h0, h1);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_hash_prefix_different_topics() {
+        let h0 = hash_prefix_for_partition("events", 0);
+        let h1 = hash_prefix_for_partition("other-topic", 0);
         assert_ne!(h0, h1);
-        assert_ne!(h0, h2);
-        assert_ne!(h1, h2);
     }
 
     #[test]

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -416,24 +416,25 @@ mod tests {
 
     #[test]
     fn test_format_checkpoint_list_prefix_trailing_slash_prevents_prefix_collision() {
-        // This test documents the bug fix: partition 41 must NOT match partition 419
+        // Partitions of the same topic share a hash prefix, but the trailing slash
+        // on the partition number in the path prevents prefix collision
         let prefix_41 = format_checkpoint_list_prefix("checkpoints", "events", 41);
         let prefix_419 = format_checkpoint_list_prefix("checkpoints", "events", 419);
 
-        let hash_41 = hash_prefix_for_partition("events", 41);
-        let hash_419 = hash_prefix_for_partition("events", 419);
-        assert_eq!(prefix_41, format!("{hash_41}/checkpoints/events/41/"));
-        assert_eq!(prefix_419, format!("{hash_419}/checkpoints/events/419/"));
+        let hash = hash_prefix_for_partition("events", 41);
+        assert_eq!(hash, hash_prefix_for_partition("events", 419));
+        assert_eq!(prefix_41, format!("{hash}/checkpoints/events/41/"));
+        assert_eq!(prefix_419, format!("{hash}/checkpoints/events/419/"));
 
-        // Different partitions get different hashes, so prefixes never collide
-        assert_ne!(hash_41, hash_419);
+        // Trailing slash ensures partition 41 prefix doesn't match partition 419
         assert!(!prefix_419.starts_with(&prefix_41));
+        assert!(!prefix_41.starts_with(&prefix_419));
 
-        // Simulated S3 keys that would be returned (with hash)
+        // Simulated S3 keys
         let key_for_41 =
-            format!("{hash_41}/checkpoints/events/41/2026-01-22T12-00-00Z/metadata.json");
+            format!("{hash}/checkpoints/events/41/2026-01-22T12-00-00Z/metadata.json");
         let key_for_419 =
-            format!("{hash_419}/checkpoints/events/419/2026-01-22T12-00-00Z/metadata.json");
+            format!("{hash}/checkpoints/events/419/2026-01-22T12-00-00Z/metadata.json");
 
         // Prefix 41 correctly matches only partition 41's keys
         assert!(key_for_41.starts_with(&prefix_41));

--- a/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_downloader.rs
@@ -18,8 +18,7 @@ use crate::metrics_const::{
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
-use futures::stream::FuturesUnordered;
-use futures::{StreamExt, TryStreamExt};
+use futures::{stream, StreamExt, TryStreamExt};
 use object_store::limit::LimitStore;
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt};
@@ -100,6 +99,7 @@ pub struct S3Downloader {
     s3_bucket: String,
     s3_key_prefix: String,
     checkpoint_import_window_hours: u32,
+    max_concurrent_downloads: usize,
 }
 
 impl S3Downloader {
@@ -117,6 +117,7 @@ impl S3Downloader {
             s3_bucket: config.s3_bucket.clone(),
             s3_key_prefix: config.s3_key_prefix.clone(),
             checkpoint_import_window_hours: config.checkpoint_import_window_hours,
+            max_concurrent_downloads: config.max_concurrent_checkpoint_file_downloads,
         })
     }
 }
@@ -288,9 +289,9 @@ impl CheckpointDownloader for S3Downloader {
             }
         }
 
-        // Build download futures using FuturesUnordered for early exit with sibling cancellation.
-        // LimitStore's semaphore still limits concurrent S3 requests.
-        let mut futures: FuturesUnordered<_> = remote_keys
+        // Collect download tasks as owned data upfront to avoid lifetime issues
+        // with buffer_unordered requiring 'static futures.
+        let download_tasks: Vec<_> = remote_keys
             .iter()
             .map(|remote_key| {
                 let remote_filename = remote_key
@@ -299,23 +300,32 @@ impl CheckpointDownloader for S3Downloader {
                     .unwrap_or(remote_key)
                     .to_string();
                 let local_filepath = local_base_path.join(&remote_filename);
+                (remote_key.clone(), local_filepath)
+            })
+            .collect();
 
+        // Build download stream with bounded concurrency.
+        // buffer_unordered limits how many futures are polled simultaneously,
+        // bounding memory from concurrent S3 streams and open file handles.
+        let max_concurrent = self.max_concurrent_downloads;
+        let mut download_stream =
+            stream::iter(download_tasks.into_iter().map(|(remote_key, local_filepath)| {
                 async move {
                     self.download_and_store_file_cancellable(
-                        remote_key,
+                        &remote_key,
                         &local_filepath,
                         cancel_token,
                     )
                     .await
                     .with_context(|| format!("Failed to download: {remote_key}"))
                 }
-            })
-            .collect();
+            }))
+            .buffer_unordered(max_concurrent);
 
         let mut first_error: Option<anyhow::Error> = None;
 
         // Process completions, cancel siblings on first error
-        while let Some(result) = futures.next().await {
+        while let Some(result) = download_stream.next().await {
             if let Err(e) = result {
                 first_error = Some(e);
                 // Cancel siblings via the attempt token - they'll exit on next chunk iteration
@@ -328,7 +338,7 @@ impl CheckpointDownloader for S3Downloader {
 
         // Drain remaining futures - they'll exit quickly due to cancellation check in their loop
         if first_error.is_some() {
-            while futures.next().await.is_some() {}
+            while download_stream.next().await.is_some() {}
         }
 
         if let Some(e) = first_error {

--- a/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
+++ b/rust/kafka-deduplicator/src/checkpoint/s3_uploader.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::stream::FuturesUnordered;
+use futures::stream;
 use futures::StreamExt;
 use object_store::buffered::BufWriter;
 use object_store::path::Path as ObjectPath;
@@ -214,29 +214,40 @@ impl CheckpointUploader for S3Uploader {
             .map(|parent| parent.child_token())
             .unwrap_or_default();
 
-        // Build upload futures using FuturesUnordered for early exit with sibling cancellation.
-        // LimitStore's semaphore still limits concurrent S3 requests.
-        let mut futures: FuturesUnordered<_> = plan
+        // Collect upload tasks as owned (src, dest) pairs upfront to avoid
+        // lifetime issues with buffer_unordered requiring 'static futures.
+        let upload_tasks: Vec<_> = plan
             .files_to_upload
             .iter()
             .map(|local_file| {
-                let src = local_file.local_path.clone();
-                let dest = plan.info.get_file_key(&local_file.filename);
-                let token = upload_token.clone();
-
-                async move {
-                    self.upload_file_cancellable(&src, &dest, Some(&token))
-                        .await?;
-                    Ok::<String, anyhow::Error>(dest)
-                }
+                (
+                    local_file.local_path.clone(),
+                    plan.info.get_file_key(&local_file.filename),
+                )
             })
             .collect();
+
+        // Build upload stream with bounded concurrency.
+        // buffer_unordered limits how many futures are polled simultaneously,
+        // preventing memory spikes from all upload buffers (8MB each) being
+        // allocated at once when a partition has many SST files.
+        let max_concurrent = self.config.max_concurrent_checkpoint_file_uploads;
+        let mut upload_stream = stream::iter(upload_tasks.into_iter().map(|(src, dest)| {
+            let token = upload_token.clone();
+
+            async move {
+                self.upload_file_cancellable(&src, &dest, Some(&token))
+                    .await?;
+                Ok::<String, anyhow::Error>(dest)
+            }
+        }))
+        .buffer_unordered(max_concurrent);
 
         let mut uploaded_keys = Vec::with_capacity(plan.files_to_upload.len());
         let mut first_error: Option<anyhow::Error> = None;
 
         // Process completions, cancel siblings on first error
-        while let Some(result) = futures.next().await {
+        while let Some(result) = upload_stream.next().await {
             match result {
                 Ok(key) => uploaded_keys.push(key),
                 Err(e) => {
@@ -249,7 +260,7 @@ impl CheckpointUploader for S3Uploader {
         }
 
         // Drain remaining futures - they'll exit quickly due to cancellation
-        while futures.next().await.is_some() {}
+        while upload_stream.next().await.is_some() {}
 
         // Return early on error - DO NOT upload metadata
         if let Some(e) = first_error {

--- a/rust/kafka-deduplicator/src/main.rs
+++ b/rust/kafka-deduplicator/src/main.rs
@@ -20,10 +20,15 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-/// Install a panic hook that logs panics through the structured tracing logger.
+/// Install a panic hook that logs panics through both stderr and the structured
+/// tracing logger.
 ///
 /// Without this, panics write to stderr using the default formatter, which
 /// bypasses the JSON log layer and makes them invisible in Loki/Grafana.
+///
+/// We write to stderr first as a guaranteed fallback — tracing may be in a bad
+/// state (deadlocked, subscriber dropped) when the panic hook runs, so direct
+/// IO ensures the message is always visible in container logs.
 fn install_tracing_panic_hook() {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
@@ -41,6 +46,13 @@ fn install_tracing_panic_hook() {
             "unknown panic payload".to_string()
         };
 
+        // Write directly to stderr first — this always works even if the tracing
+        // subscriber is deadlocked, poisoned, or already dropped.
+        eprintln!("PANIC in thread '{thread_name}' at {location}: {payload}");
+
+        // Also try to log through tracing for structured logging (Loki/Grafana).
+        // This may silently fail if the subscriber is in a bad state, which is
+        // why we always write to stderr above.
         error!(
             thread = %thread_name,
             location = %location,
@@ -163,9 +175,15 @@ fn start_server(config: &Config, liveness: HealthRegistry) -> JoinHandle<()> {
                         .filter(|(_, component_status)| !component_status.is_healthy())
                         .map(|(name, component_status)| format!("{name}: {component_status:?}"))
                         .collect();
+                    let all_components: Vec<String> = status
+                        .components
+                        .iter()
+                        .map(|(name, component_status)| format!("{name}: {component_status:?}"))
+                        .collect();
                     error!(
-                        "Health check FAILED - unhealthy components: [{}]",
-                        unhealthy_components.join(", ")
+                        unhealthy = %unhealthy_components.join(", "),
+                        all_components = %all_components.join(", "),
+                        "Health check FAILED"
                     );
                 }
                 status

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -600,6 +600,10 @@ impl KafkaDeduplicatorService {
         // Shutdown all stores cleanly
         self.store_manager.shutdown().await;
 
+        if consumer_exited_early {
+            anyhow::bail!("Consumer exited unexpectedly — exiting with non-zero status");
+        }
+
         info!("Kafka Deduplicator service stopped");
         Ok(())
     }
@@ -683,6 +687,10 @@ impl KafkaDeduplicatorService {
 
         // Shutdown all stores cleanly
         self.store_manager.shutdown().await;
+
+        if consumer_exited_early {
+            anyhow::bail!("Consumer exited unexpectedly — exiting with non-zero status");
+        }
 
         Ok(())
     }

--- a/rust/kafka-deduplicator/src/service.rs
+++ b/rust/kafka-deduplicator/src/service.rs
@@ -544,14 +544,29 @@ impl KafkaDeduplicatorService {
         }
 
         // Start consumption
-        let consumer_handle = tokio::spawn(async move { consumer.start_consumption().await });
+        let mut consumer_handle = tokio::spawn(async move { consumer.start_consumption().await });
 
         // Wait for SIGTERM signal (Kubernetes graceful shutdown)
         use tokio::signal::unix::{signal, SignalKind};
         let mut sigterm = signal(SignalKind::terminate()).expect("Failed to listen for SIGTERM");
 
-        sigterm.recv().await;
-        info!("Received SIGTERM signal, shutting down gracefully...");
+        // Monitor both SIGTERM and the consumer task — if the consumer dies
+        // unexpectedly, we log the error immediately instead of sitting idle
+        // with stale health checks until k8s eventually kills us.
+        let consumer_exited_early = tokio::select! {
+            _ = sigterm.recv() => {
+                info!("Received SIGTERM signal, shutting down gracefully...");
+                false
+            }
+            result = &mut consumer_handle => {
+                match result {
+                    Ok(Ok(_)) => error!("Consumer exited unexpectedly without error"),
+                    Ok(Err(ref e)) => error!(error = %e, "Consumer stopped with error"),
+                    Err(ref e) => error!(error = %e, "Consumer task panicked"),
+                }
+                true
+            }
+        };
 
         // Send shutdown signal
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
@@ -569,15 +584,17 @@ impl KafkaDeduplicatorService {
             checkpoint_manager.stop().await;
         }
 
-        // Wait for consumer to finish with timeout
-        match tokio::time::timeout(self.config.shutdown_timeout(), consumer_handle).await {
-            Ok(Ok(Ok(_))) => info!("Consumer stopped normally"),
-            Ok(Ok(Err(e))) => error!("Consumer stopped with error: {e:#}"),
-            Ok(Err(e)) => error!("Consumer task panicked: {e:#}"),
-            Err(_) => error!(
-                "Consumer shutdown timed out after {:?}",
-                self.config.shutdown_timeout()
-            ),
+        // Wait for consumer to finish with timeout (only if it didn't already exit)
+        if !consumer_exited_early {
+            match tokio::time::timeout(self.config.shutdown_timeout(), consumer_handle).await {
+                Ok(Ok(Ok(_))) => info!("Consumer stopped normally"),
+                Ok(Ok(Err(e))) => error!("Consumer stopped with error: {e:#}"),
+                Ok(Err(e)) => error!("Consumer task panicked: {e:#}"),
+                Err(_) => error!(
+                    "Consumer shutdown timed out after {:?}",
+                    self.config.shutdown_timeout()
+                ),
+            }
         }
 
         // Shutdown all stores cleanly
@@ -616,12 +633,24 @@ impl KafkaDeduplicatorService {
         }
 
         // Start consumption
-        let consumer_handle = tokio::spawn(async move { consumer.start_consumption().await });
+        let mut consumer_handle = tokio::spawn(async move { consumer.start_consumption().await });
 
-        // Wait for shutdown signal
-        shutdown_signal.await;
-
-        info!("Received shutdown signal, shutting down gracefully...");
+        // Monitor both the shutdown signal and the consumer task — if the consumer
+        // dies unexpectedly, we log the error immediately.
+        let consumer_exited_early = tokio::select! {
+            _ = shutdown_signal => {
+                info!("Received shutdown signal, shutting down gracefully...");
+                false
+            }
+            result = &mut consumer_handle => {
+                match result {
+                    Ok(Ok(_)) => error!("Consumer exited unexpectedly without error"),
+                    Ok(Err(ref e)) => error!(error = %e, "Consumer stopped with error"),
+                    Err(ref e) => error!(error = %e, "Consumer task panicked"),
+                }
+                true
+            }
+        };
 
         // Send shutdown signal
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
@@ -639,15 +668,17 @@ impl KafkaDeduplicatorService {
             checkpoint_manager.stop().await;
         }
 
-        // Wait for consumer to finish with timeout
-        match tokio::time::timeout(self.config.shutdown_timeout(), consumer_handle).await {
-            Ok(Ok(Ok(_))) => info!("Consumer stopped normally"),
-            Ok(Ok(Err(e))) => error!("Consumer stopped with error: {e:#}"),
-            Ok(Err(e)) => error!("Consumer task panicked: {e:#}"),
-            Err(_) => error!(
-                "Consumer shutdown timed out after {:?}",
-                self.config.shutdown_timeout()
-            ),
+        // Wait for consumer to finish with timeout (only if it didn't already exit)
+        if !consumer_exited_early {
+            match tokio::time::timeout(self.config.shutdown_timeout(), consumer_handle).await {
+                Ok(Ok(Ok(_))) => info!("Consumer stopped normally"),
+                Ok(Ok(Err(e))) => error!("Consumer stopped with error: {e:#}"),
+                Ok(Err(e)) => error!("Consumer task panicked: {e:#}"),
+                Err(_) => error!(
+                    "Consumer shutdown timed out after {:?}",
+                    self.config.shutdown_timeout()
+                ),
+            }
         }
 
         // Shutdown all stores cleanly

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -60,8 +60,8 @@ impl DeduplicationStore {
         let mut ts_cf_opts = Options::default();
         ts_cf_opts.set_block_based_table_factory(&block_opts);
         ts_cf_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(8)); // <- per-CF
-        ts_cf_opts.set_write_buffer_size(8 * 1024 * 1024);
-        ts_cf_opts.set_max_write_buffer_number(3);
+        ts_cf_opts.set_write_buffer_size(rocksdb_config.write_buffer_size_bytes);
+        ts_cf_opts.set_max_write_buffer_number(2);
         // IMPORTANT: CF options don't inherit from DB options, must set compression explicitly
         if let Some(ref per_level) = rocksdb_config.compression_per_level {
             ts_cf_opts.set_compression_per_level(per_level);

--- a/rust/kafka-deduplicator/src/store/deduplication_store.rs
+++ b/rust/kafka-deduplicator/src/store/deduplication_store.rs
@@ -320,13 +320,14 @@ impl DeduplicationStore {
         };
         drop(first_iter);
 
-        // Calculate age using wall clock
-        let now = std::time::SystemTime::now()
+        // Timestamps in keys are stored as milliseconds since epoch
+        let oldest_secs = oldest_timestamp / 1000;
+        let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
 
-        Ok(Some(now.saturating_sub(oldest_timestamp)))
+        Ok(Some(now_secs.saturating_sub(oldest_secs)))
     }
 
     /// Flush the store to disk
@@ -472,5 +473,81 @@ mod tests {
 
         // Test getting total size (should not error)
         let _size = store.get_total_size().unwrap();
+    }
+
+    #[test]
+    fn test_oldest_data_age_empty_store() {
+        let (store, _temp_dir) = create_test_store();
+        assert_eq!(store.get_oldest_data_age_seconds().unwrap(), None);
+    }
+
+    #[test]
+    fn test_oldest_data_age_with_ingestion_event_timestamp() {
+        // Ingestion events: parse_timestamp("2021-01-01T00:00:00Z") returns milliseconds
+        let (store, _temp_dir) = create_test_store();
+
+        let event = create_test_raw_event(); // timestamp: "2021-01-01T00:00:00Z"
+        let key = TimestampKey::from(&event);
+
+        // Verify the key timestamp is in milliseconds (1609459200000 for 2021-01-01)
+        assert_eq!(key.timestamp, 1609459200000);
+
+        let metadata = TimestampMetadata::new(&event);
+        store.put_timestamp_record(&key, &metadata).unwrap();
+
+        let age = store.get_oldest_data_age_seconds().unwrap().unwrap();
+
+        // Data from 2021 should be ~4-5 years old, i.e. roughly 126_230_400..189_345_600 seconds
+        // With the millis→seconds bug, saturating_sub(now_secs, timestamp_millis) returns 0
+        // because timestamp_millis (1.6 trillion) > now_secs (1.7 billion)
+        assert!(
+            age > 100_000_000,
+            "Age should be > ~3 years in seconds, got {age}. \
+             If age is 0, the millis vs seconds bug is present."
+        );
+        assert!(
+            age < 200_000_000,
+            "Age should be < ~6 years in seconds, got {age}. \
+             If age is ~1.7 billion, timestamps are not being converted to seconds."
+        );
+    }
+
+    #[test]
+    fn test_oldest_data_age_with_clickhouse_event_timestamp() {
+        // ClickHouse events: parse_clickhouse_timestamp("2024-01-01 12:00:00.000000")
+        // returns milliseconds (1704110400000)
+        use crate::utils::timestamp::parse_clickhouse_timestamp;
+
+        let (store, _temp_dir) = create_test_store();
+
+        let timestamp_millis =
+            parse_clickhouse_timestamp("2024-01-01 12:00:00.000000").unwrap();
+        assert_eq!(timestamp_millis, 1704110400000);
+
+        let key = TimestampKey::new(
+            timestamp_millis,
+            "user1".to_string(),
+            "123".to_string(),
+            "test_event".to_string(),
+        );
+        let key_bytes: Vec<u8> = (&key).into();
+        store
+            .store
+            .put(DeduplicationStore::TIMESTAMP_CF, &key_bytes, b"v")
+            .unwrap();
+
+        let age = store.get_oldest_data_age_seconds().unwrap().unwrap();
+
+        // Data from Jan 2024 should be ~1-2 years old, i.e. roughly 31_536_000..94_608_000 seconds
+        assert!(
+            age > 30_000_000,
+            "Age should be > ~1 year in seconds, got {age}. \
+             If age is 0, the millis vs seconds bug is present."
+        );
+        assert!(
+            age < 100_000_000,
+            "Age should be < ~3 years in seconds, got {age}. \
+             If age is ~1.7 billion, timestamps are not being converted to seconds."
+        );
     }
 }


### PR DESCRIPTION
## Problem

The kafka-deduplicator service was blind to runtime failures: panics logged through the tracing subscriber could silently fail if the subscriber was in a bad state, and consumer task crashes went undetected until k8s sent SIGTERM — leaving the service idle with stale health checks and no logs about the root cause.

## Changes

- Add `eprintln!` as a direct stderr fallback in the panic hook before the tracing `error!()` call, ensuring panic messages are always visible in container logs even if the tracing subscriber is deadlocked or dropped
- Replace sequential SIGTERM wait with `tokio::select!` that monitors both SIGTERM and the consumer task in `run()` and `run_with_shutdown()`, so consumer panics/errors are logged immediately instead of only at shutdown
- Add structured logging fields (`unhealthy`, `all_components`) to the liveness endpoint for easier filtering in Loki/Grafana


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
