### PR TITLE
refactor(experiments): Move pausing/resuming experiments to API

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -322,6 +322,45 @@ class EnterpriseExperimentsViewSet(
         archived_experiment = service.archive_experiment(experiment, request=request)
         return Response(ExperimentSerializer(archived_experiment, context=self.get_serializer_context()).data)
 
+    @extend_schema(
+        request=None,
+        responses=ExperimentSerializer,
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["experiment:write"])
+    def pause(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """
+        Pause a running experiment.
+
+        Deactivates the linked feature flag so it is no longer returned by the
+        /decide endpoint. Users fall back to the application default (typically
+        the control experience), and no new exposure events are recorded (i.e.
+        $feature_flag_called is not fired).
+        Returns 400 if the experiment is not running or is already paused.
+        """
+        experiment: Experiment = self.get_object()
+        service = ExperimentService(team=self.team, user=request.user)
+        paused_experiment = service.pause_experiment(experiment, request=request)
+        return Response(ExperimentSerializer(paused_experiment, context=self.get_serializer_context()).data)
+
+    @extend_schema(
+        request=None,
+        responses=ExperimentSerializer,
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["experiment:write"])
+    def resume(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """
+        Resume a paused experiment.
+
+        Reactivates the linked feature flag so it is returned by /decide again.
+        Users are re-bucketed deterministically into the same variants they had
+        before the pause, and exposure tracking resumes.
+        Returns 400 if the experiment is not running or is not paused.
+        """
+        experiment: Experiment = self.get_object()
+        service = ExperimentService(team=self.team, user=request.user)
+        resumed_experiment = service.resume_experiment(experiment, request=request)
+        return Response(ExperimentSerializer(resumed_experiment, context=self.get_serializer_context()).data)
+
     @action(methods=["POST"], detail=True, required_scopes=["experiment:write"])
     def duplicate(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         source_experiment: Experiment = self.get_object()

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -3658,6 +3658,128 @@ class TestExperimentCRUD(APILicensedTest):
         )
         self.assertEqual(archive_response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def _create_running_experiment(self, name: str = "Running Test", flag_key: str = "running-flag") -> dict:
+        """Helper: create an experiment and launch it via the API."""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": name,
+                "feature_flag_key": flag_key,
+                "metrics": [
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "source": {"kind": "EventsNode", "event": "$pageview"},
+                    }
+                ],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        launch_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/launch/",
+        )
+        self.assertEqual(launch_response.status_code, status.HTTP_200_OK)
+        return launch_response.json()
+
+    def test_pause_experiment_endpoint(self):
+        data = self._create_running_experiment(name="Pause Endpoint", flag_key="pause-endpoint-flag")
+        experiment_id = data["id"]
+
+        # Flag should be active after launch
+        flag = FeatureFlag.objects.get(key="pause-endpoint-flag", team=self.team)
+        self.assertTrue(flag.active)
+
+        pause_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/pause/",
+        )
+        self.assertEqual(pause_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(pause_response.json()["status"], "running")
+        self.assertFalse(pause_response.json()["feature_flag"]["active"])
+
+        # Verify flag is now inactive
+        flag.refresh_from_db()
+        self.assertFalse(flag.active)
+
+    def test_resume_experiment_endpoint(self):
+        data = self._create_running_experiment(name="Resume Endpoint", flag_key="resume-endpoint-flag")
+        experiment_id = data["id"]
+
+        # Pause first
+        pause_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/pause/",
+        )
+        self.assertEqual(pause_response.status_code, status.HTTP_200_OK)
+
+        # Resume
+        resume_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/resume/",
+        )
+        self.assertEqual(resume_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(resume_response.json()["status"], "running")
+        self.assertTrue(resume_response.json()["feature_flag"]["active"])
+
+        flag = FeatureFlag.objects.get(key="resume-endpoint-flag", team=self.team)
+        self.assertTrue(flag.active)
+
+    def test_pause_experiment_already_paused_returns_400(self):
+        data = self._create_running_experiment(name="Double Pause", flag_key="double-pause-flag")
+        experiment_id = data["id"]
+
+        self.client.post(f"/api/projects/{self.team.id}/experiments/{experiment_id}/pause/")
+
+        second_pause = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/pause/",
+        )
+        self.assertEqual(second_pause.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_resume_experiment_not_paused_returns_400(self):
+        data = self._create_running_experiment(name="Resume Not Paused", flag_key="resume-not-paused-flag")
+        experiment_id = data["id"]
+
+        resume_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/resume/",
+        )
+        self.assertEqual(resume_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_pause_draft_experiment_returns_400(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Pause Draft",
+                "feature_flag_key": "pause-draft-flag",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        pause_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/pause/",
+        )
+        self.assertEqual(pause_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_pause_ended_experiment_returns_400(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Pause Ended",
+                "feature_flag_key": "pause-ended-flag",
+                "start_date": "2024-01-01T10:00",
+                "end_date": "2024-01-15T10:00",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        pause_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/pause/",
+        )
+        self.assertEqual(pause_response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
     def _generate_experiment(self, start_date="2024-01-01T10:23", extra_parameters=None):

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -468,8 +468,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportHelpButtonUsed: (help_type: HelpType) => ({ help_type }),
         reportExperimentWizardStarted: (guideVisible: boolean) => ({ guideVisible }),
         reportExperimentWizardGuideToggled: (visible: boolean, currentStep: string) => ({ visible, currentStep }),
-        reportExperimentPaused: (experiment: Experiment) => ({ experiment }),
-        reportExperimentResumed: (experiment: Experiment) => ({ experiment }),
         reportExperimentStopped: (experiment: Experiment) => ({ experiment }),
         reportExperimentReset: (experiment: Experiment) => ({ experiment }),
         reportExperimentCreated: (
@@ -1398,16 +1396,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                     delay,
                 })
             }
-        },
-        reportExperimentPaused: ({ experiment }) => {
-            posthog.capture('experiment paused', {
-                ...getEventPropertiesForExperiment(experiment),
-            })
-        },
-        reportExperimentResumed: ({ experiment }) => {
-            posthog.capture('experiment resumed', {
-                ...getEventPropertiesForExperiment(experiment),
-            })
         },
         reportExperimentStopped: ({ experiment }) => {
             posthog.capture('experiment stopped', {

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -846,7 +846,7 @@ describe('experimentLogic', () => {
             const pausedExperiment = {
                 ...experiment,
                 feature_flag: { ...experiment.feature_flag, active: false },
-            }
+            } as Experiment
             const resumedResponse = {
                 ...experiment,
                 feature_flag: { ...experiment.feature_flag, active: true },

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -381,72 +381,6 @@ describe('experimentLogic', () => {
             )
         })
     })
-    describe('pause and resume experiment', () => {
-        beforeEach(() => {
-            jest.spyOn(api, 'update')
-            jest.spyOn(api, 'get')
-            api.update.mockClear()
-            api.get.mockClear()
-
-            const experimentWithFlag = {
-                ...experiment,
-                feature_flag: { id: 123, key: 'test-flag', active: true },
-            } as Experiment
-            logic.actions.setExperiment(experimentWithFlag)
-        })
-
-        it('should pause experiment by disabling feature flag', async () => {
-            api.update.mockResolvedValue({ id: 123, key: 'test-flag', active: false })
-
-            await expectLogic(logic, () => {
-                logic.actions.pauseExperiment()
-            })
-                .toDispatchActions(['pauseExperiment'])
-                .toFinishAllListeners()
-
-            expect(api.update).toHaveBeenCalledWith(
-                expect.stringContaining('/feature_flags/123'),
-                expect.objectContaining({ active: false })
-            )
-        })
-
-        it('should resume experiment by enabling feature flag', async () => {
-            const experimentWithInactiveFlag = {
-                ...experiment,
-                feature_flag: { id: 123, key: 'test-flag', active: false },
-            } as Experiment
-            logic.actions.setExperiment(experimentWithInactiveFlag)
-
-            api.update.mockResolvedValue({ id: 123, key: 'test-flag', active: true })
-
-            await expectLogic(logic, () => {
-                logic.actions.resumeExperiment()
-            })
-                .toDispatchActions(['resumeExperiment'])
-                .toFinishAllListeners()
-
-            expect(api.update).toHaveBeenCalledWith(
-                expect.stringContaining('/feature_flags/123'),
-                expect.objectContaining({ active: true })
-            )
-        })
-
-        it('should reload experiment after pause/resume', async () => {
-            api.update.mockResolvedValue({ id: 123, key: 'test-flag', active: false })
-
-            // The experiment will be reloaded via loadExperiment action
-            // which uses the GET endpoint already set up in useMocks
-            await expectLogic(logic, () => {
-                logic.actions.pauseExperiment()
-            })
-                .toDispatchActions(['pauseExperiment', 'loadExperiment'])
-                .toFinishAllListeners()
-
-            // Verify that loadExperiment was called which will fetch the experiment again
-            expect(logic.values.experiment).not.toBeNull()
-        })
-    })
-
     describe('breakdown management', () => {
         it('should add breakdown to inline metric', () => {
             const breakdown: Breakdown = { property: '$browser', type: 'event' }
@@ -839,6 +773,138 @@ describe('experimentLogic', () => {
             }).toFinishAllListeners()
 
             expect(errorMock).toHaveBeenCalledWith('Failed to archive experiment')
+            createSpy.mockRestore()
+        })
+    })
+
+    describe('pauseExperiment', () => {
+        it('calls pause endpoint and updates both experiment and feature flag state', async () => {
+            const pausedResponse = {
+                ...experiment,
+                feature_flag: { ...experiment.feature_flag, active: false },
+            }
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValue(pausedResponse)
+
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(experiment)
+
+            // Pre-condition: flag is active
+            expect(keyed.values.experiment.feature_flag?.active).toBe(true)
+
+            await expectLogic(keyed, () => {
+                keyed.actions.pauseExperiment()
+            })
+                .toDispatchActions(['pauseExperiment', 'setExperiment'])
+                .toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledWith(expect.stringContaining(`/experiments/${experiment.id}/pause`))
+
+            // Post-condition: both experiment and nested feature flag are updated
+            expect(keyed.values.experiment.feature_flag?.active).toBe(false)
+            expect(keyed.values.experiment.id).toBe(experiment.id)
+
+            createSpy.mockRestore()
+            keyed.unmount()
+        })
+
+        it('shows error toast on validation error', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({
+                detail: 'Experiment is already paused.',
+            })
+            const errorMock = lemonToast.error as jest.Mock
+            errorMock.mockClear()
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.pauseExperiment()
+            }).toFinishAllListeners()
+
+            expect(errorMock).toHaveBeenCalledWith('Experiment is already paused.')
+            createSpy.mockRestore()
+        })
+
+        it('shows generic error toast when detail is missing', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue(new Error('Network error'))
+            const errorMock = lemonToast.error as jest.Mock
+            errorMock.mockClear()
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.pauseExperiment()
+            }).toFinishAllListeners()
+
+            expect(errorMock).toHaveBeenCalledWith('Failed to pause experiment')
+            createSpy.mockRestore()
+        })
+    })
+
+    describe('resumeExperiment', () => {
+        it('calls resume endpoint and updates both experiment and feature flag state', async () => {
+            const pausedExperiment = {
+                ...experiment,
+                feature_flag: { ...experiment.feature_flag, active: false },
+            }
+            const resumedResponse = {
+                ...experiment,
+                feature_flag: { ...experiment.feature_flag, active: true },
+            }
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValue(resumedResponse)
+
+            const keyed = experimentLogic({ experimentId: experiment.id })
+            keyed.mount()
+            keyed.actions.setExperiment(pausedExperiment)
+
+            // Pre-condition: flag is inactive (paused)
+            expect(keyed.values.experiment.feature_flag?.active).toBe(false)
+
+            await expectLogic(keyed, () => {
+                keyed.actions.resumeExperiment()
+            })
+                .toDispatchActions(['resumeExperiment', 'setExperiment'])
+                .toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledWith(expect.stringContaining(`/experiments/${experiment.id}/resume`))
+
+            // Post-condition: both experiment and nested feature flag are updated
+            expect(keyed.values.experiment.feature_flag?.active).toBe(true)
+            expect(keyed.values.experiment.id).toBe(experiment.id)
+
+            createSpy.mockRestore()
+            keyed.unmount()
+        })
+
+        it('shows error toast on validation error', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue({
+                detail: 'Experiment is not paused.',
+            })
+            const errorMock = lemonToast.error as jest.Mock
+            errorMock.mockClear()
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.resumeExperiment()
+            }).toFinishAllListeners()
+
+            expect(errorMock).toHaveBeenCalledWith('Experiment is not paused.')
+            createSpy.mockRestore()
+        })
+
+        it('shows generic error toast when detail is missing', async () => {
+            const createSpy = jest.spyOn(api, 'create').mockRejectedValue(new Error('Network error'))
+            const errorMock = lemonToast.error as jest.Mock
+            errorMock.mockClear()
+
+            logic.actions.setExperiment(experiment)
+
+            await expectLogic(logic, () => {
+                logic.actions.resumeExperiment()
+            }).toFinishAllListeners()
+
+            expect(errorMock).toHaveBeenCalledWith('Failed to resume experiment')
             createSpy.mockRestore()
         })
     })

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -586,7 +586,7 @@ export const experimentLogic = kea<experimentLogicType>([
         setCreateExperimentLoading: (loading: boolean) => ({ loading }),
         setLaunchExperimentLoading: (loading: boolean) => ({ loading }),
         setExperimentType: (type?: string) => ({ type }),
-        setFeatureFlagActive: (isActive: boolean) => ({ isActive }),
+
         addVariant: true,
         removeVariant: (idx: number) => ({ idx }),
         setEditExperiment: (editing: boolean) => ({ editing }),
@@ -1263,19 +1263,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 )
             }
         },
-        setFeatureFlagActive: async ({ isActive }) => {
-            if (!values.experiment.feature_flag) {
-                lemonToast.error('Experiment does not have a feature flag linked')
-                return
-            }
-
-            const flagId = values.experiment.feature_flag.id
-            await featureFlagsLogic.asyncActions.updateFeatureFlag({
-                id: flagId,
-                payload: { active: isActive },
-            })
-            actions.loadExperiment({ triggeredBy: 'config_change' })
-        },
         createExperiment: async ({ draft, folder }) => {
             actions.setCreateExperimentLoading(true)
             const { recommendedRunningTime, recommendedSampleSize, minimumDetectableEffect } = values
@@ -1474,14 +1461,26 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         pauseExperiment: async () => {
-            await actions.setFeatureFlagActive(false)
-            actions.closePauseExperimentModal()
-            values.experiment && eventUsageLogic.actions.reportExperimentPaused(values.experiment)
+            try {
+                const response: Experiment = await api.create(
+                    `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/pause`
+                )
+                actions.setExperiment(response)
+                actions.closePauseExperimentModal()
+            } catch (error: any) {
+                lemonToast.error(error.detail || 'Failed to pause experiment')
+            }
         },
         resumeExperiment: async () => {
-            await actions.setFeatureFlagActive(true)
-            actions.closeResumeExperimentModal()
-            values.experiment && eventUsageLogic.actions.reportExperimentResumed(values.experiment)
+            try {
+                const response: Experiment = await api.create(
+                    `/api/projects/${values.currentProjectId}/experiments/${values.experimentId}/resume`
+                )
+                actions.setExperiment(response)
+                actions.closeResumeExperimentModal()
+            } catch (error: any) {
+                lemonToast.error(error.detail || 'Failed to resume experiment')
+            }
         },
         archiveExperiment: async () => {
             try {

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -607,7 +607,7 @@ class ExperimentService:
         """Archive an ended experiment: validate it has ended, set archived=True."""
         if experiment.archived:
             raise ValidationError("Experiment is already archived.")
-        if not experiment.end_date:
+        if not experiment.has_ended:
             raise ValidationError("Experiment must be ended before it can be archived.")
 
         experiment.archived = True
@@ -629,6 +629,92 @@ class ExperimentService:
         report_user_action(
             self.user,
             "experiment archived",
+            experiment.get_analytics_metadata(),
+            team=experiment.team,
+            request=request,
+        )
+
+    # ------------------------------------------------------------------
+    # Pause / Resume
+    # ------------------------------------------------------------------
+
+    @transaction.atomic
+    def pause_experiment(self, experiment: Experiment, *, request: Any | None = None) -> Experiment:
+        """Pause a running experiment: deactivate its feature flag so it is no longer served by /decide."""
+        if experiment.is_draft:
+            raise ValidationError("Experiment has not been launched yet.")
+        if experiment.has_ended:
+            raise ValidationError("Experiment has already ended.")
+
+        feature_flag = experiment.feature_flag
+        if feature_flag is None:
+            raise ValidationError("Experiment does not have a feature flag linked.")
+        if not feature_flag.active:
+            raise ValidationError("Experiment is already paused.")
+
+        feature_flag.active = False
+        feature_flag.save(update_fields=["active"])
+
+        # Re-fetch so the serializer sees the updated flag
+        experiment.feature_flag = feature_flag
+
+        self._report_experiment_paused(experiment, request=request)
+
+        return experiment
+
+    @transaction.atomic
+    def resume_experiment(self, experiment: Experiment, *, request: Any | None = None) -> Experiment:
+        """Resume a paused experiment: reactivate its feature flag so /decide serves variants again."""
+        if experiment.is_draft:
+            raise ValidationError("Experiment has not been launched yet.")
+        if experiment.has_ended:
+            raise ValidationError("Experiment has already ended.")
+
+        feature_flag = experiment.feature_flag
+        if feature_flag is None:
+            raise ValidationError("Experiment does not have a feature flag linked.")
+        if feature_flag.active:
+            raise ValidationError("Experiment is not paused.")
+
+        feature_flag.active = True
+        feature_flag.save(update_fields=["active"])
+
+        # Re-fetch so the serializer sees the updated flag
+        experiment.feature_flag = feature_flag
+
+        self._report_experiment_resumed(experiment, request=request)
+
+        return experiment
+
+    def _report_experiment_paused(
+        self,
+        experiment: Experiment,
+        *,
+        request: Any | None = None,
+    ) -> None:
+        if request is None:
+            return
+
+        report_user_action(
+            self.user,
+            "experiment paused",
+            experiment.get_analytics_metadata(),
+            team=experiment.team,
+            request=request,
+        )
+
+    def _report_experiment_resumed(
+        self,
+        experiment: Experiment,
+        *,
+        request: Any | None = None,
+    ) -> None:
+        if request is None:
+            return
+
+        report_user_action(
+            self.user,
+            "experiment resumed",
             experiment.get_analytics_metadata(),
             team=experiment.team,
             request=request,

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -607,7 +607,7 @@ class ExperimentService:
         """Archive an ended experiment: validate it has ended, set archived=True."""
         if experiment.archived:
             raise ValidationError("Experiment is already archived.")
-        if not experiment.has_ended:
+        if not experiment.is_stopped:
             raise ValidationError("Experiment must be ended before it can be archived.")
 
         experiment.archived = True
@@ -643,7 +643,7 @@ class ExperimentService:
         """Pause a running experiment: deactivate its feature flag so it is no longer served by /decide."""
         if experiment.is_draft:
             raise ValidationError("Experiment has not been launched yet.")
-        if experiment.has_ended:
+        if experiment.is_stopped:
             raise ValidationError("Experiment has already ended.")
 
         feature_flag = experiment.feature_flag
@@ -667,7 +667,7 @@ class ExperimentService:
         """Resume a paused experiment: reactivate its feature flag so /decide serves variants again."""
         if experiment.is_draft:
             raise ValidationError("Experiment has not been launched yet.")
-        if experiment.has_ended:
+        if experiment.is_stopped:
             raise ValidationError("Experiment has already ended.")
 
         feature_flag = experiment.feature_flag

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -150,7 +150,7 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
         return (self.status or Experiment.compute_status(self.start_date, self.end_date)) == Experiment.Status.RUNNING
 
     @property
-    def has_ended(self):
+    def is_stopped(self):
         return (self.status or Experiment.compute_status(self.start_date, self.end_date)) == Experiment.Status.STOPPED
 
     @classmethod

--- a/products/experiments/backend/models/experiment.py
+++ b/products/experiments/backend/models/experiment.py
@@ -145,6 +145,14 @@ class Experiment(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models.
     def is_draft(self):
         return (self.status or Experiment.compute_status(self.start_date, self.end_date)) == Experiment.Status.DRAFT
 
+    @property
+    def is_running(self):
+        return (self.status or Experiment.compute_status(self.start_date, self.end_date)) == Experiment.Status.RUNNING
+
+    @property
+    def has_ended(self):
+        return (self.status or Experiment.compute_status(self.start_date, self.end_date)) == Experiment.Status.STOPPED
+
     @classmethod
     def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Experiment"]:
         base_qs = cls.objects.filter(team=team).exclude(deleted=True)

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -1379,6 +1379,98 @@ class TestExperimentService(APIBaseTest):
         assert "must be ended" in str(ctx.exception)
 
     # ------------------------------------------------------------------
+    # Pause / Resume
+    # ------------------------------------------------------------------
+
+    def _create_running_experiment(
+        self,
+        name: str = "Running",
+        feature_flag_key: str = "running-flag",
+        **kwargs: Any,
+    ) -> Experiment:
+        experiment = self._create_launchable_experiment(name=name, feature_flag_key=feature_flag_key, **kwargs)
+        self._service().launch_experiment(experiment)
+        return experiment
+
+    def test_pause_experiment_success(self):
+        experiment = self._create_running_experiment(name="Pause Test", feature_flag_key="pause-flag")
+
+        assert experiment.feature_flag.active is True
+
+        paused = self._service().pause_experiment(experiment)
+
+        paused.feature_flag.refresh_from_db()
+        assert paused.feature_flag.active is False
+        assert paused.start_date is not None
+        assert paused.end_date is None
+
+    def test_resume_experiment_success(self):
+        experiment = self._create_running_experiment(name="Resume Test", feature_flag_key="resume-flag")
+        service = self._service()
+        service.pause_experiment(experiment)
+
+        assert experiment.feature_flag.active is False
+
+        resumed = service.resume_experiment(experiment)
+
+        resumed.feature_flag.refresh_from_db()
+        assert resumed.feature_flag.active is True
+        assert resumed.start_date is not None
+        assert resumed.end_date is None
+
+    def test_pause_experiment_already_paused_raises(self):
+        experiment = self._create_running_experiment(name="Already Paused", feature_flag_key="already-paused-flag")
+        service = self._service()
+        service.pause_experiment(experiment)
+
+        with self.assertRaises(ValidationError) as ctx:
+            service.pause_experiment(experiment)
+
+        assert "already paused" in str(ctx.exception)
+
+    def test_resume_experiment_not_paused_raises(self):
+        experiment = self._create_running_experiment(name="Not Paused", feature_flag_key="not-paused-flag")
+
+        with self.assertRaises(ValidationError) as ctx:
+            self._service().resume_experiment(experiment)
+
+        assert "not paused" in str(ctx.exception)
+
+    @parameterized.expand(
+        [
+            ("draft",),
+            ("ended",),
+        ]
+    )
+    def test_pause_experiment_wrong_state_raises(self, state: str):
+        service = self._service()
+        if state == "draft":
+            experiment = self._create_launchable_experiment(name="Pause Draft", feature_flag_key=f"pause-{state}-flag")
+        else:
+            experiment = self._create_ended_experiment(name="Pause Ended", feature_flag_key=f"pause-{state}-flag")
+
+        with self.assertRaises(ValidationError):
+            service.pause_experiment(experiment)
+
+    @parameterized.expand(
+        [
+            ("draft",),
+            ("ended",),
+        ]
+    )
+    def test_resume_experiment_wrong_state_raises(self, state: str):
+        service = self._service()
+        if state == "draft":
+            experiment = self._create_launchable_experiment(
+                name="Resume Draft", feature_flag_key=f"resume-{state}-flag"
+            )
+        else:
+            experiment = self._create_ended_experiment(name="Resume Ended", feature_flag_key=f"resume-{state}-flag")
+
+        with self.assertRaises(ValidationError):
+            service.resume_experiment(experiment)
+
+    # ------------------------------------------------------------------
     # Exposure cohort
     # ------------------------------------------------------------------
 

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -450,6 +450,30 @@ export const experimentsLaunchCreate = async (
     })
 }
 
+/**
+ * Pause a running experiment.
+
+Deactivates the linked feature flag so it is no longer returned by the
+/decide endpoint. Users fall back to the application default (typically
+the control experience), and no new exposure events are recorded (i.e.
+$feature_flag_called is not fired).
+Returns 400 if the experiment is not running or is already paused.
+ */
+export const getExperimentsPauseCreateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiments/${id}/pause/`
+}
+
+export const experimentsPauseCreate = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<ExperimentApi> => {
+    return apiMutator<ExperimentApi>(getExperimentsPauseCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+    })
+}
+
 export const getExperimentsRecalculateTimeseriesCreateUrl = (projectId: string, id: number) => {
     return `/api/projects/${projectId}/experiments/${id}/recalculate_timeseries/`
 }
@@ -465,6 +489,29 @@ export const experimentsRecalculateTimeseriesCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(experimentApi),
+    })
+}
+
+/**
+ * Resume a paused experiment.
+
+Reactivates the linked feature flag so it is returned by /decide again.
+Users are re-bucketed deterministically into the same variants they had
+before the pause, and exposure tracking resumes.
+Returns 400 if the experiment is not running or is not paused.
+ */
+export const getExperimentsResumeCreateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiments/${id}/resume/`
+}
+
+export const experimentsResumeCreate = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<ExperimentApi> => {
+    return apiMutator<ExperimentApi>(getExperimentsResumeCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
     })
 }
 


### PR DESCRIPTION
## Problem

This is one step in the bigger initiative to reduce logic from the client and add it to the API.

In this PR: Move pausing/resuming to API

## Changes

- New API endpoints
- New actions in service object
- Validation moved
- Tracking moved

As a nice UX benefit, the actions feel snappier as the frontend state update got simpler (no await for two separate state updates)

## How did you test this code?

- Test cases for feature flag update, frontend state update and error handling
- Manually: Pause and resume experiment

## Publish to changelog?

No