### PR TITLE
fix(warehouse): persist Convex API cursor on empty syncs

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -235,6 +235,16 @@ class PipelineNonDLT(Generic[ResumableData]):
                     is_first_ever_sync=is_first_ever_sync,
                 )
 
+            # Apply source-provided cursor override (e.g. Convex API cursor that advances
+            # even when no records are returned). Must run before _post_run_operations which
+            # early-returns when there's no delta table (i.e. zero records).
+            if self._resource.override_incremental_field_last_value is not None:
+                override = self._resource.override_incremental_field_last_value
+                if self._last_incremental_field_value is None or override > self._last_incremental_field_value:
+                    await self._logger.adebug(f"Applying source override for incremental_field_last_value: {override}")
+                    await database_sync_to_async_pool(self._schema.refresh_from_db)()
+                    await database_sync_to_async_pool(self._schema.update_incremental_field_value)(override)
+
             await self._post_run_operations(row_count=row_count)
 
             return {"should_trigger_cdp_producer": await self._cdp_producer.should_produce_table()}

--- a/posthog/temporal/data_imports/pipelines/pipeline/typings.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/typings.py
@@ -38,6 +38,10 @@ class SourceResponse:
     rows_to_sync: Optional[int] = None
     has_duplicate_primary_keys: Optional[bool] = None
     """Whether incremental tables have non-unique primary keys"""
+    override_incremental_field_last_value: Optional[Any] = None
+    """When set by the source after iteration, the pipeline persists this as the incremental cursor
+    instead of deriving it from record fields. This ensures the cursor advances even when no
+    records are returned (e.g. Convex API cursor on quiet tables)."""
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -8,6 +8,7 @@ from structlog.types import FilteringBoundLogger
 from temporalio import activity
 
 from posthog.models import DataWarehouseTable
+from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.shutdown import ShutdownMonitor
 from posthog.temporal.data_imports.pipelines.common.extract import (
     cdp_producer_clear_chunks,
@@ -241,6 +242,17 @@ class PipelineV3(Generic[ResumableData]):
                 if activity.in_activity():
                     get_rows_extracted_metric(team_id_str, schema_id_str, source_type).add(py_table.num_rows)
                     get_batches_produced_metric(team_id_str, schema_id_str).add(1)
+
+            # Apply source-provided cursor override (e.g. Convex API cursor that advances
+            # even when no records are returned).
+            if self._resource.override_incremental_field_last_value is not None:
+                override = self._resource.override_incremental_field_last_value
+                if self._last_incremental_field_value is None or override > self._last_incremental_field_value:
+                    await self._logger.adebug(
+                        f"V3 Pipeline: Applying source override for incremental_field_last_value: {override}"
+                    )
+                    await database_sync_to_async_pool(self._schema.refresh_from_db)()
+                    await database_sync_to_async_pool(self._schema.update_incremental_field_value)(override)
 
             await self._finalize(row_count=row_count)
 

--- a/posthog/temporal/data_imports/sources/convex/convex.py
+++ b/posthog/temporal/data_imports/sources/convex/convex.py
@@ -139,16 +139,9 @@ def convex_source(
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Any | None,
 ) -> SourceResponse:
-    def items_generator():
-        if should_use_incremental_field and db_incremental_field_last_value is not None:
-            cursor = int(db_incremental_field_last_value)
-            yield from document_deltas(deploy_url, deploy_key, table_name, cursor)
-        else:
-            yield from list_snapshot(deploy_url, deploy_key, table_name)
-
-    return SourceResponse(
+    response = SourceResponse(
         name=table_name,
-        items=items_generator,
+        items=lambda: iter([]),
         primary_keys=["_id"],
         partition_count=1,
         partition_size=1,
@@ -156,3 +149,17 @@ def convex_source(
         partition_format="month",
         partition_keys=["_creationTime"],
     )
+
+    def items_generator():
+        if should_use_incremental_field and db_incremental_field_last_value is not None:
+            cursor = int(db_incremental_field_last_value)
+            gen = document_deltas(deploy_url, deploy_key, table_name, cursor)
+        else:
+            gen = list_snapshot(deploy_url, deploy_key, table_name)
+
+        new_cursor: int = yield from gen
+        if new_cursor is not None:
+            response.override_incremental_field_last_value = new_cursor
+
+    response.items = items_generator
+    return response

--- a/posthog/temporal/tests/data_imports/test_convex_source.py
+++ b/posthog/temporal/tests/data_imports/test_convex_source.py
@@ -1,0 +1,204 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.data_imports.sources.convex.convex import (
+    InvalidWindowError,
+    convex_source,
+    document_deltas,
+    list_snapshot,
+)
+
+DEPLOY_URL = "https://test-deployment.convex.cloud"
+DEPLOY_KEY = "prod:test-key"
+
+
+def _mock_response(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"{status_code} Client Error")
+    return resp
+
+
+class TestListSnapshot:
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_single_page(self, mock_get):
+        mock_get.return_value = _mock_response(
+            {"values": [{"_id": "1", "_ts": 100}], "snapshot": 12345, "cursor": "abc", "hasMore": False}
+        )
+
+        gen = list_snapshot(DEPLOY_URL, DEPLOY_KEY, "events")
+        batches = []
+        try:
+            while True:
+                batches.append(next(gen))
+        except StopIteration as e:
+            cursor = e.value
+
+        assert len(batches) == 1
+        assert batches[0] == [{"_id": "1", "_ts": 100}]
+        assert cursor == 12345
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_multi_page(self, mock_get):
+        mock_get.side_effect = [
+            _mock_response(
+                {"values": [{"_id": "1", "_ts": 100}], "snapshot": 12345, "cursor": "page2", "hasMore": True}
+            ),
+            _mock_response(
+                {"values": [{"_id": "2", "_ts": 200}], "snapshot": 12345, "cursor": "page3", "hasMore": False}
+            ),
+        ]
+
+        gen = list_snapshot(DEPLOY_URL, DEPLOY_KEY, "events")
+        batches = []
+        try:
+            while True:
+                batches.append(next(gen))
+        except StopIteration as e:
+            cursor = e.value
+
+        assert len(batches) == 2
+        assert cursor == 12345
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_empty_table_returns_snapshot_cursor(self, mock_get):
+        mock_get.return_value = _mock_response({"values": [], "snapshot": 99999, "cursor": None, "hasMore": False})
+
+        gen = list_snapshot(DEPLOY_URL, DEPLOY_KEY, "empty_table")
+        batches = []
+        try:
+            while True:
+                batches.append(next(gen))
+        except StopIteration as e:
+            cursor = e.value
+
+        assert len(batches) == 0
+        assert cursor == 99999
+
+
+class TestDocumentDeltas:
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_returns_new_cursor(self, mock_get):
+        mock_get.return_value = _mock_response({"values": [{"_id": "1", "_ts": 200}], "cursor": 300, "hasMore": False})
+
+        gen = document_deltas(DEPLOY_URL, DEPLOY_KEY, "events", cursor=100)
+        batches = []
+        try:
+            while True:
+                batches.append(next(gen))
+        except StopIteration as e:
+            new_cursor = e.value
+
+        assert len(batches) == 1
+        assert new_cursor == 300
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_no_changes_still_returns_cursor(self, mock_get):
+        mock_get.return_value = _mock_response({"values": [], "cursor": 500, "hasMore": False})
+
+        gen = document_deltas(DEPLOY_URL, DEPLOY_KEY, "events", cursor=100)
+        batches = []
+        try:
+            while True:
+                batches.append(next(gen))
+        except StopIteration as e:
+            new_cursor = e.value
+
+        assert len(batches) == 0
+        assert new_cursor == 500
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_invalid_window_raises(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 400
+        resp.json.return_value = {
+            "code": "InvalidWindowToReadDocuments",
+            "message": "Cursor too old",
+        }
+        mock_get.return_value = resp
+
+        gen = document_deltas(DEPLOY_URL, DEPLOY_KEY, "events", cursor=100)
+        with pytest.raises(InvalidWindowError, match="retention window"):
+            next(gen)
+
+
+class TestConvexSource:
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_incremental_sync_captures_cursor_on_response(self, mock_get):
+        mock_get.return_value = _mock_response({"values": [{"_id": "1", "_ts": 200}], "cursor": 300, "hasMore": False})
+
+        response = convex_source(
+            deploy_url=DEPLOY_URL,
+            deploy_key=DEPLOY_KEY,
+            table_name="events",
+            team_id=1,
+            job_id="job-1",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=100,
+        )
+
+        assert response.override_incremental_field_last_value is None
+
+        batches = list(response.items())  # type: ignore[arg-type]
+
+        assert len(batches) == 1
+        assert response.override_incremental_field_last_value == 300
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_incremental_sync_no_records_still_captures_cursor(self, mock_get):
+        mock_get.return_value = _mock_response({"values": [], "cursor": 500, "hasMore": False})
+
+        response = convex_source(
+            deploy_url=DEPLOY_URL,
+            deploy_key=DEPLOY_KEY,
+            table_name="quiet_table",
+            team_id=1,
+            job_id="job-1",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=100,
+        )
+
+        list(response.items())  # type: ignore[arg-type]
+
+        assert response.override_incremental_field_last_value == 500
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_initial_sync_captures_snapshot_cursor(self, mock_get):
+        mock_get.return_value = _mock_response(
+            {"values": [{"_id": "1", "_ts": 100}], "snapshot": 12345, "cursor": "abc", "hasMore": False}
+        )
+
+        response = convex_source(
+            deploy_url=DEPLOY_URL,
+            deploy_key=DEPLOY_KEY,
+            table_name="events",
+            team_id=1,
+            job_id="job-1",
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+        )
+
+        list(response.items())  # type: ignore[arg-type]
+
+        assert response.override_incremental_field_last_value == 12345
+
+    @patch("posthog.temporal.data_imports.sources.convex.convex.requests.get")
+    def test_initial_sync_empty_table_captures_snapshot_cursor(self, mock_get):
+        mock_get.return_value = _mock_response({"values": [], "snapshot": 99999, "cursor": None, "hasMore": False})
+
+        response = convex_source(
+            deploy_url=DEPLOY_URL,
+            deploy_key=DEPLOY_KEY,
+            table_name="empty_table",
+            team_id=1,
+            job_id="job-1",
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+        )
+
+        list(response.items())  # type: ignore[arg-type]
+
+        assert response.override_incremental_field_last_value == 99999

--- a/products/data_warehouse/frontend/generated/api.schemas.ts
+++ b/products/data_warehouse/frontend/generated/api.schemas.ts
@@ -287,10 +287,11 @@ export interface PaginatedExternalDataSchemaListApi {
  * `Postmark` - Postmark
  * `Granola` - Granola
  * `BuildBetter` - BuildBetter
+ * `Convex` - Convex
  */
-export type SourceTypeE09EnumApi = (typeof SourceTypeE09EnumApi)[keyof typeof SourceTypeE09EnumApi]
+export type SourceType432EnumApi = (typeof SourceType432EnumApi)[keyof typeof SourceType432EnumApi]
 
-export const SourceTypeE09EnumApi = {
+export const SourceType432EnumApi = {
     Ashby: 'Ashby',
     Supabase: 'Supabase',
     CustomerIO: 'CustomerIO',
@@ -431,6 +432,7 @@ export const SourceTypeE09EnumApi = {
     Postmark: 'Postmark',
     Granola: 'Granola',
     BuildBetter: 'BuildBetter',
+    Convex: 'Convex',
 } as const
 
 /**
@@ -460,7 +462,7 @@ export interface ExternalDataSourceSerializersApi {
     readonly status: string
     client_secret: string
     account_id: string
-    readonly source_type: SourceTypeE09EnumApi
+    readonly source_type: SourceType432EnumApi
     readonly latest_error: string
     /**
      * @maxLength 100
@@ -504,7 +506,7 @@ export interface PatchedExternalDataSourceSerializersApi {
     readonly status?: string
     client_secret?: string
     account_id?: string
-    readonly source_type?: SourceTypeE09EnumApi
+    readonly source_type?: SourceType432EnumApi
     readonly latest_error?: string
     /**
      * @maxLength 100
@@ -840,7 +842,7 @@ export interface SimpleExternalDataSourceSerializersApi {
     /** @nullable */
     readonly created_by: number | null
     readonly status: string
-    readonly source_type: SourceTypeE09EnumApi
+    readonly source_type: SourceType432EnumApi
 }
 
 export type TableApiOptions = { [key: string]: unknown }

--- a/products/metrics/frontend/generated/api.schemas.ts
+++ b/products/metrics/frontend/generated/api.schemas.ts
@@ -1,0 +1,81 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+/**
+ * * `numeric` - numeric
+ * `currency` - currency
+ */
+export type GroupUsageMetricFormatEnumApi =
+    (typeof GroupUsageMetricFormatEnumApi)[keyof typeof GroupUsageMetricFormatEnumApi]
+
+export const GroupUsageMetricFormatEnumApi = {
+    Numeric: 'numeric',
+    Currency: 'currency',
+} as const
+
+/**
+ * * `number` - number
+ * `sparkline` - sparkline
+ */
+export type DisplayEnumApi = (typeof DisplayEnumApi)[keyof typeof DisplayEnumApi]
+
+export const DisplayEnumApi = {
+    Number: 'number',
+    Sparkline: 'sparkline',
+} as const
+
+export interface GroupUsageMetricApi {
+    readonly id: string
+    /** @maxLength 255 */
+    name: string
+    format?: GroupUsageMetricFormatEnumApi
+    /**
+     * In days
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    interval?: number
+    display?: DisplayEnumApi
+    filters: unknown
+}
+
+export interface PaginatedGroupUsageMetricListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: GroupUsageMetricApi[]
+}
+
+export interface PatchedGroupUsageMetricApi {
+    readonly id?: string
+    /** @maxLength 255 */
+    name?: string
+    format?: GroupUsageMetricFormatEnumApi
+    /**
+     * In days
+     * @minimum -2147483648
+     * @maximum 2147483647
+     */
+    interval?: number
+    display?: DisplayEnumApi
+    filters?: unknown
+}
+
+export type GroupsTypesMetricsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}

--- a/products/metrics/frontend/generated/api.ts
+++ b/products/metrics/frontend/generated/api.ts
@@ -1,0 +1,186 @@
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import type {
+    GroupUsageMetricApi,
+    GroupsTypesMetricsListParams,
+    PaginatedGroupUsageMetricListApi,
+    PatchedGroupUsageMetricApi,
+} from './api.schemas'
+
+// https://stackoverflow.com/questions/49579094/typescript-conditional-types-filter-out-readonly-properties-pick-only-requir/49579497#49579497
+type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? A : B
+
+type WritableKeys<T> = {
+    [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P>
+}[keyof T]
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never
+type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never
+
+type Writable<T> = Pick<T, WritableKeys<T>>
+type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
+    ? {
+          [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
+      }
+    : DistributeReadOnlyOverUnions<T>
+
+export const getGroupsTypesMetricsListUrl = (
+    projectId: string,
+    groupTypeIndex: number,
+    params?: GroupsTypesMetricsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/groups_types/${groupTypeIndex}/metrics/?${stringifiedParams}`
+        : `/api/projects/${projectId}/groups_types/${groupTypeIndex}/metrics/`
+}
+
+export const groupsTypesMetricsList = async (
+    projectId: string,
+    groupTypeIndex: number,
+    params?: GroupsTypesMetricsListParams,
+    options?: RequestInit
+): Promise<PaginatedGroupUsageMetricListApi> => {
+    return apiMutator<PaginatedGroupUsageMetricListApi>(
+        getGroupsTypesMetricsListUrl(projectId, groupTypeIndex, params),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
+}
+
+export const getGroupsTypesMetricsCreateUrl = (projectId: string, groupTypeIndex: number) => {
+    return `/api/projects/${projectId}/groups_types/${groupTypeIndex}/metrics/`
+}
+
+export const groupsTypesMetricsCreate = async (
+    projectId: string,
+    groupTypeIndex: number,
+    groupUsageMetricApi: NonReadonly<GroupUsageMetricApi>,
+    options?: RequestInit
+): Promise<GroupUsageMetricApi> => {
+    return apiMutator<GroupUsageMetricApi>(getGroupsTypesMetricsCreateUrl(projectId, groupTypeIndex), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(groupUsageMetricApi),
+    })
+}
+
+export const getGroupsTypesMetricsRetrieveUrl = (projectId: string, groupTypeIndex: number, id: string) => {
+    return `/api/projects/${projectId}/groups_types/${groupTypeIndex}/metrics/${id}/`
+}
+
+export const groupsTypesMetricsRetrieve = async (
+    projectId: string,
+    groupTypeIndex: number,
+    id: string,
+    options?: RequestInit
+): Promise<GroupUsageMetricApi> => {
+    return apiMutator<GroupUsageMetricApi>(getGroupsTypesMetricsRetrieveUrl(projectId, groupTypeIndex, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getGroupsTypesMetricsUpdateUrl = (projectId: string, groupTypeIndex: number, id: string) => {
+    return `/api/projects/${projectId}/groups_types/${groupTypeIndex}/metrics/${id}/`
+}
+
+export const groupsTypesMetricsUpdate = async (
+    projectId: string,
+    groupTypeIndex: number,
+    id: string,
+    groupUsageMetricApi: NonReadonly<GroupUsageMetricApi>,
+    options?: RequestInit
+): Promise<GroupUsageMetricApi> => {
+    return apiMutator<GroupUsageMetricApi>(getGroupsTypesMetricsUpdateUrl(projectId, groupTypeIndex, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(groupUsageMetricApi),
+    })
+}
+
+export const getGroupsTypesMetricsPartialUpdateUrl = (projectId: string, groupTypeIndex: number, id: string) => {
+    return `/api/projects/${projectId}/groups_types/${groupTypeIndex}/metrics/${id}/`
+}
+
+export const groupsTypesMetricsPartialUpdate = async (
+    projectId: string,
+    groupTypeIndex: number,
+    id: string,
+    patchedGroupUsageMetricApi: NonReadonly<PatchedGroupUsageMetricApi>,
+    options?: RequestInit
+): Promise<GroupUsageMetricApi> => {
+    return apiMutator<GroupUsageMetricApi>(getGroupsTypesMetricsPartialUpdateUrl(projectId, groupTypeIndex, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedGroupUsageMetricApi),
+    })
+}
+
+export const getGroupsTypesMetricsDestroyUrl = (projectId: string, groupTypeIndex: number, id: string) => {
+    return `/api/projects/${projectId}/groups_types/${groupTypeIndex}/metrics/${id}/`
+}
+
+export const groupsTypesMetricsDestroy = async (
+    projectId: string,
+    groupTypeIndex: number,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getGroupsTypesMetricsDestroyUrl(projectId, groupTypeIndex, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getHogFunctionsMetricsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_functions/${id}/metrics/`
+}
+
+export const hogFunctionsMetricsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getHogFunctionsMetricsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getHogFunctionsMetricsTotalsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_functions/${id}/metrics/totals/`
+}
+
+export const hogFunctionsMetricsTotalsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getHogFunctionsMetricsTotalsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}

--- a/products/tracing/frontend/generated/api.schemas.ts
+++ b/products/tracing/frontend/generated/api.schemas.ts
@@ -1,0 +1,9 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */

--- a/products/tracing/frontend/generated/api.ts
+++ b/products/tracing/frontend/generated/api.ts
@@ -1,0 +1,47 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+
+export const getTracingSpansRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/tracing/spans/`
+}
+
+export const tracingSpansRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getTracingSpansRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTracingSpansSparklineRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/tracing/spans/sparkline/`
+}
+
+export const tracingSpansSparklineRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getTracingSpansSparklineRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTracingSpansTraceRetrieveUrl = (projectId: string, traceId: string) => {
+    return `/api/projects/${projectId}/tracing/spans/trace/${traceId}/`
+}
+
+export const tracingSpansTraceRetrieve = async (
+    projectId: string,
+    traceId: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTracingSpansTraceRetrieveUrl(projectId, traceId), {
+        ...options,
+        method: 'GET',
+    })
+}

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13458,11 +13458,12 @@ export namespace Schemas {
     * `Postmark` - Postmark
     * `Granola` - Granola
     * `BuildBetter` - BuildBetter
+    * `Convex` - Convex
      */
-    export type SourceTypeE09Enum = typeof SourceTypeE09Enum[keyof typeof SourceTypeE09Enum];
+    export type SourceType432Enum = typeof SourceType432Enum[keyof typeof SourceType432Enum];
 
 
-    export const SourceTypeE09Enum = {
+    export const SourceType432Enum = {
       Ashby: 'Ashby',
       Supabase: 'Supabase',
       CustomerIO: 'CustomerIO',
@@ -13603,6 +13604,7 @@ export namespace Schemas {
       Postmark: 'Postmark',
       Granola: 'Granola',
       BuildBetter: 'BuildBetter',
+      Convex: 'Convex',
     } as const;
 
     /**
@@ -13616,7 +13618,7 @@ export namespace Schemas {
       readonly status: string;
       client_secret: string;
       account_id: string;
-      readonly source_type: SourceTypeE09Enum;
+      readonly source_type: SourceType432Enum;
       readonly latest_error: string;
       /**
        * @maxLength 100
@@ -19172,7 +19174,7 @@ export namespace Schemas {
       /** @nullable */
       readonly created_by: number | null;
       readonly status: string;
-      readonly source_type: SourceTypeE09Enum;
+      readonly source_type: SourceType432Enum;
     }
 
     export type TableOptions = {[key: string]: unknown};
@@ -20800,7 +20802,7 @@ export namespace Schemas {
       readonly status?: string;
       client_secret?: string;
       account_id?: string;
-      readonly source_type?: SourceTypeE09Enum;
+      readonly source_type?: SourceType432Enum;
       readonly latest_error?: string;
       /**
        * @maxLength 100


### PR DESCRIPTION
## Problem

The Convex source derives the incremental cursor (`db_incremental_field_last_value`) from the `_ts` field on synced records. When a table has no new records, the cursor never advances. After 30 days of no changes, the cursor falls outside Convex's delta log retention window, causing `InvalidWindowToReadDocuments` errors on every sync.

## Changes

- Add `override_incremental_field_last_value` field to `SourceResponse` — allows sources to set the cursor value directly from the API response rather than deriving it from record fields
- Update `convex_source` to capture the generator return value (the API cursor from `list_snapshot` or `document_deltas`) and store it on the response via `yield from`
- Apply the override in both pipeline v1 and v3 **before** `_post_run_operations`/`_finalize`, which early-return when there are zero records (the exact case we need to handle)

## How did you test this code?

- 10 unit tests covering: `list_snapshot` cursor capture (single page, multi page, empty table), `document_deltas` cursor return (with records, no records, stale cursor error), `convex_source` cursor capture (incremental with records, incremental with no records, initial sync, initial sync empty table)
- All tests pass, ruff and mypy clean

## Publish to changelog?

no