### PR TITLE
feat(cymbal): add typed frame resolution metrics

### DIFF
--- a/rust/common/symbol_data/src/error.rs
+++ b/rust/common/symbol_data/src/error.rs
@@ -3,7 +3,7 @@ use std::string::FromUtf8Error;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
 pub enum Error {
     #[error("Wrong version: {0}, expected {1}")]
     WrongVersion(u32, u32),

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -64,7 +64,7 @@ pub enum UnhandledError {
 // NOTE - these are serialized and deserialized, so that when we fail to get a symbol set from
 // some provider (e.g. we fail to look up a sourcemap), we can return the correct error in the future
 // without hitting their infra again (by storing it in PG).
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
 pub enum FrameError {
     #[error(transparent)]
     JavaScript(#[from] JsResolveErr),
@@ -78,7 +78,7 @@ pub enum FrameError {
     MissingChunkIdData(String),
 }
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
 pub enum JsResolveErr {
     #[error("This frame had no source url or chunk id")]
     NoUrlOrChunkId,
@@ -130,7 +130,7 @@ pub enum JsResolveErr {
     NoSourcemapUploaded(String),
 }
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
 pub enum HermesError {
     #[error("Data error: {0}")]
     DataError(#[from] SymbolDataError),
@@ -144,7 +144,7 @@ pub enum HermesError {
     NoTokenForColumn(u32, String),
 }
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
 pub enum ProguardError {
     #[error("Data error: {0}")]
     DataError(#[from] SymbolDataError),
@@ -164,7 +164,7 @@ pub enum ProguardError {
     InvalidClass,
 }
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
 pub enum AppleError {
     #[error("Data error: {0}")]
     DataError(#[from] SymbolDataError),
@@ -204,6 +204,70 @@ pub enum EventError {
     FailedToDeserialize(Box<CapturedEvent>, String),
     #[error("Filtered by team id")]
     FilteredByTeamId,
+}
+
+impl JsResolveErr {
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::NoUrlOrChunkId | Self::NoSourceUrl => "no_reference",
+            Self::NoSourcemap(_) | Self::NoSourcemapUploaded(_) => "no_symbol_set",
+            Self::TokenNotFound(..) => "symbol_not_found",
+            Self::Timeout(_) | Self::HttpStatus(..) | Self::NetworkError(_)
+            | Self::RedirectError(_) => "network_error",
+            Self::InvalidSourceMap(_)
+            | Self::InvalidSourceUrl(_)
+            | Self::InvalidSourceMapHeader(_)
+            | Self::InvalidSourceMapUrl(_)
+            | Self::InvalidDataUrl(..)
+            | Self::JSDataError(_)
+            | Self::InvalidSourceAndMap => "invalid_data",
+        }
+    }
+}
+
+impl HermesError {
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::NoChunkId => "no_reference",
+            Self::NoSourcemapUploaded(_) => "no_symbol_set",
+            Self::NoTokenForColumn(..) => "symbol_not_found",
+            Self::DataError(_) | Self::InvalidMap(_) => "invalid_data",
+        }
+    }
+}
+
+impl ProguardError {
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::NoMapId | Self::NoModuleProvided => "no_reference",
+            Self::MissingMap(_) => "no_symbol_set",
+            Self::NoOriginalFrames | Self::MissingClass => "symbol_not_found",
+            Self::DataError(_) | Self::InvalidMapping | Self::InvalidClass => "invalid_data",
+        }
+    }
+}
+
+impl AppleError {
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::NoDebugId | Self::NoMatchingDebugImage => "no_reference",
+            Self::MissingDsym(_) => "no_symbol_set",
+            Self::SymbolNotFound(_) => "symbol_not_found",
+            Self::DataError(_) | Self::InvalidAddress(_) | Self::ParseError(_) => "invalid_data",
+        }
+    }
+}
+
+impl FrameError {
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::JavaScript(e) => e.metric_reason(),
+            Self::Hermes(e) => e.metric_reason(),
+            Self::Proguard(e) => e.metric_reason(),
+            Self::Apple(e) => e.metric_reason(),
+            Self::MissingChunkIdData(_) => "no_symbol_set",
+        }
+    }
 }
 
 impl From<JsResolveErr> for ResolveError {

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -212,7 +212,9 @@ impl JsResolveErr {
             Self::NoUrlOrChunkId | Self::NoSourceUrl => "no_reference",
             Self::NoSourcemap(_) | Self::NoSourcemapUploaded(_) => "no_symbol_set",
             Self::TokenNotFound(..) => "symbol_not_found",
-            Self::Timeout(_) | Self::HttpStatus(..) | Self::NetworkError(_)
+            Self::Timeout(_)
+            | Self::HttpStatus(..)
+            | Self::NetworkError(_)
             | Self::RedirectError(_) => "network_error",
             Self::InvalidSourceMap(_)
             | Self::InvalidSourceUrl(_)

--- a/rust/cymbal/src/fingerprinting/mod.rs
+++ b/rust/cymbal/src/fingerprinting/mod.rs
@@ -144,6 +144,7 @@ mod test {
                 resolved_name: Some("bar".to_string()),
                 resolved: true,
                 resolve_failure: None,
+
                 lang: "javascript".to_string(),
                 junk_drawer: None,
                 code_variables: None,
@@ -163,6 +164,7 @@ mod test {
                 resolved_name: Some("baz".to_string()),
                 resolved: true,
                 resolve_failure: None,
+
                 lang: "javascript".to_string(),
                 junk_drawer: None,
                 code_variables: None,
@@ -184,6 +186,7 @@ mod test {
             resolved_name: None,
             resolved: false,
             resolve_failure: None,
+
             lang: "javascript".to_string(),
             junk_drawer: None,
             code_variables: None,
@@ -236,6 +239,7 @@ mod test {
                 resolved_name: Some("bar".to_string()),
                 resolved: false,
                 resolve_failure: None,
+
                 lang: "javascript".to_string(),
                 junk_drawer: None,
                 code_variables: None,
@@ -255,6 +259,7 @@ mod test {
                 resolved_name: Some("baz".to_string()),
                 resolved: false,
                 resolve_failure: None,
+
                 lang: "javascript".to_string(),
                 junk_drawer: None,
                 code_variables: None,
@@ -274,6 +279,7 @@ mod test {
                 resolved_name: None,
                 resolved: false,
                 resolve_failure: None,
+
                 lang: "javascript".to_string(),
                 junk_drawer: None,
                 code_variables: None,
@@ -321,6 +327,7 @@ mod test {
             resolved_name: Some("bar".to_string()),
             resolved: false,
             resolve_failure: None,
+
             lang: "javascript".to_string(),
             junk_drawer: None,
             code_variables: None,
@@ -341,6 +348,7 @@ mod test {
             resolved_name: Some("baz".to_string()),
             resolved: false,
             resolve_failure: None,
+
             lang: "javascript".to_string(),
             junk_drawer: None,
             code_variables: None,

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -113,8 +113,16 @@ impl RawFrame {
                 if frame.resolved {
                     metrics::counter!(FRAME_RESOLVED, "lang" => lang_tag).increment(1);
                 } else if let Some(err) = &frame.resolve_failure {
-                    tracing::warn!(lang = lang_tag, reason = err.metric_reason(), error = %err, "frame resolution failed");
-                    metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang_tag, "reason" => err.metric_reason())
+                    let reason = err.metric_reason();
+                    match reason {
+                        "network_error" | "invalid_data" | "symbol_not_found" => {
+                            tracing::warn!(lang = lang_tag, reason = reason, error = %err, "frame resolution failed");
+                        }
+                        _ => {
+                            tracing::debug!(lang = lang_tag, reason = reason, error = %err, "frame resolution failed");
+                        }
+                    }
+                    metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang_tag, "reason" => reason)
                         .increment(1);
                 } else {
                     metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang_tag, "reason" => "unknown")

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    error::UnhandledError,
+    error::{FrameError, UnhandledError},
     fingerprinting::{FingerprintBuilder, FingerprintComponent, FingerprintRecordPart},
     langs::{
         apple::{AppleDebugImage, RawAppleFrame},
@@ -20,7 +20,7 @@ use crate::{
         python::RawPythonFrame,
         ruby::RawRubyFrame,
     },
-    metric_consts::{LEGACY_JS_FRAME_RESOLVED, PER_FRAME_TIME},
+    metric_consts::{FRAME_NOT_RESOLVED, FRAME_RESOLVED, LEGACY_JS_FRAME_RESOLVED, PER_FRAME_TIME},
     sanitize_string,
     symbol_store::Catalog,
 };
@@ -108,6 +108,21 @@ impl RawFrame {
         .label("lang", lang_tag)
         .fin();
 
+        if let Ok(frames) = &res {
+            for frame in frames {
+                if frame.resolved {
+                    metrics::counter!(FRAME_RESOLVED, "lang" => lang_tag).increment(1);
+                } else if let Some(err) = &frame.resolve_failure {
+                    tracing::warn!(lang = lang_tag, reason = err.metric_reason(), error = %err, "frame resolution failed");
+                    metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang_tag, "reason" => err.metric_reason())
+                        .increment(1);
+                } else {
+                    metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang_tag, "reason" => "unknown")
+                        .increment(1);
+                }
+            }
+        }
+
         res
     }
 
@@ -176,8 +191,13 @@ pub struct Frame {
     pub resolved_name: Option<String>, // The name of the function, after symbolification
     pub lang: String, // The language of the frame. Always known (I guess?)
     pub resolved: bool, // Did we manage to resolve the frame?
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolve_failure: Option<String>, // If we failed to resolve the frame, why?
+    #[serde(
+        serialize_with = "frame_error_serde::serialize",
+        deserialize_with = "frame_error_serde::deserialize",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub resolve_failure: Option<FrameError>, // If we failed to resolve the frame, why?
 
     #[serde(default)] // Defaults to false
     pub synthetic: bool, // Some SDKs construct stack traces, or partially reconstruct them. This flag indicates whether the frame is synthetic or not.
@@ -344,7 +364,7 @@ impl std::fmt::Display for Frame {
         writeln!(
             f,
             "  resolve_failure: {}",
-            self.resolve_failure.as_deref().unwrap_or("no failure")
+            self.resolve_failure.as_ref().map(|e| e.to_string()).as_deref().unwrap_or("no failure")
         )?;
 
         // Context
@@ -394,6 +414,31 @@ impl From<Frame> for FrameData {
             lang: frame.lang,
             code_variables: frame.code_variables,
         }
+    }
+}
+
+mod frame_error_serde {
+    use super::FrameError;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &Option<FrameError>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            Some(err) => serializer.serialize_str(&err.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FrameError>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // We can't reconstruct the typed error from a string, so just discard it.
+        // This only matters for test deserialization; production never deserializes Frame.
+        let _unused: Option<String> = Option::deserialize(deserializer)?;
+        Ok(None)
     }
 }
 

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -429,9 +429,11 @@ mod frame_error_serde {
     where
         S: Serializer,
     {
+        // skip_serializing_if = "Option::is_none" guarantees value is Some here,
+        // but we match exhaustively to satisfy the type checker.
         match value {
             Some(err) => serializer.serialize_str(&err.to_string()),
-            None => serializer.serialize_none(),
+            None => unreachable!("skip_serializing_if = Option::is_none prevents None reaching here"),
         }
     }
 }

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -441,7 +441,9 @@ mod frame_error_serde {
         // but we match exhaustively to satisfy the type checker.
         match value {
             Some(err) => serializer.serialize_str(&err.to_string()),
-            None => unreachable!("skip_serializing_if = Option::is_none prevents None reaching here"),
+            None => {
+                unreachable!("skip_serializing_if = Option::is_none prevents None reaching here")
+            }
         }
     }
 }

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -193,7 +193,7 @@ pub struct Frame {
     pub resolved: bool, // Did we manage to resolve the frame?
     #[serde(
         serialize_with = "frame_error_serde::serialize",
-        deserialize_with = "frame_error_serde::deserialize",
+        skip_deserializing,
         skip_serializing_if = "Option::is_none",
         default
     )]
@@ -364,7 +364,11 @@ impl std::fmt::Display for Frame {
         writeln!(
             f,
             "  resolve_failure: {}",
-            self.resolve_failure.as_ref().map(|e| e.to_string()).as_deref().unwrap_or("no failure")
+            self.resolve_failure
+                .as_ref()
+                .map(|e| e.to_string())
+                .as_deref()
+                .unwrap_or("no failure")
         )?;
 
         // Context
@@ -419,7 +423,7 @@ impl From<Frame> for FrameData {
 
 mod frame_error_serde {
     use super::FrameError;
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::Serializer;
 
     pub fn serialize<S>(value: &Option<FrameError>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -429,16 +433,6 @@ mod frame_error_serde {
             Some(err) => serializer.serialize_str(&err.to_string()),
             None => serializer.serialize_none(),
         }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<FrameError>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // We can't reconstruct the typed error from a string, so just discard it.
-        // This only matters for test deserialization; production never deserializes Frame.
-        let _unused: Option<String> = Option::deserialize(deserializer)?;
-        Ok(None)
     }
 }
 

--- a/rust/cymbal/src/langs/apple.rs
+++ b/rust/cymbal/src/langs/apple.rs
@@ -301,6 +301,7 @@ impl RawAppleFrame {
             lang: lang_from_filename(symbol_info.filename.as_deref()).to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             release: None,
             synthetic: self.meta.synthetic,
@@ -366,7 +367,7 @@ impl RawAppleFrame {
             resolved_name,
             lang: lang_from_filename(self.filename.as_deref()).to_string(),
             resolved: false,
-            resolve_failure: Some(err.to_string()),
+            resolve_failure: Some(FrameError::from(err)),
             junk_drawer: None,
             release: None,
             synthetic: self.meta.synthetic,
@@ -435,6 +436,7 @@ impl From<&RawAppleFrame> for Frame {
             lang: lang_from_filename(raw.filename.as_deref()).to_string(),
             resolved: raw.function.is_some(),
             resolve_failure: None,
+
             junk_drawer: None,
             release: None,
             synthetic: raw.meta.synthetic,

--- a/rust/cymbal/src/langs/custom.rs
+++ b/rust/cymbal/src/langs/custom.rs
@@ -98,6 +98,7 @@ impl From<&CustomFrame> for Frame {
             lang: value.lang.clone(),
             resolved: value.resolved,
             resolve_failure: None,
+
             junk_drawer: None,
             context: value.get_context(),
             release: None,

--- a/rust/cymbal/src/langs/dart.rs
+++ b/rust/cymbal/src/langs/dart.rs
@@ -48,6 +48,7 @@ impl From<&RawDartFrame> for Frame {
             lang: "dart".to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             release: None,
             synthetic: raw.meta.synthetic,

--- a/rust/cymbal/src/langs/go.rs
+++ b/rust/cymbal/src/langs/go.rs
@@ -36,6 +36,7 @@ impl From<&RawGoFrame> for Frame {
             lang: "go".to_string(),
             resolved: true,
             resolve_failure: None,
+
             synthetic: frame.meta.synthetic,
             junk_drawer: None,
             context: None,

--- a/rust/cymbal/src/langs/hermes.rs
+++ b/rust/cymbal/src/langs/hermes.rs
@@ -12,7 +12,6 @@ use crate::{
         utils::{add_raw_to_junk, get_token_context},
         CommonFrameMetadata,
     },
-    metric_consts::FRAME_NOT_RESOLVED,
     sanitize_string,
     symbol_store::{chunk_id::OrChunkId, hermesmap::ParsedHermesMap, SymbolCatalog},
 };
@@ -134,7 +133,7 @@ impl From<(&RawHermesFrame, HermesError)> for Frame {
             resolved_name: None,
             lang: "javascript".to_string(),
             resolved: false,
-            resolve_failure: Some(err.to_string()),
+            resolve_failure: Some(FrameError::from(err)),
             synthetic: frame.meta.synthetic,
             junk_drawer: None,
             code_variables: None,
@@ -169,6 +168,7 @@ impl From<(&RawHermesFrame, Token<'_>, Option<String>)> for Frame {
             lang: "javascript".to_string(),
             resolved: true,
             resolve_failure: None,
+
             synthetic: frame.meta.synthetic,
             junk_drawer: None,
             code_variables: None,
@@ -188,8 +188,6 @@ impl From<(&RawHermesFrame, Token<'_>, Option<String>)> for Frame {
 // probably a native function or something else weird
 impl From<&RawHermesFrame> for Frame {
     fn from(raw_frame: &RawHermesFrame) -> Self {
-        metrics::counter!(FRAME_NOT_RESOLVED, "lang" => "hermes").increment(1);
-
         // If this is a source_url: <anonymous> frame, we always assume it's not in_app
         let is_anon = raw_frame.source.eq("<anonymous>");
 
@@ -206,6 +204,7 @@ impl From<&RawHermesFrame> for Frame {
             lang: "javascript".to_string(),
             resolved: true, // Without location information, we're assuming this is not minified
             resolve_failure: None,
+
             junk_drawer: None,
             code_variables: None,
             context: None,

--- a/rust/cymbal/src/langs/java.rs
+++ b/rust/cymbal/src/langs/java.rs
@@ -157,6 +157,7 @@ impl<'a> From<(&'a RawJavaFrame, StackFrame<'a>)> for Frame {
             lang: "java".to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             code_variables: None,
             release: None,
@@ -184,7 +185,7 @@ impl From<(&RawJavaFrame, ProguardError)> for Frame {
             resolved_name: None,
             lang: "java".to_string(),
             resolved: false,
-            resolve_failure: Some(error.to_string()),
+            resolve_failure: Some(FrameError::from(error)),
             junk_drawer: None,
             code_variables: None,
             release: None,

--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -8,7 +8,6 @@ use crate::{
     error::{FrameError, JsResolveErr, ResolveError, UnhandledError},
     frames::Frame,
     langs::CommonFrameMetadata,
-    metric_consts::{FRAME_NOT_RESOLVED, FRAME_RESOLVED},
     sanitize_string,
     symbol_store::{chunk_id::OrChunkId, sourcemap::OwnedSourceMapCache, SymbolCatalog},
 };
@@ -178,7 +177,6 @@ impl RawJSFrame {
 impl From<(&RawJSFrame, SourceLocation<'_>)> for Frame {
     fn from(src: (&RawJSFrame, SourceLocation)) -> Self {
         let (raw_frame, token) = src;
-        metrics::counter!(FRAME_RESOLVED, "lang" => "javascript").increment(1);
 
         let resolved_name = match token.scope() {
             // The `$async$` prefix is a Dart/Flutter compiler artifact that appears in
@@ -221,6 +219,7 @@ impl From<(&RawJSFrame, SourceLocation<'_>)> for Frame {
             lang: "javascript".to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             code_variables: None,
             context: get_sourcelocation_context(&token),
@@ -240,8 +239,6 @@ impl From<(&RawJSFrame, SourceLocation<'_>)> for Frame {
 // mark it as a failed resolve and emit an "unresolved" frame
 impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
     fn from((raw_frame, err, location): (&RawJSFrame, JsResolveErr, &FrameLocation)) -> Self {
-        metrics::counter!(FRAME_NOT_RESOLVED, "lang" => "javascript").increment(1);
-
         // TODO - extremely rough
         let was_minified = match err {
             JsResolveErr::NoSourceUrl | JsResolveErr::NoUrlOrChunkId => false, // This frame's `source` didn't exist
@@ -269,7 +266,7 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
             // Regardless of whather we think this was a minified frame or not, we still put
             // the error message in resolve_failure, so if a user comes along and want to know
             // why we thought a frame wasn't minified, they can see the error message
-            resolve_failure: Some(err.to_string()),
+            resolve_failure: Some(FrameError::from(err)),
             junk_drawer: None,
             code_variables: None,
             context: None,
@@ -289,8 +286,6 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
 // probably a native function or something else weird
 impl From<&RawJSFrame> for Frame {
     fn from(raw_frame: &RawJSFrame) -> Self {
-        metrics::counter!(FRAME_NOT_RESOLVED, "lang" => "javascript").increment(1);
-
         // If this is a source_url: <anonymous> frame, we always assume it's not in_app
         let is_anon = raw_frame
             .source_url
@@ -311,6 +306,7 @@ impl From<&RawJSFrame> for Frame {
             lang: "javascript".to_string(),
             resolved: true, // Without location information, we're assuming this is not minified
             resolve_failure: None,
+
             junk_drawer: None,
             code_variables: None,
             context: None,

--- a/rust/cymbal/src/langs/node.rs
+++ b/rust/cymbal/src/langs/node.rs
@@ -2,7 +2,6 @@ use crate::{
     error::{FrameError, JsResolveErr, ResolveError, UnhandledError},
     frames::{Context, ContextLine, Frame},
     langs::CommonFrameMetadata,
-    metric_consts::{FRAME_NOT_RESOLVED, FRAME_RESOLVED},
     sanitize_string,
     symbol_store::{chunk_id::OrChunkId, sourcemap::OwnedSourceMapCache, SymbolCatalog},
 };
@@ -160,6 +159,7 @@ impl From<&RawNodeFrame> for Frame {
             lang: "javascript".to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             context: raw.get_context(),
             release: None,
@@ -173,8 +173,6 @@ impl From<&RawNodeFrame> for Frame {
 
 impl From<(&RawNodeFrame, SourceLocation<'_>)> for Frame {
     fn from((raw_frame, location): (&RawNodeFrame, SourceLocation)) -> Self {
-        metrics::counter!(FRAME_RESOLVED, "lang" => "javascript").increment(1);
-
         let resolved_name = match location.scope() {
             ScopeLookupResult::NamedScope(name) => Some(sanitize_string(name.to_string())),
             ScopeLookupResult::AnonymousScope => Some("<anonymous>".to_string()),
@@ -204,6 +202,7 @@ impl From<(&RawNodeFrame, SourceLocation<'_>)> for Frame {
             lang: "javascript".to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             code_variables: None,
             context: get_sourcelocation_context(&location),
@@ -221,8 +220,6 @@ impl From<(&RawNodeFrame, SourceLocation<'_>)> for Frame {
 
 impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
     fn from((raw_frame, resolve_err): (&RawNodeFrame, JsResolveErr)) -> Self {
-        metrics::counter!(FRAME_NOT_RESOLVED, "lang" => "javascript").increment(1);
-
         let was_minified = raw_frame
             .get_context()
             .as_ref()
@@ -248,7 +245,7 @@ impl From<(&RawNodeFrame, JsResolveErr)> for Frame {
             // Regardless of whather we think this was a minified frame or not, we still put
             // the error message in resolve_failure, so if a user comes along and want to know
             // why we thought a frame wasn't minified, they can see the error message
-            resolve_failure: Some(resolve_err.to_string()),
+            resolve_failure: Some(FrameError::from(resolve_err)),
             junk_drawer: None,
             code_variables: None,
             context: raw_frame.get_context(),

--- a/rust/cymbal/src/langs/python.rs
+++ b/rust/cymbal/src/langs/python.rs
@@ -92,6 +92,7 @@ impl From<&RawPythonFrame> for Frame {
             lang: "python".to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             context: raw.get_context(),
             release: None,

--- a/rust/cymbal/src/langs/ruby.rs
+++ b/rust/cymbal/src/langs/ruby.rs
@@ -86,6 +86,7 @@ impl From<&RawRubyFrame> for Frame {
             lang: "ruby".to_string(),
             resolved: true,
             resolve_failure: None,
+
             junk_drawer: None,
             context: raw.get_context(),
             release: None,

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -95,6 +95,7 @@ fn make_frame_js(name: &str) -> Frame {
         resolved: true,
         lang: "javascript".to_string(),
         resolve_failure: None,
+
         synthetic: false,
         suspicious: false,
         junk_drawer: None,
@@ -117,6 +118,7 @@ fn make_frame_ts(name: &str) -> Frame {
         resolved: true,
         lang: "typescript".to_string(),
         resolve_failure: None,
+
         synthetic: false,
         suspicious: false,
         junk_drawer: None,

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -301,6 +301,12 @@ fn extract_exception_list(response: &SuccessResponse) -> ExceptionList {
     props.exception_list
 }
 
+fn extract_exception_list_raw(response: &SuccessResponse) -> serde_json::Value {
+    let event = response.first_event();
+    let props = event.as_ref().unwrap().properties.clone();
+    props["$exception_list"].clone()
+}
+
 // Tests
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -547,8 +553,10 @@ async fn handles_missing_sourcemap(db: PgPool) {
     let (status, body): (_, SuccessResponse) = harness.post_event(&event).await;
 
     assert!(status.is_success());
-    let exception_list = extract_exception_list(&body);
-    assert_json_snapshot!(exception_list.0, {
+    // Use raw JSON extraction to avoid losing resolve_failure during
+    // typed deserialization (Frame's resolve_failure is skip_deserializing).
+    let exception_list = extract_exception_list_raw(&body);
+    assert_json_snapshot!(exception_list, {
         "[].id" => "REDACTED",
     });
 }

--- a/rust/cymbal/tests/snapshots/event__handles_missing_sourcemap.snap
+++ b/rust/cymbal/tests/snapshots/event__handles_missing_sourcemap.snap
@@ -5,22 +5,11 @@ expression: exception_list
 [
   {
     "id": "REDACTED",
-    "type": "CustomError",
-    "value": "Custom error message",
     "stacktrace": {
-      "type": "resolved",
       "frames": [
         {
-          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
-          "mangled_name": "onClok",
-          "line": 123,
           "column": 45,
           "in_app": true,
-          "lang": "javascript",
-          "resolved": false,
-          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
-          "synthetic": false,
-          "suspicious": false,
           "junk_drawer": {
             "raw_frame": {
               "chunk_id": "124",
@@ -31,19 +20,19 @@ expression: exception_list
               "lineno": 123,
               "synthetic": false
             }
-          }
+          },
+          "lang": "javascript",
+          "line": 123,
+          "mangled_name": "onClok",
+          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
+          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
+          "resolved": false,
+          "suspicious": false,
+          "synthetic": false
         },
         {
-          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
-          "mangled_name": "onClok",
-          "line": 123,
           "column": 45,
           "in_app": true,
-          "lang": "javascript",
-          "resolved": false,
-          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
-          "synthetic": false,
-          "suspicious": false,
           "junk_drawer": {
             "raw_frame": {
               "chunk_id": "124",
@@ -54,19 +43,19 @@ expression: exception_list
               "lineno": 123,
               "synthetic": false
             }
-          }
+          },
+          "lang": "javascript",
+          "line": 123,
+          "mangled_name": "onClok",
+          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
+          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
+          "resolved": false,
+          "suspicious": false,
+          "synthetic": false
         },
         {
-          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
-          "mangled_name": "onClok",
-          "line": 123,
           "column": 45,
           "in_app": true,
-          "lang": "javascript",
-          "resolved": false,
-          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
-          "synthetic": false,
-          "suspicious": false,
           "junk_drawer": {
             "raw_frame": {
               "chunk_id": "124",
@@ -77,9 +66,20 @@ expression: exception_list
               "lineno": 123,
               "synthetic": false
             }
-          }
+          },
+          "lang": "javascript",
+          "line": 123,
+          "mangled_name": "onClok",
+          "raw_id": "4b9c7000c31be8f2264cba6a3bfb52213d7b4fe22a0b8ca56a7294ac7b56c24245825e2453b79bc05288f0cda771ff9aae9559c4db01a162c4d00d59aeefe299/0",
+          "resolve_failure": "No sourcemap uploaded for chunk id: 124",
+          "resolved": false,
+          "suspicious": false,
+          "synthetic": false
         }
-      ]
-    }
+      ],
+      "type": "resolved"
+    },
+    "type": "CustomError",
+    "value": "Custom error message"
   }
 ]

--- a/rust/cymbal/tests/snapshots/event__handles_missing_sourcemap.snap
+++ b/rust/cymbal/tests/snapshots/event__handles_missing_sourcemap.snap
@@ -1,6 +1,6 @@
 ---
 source: cymbal/tests/event.rs
-expression: exception_list.0
+expression: exception_list
 ---
 [
   {


### PR DESCRIPTION
## Problem

Cymbal lacked centralized metrics for frame resolution outcomes, making it hard to monitor resolution success rates and diagnose failure patterns (missing symbol sets, network errors, invalid data, etc.).

## Changes

- Store `Option<FrameError>` directly on `Frame` instead of separate `Option<String>` + `Option<&'static str>` fields — the typed error provides both the human-readable message (via `Display`) and a metric-friendly reason (via `metric_reason()`)
- Add `metric_reason()` methods to all resolution error enums (`JsResolveErr`, `HermesError`, `ProguardError`, `AppleError`, `FrameError`) returning categorized labels: `no_reference`, `no_symbol_set`, `symbol_not_found`, `network_error`, `invalid_data`
- Emit `cymbal_frame_resolved` and `cymbal_frame_not_resolved` counters with `lang` and `reason` labels in the centralized `RawFrame::resolve()` method
- Add `warn!` log on frame resolution failures with structured `lang`, `reason`, and `error` fields
- Add `Clone`, `PartialEq`, `Eq` derives to `FrameError` and all child error enums (+ `SymbolDataError`) so they can live on the `Frame` struct
- Custom serde for `resolve_failure` field: serializes `FrameError` as its `Display` string for backward-compatible JSON output

## How did you test this code?

- `cargo check -p cymbal --tests` passes
- All non-DB unit tests pass (57 passed, DB-dependent tests skip without local Postgres)
- Snapshot format unchanged (custom serializer preserves string representation)

## Publish to changelog?

no