### PR TITLE
fix(tracing): calculate traceid in python not clickhouse to avoid nullable checks

### DIFF
--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -176,11 +176,12 @@ class TraceSpansQueryRunner(AnalyticsQueryRunner[TraceSpansQueryResponse]):
             )
 
         if self.query.traceId:
+            trace_id_b64 = base64.b64encode(bytes.fromhex(self.query.traceId)).decode("ascii")
             exprs.append(
                 parse_expr(
-                    "trace_id = assumeNotNull(base64Encode(unhex({traceId})))",
+                    "trace_id = {traceId}",
                     placeholders={
-                        "traceId": ast.Constant(value=self.query.traceId),
+                        "traceId": ast.Constant(value=trace_id_b64),
                     },
                 )
             )

--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -84,6 +84,11 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
     def trace(self, request: Request, trace_id: str, *args, **kwargs) -> Response:
         query_data = request.data or {}
         date_range = self.get_model(query_data.get("dateRange", {"date_from": "-24h"}), DateRange)
+        try:
+            # verify the trace_id is valid
+            base64.b64encode(bytes.fromhex(trace_id)).decode("ascii")
+        except ValueError:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         spans_query = TraceSpansQuery(
             dateRange=date_range,


### PR DESCRIPTION

## Problem

hogql was wrapping the clickhouse comparison in ifNull checks, which breaks clickhouse's index analysis

assumeNotNull did not fix this - instead calculate in python so it's a constant check which should avoid the ifNull check

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
