### PR TITLE
fix: Wire up leadership into personhog-router

### DIFF
--- a/rust/personhog-coordination/src/coordinator.rs
+++ b/rust/personhog-coordination/src/coordinator.rs
@@ -120,6 +120,10 @@ impl Coordinator {
     }
 
     async fn run_coordination_loop(&self, cancel: CancellationToken) -> Result<()> {
+        // Reconcile any handoffs that already have full ack quorum.
+        // This handles acks that arrived before this coordinator took leadership.
+        self.reconcile_pending_handoffs().await?;
+
         // Compute initial assignments for any pods that are already registered
         self.handle_pod_change().await?;
 
@@ -300,6 +304,29 @@ impl Coordinator {
                     tracing::warn!(partition, "handoff already deleted, ignoring duplicate ack");
                 }
                 Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check all in-flight handoffs for completed ack quorum. Completes any
+    /// handoffs where all routers have already acked, which can happen when the
+    /// coordinator restarts or a new leader is elected after acks were written.
+    async fn reconcile_pending_handoffs(&self) -> Result<()> {
+        let handoffs = self.store.list_handoffs().await?;
+        if handoffs.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            count = handoffs.len(),
+            "reconciling existing handoffs on startup"
+        );
+
+        for handoff in &handoffs {
+            if handoff.phase == HandoffPhase::Ready {
+                Self::check_ack_completion(&self.store, handoff.partition).await?;
             }
         }
 

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -105,6 +105,23 @@ pub struct Config {
     /// Leader gRPC port used when resolving pod names to addresses
     #[envconfig(default = "50053")]
     pub leader_port: u16,
+
+    // ── coordinator (leader election among router-leader pods) ───
+    /// Lease TTL for the coordinator leader election
+    #[envconfig(default = "15")]
+    pub coordinator_lease_ttl: i64,
+
+    /// Keepalive interval for the coordinator lease
+    #[envconfig(default = "5")]
+    pub coordinator_keepalive_secs: u64,
+
+    /// Retry interval when coordinator fails to acquire leadership
+    #[envconfig(default = "5")]
+    pub coordinator_election_retry_secs: u64,
+
+    /// Debounce interval (ms) for batching pod events before rebalancing
+    #[envconfig(default = "1000")]
+    pub coordinator_rebalance_debounce_ms: u64,
 }
 
 impl Config {
@@ -162,6 +179,18 @@ impl Config {
 
     pub fn heartbeat_interval(&self) -> Duration {
         Duration::from_secs(self.heartbeat_interval_secs)
+    }
+
+    pub fn coordinator_keepalive_interval(&self) -> Duration {
+        Duration::from_secs(self.coordinator_keepalive_secs)
+    }
+
+    pub fn coordinator_election_retry_interval(&self) -> Duration {
+        Duration::from_secs(self.coordinator_election_retry_secs)
+    }
+
+    pub fn coordinator_rebalance_debounce_interval(&self) -> Duration {
+        Duration::from_millis(self.coordinator_rebalance_debounce_ms)
     }
 }
 

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -11,7 +11,7 @@ use personhog_coordination::coordinator::{Coordinator, CoordinatorConfig};
 use personhog_coordination::error::Result as CoordResult;
 use personhog_coordination::routing_table::{CutoverHandler, RoutingTable, RoutingTableConfig};
 use personhog_coordination::store::PersonhogStore;
-use personhog_coordination::strategy::JumpHashStrategy;
+use personhog_coordination::strategy::StickyBalancedStrategy;
 use personhog_proto::personhog::service::v1::person_hog_service_server::PersonHogServiceServer;
 use personhog_router::backend::{LeaderBackend, ReplicaBackend};
 use personhog_router::config::{Config, RouterMode};
@@ -246,7 +246,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 election_retry_interval: config.coordinator_election_retry_interval(),
                 rebalance_debounce_interval: config.coordinator_rebalance_debounce_interval(),
             },
-            Arc::new(JumpHashStrategy),
+            Arc::new(StickyBalancedStrategy),
         );
 
         tokio::spawn(async move {

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -7,9 +7,11 @@ use envconfig::Envconfig;
 use lifecycle::{ComponentOptions, Manager};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use personhog_common::grpc::{tracked_tcp_incoming, GrpcMetricsLayer};
+use personhog_coordination::coordinator::{Coordinator, CoordinatorConfig};
 use personhog_coordination::error::Result as CoordResult;
 use personhog_coordination::routing_table::{CutoverHandler, RoutingTable, RoutingTableConfig};
 use personhog_coordination::store::PersonhogStore;
+use personhog_coordination::strategy::JumpHashStrategy;
 use personhog_proto::personhog::service::v1::person_hog_service_server::PersonHogServiceServer;
 use personhog_router::backend::{LeaderBackend, ReplicaBackend};
 use personhog_router::config::{Config, RouterMode};
@@ -99,14 +101,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ComponentOptions::new().is_observability(true),
     );
 
-    // Only register coordination component in leader mode
-    let coordination_handle = if config.router_mode == RouterMode::Leader {
-        Some(manager.register(
-            "coordination",
+    // Only register coordination components in leader mode
+    let (routing_table_handle, coordinator_handle) = if config.router_mode == RouterMode::Leader {
+        let rt = manager.register(
+            "routing-table",
             ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(5)),
-        ))
+        );
+        let coord = manager.register(
+            "coordinator",
+            ComponentOptions::new().with_graceful_shutdown(Duration::from_secs(5)),
+        );
+        (Some(rt), Some(coord))
     } else {
-        None
+        (None, None)
     };
 
     let readiness = manager.readiness_handler();
@@ -213,17 +220,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             leader_backend: Arc::clone(&leader_backend),
         });
 
-        // Start coordination (etcd registration + routing table watches)
-        let coordination_handle =
-            coordination_handle.expect("coordination handle must be registered in leader mode");
+        // Start routing table (etcd registration + assignment/handoff watches)
+        let routing_table_handle =
+            routing_table_handle.expect("routing-table handle must be registered in leader mode");
 
         tokio::spawn(async move {
-            let _guard = coordination_handle.process_scope();
+            let _guard = routing_table_handle.process_scope();
             if let Err(e) = coordination_routing_table
-                .run(coordination_handle.shutdown_token(), cutover_handler)
+                .run(routing_table_handle.shutdown_token(), cutover_handler)
                 .await
             {
-                coordination_handle.signal_failure(format!("Coordination error: {e}"));
+                routing_table_handle.signal_failure(format!("Routing table error: {e}"));
+            }
+        });
+
+        // Start coordinator (leader election + partition assignment)
+        let coordinator_handle =
+            coordinator_handle.expect("coordinator handle must be registered in leader mode");
+        let coordinator = Coordinator::new(
+            store,
+            CoordinatorConfig {
+                name: config.pod_name.clone(),
+                leader_lease_ttl: config.coordinator_lease_ttl,
+                keepalive_interval: config.coordinator_keepalive_interval(),
+                election_retry_interval: config.coordinator_election_retry_interval(),
+                rebalance_debounce_interval: config.coordinator_rebalance_debounce_interval(),
+            },
+            Arc::new(JumpHashStrategy),
+        );
+
+        tokio::spawn(async move {
+            let _guard = coordinator_handle.process_scope();
+            if let Err(e) = coordinator.run(coordinator_handle.shutdown_token()).await {
+                coordinator_handle.signal_failure(format!("Coordinator error: {e}"));
             }
         });
 


### PR DESCRIPTION
## Problem

In leader mode, the `personhog-router` watches etcd for partition assignments but no component was responsible for computing and writing those assignments. The coordinator was defined in `personhog-coordination` but never wired into any running process, so partition assignment keys were never created in etcd even when pods were registered and ready.

## Changes

- Added coordinator config fields to `personhog-router` (`coordinator_lease_ttl`, `coordinator_keepalive_secs`, `coordinator_election_retry_secs`, `coordinator_rebalance_debounce_ms`) with helper methods
- Split the single `coordination` lifecycle component into two: `routing-table` (router registration + assignment/handoff watches) and `coordinator` (leader election + partition assignment via `JumpHashStrategy`)
- Each router-leader pod now runs both components; etcd leader election ensures only one instance actively computes assignments at a time


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
