### PR TITLE
fix(hogql): fix nullable checks, and add check for assumenotnull

### DIFF
--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -2127,6 +2127,25 @@ class TestPrinter(BaseTest):
             f"FROM (SELECT min(toTimeZone(session_replay_events.min_first_timestamp, %(hogql_val_0)s)) AS start_time, sum(session_replay_events.click_count) AS click_count, sum(session_replay_events.keypress_count) AS keypress_count FROM session_replay_events WHERE equals(session_replay_events.team_id, {self.team.pk})) AS session_replay_events LIMIT {MAX_SELECT_RETURNED_ROWS}"
         )
 
+    def test_assume_not_null_prevents_ifnull_wrapping_in_comparison(self):
+        # base64Encode has no type signatures → returns UnknownType(nullable=True)
+        # Without assumeNotNull, one side is considered nullable → comparison gets ifNull wrapping
+        sql_without = self._expr("event = base64Encode('test')")
+        self.assertIn("ifNull(", sql_without)
+
+        # assumeNotNull forces nullable=False → both sides non-nullable → no wrapping
+        sql_with = self._expr("event = assumeNotNull(base64Encode('test'))")
+        self.assertNotIn("ifNull(", sql_with)
+        self.assertTrue(sql_with.startswith("equals("))
+
+    def test_assume_not_null_prevents_ifnull_wrapping_not_equals(self):
+        sql_without = self._expr("event != base64Encode('test')")
+        self.assertIn("ifNull(", sql_without)
+
+        sql_with = self._expr("event != assumeNotNull(base64Encode('test'))")
+        self.assertNotIn("ifNull(", sql_with)
+        self.assertTrue(sql_with.startswith("notEquals("))
+
     def test_field_nullable_boolean(self):
         PropertyDefinition.objects.create(
             team=self.team, name="is_boolean", property_type="Boolean", type=PropertyDefinition.Type.EVENT

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -1323,8 +1323,10 @@ class Resolver(CloningVisitor):
         elif not isinstance(return_type, ast.UnknownType):  # why cannot we set nullability here?
             return_type.nullable = any(arg_type.nullable for arg_type in arg_types)
 
-        if node.name.lower() in ("nullif", "toNullable") or node.name.lower().endswith("OrNull"):
+        if node.name.lower() in ("nullif", "tonullable") or node.name.lower().endswith("ornull"):
             return_type.nullable = True
+        elif node.name.lower() == "assumenotnull":
+            return_type.nullable = False
 
         node.type = ast.CallType(
             name=node.name,

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1202,42 +1202,18 @@ class TestResolver(BaseTest):
         assert isinstance(selected.type, ast.CallType)
         assert selected.type.return_type.nullable is False
 
-    def test_to_nullable_forces_nullable_true(self):
-        # toNullable should always set nullable=True, even when the arg is non-nullable
-        node = self._select("SELECT toNullable('hello')")
-        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
-
-        [selected] = node.select
-        assert isinstance(selected.type, ast.CallType)
-        assert selected.type.return_type.nullable is True
-
-    def test_to_nullable_with_non_nullable_field(self):
-        node = self._select("SELECT toNullable(event) FROM events")
-        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
-
-        [selected] = node.select
-        assert isinstance(selected.type, ast.CallType)
-        assert selected.type.return_type.nullable is True
-
-    def test_or_null_suffix_forces_nullable_true(self):
-        # Functions ending in OrNull should always produce nullable return types
-        node = self._select("SELECT toUInt64OrNull('123')")
-        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
-
-        [selected] = node.select
-        assert isinstance(selected.type, ast.CallType)
-        assert selected.type.return_type.nullable is True
-
-    def test_or_null_suffix_with_datetime(self):
-        node = self._select("SELECT parseDateTimeBestEffortOrNull('2020-01-01')")
-        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
-
-        [selected] = node.select
-        assert isinstance(selected.type, ast.CallType)
-        assert selected.type.return_type.nullable is True
-
-    def test_nullif_forces_nullable_true(self):
-        node = self._select("SELECT nullIf(event, '') FROM events")
+    @pytest.mark.parametrize(
+        "expr,from_clause",
+        [
+            ("toNullable('hello')", ""),
+            ("toNullable(event)", "FROM events"),
+            ("toUInt64OrNull('123')", ""),
+            ("parseDateTimeBestEffortOrNull('2020-01-01')", ""),
+            ("nullIf(event, '')", "FROM events"),
+        ],
+    )
+    def test_nullable_functions_force_nullable_true(self, expr, from_clause):
+        node = self._select(f"SELECT {expr} {from_clause}".strip())
         node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
 
         [selected] = node.select

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1193,6 +1193,57 @@ class TestResolver(BaseTest):
         assert isinstance(selected.type, ast.CallType)
         assert selected.type.return_type == ast.DateTimeType(nullable=False)
 
+    def test_assume_not_null_with_unknown_arg_type(self):
+        # When the inner function has no signatures (returns UnknownType), assumeNotNull should still force nullable=False
+        node = self._select("SELECT assumeNotNull(base64Encode(unhex('DEADBEEF')))")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+
+        [selected] = node.select
+        assert isinstance(selected.type, ast.CallType)
+        assert selected.type.return_type.nullable is False
+
+    def test_to_nullable_forces_nullable_true(self):
+        # toNullable should always set nullable=True, even when the arg is non-nullable
+        node = self._select("SELECT toNullable('hello')")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+
+        [selected] = node.select
+        assert isinstance(selected.type, ast.CallType)
+        assert selected.type.return_type.nullable is True
+
+    def test_to_nullable_with_non_nullable_field(self):
+        node = self._select("SELECT toNullable(event) FROM events")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+
+        [selected] = node.select
+        assert isinstance(selected.type, ast.CallType)
+        assert selected.type.return_type.nullable is True
+
+    def test_or_null_suffix_forces_nullable_true(self):
+        # Functions ending in OrNull should always produce nullable return types
+        node = self._select("SELECT toUInt64OrNull('123')")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+
+        [selected] = node.select
+        assert isinstance(selected.type, ast.CallType)
+        assert selected.type.return_type.nullable is True
+
+    def test_or_null_suffix_with_datetime(self):
+        node = self._select("SELECT parseDateTimeBestEffortOrNull('2020-01-01')")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+
+        [selected] = node.select
+        assert isinstance(selected.type, ast.CallType)
+        assert selected.type.return_type.nullable is True
+
+    def test_nullif_forces_nullable_true(self):
+        node = self._select("SELECT nullIf(event, '') FROM events")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+
+        [selected] = node.select
+        assert isinstance(selected.type, ast.CallType)
+        assert selected.type.return_type.nullable is True
+
     def test_interval_type_arithmetic(self):
         operators = ["+", "-"]
         granularites = ["Second", "Minute", "Hour", "Day", "Week", "Month", "Quarter", "Year"]

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1202,8 +1202,7 @@ class TestResolver(BaseTest):
         assert isinstance(selected.type, ast.CallType)
         assert selected.type.return_type.nullable is False
 
-    @pytest.mark.parametrize(
-        "expr,from_clause",
+    @parameterized.expand(
         [
             ("toNullable('hello')", ""),
             ("toNullable(event)", "FROM events"),

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1206,8 +1206,6 @@ class TestResolver(BaseTest):
         [
             ("toNullable('hello')", ""),
             ("toNullable(event)", "FROM events"),
-            ("toUInt64OrNull('123')", ""),
-            ("parseDateTimeBestEffortOrNull('2020-01-01')", ""),
             ("nullIf(event, '')", "FROM events"),
         ],
     )


### PR DESCRIPTION
## Problem

we detect various functions to determine if an expression is nullable or not, however we were comparing "lower" on the name with camelcase values, which would never be true. Fix those problems

Also add the opposite check for "assumeNotNull", to make it always not nullable

## Changes

correctly detect nullable functions, and add assumeNotNull check

## How did you test this code?
locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
