### PR TITLE
fix(metalytics): guard against undefined results from async HogQL queries

### DIFF
--- a/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
+++ b/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
@@ -43,10 +43,10 @@ export const metalyticsLogic = kea<metalyticsLogicType>([
                         { scene: currentScene, productKey: 'platform_and_support' },
                         { refresh: 'async' }
                     )
-                    const result = response.results as number[][]
+                    const result = response.results as number[][] | undefined
                     return {
-                        views: result[0][0],
-                        users: result[0][1],
+                        views: result?.[0]?.[0] ?? 0,
+                        users: result?.[0]?.[1] ?? 0,
                     }
                 },
             },
@@ -69,7 +69,7 @@ export const metalyticsLogic = kea<metalyticsLogicType>([
                         { scene: currentScene, productKey: 'platform_and_support' },
                         { refresh: 'async' }
                     )
-                    return response.results.map((result) => result[0]) as string[]
+                    return (response.results?.map((result) => result[0]) ?? []) as string[]
                 },
             },
         ],


### PR DESCRIPTION
## Problem

<img width="1254" height="572" alt="Screenshot 2026-03-24 at 11 52 25" src="https://github.com/user-attachments/assets/5abf56b4-536a-479b-9de1-f435b8e6054d" />

Spike of "Cannot read properties of undefined (reading 'map')" and "Cannot read properties of undefined (reading '0')" exceptions on dashboards since March 23rd.

Timing matches with PR #51939 switching metalytics HogQL queries from `force_blocking` to `async` refresh.
The traces also point to the exception being fired in this file:

> Both errors trace back to a single file:
> src/lib/components/Metalytics/metalyticsLogic.ts
> 
> Line 52, col 47 – recentUsers.loadUsersLast30days → calls .map() on results which is null
> Line 31, col 47 – viewCount.loadViewCount → tries to access .results on a null response

## Changes

- Guard `response.results` with optional chaining and nullish coalescing in `loadViewCount`
- Guard `response.results` with optional chaining and fallback empty array in `loadUsersLast30days`

## How did you test this code?

I can't actually reproduce the error, but the error message points to this and optional chaining can't hurt.

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude. Root-caused by tracing Sentry error spike timing to the `refresh: 'async'` change in #51939.