### PR TITLE
fix(cli,cymbal): create per-UUID ZIP for dSYM uploads

### DIFF
--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -119,10 +119,7 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
             // Format: "UUID: <uuid> (<arch>) <full_path>"
             let path_start = line.rfind(')')? + 2; // Skip ") "
             let dwarf_path = line.get(path_start..)?;
-            let dwarf_filename = Path::new(dwarf_path)
-                .file_name()?
-                .to_str()?
-                .to_string();
+            let dwarf_filename = Path::new(dwarf_path).file_name()?.to_str()?.to_string();
 
             Some((uuid, dwarf_filename))
         })

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -116,7 +116,9 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
             let uuid = uuid_part[..uuid_end].to_uppercase();
 
             // Extract the DWARF filename from the path at end of line
-            let dwarf_path = line.rsplit(' ').next()?;
+            // Format: "UUID: <uuid> (<arch>) <full_path>"
+            let path_start = line.rfind(')')? + 2; // Skip ") "
+            let dwarf_path = line.get(path_start..)?;
             let dwarf_filename = Path::new(dwarf_path)
                 .file_name()?
                 .to_str()?

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::api::symbol_sets::SymbolSetUpload;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
+use posthog_symbol_data::{write_symbol_data, AppleDsym};
 
 pub mod source_bundle;
 pub mod upload;
@@ -13,20 +14,28 @@ pub enum DsymSubcommand {
     Upload(upload::Args),
 }
 
-/// Represents a dSYM bundle ready for upload
+/// A single DWARF binary extracted from a dSYM bundle, ready for upload
+struct DsymEntry {
+    /// The UUID of this DWARF binary (used as chunk_id)
+    uuid: String,
+    /// ZIP containing only this DWARF binary (+ optional source files)
+    data: Vec<u8>,
+}
+
+/// Represents a dSYM bundle ready for upload.
+/// Each DWARF binary in the bundle gets its own ZIP, keyed by its UUID.
 pub struct DsymFile {
-    /// The UUIDs of the dSYM (one per architecture, used as chunk_id for matching)
-    pub uuids: Vec<String>,
-    /// The zipped dSYM bundle data
-    pub data: Vec<u8>,
+    entries: Vec<DsymEntry>,
     /// Optional release ID
     pub release_id: Option<String>,
 }
 
 impl DsymFile {
-    /// Create a new DsymFile from a .dSYM bundle path
+    /// Create a new DsymFile from a .dSYM bundle path.
+    /// Each DWARF binary in the bundle gets its own ZIP so that
+    /// stable UUIDs (e.g. app stubs) don't get a new content hash
+    /// when a sibling binary (e.g. debug dylib) changes.
     pub fn new(path: &PathBuf, include_source: bool) -> Result<Self> {
-        // Validate it's a dSYM bundle
         if !path.is_dir() {
             anyhow::bail!("Path {} is not a directory", path.display());
         }
@@ -39,37 +48,49 @@ impl DsymFile {
             );
         }
 
-        // Extract UUIDs from the dSYM (one per architecture for universal binaries)
-        let uuids = extract_dsym_uuids(path)?;
+        let dwarf_dir = path.join("Contents/Resources/DWARF");
+        let uuid_entries = extract_dsym_uuids(path)?;
 
-        // Zip the dSYM bundle
-        let data = zip_dsym_bundle(path, include_source)?;
+        let mut entries = Vec::new();
+        for (uuid, dwarf_filename) in &uuid_entries {
+            let dwarf_path = dwarf_dir.join(dwarf_filename);
+            let data = zip_dwarf_binary(&dwarf_path, include_source)?;
+            entries.push(DsymEntry {
+                uuid: uuid.clone(),
+                data,
+            });
+        }
 
         Ok(Self {
-            uuids,
-            data,
+            entries,
             release_id: None,
         })
     }
-}
 
-impl DsymFile {
-    /// Convert to SymbolSetUploads (one per UUID/architecture)
+    pub fn uuids(&self) -> Vec<&str> {
+        self.entries.iter().map(|e| e.uuid.as_str()).collect()
+    }
+
+    pub fn total_size(&self) -> usize {
+        self.entries.iter().map(|e| e.data.len()).sum()
+    }
+
+    /// Convert to SymbolSetUploads (one per UUID)
     pub fn into_uploads(self) -> Vec<SymbolSetUpload> {
-        self.uuids
+        self.entries
             .into_iter()
-            .map(|uuid| SymbolSetUpload {
-                chunk_id: uuid,
+            .map(|entry| SymbolSetUpload {
+                chunk_id: entry.uuid,
                 release_id: self.release_id.clone(),
-                data: self.data.clone(),
+                data: entry.data,
             })
             .collect()
     }
 }
 
-/// Extract all UUIDs from a dSYM bundle using dwarfdump
-/// Universal binaries have multiple UUIDs (one per architecture)
-fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<String>> {
+/// Extract all UUIDs and their corresponding DWARF filenames from a dSYM bundle.
+/// Returns (uuid, dwarf_filename) pairs.
+fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
     use std::process::Command;
 
     let output = Command::new("dwarfdump")
@@ -85,22 +106,27 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<String>> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Parse output like: "UUID: 12345678-1234-1234-1234-123456789ABC (arm64) /path/to/file"
-    // Universal binaries have multiple lines, one per architecture
-    let uuids: Vec<String> = stdout
+    // Parse output like: "UUID: 12345678-1234-1234-1234-123456789ABC (arm64) /path/to/DWARF/PostHogExample"
+    let entries: Vec<(String, String)> = stdout
         .lines()
         .filter_map(|line| {
-            line.find("UUID: ").and_then(|uuid_start| {
-                let uuid_part = &line[uuid_start + 6..];
-                uuid_part.find(' ').map(|uuid_end| {
-                    // Uppercase for standard UUID format
-                    uuid_part[..uuid_end].to_uppercase()
-                })
-            })
+            let uuid_start = line.find("UUID: ")? + 6;
+            let uuid_part = &line[uuid_start..];
+            let uuid_end = uuid_part.find(' ')?;
+            let uuid = uuid_part[..uuid_end].to_uppercase();
+
+            // Extract the DWARF filename from the path at end of line
+            let dwarf_path = line.rsplit(' ').next()?;
+            let dwarf_filename = Path::new(dwarf_path)
+                .file_name()?
+                .to_str()?
+                .to_string();
+
+            Some((uuid, dwarf_filename))
         })
         .collect();
 
-    if uuids.is_empty() {
+    if entries.is_empty() {
         anyhow::bail!(
             "Could not extract any UUIDs from dSYM at {}. dwarfdump output: {}",
             dsym_path.display(),
@@ -108,16 +134,19 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<String>> {
         );
     }
 
-    Ok(uuids)
+    Ok(entries)
 }
 
-/// Zip a dSYM bundle into memory, optionally including source files
-fn zip_dsym_bundle(dsym_path: &PathBuf, include_source: bool) -> Result<Vec<u8>> {
+/// Create a minimal ZIP containing a single DWARF binary and optional source files.
+/// The ZIP layout is:
+///   dwarf                    — the raw DWARF Mach-O binary
+///   __source/manifest.json   — (optional) source file manifest
+///   __source/...             — (optional) source files
+fn zip_dwarf_binary(dwarf_path: &Path, include_source: bool) -> Result<Vec<u8>> {
     use std::fs::File;
     use std::io::Read;
     use std::io::{Cursor, Write};
     use tracing::info;
-    use walkdir::WalkDir;
 
     let mut buffer = Cursor::new(Vec::new());
 
@@ -126,34 +155,16 @@ fn zip_dsym_bundle(dsym_path: &PathBuf, include_source: bool) -> Result<Vec<u8>>
         let options = zip::write::SimpleFileOptions::default()
             .compression_method(zip::CompressionMethod::Deflated);
 
-        // Collect and sort entries for deterministic zip output
-        let mut entries: Vec<_> = WalkDir::new(dsym_path)
-            .into_iter()
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        entries.sort_by(|a, b| a.path().cmp(b.path()));
+        // Add the DWARF binary as "dwarf"
+        zip.start_file("dwarf", options)?;
+        let mut file = File::open(dwarf_path)?;
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents)?;
+        zip.write_all(&contents)?;
 
-        for entry in &entries {
-            let path = entry.path();
-
-            // Create relative path within the zip
-            let relative_path = path.strip_prefix(dsym_path.parent().unwrap_or(dsym_path))?;
-            let zip_path = relative_path.to_string_lossy();
-
-            if path.is_file() {
-                zip.start_file(zip_path.to_string(), options)?;
-                let mut file = File::open(path)?;
-                let mut contents = Vec::new();
-                file.read_to_end(&mut contents)?;
-                zip.write_all(&contents)?;
-            } else if path.is_dir() && path != dsym_path.as_path() {
-                // Add directory entry (but not the root)
-                zip.add_directory(format!("{zip_path}/"), options)?;
-            }
-        }
-
-        // Optionally include source files referenced by DWARF debug info
+        // Optionally include source files referenced by this DWARF binary
         if include_source {
-            match source_bundle::extract_dwarf_source_paths(dsym_path) {
+            match source_bundle::extract_source_paths_from_dwarf(dwarf_path) {
                 Ok(all_paths) => {
                     let filtered = source_bundle::filter_source_paths(&all_paths);
                     info!(
@@ -185,7 +196,9 @@ fn zip_dsym_bundle(dsym_path: &PathBuf, include_source: bool) -> Result<Vec<u8>>
         zip.finish()?;
     }
 
-    Ok(buffer.into_inner())
+    let zip_data = buffer.into_inner();
+    let wrapped = write_symbol_data(AppleDsym { data: zip_data })?;
+    Ok(wrapped)
 }
 
 /// Find all dSYM bundles in a directory

--- a/cli/src/dsym/source_bundle.rs
+++ b/cli/src/dsym/source_bundle.rs
@@ -23,24 +23,9 @@ pub struct SourceFiles {
     pub contents: BTreeMap<String, Vec<u8>>,
 }
 
-/// Extract all source file paths referenced in DWARF debug info from a dSYM bundle.
-///
-/// Finds the DWARF binary at `<dSYM>/Contents/Resources/DWARF/<name>`,
-/// parses it with `symbolic`, and collects all referenced source file paths.
-pub fn extract_dwarf_source_paths(dsym_path: &Path) -> Result<Vec<String>> {
-    let dwarf_dir = dsym_path.join("Contents/Resources/DWARF");
-
-    if !dwarf_dir.is_dir() {
-        anyhow::bail!("DWARF directory not found at {}", dwarf_dir.display());
-    }
-
-    // Find the DWARF binary (there's typically one file in this directory)
-    let dwarf_binary = fs::read_dir(&dwarf_dir)?
-        .filter_map(|e| e.ok())
-        .find(|e| e.path().is_file())
-        .ok_or_else(|| anyhow::anyhow!("No DWARF binary found in {}", dwarf_dir.display()))?;
-
-    let dwarf_data = fs::read(dwarf_binary.path())?;
+/// Extract all source file paths referenced in a DWARF binary file.
+pub fn extract_source_paths_from_dwarf(dwarf_path: &Path) -> Result<Vec<String>> {
+    let dwarf_data = fs::read(dwarf_path)?;
     let archive = Archive::parse(&dwarf_data)?;
 
     let mut paths = Vec::new();

--- a/cli/src/dsym/upload.rs
+++ b/cli/src/dsym/upload.rs
@@ -186,10 +186,10 @@ pub fn upload(args: &Args) -> Result<()> {
                 dsym_file.release_id = release_id.clone();
                 info!(
                     "  UUIDs: {} ({})",
-                    dsym_file.uuids.join(", "),
-                    dsym_file.uuids.len()
+                    dsym_file.uuids().join(", "),
+                    dsym_file.uuids().len()
                 );
-                info!("  Size: {} bytes", dsym_file.data.len());
+                info!("  Total size: {} bytes", dsym_file.total_size());
 
                 uploads.extend(dsym_file.into_uploads());
             }

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -63,17 +63,10 @@ impl Parser for AppleProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<ParsedAppleSymbols, ResolveError> {
-        // Try to unwrap symbol_data container first (new format),
-        // fall back to raw ZIP for backward compatibility with existing uploads
-        let (zip_data, decompressed_bytes) =
-            match read_symbol_data_with_byte_count::<AppleDsym>(source.clone()) {
-                Ok((dsym, bytes)) => (dsym.data, bytes),
-                Err(_) => {
-                    let len = source.len();
-                    (source, len)
-                }
-            };
-        ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
+        let (dsym, decompressed_bytes) =
+            read_symbol_data_with_byte_count::<AppleDsym>(source)
+                .map_err(|e| AppleError::ParseError(e.to_string()))?;
+        ParsedAppleSymbols::from_dsym_zip(dsym.data, decompressed_bytes)
     }
 }
 
@@ -142,19 +135,12 @@ impl ParsedAppleSymbols {
     fn extract_dwarf_from_zip(
         archive: &mut ZipArchive<Cursor<Vec<u8>>>,
     ) -> Result<Vec<u8>, ResolveError> {
-        for i in 0..archive.len() {
-            let mut file = archive
-                .by_index(i)
+        // New format: single DWARF binary stored as "dwarf" at root level
+        if let Ok(mut file) = archive.by_name("dwarf") {
+            let mut data = Vec::new();
+            file.read_to_end(&mut data)
                 .map_err(|e| AppleError::ParseError(e.to_string()))?;
-
-            let name = file.name().to_string();
-
-            if name.contains("/Contents/Resources/DWARF/") && !name.ends_with('/') {
-                let mut data = Vec::new();
-                file.read_to_end(&mut data)
-                    .map_err(|e| AppleError::ParseError(e.to_string()))?;
-                return Ok(data);
-            }
+            return Ok(data);
         }
 
         Err(AppleError::ParseError("No DWARF file found in dSYM bundle".to_string()).into())

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -63,10 +63,18 @@ impl Parser for AppleProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<ParsedAppleSymbols, ResolveError> {
-        let (dsym, decompressed_bytes) =
-            read_symbol_data_with_byte_count::<AppleDsym>(source)
-                .map_err(|e| AppleError::ParseError(e.to_string()))?;
-        ParsedAppleSymbols::from_dsym_zip(dsym.data, decompressed_bytes)
+        // Try to unwrap symbol_data container first (new format),
+        // fall back to raw ZIP for backward compatibility with existing uploads.
+        // TODO(2026-09-24): Remove raw ZIP fallback once all old uploads have expired.
+        let (zip_data, decompressed_bytes) =
+            match read_symbol_data_with_byte_count::<AppleDsym>(source.clone()) {
+                Ok((dsym, bytes)) => (dsym.data, bytes),
+                Err(_) => {
+                    let len = source.len();
+                    (source, len)
+                }
+            };
+        ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
     }
 }
 
@@ -141,6 +149,23 @@ impl ParsedAppleSymbols {
             file.read_to_end(&mut data)
                 .map_err(|e| AppleError::ParseError(e.to_string()))?;
             return Ok(data);
+        }
+
+        // Old format: full dSYM bundle with Contents/Resources/DWARF/<name>
+        // TODO(2026-09-24): Remove this fallback once all old uploads have expired.
+        for i in 0..archive.len() {
+            let mut file = archive
+                .by_index(i)
+                .map_err(|e| AppleError::ParseError(e.to_string()))?;
+
+            let name = file.name().to_string();
+
+            if name.contains("/Contents/Resources/DWARF/") && !name.ends_with('/') {
+                let mut data = Vec::new();
+                file.read_to_end(&mut data)
+                    .map_err(|e| AppleError::ParseError(e.to_string()))?;
+                return Ok(data);
+            }
         }
 
         Err(AppleError::ParseError("No DWARF file found in dSYM bundle".to_string()).into())


### PR DESCRIPTION
## Problem

When a dSYM bundle contains multiple DWARF binaries (e.g. an Xcode debug dylib + app stub), the CLI zipped the entire bundle and shared that same blob across all UUIDs. On incremental rebuilds, stable UUIDs (like the app stub loader) got a new content hash whenever a sibling binary changed, causing `content_hash_mismatch` errors from the server.

## Changes

- **CLI (`cli/src/dsym/`)**: Each UUID now gets its own ZIP containing only its DWARF binary (+ optional source files), wrapped in the `symbol_data` container with Zstd compression. No more shared blob across UUIDs.
- **Cymbal (`rust/cymbal/src/symbol_store/apple.rs`)**: Updated to parse the new format — looks for a root-level `dwarf` file instead of scanning `Contents/Resources/DWARF/`. Removed raw ZIP fallback (requires `symbol_data` container).

**Breaking changes:**
- Existing symbol sets uploaded with the old format will need to be re-uploaded
- Cymbal no longer falls back to raw ZIP

## How did you test this code?

Tested by building the PostHog iOS example app and uploading dSYMs end-to-end:
1. First upload succeeded (3 symbol sets uploaded)
2. Made a source code string change, rebuilt, uploaded again — no `content_hash_mismatch` (1 new UUID uploaded, 2 skipped as already present with matching hash)

Manual verification still needed:
- Cymbal symbolicating crash frames using the new format
- Source bundling (`--include-source`) with per-UUID ZIPs

## Publish to changelog?

no