### PR TITLE
fix(insights): fix global filters reappearing in insights

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -262,7 +262,7 @@ describe('insightNavLogic', () => {
             })
 
             it('does not restore removed global filters when switching insight types', async () => {
-                const trendsQueryWithGlobalFilters: InsightVizNode = {
+                const trendsQueryWithGlobalFilters: InsightVizNode<TrendsQuery> = {
                     kind: NodeKind.InsightVizNode,
                     source: {
                         kind: NodeKind.TrendsQuery,
@@ -299,7 +299,7 @@ describe('insightNavLogic', () => {
                 })
 
                 await expectLogic(logic, () => {
-                    const trendsQueryWithoutGlobalFilters: InsightVizNode = {
+                    const trendsQueryWithoutGlobalFilters: InsightVizNode<TrendsQuery> = {
                         ...trendsQueryWithGlobalFilters,
                         source: {
                             ...trendsQueryWithGlobalFilters.source,

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -16,6 +16,8 @@ import {
     InsightLogicProps,
     InsightShortId,
     InsightType,
+    PropertyFilterType,
+    PropertyOperator,
     QueryBasedInsightModel,
     StepOrderValue,
 } from '~/types'
@@ -257,6 +259,107 @@ describe('insightNavLogic', () => {
                         },
                     } as Node),
                 ])
+            })
+
+            it('does not restore removed global filters when switching insight types', async () => {
+                const trendsQueryWithGlobalFilters: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        properties: [
+                            {
+                                key: '$browser',
+                                type: PropertyFilterType.Event,
+                                value: 'Chrome',
+                                operator: PropertyOperator.Exact,
+                            },
+                        ],
+                        trendsFilter: { showValuesOnSeries: true },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsQueryWithGlobalFilters)
+                }).toMatchValues({
+                    queryPropertyCache: expect.objectContaining({
+                        properties: [
+                            expect.objectContaining({
+                                key: '$browser',
+                                value: 'Chrome',
+                            }),
+                        ],
+                    }),
+                })
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery({
+                        ...trendsQueryWithGlobalFilters,
+                        source: {
+                            ...trendsQueryWithGlobalFilters.source,
+                            properties: undefined,
+                        },
+                    })
+                }).toMatchValues({
+                    queryPropertyCache: expect.not.objectContaining({
+                        properties: expect.anything(),
+                    }),
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                expect((builtInsightDataLogic.values.query as InsightVizNode).source).not.toMatchObject({
+                    properties: expect.anything(),
+                })
+            })
+
+            it('keeps trends-only filters when switching away and back', async () => {
+                const trendsQueryWithTrendLine: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        trendsFilter: {
+                            showTrendLines: true,
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsQueryWithTrendLine)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: 'InsightVizNode',
+                    source: {
+                        kind: 'TrendsQuery',
+                        trendsFilter: expect.objectContaining({
+                            showTrendLines: true,
+                        }),
+                    },
+                })
             })
 
             it('gets rid of minute when leaving trends', async () => {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -299,13 +299,15 @@ describe('insightNavLogic', () => {
                 })
 
                 await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery({
+                    const trendsQueryWithoutGlobalFilters: InsightVizNode = {
                         ...trendsQueryWithGlobalFilters,
                         source: {
                             ...trendsQueryWithGlobalFilters.source,
                             properties: undefined,
                         },
-                    })
+                    }
+
+                    builtInsightDataLogic.actions.setQuery(trendsQueryWithoutGlobalFilters)
                 }).toMatchValues({
                     queryPropertyCache: expect.not.objectContaining({
                         properties: expect.anything(),

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -364,8 +364,7 @@ const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyC
     const newCache = JSON.parse(JSON.stringify(query)) as QueryPropertyCache
 
     // Preserve explicit removals for global filters when merging with the existing cache.
-    newCache.properties =
-        query.properties === undefined ? undefined : JSON.parse(JSON.stringify(query.properties))
+    newCache.properties = query.properties === undefined ? undefined : JSON.parse(JSON.stringify(query.properties))
 
     // // set series (first two entries) from retention target and returning entity
     // if (isRetentionQuery(query)) {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -364,7 +364,8 @@ const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyC
     const newCache = JSON.parse(JSON.stringify(query)) as QueryPropertyCache
 
     // Preserve explicit removals for global filters when merging with the existing cache.
-    newCache.properties = query.properties
+    newCache.properties =
+        query.properties === undefined ? undefined : JSON.parse(JSON.stringify(query.properties))
 
     // // set series (first two entries) from retention target and returning entity
     // if (isRetentionQuery(query)) {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -363,6 +363,9 @@ export const insightNavLogic = kea<insightNavLogicType>([
 const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyCache | null): QueryPropertyCache => {
     const newCache = JSON.parse(JSON.stringify(query)) as QueryPropertyCache
 
+    // Preserve explicit removals for global filters when merging with the existing cache.
+    newCache.properties = query.properties
+
     // // set series (first two entries) from retention target and returning entity
     // if (isRetentionQuery(query)) {
     //     const { targetEntity, returningEntity } = query.retentionFilter || {}


### PR DESCRIPTION
## Problem

1. Create a new trends insight and add a global property filter
2. Switch to a stickiness insight and remove the global property filter there
3. Go back to trends insight and observe that the filter reappears

## Changes

Preserves the removed properties

## How did you test this code?

Verified that:
- Doing the above results in the filter not reappering
- Adding a global property filter still carries over to other insights
- Other changed settings also carry over