### PR TITLE
fix(sessions): use range-based chunking for distinct_id in experimental backfill

### DIFF
--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -450,9 +450,12 @@ def _get_experimental_chunking(config: ExperimentalSessionsBackfillConfig) -> tu
 
         def distinct_id_range(i: int) -> str:
             low = i * chunk_size
+            high = (i + 1) * chunk_size
+            if i == 0:
+                return f"cityHash64(distinct_id) < {high}"
             if i == num_chunks - 1:
                 return f"cityHash64(distinct_id) >= {low}"
-            return f"cityHash64(distinct_id) >= {low} AND cityHash64(distinct_id) < {(i + 1) * chunk_size}"
+            return f"cityHash64(distinct_id) >= {low} AND cityHash64(distinct_id) < {high}"
 
         return num_chunks, "cityHash64(distinct_id) range", distinct_id_range
     else:

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -502,8 +502,9 @@ def _do_experimental_backfill(
                 wait_for_parts_to_merge(context, config, sync_client=client, table=target_table, use_cluster=False)
 
                 if num_chunks > 1:
-                    chunk_where_clause = f"({where_clause}) AND {chunk_where_fn(chunk_i)}"
-                    context.log.info(f"Processing chunk {chunk_i + 1}/{num_chunks} ({chunk_where_fn(chunk_i)})")
+                    chunk_condition = chunk_where_fn(chunk_i)
+                    chunk_where_clause = f"({where_clause}) AND {chunk_condition}"
+                    context.log.info(f"Processing chunk {chunk_i + 1}/{num_chunks} ({chunk_condition})")
                 else:
                     chunk_where_clause = where_clause
 

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -422,12 +422,15 @@ experimental_sessions_backfill_job = define_asset_job(
 )
 
 
-def _get_experimental_chunking(config: ExperimentalSessionsBackfillConfig) -> tuple[int, str]:
-    """Return (num_chunks, chunk_expression) for the experimental backfill.
+def _get_experimental_chunking(config: ExperimentalSessionsBackfillConfig) -> tuple[int, str, Callable[[int], str]]:
+    """Return (num_chunks, description, chunk_where_fn) for the experimental backfill.
+
+    chunk_where_fn(chunk_i) returns a SQL condition string for that chunk.
 
     Supports two mutually exclusive chunking strategies:
     - team_id_chunks: splits by team_id % N (can be uneven for large teams)
-    - distinct_id_chunks: splits by cityHash64(distinct_id) % N (more even distribution)
+    - distinct_id_chunks: splits by cityHash64(distinct_id) range — uses contiguous
+      ranges instead of modulo so ClickHouse can skip granules via the primary index
 
     Raises ValueError if both are specified.
     """
@@ -439,12 +442,21 @@ def _get_experimental_chunking(config: ExperimentalSessionsBackfillConfig) -> tu
 
     if has_team:
         num_chunks = max(1, config.team_id_chunks or 1)
-        return num_chunks, "team_id"
+        return num_chunks, "team_id", lambda i: f"team_id % {num_chunks} = {i}"
     elif has_distinct:
         num_chunks = max(1, config.distinct_id_chunks or 1)
-        return num_chunks, "cityHash64(distinct_id)"
+        max_uint64 = 2**64
+        chunk_size = max_uint64 // num_chunks
+
+        def distinct_id_range(i: int) -> str:
+            low = i * chunk_size
+            if i == num_chunks - 1:
+                return f"cityHash64(distinct_id) >= {low}"
+            return f"cityHash64(distinct_id) >= {low} AND cityHash64(distinct_id) < {(i + 1) * chunk_size}"
+
+        return num_chunks, "cityHash64(distinct_id) range", distinct_id_range
     else:
-        return 1, "team_id"
+        return 1, "team_id", lambda i: "1"
 
 
 def _do_experimental_backfill(
@@ -466,11 +478,11 @@ def _do_experimental_backfill(
         merged_settings.update(config.clickhouse_settings)
         context.log.info(f"Using custom ClickHouse settings: {config.clickhouse_settings}")
 
-    num_chunks, chunk_expr = _get_experimental_chunking(config)
+    num_chunks, chunk_desc, chunk_where_fn = _get_experimental_chunking(config)
 
     context.log.info(
         f"Running backfill for Dagster partitions {partition_range_str} "
-        f"(where='{where_clause}', chunking={num_chunks} chunks on {chunk_expr}) "
+        f"(where='{where_clause}', chunking={num_chunks} chunks on {chunk_desc}) "
         f"using commit {get_git_commit_short() or 'unknown'}"
     )
     if debug_url := metabase_debug_query_url(context.run_id):
@@ -490,10 +502,8 @@ def _do_experimental_backfill(
                 wait_for_parts_to_merge(context, config, sync_client=client, table=target_table, use_cluster=False)
 
                 if num_chunks > 1:
-                    chunk_where_clause = f"({where_clause}) AND {chunk_expr} % {num_chunks} = {chunk_i}"
-                    context.log.info(
-                        f"Processing chunk {chunk_i + 1}/{num_chunks} ({chunk_expr} % {num_chunks} = {chunk_i})"
-                    )
+                    chunk_where_clause = f"({where_clause}) AND {chunk_where_fn(chunk_i)}"
+                    context.log.info(f"Processing chunk {chunk_i + 1}/{num_chunks} ({chunk_where_fn(chunk_i)})")
                 else:
                     chunk_where_clause = where_clause
 

--- a/posthog/dags/tests/__snapshots__/test_sessions.ambr
+++ b/posthog/dags/tests/__snapshots__/test_sessions.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestExperimentalBackfillChunking.test_chunking_sql[distinct_id_chunks]
   list([
-    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 0 AND cityHash64(distinct_id) < 4611686018427387904",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) < 4611686018427387904",
     "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 4611686018427387904 AND cityHash64(distinct_id) < 9223372036854775808",
     "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 9223372036854775808 AND cityHash64(distinct_id) < 13835058055282163712",
     "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 13835058055282163712",

--- a/posthog/dags/tests/__snapshots__/test_sessions.ambr
+++ b/posthog/dags/tests/__snapshots__/test_sessions.ambr
@@ -1,10 +1,10 @@
 # serializer version: 1
 # name: TestExperimentalBackfillChunking.test_chunking_sql[distinct_id_chunks]
   list([
-    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 0",
-    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 1",
-    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 2",
-    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) % 4 = 3",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 0 AND cityHash64(distinct_id) < 4611686018427387904",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 4611686018427387904 AND cityHash64(distinct_id) < 9223372036854775808",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 9223372036854775808 AND cityHash64(distinct_id) < 13835058055282163712",
+    "INSERT INTO raw_sessions_v3 SELECT ... WHERE ('2025-06-15' <= timestamp AND timestamp <= '2025-06-16') AND cityHash64(distinct_id) >= 13835058055282163712",
   ])
 # ---
 # name: TestExperimentalBackfillChunking.test_chunking_sql[no_chunks]


### PR DESCRIPTION
## Problem

The experimental sessions backfill chunks events by `cityHash64(distinct_id) % N`, but the events table ORDER BY includes `cityHash64(distinct_id)` as a sorted column:

```sql
ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
```

With modulo, matching values are uniformly scattered across the entire UInt64 range, so ClickHouse cannot use the primary index to skip granules — every chunk reads essentially all the data and filters at scan time. With 64 chunks this means ~64x total I/O over the source table.

## Changes

Switches `distinct_id_chunks` from modulo to contiguous range-based chunking. Each chunk now targets a contiguous slice of the `cityHash64(distinct_id)` space (e.g. `>= low AND < high`), which aligns with the physical sort order so ClickHouse can skip granules outside the range. Each chunk reads ~1/Nth of the data instead of all of it.

`team_id_chunks` is left as modulo — we don't know the distribution of rows across teams.

## How did you test this code?

Existing snapshot tests updated and passing — they confirm the generated SQL uses range predicates for `distinct_id_chunks` and still uses modulo for `team_id_chunks`.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code (Opus). The idea and rationale came from a discussion about ClickHouse granule skipping efficiency.