### PR TITLE
fix(visual-review): match oxfmt 4-space indent in baseline YAML

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -744,7 +744,7 @@ def _build_snapshots_yaml(
         "snapshots": sorted_snapshots,
     }
 
-    return yaml.dump(data, default_flow_style=False, sort_keys=False)
+    return yaml.dump(data, default_flow_style=False, sort_keys=False, indent=4)
 
 
 def _post_commit_status(


### PR DESCRIPTION
PyYAML defaults to 2-space indent but oxfmt enforces 4-space on YAML files. The auto-approve endpoint writes baselines that fail the oxfmt check on the next CI run. One-line fix: `indent=4` on `yaml.dump`.