### PR TITLE
chore(CODEOWNERS): add ownership for logs, metrics and tracing products to @PostHog/logs

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -180,7 +180,7 @@ posthog/temporal/data_modeling/** @PostHog/team-data-modeling
 # and also hard owned by the @PostHog/hogql on `CODEOWNERS` file
 posthog/hogql/\*\* @PostHog/team-data-tools
 
-# Logs - owned by @PostHog/logs
+# Logs/Metrics/Tracing - owned by @PostHog/logs
 products/logs/** @PostHog/logs
 products/tracing/** @PostHog/logs
 products/metrics/** @PostHog/logs

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -180,6 +180,11 @@ posthog/temporal/data_modeling/** @PostHog/team-data-modeling
 # and also hard owned by the @PostHog/hogql on `CODEOWNERS` file
 posthog/hogql/\*\* @PostHog/team-data-tools
 
+# Logs - owned by @PostHog/logs
+products/logs/** @PostHog/logs
+products/tracing/** @PostHog/logs
+products/metrics/** @PostHog/logs
+
 # Error Tracking - owned by @PostHog/team-error-tracking
 products/error_tracking/backend/** @PostHog/team-error-tracking
 products/error_tracking/frontend/** @PostHog/team-error-tracking


### PR DESCRIPTION
## Problem

Team logs needs to be tagged on PRs concerning APM stuff

## Changes

Added code ownership rules for the PostHog/logs team covering:

- `products/logs/**`
- `products/tracing/**`
- `products/metrics/**`

## How did you test this code?

This is a configuration change to the CODEOWNERS-soft file that assigns team ownership. No functional testing is required as this only affects GitHub's code review assignment behavior.

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No