### PR TITLE
feat: add product animations component library with sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ junit.xml
 
 # Downloaded GitHub issues for signals
 products/signals/backend/github_issues/
+.planning/

--- a/frontend/src/lib/components/ProductAnimations/ProductAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/ProductAnimation.tsx
@@ -1,0 +1,85 @@
+import { LazyMotion, domAnimation } from 'motion/react'
+import { Suspense, lazy, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { AnimationCanvas } from './primitives/AnimationCanvas'
+import { HedgehogCharacter } from './primitives/HedgehogCharacter'
+import { useAnimationMode } from './primitives/useAnimationMode'
+import { animationRegistry } from './registry'
+import type { AnimationMode, ProductAnimationProps } from './types'
+
+function StaticFallback({ size }: { size: 'small' | 'medium' | 'large' }): JSX.Element {
+    return (
+        <AnimationCanvas size={size}>
+            <HedgehogCharacter pose="standing" expression="happy" />
+        </AnimationCanvas>
+    )
+}
+
+/** Hook: pause looping animations when off-screen (INFR-05) */
+function useVisibilityPause(ref: React.RefObject<HTMLDivElement | null>): boolean {
+    const [isVisible, setIsVisible] = useState(true)
+
+    useEffect(() => {
+        const el = ref.current
+        if (!el) {
+            return
+        }
+        const observer = new IntersectionObserver(([entry]) => setIsVisible(entry.isIntersecting), { threshold: 0.1 })
+        observer.observe(el)
+        return () => observer.disconnect()
+    }, [ref])
+
+    return isVisible
+}
+
+function ProductAnimationInner({
+    product,
+    size = 'medium',
+    mode = 'loop',
+    className,
+    hover,
+}: ProductAnimationProps & { hover?: boolean }): JSX.Element {
+    const { shouldAnimate, resolvedMode } = useAnimationMode(mode)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const isVisible = useVisibilityPause(containerRef)
+    const [isHovered, setIsHovered] = useState(false)
+
+    const AnimationComponent = useMemo(() => {
+        const loader = animationRegistry[product] ?? animationRegistry._fallback
+        return lazy(loader)
+    }, [product])
+
+    // Determine effective mode considering hover, visibility, and reduced motion
+    const effectiveMode = useMemo((): AnimationMode | 'static' => {
+        if (!shouldAnimate) {
+            return 'static'
+        }
+        if (hover && !isHovered) {
+            return 'static'
+        }
+        if (!isVisible && resolvedMode === 'loop') {
+            return 'static'
+        }
+        return resolvedMode
+    }, [shouldAnimate, hover, isHovered, isVisible, resolvedMode])
+
+    const handleMouseEnter = useCallback((): void => setIsHovered(true), [])
+    const handleMouseLeave = useCallback((): void => setIsHovered(false), [])
+
+    return (
+        <div
+            ref={containerRef}
+            className={className}
+            onMouseEnter={hover ? handleMouseEnter : undefined}
+            onMouseLeave={hover ? handleMouseLeave : undefined}
+        >
+            <LazyMotion features={domAnimation} strict>
+                <Suspense fallback={<StaticFallback size={size} />}>
+                    <AnimationComponent size={size} mode={effectiveMode} />
+                </Suspense>
+            </LazyMotion>
+        </div>
+    )
+}
+
+export const ProductAnimation = memo(ProductAnimationInner)

--- a/frontend/src/lib/components/ProductAnimations/animations/DataPipelinesAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/DataPipelinesAnimation.tsx
@@ -1,0 +1,136 @@
+/**
+ * Data pipelines: Hedgehog directs data flow through connected pipes.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { PipeSegment } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function DataPipelinesAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    {/* Pipeline structure */}
+                    <PipeSegment x1={20} y1={60} x2={80} y2={60} />
+                    <PipeSegment x1={80} y1={60} x2={80} y2={100} />
+                    <PipeSegment x1={80} y1={100} x2={160} y2={100} />
+                    <PipeSegment x1={160} y1={100} x2={160} y2={140} />
+                    <PipeSegment x1={160} y1={140} x2={190} y2={140} />
+                    {/* Data dots along pipe */}
+                    <circle cx="50" cy="60" r="4" fill="var(--hog-belly)" stroke="var(--hog-body)" strokeWidth="1.5" />
+                    <circle
+                        cx="120"
+                        cy="100"
+                        r="4"
+                        fill="var(--hog-belly)"
+                        stroke="var(--hog-body)"
+                        strokeWidth="1.5"
+                    />
+                    <circle
+                        cx="175"
+                        cy="140"
+                        r="4"
+                        fill="var(--hog-belly)"
+                        stroke="var(--hog-body)"
+                        strokeWidth="1.5"
+                    />
+                    <g transform="translate(-15, 45) scale(0.42)">
+                        <HedgehogCharacter pose="standing" expression="happy" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Pipes draw in */}
+                    <m.line
+                        x1={20}
+                        y1={60}
+                        x2={80}
+                        y2={60}
+                        stroke="var(--hog-body)"
+                        strokeWidth="6"
+                        strokeLinecap="round"
+                        opacity="0.6"
+                        initial={{ pathLength: 0 }}
+                        animate={{ pathLength: 1 }}
+                        transition={{ duration: 0.5 }}
+                    />
+                    <m.line
+                        x1={80}
+                        y1={60}
+                        x2={80}
+                        y2={100}
+                        stroke="var(--hog-body)"
+                        strokeWidth="6"
+                        strokeLinecap="round"
+                        opacity="0.6"
+                        initial={{ pathLength: 0 }}
+                        animate={{ pathLength: 1 }}
+                        transition={{ delay: 0.4, duration: 0.4 }}
+                    />
+                    <m.line
+                        x1={80}
+                        y1={100}
+                        x2={160}
+                        y2={100}
+                        stroke="var(--hog-body)"
+                        strokeWidth="6"
+                        strokeLinecap="round"
+                        opacity="0.6"
+                        initial={{ pathLength: 0 }}
+                        animate={{ pathLength: 1 }}
+                        transition={{ delay: 0.7, duration: 0.5 }}
+                    />
+                    <m.line
+                        x1={160}
+                        y1={100}
+                        x2={160}
+                        y2={140}
+                        stroke="var(--hog-body)"
+                        strokeWidth="6"
+                        strokeLinecap="round"
+                        opacity="0.6"
+                        initial={{ pathLength: 0 }}
+                        animate={{ pathLength: 1 }}
+                        transition={{ delay: 1.1, duration: 0.3 }}
+                    />
+                    <m.line
+                        x1={160}
+                        y1={140}
+                        x2={190}
+                        y2={140}
+                        stroke="var(--hog-body)"
+                        strokeWidth="6"
+                        strokeLinecap="round"
+                        opacity="0.6"
+                        initial={{ pathLength: 0 }}
+                        animate={{ pathLength: 1 }}
+                        transition={{ delay: 1.3, duration: 0.3 }}
+                    />
+                    {/* Data dots flow through */}
+                    <m.circle
+                        r="4"
+                        fill="var(--hog-belly)"
+                        stroke="var(--hog-body)"
+                        strokeWidth="1.5"
+                        animate={{ cx: [20, 80, 80, 160, 160, 190], cy: [60, 60, 100, 100, 140, 140] }}
+                        transition={{ duration: 3, repeat: Infinity, ease: 'linear', delay: 1.5 }}
+                    />
+                    {/* Hedgehog directing */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-15, 45) scale(0.42)">
+                            <HedgehogCharacter pose="standing" expression="happy" />
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default DataPipelinesAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/DataWarehouseAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/DataWarehouseAnimation.tsx
@@ -1,0 +1,96 @@
+/**
+ * Data warehouse: Hedgehog organizes data into shelves/boxes.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { DataBox } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function DataWarehouseAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    {/* Shelves */}
+                    <line
+                        x1="60"
+                        y1="60"
+                        x2="180"
+                        y2="60"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1.5"
+                        opacity="0.3"
+                    />
+                    <line
+                        x1="60"
+                        y1="100"
+                        x2="180"
+                        y2="100"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1.5"
+                        opacity="0.3"
+                    />
+                    <line
+                        x1="60"
+                        y1="140"
+                        x2="180"
+                        y2="140"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1.5"
+                        opacity="0.3"
+                    />
+                    {/* Data boxes on shelves */}
+                    <DataBox x={70} y={35} />
+                    <DataBox x={110} y={35} />
+                    <DataBox x={150} y={35} />
+                    <DataBox x={80} y={75} />
+                    <DataBox x={130} y={75} />
+                    <DataBox x={90} y={115} />
+                    <g transform="translate(-30, 40) scale(0.42)">
+                        <HedgehogCharacter pose="standing" expression="focused" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Shelves fade in */}
+                    <m.g initial={{ opacity: 0 }} animate={{ opacity: 0.3 }} transition={{ duration: 0.5 }}>
+                        <line x1="60" y1="60" x2="180" y2="60" stroke="var(--hog-outline)" strokeWidth="1.5" />
+                        <line x1="60" y1="100" x2="180" y2="100" stroke="var(--hog-outline)" strokeWidth="1.5" />
+                        <line x1="60" y1="140" x2="180" y2="140" stroke="var(--hog-outline)" strokeWidth="1.5" />
+                    </m.g>
+                    {/* Boxes slide in staggered */}
+                    {[
+                        { x: 70, y: 35, delay: 0.3 },
+                        { x: 110, y: 35, delay: 0.5 },
+                        { x: 150, y: 35, delay: 0.7 },
+                        { x: 80, y: 75, delay: 0.9 },
+                        { x: 130, y: 75, delay: 1.1 },
+                        { x: 90, y: 115, delay: 1.3 },
+                    ].map((box, i) => (
+                        <m.g
+                            key={i}
+                            initial={{ y: -20, opacity: 0 }}
+                            animate={{ y: 0, opacity: 1 }}
+                            transition={{ delay: box.delay, duration: 0.4, type: 'spring', damping: 15 }}
+                        >
+                            <DataBox x={box.x} y={box.y} />
+                        </m.g>
+                    ))}
+                    {/* Hedgehog organizing */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-30, 40) scale(0.42)">
+                            <HedgehogCharacter pose="standing" expression="focused" />
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default DataWarehouseAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/ErrorTrackingAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/ErrorTrackingAnimation.tsx
@@ -1,0 +1,78 @@
+/**
+ * Error tracking: Hedgehog spots a bug, catches it with a net.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { BugIcon } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function ErrorTrackingAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <BugIcon x={140} y={50} />
+                    {/* Net */}
+                    <ellipse
+                        cx="145"
+                        cy="55"
+                        rx="18"
+                        ry="14"
+                        fill="none"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1.5"
+                        strokeDasharray="3 2"
+                    />
+                    <g transform="translate(-25, 35) scale(0.45)">
+                        <HedgehogCharacter pose="standing" expression="surprised" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Bug bouncing around */}
+                    <m.g
+                        animate={{
+                            x: [0, 20, -10, 30, 0],
+                            y: [0, -15, 10, -5, 0],
+                        }}
+                        transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+                    >
+                        <BugIcon x={130} y={50} />
+                    </m.g>
+                    {/* Net swoops in */}
+                    <m.ellipse
+                        cx="145"
+                        cy="55"
+                        rx="18"
+                        ry="14"
+                        fill="none"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1.5"
+                        strokeDasharray="3 2"
+                        initial={{ scale: 0, opacity: 0 }}
+                        animate={{ scale: [0, 1.2, 1], opacity: [0, 1, 1] }}
+                        transition={{ delay: 1.5, duration: 0.5 }}
+                    />
+                    {/* Hedgehog alert then catching */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-25, 35) scale(0.45)">
+                            <m.g
+                                animate={{ x: [0, 5, 0] }}
+                                transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+                            >
+                                <HedgehogCharacter pose="standing" expression="surprised" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default ErrorTrackingAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/ExperimentsAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/ExperimentsAnimation.tsx
@@ -1,0 +1,94 @@
+/**
+ * Experiments: Hedgehog compares A/B variants side by side, picks winner.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { ABLabel } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function ExperimentsAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <ABLabel variant="A" x={30} y={25} />
+                    <ABLabel variant="B" x={146} y={25} />
+                    {/* Result bars */}
+                    <rect x="30" y="55" width="24" height="60" rx="3" fill="var(--hog-body)" opacity="0.5" />
+                    <rect x="146" y="35" width="24" height="80" rx="3" fill="var(--hog-cheek)" opacity="0.6" />
+                    {/* Crown on B */}
+                    <text x="158" y="28" textAnchor="middle" fontSize="16">
+                        👑
+                    </text>
+                    <g transform="translate(-10, 45) scale(0.4)">
+                        <HedgehogCharacter pose="standing" expression="happy" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Labels slide in */}
+                    <m.g initial={{ x: -30, opacity: 0 }} animate={{ x: 0, opacity: 1 }} transition={{ duration: 0.5 }}>
+                        <ABLabel variant="A" x={30} y={25} />
+                    </m.g>
+                    <m.g initial={{ x: 30, opacity: 0 }} animate={{ x: 0, opacity: 1 }} transition={{ duration: 0.5 }}>
+                        <ABLabel variant="B" x={146} y={25} />
+                    </m.g>
+                    {/* Bars grow */}
+                    <m.rect
+                        x="30"
+                        y="55"
+                        width="24"
+                        rx="3"
+                        fill="var(--hog-body)"
+                        opacity="0.5"
+                        initial={{ height: 0 }}
+                        animate={{ height: 60 }}
+                        transition={{ delay: 0.6, duration: 1, ease: 'easeOut' }}
+                    />
+                    <m.rect
+                        x="146"
+                        y="35"
+                        width="24"
+                        rx="3"
+                        fill="var(--hog-cheek)"
+                        opacity="0.6"
+                        initial={{ height: 0 }}
+                        animate={{ height: 80 }}
+                        transition={{ delay: 0.6, duration: 1.2, ease: 'easeOut' }}
+                    />
+                    {/* Crown appears on winner */}
+                    <m.text
+                        x="158"
+                        y="28"
+                        textAnchor="middle"
+                        fontSize="16"
+                        initial={{ opacity: 0, scale: 0 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        transition={{ delay: 2, duration: 0.4, type: 'spring', stiffness: 300, damping: 15 }}
+                    >
+                        👑
+                    </m.text>
+                    {/* Hedgehog celebrates */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-10, 45) scale(0.4)">
+                            <m.g
+                                initial={{ y: 0 }}
+                                animate={{ y: [0, -6, 0] }}
+                                transition={{ delay: 2.2, duration: 0.5 }}
+                            >
+                                <HedgehogCharacter pose="standing" expression="happy" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default ExperimentsAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/FallbackAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/FallbackAnimation.tsx
@@ -1,0 +1,24 @@
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import type { AnimationComponentProps } from '../types'
+
+function FallbackAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <HedgehogCharacter pose="standing" expression="happy" />
+            ) : (
+                <m.g variants={breathe} animate="idle">
+                    <HedgehogCharacter pose="standing" expression="happy" />
+                </m.g>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default FallbackAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/FeatureFlagsAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/FeatureFlagsAnimation.tsx
@@ -1,0 +1,61 @@
+/**
+ * Feature flags: Hedgehog toggles a flag switch on/off, sees UI change.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { FlagPole, ToggleSwitch } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function FeatureFlagsAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <FlagPole x={140} y={30} />
+                    <ToggleSwitch on={true} x={100} y={100} />
+                    <g transform="translate(-25, 30) scale(0.5)">
+                        <HedgehogCharacter pose="standing" expression="happy" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Flag pole */}
+                    <m.g initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.4 }}>
+                        <FlagPole x={140} y={30} />
+                    </m.g>
+                    {/* Toggle switch animating on/off */}
+                    <m.g initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.3, duration: 0.4 }}>
+                        {/* Track */}
+                        <rect x="100" y="100" width="36" height="20" rx="10" fill="var(--hog-body)" />
+                        {/* Knob slides back and forth */}
+                        <m.circle
+                            cy={110}
+                            r={7}
+                            fill="var(--hog-belly)"
+                            animate={{ cx: [110, 126, 110, 126] }}
+                            transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut', times: [0, 0.3, 0.6, 1] }}
+                        />
+                    </m.g>
+                    {/* Hedgehog reaching for toggle */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-25, 30) scale(0.5)">
+                            <m.g
+                                animate={{ x: [0, 3, 0] }}
+                                transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+                            >
+                                <HedgehogCharacter pose="standing" expression="happy" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default FeatureFlagsAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/LlmObservabilityAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/LlmObservabilityAnimation.tsx
@@ -1,0 +1,90 @@
+/**
+ * LLM observability: Hedgehog monitors AI conversation bubbles, checks metrics.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { ChatBubble } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function LlmObservabilityAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <ChatBubble x={60} y={15} side="left" />
+                    <ChatBubble x={80} y={45} side="right" />
+                    <ChatBubble x={60} y={75} side="left" />
+                    {/* Metrics badge */}
+                    <rect x="145" y="20" width="40" height="18" rx="3" fill="var(--hog-body)" opacity="0.8" />
+                    <text
+                        x="165"
+                        y="33"
+                        textAnchor="middle"
+                        fontSize="8"
+                        fill="var(--hog-belly)"
+                        fontFamily="monospace"
+                    >
+                        0.8s
+                    </text>
+                    <g transform="translate(-25, 40) scale(0.4)">
+                        <HedgehogCharacter pose="standing" expression="curious" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Chat bubbles appear in sequence */}
+                    <m.g initial={{ x: -20, opacity: 0 }} animate={{ x: 0, opacity: 1 }} transition={{ duration: 0.4 }}>
+                        <ChatBubble x={60} y={15} side="left" />
+                    </m.g>
+                    <m.g
+                        initial={{ x: 20, opacity: 0 }}
+                        animate={{ x: 0, opacity: 1 }}
+                        transition={{ delay: 0.6, duration: 0.4 }}
+                    >
+                        <ChatBubble x={80} y={45} side="right" />
+                    </m.g>
+                    <m.g
+                        initial={{ x: -20, opacity: 0 }}
+                        animate={{ x: 0, opacity: 1 }}
+                        transition={{ delay: 1.2, duration: 0.4 }}
+                    >
+                        <ChatBubble x={60} y={75} side="left" />
+                    </m.g>
+                    {/* Metrics badge pops in */}
+                    <m.g
+                        initial={{ scale: 0 }}
+                        animate={{ scale: 1 }}
+                        transition={{ delay: 1.8, duration: 0.3, type: 'spring', stiffness: 300 }}
+                    >
+                        <rect x="145" y="20" width="40" height="18" rx="3" fill="var(--hog-body)" opacity="0.8" />
+                        <text
+                            x="165"
+                            y="33"
+                            textAnchor="middle"
+                            fontSize="8"
+                            fill="var(--hog-belly)"
+                            fontFamily="monospace"
+                        >
+                            0.8s
+                        </text>
+                    </m.g>
+                    {/* Hedgehog monitoring */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-25, 40) scale(0.4)">
+                            <m.g animate={{ y: [0, -2, 0] }} transition={{ delay: 2, duration: 0.4, ease: 'easeOut' }}>
+                                <HedgehogCharacter pose="standing" expression="curious" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default LlmObservabilityAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/LogsAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/LogsAnimation.tsx
@@ -1,0 +1,98 @@
+/**
+ * Logs: Hedgehog scrolls through log entries, highlights one.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { LogLine } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function LogsAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    {/* Log panel */}
+                    <rect
+                        x="55"
+                        y="10"
+                        width="135"
+                        height="110"
+                        rx="4"
+                        fill="var(--hog-outline)"
+                        opacity="0.05"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1"
+                    />
+                    <LogLine x={62} y={20} width={55} />
+                    <LogLine x={62} y={30} width={45} />
+                    <LogLine x={62} y={40} width={60} />
+                    {/* Highlighted line */}
+                    <rect x="58" y="48" width="126" height="10" rx="2" fill="var(--hog-body)" opacity="0.15" />
+                    <LogLine x={62} y={50} width={50} />
+                    <LogLine x={62} y={62} width={40} />
+                    <LogLine x={62} y={72} width={55} />
+                    <LogLine x={62} y={82} width={35} />
+                    <LogLine x={62} y={92} width={48} />
+                    <LogLine x={62} y={102} width={42} />
+                    <g transform="translate(-30, 30) scale(0.42)">
+                        <HedgehogCharacter pose="standing" expression="focused" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Log panel */}
+                    <m.rect
+                        x="55"
+                        y="10"
+                        width="135"
+                        height="110"
+                        rx="4"
+                        fill="var(--hog-outline)"
+                        opacity="0.05"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 0.3 }}
+                    />
+                    {/* Log lines stream in */}
+                    {[20, 30, 40, 50, 62, 72, 82, 92, 102].map((y, i) => (
+                        <m.g
+                            key={y}
+                            initial={{ x: 10, opacity: 0 }}
+                            animate={{ x: 0, opacity: 1 }}
+                            transition={{ delay: 0.2 + i * 0.15, duration: 0.3 }}
+                        >
+                            <LogLine x={62} y={y} width={35 + ((i * 17) % 25)} />
+                        </m.g>
+                    ))}
+                    {/* Highlight slides over one entry */}
+                    <m.rect
+                        x="58"
+                        y="48"
+                        width="126"
+                        height="10"
+                        rx="2"
+                        fill="var(--hog-body)"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: [0, 0, 0.15, 0.15] }}
+                        transition={{ delay: 1.5, duration: 1 }}
+                    />
+                    {/* Hedgehog reading */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-30, 30) scale(0.42)">
+                            <HedgehogCharacter pose="standing" expression="focused" />
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default LogsAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/ProductAnalyticsAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/ProductAnalyticsAnimation.tsx
@@ -1,0 +1,66 @@
+/**
+ * Product analytics: Hedgehog watches a trend line draw itself, points at the peak, celebrates.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { ChartGrid, DataPoints, TrendLine } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function ProductAnalyticsAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <ChartGrid />
+                    <TrendLine />
+                    <DataPoints />
+                    <g transform="translate(-30, 30) scale(0.5)">
+                        <HedgehogCharacter pose="standing" expression="happy" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    <ChartGrid />
+                    {/* Trend line draws in */}
+                    <m.path
+                        d="M20,160 Q50,150 70,130 T110,90 T150,50 T180,30"
+                        fill="none"
+                        stroke="var(--hog-body)"
+                        strokeWidth="3"
+                        strokeLinecap="round"
+                        initial={{ pathLength: 0 }}
+                        animate={{ pathLength: 1 }}
+                        transition={{ duration: 2, ease: 'easeOut' }}
+                    />
+                    {/* Data points pop in */}
+                    <m.g
+                        initial={{ opacity: 0, scale: 0 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        transition={{ delay: 1.5, duration: 0.5, staggerChildren: 0.15 }}
+                    >
+                        <DataPoints />
+                    </m.g>
+                    {/* Hedgehog watches then celebrates */}
+                    <m.g variants={breathe} animate="idle" style={{ transformOrigin: 'center' }}>
+                        <g transform="translate(-30, 30) scale(0.5)">
+                            <m.g
+                                initial={{ y: 0 }}
+                                animate={{ y: [0, -5, 0] }}
+                                transition={{ delay: 2.2, duration: 0.4, ease: 'easeOut' }}
+                            >
+                                <HedgehogCharacter pose="standing" expression="happy" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default ProductAnalyticsAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/SessionReplayAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/SessionReplayAnimation.tsx
@@ -1,0 +1,65 @@
+/**
+ * Session replay: Hedgehog watches a screen recording playback, reacts to user actions.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { MiniScreen } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function SessionReplayAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <MiniScreen x={55} y={20} />
+                    {/* Play button overlay */}
+                    <polygon points="85,42 100,50 85,58" fill="var(--hog-body)" opacity="0.8" />
+                    <g transform="translate(-15, 40) scale(0.45)">
+                        <HedgehogCharacter pose="sitting" expression="focused" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Screen slides in */}
+                    <m.g
+                        initial={{ y: -20, opacity: 0 }}
+                        animate={{ y: 0, opacity: 1 }}
+                        transition={{ duration: 0.6, ease: 'easeOut' }}
+                    >
+                        <MiniScreen x={55} y={20} />
+                        {/* Animated cursor moving on screen */}
+                        <m.circle
+                            cx={80}
+                            cy={45}
+                            r={3}
+                            fill="var(--hog-cheek)"
+                            animate={{
+                                cx: [80, 100, 115, 95, 80],
+                                cy: [45, 38, 50, 55, 45],
+                            }}
+                            transition={{ duration: 3, repeat: Infinity, ease: 'linear' }}
+                        />
+                    </m.g>
+                    {/* Hedgehog watching */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-15, 40) scale(0.45)">
+                            <m.g
+                                animate={{ rotate: [0, -2, 0, 2, 0] }}
+                                transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+                            >
+                                <HedgehogCharacter pose="sitting" expression="focused" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default SessionReplayAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/SqlAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/SqlAnimation.tsx
@@ -1,0 +1,134 @@
+/**
+ * SQL/HogQL: Hedgehog types a query, table of results appears.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { QueryBox } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function SqlAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <QueryBox x={65} y={15} />
+                    {/* Results table */}
+                    <rect
+                        x="65"
+                        y="60"
+                        width="70"
+                        height="40"
+                        rx="2"
+                        fill="var(--hog-belly)"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="1"
+                    />
+                    <line
+                        x1="65"
+                        y1="72"
+                        x2="135"
+                        y2="72"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="0.5"
+                        opacity="0.3"
+                    />
+                    <line
+                        x1="65"
+                        y1="82"
+                        x2="135"
+                        y2="82"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="0.5"
+                        opacity="0.2"
+                    />
+                    <line
+                        x1="65"
+                        y1="92"
+                        x2="135"
+                        y2="92"
+                        stroke="var(--hog-outline)"
+                        strokeWidth="0.5"
+                        opacity="0.15"
+                    />
+                    <g transform="translate(-25, 30) scale(0.45)">
+                        <HedgehogCharacter pose="standing" expression="focused" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Query box appears */}
+                    <m.g initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }}>
+                        <QueryBox x={65} y={15} />
+                    </m.g>
+                    {/* Typing cursor blinks */}
+                    <m.rect
+                        x="60"
+                        y="37"
+                        width="2"
+                        height="8"
+                        fill="var(--hog-body)"
+                        animate={{ opacity: [1, 0, 1] }}
+                        transition={{ duration: 1, repeat: Infinity }}
+                    />
+                    {/* Results appear */}
+                    <m.g
+                        initial={{ y: 10, opacity: 0 }}
+                        animate={{ y: 0, opacity: 1 }}
+                        transition={{ delay: 1.5, duration: 0.5, ease: 'easeOut' }}
+                    >
+                        <rect
+                            x="65"
+                            y="60"
+                            width="70"
+                            height="40"
+                            rx="2"
+                            fill="var(--hog-belly)"
+                            stroke="var(--hog-outline)"
+                            strokeWidth="1"
+                        />
+                        <line
+                            x1="65"
+                            y1="72"
+                            x2="135"
+                            y2="72"
+                            stroke="var(--hog-outline)"
+                            strokeWidth="0.5"
+                            opacity="0.3"
+                        />
+                        <line
+                            x1="65"
+                            y1="82"
+                            x2="135"
+                            y2="82"
+                            stroke="var(--hog-outline)"
+                            strokeWidth="0.5"
+                            opacity="0.2"
+                        />
+                        <line
+                            x1="65"
+                            y1="92"
+                            x2="135"
+                            y2="92"
+                            stroke="var(--hog-outline)"
+                            strokeWidth="0.5"
+                            opacity="0.15"
+                        />
+                    </m.g>
+                    {/* Hedgehog typing */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-25, 30) scale(0.45)">
+                            <HedgehogCharacter pose="standing" expression="focused" />
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default SqlAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/SurveysAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/SurveysAnimation.tsx
@@ -1,0 +1,57 @@
+/**
+ * Surveys: Hedgehog fills out a survey form, submits with satisfaction.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { SurveyForm } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function SurveysAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <SurveyForm x={65} y={15} />
+                    <g transform="translate(-20, 35) scale(0.45)">
+                        <HedgehogCharacter pose="standing" expression="focused" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    {/* Survey form slides in */}
+                    <m.g initial={{ y: -15, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ duration: 0.5 }}>
+                        <SurveyForm x={65} y={15} />
+                        {/* Animated checkmark on selected option */}
+                        <m.circle
+                            cx={75}
+                            cy={47}
+                            r={3}
+                            fill="var(--hog-body)"
+                            initial={{ scale: 0 }}
+                            animate={{ scale: 1 }}
+                            transition={{ delay: 1.2, duration: 0.3, type: 'spring', stiffness: 400 }}
+                        />
+                    </m.g>
+                    {/* Hedgehog typing/filling */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-20, 35) scale(0.45)">
+                            <m.g
+                                animate={{ x: [0, 2, 0, -1, 0] }}
+                                transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
+                            >
+                                <HedgehogCharacter pose="standing" expression="focused" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default SurveysAnimation

--- a/frontend/src/lib/components/ProductAnimations/animations/WebAnalyticsAnimation.tsx
+++ b/frontend/src/lib/components/ProductAnimations/animations/WebAnalyticsAnimation.tsx
@@ -1,0 +1,54 @@
+/**
+ * Web analytics: Hedgehog browses pages, sees traffic data flowing in.
+ */
+import * as m from 'motion/react-m'
+
+import { AnimationCanvas } from '../primitives/AnimationCanvas'
+import { breathe } from '../primitives/AnimationPresets'
+import { HedgehogCharacter } from '../primitives/HedgehogCharacter'
+import { BarChart, ChartGrid } from '../primitives/ScenePrimitives'
+import type { AnimationComponentProps } from '../types'
+
+function WebAnalyticsAnimation({ size, mode }: AnimationComponentProps): JSX.Element {
+    const isStatic = mode === 'static'
+
+    return (
+        <AnimationCanvas size={size}>
+            {isStatic ? (
+                <>
+                    <ChartGrid />
+                    <BarChart />
+                    <g transform="translate(-20, 35) scale(0.45)">
+                        <HedgehogCharacter pose="standing" expression="curious" />
+                    </g>
+                </>
+            ) : (
+                <>
+                    <ChartGrid />
+                    {/* Bars grow up */}
+                    <m.g
+                        initial={{ scaleY: 0 }}
+                        animate={{ scaleY: 1 }}
+                        transition={{ duration: 1.2, ease: 'easeOut' }}
+                        style={{ transformOrigin: 'bottom' }}
+                    >
+                        <BarChart />
+                    </m.g>
+                    {/* Hedgehog watches data */}
+                    <m.g variants={breathe} animate="idle">
+                        <g transform="translate(-20, 35) scale(0.45)">
+                            <m.g
+                                animate={{ x: [0, 3, 0, -3, 0] }}
+                                transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
+                            >
+                                <HedgehogCharacter pose="standing" expression="curious" />
+                            </m.g>
+                        </g>
+                    </m.g>
+                </>
+            )}
+        </AnimationCanvas>
+    )
+}
+
+export default WebAnalyticsAnimation

--- a/frontend/src/lib/components/ProductAnimations/index.ts
+++ b/frontend/src/lib/components/ProductAnimations/index.ts
@@ -1,0 +1,14 @@
+// Primary public API
+export { ProductAnimation } from './ProductAnimation'
+
+// Primitives for animation authors (used by product-specific animations)
+export { AnimationCanvas } from './primitives/AnimationCanvas'
+export { HedgehogCharacter } from './primitives/HedgehogCharacter'
+export { useAnimationMode } from './primitives/useAnimationMode'
+export { useSvgIds, SvgIdContext } from './primitives/useSvgIds'
+export * from './primitives/AnimationPresets'
+
+// Types
+export type { AnimationSize, AnimationMode, AnimationComponentProps, ProductAnimationProps } from './types'
+export type { HedgehogPose } from './primitives/HedgehogCharacter'
+export type { HedgehogExpression } from './primitives/HedgehogParts'

--- a/frontend/src/lib/components/ProductAnimations/primitives/AnimationCanvas.tsx
+++ b/frontend/src/lib/components/ProductAnimations/primitives/AnimationCanvas.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react'
+
+import { SIZE_MAP } from '../types'
+import type { AnimationSize } from '../types'
+import { SvgIdContext, useSvgIdPrefix } from './useSvgIds'
+
+interface AnimationCanvasProps {
+    size: AnimationSize
+    children: ReactNode
+    className?: string
+}
+
+export function AnimationCanvas({ size, children, className }: AnimationCanvasProps): JSX.Element {
+    const px = SIZE_MAP[size]
+    const idPrefix = useSvgIdPrefix()
+
+    return (
+        <SvgIdContext.Provider value={idPrefix}>
+            <svg
+                viewBox="0 0 200 200"
+                width={px}
+                height={px}
+                xmlns="http://www.w3.org/2000/svg"
+                className={className}
+                role="img"
+                aria-hidden="true"
+                style={
+                    {
+                        '--hog-body': 'var(--color-warning-light, #F7A501)',
+                        '--hog-spines': 'var(--color-text-primary, #2D2D2D)',
+                        '--hog-belly': 'var(--color-bg-surface-primary, #FFFFFF)',
+                        '--hog-outline': 'var(--color-text-primary, #2D2D2D)',
+                        '--hog-cheek': 'var(--color-danger-light, #FF8A80)',
+                        '--hog-eye': 'var(--color-text-primary, #2D2D2D)',
+                    } as React.CSSProperties
+                }
+            >
+                {children}
+            </svg>
+        </SvgIdContext.Provider>
+    )
+}

--- a/frontend/src/lib/components/ProductAnimations/primitives/AnimationPresets.ts
+++ b/frontend/src/lib/components/ProductAnimations/primitives/AnimationPresets.ts
@@ -1,0 +1,59 @@
+import type { Transition, Variants } from 'motion/react'
+
+export const springDefault: Transition = {
+    type: 'spring',
+    stiffness: 300,
+    damping: 20,
+}
+
+export const springBouncy: Transition = {
+    type: 'spring',
+    stiffness: 400,
+    damping: 10,
+}
+
+export const springGentle: Transition = {
+    type: 'spring',
+    stiffness: 200,
+    damping: 25,
+}
+
+export const breathe: Variants = {
+    idle: {
+        y: [0, -1.5, 0],
+        transition: { duration: 3, ease: 'easeInOut', repeat: Infinity },
+    },
+}
+
+export const blink: Variants = {
+    idle: {
+        scaleY: [1, 1, 0.1, 1, 1],
+        transition: {
+            duration: 4,
+            times: [0, 0.48, 0.5, 0.52, 1],
+            repeat: Infinity,
+            repeatDelay: 2,
+        },
+    },
+}
+
+export const bounce: Variants = {
+    initial: { y: 0 },
+    animate: {
+        y: [0, -8, 0],
+        transition: { duration: 0.6, ease: 'easeInOut', repeat: Infinity, repeatDelay: 1.5 },
+    },
+}
+
+export const float: Variants = {
+    initial: { y: 0 },
+    animate: {
+        y: [0, -4, 0],
+        transition: { duration: 2, ease: 'easeInOut', repeat: Infinity },
+    },
+}
+
+export const fadeIn: Variants = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1, transition: { duration: 0.3 } },
+}

--- a/frontend/src/lib/components/ProductAnimations/primitives/HedgehogCharacter.tsx
+++ b/frontend/src/lib/components/ProductAnimations/primitives/HedgehogCharacter.tsx
@@ -1,0 +1,51 @@
+import { HedgehogArm, HedgehogBelly, HedgehogBody, HedgehogFace, HedgehogLegs, HedgehogSpines } from './HedgehogParts'
+import type { HedgehogExpression } from './HedgehogParts'
+
+export type HedgehogPose = 'standing' | 'sitting' | 'walking' | 'leaning' | 'typing'
+
+interface HedgehogCharacterProps {
+    pose?: HedgehogPose
+    expression?: HedgehogExpression
+    className?: string
+}
+
+function getTransformForPose(pose: HedgehogPose): string {
+    switch (pose) {
+        case 'sitting':
+            return 'translate(0, 10)'
+        case 'walking':
+            // Slight forward lean
+            return 'rotate(-5, 100, 120)'
+        case 'leaning':
+            return 'rotate(8, 100, 140)'
+        case 'typing':
+            // Slight forward lean with lower center
+            return 'rotate(-8, 100, 130)'
+        case 'standing':
+        default:
+            return ''
+    }
+}
+
+export function HedgehogCharacter({ pose = 'standing', expression = 'neutral' }: HedgehogCharacterProps): JSX.Element {
+    const transform = getTransformForPose(pose)
+
+    return (
+        <g transform={transform}>
+            {/* Render back to front for correct layering */}
+            {/* 1. Spines (behind everything) */}
+            <HedgehogSpines />
+            {/* 2. Body */}
+            <HedgehogBody />
+            {/* 3. Belly (on top of body) */}
+            <HedgehogBelly />
+            {/* 4. Arms (behind face but in front of body) */}
+            <HedgehogArm side="left" />
+            <HedgehogArm side="right" />
+            {/* 5. Legs */}
+            <HedgehogLegs />
+            {/* 6. Face (on top of everything) */}
+            <HedgehogFace expression={expression} />
+        </g>
+    )
+}

--- a/frontend/src/lib/components/ProductAnimations/primitives/HedgehogParts.tsx
+++ b/frontend/src/lib/components/ProductAnimations/primitives/HedgehogParts.tsx
@@ -1,0 +1,241 @@
+export type HedgehogExpression = 'happy' | 'curious' | 'focused' | 'surprised' | 'neutral'
+
+// --- Individual SVG body parts, each using CSS custom properties for fills ---
+// All parts are designed within a 200x200 viewBox coordinate system.
+// Use group-based positioning: <g transform="translate(x,y)"> so rotation
+// pivots at the joint/origin of each part.
+
+export function HedgehogSpines(): JSX.Element {
+    return (
+        <g transform="translate(100, 65)">
+            {/* Five spines radiating from top-back of body */}
+            <path
+                d="M-30,10 L-20,-20 L-8,8 Z"
+                fill="var(--hog-spines)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M-15,5 L-5,-28 L5,3 Z"
+                fill="var(--hog-spines)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M-2,2 L5,-32 L14,0 Z"
+                fill="var(--hog-spines)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M10,5 L20,-28 L25,3 Z"
+                fill="var(--hog-spines)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M20,10 L32,-18 L35,10 Z"
+                fill="var(--hog-spines)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+                strokeLinejoin="round"
+            />
+        </g>
+    )
+}
+
+export function HedgehogBody(): JSX.Element {
+    return (
+        <g transform="translate(100, 115)">
+            {/* Main body: rounded oval */}
+            <ellipse
+                cx="0"
+                cy="0"
+                rx="38"
+                ry="32"
+                fill="var(--hog-body)"
+                stroke="var(--hog-outline)"
+                strokeWidth="2"
+                strokeLinecap="round"
+            />
+        </g>
+    )
+}
+
+export function HedgehogBelly(): JSX.Element {
+    return (
+        <g transform="translate(100, 120)">
+            {/* Lighter belly patch on front */}
+            <ellipse
+                cx="0"
+                cy="2"
+                rx="22"
+                ry="18"
+                fill="var(--hog-belly)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1"
+                opacity="0.9"
+            />
+        </g>
+    )
+}
+
+function EyesHappy(): JSX.Element {
+    return (
+        <>
+            {/* Happy eyes: upward crescents */}
+            <path
+                d="M-10,-2 Q-8,-7 -4,-2"
+                fill="none"
+                stroke="var(--hog-eye)"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+            />
+            <path d="M4,-2 Q8,-7 10,-2" fill="none" stroke="var(--hog-eye)" strokeWidth="2.5" strokeLinecap="round" />
+        </>
+    )
+}
+
+function EyesCurious(): JSX.Element {
+    return (
+        <>
+            {/* Curious: one eye slightly larger */}
+            <circle cx="-8" cy="-3" r="3" fill="var(--hog-eye)" />
+            <circle cx="8" cy="-3" r="3.5" fill="var(--hog-eye)" />
+        </>
+    )
+}
+
+function EyesFocused(): JSX.Element {
+    return (
+        <>
+            {/* Focused: eyes looking to one side */}
+            <circle cx="-6" cy="-3" r="3" fill="var(--hog-eye)" />
+            <circle cx="9" cy="-3" r="3" fill="var(--hog-eye)" />
+            {/* Pupils shifted right */}
+            <circle cx="-4.5" cy="-3" r="1.5" fill="var(--hog-belly)" />
+            <circle cx="10.5" cy="-3" r="1.5" fill="var(--hog-belly)" />
+        </>
+    )
+}
+
+function EyesSurprised(): JSX.Element {
+    return (
+        <>
+            {/* Surprised: wide round eyes */}
+            <circle cx="-8" cy="-3" r="4" fill="var(--hog-eye)" />
+            <circle cx="8" cy="-3" r="4" fill="var(--hog-eye)" />
+            <circle cx="-8" cy="-3.5" r="1.5" fill="var(--hog-belly)" />
+            <circle cx="8" cy="-3.5" r="1.5" fill="var(--hog-belly)" />
+        </>
+    )
+}
+
+function EyesNeutral(): JSX.Element {
+    return (
+        <>
+            {/* Neutral: standard round eyes */}
+            <circle cx="-8" cy="-3" r="3" fill="var(--hog-eye)" />
+            <circle cx="8" cy="-3" r="3" fill="var(--hog-eye)" />
+        </>
+    )
+}
+
+function MouthForExpression({ expression }: { expression: HedgehogExpression }): JSX.Element {
+    switch (expression) {
+        case 'happy':
+            return (
+                <path
+                    d="M-5,5 Q0,10 5,5"
+                    fill="none"
+                    stroke="var(--hog-outline)"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                />
+            )
+        case 'surprised':
+            return <ellipse cx="0" cy="7" rx="3" ry="4" fill="var(--hog-outline)" />
+        case 'focused':
+            return (
+                <path d="M-4,6 L4,6" fill="none" stroke="var(--hog-outline)" strokeWidth="1.5" strokeLinecap="round" />
+            )
+        default:
+            return (
+                <path
+                    d="M-4,5 Q0,7 4,5"
+                    fill="none"
+                    stroke="var(--hog-outline)"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                />
+            )
+    }
+}
+
+export function HedgehogFace({ expression }: { expression: HedgehogExpression }): JSX.Element {
+    return (
+        <g transform="translate(100, 90)">
+            {/* Nose: small dark circle */}
+            <circle cx="0" cy="1" r="2" fill="var(--hog-outline)" />
+
+            {/* Eyes based on expression */}
+            {expression === 'happy' && <EyesHappy />}
+            {expression === 'curious' && <EyesCurious />}
+            {expression === 'focused' && <EyesFocused />}
+            {expression === 'surprised' && <EyesSurprised />}
+            {expression === 'neutral' && <EyesNeutral />}
+
+            {/* Mouth */}
+            <MouthForExpression expression={expression} />
+
+            {/* Cheeks */}
+            <circle cx="-16" cy="2" r="4" fill="var(--hog-cheek)" opacity="0.5" />
+            <circle cx="16" cy="2" r="4" fill="var(--hog-cheek)" opacity="0.5" />
+        </g>
+    )
+}
+
+export function HedgehogArm({ side }: { side: 'left' | 'right' }): JSX.Element {
+    const x = side === 'left' ? 65 : 135
+    const scaleX = side === 'left' ? 1 : -1
+
+    return (
+        <g transform={`translate(${x}, 110) scale(${scaleX}, 1)`}>
+            {/* Arm: small rounded limb path, pivot at shoulder */}
+            <path d="M0,0 Q-5,12 -2,22" fill="none" stroke="var(--hog-body)" strokeWidth="6" strokeLinecap="round" />
+            {/* Hand: small circle */}
+            <circle cx="-2" cy="22" r="4" fill="var(--hog-body)" stroke="var(--hog-outline)" strokeWidth="1" />
+        </g>
+    )
+}
+
+export function HedgehogLegs(): JSX.Element {
+    return (
+        <g transform="translate(100, 142)">
+            {/* Left foot */}
+            <ellipse
+                cx="-14"
+                cy="5"
+                rx="10"
+                ry="5"
+                fill="var(--hog-body)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+            />
+            {/* Right foot */}
+            <ellipse
+                cx="14"
+                cy="5"
+                rx="10"
+                ry="5"
+                fill="var(--hog-body)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+            />
+        </g>
+    )
+}

--- a/frontend/src/lib/components/ProductAnimations/primitives/ScenePrimitives.tsx
+++ b/frontend/src/lib/components/ProductAnimations/primitives/ScenePrimitives.tsx
@@ -1,0 +1,302 @@
+/**
+ * Reusable SVG scene elements for product animations.
+ * All elements are designed for a 200x200 viewBox and use CSS custom properties.
+ */
+
+// --- Chart elements ---
+
+export function TrendLine({ color = 'var(--hog-body)' }: { color?: string }): JSX.Element {
+    return (
+        <path
+            d="M20,160 Q50,150 70,130 T110,90 T150,50 T180,30"
+            fill="none"
+            stroke={color}
+            strokeWidth="3"
+            strokeLinecap="round"
+        />
+    )
+}
+
+export function DataPoints({ color = 'var(--hog-body)' }: { color?: string }): JSX.Element {
+    return (
+        <g>
+            <circle cx="70" cy="130" r="4" fill={color} />
+            <circle cx="110" cy="90" r="4" fill={color} />
+            <circle cx="150" cy="50" r="4" fill={color} />
+            <circle cx="180" cy="30" r="4" fill={color} />
+        </g>
+    )
+}
+
+export function ChartGrid(): JSX.Element {
+    return (
+        <g opacity="0.15">
+            <line x1="20" y1="160" x2="190" y2="160" stroke="var(--hog-outline)" strokeWidth="1" />
+            <line x1="20" y1="130" x2="190" y2="130" stroke="var(--hog-outline)" strokeWidth="0.5" />
+            <line x1="20" y1="100" x2="190" y2="100" stroke="var(--hog-outline)" strokeWidth="0.5" />
+            <line x1="20" y1="70" x2="190" y2="70" stroke="var(--hog-outline)" strokeWidth="0.5" />
+            <line x1="20" y1="40" x2="190" y2="40" stroke="var(--hog-outline)" strokeWidth="0.5" />
+        </g>
+    )
+}
+
+export function BarChart(): JSX.Element {
+    return (
+        <g>
+            <rect x="30" y="120" width="16" height="40" rx="2" fill="var(--hog-body)" opacity="0.7" />
+            <rect x="55" y="90" width="16" height="70" rx="2" fill="var(--hog-body)" opacity="0.8" />
+            <rect x="80" y="105" width="16" height="55" rx="2" fill="var(--hog-body)" opacity="0.7" />
+            <rect x="105" y="70" width="16" height="90" rx="2" fill="var(--hog-body)" opacity="0.9" />
+            <rect x="130" y="85" width="16" height="75" rx="2" fill="var(--hog-body)" opacity="0.8" />
+        </g>
+    )
+}
+
+// --- UI elements ---
+
+export function MiniScreen({ x = 0, y = 0 }: { x?: number; y?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect
+                x="0"
+                y="0"
+                width="80"
+                height="55"
+                rx="4"
+                fill="var(--hog-belly)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+            />
+            {/* Title bar */}
+            <rect x="0" y="0" width="80" height="10" rx="4" fill="var(--hog-outline)" opacity="0.15" />
+            <circle cx="8" cy="5" r="2" fill="var(--hog-cheek)" opacity="0.6" />
+            <circle cx="15" cy="5" r="2" fill="var(--hog-body)" opacity="0.6" />
+            <circle
+                cx="22"
+                cy="5"
+                r="2"
+                fill="var(--hog-belly)"
+                stroke="var(--hog-outline)"
+                strokeWidth="0.5"
+                opacity="0.6"
+            />
+            {/* Content lines */}
+            <rect x="6" y="16" width="40" height="3" rx="1" fill="var(--hog-outline)" opacity="0.2" />
+            <rect x="6" y="23" width="55" height="3" rx="1" fill="var(--hog-outline)" opacity="0.15" />
+            <rect x="6" y="30" width="35" height="3" rx="1" fill="var(--hog-outline)" opacity="0.1" />
+        </g>
+    )
+}
+
+export function ToggleSwitch({ on = false, x = 0, y = 0 }: { on?: boolean; x?: number; y?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect
+                x="0"
+                y="0"
+                width="36"
+                height="20"
+                rx="10"
+                fill={on ? 'var(--hog-body)' : 'var(--hog-outline)'}
+                opacity={on ? 1 : 0.3}
+            />
+            <circle cx={on ? 26 : 10} cy="10" r="7" fill="var(--hog-belly)" />
+        </g>
+    )
+}
+
+export function FlagPole({ x = 0, y = 0 }: { x?: number; y?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <line x1="0" y1="0" x2="0" y2="50" stroke="var(--hog-outline)" strokeWidth="2" strokeLinecap="round" />
+            <path d="M2,-2 L28,8 L2,18 Z" fill="var(--hog-body)" stroke="var(--hog-outline)" strokeWidth="1" />
+        </g>
+    )
+}
+
+export function ABLabel({ variant, x = 0, y = 0 }: { variant: 'A' | 'B'; x?: number; y?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect
+                x="0"
+                y="0"
+                width="24"
+                height="24"
+                rx="4"
+                fill={variant === 'A' ? 'var(--hog-body)' : 'var(--hog-cheek)'}
+            />
+            <text
+                x="12"
+                y="17"
+                textAnchor="middle"
+                fill="var(--hog-belly)"
+                fontSize="14"
+                fontWeight="bold"
+                fontFamily="sans-serif"
+            >
+                {variant}
+            </text>
+        </g>
+    )
+}
+
+export function SurveyForm({ x = 0, y = 0 }: { x?: number; y?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect
+                x="0"
+                y="0"
+                width="70"
+                height="60"
+                rx="4"
+                fill="var(--hog-belly)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1.5"
+            />
+            {/* Question text */}
+            <rect x="6" y="6" width="40" height="3" rx="1" fill="var(--hog-outline)" opacity="0.3" />
+            {/* Radio options */}
+            <circle cx="10" cy="20" r="4" fill="none" stroke="var(--hog-outline)" strokeWidth="1" />
+            <rect x="18" y="18" width="30" height="3" rx="1" fill="var(--hog-outline)" opacity="0.2" />
+            <circle cx="10" cy="32" r="4" fill="var(--hog-body)" stroke="var(--hog-outline)" strokeWidth="1" />
+            <rect x="18" y="30" width="25" height="3" rx="1" fill="var(--hog-outline)" opacity="0.2" />
+            {/* Submit button */}
+            <rect x="6" y="44" width="30" height="10" rx="3" fill="var(--hog-body)" />
+        </g>
+    )
+}
+
+export function DataBox({ x = 0, y = 0, label = '' }: { x?: number; y?: number; label?: string }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect
+                x="0"
+                y="0"
+                width="30"
+                height="24"
+                rx="3"
+                fill="var(--hog-belly)"
+                stroke="var(--hog-outline)"
+                strokeWidth="1"
+            />
+            <rect x="3" y="3" width="24" height="4" rx="1" fill="var(--hog-body)" opacity="0.5" />
+            <rect x="3" y="10" width="18" height="3" rx="1" fill="var(--hog-outline)" opacity="0.15" />
+            <rect x="3" y="16" width="12" height="3" rx="1" fill="var(--hog-outline)" opacity="0.1" />
+            {label && (
+                <text
+                    x="15"
+                    y="-3"
+                    textAnchor="middle"
+                    fontSize="7"
+                    fill="var(--hog-outline)"
+                    opacity="0.5"
+                    fontFamily="sans-serif"
+                >
+                    {label}
+                </text>
+            )}
+        </g>
+    )
+}
+
+export function PipeSegment({ x1, y1, x2, y2 }: { x1: number; y1: number; x2: number; y2: number }): JSX.Element {
+    return (
+        <line
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke="var(--hog-body)"
+            strokeWidth="6"
+            strokeLinecap="round"
+            opacity="0.6"
+        />
+    )
+}
+
+export function BugIcon({ x = 0, y = 0 }: { x?: number; y?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            {/* Bug body */}
+            <ellipse cx="0" cy="0" rx="8" ry="10" fill="var(--hog-cheek)" stroke="var(--hog-outline)" strokeWidth="1" />
+            {/* Eyes */}
+            <circle cx="-3" cy="-4" r="1.5" fill="var(--hog-belly)" />
+            <circle cx="3" cy="-4" r="1.5" fill="var(--hog-belly)" />
+            {/* Antennae */}
+            <line x1="-3" y1="-10" x2="-6" y2="-16" stroke="var(--hog-outline)" strokeWidth="1" strokeLinecap="round" />
+            <line x1="3" y1="-10" x2="6" y2="-16" stroke="var(--hog-outline)" strokeWidth="1" strokeLinecap="round" />
+            {/* Legs */}
+            <line x1="-8" y1="-3" x2="-13" y2="-6" stroke="var(--hog-outline)" strokeWidth="1" strokeLinecap="round" />
+            <line x1="-8" y1="3" x2="-13" y2="6" stroke="var(--hog-outline)" strokeWidth="1" strokeLinecap="round" />
+            <line x1="8" y1="-3" x2="13" y2="-6" stroke="var(--hog-outline)" strokeWidth="1" strokeLinecap="round" />
+            <line x1="8" y1="3" x2="13" y2="6" stroke="var(--hog-outline)" strokeWidth="1" strokeLinecap="round" />
+        </g>
+    )
+}
+
+export function LogLine({ x = 0, y = 0, width = 50 }: { x?: number; y?: number; width?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect x="0" y="0" width={8} height="4" rx="1" fill="var(--hog-body)" opacity="0.6" />
+            <rect x="12" y="0" width={width} height="4" rx="1" fill="var(--hog-outline)" opacity="0.15" />
+        </g>
+    )
+}
+
+export function ChatBubble({
+    x = 0,
+    y = 0,
+    side = 'left',
+}: {
+    x?: number
+    y?: number
+    side?: 'left' | 'right'
+}): JSX.Element {
+    const isLeft = side === 'left'
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect
+                x={isLeft ? 0 : 10}
+                y="0"
+                width="50"
+                height="20"
+                rx="8"
+                fill={isLeft ? 'var(--hog-belly)' : 'var(--hog-body)'}
+                stroke="var(--hog-outline)"
+                strokeWidth="1"
+                opacity={isLeft ? 1 : 0.8}
+            />
+            {/* Text lines */}
+            <rect x={isLeft ? 6 : 16} y="6" width="30" height="2.5" rx="1" fill="var(--hog-outline)" opacity="0.2" />
+            <rect x={isLeft ? 6 : 16} y="11" width="20" height="2.5" rx="1" fill="var(--hog-outline)" opacity="0.15" />
+        </g>
+    )
+}
+
+export function QueryBox({ x = 0, y = 0 }: { x?: number; y?: number }): JSX.Element {
+    return (
+        <g transform={`translate(${x}, ${y})`}>
+            <rect
+                x="0"
+                y="0"
+                width="70"
+                height="35"
+                rx="3"
+                fill="var(--hog-outline)"
+                opacity="0.08"
+                stroke="var(--hog-outline)"
+                strokeWidth="1"
+            />
+            {/* "SELECT" keyword */}
+            <text x="5" y="12" fontSize="7" fill="var(--hog-body)" fontFamily="monospace" fontWeight="bold">
+                SELECT
+            </text>
+            <text x="5" y="22" fontSize="7" fill="var(--hog-outline)" opacity="0.5" fontFamily="monospace">
+                FROM events
+            </text>
+            <text x="5" y="32" fontSize="7" fill="var(--hog-outline)" opacity="0.4" fontFamily="monospace">
+                WHERE ...
+            </text>
+        </g>
+    )
+}

--- a/frontend/src/lib/components/ProductAnimations/primitives/useAnimationMode.ts
+++ b/frontend/src/lib/components/ProductAnimations/primitives/useAnimationMode.ts
@@ -1,0 +1,16 @@
+import { useReducedMotion } from 'motion/react'
+
+import type { AnimationMode } from '../types'
+
+interface AnimationModeResult {
+    shouldAnimate: boolean
+    resolvedMode: AnimationMode | 'static'
+}
+
+export function useAnimationMode(requestedMode: AnimationMode): AnimationModeResult {
+    const prefersReduced = useReducedMotion()
+    return {
+        shouldAnimate: !prefersReduced,
+        resolvedMode: prefersReduced ? 'static' : requestedMode,
+    }
+}

--- a/frontend/src/lib/components/ProductAnimations/primitives/useSvgIds.ts
+++ b/frontend/src/lib/components/ProductAnimations/primitives/useSvgIds.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext, useId } from 'react'
+
+export const SvgIdContext = createContext<string>('')
+
+export function useSvgIds(): (localId: string) => string {
+    const prefix = useContext(SvgIdContext)
+    return (localId: string): string => `${prefix}-${localId}`
+}
+
+export function useSvgIdPrefix(): string {
+    return useId()
+}

--- a/frontend/src/lib/components/ProductAnimations/registry.ts
+++ b/frontend/src/lib/components/ProductAnimations/registry.ts
@@ -1,0 +1,25 @@
+import type { LazyAnimationFactory } from './types'
+
+export const animationRegistry: Record<string, LazyAnimationFactory> = {
+    _fallback: () => import('./animations/FallbackAnimation'),
+
+    // Core analytics
+    product_analytics: () => import('./animations/ProductAnalyticsAnimation'),
+    web_analytics: () => import('./animations/WebAnalyticsAnimation'),
+    session_replay: () => import('./animations/SessionReplayAnimation'),
+    feature_flags: () => import('./animations/FeatureFlagsAnimation'),
+    experiments: () => import('./animations/ExperimentsAnimation'),
+    surveys: () => import('./animations/SurveysAnimation'),
+
+    // Data tools
+    data_warehouse: () => import('./animations/DataWarehouseAnimation'),
+    pipeline: () => import('./animations/DataPipelinesAnimation'),
+    hog_ql: () => import('./animations/SqlAnimation'),
+
+    // Error & monitoring
+    error_tracking: () => import('./animations/ErrorTrackingAnimation'),
+    logs: () => import('./animations/LogsAnimation'),
+
+    // AI
+    llm_observability: () => import('./animations/LlmObservabilityAnimation'),
+}

--- a/frontend/src/lib/components/ProductAnimations/sandbox/AnimationsSandbox.tsx
+++ b/frontend/src/lib/components/ProductAnimations/sandbox/AnimationsSandbox.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+
+import { ProductAnimation } from '../ProductAnimation'
+import { animationRegistry } from '../registry'
+import type { AnimationMode, AnimationSize } from '../types'
+import { AnimationsSandboxControls } from './AnimationsSandboxControls'
+
+const PRODUCT_LABELS: Record<string, string> = {
+    product_analytics: 'Product analytics',
+    web_analytics: 'Web analytics',
+    session_replay: 'Session replay',
+    feature_flags: 'Feature flags',
+    experiments: 'Experiments',
+    surveys: 'Surveys',
+    data_warehouse: 'Data warehouse',
+    pipeline: 'Data pipelines',
+    hog_ql: 'SQL / HogQL',
+    error_tracking: 'Error tracking',
+    logs: 'Logs',
+    llm_observability: 'LLM observability',
+}
+
+function AnimationsSandbox(): JSX.Element {
+    const [size, setSize] = useState<AnimationSize>('medium')
+    const [mode, setMode] = useState<AnimationMode>('loop')
+
+    const productKeys = Object.keys(animationRegistry).filter((k) => k !== '_fallback')
+
+    return (
+        <div className="space-y-6 p-4">
+            <div>
+                <h1 className="text-2xl font-bold">Animations sandbox</h1>
+                <p className="mt-1 text-muted">
+                    Preview all product animations at different sizes and modes. Hover over a card to see it animate.
+                </p>
+            </div>
+
+            <AnimationsSandboxControls size={size} mode={mode} onSizeChange={setSize} onModeChange={setMode} />
+
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {productKeys.map((key) => (
+                    <div key={key} className="flex flex-col items-center gap-3 rounded-lg border p-4">
+                        <ProductAnimation product={key} size={size} mode={mode} />
+                        <div className="text-center">
+                            <span className="block text-sm font-medium">{PRODUCT_LABELS[key] ?? key}</span>
+                            <span className="font-mono text-xs text-muted">{key}</span>
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            <div className="border-t pt-4">
+                <h2 className="mb-3 text-lg font-semibold">Hover mode demo</h2>
+                <p className="mb-3 text-sm text-muted">
+                    These use <code>hover=true</code> — static until you hover, then they animate.
+                </p>
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {productKeys.slice(0, 6).map((key) => (
+                        <div key={`hover-${key}`} className="flex flex-col items-center gap-3 rounded-lg border p-4">
+                            <ProductAnimation product={key} size="medium" mode="loop" hover />
+                            <span className="text-xs text-muted">hover: {PRODUCT_LABELS[key] ?? key}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default AnimationsSandbox

--- a/frontend/src/lib/components/ProductAnimations/sandbox/AnimationsSandboxControls.tsx
+++ b/frontend/src/lib/components/ProductAnimations/sandbox/AnimationsSandboxControls.tsx
@@ -1,0 +1,50 @@
+import { LemonSegmentedButton } from '@posthog/lemon-ui'
+
+import type { AnimationMode, AnimationSize } from '../types'
+
+interface AnimationsSandboxControlsProps {
+    size: AnimationSize
+    mode: AnimationMode
+    onSizeChange: (size: AnimationSize) => void
+    onModeChange: (mode: AnimationMode) => void
+}
+
+export function AnimationsSandboxControls({
+    size,
+    mode,
+    onSizeChange,
+    onModeChange,
+}: AnimationsSandboxControlsProps): JSX.Element {
+    return (
+        <div className="flex flex-wrap items-center gap-4">
+            <div className="flex items-center gap-2">
+                <span className="text-xs font-semibold uppercase text-muted">Size</span>
+                <LemonSegmentedButton
+                    value={size}
+                    onChange={(val) => onSizeChange(val as AnimationSize)}
+                    options={[
+                        { value: 'small', label: 'Small (48px)' },
+                        { value: 'medium', label: 'Medium (200px)' },
+                        { value: 'large', label: 'Large (400px)' },
+                    ]}
+                    size="small"
+                />
+            </div>
+            <div className="flex items-center gap-2">
+                <span className="text-xs font-semibold uppercase text-muted">Mode</span>
+                <LemonSegmentedButton
+                    value={mode}
+                    onChange={(val) => onModeChange(val as AnimationMode)}
+                    options={[
+                        { value: 'loop', label: 'Loop' },
+                        { value: 'once', label: 'Play once' },
+                    ]}
+                    size="small"
+                />
+            </div>
+            <p className="text-xs text-muted">
+                To test reduced motion, enable it in Chrome DevTools → Rendering → Emulate CSS prefers-reduced-motion.
+            </p>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/ProductAnimations/types.ts
+++ b/frontend/src/lib/components/ProductAnimations/types.ts
@@ -1,0 +1,27 @@
+import type { ComponentType } from 'react'
+
+export type AnimationSize = 'small' | 'medium' | 'large'
+export type AnimationMode = 'loop' | 'once'
+
+export const SIZE_MAP: Record<AnimationSize, number> = {
+    small: 48,
+    medium: 200,
+    large: 400,
+} as const
+
+export interface AnimationComponentProps {
+    size: AnimationSize
+    mode: AnimationMode | 'static'
+}
+
+export interface ProductAnimationProps {
+    product: string
+    size?: AnimationSize
+    mode?: AnimationMode
+    className?: string
+    onComplete?: () => void
+    /** When true, animation plays on hover and shows static state otherwise (INFR-03) */
+    hover?: boolean
+}
+
+export type LazyAnimationFactory = () => Promise<{ default: ComponentType<AnimationComponentProps> }>

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -31,6 +31,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.DataOps]: () => import('./data-warehouse/DataWarehouseScene'),
     [Scene.DeadLetterQueue]: () => import('./instance/DeadLetterQueue/DeadLetterQueue'),
     [Scene.Destinations]: () => import('./data-pipelines/DestinationsScene'),
+    [Scene.AnimationsSandbox]: () => import('../lib/components/ProductAnimations/sandbox/AnimationsSandbox'),
     [Scene.DebugHog]: () => import('./debug/hog/HogRepl'),
     [Scene.DebugQuery]: () => import('./debug/DebugScene'),
 

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -40,6 +40,7 @@ export enum Scene {
     DataWarehouseSourceNew = 'DataWarehouseSourceNew',
     DeadLetterQueue = 'DeadLetterQueue',
     Destinations = 'Destinations',
+    AnimationsSandbox = 'AnimationsSandbox',
     DebugHog = 'DebugHog',
     DebugQuery = 'DebugQuery',
     EarlyAccessFeatures = 'EarlyAccessFeatures',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -180,6 +180,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         defaultDocsPath: '/docs/cdp/destinations',
         iconType: 'data_pipeline',
     },
+    [Scene.AnimationsSandbox]: { projectBased: true, name: 'Animations sandbox' },
     [Scene.DebugHog]: { projectBased: true, name: 'Hog Repl' },
     [Scene.DebugQuery]: { projectBased: true },
 
@@ -925,6 +926,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.integrationsRedirect(':kind')]: [Scene.IntegrationsRedirect, 'integrationsRedirect'],
     [urls.debugQuery()]: [Scene.DebugQuery, 'debugQuery'],
     [urls.debugHog()]: [Scene.DebugHog, 'debugHog'],
+    [urls.animationsSandbox()]: [Scene.AnimationsSandbox, 'animationsSandbox'],
 
     [urls.notebook(':shortId')]: [Scene.Notebook, 'notebook'],
     [urls.notebooks()]: [Scene.Notebooks, 'notebooks'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -213,6 +213,7 @@ export const urls = {
         urls.shared(token, exportOptions).replace('/shared/', '/embedded/'),
     debugQuery: (query?: string | Record<string, any>): string =>
         combineUrl('/debug', {}, query ? { q: typeof query === 'string' ? query : JSON.stringify(query) } : {}).url,
+    animationsSandbox: (): string => '/animations-sandbox',
     debugHog: (): string => '/debug/hog',
 
     moveToPostHogCloud: (): string => '/move-to-cloud',


### PR DESCRIPTION
## Summary

- Adds a reusable SVG-based product animation system (`ProductAnimations/`) with a hedgehog character and scene primitives
- Includes animations for all major products: Product analytics, Session replay, Feature flags, Experiments, Surveys, Error tracking, Data pipelines, Data warehouse, SQL, Web analytics, LLM observability, and Logs
- Adds an `/animations-sandbox` page for previewing and tweaking animations interactively

## Test plan

- [ ] Visit `/animations-sandbox` and verify all product animations render correctly
- [ ] Test animation controls (play/pause, speed, reduced motion)
- [ ] Verify no regressions in existing scenes/routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)