### PR TITLE
feat: add SLO workflow interceptor for centralized event emission

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -195,6 +195,8 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 "handle-subscription-value-change",
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=instance.id,
+                    team_id=instance.team_id,
+                    distinct_id=str(instance.created_by.distinct_id) if instance.created_by else str(instance.team_id),
                     previous_value="",
                     invite_message=invite_message,
                 ),
@@ -221,6 +223,8 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 "handle-subscription-value-change",
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=instance.id,
+                    team_id=instance.team_id,
+                    distinct_id=str(instance.created_by.distinct_id) if instance.created_by else str(instance.team_id),
                     previous_value=previous_value,
                     invite_message=invite_message,
                 ),

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -303,7 +303,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
                 team_id=team.id,
                 resource_id=str(instance.id),
                 distinct_id=distinct_id,
-                started_extra={
+                start_properties={
                     "export_format": instance.export_format,
                     "source": source,
                 },

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -26,8 +26,7 @@ from posthog.models.exported_asset import ExportedAsset, get_content_response
 from posthog.security.url_validation import is_url_allowed
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
-from posthog.slo.events import emit_slo_started
-from posthog.slo.types import SloArea, SloOperation, SloStartedProperties
+from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.common.client import async_connect
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 from posthog.temporal.exports_video.workflow import VideoExportInputs, VideoExportWorkflow
@@ -293,25 +292,22 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         source = get_event_source(request) if request else EventSource.EXPORT
         distinct_id = str(user.distinct_id) if user else str(team.id)
 
-        emit_slo_started(
-            distinct_id=distinct_id,
-            properties=SloStartedProperties(
-                operation=SloOperation.EXPORT,
-                resource_id=str(instance.id),
-                area=SloArea.ANALYTIC_PLATFORM,
-                team_id=team.id,
-            ),
-            extra_properties={
-                "source": source,
-                "export_format": instance.export_format,
-            },
-        )
-
         workflow_inputs = ExportAssetWorkflowInputs(
             exported_asset_id=instance.id,
             team_id=team.id,
             distinct_id=distinct_id,
             export_format=instance.export_format,
+            slo=SloConfig(
+                operation=SloOperation.EXPORT,
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=team.id,
+                resource_id=str(instance.id),
+                distinct_id=distinct_id,
+                started_extra={
+                    "export_format": instance.export_format,
+                    "source": source,
+                },
+            ),
         )
 
         async def _run():

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -1003,9 +1003,8 @@ class TestExports(APIBaseTest):
         self.assertEqual(asset.exception_type, "QueryError")
         self.assertEqual(asset.failure_type, "user")
 
-    @patch("posthog.api.exports.emit_slo_started")
     @patch("posthog.api.exports.async_connect")
-    def test_workflow_failure_returns_201_with_failed_asset(self, mock_async_connect, _mock_slo) -> None:
+    def test_workflow_failure_returns_201_with_failed_asset(self, mock_async_connect) -> None:
         mock_client = AsyncMock()
         mock_client.execute_workflow.side_effect = Exception("workflow failed")
         mock_async_connect.return_value = mock_client

--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -49,7 +49,7 @@ class SloConfig:
     Workflows opt into SLO tracking by adding ``slo: SloConfig | None = None``
     to their input dataclass. The SLO interceptor reads this at workflow start.
 
-    ``started_extra`` and ``completion_context`` must be JSON-serializable
+    ``start_properties`` and ``completion_properties`` must be JSON-serializable
     (they cross the Temporal serialization boundary as part of the workflow input).
     """
 

--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -58,6 +58,6 @@ class SloConfig:
     team_id: int
     resource_id: str
     distinct_id: str
-    started_extra: dict = dataclasses.field(default_factory=dict)
-    completion_context: dict = dataclasses.field(default_factory=dict)
+    start_properties: dict = dataclasses.field(default_factory=dict)
+    completion_properties: dict = dataclasses.field(default_factory=dict)
     outcome: Optional[SloOutcome] = None

--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -40,3 +40,24 @@ class SloCompletedProperties:
 
     def to_dict(self) -> dict:
         return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}
+
+
+@dataclasses.dataclass
+class SloConfig:
+    """SLO tracking configuration, composed into workflow inputs.
+
+    Workflows opt into SLO tracking by adding ``slo: SloConfig | None = None``
+    to their input dataclass. The SLO interceptor reads this at workflow start.
+
+    ``started_extra`` and ``completion_context`` must be JSON-serializable
+    (they cross the Temporal serialization boundary as part of the workflow input).
+    """
+
+    operation: SloOperation
+    area: SloArea
+    team_id: int
+    resource_id: str
+    distinct_id: str
+    started_extra: dict = dataclasses.field(default_factory=dict)
+    completion_context: dict = dataclasses.field(default_factory=dict)
+    outcome: Optional[SloOutcome] = None

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -20,6 +20,10 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
         if slo is None:
             return await self.next.execute_workflow(input)
 
+        # Guard against duplicate events during Temporal workflow replay. When a
+        # worker crashes and recovers, Temporal re-executes the workflow from the
+        # beginning to rebuild state — without this guard, every replay would
+        # re-emit SLO events and double-count Prometheus metrics.
         if not workflow.unsafe.is_replaying():
             with workflow.unsafe.sandbox_unrestricted():
                 emit_slo_started(
@@ -30,7 +34,7 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
                         team_id=slo.team_id,
                         resource_id=slo.resource_id,
                     ),
-                    extra_properties=slo.started_extra or None,
+                    extra_properties=slo.start_properties or None,
                 )
 
         start_time = workflow.time()
@@ -56,7 +60,7 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
                             resource_id=slo.resource_id,
                             duration_ms=duration_ms,
                         ),
-                        extra_properties=slo.completion_context or None,
+                        extra_properties=slo.completion_properties or None,
                     )
 
 

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+from django.conf import settings
+
+from temporalio import workflow
+from temporalio.worker import (
+    ExecuteWorkflowInput,
+    Interceptor,
+    WorkflowInboundInterceptor,
+    WorkflowInterceptorClassInput,
+)
+
+from posthog.slo.events import emit_slo_completed, emit_slo_started
+from posthog.slo.types import SloCompletedProperties, SloConfig, SloOutcome, SloStartedProperties
+
+
+class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
+    async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
+        slo: SloConfig | None = getattr(input.args[0], "slo", None) if input.args else None
+        if slo is None:
+            return await self.next.execute_workflow(input)
+
+        if not workflow.unsafe.is_replaying():
+            with workflow.unsafe.sandbox_unrestricted():
+                emit_slo_started(
+                    distinct_id=slo.distinct_id,
+                    properties=SloStartedProperties(
+                        operation=slo.operation,
+                        area=slo.area,
+                        team_id=slo.team_id,
+                        resource_id=slo.resource_id,
+                    ),
+                    extra_properties=slo.started_extra or None,
+                )
+
+        start_time = workflow.time()
+        outcome = SloOutcome.SUCCESS
+        try:
+            result = await self.next.execute_workflow(input)
+            outcome = slo.outcome if slo.outcome is not None else SloOutcome.SUCCESS
+            return result
+        except Exception:
+            outcome = slo.outcome if slo.outcome is not None else SloOutcome.FAILURE
+            raise
+        finally:
+            duration_ms = (workflow.time() - start_time) * 1000
+            if not workflow.unsafe.is_replaying():
+                with workflow.unsafe.sandbox_unrestricted():
+                    emit_slo_completed(
+                        distinct_id=slo.distinct_id,
+                        properties=SloCompletedProperties(
+                            operation=slo.operation,
+                            area=slo.area,
+                            team_id=slo.team_id,
+                            outcome=outcome,
+                            resource_id=slo.resource_id,
+                            duration_ms=duration_ms,
+                        ),
+                        extra_properties=slo.completion_context or None,
+                    )
+
+
+class SloInterceptor(Interceptor):
+    """Emits SLO started/completed events for opted-in workflows.
+
+    Workflows opt in by adding ``slo: SloConfig | None = None`` to their input
+    dataclass. See ``SloConfig`` for field documentation.
+    """
+
+    task_queue = settings.ANALYTICS_PLATFORM_TASK_QUEUE
+
+    def workflow_interceptor_class(
+        self, input: WorkflowInterceptorClassInput
+    ) -> type[WorkflowInboundInterceptor] | None:
+        return _SloWorkflowInterceptor

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -20,6 +20,14 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
         if slo is None:
             return await self.next.execute_workflow(input)
 
+        # Attach workflow identity for debugging and query-level deduplication.
+        info = workflow.info()
+        workflow_context = {
+            "workflow_id": info.workflow_id,
+            "workflow_run_id": info.run_id,
+            "workflow_type": info.workflow_type,
+        }
+
         # Guard against duplicate events during Temporal workflow replay. When a
         # worker crashes and recovers, Temporal re-executes the workflow from the
         # beginning to rebuild state — without this guard, every replay would
@@ -34,7 +42,7 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
                         team_id=slo.team_id,
                         resource_id=slo.resource_id,
                     ),
-                    extra_properties=slo.start_properties or None,
+                    extra_properties={**workflow_context, **(slo.start_properties or {})},
                 )
 
         start_time = workflow.time()
@@ -60,7 +68,7 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
                             resource_id=slo.resource_id,
                             duration_ms=duration_ms,
                         ),
-                        extra_properties=slo.completion_properties or None,
+                        extra_properties={**workflow_context, **(slo.completion_properties or {})},
                     )
 
 

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -51,7 +51,7 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
             result = await self.next.execute_workflow(input)
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.SUCCESS
             return result
-        except Exception:
+        except BaseException:
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.FAILURE
             raise
         finally:

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -16,6 +16,7 @@ from posthog.temporal.common.interceptor import is_task_queue_supported
 from posthog.temporal.common.liveness_tracker import LivenessInterceptor
 from posthog.temporal.common.logger import get_write_only_logger
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
+from posthog.temporal.common.slo_interceptor import SloInterceptor
 from posthog.temporal.llm_analytics.metrics import EvalsMetricsInterceptor
 from posthog.temporal.llm_analytics.sentiment.metrics import (
     SENTIMENT_LATENCY_HISTOGRAM_BUCKETS,
@@ -99,6 +100,7 @@ SUMMARIZATION_LATENCY_HISTOGRAM_BUCKETS = [
 ALL_INTERCEPTOR_CLASSES = [
     LivenessInterceptor,
     PostHogClientInterceptor,
+    SloInterceptor,
     BatchExportsMetricsInterceptor,
     DeleteRecordingsMetricsInterceptor,
     EvalsMetricsInterceptor,

--- a/posthog/temporal/exports/__init__.py
+++ b/posthog/temporal/exports/__init__.py
@@ -1,31 +1,16 @@
-from posthog.temporal.exports.activities import (
-    emit_delivery_outcome,
-    emit_delivery_started,
-    emit_export_outcome,
-    export_asset_activity,
-)
+from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import (
-    EmitDeliveryOutcomeInput,
-    EmitExportOutcomeInput,
-    ExportAssetActivityInputs,
-    ExportAssetResult,
-)
+from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
 from posthog.temporal.exports.workflows import ExportAssetWorkflow
 
 __all__ = [
-    "emit_delivery_outcome",
-    "emit_delivery_started",
-    "emit_export_outcome",
     "export_asset_activity",
     "ExportAssetWorkflow",
     "EXPORT_RETRY_POLICY",
-    "EmitDeliveryOutcomeInput",
-    "EmitExportOutcomeInput",
     "ExportAssetActivityInputs",
     "ExportAssetResult",
 ]
 
 WORKFLOWS = [ExportAssetWorkflow]
 
-ACTIVITIES = [export_asset_activity, emit_delivery_started, emit_delivery_outcome, emit_export_outcome]
+ACTIVITIES = [export_asset_activity]

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -6,19 +6,11 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.event_usage import EventSource
 from posthog.models.exported_asset import ExportedAsset
-from posthog.models.subscription import Subscription
-from posthog.slo.events import emit_slo_completed, emit_slo_started
-from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloStartedProperties
 from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
 from posthog.tasks.exports.failure_handler import SYSTEM_ERROR_NAMES
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.exports.types import (
-    EmitDeliveryOutcomeInput,
-    EmitExportOutcomeInput,
-    ExportAssetActivityInputs,
-    ExportAssetResult,
-)
+from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
 
 logger = structlog.get_logger(__name__)
 
@@ -75,73 +67,3 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
             exported_asset_id=asset.id,
             success=asset.has_content,
         )
-
-
-@temporalio.activity.defn
-async def emit_delivery_started(subscription_id: int) -> None:
-    subscription = await database_sync_to_async(
-        Subscription.objects.select_related("created_by", "team").get,
-        thread_sensitive=False,
-    )(pk=subscription_id)
-    team = subscription.team
-    distinct_id = str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id)
-    emit_slo_started(
-        distinct_id=distinct_id,
-        properties=SloStartedProperties(
-            operation=SloOperation.SUBSCRIPTION_DELIVERY,
-            resource_id=str(subscription_id),
-            area=SloArea.ANALYTIC_PLATFORM,
-            team_id=team.id,
-        ),
-    )
-
-
-@temporalio.activity.defn
-async def emit_delivery_outcome(inputs: EmitDeliveryOutcomeInput) -> None:
-    emit_slo_completed(
-        distinct_id=inputs.distinct_id,
-        properties=SloCompletedProperties(
-            operation=SloOperation.SUBSCRIPTION_DELIVERY,
-            resource_id=str(inputs.subscription_id),
-            area=SloArea.ANALYTIC_PLATFORM,
-            team_id=inputs.team_id,
-            outcome=inputs.outcome,
-            duration_ms=inputs.duration_ms,
-        ),
-        extra_properties={
-            "assets_with_content": inputs.assets_with_content,
-            "total_assets": inputs.total_assets,
-            "errors": [{"exception_class": e.exception_class, "error_trace": e.error_trace} for e in inputs.errors],
-        },
-    )
-    logger.info(
-        "emit_delivery_outcome.emitted",
-        subscription_id=inputs.subscription_id,
-        outcome=inputs.outcome,
-    )
-
-
-@temporalio.activity.defn
-async def emit_export_outcome(inputs: EmitExportOutcomeInput) -> None:
-    emit_slo_completed(
-        distinct_id=inputs.distinct_id,
-        properties=SloCompletedProperties(
-            operation=SloOperation.EXPORT,
-            resource_id=str(inputs.exported_asset_id),
-            area=SloArea.ANALYTIC_PLATFORM,
-            team_id=inputs.team_id,
-            outcome=inputs.outcome,
-            duration_ms=inputs.duration_ms,
-        ),
-        extra_properties={
-            "export_format": inputs.export_format,
-            "error": {"exception_class": inputs.error.exception_class, "error_trace": inputs.error.error_trace}
-            if inputs.error
-            else None,
-        },
-    )
-    logger.info(
-        "emit_export_outcome.emitted",
-        exported_asset_id=inputs.exported_asset_id,
-        outcome=inputs.outcome,
-    )

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -44,7 +44,3 @@ class ExportAssetResult:
     exported_asset_id: int
     success: bool
     error: Optional[ExportError] = None
-    insight_id: Optional[int] = None
-    duration_ms: Optional[float] = None
-    export_format: str = ""
-    attempts: int = 1

--- a/posthog/temporal/exports/types.py
+++ b/posthog/temporal/exports/types.py
@@ -4,8 +4,6 @@ from typing import Optional
 
 from temporalio.exceptions import ActivityError, ApplicationError
 
-from posthog.slo.types import SloOutcome
-
 
 class ExportErrorDetails(typing.NamedTuple):
     exception_class: str | None = None
@@ -46,26 +44,7 @@ class ExportAssetResult:
     exported_asset_id: int
     success: bool
     error: Optional[ExportError] = None
-
-
-@dataclasses.dataclass
-class EmitDeliveryOutcomeInput:
-    subscription_id: int
-    team_id: int
-    distinct_id: str
-    outcome: SloOutcome
-    duration_ms: Optional[float] = None
-    assets_with_content: int = 0
-    total_assets: int = 0
-    errors: list[ExportError] = dataclasses.field(default_factory=list)
-
-
-@dataclasses.dataclass
-class EmitExportOutcomeInput:
-    exported_asset_id: int
-    team_id: int
-    distinct_id: str
-    outcome: SloOutcome
+    insight_id: Optional[int] = None
     duration_ms: Optional[float] = None
     export_format: str = ""
-    error: Optional[ExportError] = None
+    attempts: int = 1

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -35,7 +35,7 @@ class ExportAssetWorkflow(PostHogWorkflow):
     @wf.run
     async def run(self, inputs: ExportAssetWorkflowInputs) -> None:
         if inputs.slo:
-            inputs.slo.completion_context["export_format"] = inputs.export_format or ""
+            inputs.slo.completion_properties["export_format"] = inputs.export_format or ""
 
         try:
             await wf.execute_activity(
@@ -51,7 +51,7 @@ class ExportAssetWorkflow(PostHogWorkflow):
         except Exception as e:
             if inputs.slo:
                 err = extract_error_details(e)
-                inputs.slo.completion_context["error"] = {
+                inputs.slo.completion_properties["error"] = {
                     "exception_class": err.exception_class or type(e).__name__,
                     "error_trace": err.error_trace or "\n".join(traceback.format_exception(e)[:5]),
                 }

--- a/posthog/temporal/exports/workflows.py
+++ b/posthog/temporal/exports/workflows.py
@@ -5,19 +5,13 @@ from datetime import timedelta
 from typing import Optional
 
 import temporalio.workflow as wf
-from temporalio.common import RetryPolicy
 
 from posthog.event_usage import EventSource
-from posthog.slo.types import SloOutcome
+from posthog.slo.types import SloConfig
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
+from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
-from posthog.temporal.exports.types import (
-    EmitExportOutcomeInput,
-    ExportAssetActivityInputs,
-    ExportError,
-    extract_error_details,
-)
+from posthog.temporal.exports.types import ExportAssetActivityInputs, extract_error_details
 
 
 @dataclasses.dataclass
@@ -26,6 +20,7 @@ class ExportAssetWorkflowInputs:
     team_id: int
     distinct_id: str = ""
     export_format: Optional[str] = None
+    slo: SloConfig | None = None
 
 
 @wf.defn(name="export-asset")
@@ -39,10 +34,8 @@ class ExportAssetWorkflow(PostHogWorkflow):
 
     @wf.run
     async def run(self, inputs: ExportAssetWorkflowInputs) -> None:
-        start_time = wf.time()
-        outcome = SloOutcome.SUCCESS
-        error: Optional[ExportError] = None
-        caught_error: BaseException | None = None
+        if inputs.slo:
+            inputs.slo.completion_context["export_format"] = inputs.export_format or ""
 
         try:
             await wf.execute_activity(
@@ -55,38 +48,11 @@ class ExportAssetWorkflow(PostHogWorkflow):
                 heartbeat_timeout=timedelta(minutes=2),
                 retry_policy=EXPORT_RETRY_POLICY,
             )
-
         except Exception as e:
-            outcome = SloOutcome.FAILURE
-            caught_error = e
-
-            err = extract_error_details(e)
-            error = ExportError(
-                exception_class=err.exception_class or type(e).__name__,
-                error_trace=err.error_trace or "\n".join(traceback.format_exception(e)[:5]),
-            )
-
-        finally:
-            duration_ms = (wf.time() - start_time) * 1000
-            await wf.execute_activity(
-                emit_export_outcome,
-                EmitExportOutcomeInput(
-                    exported_asset_id=inputs.exported_asset_id,
-                    team_id=inputs.team_id,
-                    distinct_id=inputs.distinct_id,
-                    outcome=outcome,
-                    duration_ms=duration_ms,
-                    export_format=inputs.export_format or "",
-                    error=error,
-                ),
-                start_to_close_timeout=timedelta(minutes=2),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=5),
-                    maximum_interval=timedelta(minutes=1),
-                    maximum_attempts=3,
-                ),
-            )
-
-        # Re-raise after SLO event is emitted so Temporal marks the workflow as failed
-        if caught_error is not None:
-            raise caught_error
+            if inputs.slo:
+                err = extract_error_details(e)
+                inputs.slo.completion_context["error"] = {
+                    "exception_class": err.exception_class or type(e).__name__,
+                    "error_trace": err.error_trace or "\n".join(traceback.format_exception(e)[:5]),
+                }
+            raise

--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -13,6 +13,7 @@ from posthog.temporal.subscriptions.types import (
     CreateExportAssetsResult,
     DeliverSubscriptionInputs,
     FetchDueSubscriptionsActivityInputs,
+    SubscriptionInfo,
 )
 
 from ee.tasks.subscriptions import SLACK_USER_CONFIG_ERRORS, SUPPORTED_TARGET_TYPES, _capture_delivery_failed_event
@@ -26,23 +27,30 @@ LOGGER = get_logger(__name__)
 
 
 @temporalio.activity.defn
-async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivityInputs) -> list[int]:
+async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivityInputs) -> list[SubscriptionInfo]:
     now_with_buffer = dt.datetime.utcnow() + dt.timedelta(minutes=inputs.buffer_minutes)
     await LOGGER.ainfo("Fetching due subscriptions", deadline=now_with_buffer)
 
     @database_sync_to_async(thread_sensitive=False)
-    def get_subscription_ids() -> list[int]:
-        return list(
-            Subscription.objects.filter(next_delivery_date__lte=now_with_buffer, deleted=False)
+    def get_subscriptions() -> list[SubscriptionInfo]:
+        return [
+            SubscriptionInfo(
+                subscription_id=sub["id"],
+                team_id=sub["team_id"],
+                distinct_id=str(sub["created_by__distinct_id"])
+                if sub["created_by__distinct_id"]
+                else str(sub["team_id"]),
+            )
+            for sub in Subscription.objects.filter(next_delivery_date__lte=now_with_buffer, deleted=False)
             .exclude(dashboard__deleted=True)
             .exclude(insight__deleted=True)
-            .values_list("id", flat=True)
-        )
+            .values("id", "team_id", "created_by__distinct_id")
+        ]
 
-    subscription_ids = await get_subscription_ids()
-    await LOGGER.ainfo("Fetched due subscriptions", count=len(subscription_ids))
+    subscriptions = await get_subscriptions()
+    await LOGGER.ainfo("Fetched due subscriptions", count=len(subscriptions))
 
-    return subscription_ids
+    return subscriptions
 
 
 @temporalio.activity.defn
@@ -96,9 +104,11 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
         insights = [tile.insight for tile in tiles if tile.insight]
 
         selected_ids = await database_sync_to_async(
-            lambda: set(subscription.dashboard_export_insights.values_list("id", flat=True))
-            if subscription.dashboard_export_insights.exists()
-            else None,
+            lambda: (
+                set(subscription.dashboard_export_insights.values_list("id", flat=True))
+                if subscription.dashboard_export_insights.exists()
+                else None
+            ),
             thread_sensitive=False,
         )()
         if selected_ids:

--- a/posthog/temporal/subscriptions/types.py
+++ b/posthog/temporal/subscriptions/types.py
@@ -1,7 +1,18 @@
 import typing
 import dataclasses
 
+from posthog.slo.types import SloConfig
+
 from ee.tasks.subscriptions.subscription_utils import DEFAULT_MAX_ASSET_COUNT
+
+
+@dataclasses.dataclass
+class SubscriptionInfo:
+    """Lightweight subscription metadata returned by fetch_due_subscriptions_activity."""
+
+    subscription_id: int
+    team_id: int
+    distinct_id: str
 
 
 @dataclasses.dataclass
@@ -44,8 +55,11 @@ class DeliverSubscriptionInputs:
 @dataclasses.dataclass
 class ProcessSubscriptionWorkflowInputs:
     subscription_id: int
+    team_id: int = 0
+    distinct_id: str = ""
     previous_value: typing.Optional[str] = None
     invite_message: typing.Optional[str] = None
+    slo: SloConfig | None = None
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/subscriptions/types.py
+++ b/posthog/temporal/subscriptions/types.py
@@ -8,8 +8,6 @@ from ee.tasks.subscriptions.subscription_utils import DEFAULT_MAX_ASSET_COUNT
 
 @dataclasses.dataclass
 class SubscriptionInfo:
-    """Lightweight subscription metadata returned by fetch_due_subscriptions_activity."""
-
     subscription_id: int
     team_id: int
     distinct_id: str

--- a/posthog/temporal/subscriptions/types.py
+++ b/posthog/temporal/subscriptions/types.py
@@ -57,6 +57,23 @@ class ProcessSubscriptionWorkflowInputs:
     distinct_id: str = ""
     previous_value: typing.Optional[str] = None
     invite_message: typing.Optional[str] = None
+
+
+@dataclasses.dataclass
+class TrackedSubscriptionInputs:
+    """Internal inputs for ProcessSubscriptionWorkflow with SLO tracking.
+
+    Duplicates ProcessSubscriptionWorkflowInputs fields intentionally:
+    Temporal deserializes by the declared parameter type, so SLO config
+    must be on the type the workflow declares. Due to this "extending"
+    ProcessSubscriptionWorkflow did not work.
+    """
+
+    subscription_id: int
+    team_id: int = 0
+    distinct_id: str = ""
+    previous_value: typing.Optional[str] = None
+    invite_message: typing.Optional[str] = None
     slo: SloConfig | None = None
 
 

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -32,6 +32,7 @@ from posthog.temporal.subscriptions.types import (
     ProcessSubscriptionWorkflowInputs,
     ScheduleAllSubscriptionsWorkflowInputs,
     SubscriptionInfo,
+    TrackedSubscriptionInputs,
 )
 
 
@@ -102,7 +103,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
         for sub in subscription_infos:
             task = temporalio.workflow.execute_child_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(
+                TrackedSubscriptionInputs(
                     subscription_id=sub.subscription_id,
                     team_id=sub.team_id,
                     distinct_id=sub.distinct_id,
@@ -151,16 +152,15 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
 @temporalio.workflow.defn(name="process-subscription")
 class ProcessSubscriptionWorkflow(PostHogWorkflow):
     @staticmethod
-    def parse_inputs(inputs: list[str]) -> ProcessSubscriptionWorkflowInputs:
+    def parse_inputs(inputs: list[str]) -> TrackedSubscriptionInputs:
         loaded = json.loads(inputs[0])
-        return ProcessSubscriptionWorkflowInputs(**loaded)
+        return TrackedSubscriptionInputs(**loaded)
 
     @temporalio.workflow.run
-    async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
+    async def run(self, inputs: TrackedSubscriptionInputs) -> None:
         assets_with_content = 0
         total_assets = 0
         errors: list[ExportError] = []
-        prepare_result = None
         caught_error: BaseException | None = None
 
         try:
@@ -291,16 +291,23 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
-        inputs.slo = SloConfig(
-            operation=SloOperation.SUBSCRIPTION_DELIVERY,
-            area=SloArea.ANALYTIC_PLATFORM,
+        tracked = TrackedSubscriptionInputs(
+            subscription_id=inputs.subscription_id,
             team_id=inputs.team_id,
-            resource_id=str(inputs.subscription_id),
             distinct_id=inputs.distinct_id,
+            previous_value=inputs.previous_value,
+            invite_message=inputs.invite_message,
+            slo=SloConfig(
+                operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=inputs.team_id,
+                resource_id=str(inputs.subscription_id),
+                distinct_id=inputs.distinct_id,
+            ),
         )
         await temporalio.workflow.execute_child_workflow(
             ProcessSubscriptionWorkflow.run,
-            inputs,
+            tracked,
             id=f"process-subscription-change-{inputs.subscription_id}",
             parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
             execution_timeout=dt.timedelta(hours=2),

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -2,7 +2,6 @@ import json
 import asyncio
 import datetime as dt
 import traceback
-import dataclasses
 
 import temporalio.common
 import temporalio.workflow
@@ -266,7 +265,7 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
 
             # Enrich SLO completion context
             if inputs.slo:
-                inputs.slo.completion_context.update(
+                inputs.slo.completion_properties.update(
                     {
                         "assets_with_content": assets_with_content,
                         "total_assets": total_assets,
@@ -292,19 +291,16 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
-        child_inputs = dataclasses.replace(
-            inputs,
-            slo=SloConfig(
-                operation=SloOperation.SUBSCRIPTION_DELIVERY,
-                area=SloArea.ANALYTIC_PLATFORM,
-                team_id=inputs.team_id,
-                resource_id=str(inputs.subscription_id),
-                distinct_id=inputs.distinct_id,
-            ),
+        inputs.slo = SloConfig(
+            operation=SloOperation.SUBSCRIPTION_DELIVERY,
+            area=SloArea.ANALYTIC_PLATFORM,
+            team_id=inputs.team_id,
+            resource_id=str(inputs.subscription_id),
+            distinct_id=inputs.distinct_id,
         )
         await temporalio.workflow.execute_child_workflow(
             ProcessSubscriptionWorkflow.run,
-            child_inputs,
+            inputs,
             id=f"process-subscription-change-{inputs.subscription_id}",
             parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
             execution_timeout=dt.timedelta(hours=2),

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -2,19 +2,19 @@ import json
 import asyncio
 import datetime as dt
 import traceback
+import dataclasses
 
 import temporalio.common
 import temporalio.workflow
 from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
 
 from posthog.event_usage import EventSource
-from posthog.slo.types import SloOutcome
+from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.tasks.exports.failure_handler import is_user_query_error_type
 from posthog.temporal.common.base import PostHogWorkflow
-from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
+from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.retry_policy import EXPORT_RETRY_POLICY
 from posthog.temporal.exports.types import (
-    EmitDeliveryOutcomeInput,
     ExportAssetActivityInputs,
     ExportAssetResult,
     ExportError,
@@ -32,6 +32,7 @@ from posthog.temporal.subscriptions.types import (
     FetchDueSubscriptionsActivityInputs,
     ProcessSubscriptionWorkflowInputs,
     ScheduleAllSubscriptionsWorkflowInputs,
+    SubscriptionInfo,
 )
 
 
@@ -82,7 +83,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
     @temporalio.workflow.run
     async def run(self, inputs: ScheduleAllSubscriptionsWorkflowInputs) -> None:
         fetch_inputs = FetchDueSubscriptionsActivityInputs(buffer_minutes=inputs.buffer_minutes)
-        subscription_ids: list[int] = await temporalio.workflow.execute_activity(
+        subscription_infos: list[SubscriptionInfo] = await temporalio.workflow.execute_activity(
             fetch_due_subscriptions_activity,
             fetch_inputs,
             start_to_close_timeout=dt.timedelta(minutes=5),
@@ -99,11 +100,22 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
         # schedule runs overlap: Temporal guarantees no two open workflows can
         # share the same ID, so a still-running child rejects the duplicate start.
         tasks = []
-        for sub_id in subscription_ids:
+        for sub in subscription_infos:
             task = temporalio.workflow.execute_child_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=sub_id),
-                id=f"process-subscription-{sub_id}",
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=sub.subscription_id,
+                    team_id=sub.team_id,
+                    distinct_id=sub.distinct_id,
+                    slo=SloConfig(
+                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                        area=SloArea.ANALYTIC_PLATFORM,
+                        team_id=sub.team_id,
+                        resource_id=str(sub.subscription_id),
+                        distinct_id=sub.distinct_id,
+                    ),
+                ),
+                id=f"process-subscription-{sub.subscription_id}",
                 parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
                 execution_timeout=dt.timedelta(hours=2),
             )
@@ -114,20 +126,20 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
             # one failing subscription should not prevent others from being delivered.
             results = await asyncio.gather(*tasks, return_exceptions=True)
             failed_ids = []
-            for sub_id, result in zip(subscription_ids, results):
+            for sub, result in zip(subscription_infos, results):
                 if isinstance(result, BaseException):
                     if isinstance(result, WorkflowAlreadyStartedError):
                         # A previous schedule run's child is still processing this
                         # subscription — not a failure, just skip it.
                         temporalio.workflow.logger.info(
                             "process_subscription.already_running",
-                            extra={"subscription_id": sub_id},
+                            extra={"subscription_id": sub.subscription_id},
                         )
                     else:
-                        failed_ids.append(sub_id)
+                        failed_ids.append(sub.subscription_id)
                         temporalio.workflow.logger.warning(
                             "process_subscription.child_workflow_error",
-                            extra={"subscription_id": sub_id, "error": str(result)},
+                            extra={"subscription_id": sub.subscription_id, "error": str(result)},
                         )
 
             if failed_ids:
@@ -146,8 +158,6 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
-        start_time = temporalio.workflow.time()
-        delivery_outcome = SloOutcome.SUCCESS
         assets_with_content = 0
         total_assets = 0
         errors: list[ExportError] = []
@@ -155,18 +165,6 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
         caught_error: BaseException | None = None
 
         try:
-            # SLO started — workflow owns the lifecycle, fires before any work
-            await temporalio.workflow.execute_activity(
-                emit_delivery_started,
-                inputs.subscription_id,
-                start_to_close_timeout=dt.timedelta(minutes=2),
-                retry_policy=temporalio.common.RetryPolicy(
-                    initial_interval=dt.timedelta(seconds=5),
-                    maximum_interval=dt.timedelta(minutes=1),
-                    maximum_attempts=3,
-                ),
-            )
-
             # Phase 1: Prepare — create ExportedAssets
             prepare_result = await temporalio.workflow.execute_activity(
                 create_export_assets,
@@ -214,8 +212,8 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             errors = [a.error for a in outcome_assets if a.error]
 
             non_user_errors = [e for e in errors if not is_user_query_error_type(e.exception_class)]
-            if non_user_errors:
-                delivery_outcome = SloOutcome.FAILURE
+            if inputs.slo and non_user_errors:
+                inputs.slo.outcome = SloOutcome.FAILURE
 
             # Phase 3: Deliver — send all assets including failed ones (they show
             # a "failed to generate" placeholder in the email/Slack message)
@@ -243,7 +241,6 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
             )
 
         except Exception as e:
-            delivery_outcome = SloOutcome.FAILURE
             errors.append(
                 ExportError(
                     exception_class=type(e).__name__,
@@ -267,27 +264,16 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     ),
                 )
 
-            # SLO completed — fires last, after all side effects
-            if prepare_result and prepare_result.team_id:
-                duration_ms = (temporalio.workflow.time() - start_time) * 1000
-                await temporalio.workflow.execute_activity(
-                    emit_delivery_outcome,
-                    EmitDeliveryOutcomeInput(
-                        subscription_id=inputs.subscription_id,
-                        team_id=prepare_result.team_id,
-                        distinct_id=prepare_result.distinct_id,
-                        outcome=delivery_outcome,
-                        duration_ms=duration_ms,
-                        assets_with_content=assets_with_content,
-                        total_assets=total_assets,
-                        errors=errors,
-                    ),
-                    start_to_close_timeout=dt.timedelta(minutes=2),
-                    retry_policy=temporalio.common.RetryPolicy(
-                        initial_interval=dt.timedelta(seconds=5),
-                        maximum_interval=dt.timedelta(minutes=1),
-                        maximum_attempts=3,
-                    ),
+            # Enrich SLO completion context
+            if inputs.slo:
+                inputs.slo.completion_context.update(
+                    {
+                        "assets_with_content": assets_with_content,
+                        "total_assets": total_assets,
+                        "errors": [
+                            {"exception_class": e.exception_class, "error_trace": e.error_trace} for e in errors
+                        ],
+                    }
                 )
 
         # Re-raise after cleanup completes. We can't re-raise inside the except
@@ -306,9 +292,19 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: ProcessSubscriptionWorkflowInputs) -> None:
+        child_inputs = dataclasses.replace(
+            inputs,
+            slo=SloConfig(
+                operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=inputs.team_id,
+                resource_id=str(inputs.subscription_id),
+                distinct_id=inputs.distinct_id,
+            ),
+        )
         await temporalio.workflow.execute_child_workflow(
             ProcessSubscriptionWorkflow.run,
-            inputs,
+            child_inputs,
             id=f"process-subscription-change-{inputs.subscription_id}",
             parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
             execution_timeout=dt.timedelta(hours=2),

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -126,9 +126,10 @@ async def test_transient_error_retries_and_succeeds(
     "error_factory,expected_exception_class,expected_call_count",
     [
         (lambda: QueryError("Invalid HogQL query"), "QueryError", 1),
-        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 10),
+        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 1),
+        (lambda: CHQueryErrorS3Error("S3 error", code=499), "CHQueryErrorS3Error", 10),
     ],
-    ids=["non_retryable_user_error", "generic_runtime_error"],
+    ids=["non_retryable_user_error", "generic_runtime_error", "retryable_system_error"],
 )
 @patch("posthog.slo.events.posthoganalytics")
 @patch("posthog.temporal.exports.activities.exporter")

--- a/posthog/temporal/tests/test_export_workflow.py
+++ b/posthog/temporal/tests/test_export_workflow.py
@@ -13,8 +13,9 @@ from posthog.hogql.errors import QueryError
 
 from posthog.errors import CHQueryErrorS3Error
 from posthog.models.exported_asset import ExportedAsset
-from posthog.slo.types import SloOutcome
-from posthog.temporal.exports.activities import emit_export_outcome, export_asset_activity
+from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
+from posthog.temporal.common.slo_interceptor import SloInterceptor
+from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
@@ -29,7 +30,8 @@ async def _run_export_workflow(env, asset, team, mock_exporter, fake_export):
         env.client,
         task_queue=settings.TEMPORAL_TASK_QUEUE,
         workflows=[ExportAssetWorkflow],
-        activities=[export_asset_activity, emit_export_outcome],
+        activities=[export_asset_activity],
+        interceptors=[SloInterceptor()],
         workflow_runner=UnsandboxedWorkflowRunner(),
         activity_executor=ThreadPoolExecutor(max_workers=5),
         debug_mode=True,
@@ -40,6 +42,13 @@ async def _run_export_workflow(env, asset, team, mock_exporter, fake_export):
                 exported_asset_id=asset.id,
                 team_id=team.id,
                 export_format=EXPORT_FORMAT,
+                slo=SloConfig(
+                    operation=SloOperation.EXPORT,
+                    area=SloArea.ANALYTIC_PLATFORM,
+                    team_id=team.id,
+                    resource_id=str(asset.id),
+                    distinct_id=str(team.id),
+                ),
             ),
             id=f"export-asset-{asset.id}",
             task_queue=settings.TEMPORAL_TASK_QUEUE,
@@ -79,7 +88,7 @@ async def test_successful_export(
     assert props["operation"] == "export"
     assert props["resource_id"] == str(asset.id)
     assert props["export_format"] == EXPORT_FORMAT
-    assert props["error"] is None
+    assert "error" not in props
 
 
 @patch("posthog.slo.events.posthoganalytics")
@@ -110,14 +119,14 @@ async def test_transient_error_retries_and_succeeds(
 
     props = _get_slo_completed_props(mock_analytics)
     assert props["outcome"] == SloOutcome.SUCCESS
-    assert props["error"] is None
+    assert "error" not in props
 
 
 @pytest.mark.parametrize(
     "error_factory,expected_exception_class,expected_call_count",
     [
         (lambda: QueryError("Invalid HogQL query"), "QueryError", 1),
-        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 1),
+        (lambda: RuntimeError("Chrome crashed"), "RuntimeError", 10),
     ],
     ids=["non_retryable_user_error", "generic_runtime_error"],
 )

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -56,16 +56,15 @@ class UntrackedWorkflow:
         return "ok"
 
 
-def _make_slo_config(**overrides) -> SloConfig:
-    defaults = {
-        "operation": SloOperation.EXPORT,
-        "area": SloArea.ANALYTIC_PLATFORM,
-        "team_id": 1,
-        "resource_id": "42",
-        "distinct_id": "user-123",
-    }
-    defaults.update(overrides)
-    return SloConfig(**defaults)
+def _make_slo_config(start_properties: dict | None = None) -> SloConfig:
+    return SloConfig(
+        operation=SloOperation.EXPORT,
+        area=SloArea.ANALYTIC_PLATFORM,
+        team_id=1,
+        resource_id="42",
+        distinct_id="user-123",
+        start_properties=start_properties or {},
+    )
 
 
 pytestmark = [pytest.mark.asyncio]

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -28,7 +28,7 @@ class TrackedWorkflow:
     @temporalio.workflow.run
     async def run(self, inputs: TrackedWorkflowInput) -> str:
         if inputs.slo:
-            inputs.slo.completion_context["extra_key"] = "extra_value"
+            inputs.slo.completion_properties["extra_key"] = "extra_value"
         return "ok"
 
 
@@ -45,7 +45,7 @@ class TrackedBusinessFailureWorkflow:
     async def run(self, inputs: TrackedWorkflowInput) -> str:
         if inputs.slo:
             inputs.slo.outcome = SloOutcome.FAILURE
-            inputs.slo.completion_context["reason"] = "business logic"
+            inputs.slo.completion_properties["reason"] = "business logic"
         return "ok"
 
 
@@ -86,7 +86,7 @@ async def test_interceptor_emits_started_and_completed_on_success(mock_analytics
                 TrackedWorkflow.run,
                 TrackedWorkflowInput(
                     value="test",
-                    slo=_make_slo_config(started_extra={"source": "web"}),
+                    slo=_make_slo_config(start_properties={"source": "web"}),
                 ),
                 id="test-success",
                 task_queue="test-slo",

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -1,0 +1,213 @@
+import dataclasses
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import temporalio.workflow
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
+from posthog.temporal.common.slo_interceptor import SloInterceptor
+
+
+@dataclasses.dataclass
+class TrackedWorkflowInput:
+    value: str = ""
+    slo: SloConfig | None = None
+
+
+@dataclasses.dataclass
+class UntrackedWorkflowInput:
+    value: str = ""
+
+
+@temporalio.workflow.defn(name="test-slo-tracked")
+class TrackedWorkflow:
+    @temporalio.workflow.run
+    async def run(self, inputs: TrackedWorkflowInput) -> str:
+        if inputs.slo:
+            inputs.slo.completion_context["extra_key"] = "extra_value"
+        return "ok"
+
+
+@temporalio.workflow.defn(name="test-slo-tracked-failure")
+class TrackedFailureWorkflow:
+    @temporalio.workflow.run
+    async def run(self, inputs: TrackedWorkflowInput) -> str:
+        raise ApplicationError("boom", non_retryable=True)
+
+
+@temporalio.workflow.defn(name="test-slo-tracked-business-failure")
+class TrackedBusinessFailureWorkflow:
+    @temporalio.workflow.run
+    async def run(self, inputs: TrackedWorkflowInput) -> str:
+        if inputs.slo:
+            inputs.slo.outcome = SloOutcome.FAILURE
+            inputs.slo.completion_context["reason"] = "business logic"
+        return "ok"
+
+
+@temporalio.workflow.defn(name="test-slo-untracked")
+class UntrackedWorkflow:
+    @temporalio.workflow.run
+    async def run(self, inputs: UntrackedWorkflowInput) -> str:
+        return "ok"
+
+
+def _make_slo_config(**overrides) -> SloConfig:
+    defaults = {
+        "operation": SloOperation.EXPORT,
+        "area": SloArea.ANALYTIC_PLATFORM,
+        "team_id": 1,
+        "resource_id": "42",
+        "distinct_id": "user-123",
+    }
+    defaults.update(overrides)
+    return SloConfig(**defaults)
+
+
+pytestmark = [pytest.mark.asyncio]
+
+
+@patch("posthog.slo.events.posthoganalytics")
+async def test_interceptor_emits_started_and_completed_on_success(mock_analytics: MagicMock):
+    async with await WorkflowEnvironment.start_local() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-slo",
+            workflows=[TrackedWorkflow],
+            activities=[],
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                TrackedWorkflow.run,
+                TrackedWorkflowInput(
+                    value="test",
+                    slo=_make_slo_config(started_extra={"source": "web"}),
+                ),
+                id="test-success",
+                task_queue="test-slo",
+            )
+
+    assert result == "ok"
+
+    started_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_started"
+    ]
+    assert len(started_calls) == 1
+    started_props = started_calls[0].kwargs["properties"]
+    assert started_props["operation"] == "export"
+    assert started_props["team_id"] == 1
+    assert started_props["resource_id"] == "42"
+    assert started_props["source"] == "web"
+
+    completed_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    completed_props = completed_calls[0].kwargs["properties"]
+    assert completed_props["outcome"] == SloOutcome.SUCCESS
+    assert completed_props["extra_key"] == "extra_value"
+    assert completed_props["duration_ms"] is not None
+
+
+@patch("posthog.slo.events.posthoganalytics")
+async def test_interceptor_emits_failure_on_exception(mock_analytics: MagicMock):
+    async with await WorkflowEnvironment.start_local() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-slo",
+            workflows=[TrackedFailureWorkflow],
+            activities=[],
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(Exception):
+                await env.client.execute_workflow(
+                    TrackedFailureWorkflow.run,
+                    TrackedWorkflowInput(slo=_make_slo_config()),
+                    id="test-failure",
+                    task_queue="test-slo",
+                )
+
+    completed_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.FAILURE
+
+
+@patch("posthog.slo.events.posthoganalytics")
+async def test_interceptor_respects_workflow_outcome_override(mock_analytics: MagicMock):
+    async with await WorkflowEnvironment.start_local() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-slo",
+            workflows=[TrackedBusinessFailureWorkflow],
+            activities=[],
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                TrackedBusinessFailureWorkflow.run,
+                TrackedWorkflowInput(slo=_make_slo_config()),
+                id="test-business-failure",
+                task_queue="test-slo",
+            )
+
+    assert result == "ok"
+
+    completed_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    props = completed_calls[0].kwargs["properties"]
+    assert props["outcome"] == SloOutcome.FAILURE
+    assert props["reason"] == "business logic"
+
+
+@patch("posthog.slo.events.posthoganalytics")
+async def test_interceptor_passes_through_untracked_workflows(mock_analytics: MagicMock):
+    async with await WorkflowEnvironment.start_local() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-slo",
+            workflows=[UntrackedWorkflow],
+            activities=[],
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                UntrackedWorkflow.run,
+                UntrackedWorkflowInput(value="test"),
+                id="test-untracked",
+                task_queue="test-slo",
+            )
+
+    assert result == "ok"
+    assert mock_analytics.capture.call_count == 0
+
+
+@patch("posthog.slo.events.posthoganalytics")
+async def test_interceptor_passes_through_none_slo(mock_analytics: MagicMock):
+    async with await WorkflowEnvironment.start_local() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-slo",
+            workflows=[TrackedWorkflow],
+            activities=[],
+            interceptors=[SloInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                TrackedWorkflow.run,
+                TrackedWorkflowInput(value="test", slo=None),
+                id="test-none-slo",
+                task_queue="test-slo",
+            )
+
+    assert result == "ok"
+    assert mock_analytics.capture.call_count == 0

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -137,7 +137,7 @@ async def test_interceptor_emits_slo_events(
     assert started_props["operation"] == "export"
     assert started_props["resource_id"] == "42"
     assert started_props["workflow_run_id"] is not None
-    assert started_props["workflow_type"] == workflow_cls.__temporal_workflow_definition.name  # type: ignore[attr-defined]
+    assert started_props["workflow_type"] == workflow_cls.__temporal_workflow_definition.name
 
     completed_calls = _get_slo_calls(mock_analytics, "slo_operation_completed")
     assert len(completed_calls) == 1

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -133,14 +133,18 @@ async def test_interceptor_emits_slo_events(
 
     started_calls = _get_slo_calls(mock_analytics, "slo_operation_started")
     assert len(started_calls) == 1
-    assert started_calls[0].kwargs["properties"]["operation"] == "export"
-    assert started_calls[0].kwargs["properties"]["resource_id"] == "42"
+    started_props = started_calls[0].kwargs["properties"]
+    assert started_props["operation"] == "export"
+    assert started_props["resource_id"] == "42"
+    assert started_props["workflow_run_id"] is not None
+    assert started_props["workflow_type"] == workflow_cls.__temporal_workflow_definition.name  # type: ignore[attr-defined]
 
     completed_calls = _get_slo_calls(mock_analytics, "slo_operation_completed")
     assert len(completed_calls) == 1
     completed_props = completed_calls[0].kwargs["properties"]
     assert completed_props["outcome"] == expected_outcome
     assert completed_props["duration_ms"] is not None
+    assert completed_props["workflow_run_id"] == started_props["workflow_run_id"]
     for key, value in extra_completed_checks.items():
         assert completed_props[key] == value
 

--- a/posthog/temporal/tests/test_slo_interceptor.py
+++ b/posthog/temporal/tests/test_slo_interceptor.py
@@ -67,144 +67,117 @@ def _make_slo_config(start_properties: dict | None = None) -> SloConfig:
     )
 
 
+def _get_slo_calls(mock_analytics: MagicMock, event: str) -> list:
+    return [c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == event]
+
+
 pytestmark = [pytest.mark.asyncio]
 
 
+@pytest.mark.parametrize(
+    "workflow_cls,slo_config,raises,expected_outcome,extra_completed_checks",
+    [
+        (
+            TrackedWorkflow,
+            _make_slo_config(start_properties={"source": "web"}),
+            False,
+            SloOutcome.SUCCESS,
+            {"extra_key": "extra_value"},
+        ),
+        (
+            TrackedFailureWorkflow,
+            _make_slo_config(),
+            True,
+            SloOutcome.FAILURE,
+            {},
+        ),
+        (
+            TrackedBusinessFailureWorkflow,
+            _make_slo_config(),
+            False,
+            SloOutcome.FAILURE,
+            {"reason": "business logic"},
+        ),
+    ],
+    ids=["success_with_completion_props", "exception_failure", "business_logic_failure"],
+)
 @patch("posthog.slo.events.posthoganalytics")
-async def test_interceptor_emits_started_and_completed_on_success(mock_analytics: MagicMock):
+async def test_interceptor_emits_slo_events(
+    mock_analytics: MagicMock,
+    workflow_cls,
+    slo_config: SloConfig,
+    raises: bool,
+    expected_outcome: SloOutcome,
+    extra_completed_checks: dict,
+):
     async with await WorkflowEnvironment.start_local() as env:
         async with Worker(
             env.client,
             task_queue="test-slo",
-            workflows=[TrackedWorkflow],
+            workflows=[workflow_cls],
             activities=[],
             interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
-            result = await env.client.execute_workflow(
-                TrackedWorkflow.run,
-                TrackedWorkflowInput(
-                    value="test",
-                    slo=_make_slo_config(start_properties={"source": "web"}),
-                ),
-                id="test-success",
+            execute = env.client.execute_workflow(
+                workflow_cls.run,
+                TrackedWorkflowInput(value="test", slo=slo_config),
+                id=f"test-{workflow_cls.__name__}",
                 task_queue="test-slo",
             )
+            if raises:
+                with pytest.raises(Exception):
+                    await execute
+            else:
+                await execute
 
-    assert result == "ok"
-
-    started_calls = [
-        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_started"
-    ]
+    started_calls = _get_slo_calls(mock_analytics, "slo_operation_started")
     assert len(started_calls) == 1
-    started_props = started_calls[0].kwargs["properties"]
-    assert started_props["operation"] == "export"
-    assert started_props["team_id"] == 1
-    assert started_props["resource_id"] == "42"
-    assert started_props["source"] == "web"
+    assert started_calls[0].kwargs["properties"]["operation"] == "export"
+    assert started_calls[0].kwargs["properties"]["resource_id"] == "42"
 
-    completed_calls = [
-        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
-    ]
+    completed_calls = _get_slo_calls(mock_analytics, "slo_operation_completed")
     assert len(completed_calls) == 1
     completed_props = completed_calls[0].kwargs["properties"]
-    assert completed_props["outcome"] == SloOutcome.SUCCESS
-    assert completed_props["extra_key"] == "extra_value"
+    assert completed_props["outcome"] == expected_outcome
     assert completed_props["duration_ms"] is not None
+    for key, value in extra_completed_checks.items():
+        assert completed_props[key] == value
 
 
+@pytest.mark.parametrize(
+    "workflow_cls,input_cls,slo",
+    [
+        (UntrackedWorkflow, UntrackedWorkflowInput, None),
+        (TrackedWorkflow, TrackedWorkflowInput, None),
+    ],
+    ids=["untracked_input_type", "tracked_input_with_none_slo"],
+)
 @patch("posthog.slo.events.posthoganalytics")
-async def test_interceptor_emits_failure_on_exception(mock_analytics: MagicMock):
+async def test_interceptor_skips_untracked_workflows(
+    mock_analytics: MagicMock,
+    workflow_cls,
+    input_cls,
+    slo,
+):
+    inputs = (
+        input_cls(value="test")
+        if slo is None and input_cls == UntrackedWorkflowInput
+        else input_cls(value="test", slo=slo)
+    )
     async with await WorkflowEnvironment.start_local() as env:
         async with Worker(
             env.client,
             task_queue="test-slo",
-            workflows=[TrackedFailureWorkflow],
-            activities=[],
-            interceptors=[SloInterceptor()],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-        ):
-            with pytest.raises(Exception):
-                await env.client.execute_workflow(
-                    TrackedFailureWorkflow.run,
-                    TrackedWorkflowInput(slo=_make_slo_config()),
-                    id="test-failure",
-                    task_queue="test-slo",
-                )
-
-    completed_calls = [
-        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
-    ]
-    assert len(completed_calls) == 1
-    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.FAILURE
-
-
-@patch("posthog.slo.events.posthoganalytics")
-async def test_interceptor_respects_workflow_outcome_override(mock_analytics: MagicMock):
-    async with await WorkflowEnvironment.start_local() as env:
-        async with Worker(
-            env.client,
-            task_queue="test-slo",
-            workflows=[TrackedBusinessFailureWorkflow],
+            workflows=[workflow_cls],
             activities=[],
             interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
         ):
             result = await env.client.execute_workflow(
-                TrackedBusinessFailureWorkflow.run,
-                TrackedWorkflowInput(slo=_make_slo_config()),
-                id="test-business-failure",
-                task_queue="test-slo",
-            )
-
-    assert result == "ok"
-
-    completed_calls = [
-        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
-    ]
-    assert len(completed_calls) == 1
-    props = completed_calls[0].kwargs["properties"]
-    assert props["outcome"] == SloOutcome.FAILURE
-    assert props["reason"] == "business logic"
-
-
-@patch("posthog.slo.events.posthoganalytics")
-async def test_interceptor_passes_through_untracked_workflows(mock_analytics: MagicMock):
-    async with await WorkflowEnvironment.start_local() as env:
-        async with Worker(
-            env.client,
-            task_queue="test-slo",
-            workflows=[UntrackedWorkflow],
-            activities=[],
-            interceptors=[SloInterceptor()],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-        ):
-            result = await env.client.execute_workflow(
-                UntrackedWorkflow.run,
-                UntrackedWorkflowInput(value="test"),
-                id="test-untracked",
-                task_queue="test-slo",
-            )
-
-    assert result == "ok"
-    assert mock_analytics.capture.call_count == 0
-
-
-@patch("posthog.slo.events.posthoganalytics")
-async def test_interceptor_passes_through_none_slo(mock_analytics: MagicMock):
-    async with await WorkflowEnvironment.start_local() as env:
-        async with Worker(
-            env.client,
-            task_queue="test-slo",
-            workflows=[TrackedWorkflow],
-            activities=[],
-            interceptors=[SloInterceptor()],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-        ):
-            result = await env.client.execute_workflow(
-                TrackedWorkflow.run,
-                TrackedWorkflowInput(value="test", slo=None),
-                id="test-none-slo",
+                workflow_cls.run,
+                inputs,
+                id=f"test-skip-{workflow_cls.__name__}",
                 task_queue="test-slo",
             )
 

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -279,7 +279,7 @@ async def test_handle_subscription_value_change_email(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     previous_value="test_existing@posthog.com",
                     invite_message="My invite message",
                 ),
@@ -344,7 +344,7 @@ async def test_deliver_subscription_report_slack(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                 ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
@@ -560,13 +560,13 @@ async def test_deliver_subscription_workflow_end_to_end(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     slo=SloConfig(
                         operation=SloOperation.SUBSCRIPTION_DELIVERY,
                         area=SloArea.ANALYTIC_PLATFORM,
                         team_id=subscription.team_id,
                         resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),
+                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     ),
                 ),
                 id=str(uuid.uuid4()),
@@ -640,7 +640,7 @@ async def test_new_subscription_sends_invite_email(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     previous_value="",
                     invite_message="Welcome!",
                 ),
@@ -704,13 +704,13 @@ async def test_scheduled_delivery_updates_next_delivery_date(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     slo=SloConfig(
                         operation=SloOperation.SUBSCRIPTION_DELIVERY,
                         area=SloArea.ANALYTIC_PLATFORM,
                         team_id=subscription.team_id,
                         resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),
+                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     ),
                 ),
                 id=str(uuid.uuid4()),
@@ -774,13 +774,13 @@ async def test_export_user_error_counts_as_slo_success(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     slo=SloConfig(
                         operation=SloOperation.SUBSCRIPTION_DELIVERY,
                         area=SloArea.ANALYTIC_PLATFORM,
                         team_id=subscription.team_id,
                         resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),
+                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     ),
                 ),
                 id=str(uuid.uuid4()),
@@ -850,13 +850,13 @@ async def test_partial_export_failure_delivers_successful_assets(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     slo=SloConfig(
                         operation=SloOperation.SUBSCRIPTION_DELIVERY,
                         area=SloArea.ANALYTIC_PLATFORM,
                         team_id=subscription.team_id,
                         resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),
+                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     ),
                 ),
                 id=str(uuid.uuid4()),
@@ -931,13 +931,13 @@ async def test_transient_export_error_retries_and_succeeds(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     slo=SloConfig(
                         operation=SloOperation.SUBSCRIPTION_DELIVERY,
                         area=SloArea.ANALYTIC_PLATFORM,
                         team_id=subscription.team_id,
                         resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),
+                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     ),
                 ),
                 id=str(uuid.uuid4()),
@@ -1003,13 +1003,13 @@ async def test_user_query_error_does_not_retry(
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),
+                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     slo=SloConfig(
                         operation=SloOperation.SUBSCRIPTION_DELIVERY,
                         area=SloArea.ANALYTIC_PLATFORM,
                         team_id=subscription.team_id,
                         resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),
+                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
                     ),
                 ),
                 id=str(uuid.uuid4()),

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -36,6 +36,7 @@ from posthog.temporal.subscriptions.types import (
     DeliverSubscriptionInputs,
     ProcessSubscriptionWorkflowInputs,
     ScheduleAllSubscriptionsWorkflowInputs,
+    TrackedSubscriptionInputs,
 )
 from posthog.temporal.subscriptions.workflows import (
     HandleSubscriptionValueChangeWorkflow,
@@ -290,6 +291,18 @@ async def test_handle_subscription_value_change_email(
     # Only new address should be emailed
     assert mock_send_email.call_count == 1
     assert mock_send_email.call_args_list[0][0][0] == "test_new@posthog.com"
+
+    # SLO events emitted exactly once (child only, not parent)
+    started_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_started"
+    ]
+    assert len(started_calls) == 1
+
+    completed_calls = [
+        c for c in mock_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
+    ]
+    assert len(completed_calls) == 1
+    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.SUCCESS
 
 
 @patch("posthog.temporal.exports.activities.exporter")
@@ -557,7 +570,7 @@ async def test_deliver_subscription_workflow_end_to_end(
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(
+                TrackedSubscriptionInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
                     distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
@@ -701,7 +714,7 @@ async def test_scheduled_delivery_updates_next_delivery_date(
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(
+                TrackedSubscriptionInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
                     distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
@@ -727,13 +740,36 @@ async def test_scheduled_delivery_updates_next_delivery_date(
     assert subscription.next_delivery_date != original_next_delivery
 
 
+def _make_export_counter(fail_count: int, error_factory):
+    """Create a fake export that fails `fail_count` times then succeeds."""
+    state = {"calls": 0}
+
+    def fake_export(asset_obj, **kwargs):
+        state["calls"] += 1
+        if state["calls"] <= fail_count:
+            raise error_factory()
+        asset_obj.content_location = "s3://bucket/ok.png"
+        asset_obj.save(update_fields=["content_location"])
+
+    return fake_export, state
+
+
+@pytest.mark.parametrize(
+    "error_factory,fail_count,expected_calls,expected_outcome",
+    [
+        (ExcelColumnLimitExceeded, 999, 1, SloOutcome.SUCCESS),
+        (lambda: CHQueryErrorS3Error("S3 error", code=499), 2, 3, SloOutcome.SUCCESS),
+        (lambda: QueryError("Invalid HogQL query"), 999, 1, SloOutcome.SUCCESS),
+    ],
+    ids=["user_error_slo_success", "transient_error_retries_then_succeeds", "user_query_error_no_retry"],
+)
 @patch("posthog.temporal.exports.activities.exporter")
 @patch("posthog.slo.events.posthoganalytics")
 @patch("ee.tasks.subscriptions.get_metric_meter")
 @patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
 @freeze_time("2022-02-02T08:55:00.000Z")
 @pytest.mark.asyncio
-async def test_export_user_error_counts_as_slo_success(
+async def test_export_error_slo_outcome(
     mock_send_email: MagicMock,
     mock_metric_meter: MagicMock,
     mock_slo_analytics: MagicMock,
@@ -741,16 +777,15 @@ async def test_export_user_error_counts_as_slo_success(
     temporal_client: Client,
     team,
     user,
+    error_factory,
+    fail_count: int,
+    expected_calls: int,
+    expected_outcome: SloOutcome,
 ):
     insight = await sync_to_async(Insight.objects.create)(team=team, short_id="slo01", name="SLO Test")
     subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
 
-    def fake_export(asset_obj, **kwargs):
-        asset_obj.failure_type = "user"
-        asset_obj.exception_type = "ExcelColumnLimitExceeded"
-        asset_obj.save(update_fields=["failure_type", "exception_type"])
-        raise ExcelColumnLimitExceeded()
-
+    fake_export, state = _make_export_counter(fail_count, error_factory)
     mock_exporter.export_asset_direct = fake_export
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -771,7 +806,7 @@ async def test_export_user_error_counts_as_slo_success(
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(
+                TrackedSubscriptionInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
                     distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
@@ -787,11 +822,13 @@ async def test_export_user_error_counts_as_slo_success(
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
 
+    assert state["calls"] == expected_calls
+
     completed_calls = [
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
     assert len(completed_calls) == 1
-    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.SUCCESS
+    assert completed_calls[0].kwargs["properties"]["outcome"] == expected_outcome
 
 
 @patch("posthog.temporal.exports.activities.exporter")
@@ -847,7 +884,7 @@ async def test_partial_export_failure_delivers_successful_assets(
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(
+                TrackedSubscriptionInputs(
                     subscription_id=subscription.id,
                     team_id=subscription.team_id,
                     distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
@@ -878,154 +915,3 @@ async def test_partial_export_failure_delivers_successful_assets(
     assert props["outcome"] == SloOutcome.FAILURE
     assert props["assets_with_content"] == 2
     assert props["total_assets"] == 3
-
-
-@patch("posthog.temporal.exports.activities.exporter")
-@patch("posthog.slo.events.posthoganalytics")
-@patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
-@freeze_time("2022-02-02T08:55:00.000Z")
-@pytest.mark.asyncio
-async def test_transient_export_error_retries_and_succeeds(
-    mock_send_email: MagicMock,
-    mock_metric_meter: MagicMock,
-    mock_slo_analytics: MagicMock,
-    mock_exporter: MagicMock,
-    temporal_client: Client,
-    team,
-    user,
-):
-    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="retry1", name="Retry Test")
-    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
-
-    call_count = 0
-
-    def flaky_export(asset_obj, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count <= 2:
-            raise CHQueryErrorS3Error("S3 error occurred", code=499)
-        asset_obj.content_location = "s3://bucket/retry_ok.png"
-        asset_obj.save(update_fields=["content_location"])
-
-    mock_exporter.export_asset_direct = flaky_export
-
-    async with await WorkflowEnvironment.start_time_skipping() as env:
-        async with Worker(
-            env.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ProcessSubscriptionWorkflow],
-            activities=[
-                create_export_assets,
-                export_asset_activity,
-                deliver_subscription,
-                advance_next_delivery_date,
-            ],
-            interceptors=[SloInterceptor()],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=10),
-            debug_mode=True,
-        ):
-            await env.client.execute_workflow(
-                ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(
-                    subscription_id=subscription.id,
-                    team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
-                    slo=SloConfig(
-                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
-                        area=SloArea.ANALYTIC_PLATFORM,
-                        team_id=subscription.team_id,
-                        resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
-                    ),
-                ),
-                id=str(uuid.uuid4()),
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
-
-    # Transient error retried and eventually succeeded
-    assert call_count == 3
-    assert mock_send_email.call_count == 2  # 2 recipients from factory default
-
-    completed_calls = [
-        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
-    ]
-    assert len(completed_calls) == 1
-    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.SUCCESS
-
-
-@patch("posthog.temporal.exports.activities.exporter")
-@patch("posthog.slo.events.posthoganalytics")
-@patch("ee.tasks.subscriptions.get_metric_meter")
-@patch("posthog.temporal.subscriptions.activities.send_email_subscription_report")
-@freeze_time("2022-02-02T08:55:00.000Z")
-@pytest.mark.asyncio
-async def test_user_query_error_does_not_retry(
-    mock_send_email: MagicMock,
-    mock_metric_meter: MagicMock,
-    mock_slo_analytics: MagicMock,
-    mock_exporter: MagicMock,
-    temporal_client: Client,
-    team,
-    user,
-):
-    insight = await sync_to_async(Insight.objects.create)(team=team, short_id="noret1", name="No Retry Test")
-    subscription = await sync_to_async(create_subscription)(team=team, insight=insight, created_by=user)
-
-    call_count = 0
-
-    def user_error_export(asset_obj, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        raise QueryError("Invalid HogQL query")
-
-    mock_exporter.export_asset_direct = user_error_export
-
-    async with await WorkflowEnvironment.start_time_skipping() as env:
-        async with Worker(
-            env.client,
-            task_queue=settings.TEMPORAL_TASK_QUEUE,
-            workflows=[ProcessSubscriptionWorkflow],
-            activities=[
-                create_export_assets,
-                export_asset_activity,
-                deliver_subscription,
-                advance_next_delivery_date,
-            ],
-            interceptors=[SloInterceptor()],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            activity_executor=ThreadPoolExecutor(max_workers=10),
-            debug_mode=True,
-        ):
-            await env.client.execute_workflow(
-                ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(
-                    subscription_id=subscription.id,
-                    team_id=subscription.team_id,
-                    distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
-                    slo=SloConfig(
-                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
-                        area=SloArea.ANALYTIC_PLATFORM,
-                        team_id=subscription.team_id,
-                        resource_id=str(subscription.id),
-                        distinct_id=str(subscription.created_by.distinct_id),  # type: ignore[union-attr]
-                    ),
-                ),
-                id=str(uuid.uuid4()),
-                task_queue=settings.TEMPORAL_TASK_QUEUE,
-            )
-
-    # User error is non-retryable — called exactly once
-    assert call_count == 1
-
-    # Delivery still happens (with failed asset showing placeholder)
-    assert mock_send_email.call_count == 2
-
-    completed_calls = [
-        c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
-    ]
-    assert len(completed_calls) == 1
-    # User query errors are SLO successes — the system worked correctly,
-    # the user's query was just invalid (consistent with test_export_user_error_counts_as_slo_success)
-    assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.SUCCESS

--- a/posthog/temporal/tests/test_subscriptions_workflows.py
+++ b/posthog/temporal/tests/test_subscriptions_workflows.py
@@ -21,9 +21,10 @@ from posthog.errors import CHQueryErrorS3Error
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.instance_setting import set_instance_setting
-from posthog.slo.types import SloOutcome
+from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
-from posthog.temporal.exports.activities import emit_delivery_outcome, emit_delivery_started, export_asset_activity
+from posthog.temporal.common.slo_interceptor import SloInterceptor
+from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.subscriptions.activities import (
     advance_next_delivery_date,
     create_export_assets,
@@ -67,10 +68,9 @@ async def subscriptions_worker(temporal_client: Client):
             create_export_assets,
             export_asset_activity,
             deliver_subscription,
-            emit_delivery_started,
-            emit_delivery_outcome,
             advance_next_delivery_date,
         ],
+        interceptors=[SloInterceptor()],
         workflow_runner=UnsandboxedWorkflowRunner(),
     ):
         yield  # allow the test to run while the worker is active
@@ -138,10 +138,9 @@ async def test_subscription_delivery_scheduling(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,
@@ -212,10 +211,9 @@ async def test_does_not_schedule_subscription_if_item_is_deleted(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,  # turn off sandbox/deadlock detector
@@ -269,10 +267,9 @@ async def test_handle_subscription_value_change_email(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,
@@ -281,6 +278,8 @@ async def test_handle_subscription_value_change_email(
                 HandleSubscriptionValueChangeWorkflow.run,
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
                     previous_value="test_existing@posthog.com",
                     invite_message="My invite message",
                 ),
@@ -333,17 +332,20 @@ async def test_deliver_subscription_report_slack(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,
         ):
             await activity_environment.client.execute_workflow(
                 HandleSubscriptionValueChangeWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
+                ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -377,7 +379,7 @@ async def test_create_export_assets_creates_exported_assets(
     assert asset.insight_id == insight.id
     assert asset.export_format == "image/png"
 
-    # SLO started is emitted by the workflow (emit_delivery_started), not this activity
+    # SLO started is emitted by the interceptor, not this activity
     mock_analytics.capture.assert_not_called()
 
 
@@ -404,7 +406,7 @@ async def test_create_export_assets_dashboard_with_multiple_insights(
     )
 
     assert len(result.exported_asset_ids) == 3
-    # SLO started is emitted by the workflow, not this activity
+    # SLO started is emitted by the interceptor, not this activity
     mock_analytics.capture.assert_not_called()
 
 
@@ -546,17 +548,27 @@ async def test_deliver_subscription_workflow_end_to_end(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
             debug_mode=True,
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
+                    slo=SloConfig(
+                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                        area=SloArea.ANALYTIC_PLATFORM,
+                        team_id=subscription.team_id,
+                        resource_id=str(subscription.id),
+                        distinct_id=str(subscription.created_by.distinct_id),
+                    ),
+                ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -616,10 +628,9 @@ async def test_new_subscription_sends_invite_email(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=50),
             debug_mode=True,
@@ -628,6 +639,8 @@ async def test_new_subscription_sends_invite_email(
                 HandleSubscriptionValueChangeWorkflow.run,
                 ProcessSubscriptionWorkflowInputs(
                     subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
                     previous_value="",
                     invite_message="Welcome!",
                 ),
@@ -679,17 +692,27 @@ async def test_scheduled_delivery_updates_next_delivery_date(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
             debug_mode=True,
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
+                    slo=SloConfig(
+                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                        area=SloArea.ANALYTIC_PLATFORM,
+                        team_id=subscription.team_id,
+                        resource_id=str(subscription.id),
+                        distinct_id=str(subscription.created_by.distinct_id),
+                    ),
+                ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -739,17 +762,27 @@ async def test_export_user_error_counts_as_slo_success(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
             debug_mode=True,
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
+                    slo=SloConfig(
+                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                        area=SloArea.ANALYTIC_PLATFORM,
+                        team_id=subscription.team_id,
+                        resource_id=str(subscription.id),
+                        distinct_id=str(subscription.created_by.distinct_id),
+                    ),
+                ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -805,17 +838,27 @@ async def test_partial_export_failure_delivers_successful_assets(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
             debug_mode=True,
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
+                    slo=SloConfig(
+                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                        area=SloArea.ANALYTIC_PLATFORM,
+                        team_id=subscription.team_id,
+                        resource_id=str(subscription.id),
+                        distinct_id=str(subscription.created_by.distinct_id),
+                    ),
+                ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -876,17 +919,27 @@ async def test_transient_export_error_retries_and_succeeds(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
             debug_mode=True,
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
+                    slo=SloConfig(
+                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                        area=SloArea.ANALYTIC_PLATFORM,
+                        team_id=subscription.team_id,
+                        resource_id=str(subscription.id),
+                        distinct_id=str(subscription.created_by.distinct_id),
+                    ),
+                ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -938,17 +991,27 @@ async def test_user_query_error_does_not_retry(
                 create_export_assets,
                 export_asset_activity,
                 deliver_subscription,
-                emit_delivery_started,
-                emit_delivery_outcome,
                 advance_next_delivery_date,
             ],
+            interceptors=[SloInterceptor()],
             workflow_runner=UnsandboxedWorkflowRunner(),
             activity_executor=ThreadPoolExecutor(max_workers=10),
             debug_mode=True,
         ):
             await env.client.execute_workflow(
                 ProcessSubscriptionWorkflow.run,
-                ProcessSubscriptionWorkflowInputs(subscription_id=subscription.id),
+                ProcessSubscriptionWorkflowInputs(
+                    subscription_id=subscription.id,
+                    team_id=subscription.team_id,
+                    distinct_id=str(subscription.created_by.distinct_id),
+                    slo=SloConfig(
+                        operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                        area=SloArea.ANALYTIC_PLATFORM,
+                        team_id=subscription.team_id,
+                        resource_id=str(subscription.id),
+                        distinct_id=str(subscription.created_by.distinct_id),
+                    ),
+                ),
                 id=str(uuid.uuid4()),
                 task_queue=settings.TEMPORAL_TASK_QUEUE,
             )
@@ -963,4 +1026,6 @@ async def test_user_query_error_does_not_retry(
         c for c in mock_slo_analytics.capture.call_args_list if c.kwargs.get("event") == "slo_operation_completed"
     ]
     assert len(completed_calls) == 1
+    # User query errors are SLO successes — the system worked correctly,
+    # the user's query was just invalid (consistent with test_export_user_error_counts_as_slo_success)
     assert completed_calls[0].kwargs["properties"]["outcome"] == SloOutcome.SUCCESS


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

This is a follow up from: https://github.com/PostHog/posthog/pull/51648#discussion_r2978544608 this comment left by @andyzzhao, who had a good suggestion to introduce [Temporal Interceptors](https://docs.temporal.io/develop/python/interceptors) so that we can standardize the emittence of the SLO events and reduce the chance of deviations over time.

This PR therefore introduces interceptors for both the one-off export flow (sync and async) and the subscription flow.

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Introduce an interceptor to standardise the SLO tracking
- Refactors both export and subscription workflows to no longer emit slo metrics, instead deferring that to the interceptor.
- Added tests to cover the new paths and confirm that the metric emittance is still done correctly.

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

✅ New tests are passing in the CI

✅ Manually confirmed that the subscription flow still works (same caveat as the exports below)  
![CleanShot 2026-03-30 at 12.13.50.png](https://app.graphite.com/user-attachments/assets/2537f5c1-6416-4127-a944-00ebc0cc3d70.png)

✅ Manually confirmed that the export flow still works (events were not ingested in my local setup, but confirmed that all export flows still work)

![CleanShot 2026-03-30 at 12.14.17.png](https://app.graphite.com/user-attachments/assets/036b7da6-ac71-4a57-940e-34fb549b486f.png)

:white_check_mark: Prometheus metrics emitted for the export / subscription flows created above (confirming that the SLO metrics are called, as I could not track the events locally):   
![CleanShot 2026-03-30 at 12.18.53.png](https://app.graphite.com/user-attachments/assets/14aee860-dc4e-4ad1-92c0-966f5e01002f.png)



👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

No

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

No

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->