### PR TITLE
feat(retention): add support for extended person properties

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1184,7 +1184,16 @@
             ]
         },
         "AssistantEventMultipleBreakdownFilterType": {
-            "enum": ["cohort", "person", "event", "event_metadata", "session", "hogql", "revenue_analytics"],
+            "enum": [
+                "cohort",
+                "person",
+                "event",
+                "event_metadata",
+                "session",
+                "hogql",
+                "data_warehouse_person_property",
+                "revenue_analytics"
+            ],
             "type": "string"
         },
         "AssistantEventType": {
@@ -23383,7 +23392,17 @@
             "type": "object"
         },
         "MultipleBreakdownType": {
-            "enum": ["cohort", "person", "event", "event_metadata", "group", "session", "hogql", "revenue_analytics"],
+            "enum": [
+                "cohort",
+                "person",
+                "event",
+                "event_metadata",
+                "group",
+                "session",
+                "hogql",
+                "data_warehouse_person_property",
+                "revenue_analytics"
+            ],
             "type": "string"
         },
         "NativeMarketingSource": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3845,7 +3845,15 @@ export interface ResolvedDateRangeResponse {
 
 export type MultipleBreakdownType = Extract<
     BreakdownType,
-    'person' | 'event' | 'event_metadata' | 'group' | 'session' | 'hogql' | 'cohort' | 'revenue_analytics'
+    | 'person'
+    | 'event'
+    | 'event_metadata'
+    | 'group'
+    | 'session'
+    | 'hogql'
+    | 'cohort'
+    | 'revenue_analytics'
+    | 'data_warehouse_person_property'
 >
 
 export interface Breakdown {

--- a/frontend/src/queries/validators.js
+++ b/frontend/src/queries/validators.js
@@ -5439,7 +5439,17 @@ const schema66 = {
     type: 'object',
 }
 const schema70 = {
-    enum: ['cohort', 'person', 'event', 'event_metadata', 'group', 'session', 'hogql', 'revenue_analytics'],
+    enum: [
+        'cohort',
+        'person',
+        'event',
+        'event_metadata',
+        'group',
+        'session',
+        'hogql',
+        'data_warehouse_person_property',
+        'revenue_analytics',
+    ],
     type: 'string',
 }
 function validate75(data, { instancePath = '', parentData, parentDataProperty, rootData = data } = {}) {
@@ -5709,6 +5719,7 @@ function validate75(data, { instancePath = '', parentData, parentDataProperty, r
                                                 data4 === 'group' ||
                                                 data4 === 'session' ||
                                                 data4 === 'hogql' ||
+                                                data4 === 'data_warehouse_person_property' ||
                                                 data4 === 'revenue_analytics'
                                             )
                                         ) {

--- a/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { getOrdinalSuffix } from 'lib/utils'
 import { AggregationSelect } from 'scenes/insights/filters/AggregationSelect'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
+import { getRetentionPropertyFilterGroupTypes } from 'scenes/insights/utils/propertyTaxonomicGroupTypes'
 import {
     dateOptionPlurals,
     dateOptions,
@@ -157,6 +158,7 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
                     }
                 }}
                 typeKey={`${keyForInsightLogicProps('new')(insightProps)}-targetEntity`}
+                propertiesTaxonomicGroupTypes={getRetentionPropertyFilterGroupTypes()}
             />
             <LemonSelect
                 options={Object.entries(retentionOptions).map(([key, value]) => ({
@@ -198,6 +200,7 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
                     }
                 }}
                 typeKey={`${keyForInsightLogicProps('new')(insightProps)}-returningEntity`}
+                propertiesTaxonomicGroupTypes={getRetentionPropertyFilterGroupTypes()}
             />
             <div className="flex items-center gap-2">
                 {!retentionCustomBrackets ? (

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
@@ -44,6 +44,7 @@ export const TaxonomicBreakdownPopover = ({
             TaxonomicFilterGroupType.EventProperties,
             TaxonomicFilterGroupType.PersonProperties,
             TaxonomicFilterGroupType.CohortsWithAllUsers,
+            TaxonomicFilterGroupType.DataWarehousePersonProperties,
         ]
     } else {
         taxonomicGroupTypes = [

--- a/frontend/src/scenes/insights/utils/propertyTaxonomicGroupTypes.ts
+++ b/frontend/src/scenes/insights/utils/propertyTaxonomicGroupTypes.ts
@@ -1,13 +1,8 @@
+import { DEFAULT_TAXONOMIC_GROUP_TYPES } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 export function getRetentionPropertyFilterGroupTypes(): TaxonomicFilterGroupType[] {
-    return [
-        TaxonomicFilterGroupType.EventProperties,
-        TaxonomicFilterGroupType.PersonProperties,
-        TaxonomicFilterGroupType.Cohorts,
-        TaxonomicFilterGroupType.HogQLExpression,
-        TaxonomicFilterGroupType.DataWarehousePersonProperties,
-    ]
+    return [...DEFAULT_TAXONOMIC_GROUP_TYPES, TaxonomicFilterGroupType.DataWarehousePersonProperties]
 }
 
 export function getInsightPropertyFilterGroupTypes({

--- a/frontend/src/scenes/insights/utils/propertyTaxonomicGroupTypes.ts
+++ b/frontend/src/scenes/insights/utils/propertyTaxonomicGroupTypes.ts
@@ -1,5 +1,15 @@
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
+export function getRetentionPropertyFilterGroupTypes(): TaxonomicFilterGroupType[] {
+    return [
+        TaxonomicFilterGroupType.EventProperties,
+        TaxonomicFilterGroupType.PersonProperties,
+        TaxonomicFilterGroupType.Cohorts,
+        TaxonomicFilterGroupType.HogQLExpression,
+        TaxonomicFilterGroupType.DataWarehousePersonProperties,
+    ]
+}
+
 export function getInsightPropertyFilterGroupTypes({
     groupsTaxonomicTypes,
     hasPageview,

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -408,6 +408,8 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
                 properties_chain = ["person", property_name]
             else:
                 properties_chain = ["person", "properties", property_name]
+        elif breakdown_type == "data_warehouse_person_property":
+            properties_chain = ["person", *property_name.split(".")]
         elif breakdown_type == "group":
             if property_name.startswith("$virt_"):
                 # Virtual properties exist as expression fields on the groups table

--- a/posthog/hogql_queries/insights/test/data/retention_extended_person_properties.csv
+++ b/posthog/hogql_queries/insights/test/data/retention_extended_person_properties.csv
@@ -1,4 +1,4 @@
-email,account_tier
-person1@example.com,pro
-person2@example.com,free
-person3@example.com,pro
+email
+person1@example.com
+person2@example.com
+person3@example.com

--- a/posthog/hogql_queries/insights/test/data/retention_extended_person_properties.csv
+++ b/posthog/hogql_queries/insights/test/data/retention_extended_person_properties.csv
@@ -1,0 +1,4 @@
+email,account_tier
+person1@example.com,pro
+person2@example.com,free
+person3@example.com,pro

--- a/posthog/hogql_queries/insights/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_retention_query_runner.py
@@ -109,7 +109,6 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
             table_name="extended_properties",
             table_columns={
                 "email": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                "account_tier": {"clickhouse": "String", "hogql": "StringDatabaseField"},
             },
             test_bucket=TEST_BUCKET,
             team=self.team,

--- a/posthog/hogql_queries/insights/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_retention_query_runner.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 from zoneinfo import ZoneInfo
 
@@ -41,6 +42,11 @@ from posthog.models.person import Person
 from posthog.queries.breakdown_props import ALL_USERS_COHORT_ID
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
+
+from products.data_warehouse.backend.models import DataWarehouseJoin
+from products.data_warehouse.backend.test.utils import create_data_warehouse_table_from_csv
+
+TEST_BUCKET = "test_storage_bucket-posthog.hogql_queries.insights.retention"
 
 
 def _create_signup_actions(team, user_and_timestamps):
@@ -93,6 +99,24 @@ def _create_events(team, user_and_timestamps, event="$pageview"):
 
 
 class TestRetention(ClickhouseTestMixin, APIBaseTest):
+    def teardown_method(self, method) -> None:
+        if getattr(self, "cleanUpDataWarehouse", None):
+            self.cleanUpDataWarehouse()
+
+    def setup_data_warehouse_person_properties(self) -> str:
+        table, _source, _credential, _df, self.cleanUpDataWarehouse = create_data_warehouse_table_from_csv(
+            csv_path=Path(__file__).parent / "data" / "retention_extended_person_properties.csv",
+            table_name="extended_properties",
+            table_columns={
+                "email": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "account_tier": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+            },
+            test_bucket=TEST_BUCKET,
+            team=self.team,
+        )
+
+        return table.name
+
     def run_query(self, query):
         if not query.get("retentionFilter"):
             query["retentionFilter"] = {}
@@ -3576,6 +3600,116 @@ class TestRetention(ClickhouseTestMixin, APIBaseTest):
                     [0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0],
                     [1, 0, 0, 0, 0, 0],
+                ]
+            ),
+        )
+
+    @override_settings(IN_UNIT_TESTING=True)
+    def test_retention_with_breakdown_with_data_warehouse_person_properties(self):
+        table_name = self.setup_data_warehouse_person_properties()
+
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name="persons",
+            source_table_key="properties.email",
+            joining_table_name=table_name,
+            joining_table_key="email",
+            field_name="extended_properties",
+        )
+
+        _create_person(team_id=self.team.pk, distinct_ids=["person1"], properties={"email": "person1@example.com"})
+        _create_person(team_id=self.team.pk, distinct_ids=["person2"], properties={"email": "person2@example.com"})
+        _create_person(team_id=self.team.pk, distinct_ids=["person3"], properties={"email": "person3@example.com"})
+
+        _create_events(
+            self.team,
+            [
+                ("person1", _date(0)),
+                ("person1", _date(1)),
+                ("person1", _date(3)),
+                ("person2", _date(0)),
+                ("person2", _date(1)),
+                ("person2", _date(4)),
+                ("person3", _date(0)),
+                ("person3", _date(2)),
+            ],
+        )
+        flush_persons_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(5, hour=0)},
+                "retentionFilter": {
+                    "totalIntervals": 6,
+                    "period": "Day",
+                },
+                "breakdownFilter": {
+                    "breakdown": "extended_properties.email",
+                    "breakdown_type": "data_warehouse_person_property",
+                },
+            }
+        )
+
+        breakdown_values = {c.get("breakdown_value") for c in result}
+
+        self.assertEqual(
+            breakdown_values,
+            {"person1@example.com", "person2@example.com", "person3@example.com"},
+        )
+
+        person1_cohorts = pluck(
+            [c for c in result if c.get("breakdown_value") == "person1@example.com"],
+            "values",
+            "count",
+        )
+        self.assertEqual(
+            person1_cohorts,
+            pad(
+                [
+                    [1, 1, 0, 1, 0, 0],
+                    [1, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                ]
+            ),
+        )
+
+        person2_cohorts = pluck(
+            [c for c in result if c.get("breakdown_value") == "person2@example.com"],
+            "values",
+            "count",
+        )
+        self.assertEqual(
+            person2_cohorts,
+            pad(
+                [
+                    [1, 1, 0, 0, 1, 0],
+                    [1, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                ]
+            ),
+        )
+
+        person3_cohorts = pluck(
+            [c for c in result if c.get("breakdown_value") == "person3@example.com"],
+            "values",
+            "count",
+        )
+        self.assertEqual(
+            person3_cohorts,
+            pad(
+                [
+                    [1, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
                 ]
             ),
         )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -231,6 +231,7 @@ class AssistantEventMultipleBreakdownFilterType(StrEnum):
     EVENT_METADATA = "event_metadata"
     SESSION = "session"
     HOGQL = "hogql"
+    DATA_WAREHOUSE_PERSON_PROPERTY = "data_warehouse_person_property"
     REVENUE_ANALYTICS = "revenue_analytics"
 
 
@@ -3032,6 +3033,7 @@ class MultipleBreakdownType(StrEnum):
     GROUP = "group"
     SESSION = "session"
     HOGQL = "hogql"
+    DATA_WAREHOUSE_PERSON_PROPERTY = "data_warehouse_person_property"
     REVENUE_ANALYTICS = "revenue_analytics"
 
 

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -889,6 +889,7 @@ export const MultipleBreakdownTypeApi = {
     Group: 'group',
     Session: 'session',
     Hogql: 'hogql',
+    DataWarehousePersonProperty: 'data_warehouse_person_property',
     RevenueAnalytics: 'revenue_analytics',
 } as const
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1830,6 +1830,7 @@ export namespace Schemas {
       Group: 'group',
       Session: 'session',
       Hogql: 'hogql',
+      DataWarehousePersonProperty: 'data_warehouse_person_property',
       RevenueAnalytics: 'revenue_analytics',
     } as const;
 

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -24,6 +24,7 @@ const AssistantEventMultipleBreakdownFilterType = z.enum([
     'event_metadata',
     'session',
     'hogql',
+    'data_warehouse_person_property',
     'revenue_analytics',
 ])
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/query-trends.json
@@ -70,6 +70,7 @@
                                             "event_metadata",
                                             "session",
                                             "hogql",
+                                            "data_warehouse_person_property",
                                             "revenue_analytics"
                                         ],
                                         "type": "string"


### PR DESCRIPTION
## Problem

Retention insights did not support extended person properties yet.

## Changes

Adds support for extended person properties in retention step filters, global filters and breakdowns.

## How did you test this code?

Tested locally and added a backend side test for the new breakdown functionality