### PR TITLE
perf(dashboard): Memoize part of text card tiles for perf improvements with edit mode

### DIFF
--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -2,7 +2,7 @@ import './TextCard.scss'
 
 import { EditorContent } from '@tiptap/react'
 import clsx from 'clsx'
-import React, { useEffect } from 'react'
+import React, { memo, useEffect, useMemo } from 'react'
 
 import 'lib/components/MarkdownEditor/RichMarkdownEditor.scss'
 import { Resizeable } from 'lib/components/Cards/CardMeta'
@@ -36,10 +36,12 @@ interface TextCardBodyProps extends Pick<React.HTMLAttributes<HTMLDivElement>, '
     closeDetails?: () => void
 }
 
-export function TextContent({ text, closeDetails, className }: TextCardBodyProps): JSX.Element {
+function TextContentImpl({ text, closeDetails, className }: TextCardBodyProps): JSX.Element {
+    const initialDoc = useMemo(() => markdownToTextCardDoc(text), [text])
+
     const editor = useRichContentEditor({
         extensions: TEXT_CARD_MARKDOWN_READONLY_EXTENSIONS,
-        initialContent: markdownToTextCardDoc(text),
+        initialContent: initialDoc,
         disabled: true,
     })
 
@@ -48,8 +50,8 @@ export function TextContent({ text, closeDetails, className }: TextCardBodyProps
             return
         }
 
-        editor.commands.setContent(markdownToTextCardDoc(text), { emitUpdate: false })
-    }, [editor, text])
+        editor.commands.setContent(initialDoc, { emitUpdate: false })
+    }, [editor, initialDoc])
 
     return (
         <div className={clsx('w-full', className)} onClick={() => closeDetails?.()}>
@@ -63,6 +65,9 @@ export function TextContent({ text, closeDetails, className }: TextCardBodyProps
         </div>
     )
 }
+
+export const TextContent = memo(TextContentImpl)
+TextContent.displayName = 'TextContent'
 
 function TextCardInternal(
     {


### PR DESCRIPTION
## Problem

Using React Scan, noticed some performance bugs caused by the text card.

## Changes

Memoized part of content for tiptap to avoid re-renders each time, and memoize the text card itself

## How did you test this code?

Locally.
## Publish to changelog?



No.

 ## 🤖 LLM context 

```

## What was going wrong

**React Compiler:** Off — only `@vitejs/plugin-react()` in `vite.config.ts`, no `babel-plugin-react-compiler`.

**Why “other” ≫ React (255ms vs 75ms):** `TextContent` uses TipTap’s `useEditor` via `useRichContentEditor`. TipTap’s `EditorInstanceManager.compareOptions` treats `content` as **reference equality** (see `useEditor.ts` in `@tiptap/react`). You passed `initialContent: markdownToTextCardDoc(text)` on **every** render, so the parsed doc was a **new object** even when `text` was unchanged. That made `compareOptions` fail and **`editor.setOptions`** run after commits — ProseMirror/DOM work that does **not** show up as React render time.

**Why 8 renders / 14ms on `TextContent`:** Parent churn still re-renders; memo + stable doc address the expensive path. If props are stable, `memo` skips the subtree.

## What we changed

In `TextCard.tsx`:

1. **`useMemo(() => markdownToTextCardDoc(text), [text])`** so `content` only changes when `text` changes.
2. **`useEffect` deps** use that stable `initialDoc` instead of re-parsing in the effect body.
3. **`memo(TextContentImpl)`** so identical `text` / `className` / `closeDetails` do not re-run TipTap when a parent re-renders.

```39:66:frontend/src/lib/components/Cards/TextCard/TextCard.tsx
function TextContentImpl({ text, closeDetails, className }: TextCardBodyProps): JSX.Element {
    // TipTap's useEditor compares `content` by reference; a fresh JSON object each render forces
    // setOptions → expensive ProseMirror work (shows up as "other" time, not React render time).
    const initialDoc = useMemo(() => markdownToTextCardDoc(text), [text])

    const editor = useRichContentEditor({
        extensions: TEXT_CARD_MARKDOWN_READONLY_EXTENSIONS,
        initialContent: initialDoc,
        disabled: true,
    })

    useEffect(() => {
        if (!editor) {
            return
        }

        editor.commands.setContent(initialDoc, { emitUpdate: false })
    }, [editor, initialDoc])
    // ...
}

export const TextContent = memo(TextContentImpl)
TextContent.displayName = 'TextContent'
```

`TextCard.test.tsx` passes.

## What you should do next

Repeat the same interaction and check React Scan’s Optimize tab. You want:

- Lower **other** time (main signal for this fix).
- Fewer unnecessary `TextContent` renders if the parent was the only thing updating.

If **`closeDetails` is a new inline function every render** from a parent, `memo` will still bail — then stabilize that callback or use a custom `memo` comparator. Paste **Formatted Data** from the same interaction so we can confirm it matches this path.

**If it’s still slow:** profile whether other call sites of `useRichContentEditor` pass unstable `content` / options the same way, or whether another heavy hook (e.g. `useEditorState`) is involved.

---

**Sources:** `frontend/vite.config.ts` (React plugin), `@tiptap/react` `src/useEditor.ts` (`EditorInstanceManager.compareOptions`, `onRender` with `deps.length === 0`), `frontend/src/lib/components/RichContentEditor/index.tsx`, `frontend/src/lib/components/Cards/TextCard/TextCard.tsx`.
```

