### PR TITLE
fix: pin litellm in gateway

### DIFF
--- a/services/llm-gateway/pyproject.toml
+++ b/services/llm-gateway/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pydantic-settings>=2.1.0",
     "asyncpg>=0.30.0",
     "redis==5.3.1",
-    "litellm>=1.81.0",
+    "litellm==1.81.13",
     "orjson>=3.10.0",
     "prometheus-client>=0.21.0",
     "prometheus-fastapi-instrumentator>=7.0.0",


### PR DESCRIPTION
a new version is compromised, our existing version is not, lets pin this for now

See https://github.com/BerriAI/litellm/issues/24512
See https://news.ycombinator.com/item?id=47501729