### PR TITLE
fix: Fix litellm lock

### DIFF
--- a/services/llm-gateway/uv.lock
+++ b/services/llm-gateway/uv.lock
@@ -980,7 +980,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "litellm", specifier = ">=1.81.0" },
+    { name = "litellm", specifier = "==1.81.13" },
     { name = "orjson", specifier = ">=3.10.0" },
     { name = "posthoganalytics", specifier = ">=3.0.0" },
     { name = "prometheus-client", specifier = ">=0.21.0" },


### PR DESCRIPTION
We updated pyproject.toml in 065735325efe69a701d65eb93fd15072ec47f894 but not the lock
