### PR TITLE
perf(dashboard): avoid spurious edit mode when clicking text card markdown

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -300,10 +300,10 @@ export function DashboardItems(): JSX.Element {
                                               return
                                           }
 
-                                          // Don't trigger when clicking obvious interactive controls
+                                          // Don't trigger when clicking obvious interactive controls or readonly rich text (TipTap/LemonMarkdown).
                                           if (
                                               target.closest(
-                                                  'input,textarea,button,select,a,p,h4,[contenteditable="true"],[role="textbox"]'
+                                                  'input,textarea,button,select,a,p,h4,[contenteditable="true"],[role="textbox"],.ProseMirror,.LemonMarkdown'
                                               )
                                           ) {
                                               return


### PR DESCRIPTION
## Problem

Clicking inside dashboard text tiles (TipTap readonly / LemonMarkdown) could still route through the "enter edit mode from card body" `mousedown` handler. The ignore list matched `p` and `[contenteditable="true"]`, but readonly ProseMirror uses `contenteditable="false"`, and many nodes (`li`, `span`, headings, etc.) are not `p`. That unintentionally called `setDashboardMode(Edit)` and forced a full-dashboard repaint.

React Scan / interaction timing showed **~23ms React render** and **~38ms non-render JS**, but **~1323ms from DOM commit to frame presented** — a compositor/GPU-heavy path consistent with switching the whole dashboard into edit mode, not with missing `memo()` on `TextCard`.

## Changes

- Extend the `closest()` selector in `DashboardItems.tsx` to include `.ProseMirror` and `.LemonMarkdown` so clicks on readonly rich text do not trigger edit mode from the body drag-handle path.

## How did you test this code?

Not manually tested in the browser (agent). Please verify: on a dashboard with "enter edit from edge" behavior, click list items, headings, and inline spans inside a text card — the dashboard should stay in view mode unless you use the intended affordances (e.g. edge overlay, Edit layout, shortcut).

## Publish to changelog?

no — internal performance fix

## Docs update

N/A
