### PR TITLE
fix(bigquery): Only check for duplicates when impersonating

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1171,6 +1171,30 @@ class GoogleAdsIntegration:
         return all_accounts
 
 
+def is_unique_service_account_by_organization_id(service_account_email: str, organization_id: str) -> bool:
+    """Check if the service account is only in one organization.
+
+    This is used as a security measure to block multiple organizations from
+    impersonating the same service account.
+
+    In the future we may lift this restriction, but initially we want to make sure about
+    service account ownership with this check. This complements other runtime checks in
+    batch exports; see `verify_impersonated_service_account_ownership` in
+    `bigquery_batch_export.py`.
+    """
+    same_service_account_integrations = (
+        Integration.objects.select_related("team__organization")
+        .filter(kind="google-cloud-service-account", config__service_account_email=service_account_email)
+        # If private key is present, then we are not impersonating
+        .exclude(sensitive_config__has_key="private_key")
+    )
+    for integration in same_service_account_integrations:
+        if str(integration.team.organization.id) != organization_id:
+            return True
+
+    return False
+
+
 class GoogleCloudServiceAccountIntegration:
     integration: Integration
 
@@ -1189,15 +1213,8 @@ class GoogleCloudServiceAccountIntegration:
         token_uri: str | None = None,
         created_by: User | None = None,
     ) -> Integration:
-        # Do not allow multiple organizations that want to impersonate the same service account
-        same_service_account_integrations = (
-            Integration.objects.select_related("team__organization")
-            .filter(kind="google-cloud-service-account", config__service_account_email=service_account_email)
-            # If private key is present, then we are not impersonating
-            .exclude(sensitive_config__has_key="private_key")
-        )
-        for integration in same_service_account_integrations:
-            if str(integration.team.organization.id) != str(organization_id):
+        if private_key is None:
+            if is_unique_service_account_by_organization_id(service_account_email, organization_id):
                 raise ValidationError("Cannot create Google Cloud service account integration: Invalid service account")
 
         sensitive_config = {}

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1190,9 +1190,9 @@ def is_unique_service_account_by_organization_id(service_account_email: str, org
     )
     for integration in same_service_account_integrations:
         if str(integration.team.organization.id) != organization_id:
-            return True
+            return False
 
-    return False
+    return True
 
 
 class GoogleCloudServiceAccountIntegration:
@@ -1214,7 +1214,7 @@ class GoogleCloudServiceAccountIntegration:
         created_by: User | None = None,
     ) -> Integration:
         if private_key is None:
-            if is_unique_service_account_by_organization_id(service_account_email, organization_id):
+            if not is_unique_service_account_by_organization_id(service_account_email, organization_id):
                 raise ValidationError("Cannot create Google Cloud service account integration: Invalid service account")
 
         sensitive_config = {}

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1189,9 +1189,11 @@ class GoogleCloudServiceAccountIntegration:
         token_uri: str | None = None,
         created_by: User | None = None,
     ) -> Integration:
-        # Do not allow the same project_id in multiple organizations
-        same_service_account_integrations = Integration.objects.select_related("team__organization").filter(
-            kind="google-cloud-service-account", config__service_account_email=service_account_email
+        # Do not allow multiple organizations that want to impersonate the same service account
+        same_service_account_integrations = (
+            Integration.objects.select_related("team__organization")
+            .filter(kind="google-cloud-service-account", config__service_account_email=service_account_email)
+            .exclude(sensitive_config__has_key="private_key")
         )
         for integration in same_service_account_integrations:
             if str(integration.team.organization.id) != str(organization_id):

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1193,6 +1193,7 @@ class GoogleCloudServiceAccountIntegration:
         same_service_account_integrations = (
             Integration.objects.select_related("team__organization")
             .filter(kind="google-cloud-service-account", config__service_account_email=service_account_email)
+            # If private key is present, then we are not impersonating
             .exclude(sensitive_config__has_key="private_key")
         )
         for integration in same_service_account_integrations:

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -21,6 +21,7 @@ from posthog.models.integration import (
     EmailIntegration,
     GitHubIntegration,
     GoogleCloudIntegration,
+    GoogleCloudServiceAccountIntegration,
     Integration,
     OauthIntegration,
     SlackIntegration,
@@ -820,6 +821,23 @@ class TestDatabricksIntegrationModel(BaseTest):
                 client_id="client_id",
                 client_secret="client_secret",
                 created_by=self.user,
+            )
+
+
+class TestGoogleCloudServiceAccountIntegration(BaseTest):
+    def test_raises_on_duplicate_service_account_email(self):
+        _ = GoogleCloudServiceAccountIntegration.integration_from_service_account(
+            team_id=self.team.pk,
+            organization_id=str(self.team.organization.id),
+            service_account_email="test@test.iam.gserviceaccount.com",
+            project_id="test",
+        )
+        with pytest.raises(ValidationError):
+            _ = GoogleCloudServiceAccountIntegration.integration_from_service_account(
+                team_id=self.team.pk + 1,
+                organization_id="a-different-org",
+                service_account_email="test@test.iam.gserviceaccount.com",
+                project_id="test",
             )
 
 

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -840,6 +840,42 @@ class TestGoogleCloudServiceAccountIntegration(BaseTest):
                 project_id="test",
             )
 
+    def test_allows_duplicate_service_account_email_when_using_key(self):
+        key_file_integration = GoogleCloudServiceAccountIntegration.integration_from_service_account(
+            team_id=self.team.pk,
+            organization_id=str(self.team.organization.id),
+            service_account_email="test@test.iam.gserviceaccount.com",
+            project_id="test",
+            private_key="something",
+            private_key_id="something",
+            token_uri="something",
+        )
+
+        other_org = Organization.objects.create(name="other org")
+        other_team = Team.objects.create(organization=other_org, name="other team")
+        new_impersonated_integration = GoogleCloudServiceAccountIntegration.integration_from_service_account(
+            team_id=other_team.id,
+            organization_id=other_org.id,
+            service_account_email="test@test.iam.gserviceaccount.com",
+            project_id="test",
+        )
+
+        new_key_file_integration = GoogleCloudServiceAccountIntegration.integration_from_service_account(
+            team_id=other_team.pk,
+            organization_id=other_org.id,
+            service_account_email="test@test.iam.gserviceaccount.com",
+            project_id="test",
+            private_key="something",
+            private_key_id="something",
+            token_uri="something",
+        )
+
+        assert (
+            GoogleCloudServiceAccountIntegration(key_file_integration).service_account_email
+            == GoogleCloudServiceAccountIntegration(new_impersonated_integration).service_account_email
+            == GoogleCloudServiceAccountIntegration(new_key_file_integration).service_account_email
+        )
+
 
 class TestEmailIntegrationDomainValidation(BaseTest):
     @patch("products.workflows.backend.providers.SESProvider.create_email_domain")


### PR DESCRIPTION
## Problem

The integration model used in big query batch exports does a security check that doesn't allow multiple integrations with the same service account email to exist on different organizations. However, this is too restrictive: If keys are presented, then it's reasonable to assume ownership of the account, regardless if the organization is duplicated.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Exclude integrations with private keys when checking for duplicates.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
