### PR TITLE
feat(cli,error-tracking): add --force flag to symbol set uploads

### DIFF
--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -45,6 +45,8 @@ pub struct PresignedUrl {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct BulkUploadStartRequest {
     symbol_sets: Vec<CreateSymbolSetRequest>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    force: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,12 +62,14 @@ struct BulkUploadFinishRequest {
 /// Upload symbol sets with optional retry on release_id_mismatch error.
 /// If `skip_release_on_fail` is true and the server returns a release_id_mismatch error,
 /// the upload will be retried without release IDs.
+/// If `force` is true, existing symbol sets with different content will be overwritten.
 pub fn upload_with_retry(
     input_sets: Vec<SymbolSetUpload>,
     batch_size: usize,
     skip_release_on_fail: bool,
+    force: bool,
 ) -> Result<()> {
-    let res = upload_inner(&input_sets, batch_size);
+    let res = upload_inner(&input_sets, batch_size, force);
     match res {
         Ok(()) => Ok(()),
         Err(UploadError::ReleaseIdMismatch) if skip_release_on_fail => {
@@ -78,13 +82,17 @@ pub fn upload_with_retry(
                     data: s.data,
                 })
                 .collect();
-            upload_inner(&sets_without_release, batch_size).map_err(|e| e.into())
+            upload_inner(&sets_without_release, batch_size, force).map_err(|e| e.into())
         }
         Err(e) => Err(e.into()),
     }
 }
 
-fn upload_inner(input_sets: &[SymbolSetUpload], batch_size: usize) -> Result<(), UploadError> {
+fn upload_inner(
+    input_sets: &[SymbolSetUpload],
+    batch_size: usize,
+    force: bool,
+) -> Result<(), UploadError> {
     let upload_requests: Vec<_> = input_sets
         .iter()
         .filter(|s| {
@@ -100,7 +108,7 @@ fn upload_inner(input_sets: &[SymbolSetUpload], batch_size: usize) -> Result<(),
 
     for (i, batch) in upload_requests.chunks(batch_size).enumerate() {
         info!("Starting upload of batch {i}, {} symbol sets", batch.len());
-        let start_response = start_upload(batch)?;
+        let start_response = start_upload(batch, force)?;
 
         let id_map: HashMap<_, _> = batch.iter().map(|u| (u.chunk_id.as_str(), u)).collect();
 
@@ -133,7 +141,10 @@ fn upload_inner(input_sets: &[SymbolSetUpload], batch_size: usize) -> Result<(),
     Ok(())
 }
 
-fn start_upload(symbol_sets: &[&SymbolSetUpload]) -> Result<BulkUploadStartResponse, UploadError> {
+fn start_upload(
+    symbol_sets: &[&SymbolSetUpload],
+    force: bool,
+) -> Result<BulkUploadStartResponse, UploadError> {
     let client = &context().client;
 
     let request = BulkUploadStartRequest {
@@ -141,6 +152,7 @@ fn start_upload(symbol_sets: &[&SymbolSetUpload]) -> Result<BulkUploadStartRespo
             .iter()
             .map(|s| CreateSymbolSetRequest::new(s))
             .collect(),
+        force,
     };
 
     let res = retry(retry_policy(500, 2, 3), |_| {

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -119,10 +119,7 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
             // Format: "UUID: <uuid> (<arch>) <full_path>"
             let path_start = line.rfind(')')? + 2; // Skip ") "
             let dwarf_path = line.get(path_start..)?;
-            let dwarf_filename = Path::new(dwarf_path)
-                .file_name()?
-                .to_str()?
-                .to_string();
+            let dwarf_filename = Path::new(dwarf_path).file_name()?.to_str()?.to_string();
 
             Some((uuid, dwarf_filename))
         })

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -116,7 +116,9 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
             let uuid = uuid_part[..uuid_end].to_uppercase();
 
             // Extract the DWARF filename from the path at end of line
-            let dwarf_path = line.rsplit(' ').next()?;
+            // Format: "UUID: <uuid> (<arch>) <full_path>"
+            let path_start = line.rfind(')')? + 2; // Skip ") "
+            let dwarf_path = line.get(path_start..)?;
             let dwarf_filename = Path::new(dwarf_path)
                 .file_name()?
                 .to_str()?

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::api::symbol_sets::SymbolSetUpload;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
+use posthog_symbol_data::{write_symbol_data, AppleDsym};
 
 pub mod source_bundle;
 pub mod upload;
@@ -13,20 +14,28 @@ pub enum DsymSubcommand {
     Upload(upload::Args),
 }
 
-/// Represents a dSYM bundle ready for upload
+/// A single DWARF binary extracted from a dSYM bundle, ready for upload
+struct DsymEntry {
+    /// The UUID of this DWARF binary (used as chunk_id)
+    uuid: String,
+    /// ZIP containing only this DWARF binary (+ optional source files)
+    data: Vec<u8>,
+}
+
+/// Represents a dSYM bundle ready for upload.
+/// Each DWARF binary in the bundle gets its own ZIP, keyed by its UUID.
 pub struct DsymFile {
-    /// The UUIDs of the dSYM (one per architecture, used as chunk_id for matching)
-    pub uuids: Vec<String>,
-    /// The zipped dSYM bundle data
-    pub data: Vec<u8>,
+    entries: Vec<DsymEntry>,
     /// Optional release ID
     pub release_id: Option<String>,
 }
 
 impl DsymFile {
-    /// Create a new DsymFile from a .dSYM bundle path
+    /// Create a new DsymFile from a .dSYM bundle path.
+    /// Each DWARF binary in the bundle gets its own ZIP so that
+    /// stable UUIDs (e.g. app stubs) don't get a new content hash
+    /// when a sibling binary (e.g. debug dylib) changes.
     pub fn new(path: &PathBuf, include_source: bool) -> Result<Self> {
-        // Validate it's a dSYM bundle
         if !path.is_dir() {
             anyhow::bail!("Path {} is not a directory", path.display());
         }
@@ -39,37 +48,49 @@ impl DsymFile {
             );
         }
 
-        // Extract UUIDs from the dSYM (one per architecture for universal binaries)
-        let uuids = extract_dsym_uuids(path)?;
+        let dwarf_dir = path.join("Contents/Resources/DWARF");
+        let uuid_entries = extract_dsym_uuids(path)?;
 
-        // Zip the dSYM bundle
-        let data = zip_dsym_bundle(path, include_source)?;
+        let mut entries = Vec::new();
+        for (uuid, dwarf_filename) in &uuid_entries {
+            let dwarf_path = dwarf_dir.join(dwarf_filename);
+            let data = zip_dwarf_binary(&dwarf_path, include_source)?;
+            entries.push(DsymEntry {
+                uuid: uuid.clone(),
+                data,
+            });
+        }
 
         Ok(Self {
-            uuids,
-            data,
+            entries,
             release_id: None,
         })
     }
-}
 
-impl DsymFile {
-    /// Convert to SymbolSetUploads (one per UUID/architecture)
+    pub fn uuids(&self) -> Vec<&str> {
+        self.entries.iter().map(|e| e.uuid.as_str()).collect()
+    }
+
+    pub fn total_size(&self) -> usize {
+        self.entries.iter().map(|e| e.data.len()).sum()
+    }
+
+    /// Convert to SymbolSetUploads (one per UUID)
     pub fn into_uploads(self) -> Vec<SymbolSetUpload> {
-        self.uuids
+        self.entries
             .into_iter()
-            .map(|uuid| SymbolSetUpload {
-                chunk_id: uuid,
+            .map(|entry| SymbolSetUpload {
+                chunk_id: entry.uuid,
                 release_id: self.release_id.clone(),
-                data: self.data.clone(),
+                data: entry.data,
             })
             .collect()
     }
 }
 
-/// Extract all UUIDs from a dSYM bundle using dwarfdump
-/// Universal binaries have multiple UUIDs (one per architecture)
-fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<String>> {
+/// Extract all UUIDs and their corresponding DWARF filenames from a dSYM bundle.
+/// Returns (uuid, dwarf_filename) pairs.
+fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<(String, String)>> {
     use std::process::Command;
 
     let output = Command::new("dwarfdump")
@@ -85,22 +106,27 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<String>> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Parse output like: "UUID: 12345678-1234-1234-1234-123456789ABC (arm64) /path/to/file"
-    // Universal binaries have multiple lines, one per architecture
-    let uuids: Vec<String> = stdout
+    // Parse output like: "UUID: 12345678-1234-1234-1234-123456789ABC (arm64) /path/to/DWARF/PostHogExample"
+    let entries: Vec<(String, String)> = stdout
         .lines()
         .filter_map(|line| {
-            line.find("UUID: ").and_then(|uuid_start| {
-                let uuid_part = &line[uuid_start + 6..];
-                uuid_part.find(' ').map(|uuid_end| {
-                    // Uppercase for standard UUID format
-                    uuid_part[..uuid_end].to_uppercase()
-                })
-            })
+            let uuid_start = line.find("UUID: ")? + 6;
+            let uuid_part = &line[uuid_start..];
+            let uuid_end = uuid_part.find(' ')?;
+            let uuid = uuid_part[..uuid_end].to_uppercase();
+
+            // Extract the DWARF filename from the path at end of line
+            let dwarf_path = line.rsplit(' ').next()?;
+            let dwarf_filename = Path::new(dwarf_path)
+                .file_name()?
+                .to_str()?
+                .to_string();
+
+            Some((uuid, dwarf_filename))
         })
         .collect();
 
-    if uuids.is_empty() {
+    if entries.is_empty() {
         anyhow::bail!(
             "Could not extract any UUIDs from dSYM at {}. dwarfdump output: {}",
             dsym_path.display(),
@@ -108,16 +134,19 @@ fn extract_dsym_uuids(dsym_path: &PathBuf) -> Result<Vec<String>> {
         );
     }
 
-    Ok(uuids)
+    Ok(entries)
 }
 
-/// Zip a dSYM bundle into memory, optionally including source files
-fn zip_dsym_bundle(dsym_path: &PathBuf, include_source: bool) -> Result<Vec<u8>> {
+/// Create a minimal ZIP containing a single DWARF binary and optional source files.
+/// The ZIP layout is:
+///   dwarf                    — the raw DWARF Mach-O binary
+///   __source/manifest.json   — (optional) source file manifest
+///   __source/...             — (optional) source files
+fn zip_dwarf_binary(dwarf_path: &Path, include_source: bool) -> Result<Vec<u8>> {
     use std::fs::File;
     use std::io::Read;
     use std::io::{Cursor, Write};
     use tracing::info;
-    use walkdir::WalkDir;
 
     let mut buffer = Cursor::new(Vec::new());
 
@@ -126,34 +155,16 @@ fn zip_dsym_bundle(dsym_path: &PathBuf, include_source: bool) -> Result<Vec<u8>>
         let options = zip::write::SimpleFileOptions::default()
             .compression_method(zip::CompressionMethod::Deflated);
 
-        // Collect and sort entries for deterministic zip output
-        let mut entries: Vec<_> = WalkDir::new(dsym_path)
-            .into_iter()
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-        entries.sort_by(|a, b| a.path().cmp(b.path()));
+        // Add the DWARF binary as "dwarf"
+        zip.start_file("dwarf", options)?;
+        let mut file = File::open(dwarf_path)?;
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents)?;
+        zip.write_all(&contents)?;
 
-        for entry in &entries {
-            let path = entry.path();
-
-            // Create relative path within the zip
-            let relative_path = path.strip_prefix(dsym_path.parent().unwrap_or(dsym_path))?;
-            let zip_path = relative_path.to_string_lossy();
-
-            if path.is_file() {
-                zip.start_file(zip_path.to_string(), options)?;
-                let mut file = File::open(path)?;
-                let mut contents = Vec::new();
-                file.read_to_end(&mut contents)?;
-                zip.write_all(&contents)?;
-            } else if path.is_dir() && path != dsym_path.as_path() {
-                // Add directory entry (but not the root)
-                zip.add_directory(format!("{zip_path}/"), options)?;
-            }
-        }
-
-        // Optionally include source files referenced by DWARF debug info
+        // Optionally include source files referenced by this DWARF binary
         if include_source {
-            match source_bundle::extract_dwarf_source_paths(dsym_path) {
+            match source_bundle::extract_source_paths_from_dwarf(dwarf_path) {
                 Ok(all_paths) => {
                     let filtered = source_bundle::filter_source_paths(&all_paths);
                     info!(
@@ -185,7 +196,9 @@ fn zip_dsym_bundle(dsym_path: &PathBuf, include_source: bool) -> Result<Vec<u8>>
         zip.finish()?;
     }
 
-    Ok(buffer.into_inner())
+    let zip_data = buffer.into_inner();
+    let wrapped = write_symbol_data(AppleDsym { data: zip_data })?;
+    Ok(wrapped)
 }
 
 /// Find all dSYM bundles in a directory

--- a/cli/src/dsym/source_bundle.rs
+++ b/cli/src/dsym/source_bundle.rs
@@ -23,24 +23,9 @@ pub struct SourceFiles {
     pub contents: BTreeMap<String, Vec<u8>>,
 }
 
-/// Extract all source file paths referenced in DWARF debug info from a dSYM bundle.
-///
-/// Finds the DWARF binary at `<dSYM>/Contents/Resources/DWARF/<name>`,
-/// parses it with `symbolic`, and collects all referenced source file paths.
-pub fn extract_dwarf_source_paths(dsym_path: &Path) -> Result<Vec<String>> {
-    let dwarf_dir = dsym_path.join("Contents/Resources/DWARF");
-
-    if !dwarf_dir.is_dir() {
-        anyhow::bail!("DWARF directory not found at {}", dwarf_dir.display());
-    }
-
-    // Find the DWARF binary (there's typically one file in this directory)
-    let dwarf_binary = fs::read_dir(&dwarf_dir)?
-        .filter_map(|e| e.ok())
-        .find(|e| e.path().is_file())
-        .ok_or_else(|| anyhow::anyhow!("No DWARF binary found in {}", dwarf_dir.display()))?;
-
-    let dwarf_data = fs::read(dwarf_binary.path())?;
+/// Extract all source file paths referenced in a DWARF binary file.
+pub fn extract_source_paths_from_dwarf(dwarf_path: &Path) -> Result<Vec<String>> {
+    let dwarf_data = fs::read(dwarf_path)?;
     let archive = Archive::parse(&dwarf_data)?;
 
     let mut paths = Vec::new();

--- a/cli/src/dsym/upload.rs
+++ b/cli/src/dsym/upload.rs
@@ -186,10 +186,10 @@ pub fn upload(args: &Args) -> Result<()> {
                 dsym_file.release_id = release_id.clone();
                 info!(
                     "  UUIDs: {} ({})",
-                    dsym_file.uuids.join(", "),
-                    dsym_file.uuids.len()
+                    dsym_file.uuids().join(", "),
+                    dsym_file.uuids().len()
                 );
-                info!("  Size: {} bytes", dsym_file.data.len());
+                info!("  Total size: {} bytes", dsym_file.total_size());
 
                 uploads.extend(dsym_file.into_uploads());
             }

--- a/cli/src/dsym/upload.rs
+++ b/cli/src/dsym/upload.rs
@@ -42,6 +42,10 @@ pub struct Args {
     /// allowing PostHog to display source code context around crash locations.
     #[arg(long, default_value_t = false)]
     pub include_source: bool,
+
+    /// Force overwrite existing symbol sets even if they have different content.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -52,6 +56,7 @@ pub fn upload(args: &Args) -> Result<()> {
         build,
         main_dsym,
         include_source,
+        force: _,
     } = args;
 
     let directory = directory.canonicalize().map_err(|e| {
@@ -205,7 +210,7 @@ pub fn upload(args: &Args) -> Result<()> {
     }
 
     info!("Uploading {} dSYM(s)...", uploads.len());
-    api::symbol_sets::upload_with_retry(uploads, 10, true)?;
+    api::symbol_sets::upload_with_retry(uploads, 10, true, args.force)?;
     info!("dSYM upload complete");
 
     Ok(())

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -76,7 +76,12 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
-    api::symbol_sets::upload_with_retry(vec![to_upload], *batch_size, *skip_release_on_fail, *force)?;
+    api::symbol_sets::upload_with_retry(
+        vec![to_upload],
+        *batch_size,
+        *skip_release_on_fail,
+        *force,
+    )?;
 
     Ok(())
 }

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -26,6 +26,10 @@ pub struct Args {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    /// Force overwrite existing symbol sets even if they have different content.
+    #[arg(long, default_value = "false")]
+    pub force: bool,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -34,6 +38,7 @@ pub fn upload(args: &Args) -> Result<()> {
         map_id,
         batch_size,
         release,
+        force,
     } = args;
 
     let ReleaseArgs {
@@ -71,7 +76,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
-    api::symbol_sets::upload_with_retry(vec![to_upload], *batch_size, *skip_release_on_fail)?;
+    api::symbol_sets::upload_with_retry(vec![to_upload], *batch_size, *skip_release_on_fail, *force)?;
 
     Ok(())
 }

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -23,6 +23,10 @@ pub struct Args {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    /// Force overwrite existing symbol sets even if they have different content.
+    #[arg(long, default_value = "false")]
+    pub force: bool,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -31,6 +35,7 @@ pub fn upload(args: &Args) -> Result<()> {
         directory,
         release,
         batch_size,
+        force: _,
     } = args;
 
     let directory = directory.canonicalize().map_err(|e| {
@@ -78,7 +83,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let started_at = Instant::now();
     let upload_result =
-        symbol_sets::upload_with_retry(uploads, *batch_size, release.skip_release_on_fail);
+        symbol_sets::upload_with_retry(uploads, *batch_size, release.skip_release_on_fail, args.force);
     let duration_ms = started_at.elapsed().as_millis();
 
     let mut props = vec![

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -82,8 +82,12 @@ pub fn upload(args: &Args) -> Result<()> {
     );
 
     let started_at = Instant::now();
-    let upload_result =
-        symbol_sets::upload_with_retry(uploads, *batch_size, release.skip_release_on_fail, args.force);
+    let upload_result = symbol_sets::upload_with_retry(
+        uploads,
+        *batch_size,
+        release.skip_release_on_fail,
+        args.force,
+    );
     let duration_ms = started_at.elapsed().as_millis();
 
     let mut props = vec![

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -40,6 +40,10 @@ pub struct ProcessArgs {
     /// The maximum number of chunks to upload in a single batch
     #[arg(long, default_value = "50")]
     pub batch_size: usize,
+
+    /// Force overwrite existing symbol sets even if they have different content.
+    #[arg(long, default_value = "false")]
+    pub force: bool,
 }
 
 impl ProcessArgs {
@@ -64,6 +68,7 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             skip_ssl_verification: false,
             batch_size: args.batch_size,
             release: args.release,
+            force: args.force,
         };
 
         (inject_args, upload_args)

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -101,8 +101,12 @@ pub fn upload(args: &Args) -> Result<()> {
     );
 
     let started_at = Instant::now();
-    let upload_result =
-        symbol_sets::upload_with_retry(uploads, args.batch_size, args.release.skip_release_on_fail, args.force);
+    let upload_result = symbol_sets::upload_with_retry(
+        uploads,
+        args.batch_size,
+        args.release.skip_release_on_fail,
+        args.force,
+    );
     let duration_ms = started_at.elapsed().as_millis();
 
     let mut props = vec![

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -38,6 +38,10 @@ pub struct Args {
     #[clap(flatten)]
     pub release: ReleaseArgs,
 
+    /// Force overwrite existing symbol sets even if they have different content.
+    #[arg(long, default_value = "false")]
+    pub force: bool,
+
     /// DEPRECATED - use top-level `--skip-ssl-verification` instead
     #[arg(long, default_value = "false")]
     pub skip_ssl_verification: bool,
@@ -98,7 +102,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let started_at = Instant::now();
     let upload_result =
-        symbol_sets::upload_with_retry(uploads, args.batch_size, args.release.skip_release_on_fail);
+        symbol_sets::upload_with_retry(uploads, args.batch_size, args.release.skip_release_on_fail, args.force);
     let duration_ms = started_at.elapsed().as_millis();
 
     let mut props = vec![

--- a/products/error_tracking/backend/api/symbol_sets.py
+++ b/products/error_tracking/backend/api/symbol_sets.py
@@ -65,6 +65,15 @@ class ErrorTrackingSymbolSetUploadSerializer(serializers.Serializer):
     content_hash = serializers.CharField(allow_null=True, default=None)
 
 
+class BulkStartUploadSerializer(serializers.Serializer):
+    symbol_sets = ErrorTrackingSymbolSetUploadSerializer(many=True, required=False, default=[])
+    chunk_ids = serializers.ListField(child=serializers.CharField(), required=False, default=[])
+    release_id = serializers.CharField(allow_null=True, default=None)
+    force = serializers.BooleanField(
+        default=False, help_text="Force overwrite existing symbol sets with different content"
+    )
+
+
 @extend_schema(tags=[ProductKey.ERROR_TRACKING])
 class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "error_tracking"
@@ -239,11 +248,14 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
     def bulk_start_upload(self, request, **kwargs):
         if request.user.pk:
             posthoganalytics.identify_context(request.user.pk)
-        # Earlier ones send a list of chunk IDs, all associated with one release
-        # Extract a list of chunk IDs from the request json
-        chunk_ids: list[str] = request.data.get("chunk_ids") or []
-        # Grab the release ID from the request json
-        release_id: str | None = request.data.get("release_id", None)
+
+        serializer = BulkStartUploadSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        force: bool = data["force"]
+        chunk_ids: list[str] = data["chunk_ids"]
+        release_id: str | None = data["release_id"]
 
         _ = posthoganalytics.capture(
             "error_tracking_symbol_set_upload_started",
@@ -251,13 +263,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
             groups=groups(self.team.organization, self.team),
         )
 
-        # Validate symbol_sets using the serializer
-        symbol_sets: list[SymbolSetUpload] = []
-        if "symbol_sets" in request.data:
-            chunk_serializer = ErrorTrackingSymbolSetUploadSerializer(data=request.data["symbol_sets"], many=True)
-            _ = chunk_serializer.is_valid(raise_exception=True)
-            symbol_sets = [SymbolSetUpload(**data) for data in chunk_serializer.validated_data]
-
+        symbol_sets: list[SymbolSetUpload] = [SymbolSetUpload(**ss) for ss in data["symbol_sets"]]
         symbol_sets.extend([SymbolSetUpload(x, release_id, None) for x in chunk_ids])
 
         if not settings.OBJECT_STORAGE_ENABLED:
@@ -267,7 +273,7 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
             )
 
         chunk_id_url_map = bulk_create_symbol_sets(
-            symbol_sets, self.team, distinct_id=str(request.user.pk) if request.user.pk else None
+            symbol_sets, self.team, distinct_id=str(request.user.pk) if request.user.pk else None, force=force
         )
         return Response({"id_map": chunk_id_url_map}, status=status.HTTP_201_CREATED)
 
@@ -403,6 +409,7 @@ def bulk_create_symbol_sets(
     new_symbol_sets: list[SymbolSetUpload],
     team: Team,
     distinct_id: str | None = None,
+    force: bool = False,
 ) -> dict[str, dict[str, str]]:
     accelerate = bool(
         distinct_id
@@ -472,28 +479,45 @@ def bulk_create_symbol_sets(
             dirty = False
 
             # Allow adding an "orphan" symbol set to a release, but not
-            # moving symbols sets between releases
+            # moving symbol sets between releases (unless force is set)
             if upload.release_id:
                 if existing.release_id is None:
                     existing.release_id = upload.release_id
                     dirty = True
                 elif str(existing.release_id) != upload.release_id:
-                    raise ValidationError(
-                        code="release_id_mismatch",
-                        detail=f"Symbol set {existing.ref} already has a release ID",
-                    )
+                    if force:
+                        existing.release_id = upload.release_id
+                        dirty = True
+                    else:
+                        raise ValidationError(
+                            code="release_id_mismatch",
+                            detail=f"Symbol set {existing.ref} already has a release ID",
+                        )
 
             if existing.content_hash is not None and existing.content_hash != upload.content_hash:
-                # If this symbol set already has a content hash, and they differ, raise. We do not support changing
-                # the content of a symbol set once it's been uploaded - callers should inject a new chunk_id instead.
-                # Note - this will also return an error if the upload's content hash is None. This is
-                # intentional - we can't tell whether its safe to overwrite the existing content hash
-                # here. This will only be the case for older CLI versions, which we expect to misbehave
-                # in this code path anyway.
-                raise ValidationError(
-                    code="content_hash_mismatch",
-                    detail=f"Symbol set {existing.ref} already exists, with different content.",
-                )
+                if force:
+                    # Force overwrite: set up a new upload for the existing symbol set
+                    storage_ptr = generate_symbol_set_file_key()
+                    presigned_url = generate_symbol_set_upload_presigned_url(storage_ptr, accelerate=accelerate)
+                    id_url_map[existing.ref] = {
+                        "presigned_url": presigned_url,
+                        "symbol_set_id": str(existing.id),
+                    }
+                    existing.storage_ptr = storage_ptr
+                    existing.content_hash = None
+                    existing.failure_reason = None
+                    dirty = True
+                else:
+                    # If this symbol set already has a content hash, and they differ, raise. We do not support changing
+                    # the content of a symbol set once it's been uploaded - callers should inject a new chunk_id instead.
+                    # Note - this will also return an error if the upload's content hash is None. This is
+                    # intentional - we can't tell whether its safe to overwrite the existing content hash
+                    # here. This will only be the case for older CLI versions, which we expect to misbehave
+                    # in this code path anyway.
+                    raise ValidationError(
+                        code="content_hash_mismatch",
+                        detail=f"Symbol set {existing.ref} already exists, with different content.",
+                    )
             elif existing.content_hash is None:
                 # If the existing set doesn't have a content hash, we can set it up for an upload, and return it
                 # so the CLI will send the data to s3

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -63,17 +63,10 @@ impl Parser for AppleProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<ParsedAppleSymbols, ResolveError> {
-        // Try to unwrap symbol_data container first (new format),
-        // fall back to raw ZIP for backward compatibility with existing uploads
-        let (zip_data, decompressed_bytes) =
-            match read_symbol_data_with_byte_count::<AppleDsym>(source.clone()) {
-                Ok((dsym, bytes)) => (dsym.data, bytes),
-                Err(_) => {
-                    let len = source.len();
-                    (source, len)
-                }
-            };
-        ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
+        let (dsym, decompressed_bytes) =
+            read_symbol_data_with_byte_count::<AppleDsym>(source)
+                .map_err(|e| AppleError::ParseError(e.to_string()))?;
+        ParsedAppleSymbols::from_dsym_zip(dsym.data, decompressed_bytes)
     }
 }
 
@@ -142,19 +135,12 @@ impl ParsedAppleSymbols {
     fn extract_dwarf_from_zip(
         archive: &mut ZipArchive<Cursor<Vec<u8>>>,
     ) -> Result<Vec<u8>, ResolveError> {
-        for i in 0..archive.len() {
-            let mut file = archive
-                .by_index(i)
+        // New format: single DWARF binary stored as "dwarf" at root level
+        if let Ok(mut file) = archive.by_name("dwarf") {
+            let mut data = Vec::new();
+            file.read_to_end(&mut data)
                 .map_err(|e| AppleError::ParseError(e.to_string()))?;
-
-            let name = file.name().to_string();
-
-            if name.contains("/Contents/Resources/DWARF/") && !name.ends_with('/') {
-                let mut data = Vec::new();
-                file.read_to_end(&mut data)
-                    .map_err(|e| AppleError::ParseError(e.to_string()))?;
-                return Ok(data);
-            }
+            return Ok(data);
         }
 
         Err(AppleError::ParseError("No DWARF file found in dSYM bundle".to_string()).into())

--- a/rust/cymbal/src/symbol_store/apple.rs
+++ b/rust/cymbal/src/symbol_store/apple.rs
@@ -63,10 +63,18 @@ impl Parser for AppleProvider {
     type Err = ResolveError;
 
     async fn parse(&self, source: Self::Source) -> Result<ParsedAppleSymbols, ResolveError> {
-        let (dsym, decompressed_bytes) =
-            read_symbol_data_with_byte_count::<AppleDsym>(source)
-                .map_err(|e| AppleError::ParseError(e.to_string()))?;
-        ParsedAppleSymbols::from_dsym_zip(dsym.data, decompressed_bytes)
+        // Try to unwrap symbol_data container first (new format),
+        // fall back to raw ZIP for backward compatibility with existing uploads.
+        // TODO(2026-09-24): Remove raw ZIP fallback once all old uploads have expired.
+        let (zip_data, decompressed_bytes) =
+            match read_symbol_data_with_byte_count::<AppleDsym>(source.clone()) {
+                Ok((dsym, bytes)) => (dsym.data, bytes),
+                Err(_) => {
+                    let len = source.len();
+                    (source, len)
+                }
+            };
+        ParsedAppleSymbols::from_dsym_zip(zip_data, decompressed_bytes)
     }
 }
 
@@ -141,6 +149,23 @@ impl ParsedAppleSymbols {
             file.read_to_end(&mut data)
                 .map_err(|e| AppleError::ParseError(e.to_string()))?;
             return Ok(data);
+        }
+
+        // Old format: full dSYM bundle with Contents/Resources/DWARF/<name>
+        // TODO(2026-09-24): Remove this fallback once all old uploads have expired.
+        for i in 0..archive.len() {
+            let mut file = archive
+                .by_index(i)
+                .map_err(|e| AppleError::ParseError(e.to_string()))?;
+
+            let name = file.name().to_string();
+
+            if name.contains("/Contents/Resources/DWARF/") && !name.ends_with('/') {
+                let mut data = Vec::new();
+                file.read_to_end(&mut data)
+                    .map_err(|e| AppleError::ParseError(e.to_string()))?;
+                return Ok(data);
+            }
         }
 
         Err(AppleError::ParseError("No DWARF file found in dSYM bundle".to_string()).into())


### PR DESCRIPTION
Requires: https://github.com/PostHog/posthog/pull/52067

## Problem

When re-uploading symbol sets (dSYM, sourcemaps, proguard) with different content for the same chunk ID, the server rejects the upload with a `content_hash_mismatch` error. Similarly, moving a symbol set between releases is rejected with `release_id_mismatch`. There's no way to force an overwrite, requiring manual cleanup before re-uploading.

## Changes

- **Backend**: Add `force` field to `bulk_start_upload` request (defaults to `false`). When `true`, allows overwriting existing symbol sets with different content (generates new presigned URL, resets content hash) and reassigning release IDs
- **CLI**: Add `--force` flag to all upload commands (`dsym upload`, `sourcemaps upload`, `sourcemaps process`, `sourcemaps hermes upload`, `proguard upload`). The flag is sent as part of the `BulkUploadStartRequest` and skipped from JSON serialization when `false` for backward compatibility with older backends

## How did you test this code?

- All existing `bulk_start_upload` backend tests pass (8/8)
- All CLI tests pass (57/57)
- `cargo check` passes

## Publish to changelog?

no