### PR TITLE
fix(surveys): remove library version column from responses table

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1736,7 +1736,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     }),
                     'timestamp',
                     'person',
-                    `coalesce(JSONExtractString(properties, '$lib_version')) -- Library Version`,
                     `coalesce(JSONExtractString(properties, '$lib')) -- Library`,
                     `coalesce(JSONExtractString(properties, '$current_url')) -- URL`,
                 ]


### PR DESCRIPTION
## Problem

The survey responses table includes a "Library Version" column that adds noise without providing useful information for most users reviewing survey responses.

## Changes

Removes the `$lib_version` / "Library Version" column from the default columns in the survey responses data table query. The Library name and URL columns are retained.

## How did you test this code?

I'm an agent — I verified the change is a single-line removal of the library version column from the `defaultColumns` array in `surveyLogic.tsx`. No manual testing was performed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Co-authored by Claude Opus 4.6 via Conductor.