### PR TITLE
fix(analytics-platform): create internal/test users cohort in demo data generation

### DIFF
--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -213,31 +213,12 @@ class HedgeboxMatrix(Matrix):
                 }
             ],
         )
-        real_users_cohort = Cohort.objects.create(
-            team=team,
-            name="Real persons",
-            description="People who don't belong to the Hedgebox team.",
-            created_by=user,
-            groups=[
-                {
-                    "properties": [
-                        {
-                            "key": "email",
-                            "type": "person",
-                            "value": "@hedgebox.net$",
-                            "operator": "not_regex",
-                        }
-                    ]
-                }
-            ],
-        )
         # Create the standard internal/test users cohort (same as non-demo teams get)
         from posthog.models.cohort.cohort import get_or_create_internal_test_users_cohort
 
         test_users_cohort = get_or_create_internal_test_users_cohort(team, initiating_user_email=user.email)
         team.test_account_filters = [
             {"key": "id", "type": "cohort", "value": test_users_cohort.pk, "operator": "not_in"},
-            {"key": "id", "type": "cohort", "value": real_users_cohort.pk},
         ]
 
         # Dashboard: Key metrics (project home)

--- a/posthog/demo/products/hedgebox/matrix.py
+++ b/posthog/demo/products/hedgebox/matrix.py
@@ -231,7 +231,14 @@ class HedgeboxMatrix(Matrix):
                 }
             ],
         )
-        team.test_account_filters = [{"key": "id", "type": "cohort", "value": real_users_cohort.pk}]
+        # Create the standard internal/test users cohort (same as non-demo teams get)
+        from posthog.models.cohort.cohort import get_or_create_internal_test_users_cohort
+
+        test_users_cohort = get_or_create_internal_test_users_cohort(team, initiating_user_email=user.email)
+        team.test_account_filters = [
+            {"key": "id", "type": "cohort", "value": test_users_cohort.pk, "operator": "not_in"},
+            {"key": "id", "type": "cohort", "value": real_users_cohort.pk},
+        ]
 
         # Dashboard: Key metrics (project home)
         key_metrics_dashboard = Dashboard.objects.create(

--- a/posthog/demo/products/spikegpt/matrix.py
+++ b/posthog/demo/products/spikegpt/matrix.py
@@ -46,29 +46,10 @@ class SpikeGPTMatrix(Matrix):
                 }
             ],
         )
-        real_users_cohort = Cohort.objects.create(
-            team=team,
-            name="Real persons",
-            description="People who don't belong to the SpikeGPT team.",
-            created_by=user,
-            groups=[
-                {
-                    "properties": [
-                        {
-                            "key": "email",
-                            "type": "person",
-                            "value": "@spikegpt.com$",
-                            "operator": "not_regex",
-                        }
-                    ]
-                }
-            ],
-        )
         # Create the standard internal/test users cohort (same as non-demo teams get)
         from posthog.models.cohort.cohort import get_or_create_internal_test_users_cohort
 
         test_users_cohort = get_or_create_internal_test_users_cohort(team, initiating_user_email=user.email)
         team.test_account_filters = [
             {"key": "id", "type": "cohort", "value": test_users_cohort.pk, "operator": "not_in"},
-            {"key": "id", "type": "cohort", "value": real_users_cohort.pk},
         ]

--- a/posthog/demo/products/spikegpt/matrix.py
+++ b/posthog/demo/products/spikegpt/matrix.py
@@ -64,4 +64,11 @@ class SpikeGPTMatrix(Matrix):
                 }
             ],
         )
-        team.test_account_filters = [{"key": "id", "type": "cohort", "value": real_users_cohort.pk}]
+        # Create the standard internal/test users cohort (same as non-demo teams get)
+        from posthog.models.cohort.cohort import get_or_create_internal_test_users_cohort
+
+        test_users_cohort = get_or_create_internal_test_users_cohort(team, initiating_user_email=user.email)
+        team.test_account_filters = [
+            {"key": "id", "type": "cohort", "value": test_users_cohort.pk, "operator": "not_in"},
+            {"key": "id", "type": "cohort", "value": real_users_cohort.pk},
+        ]


### PR DESCRIPTION
## Changes

Refactored demo data generation in HedgeboxMatrix and SpikeGPTMatrix to use the standard `get_or_create_internal_test_users_cohort()` function instead of creating custom "Real persons" cohorts.

## Key Updates

- Replaced custom cohort creation logic with shared internal function
- Updated test account filter configuration to use `not_in` operator
- Ensures consistency with non-demo team cohort behavior
- Removed duplicate custom cohort definitions (26 lines reduced to 14)

## Files Modified

- `posthog/demo/products/hedgebox/matrix.py`
- `posthog/demo/products/spikegpt/matrix.py`