### PR TITLE
chore: add PR template enforcement hook for Claude Code

### DIFF
--- a/.claude/hooks/check-pr-template.sh
+++ b/.claude/hooks/check-pr-template.sh
@@ -6,48 +6,70 @@
 set -euo pipefail
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
 
-# Only check gh pr create commands
-if ! echo "$COMMAND" | grep -q "gh pr create"; then
+# Fast path: skip Python entirely if "gh pr create" doesn't appear anywhere in the input
+if ! echo "$INPUT" | grep -qF "gh pr create"; then
     exit 0
 fi
 
-TEMPLATE="$CLAUDE_PROJECT_DIR/.github/pull_request_template.md"
-if [ ! -f "$TEMPLATE" ]; then
-    exit 0
-fi
+# Use Python for all parsing to handle heredocs, --body-file, and edge cases correctly
+echo "$INPUT" | python3 -c "
+import sys, json, re, os
 
-# Extract all ## headings from the template, including commented-out ones (<!-- ## ... -->)
-# Strip HTML comment markers so we get the raw heading text
-REQUIRED_SECTIONS=()
-while IFS= read -r line; do
-    # Match lines like "## Foo" or "<!-- ## Foo -->" (with optional leading whitespace)
-    cleaned=$(echo "$line" | sed -E 's/^[[:space:]]*<!-- *//; s/ *-->.*$//; s/^[[:space:]]*//')
-    if echo "$cleaned" | grep -qE '^## '; then
-        REQUIRED_SECTIONS+=("$cleaned")
-    fi
-done < "$TEMPLATE"
+raw = sys.stdin.read()
+try:
+    command = json.loads(raw).get('tool_input', {}).get('command', '')
+except (json.JSONDecodeError, AttributeError):
+    sys.exit(0)
 
-if [ ${#REQUIRED_SECTIONS[@]} -eq 0 ]; then
-    exit 0
-fi
+# Strip heredoc bodies and quoted strings to check if 'gh pr create' is
+# the actual command being run (not just mentioned in a commit message, etc.)
+stripped = re.sub(r\"<<'?\\\"?EOF\\\"?'?.*?^EOF$\", '', command, flags=re.DOTALL | re.MULTILINE)
+stripped = re.sub(r'\"[^\"]*\"', '', stripped)
+stripped = re.sub(r\"'[^']*'\", '', stripped)
 
-MISSING=()
-for section in "${REQUIRED_SECTIONS[@]}"; do
-    if ! echo "$COMMAND" | grep -qF "$section"; then
-        MISSING+=("$section")
-    fi
-done
+if 'gh pr create' not in stripped:
+    sys.exit(0)
 
-if [ ${#MISSING[@]} -gt 0 ]; then
-    echo "BLOCKED: PR body is missing required template sections from .github/pull_request_template.md:"
-    for section in "${MISSING[@]}"; do
-        echo "  - $section"
-    done
-    echo ""
-    echo "Commented-out sections (like <!-- ## 🤖 LLM context -->) should be uncommented since this PR is authored/co-authored by an LLM agent."
-    exit 2
-fi
+# Load the PR template
+template_path = os.path.join(os.environ.get('CLAUDE_PROJECT_DIR', '.'), '.github', 'pull_request_template.md')
+if not os.path.isfile(template_path):
+    sys.exit(0)
 
-exit 0
+with open(template_path) as f:
+    template = f.read()
+
+# Extract all ## headings (including commented-out ones like <!-- ## ... -->)
+required = []
+for line in template.splitlines():
+    cleaned = re.sub(r'^\\s*<!--\\s*', '', line)
+    cleaned = re.sub(r'\\s*-->.*$', '', cleaned).strip()
+    if cleaned.startswith('## '):
+        required.append(cleaned)
+
+if not required:
+    sys.exit(0)
+
+# Resolve body content: handle --body-file or use the full command (which includes inline --body / heredoc)
+body = command
+body_file_match = re.search(r'--body-file[= ]*[\\'\"]?([^\\'\"\\ ]+)', command)
+if body_file_match:
+    path = body_file_match.group(1)
+    if os.path.isfile(path):
+        with open(path) as f:
+            body = f.read()
+    else:
+        print('BLOCKED: --body-file target not readable. Use inline --body with a heredoc instead.')
+        sys.exit(2)
+
+# Check for missing sections
+missing = [s for s in required if s not in body]
+if missing:
+    print('BLOCKED: PR body is missing required template sections from .github/pull_request_template.md:')
+    for s in missing:
+        print(f'  - {s}')
+    print()
+    print('All sections from the template must be present, including any commented-out ones')
+    print('(uncomment them since this PR is authored/co-authored by an LLM agent).')
+    sys.exit(2)
+"

--- a/.claude/hooks/check-pr-template.sh
+++ b/.claude/hooks/check-pr-template.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# PreToolUse hook: ensures `gh pr create` commands follow the PR template.
+# Reads tool input JSON from stdin. Exits non-zero to block non-compliant calls.
+# Sections are inferred from .github/pull_request_template.md (including commented-out ones).
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# Only check gh pr create commands
+if ! echo "$COMMAND" | grep -q "gh pr create"; then
+    exit 0
+fi
+
+TEMPLATE="$CLAUDE_PROJECT_DIR/.github/pull_request_template.md"
+if [ ! -f "$TEMPLATE" ]; then
+    exit 0
+fi
+
+# Extract all ## headings from the template, including commented-out ones (<!-- ## ... -->)
+# Strip HTML comment markers so we get the raw heading text
+REQUIRED_SECTIONS=()
+while IFS= read -r line; do
+    # Match lines like "## Foo" or "<!-- ## Foo -->" (with optional leading whitespace)
+    cleaned=$(echo "$line" | sed -E 's/^[[:space:]]*<!-- *//; s/ *-->.*$//; s/^[[:space:]]*//')
+    if echo "$cleaned" | grep -qE '^## '; then
+        REQUIRED_SECTIONS+=("$cleaned")
+    fi
+done < "$TEMPLATE"
+
+if [ ${#REQUIRED_SECTIONS[@]} -eq 0 ]; then
+    exit 0
+fi
+
+MISSING=()
+for section in "${REQUIRED_SECTIONS[@]}"; do
+    if ! echo "$COMMAND" | grep -qF "$section"; then
+        MISSING+=("$section")
+    fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "BLOCKED: PR body is missing required template sections from .github/pull_request_template.md:"
+    for section in "${MISSING[@]}"; do
+        echo "  - $section"
+    done
+    echo ""
+    echo "Commented-out sections (like <!-- ## 🤖 LLM context -->) should be uncommented since this PR is authored/co-authored by an LLM agent."
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
     "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-pr-template.sh"
+                    }
+                ]
+            }
+        ],
         "SessionStart": [
             {
                 "hooks": [


### PR DESCRIPTION
## Problem

When creating PRs from Claude Code, the GitHub PR template (`.github/pull_request_template.md`) is often not respected — sections get skipped or the LLM context section stays commented out.

## Changes

- Added a `PreToolUse` hook (`.claude/hooks/check-pr-template.sh`) that intercepts `gh pr create` Bash calls
- The hook dynamically parses the PR template file to extract all `##` headings, including commented-out ones like `<!-- ## 🤖 LLM context -->`
- If any required sections are missing from the PR body, the hook blocks the call with a descriptive error, prompting Claude to retry with the full template
- Registered the hook in `.claude/settings.json` as a `PreToolUse` hook on `Bash`

## How did you test this code?

This PR was authored by an LLM agent. The hook successfully blocked this very PR creation when sections were initially missing, validating the enforcement mechanism. No automated tests — the hook is a lightweight shell script.

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Authored by Claude Opus 4.6 in Claude Code. The user identified a recurring issue where Claude Code wasn't following the PR template and requested a hook-based enforcement mechanism. The hook itself validated correctly during this PR creation — it blocked the first attempt that was missing the "Publish to changelog?" and "Docs update" sections.