### PR TITLE
fix(cohorts): add $internal_or_test_user to taxonomy and fix person property label resolution

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -120,7 +120,7 @@ export function CohortTaxonomicField({
 
     const { calculatedValue, calculatedValueLoading } = useValues(logic)
     const { onChange } = useActions(logic)
-    const groupType = criteria[groupTypeFieldKey] as TaxonomicFilterGroupType
+    const groupType = (criteria[groupTypeFieldKey] as TaxonomicFilterGroupType) ?? taxonomicGroupTypes[0]
 
     return (
         <TaxonomicPopover

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4395,7 +4395,7 @@
             "system": true
         },
         "$internal_or_test_user": {
-            "description": "Whether this person has been identified as an internal or test user.",
+            "description": "Whether this person has been identified as an internal or test user. In posthog-js, see the `internal_or_test_user_hostname` config option (default: `localhost`) or `setInternalOrTestUser()` method.",
             "examples": [
                 true,
                 false

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4394,6 +4394,14 @@
             "label": "Insert ID",
             "system": true
         },
+        "$internal_or_test_user": {
+            "description": "Whether this person has been identified as an internal or test user.",
+            "examples": [
+                true,
+                false
+            ],
+            "label": "Internal or test user"
+        },
         "$ip": {
             "description": "IP address for this user when the event was sent.",
             "examples": [


### PR DESCRIPTION
## Problem

After #51852, new organizations start with a cohort filtering on `$internal_or_test_user`. However:
1. This property wasn't in the taxonomy, so the cohort UI displayed the raw property name instead of a friendly label
2. Even after adding it to the taxonomy's `person_properties` group, the cohort criteria UI still showed the raw name because of a bug in `CohortTaxonomicField`

The root cause: when cohort person property criteria are loaded from the API, they don't include an `event_type` field. `CohortTaxonomicField` looked up `criteria['event_type']` which was `undefined`, causing `PropertyKeyInfo` to fall back to the `EventProperties` taxonomy group — where person-only properties like `$internal_or_test_user` aren't found.

## Changes

1. **Taxonomy entry** — added `$internal_or_test_user` to `person_properties` with label "Internal or test user", description, and examples
2. **Bug fix** — in `CohortTaxonomicField`, fall back to the first entry in `taxonomicGroupTypes` when no explicit group type is stored in the criteria. This ensures person property labels resolve correctly for any cohort loaded from the API.

## How did you test this code?

- All 114 existing cohort frontend tests pass
- JSON validity verified
- Agent-authored — manual UI verification recommended

Screenshot from the meat pilot (Robbie):

<img width="958" height="679" alt="Screenshot 2026-03-24 at 16 21 22" src="https://github.com/user-attachments/assets/1154dcdd-157c-4fce-8bed-cce33b650788" />

Note that this fixes email address too, here's a screenshot from prod

<img width="856" height="731" alt="Screenshot 2026-03-24 at 16 22 24" src="https://github.com/user-attachments/assets/51cd458e-ba08-4412-9b4c-6d7d19163aca" />



## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Opus 4.6.