### PR TITLE
feat: add proj->proj duplication for surveys

### DIFF
--- a/frontend/src/scenes/resource-transfer/ResourceTransfer.tsx
+++ b/frontend/src/scenes/resource-transfer/ResourceTransfer.tsx
@@ -133,6 +133,8 @@ function sourceResourceUrl(resourceKind: string, resourceId: string): string {
             return urls.dashboard(resourceId)
         case 'Insight':
             return urls.insightView(resourceId as InsightShortId)
+        case 'Survey':
+            return urls.survey(resourceId)
         default:
             return urls.projectHomepage()
     }

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -1,9 +1,18 @@
 import './SurveyView.scss'
 
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import { useEffect, useMemo, useState } from 'react'
 
-import { IconArchive, IconGraph, IconLlmAnalytics, IconThumbsDown, IconThumbsUp, IconTrash } from '@posthog/icons'
+import {
+    IconArchive,
+    IconCopy,
+    IconGraph,
+    IconLlmAnalytics,
+    IconThumbsDown,
+    IconThumbsUp,
+    IconTrash,
+} from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonDivider, Tooltip } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -18,6 +27,7 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
 import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
 import { SurveyQuestionVisualization } from 'scenes/surveys/components/question-visualizations/SurveyQuestionVisualization'
 import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
@@ -94,6 +104,8 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
     const { editingSurvey, updateSurvey, stopSurvey, resumeSurvey, archiveSurvey } = useActions(surveyLogic)
     const { deleteSurvey, duplicateSurvey, setSurveyToDuplicate } = useActions(surveysLogic)
     const { currentOrganization } = useValues(organizationLogic)
+    const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { push } = useActions(router)
 
     const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
 
@@ -139,6 +151,17 @@ function SurveyViewLegacy({ id }: { id: string }): JSX.Element {
                                     }
                                 }}
                             />
+                            {canCopyToProject && surveyId && (
+                                <ButtonPrimitive
+                                    menuItem
+                                    onClick={() => push(urls.resourceTransfer('Survey', surveyId))}
+                                    data-attr="survey-copy-to-project"
+                                    tooltip="Copy this survey to another project"
+                                >
+                                    <IconCopy />
+                                    Copy to another project
+                                </ButtonPrimitive>
+                            )}
                         </ScenePanelActionsSection>
                         <ScenePanelDivider />
                         {!survey.archived && (

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconArchive, IconCode, IconTrash } from '@posthog/icons'
+import { IconArchive, IconCode, IconCopy, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonDialog, LemonDivider } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -15,6 +15,7 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
 import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
 import { SurveyQuestionVisualization } from 'scenes/surveys/components/question-visualizations/SurveyQuestionVisualization'
 import { SurveyFeedbackButton } from 'scenes/surveys/components/SurveyFeedbackButton'
@@ -65,9 +66,12 @@ export function SurveyViewRedesign(): JSX.Element {
     const { deleteSurvey, duplicateSurvey, setSurveyToDuplicate } = useActions(surveysLogic)
     const { sidePanelOpen, selectedTab: selectedSidePanelTab } = useValues(sidePanelStateLogic)
     const { currentOrganization } = useValues(organizationLogic)
+    const { canCopyToProject } = useValues(interProjectCopyLogic)
+    const { push } = useActions(router)
     const { location, searchParams, hashParams } = useValues(router)
 
     const hasMultipleProjects = currentOrganization?.teams && currentOrganization.teams.length > 1
+    const surveyIdForTransfer = survey?.id && survey.id !== 'new' ? survey.id : null
     const [tabKey, setTabKey] = useState('summary')
     const [panelTabKey, setPanelTabKey] = useState('details')
     const [sqlHelperOpen, setSqlHelperOpen] = useState(false)
@@ -218,6 +222,17 @@ export function SurveyViewRedesign(): JSX.Element {
                             }
                         }}
                     />
+                    {canCopyToProject && surveyIdForTransfer && (
+                        <ButtonPrimitive
+                            menuItem
+                            onClick={() => push(urls.resourceTransfer('Survey', surveyIdForTransfer))}
+                            data-attr="survey-copy-to-project"
+                            tooltip="Copy this survey to another project"
+                        >
+                            <IconCopy />
+                            Copy to another project
+                        </ButtonPrimitive>
+                    )}
                     {!isDraft && (
                         <ButtonPrimitive menuItem onClick={() => setSqlHelperOpen(true)}>
                             <IconCode />

--- a/posthog/api/test/test_resource_transfer.py
+++ b/posthog/api/test/test_resource_transfer.py
@@ -4,12 +4,14 @@ from unittest.mock import patch
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.models import Dashboard, Insight, Project, Team
+from posthog.models import Action, Dashboard, Insight, Project, Team
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.cohort import Cohort
 from posthog.models.dashboard_tile import DashboardTile
 from posthog.models.organization import OrganizationMembership
 from posthog.models.resource_transfer.resource_transfer import ResourceTransfer
+
+from products.surveys.backend.models import Survey
 
 from ee.models.rbac.access_control import AccessControl
 
@@ -93,6 +95,39 @@ class TestResourceTransferPreview(APIBaseTest):
 
         tile_resource = next(r for r in resources if r["resource_kind"] == "DashboardTile")
         assert tile_resource["friendly_kind"] == "Dashboard tile"
+
+    def test_preview_survey_includes_insight_and_dependencies(self) -> None:
+        insight = Insight.objects.create(team=self.team, name="Survey insight")
+        action = Action.objects.create(
+            team=self.team,
+            name="survey trigger",
+            steps_json=[{"event": "$pageview"}],
+        )
+        survey = Survey.objects.create(
+            team=self.team,
+            name="My survey",
+            type=Survey.SurveyType.POPOVER,
+            questions=[{"id": "q1", "type": "open", "question": "Hi"}],
+            linked_insight=insight,
+        )
+        survey.actions.add(action)
+
+        response = self.client.post(
+            self._preview_url(),
+            {
+                "source_team_id": self.team.pk,
+                "destination_team_id": self.dest_team.pk,
+                "resource_kind": "Survey",
+                "resource_id": str(survey.pk),
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        resources = response.json()["resources"]
+        kinds = {r["resource_kind"] for r in resources}
+        assert "Survey" in kinds
+        assert "Insight" in kinds
+        assert "Action" in kinds
 
     def test_preview_includes_suggested_substitution_from_previous_transfer(self) -> None:
         insight = Insight.objects.create(team=self.team, name="My insight")

--- a/posthog/models/resource_transfer/inter_project_transferer.py
+++ b/posthog/models/resource_transfer/inter_project_transferer.py
@@ -642,6 +642,8 @@ def _duplicate_vertex(
                 target_pk=str(edge.target_primary_key),
             )
 
+    payload = visitor.adjust_duplicate_payload(payload, vertex, new_team)
+
     if "name" in payload and payload["name"] and _model_has_name_field(visitor.get_model()):
         payload["name"] = _deduplicate_name(visitor.get_model(), payload["name"], new_team)
 

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -59,6 +59,21 @@
     'short_id',
   ])
 # ---
+# name: TestVisitorFieldSnapshots.test_excluded_fields_Survey
+  list([
+    'headline_response_count',
+    'headline_summary',
+    'internal_response_sampling_flag',
+    'internal_targeting_flag',
+    'linked_flag',
+    'question_summaries',
+    'targeting_flag',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_excluded_fields_Survey_actions
+  list([
+  ])
+# ---
 # name: TestVisitorFieldSnapshots.test_excluded_fields_Text
   list([
     'last_modified_at',
@@ -138,6 +153,41 @@
     'updated_at',
   ])
 # ---
+# name: TestVisitorFieldSnapshots.test_primitive_fields_Survey
+  list([
+    'appearance',
+    'archived',
+    'conditions',
+    'created_at',
+    'current_iteration',
+    'current_iteration_start_date',
+    'description',
+    'enable_iframe_embedding',
+    'enable_partial_responses',
+    'end_date',
+    'form_content',
+    'iteration_count',
+    'iteration_frequency_days',
+    'iteration_start_dates',
+    'name',
+    'questions',
+    'response_sampling_daily_limits',
+    'response_sampling_interval',
+    'response_sampling_interval_type',
+    'response_sampling_limit',
+    'response_sampling_start_date',
+    'responses_limit',
+    'schedule',
+    'start_date',
+    'translations',
+    'type',
+    'updated_at',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_primitive_fields_Survey_actions
+  list([
+  ])
+# ---
 # name: TestVisitorFieldSnapshots.test_primitive_fields_Text
   list([
     'body',
@@ -178,6 +228,21 @@
     'last_modified_by',
     'subscriptions_dashboard_export',
     'team',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_relation_fields_Survey
+  list([
+    'actions',
+    'created_by',
+    'linked_insight',
+    'product_tours',
+    'team',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_relation_fields_Survey_actions
+  list([
+    'action',
+    'survey',
   ])
 # ---
 # name: TestVisitorFieldSnapshots.test_relation_fields_Text
@@ -416,6 +481,58 @@
     'threshold_set',
     'type',
     'url',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_skipped_fields_Survey
+  list([
+    'DoesNotExist',
+    'MultipleObjectsReturned',
+    'Schedule',
+    'SurveySamplingIntervalType',
+    'SurveyType',
+    '__doc__',
+    '__module__',
+    '_meta',
+    'created_by_id',
+    'get_file_system_representation',
+    'get_file_system_unfiled',
+    'get_internal_flag_ids',
+    'get_next_by_created_at',
+    'get_next_by_updated_at',
+    'get_previous_by_created_at',
+    'get_previous_by_updated_at',
+    'get_response_sampling_interval_type_display',
+    'get_schedule_display',
+    'get_type_display',
+    'headline_response_count',
+    'headline_summary',
+    'id',
+    'internal_response_sampling_flag',
+    'internal_response_sampling_flag_id',
+    'internal_targeting_flag',
+    'internal_targeting_flag_id',
+    'is_publicly_shareable',
+    'linked_flag',
+    'linked_flag_id',
+    'linked_insight_id',
+    'question_summaries',
+    'response_archives',
+    'targeting_flag',
+    'targeting_flag_id',
+    'team_id',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_skipped_fields_Survey_actions
+  list([
+    'DoesNotExist',
+    'MultipleObjectsReturned',
+    '__doc__',
+    '__module__',
+    '_meta',
+    'action_id',
+    'id',
+    'objects',
+    'survey_id',
   ])
 # ---
 # name: TestVisitorFieldSnapshots.test_skipped_fields_Text

--- a/posthog/models/resource_transfer/test/test_inter_project_transferer.py
+++ b/posthog/models/resource_transfer/test/test_inter_project_transferer.py
@@ -189,6 +189,7 @@ class TestDuplicateResourceToNewTeam(BaseTest):
         copied = new_surveys[0]
         assert copied.team == dest_team
         assert copied.linked_insight_id == new_insights[0].pk
+        assert copied.linked_insight is not None
         assert copied.linked_insight.team == dest_team
         assert list(copied.actions.values_list("pk", flat=True)) == [new_actions[0].pk]
         assert copied.conditions is not None

--- a/posthog/models/resource_transfer/test/test_inter_project_transferer.py
+++ b/posthog/models/resource_transfer/test/test_inter_project_transferer.py
@@ -4,7 +4,7 @@ from posthog.test.base import BaseTest
 
 from parameterized import parameterized
 
-from posthog.models import Dashboard, Insight, Project, Team
+from posthog.models import Action, Dashboard, Insight, Project, Team
 from posthog.models.dashboard_tile import DashboardTile, Text
 from posthog.models.resource_transfer.inter_project_transferer import (
     _get_mapped_substitutions,
@@ -15,6 +15,8 @@ from posthog.models.resource_transfer.inter_project_transferer import (
 )
 from posthog.models.resource_transfer.resource_transfer import ResourceTransfer
 from posthog.models.resource_transfer.types import ResourceKind, ResourceTransferVertex
+
+from products.surveys.backend.models import Survey
 
 
 class TestBuildResourceDuplicationGraph(BaseTest):
@@ -49,6 +51,32 @@ class TestBuildResourceDuplicationGraph(BaseTest):
         assert Dashboard in model_types
         assert Insight in model_types
         assert DashboardTile in model_types
+        assert Team in model_types
+
+    def test_survey_with_insight_and_actions_includes_related_resources(self) -> None:
+        insight = Insight.objects.create(team=self.team, name="Survey insight")
+        action = Action.objects.create(
+            team=self.team,
+            name="survey action",
+            steps_json=[{"event": "$pageview"}],
+        )
+        survey = Survey.objects.create(
+            team=self.team,
+            name="My survey",
+            type=Survey.SurveyType.POPOVER,
+            questions=[{"id": "q1", "type": "open", "question": "Hello"}],
+            linked_insight=insight,
+        )
+        survey.actions.add(action)
+
+        graph = list(build_resource_duplication_graph(survey, set()))
+        model_types = {v.model for v in graph}
+        through = Survey._meta.get_field("actions").remote_field.through
+
+        assert Survey in model_types
+        assert Insight in model_types
+        assert Action in model_types
+        assert through in model_types
         assert Team in model_types
 
     def test_dashboard_text_tiles_reachable_via_m2m(self) -> None:
@@ -130,6 +158,42 @@ class TestDuplicateResourceToNewTeam(BaseTest):
         assert new_dashboards[0].pk != dashboard.pk
         assert new_dashboards[0].team == dest_team
         assert new_dashboards[0].name == "My dashboard"
+
+    def test_duplicates_survey_with_linked_insight_and_actions(self) -> None:
+        dest_team = self._create_destination_team()
+        insight = Insight.objects.create(team=self.team, name="Linked", filters={})
+        action = Action.objects.create(
+            team=self.team,
+            name="trigger action",
+            steps_json=[{"event": "subscribed"}],
+        )
+        survey = Survey.objects.create(
+            team=self.team,
+            name="NPS",
+            type=Survey.SurveyType.POPOVER,
+            questions=[{"id": "q1", "type": "open", "question": "Rate us"}],
+            conditions={"linkedFlagVariant": "control", "url": "/p"},
+            linked_insight=insight,
+        )
+        survey.actions.add(action)
+
+        results = duplicate_resource_to_new_team(survey, dest_team, created_by=self.user)
+        new_surveys = [r for r in results if isinstance(r, Survey)]
+        new_insights = [r for r in results if isinstance(r, Insight)]
+        new_actions = [r for r in results if isinstance(r, Action)]
+
+        assert len(new_surveys) == 1
+        assert len(new_insights) == 1
+        assert len(new_actions) == 1
+
+        copied = new_surveys[0]
+        assert copied.team == dest_team
+        assert copied.linked_insight_id == new_insights[0].pk
+        assert copied.linked_insight.team == dest_team
+        assert list(copied.actions.values_list("pk", flat=True)) == [new_actions[0].pk]
+        assert copied.conditions is not None
+        assert "linkedFlagVariant" not in copied.conditions
+        assert copied.conditions.get("url") == "/p"
 
     def test_duplicates_dashboard_with_insight_tile(self) -> None:
         dest_team = self._create_destination_team()

--- a/posthog/models/resource_transfer/test/test_visitors.py
+++ b/posthog/models/resource_transfer/test/test_visitors.py
@@ -3,6 +3,7 @@ from posthog.test.base import BaseTest
 from parameterized import parameterized
 
 from posthog.models.resource_transfer.visitors import CohortVisitor, InsightVisitor
+from posthog.models.resource_transfer.visitors.survey import SurveyVisitor
 
 
 class TestExtractActionIds(BaseTest):
@@ -1025,3 +1026,44 @@ class TestCohortRewriteActionIdInFilters(BaseTest):
     )
     def test_rewrite_action_id_in_filters(self, _name: str, filters, old_pk, new_pk, expected) -> None:
         assert CohortVisitor._rewrite_action_id_in_filters(filters, old_pk, new_pk) == expected
+
+
+class TestSurveyVisitorConditionsCohorts(BaseTest):
+    @parameterized.expand(
+        [
+            (
+                "properties_with_cohort",
+                {"properties": [{"key": "id", "value": 7, "type": "cohort"}]},
+                {7},
+            ),
+            (
+                "no_properties",
+                {"url": "/pricing"},
+                set(),
+            ),
+            (
+                "empty_conditions",
+                None,
+                set(),
+            ),
+        ]
+    )
+    def test_extract_cohort_ids_from_conditions(self, _name: str, conditions, expected: set[int]) -> None:
+        assert SurveyVisitor._extract_cohort_ids_from_conditions(conditions) == expected
+
+    def test_rewrite_cohort_in_payload_updates_conditions_properties(self) -> None:
+        payload = {
+            "conditions": {
+                "properties": [{"key": "id", "value": 1, "type": "cohort"}],
+                "url": "/x",
+            }
+        }
+        result = SurveyVisitor._rewrite_cohort_in_payload(payload, 1, 2)
+        assert result["conditions"]["properties"][0]["value"] == 2
+        assert result["conditions"]["url"] == "/x"
+
+    def test_adjust_duplicate_payload_strips_linked_flag_variant(self) -> None:
+        payload = {"conditions": {"linkedFlagVariant": "control", "url": "/a"}}
+        adjusted = SurveyVisitor.adjust_duplicate_payload(payload, None, None)
+        assert "linkedFlagVariant" not in adjusted["conditions"]
+        assert adjusted["conditions"]["url"] == "/a"

--- a/posthog/models/resource_transfer/types.py
+++ b/posthog/models/resource_transfer/types.py
@@ -4,7 +4,19 @@ from typing import Any, Literal
 
 from django.db import models
 
-ResourceKind = Literal["Action", "Cohort", "Dashboard", "DashboardTile", "Insight", "Text", "Team", "Project", "User"]
+ResourceKind = Literal[
+    "Action",
+    "Cohort",
+    "Dashboard",
+    "DashboardTile",
+    "Insight",
+    "Survey",
+    "Survey_actions",
+    "Text",
+    "Team",
+    "Project",
+    "User",
+]
 ResourceTransferKey = tuple[ResourceKind, Any]  # tuple of (kind, primary key)
 ResourcePayload = dict[str, Any]
 ResourceMap = dict[ResourceTransferKey, "ResourceTransferVertex"]

--- a/posthog/models/resource_transfer/visitors/__init__.py
+++ b/posthog/models/resource_transfer/visitors/__init__.py
@@ -5,6 +5,7 @@ from posthog.models.resource_transfer.visitors.dashboard import DashboardVisitor
 from posthog.models.resource_transfer.visitors.dashboard_tile import DashboardTileVisitor
 from posthog.models.resource_transfer.visitors.insight import InsightVisitor
 from posthog.models.resource_transfer.visitors.project import ProjectVisitor
+from posthog.models.resource_transfer.visitors.survey import SurveyActionsThroughVisitor, SurveyVisitor
 from posthog.models.resource_transfer.visitors.team import TeamVisitor
 from posthog.models.resource_transfer.visitors.text import TextVisitor
 from posthog.models.resource_transfer.visitors.user import UserVisitor
@@ -16,6 +17,8 @@ __all__ = [
     "DashboardVisitor",
     "DashboardTileVisitor",
     "InsightVisitor",
+    "SurveyVisitor",
+    "SurveyActionsThroughVisitor",
     "ProjectVisitor",
     "TeamVisitor",
     "TextVisitor",

--- a/posthog/models/resource_transfer/visitors/base.py
+++ b/posthog/models/resource_transfer/visitors/base.py
@@ -7,11 +7,12 @@ from django.db import models
 from django.db.models import query_utils
 from django.db.models.fields import related_descriptors
 
-from posthog.models.resource_transfer.types import ResourceKind, ResourceTransferEdge
+from posthog.models.resource_transfer.types import ResourceKind, ResourcePayload, ResourceTransferEdge
 from posthog.models.utils import UUIDTClassicModel
 
 if TYPE_CHECKING:
     from posthog.models import Team
+    from posthog.models.resource_transfer.types import ResourceTransferVertex
 
 
 class ResourceTransferVisitor:
@@ -52,6 +53,19 @@ class ResourceTransferVisitor:
         Override to return extra edges at runtime. This is useful for schemas where foreign keys might be stored in untyped columns like JSON.
         """
         return []
+
+    @classmethod
+    def adjust_duplicate_payload(
+        cls,
+        payload: ResourcePayload,
+        vertex: ResourceTransferVertex,
+        new_team: Team,
+    ) -> ResourcePayload:
+        """
+        Hook for visitors to normalize or strip fields that should not be copied as-is.
+        Default is identity; override in subclasses that store JSON with cross-project references.
+        """
+        return payload
 
     @classmethod
     def get_display_name(cls, resource: Any) -> str:

--- a/posthog/models/resource_transfer/visitors/survey.py
+++ b/posthog/models/resource_transfer/visitors/survey.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import models
+
+from posthog.models.resource_transfer.types import ResourcePayload, ResourceTransferEdge
+from posthog.models.resource_transfer.visitors.base import ResourceTransferVisitor
+from posthog.models.resource_transfer.visitors.common import (
+    build_edges_for_ids,
+    collect_cohort_ids_from_properties,
+    rewrite_cohort_id_in_properties,
+)
+
+
+class SurveyVisitor(
+    ResourceTransferVisitor,
+    kind="Survey",
+    excluded_fields=[
+        "linked_flag",
+        "targeting_flag",
+        "internal_targeting_flag",
+        "internal_response_sampling_flag",
+        "headline_summary",
+        "headline_response_count",
+        "question_summaries",
+    ],
+    friendly_name="Survey",
+):
+    """
+    TODO: When FeatureFlag duplication is supported in resource transfer, remove `linked_flag`
+    from excluded_fields so the FK rewrites to the duplicated flag; then only strip
+    linkedFlagVariant in adjust_duplicate_payload when the destination flag cannot satisfy that
+    variant (substitution / validation).
+    """
+
+    @classmethod
+    def get_model(cls) -> type[models.Model]:
+        from products.surveys.backend.models import Survey
+
+        return Survey
+
+    @classmethod
+    def get_dynamic_edges(cls, resource: Any) -> list[ResourceTransferEdge]:
+        from posthog.models import Cohort
+
+        cohort_ids = cls._extract_cohort_ids_from_conditions(resource.conditions)
+
+        return build_edges_for_ids(cohort_ids, Cohort, "conditions_cohort", cls._rewrite_cohort_in_payload)
+
+    @classmethod
+    def _extract_cohort_ids_from_conditions(cls, conditions: dict | None) -> set[int]:
+        if not conditions or not isinstance(conditions, dict):
+            return set()
+        ids: set[int] = set()
+        if "properties" in conditions:
+            ids.update(collect_cohort_ids_from_properties(conditions.get("properties")))
+        return ids
+
+    @classmethod
+    def _rewrite_cohort_in_payload(cls, payload: ResourcePayload, old_pk: Any, new_pk: Any) -> ResourcePayload:
+        result = {**payload}
+        cond = result.get("conditions")
+        if isinstance(cond, dict) and "properties" in cond:
+            result["conditions"] = {
+                **cond,
+                "properties": rewrite_cohort_id_in_properties(cond["properties"], old_pk, new_pk),
+            }
+        return result
+
+    @classmethod
+    def adjust_duplicate_payload(cls, payload: ResourcePayload, vertex: Any, new_team: Any) -> ResourcePayload:
+        """Strip linkedFlagVariant; meaningless without a linked flag in the destination (see class TODO)."""
+        result = {**payload}
+        if result.get("conditions") and isinstance(result["conditions"], dict):
+            cleaned = {**result["conditions"]}
+            cleaned.pop("linkedFlagVariant", None)
+            result["conditions"] = cleaned
+        return result
+
+
+class SurveyActionsThroughVisitor(
+    ResourceTransferVisitor,
+    kind="Survey_actions",
+    user_facing=False,
+    friendly_name="Survey action link",
+):
+    """
+    Survey has a m2m relation with Actions using an auto-generated through model with the table name Survey_actions. There is no corresponding model in the code, so we need to hack this together.
+    """
+
+    @classmethod
+    def get_model(cls) -> type[models.Model]:
+        from products.surveys.backend.models import Survey
+
+        return Survey._meta.get_field("actions").remote_field.through  # type: ignore


### PR DESCRIPTION
## Problem

You can't copy surveys between projects.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add visitor for the `Survey` model
	- Also added another visitor for a model which isn't explicitly defined in the codebase `Survey_action` which is a join table for a m2m relation between `Survey` and `Action`. Django auto generates this table so had to come up with some hacks to get it referenced in the code so it works properly.
	- Also added new `adjust_duplicate_payload` abstract class method to allow visitors to modify json data stored in columns which cannot be skipped by settings the exclude fields.
- Also added some tests for the visitors _ new logic ^^
- Add frontend code to show the `Copy to another project` for surveys

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Manually + new units
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
yes
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
