### PR TITLE
refactor(logs): decouple data fetching and analytics from scene-level URL sync

### DIFF
--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
@@ -5,8 +5,29 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
 
-import { logsViewerDataLogic } from './logsViewerDataLogic'
+import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+
+import { logsViewerDataLogic, shouldSkipFilterGroupChange } from './logsViewerDataLogic'
+
+// Shared helpers for building filter groups in tests
+const makeFilter = (
+    key: string,
+    value: string[] | null,
+    filterType: PropertyFilterType = PropertyFilterType.LogAttribute
+): any => ({
+    key,
+    value,
+    operator: PropertyOperator.Exact,
+    type: filterType,
+})
+
+const makeFilterGroup = (...filters: any[]): any => ({
+    type: FilterLogicalOperator.And,
+    values: [{ type: FilterLogicalOperator.And, values: filters }],
+})
 
 jest.mock('posthog-js')
 jest.mock('@posthog/lemon-ui', () => ({
@@ -178,5 +199,141 @@ describe('logsViewerDataLogic', () => {
                 expect(posthog.capture).not.toHaveBeenCalled()
             }
         )
+    })
+
+    describe('auto-refetch on filter changes', () => {
+        let filtersLogic: ReturnType<typeof logsViewerFiltersLogic.build>
+
+        beforeEach(async () => {
+            filtersLogic = logsViewerFiltersLogic({ id: 'test-tab' })
+            filtersLogic.mount()
+
+            // Run initial query so hasRunQuery is true
+            logic.actions.runQuery()
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        afterEach(() => {
+            filtersLogic.unmount()
+        })
+
+        it.each([
+            ['setSearchTerm', 'error message'],
+            ['setDateRange', { date_from: '-24h', date_to: null }],
+            ['setSeverityLevels', ['error', 'warn']],
+            ['setServiceNames', ['api-server']],
+        ])('%s triggers runQuery', async (action, value) => {
+            await expectLogic(logic, () => {
+                ;(filtersLogic.actions as any)[action](value)
+            }).toDispatchActions(['handleQueryChange', 'runQuery'])
+        })
+
+        it('setFilters triggers runQuery', async () => {
+            await expectLogic(logic, () => {
+                filtersLogic.actions.setFilters({ searchTerm: 'new search' })
+            }).toDispatchActions(['handleQueryChange', 'runQuery'])
+        })
+
+        it('setOrderBy triggers runQuery', async () => {
+            const configLogic = logsViewerConfigLogic({ id: 'test-tab' })
+            configLogic.mount()
+            await expectLogic(logic, () => {
+                configLogic.actions.setOrderBy('earliest')
+            }).toDispatchActions(['runQuery'])
+            configLogic.unmount()
+        })
+
+        it('adding an empty filter does not trigger runQuery', async () => {
+            jest.clearAllMocks()
+            filtersLogic.actions.setFilterGroup(
+                makeFilterGroup(makeFilter('service.name', null, PropertyFilterType.LogResourceAttribute)),
+                true
+            )
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(posthog.capture).not.toHaveBeenCalledWith(
+                'logs filter changed',
+                expect.objectContaining({ filter_type: 'attributes' })
+            )
+        })
+
+        it('completing a filter value triggers runQuery', async () => {
+            filtersLogic.actions.setFilterGroup(
+                makeFilterGroup(makeFilter('service.name', null, PropertyFilterType.LogResourceAttribute)),
+                true
+            )
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                filtersLogic.actions.setFilterGroup(
+                    makeFilterGroup(
+                        makeFilter('service.name', ['api-server'], PropertyFilterType.LogResourceAttribute)
+                    ),
+                    false
+                )
+            }).toDispatchActions(['handleQueryChange', 'runQuery'])
+        })
+
+        it('editing a filter while another is empty still triggers runQuery', async () => {
+            filtersLogic.actions.setFilterGroup(
+                makeFilterGroup(
+                    makeFilter('service.name', ['api-server'], PropertyFilterType.LogResourceAttribute),
+                    makeFilter('host', null, PropertyFilterType.LogAttribute)
+                ),
+                true
+            )
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                filtersLogic.actions.setFilterGroup(
+                    makeFilterGroup(
+                        makeFilter('service.name', ['worker'], PropertyFilterType.LogResourceAttribute),
+                        makeFilter('host', null, PropertyFilterType.LogAttribute)
+                    ),
+                    false
+                )
+            }).toDispatchActions(['handleQueryChange', 'runQuery'])
+        })
+    })
+})
+
+describe('shouldSkipFilterGroupChange', () => {
+    const emptyGroup = makeFilterGroup()
+
+    it.each([
+        ['no previous value', emptyGroup, undefined, true],
+        [
+            'values are deep equal',
+            makeFilterGroup(makeFilter('host', ['web-1'])),
+            makeFilterGroup(makeFilter('host', ['web-1'])),
+            true,
+        ],
+        ['new empty filter added', makeFilterGroup(makeFilter('host', null)), emptyGroup, true],
+        [
+            'filter value completed',
+            makeFilterGroup(makeFilter('host', ['web-1'])),
+            makeFilterGroup(makeFilter('host', null)),
+            false,
+        ],
+        [
+            'filter edited (same count)',
+            makeFilterGroup(makeFilter('host', ['web-2'])),
+            makeFilterGroup(makeFilter('host', ['web-1'])),
+            false,
+        ],
+        [
+            'edit while another empty (same count)',
+            makeFilterGroup(makeFilter('host', ['web-2']), makeFilter('env', null)),
+            makeFilterGroup(makeFilter('host', ['web-1']), makeFilter('env', null)),
+            false,
+        ],
+        [
+            'filter removed',
+            makeFilterGroup(makeFilter('host', ['web-1'])),
+            makeFilterGroup(makeFilter('host', ['web-1']), makeFilter('env', ['prod'])),
+            false,
+        ],
+    ])('%s → %s', (_, current, previous, expected) => {
+        expect(shouldSkipFilterGroupChange(current, previous)).toBe(expected)
     })
 })

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -1,6 +1,8 @@
 import colors from 'ansi-colors'
+import equal from 'fast-deep-equal'
 import { actions, afterMount, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -12,9 +14,15 @@ import { dayjs } from 'lib/dayjs'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { LogMessage, LogsQuery, LogsSparklineBreakdownBy } from '~/queries/schema/schema-general'
+import {
+    LogMessage,
+    LogsQuery,
+    LogsSparklineBreakdownBy,
+    ProductIntentContext,
+    ProductKey,
+} from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
-import { JsonType, PropertyGroupFilter } from '~/types'
+import { JsonType, PropertyGroupFilter, UniversalFiltersGroup, UniversalFiltersGroupValue } from '~/types'
 
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
@@ -69,6 +77,41 @@ export interface LogsViewerDataLogicProps {
     autoLoad?: boolean
 }
 
+/** Returns true if the filterGroup change should be skipped (no real change or new empty filter added). */
+export function shouldSkipFilterGroupChange(
+    filterGroup: UniversalFiltersGroup,
+    oldFilterGroup: UniversalFiltersGroup | undefined
+): boolean {
+    if (!oldFilterGroup || equal(filterGroup, oldFilterGroup)) {
+        return true
+    }
+    const oldCount = (oldFilterGroup.values?.[0] as UniversalFiltersGroup | undefined)?.values?.length ?? 0
+    const newCount = (filterGroup.values?.[0] as UniversalFiltersGroup | undefined)?.values?.length ?? 0
+    if (newCount <= oldCount) {
+        return false
+    }
+    const hasIncompleteValue = (filterValue: UniversalFiltersGroupValue): boolean => {
+        if (!filterValue || typeof filterValue !== 'object') {
+            return false
+        }
+        if ('type' in filterValue && 'values' in filterValue) {
+            const groupValues = (filterValue as UniversalFiltersGroup).values ?? []
+            return groupValues.some((child) => hasIncompleteValue(child))
+        }
+        if ('id' in filterValue) {
+            return (filterValue as { id: unknown }).id == null
+        }
+        if ('value' in filterValue) {
+            const val = (filterValue as { value: unknown }).value
+            return val == null || (Array.isArray(val) && val.length === 0)
+        }
+        return false
+    }
+    const rootGroup = filterGroup.values?.[0] as UniversalFiltersGroup | undefined
+    const lastFilter = rootGroup?.values?.[rootGroup.values.length - 1]
+    return lastFilter ? hasIncompleteValue(lastFilter) : false
+}
+
 export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
     props({ id: 'default', autoLoad: true } as LogsViewerDataLogicProps),
     path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'data', 'logsViewerDataLogic']),
@@ -80,17 +123,21 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
             logsViewerFiltersLogic({ id }),
             ['setDateRange', 'setFilterGroup', 'setFilters', 'setSearchTerm', 'setSeverityLevels', 'setServiceNames'],
             logsViewerConfigLogic({ id }),
-            ['setSparklineBreakdownBy'],
+            ['setSparklineBreakdownBy', 'setOrderBy'],
         ],
         values: [
             logsViewerFiltersLogic({ id }),
-            ['filters', 'utcDateRange'],
+            ['filters', 'utcDateRange', 'filterGroup'],
             logsViewerConfigLogic({ id }),
             ['sparklineBreakdownBy', 'orderBy'],
         ],
     })),
 
     actions({
+        handleQueryChange: (filterType: string, extraProps?: Record<string, unknown>) => ({
+            filterType,
+            extraProps,
+        }),
         runQuery: (debounce?: integer) => ({ debounce }),
         fetchNextLogsPage: (limit?: number) => ({ limit }),
         truncateLogs: (limit: number) => ({ limit }),
@@ -441,7 +488,49 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         ],
     }),
 
+    subscriptions(({ actions }) => ({
+        filterGroup: (filterGroup: UniversalFiltersGroup, oldFilterGroup: UniversalFiltersGroup | undefined) => {
+            if (shouldSkipFilterGroupChange(filterGroup, oldFilterGroup)) {
+                return
+            }
+            actions.handleQueryChange('attributes')
+        },
+    })),
+
     listeners(({ actions, values, cache }) => ({
+        handleQueryChange: ({ filterType, extraProps }) => {
+            if (values.hasRunQuery) {
+                posthog.capture('logs filter changed', { filter_type: filterType, ...extraProps })
+                actions.addProductIntent({
+                    product_type: ProductKey.LOGS,
+                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
+                })
+            }
+            actions.runQuery()
+        },
+        setSearchTerm: ({ searchTerm }) => {
+            actions.handleQueryChange('search', { search_term_length: searchTerm?.length ?? 0 })
+        },
+        setDateRange: () => {
+            actions.handleQueryChange('date_range')
+        },
+        setSeverityLevels: ({ severityLevels }) => {
+            actions.handleQueryChange('severity', { severity_levels: severityLevels ?? [] })
+        },
+        setServiceNames: ({ serviceNames }) => {
+            actions.handleQueryChange('service', { service_count: serviceNames?.length ?? 0 })
+        },
+        setFilters: ({ pushToHistory }) => {
+            if (pushToHistory) {
+                actions.handleQueryChange('bulk')
+            } else {
+                actions.runQuery()
+            }
+        },
+        setOrderBy: ({ orderBy, source }) => {
+            posthog.capture('logs setting changed', { setting: 'order_by', value: orderBy, source })
+            actions.runQuery()
+        },
         setSparklineBreakdownBy: () => {
             actions.fetchSparkline()
         },

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -1,7 +1,6 @@
 import equal from 'fast-deep-equal'
 import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
-import posthog from 'posthog-js'
 
 import { syncSearchParams, updateSearchParams } from '@posthog/products-error-tracking/frontend/utils'
 
@@ -11,10 +10,6 @@ import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { parseTagsFilter } from 'lib/utils'
 import { Params } from 'scenes/sceneTypes'
-import { teamLogic } from 'scenes/teamLogic'
-
-import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
-import { UniversalFiltersGroup, UniversalFiltersGroupValue } from '~/types'
 
 import {
     DEFAULT_ORDER_BY,
@@ -50,16 +45,14 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
     tabAwareScene(),
     connect((props: LogsLogicProps) => ({
         actions: [
-            teamLogic,
-            ['addProductIntent'],
             logsViewerFiltersLogic({ id: props.tabId }),
-            ['setDateRange', 'setFilterGroup', 'setFilters', 'setSearchTerm', 'setSeverityLevels', 'setServiceNames'],
+            ['setFilters'],
+            logsFilterHistoryLogic({ id: props.tabId }),
+            ['pushToFilterHistory'],
             logsViewerConfigLogic({ id: props.tabId }),
             ['setOrderBy'],
             logsViewerDataLogic({ id: props.tabId }),
-            ['setInitialLogsLimit', 'runQuery', 'clearLogs', 'fetchLogsSuccess'],
-            logsFilterHistoryLogic({ id: props.tabId }),
-            ['pushToFilterHistory'],
+            ['setInitialLogsLimit', 'fetchLogsSuccess', 'handleQueryChange'],
         ],
         values: [
             logsViewerFiltersLogic({ id: props.tabId }),
@@ -67,11 +60,14 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             logsViewerConfigLogic({ id: props.tabId }),
             ['orderBy'],
             logsViewerDataLogic({ id: props.tabId }),
-            ['initialLogsLimit', 'hasRunQuery'],
+            ['initialLogsLimit'],
         ],
     })),
-    tabAwareUrlToAction(({ actions, values }) => {
+    tabAwareUrlToAction(({ actions, values, cache }) => {
         const urlToAction = (_: any, params: Params): void => {
+            if (cache.isSyncingUrl) {
+                return
+            }
             if (
                 typeof params.activeTab === 'string' &&
                 VALID_ACTIVE_TABS.includes(params.activeTab as LogsSceneActiveTab) &&
@@ -154,8 +150,8 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
         }
     }),
 
-    tabAwareActionToUrl(({ actions, values }) => {
-        const buildUrlAndRunQuery = (): [
+    tabAwareActionToUrl(({ values, cache }) => {
+        const syncUrl = (): [
             string,
             Params,
             Record<string, any>,
@@ -163,16 +159,20 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                 replace: boolean
             },
         ] => {
-            return syncSearchParams(router, (params: Params) => {
+            cache.isSyncingUrl = true // to prevent an infinite loop between actionToUrl and urlToAction
+            const result = syncSearchParams(router, (params: Params) => {
                 updateSearchParams(params, 'searchTerm', values.filters.searchTerm, '')
                 updateSearchParams(params, 'filterGroup', values.filters.filterGroup, DEFAULT_UNIVERSAL_GROUP_FILTER)
                 updateSearchParams(params, 'dateRange', values.filters.dateRange, DEFAULT_DATE_RANGE)
                 updateSearchParams(params, 'severityLevels', values.filters.severityLevels, DEFAULT_SEVERITY_LEVELS)
                 updateSearchParams(params, 'serviceNames', values.filters.serviceNames, DEFAULT_SERVICE_NAMES)
                 updateSearchParams(params, 'orderBy', values.orderBy, DEFAULT_ORDER_BY)
-                actions.runQuery()
                 return params
             })
+            queueMicrotask(() => {
+                cache.isSyncingUrl = false
+            })
+            return result
         }
 
         const clearInitialLogsLimit = (): [
@@ -201,14 +201,14 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             // It ensures the first fetch loads enough logs to include the linked log,
             // then resets to null so subsequent queries use the default page size.
             fetchLogsSuccess: () => clearInitialLogsLimit(),
-            syncUrlAndRunQuery: () => buildUrlAndRunQuery(),
+            syncUrl: () => syncUrl(),
             setActiveTab: () => syncActiveTab(),
         }
     }),
 
     actions({
         setActiveTab: (activeTab: LogsSceneActiveTab) => ({ activeTab }),
-        syncUrlAndRunQuery: true,
+        syncUrl: true,
         toggleAttributeBreakdown: (key: string) => ({ key }),
         setExpandedAttributeBreaksdowns: (expandedAttributeBreaksdowns: string[]) => ({ expandedAttributeBreaksdowns }),
     }),
@@ -233,126 +233,18 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
     }),
 
     listeners(({ values, actions }) => ({
-        setSearchTerm: ({ searchTerm }) => {
-            if (values.hasRunQuery) {
-                posthog.capture('logs filter changed', {
-                    filter_type: 'search',
-                    search_term_length: searchTerm?.length ?? 0,
-                })
-                actions.addProductIntent({
-                    product_type: ProductKey.LOGS,
-                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
-                })
-                actions.pushToFilterHistory(values.filters)
-            }
-            actions.syncUrlAndRunQuery()
-        },
-        setFilterGroup: () => {
-            // Don't run query if there's a filter without a value (user is still selecting)
-            const hasIncompleteUniversalFilterValue = (filterValue: UniversalFiltersGroupValue): boolean => {
-                if (!filterValue || typeof filterValue !== 'object') {
-                    return false
-                }
-
-                // If this is a nested UniversalFiltersGroup, recursively check its values
-                if ('type' in filterValue && 'values' in filterValue) {
-                    const groupValues = (filterValue as UniversalFiltersGroup).values ?? []
-                    return groupValues.some((child) => hasIncompleteUniversalFilterValue(child))
-                }
-
-                // ActionFilter: check for missing id
-                if ('id' in filterValue) {
-                    return (filterValue as { id: unknown }).id == null
-                }
-
-                // Property filter: check for missing or empty value
-                if ('value' in filterValue) {
-                    const val = (filterValue as { value: unknown }).value
-                    return val == null || (Array.isArray(val) && val.length === 0)
-                }
-
-                return false
-            }
-
-            const rootGroup = values.filters.filterGroup?.values?.[0] as UniversalFiltersGroup | undefined
-            const hasIncompleteFilter =
-                rootGroup?.values?.some((filterValue) => hasIncompleteUniversalFilterValue(filterValue)) ?? false
-
-            if (hasIncompleteFilter) {
-                return
-            }
-
-            if (values.hasRunQuery) {
-                posthog.capture('logs filter changed', { filter_type: 'attributes' })
-                actions.addProductIntent({
-                    product_type: ProductKey.LOGS,
-                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
-                })
-                actions.pushToFilterHistory(values.filters)
-            }
-            actions.syncUrlAndRunQuery()
-        },
-        setSeverityLevels: ({ severityLevels }) => {
-            if (values.hasRunQuery) {
-                posthog.capture('logs filter changed', {
-                    filter_type: 'severity',
-                    severity_levels: severityLevels ?? [],
-                })
-                actions.addProductIntent({
-                    product_type: ProductKey.LOGS,
-                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
-                })
-                actions.pushToFilterHistory(values.filters)
-            }
-            actions.syncUrlAndRunQuery()
-        },
-        setServiceNames: ({ serviceNames }) => {
-            if (values.hasRunQuery) {
-                posthog.capture('logs filter changed', {
-                    filter_type: 'service',
-                    service_count: serviceNames?.length ?? 0,
-                })
-                actions.addProductIntent({
-                    product_type: ProductKey.LOGS,
-                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
-                })
-                actions.pushToFilterHistory(values.filters)
-            }
-            actions.syncUrlAndRunQuery()
-        },
-        setDateRange: () => {
-            if (values.hasRunQuery) {
-                posthog.capture('logs filter changed', { filter_type: 'date_range' })
-                actions.addProductIntent({
-                    product_type: ProductKey.LOGS,
-                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
-                })
-                actions.pushToFilterHistory(values.filters)
-            }
-            actions.syncUrlAndRunQuery()
-        },
-        setFilters: ({ pushToHistory }) => {
-            if (values.hasRunQuery) {
-                posthog.capture('logs filter changed', { filter_type: 'bulk' })
-                actions.addProductIntent({
-                    product_type: ProductKey.LOGS,
-                    intent_context: ProductIntentContext.LOGS_SET_FILTERS,
-                })
-                if (pushToHistory) {
-                    actions.pushToFilterHistory(values.filters)
-                }
-            }
-            actions.syncUrlAndRunQuery()
-        },
-        setOrderBy: ({ orderBy, source }) => {
-            posthog.capture('logs setting changed', { setting: 'order_by', value: orderBy, source })
-            actions.syncUrlAndRunQuery()
-        },
         toggleAttributeBreakdown: ({ key }) => {
             const breakdowns = [...values.expandedAttributeBreaksdowns]
             const index = breakdowns.indexOf(key)
             index >= 0 ? breakdowns.splice(index, 1) : breakdowns.push(key)
             actions.setExpandedAttributeBreaksdowns(breakdowns)
+        },
+        handleQueryChange: () => {
+            actions.pushToFilterHistory(values.filters)
+            actions.syncUrl()
+        },
+        setOrderBy: () => {
+            actions.syncUrl()
         },
     })),
 ])


### PR DESCRIPTION
## Problem

Data fetching and analytics tracking in the logs viewer were tightly coupled to `logsSceneLogic` via URL sync. This meant `LogsViewer` embedded outside the scene (e.g. in a modal) couldn't auto-refetch when filters changed.

Additionally, adding a new empty attribute filter triggered unnecessary query executions.

## Changes

- Moved query execution (`runQuery`) and analytics tracking into `logsViewerDataLogic` via listeners + a `filterGroup` subscription, so any `LogsViewer` instance auto-refetches on filter changes regardless of context
- Introduced `handleQueryChange` action as a single coordination point, data logic fires it, scene logic listens to sync URL + push filter history
- Simplified `logsSceneLogic` to only handle URL sync and filter history (removed ~130 lines of duplicated filter listeners)
- Added `shouldSkipFilterGroupChange` to prevent query execution when a new empty filter row is added, while still allowing edits to existing filters even when other filters are incomplete
- Added `isSyncingUrl` guard to prevent kea-router `urlToAction` feedback loops when syncing filters to URL

## How did you test this code?

- 43 unit tests covering auto-refetch behavior, empty filter skipping, filter completion, editing while another filter is empty, and `shouldSkipFilterGroupChange` edge cases
- Manual testing

## Publish to changelog?

No

## Docs update

N/A