### PR TITLE
fix(hogql): handle column alias shadowing in property access

### DIFF
--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -1607,6 +1607,7 @@ class Resolver(CloningVisitor):
         loop_type = type
         chain_to_parse = node.chain[1:]
         previous_types = []
+        resolved_chain: list[str] = [str(node.chain[0])]
         while True:
             if isinstance(loop_type, FieldTraverserType):
                 chain_to_parse = loop_type.chain + chain_to_parse
@@ -1626,9 +1627,12 @@ class Resolver(CloningVisitor):
                 loop_type = loop_type.get_child(str(next_chain), self.context)
             except NotImplementedError:
                 raise QueryError(
-                    f"Cannot access property '{next_chain}' on '{'.'.join(node.chain[: node.chain.index(next_chain)])}'. "
+                    f"Cannot access property '{next_chain}' on '{'.'.join(resolved_chain)}'. "
                     f"This can happen when a column alias shadows a table field. Try renaming the alias."
                 )
+            resolved_chain.append(str(next_chain))
+            # Note: get_child currently always raises rather than returning None,
+            # but this guard is kept for safety in case that contract changes.
             if loop_type is None:
                 raise ResolutionError(f"Cannot resolve type {'.'.join(node.chain)}. Unable to resolve {next_chain}.")
         node.type = loop_type

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -15,7 +15,7 @@ from posthog.hogql.database.models import FunctionCallTable, LazyTable, SavedQue
 from posthog.hogql.database.s3_table import S3Table
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.persons import PersonsTable
-from posthog.hogql.errors import ImpossibleASTError, QueryError, ResolutionError
+from posthog.hogql.errors import ImpossibleASTError, NotImplementedError, QueryError, ResolutionError
 from posthog.hogql.escape_sql import safe_identifier
 from posthog.hogql.functions import find_hogql_posthog_function
 from posthog.hogql.functions.action import matches_action
@@ -1622,10 +1622,13 @@ class Resolver(CloningVisitor):
                 loop_type = previous_types[-1]
                 next_chain = chain_to_parse.pop(0)
 
-            # TODO: This will never return None, it always raises an exception
-            # once it finds the unsupported field/type
-            # There's no reason to have the `if loop_type is None` check here
-            loop_type = loop_type.get_child(str(next_chain), self.context)
+            try:
+                loop_type = loop_type.get_child(str(next_chain), self.context)
+            except NotImplementedError:
+                raise QueryError(
+                    f"Cannot access property '{next_chain}' on '{'.'.join(node.chain[: node.chain.index(next_chain)])}'. "
+                    f"This can happen when a column alias shadows a table field. Try renaming the alias."
+                )
             if loop_type is None:
                 raise ResolutionError(f"Cannot resolve type {'.'.join(node.chain)}. Unable to resolve {next_chain}.")
         node.type = loop_type

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1729,3 +1729,12 @@ class TestResolver(BaseTest):
         with self.assertRaises(QueryError):
             expr = self._select("SELECT * FROM (SELECT 1, 'a') AS v(id, name, extra)")
             resolve_types(expr, self.context, dialect="clickhouse")
+
+    def test_alias_shadowing_table_field_property_access(self):
+        with self.assertRaises(QueryError) as ctx:
+            expr = self._select(
+                "SELECT argMin(properties, timestamp) as properties FROM events WHERE properties.foo = 'bar'"
+            )
+            resolve_types(expr, self.context, dialect="clickhouse")
+        self.assertIn("Cannot access property", str(ctx.exception))
+        self.assertIn("renaming the alias", str(ctx.exception))

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1730,11 +1730,19 @@ class TestResolver(BaseTest):
             expr = self._select("SELECT * FROM (SELECT 1, 'a') AS v(id, name, extra)")
             resolve_types(expr, self.context, dialect="clickhouse")
 
-    def test_alias_shadowing_table_field_property_access(self):
-        with self.assertRaises(QueryError) as ctx:
-            expr = self._select(
-                "SELECT argMin(properties, timestamp) as properties FROM events WHERE properties.foo = 'bar'"
-            )
+    @parameterized.expand(
+        [
+            (
+                "select_alias_shadows_properties",
+                "SELECT argMin(properties, timestamp) as properties FROM events WHERE properties.foo = 'bar'",
+            ),
+            (
+                "select_alias_shadows_deeper_chain",
+                "SELECT argMin(properties, timestamp) as properties FROM events WHERE properties.a.b = 1",
+            ),
+        ]
+    )
+    def test_alias_shadowing_table_field_property_access(self, _name, query):
+        expr = self._select(query)
+        with self.assertRaisesRegex(QueryError, "Cannot access property.*renaming the alias"):
             resolve_types(expr, self.context, dialect="clickhouse")
-        self.assertIn("Cannot access property", str(ctx.exception))
-        self.assertIn("renaming the alias", str(ctx.exception))


### PR DESCRIPTION
## Problem

HogQL queries where a column alias shadows a table field e.g. `argMin(properties, timestamp) as properties` and then accesses a child `properties.foo` crash with a 500 instead of a user-facing error.

Reported: https://posthoghelp.zendesk.com/agent/tickets/46099 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54865)

## Changes

Catch NotImplementedError in the resolver's field chain resolution and surface it as a QueryError with a helpful message.

## How did you test this code?

Unit tests

## Publish to changelog?

No
