### PR TITLE
fix(data-warehouse): Fixed an arrow invalid large string error

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -635,7 +635,13 @@ def _python_type_to_pyarrow_type(type_: type, value: Any):
 
 def _to_list_array(column_data: pa.Array | pa.ChunkedArray | np.ndarray[Any, np.dtype[Any]]):
     if isinstance(column_data, pa.ChunkedArray):
-        return column_data.combine_chunks().tolist()
+        try:
+            return column_data.combine_chunks().tolist()
+        except pa.ArrowInvalid as e:
+            if "consider casting input from `string` to `large_string`" in "".join(e.args):
+                return column_data.cast(pa.large_string()).combine_chunks().tolist()
+
+            raise
 
     return column_data.tolist()
 


### PR DESCRIPTION
## Problem
- https://us.posthog.com/project/2/error_tracking/019ce8a8-99be-79c1-94cd-481f1a83a9b2?timestamp=2026-03-24%2007%3A34%3A35.832000-07%3A00&searchQuery=offset%20overflow%20while%20concatenating%20arrays%2C%20consider%20casting%20input%20from%20%60string%60%20to%20%60large_string%60%20first

## Changes
Fixed it ! 

## How did you test this code?
