### PR TITLE
fix(experiments): disable precomputations for data warehouse metrics.

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -216,7 +216,9 @@ class ExperimentQueryRunner(QueryRunner):
             force_precomputation=self.force_precomputation,
         )
 
-        if self.experiment.exposure_preaggregation_enabled:
+        # Skip precomputation for data warehouse metrics because the precomputed table
+        # doesn't include the join keys needed to link exposures to data warehouse tables
+        if self.experiment.exposure_preaggregation_enabled and not self.is_data_warehouse_query:
             try:
                 result = self._ensure_exposures_precomputed(builder)
                 if result.ready:

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_data_warehouse_metric.ambr
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/__snapshots__/test_data_warehouse_metric.ambr
@@ -1,4 +1,157 @@
 # serializer version: 1
+# name: TestExperimentQueryRunner.test_data_warehouse_metric_skips_precomputation_0_mean_metric
+  '''
+  WITH exposures AS
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+            if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+            min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+            max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+            argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+            argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$user_id'), ''), 'null'), '^"|"$', '') AS exposure_identifier
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-01-31 00:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+     GROUP BY entity_id,
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$user_id'), ''), 'null'), '^"|"$', '')),
+       metric_events AS
+    (SELECT posthog_test_usage.userid AS entity_id,
+            posthog_test_usage.ds AS timestamp,
+            coalesce(accurateCastOrNull(1, 'Float64'), 0) AS value
+     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.experiments.queryrunner/posthog_test_usage/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`ds` Date, `id` String, `plan` String, `usage` Float64, `region` String, `userid` String') AS posthog_test_usage
+     WHERE and(greaterOrEquals(posthog_test_usage.ds, assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), less(posthog_test_usage.ds, plus(assumeNotNull(toDateTime('2023-01-31 00:00:00', 'UTC')), toIntervalSecond(0))))),
+       entity_metrics AS
+    (SELECT exposures.entity_id AS entity_id,
+            exposures.variant AS variant,
+            sum(coalesce(accurateCastOrNull(metric_events.value, 'Float64'), 0)) AS value
+     FROM exposures
+     LEFT JOIN metric_events ON and(equals(toString(exposures.exposure_identifier), toString(metric_events.entity_id)), greaterOrEquals(metric_events.timestamp, exposures.first_exposure_time))
+     GROUP BY exposures.entity_id,
+              exposures.variant)
+  SELECT entity_metrics.variant AS variant,
+         count(entity_metrics.entity_id) AS num_users,
+         sum(entity_metrics.value) AS total_sum,
+         sum(power(entity_metrics.value, 2)) AS total_sum_of_squares
+  FROM entity_metrics
+  GROUP BY entity_metrics.variant
+  LIMIT 50000 SETTINGS format_csv_allow_double_quotes=1,
+                       readonly=2,
+                       max_execution_time=600,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=39728447488,
+                       enable_analyzer=1,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---
+# name: TestExperimentQueryRunner.test_data_warehouse_metric_skips_precomputation_1_ratio_metric
+  '''
+  WITH exposures AS
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+            if(ifNull(greater(uniqExact(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+            min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time,
+            max(toTimeZone(events.timestamp, 'UTC')) AS last_exposure_time,
+            argMin(events.uuid, toTimeZone(events.timestamp, 'UTC')) AS exposure_event_uuid,
+            argMin(events.`$session_id`, toTimeZone(events.timestamp, 'UTC')) AS exposure_session_id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$user_id'), ''), 'null'), '^"|"$', '') AS exposure_identifier_num,
+            events__person.properties___email AS exposure_identifier_denom
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-01-10 00:00:00', 'UTC'))), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0)), in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']))
+     GROUP BY entity_id,
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$user_id'), ''), 'null'), '^"|"$', ''),
+              events__person.properties___email),
+       numerator_events AS
+    (SELECT posthog_test_usage.userid AS entity_id,
+            posthog_test_usage.ds AS timestamp,
+            coalesce(accurateCastOrNull(posthog_test_usage.usage, 'Float64'), 0) AS value
+     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.experiments.queryrunner/posthog_test_usage/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`ds` Date, `id` String, `plan` String, `usage` Float64, `region` String, `userid` String') AS posthog_test_usage
+     WHERE and(greaterOrEquals(posthog_test_usage.ds, assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), less(posthog_test_usage.ds, plus(assumeNotNull(toDateTime('2023-01-10 00:00:00', 'UTC')), toIntervalSecond(0))))),
+       denominator_events AS
+    (SELECT posthog_test_stripe_subscriptions__subscription_customer.customer_email AS entity_id,
+            toTimeZone(posthog_test_stripe_subscriptions.subscription_created_at, 'UTC') AS timestamp,
+            coalesce(accurateCastOrNull(1, 'Float64'), 0) AS value
+     FROM
+       (SELECT *
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.experiments.queryrunner/posthog_test_stripe_subscriptions/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`subscription_id` String, `subscription_amount` Int64, `subscription_created_at` DateTime, `subscription_customer_id` String')) AS posthog_test_stripe_subscriptions
+     LEFT JOIN
+       (SELECT posthog_test_stripe_customers.customer_email AS customer_email,
+               posthog_test_stripe_customers.customer_id AS posthog_test_stripe_subscriptions__subscription_customer___customer_id
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql.experiments.queryrunner/posthog_test_stripe_customers/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`customer_id` String, `signup_count` Int32, `customer_name` String, `customer_email` String, `customer_created_at` DateTime') AS posthog_test_stripe_customers) AS posthog_test_stripe_subscriptions__subscription_customer ON equals(posthog_test_stripe_subscriptions.subscription_customer_id, posthog_test_stripe_subscriptions__subscription_customer.posthog_test_stripe_subscriptions__subscription_customer___customer_id)
+     WHERE and(greaterOrEquals(toTimeZone(posthog_test_stripe_subscriptions.subscription_created_at, 'UTC'), assumeNotNull(toDateTime('2023-01-01 00:00:00', 'UTC'))), less(toTimeZone(posthog_test_stripe_subscriptions.subscription_created_at, 'UTC'), plus(assumeNotNull(toDateTime('2023-01-10 00:00:00', 'UTC')), toIntervalSecond(0))))),
+       numerator_agg AS
+    (SELECT exposures.entity_id AS entity_id,
+            sum(coalesce(accurateCastOrNull(numerator_events.value, 'Float64'), 0)) AS value
+     FROM numerator_events
+     JOIN exposures ON equals(toString(exposures.exposure_identifier_num), toString(numerator_events.entity_id))
+     WHERE ifNull(greaterOrEquals(numerator_events.timestamp, exposures.first_exposure_time), 0)
+     GROUP BY exposures.entity_id),
+       denominator_agg AS
+    (SELECT exposures.entity_id AS entity_id,
+            sum(coalesce(accurateCastOrNull(denominator_events.value, 'Float64'), 0)) AS value
+     FROM denominator_events
+     JOIN exposures ON equals(toString(exposures.exposure_identifier_denom), toString(denominator_events.entity_id))
+     WHERE ifNull(greaterOrEquals(toTimeZone(denominator_events.timestamp, 'UTC'), exposures.first_exposure_time), 0)
+     GROUP BY exposures.entity_id),
+       entity_metrics AS
+    (SELECT exposures.variant AS variant,
+            exposures.entity_id AS entity_id,
+            any(coalesce(numerator_agg.value, 0)) AS numerator_value,
+            any(coalesce(denominator_agg.value, 0)) AS denominator_value
+     FROM exposures
+     LEFT JOIN numerator_agg ON equals(exposures.entity_id, numerator_agg.entity_id)
+     LEFT JOIN denominator_agg ON equals(exposures.entity_id, denominator_agg.entity_id)
+     GROUP BY exposures.variant,
+              exposures.entity_id)
+  SELECT entity_metrics.variant AS variant,
+         count(entity_metrics.entity_id) AS num_users,
+         sum(entity_metrics.numerator_value) AS total_sum,
+         sum(power(entity_metrics.numerator_value, 2)) AS total_sum_of_squares,
+         sum(entity_metrics.denominator_value) AS denominator_sum,
+         sum(power(entity_metrics.denominator_value, 2)) AS denominator_sum_squares,
+         sum(multiply(entity_metrics.numerator_value, entity_metrics.denominator_value)) AS numerator_denominator_sum_product
+  FROM entity_metrics
+  GROUP BY entity_metrics.variant
+  LIMIT 50000 SETTINGS format_csv_allow_double_quotes=1,
+                       readonly=2,
+                       max_execution_time=600,
+                       allow_experimental_object_type=1,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=39728447488,
+                       enable_analyzer=1,
+                       transform_null_in=1,
+                       optimize_min_equality_disjunction_chain_length=4294967295,
+                       allow_experimental_join_condition=1,
+                       use_hive_partitioning=0
+  '''
+# ---
 # name: TestExperimentQueryRunner.test_query_runner_data_warehouse_continuous_metric
   '''
   WITH exposures AS

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_data_warehouse_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_data_warehouse_metric.py
@@ -1133,3 +1133,197 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
 
         # The test validates that queries with different join keys execute successfully
         # and produce ratio metric results with all required statistical fields
+
+    @snapshot_clickhouse_queries
+    def test_data_warehouse_metric_skips_precomputation(self):
+        """Test that data warehouse metrics skip precomputation even when enabled"""
+        table_name = self.create_data_warehouse_table_with_usage()
+
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag, start_date=datetime(2023, 1, 1), end_date=datetime(2023, 1, 31)
+        )
+
+        # Enable precomputation
+        experiment.exposure_preaggregation_enabled = True
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        metric = ExperimentMeanMetric(
+            source=ExperimentDataWarehouseNode(
+                table_name=table_name,
+                events_join_key="properties.$user_id",
+                data_warehouse_join_key="userid",
+                timestamp_field="ds",
+                math=ExperimentMetricMathType.TOTAL,
+                math_property=None,
+            ),
+        )
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+        experiment.exposure_criteria = {"filterTestAccounts": False}
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Populate exposure events
+        for variant, count in [("control", 7), ("test", 9)]:
+            for i in range(count):
+                _create_event(
+                    team=self.team,
+                    event="$feature_flag_called",
+                    distinct_id=f"distinct_{variant}_{i}",
+                    properties={
+                        "$feature_flag_response": variant,
+                        feature_flag_property: variant,
+                        "$feature_flag": feature_flag.key,
+                        "$user_id": f"user_{variant}_{i}",
+                    },
+                    timestamp=datetime(2023, 1, i + 1),
+                )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        with freeze_time("2023-01-07"):
+            result = query_runner.calculate()
+
+        # Verify that precomputation was NOT used
+        self.assertFalse(result.is_precomputed)
+
+        # Verify results are still correct
+        assert result.variant_results is not None
+        self.assertEqual(len(result.variant_results), 1)
+
+        control_result = result.baseline
+        assert control_result is not None
+        test_result = result.variant_results[0]
+        assert test_result is not None
+
+        self.assertEqual(control_result.sum, 6)
+        self.assertEqual(test_result.sum, 7)
+        self.assertEqual(control_result.number_of_samples, 7)
+        self.assertEqual(test_result.number_of_samples, 9)
+
+    @snapshot_clickhouse_queries
+    def test_ratio_metric_with_dw_skips_precomputation(self):
+        """Test that ratio metrics with data warehouse sources skip precomputation"""
+        usage_table = self.create_data_warehouse_table_with_usage()
+        subscriptions_table = self.create_data_warehouse_table_with_subscriptions()
+
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag, start_date=datetime(2023, 1, 1), end_date=datetime(2023, 1, 10)
+        )
+
+        # Enable precomputation
+        experiment.exposure_preaggregation_enabled = True
+        experiment.save()
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        metric = ExperimentRatioMetric(
+            numerator=ExperimentDataWarehouseNode(
+                table_name=usage_table,
+                events_join_key="properties.$user_id",
+                data_warehouse_join_key="userid",
+                timestamp_field="ds",
+                math=ExperimentMetricMathType.SUM,
+                math_property="usage",
+            ),
+            denominator=ExperimentDataWarehouseNode(
+                table_name=subscriptions_table,
+                events_join_key="person.properties.email",
+                data_warehouse_join_key="subscription_customer.customer_email",
+                timestamp_field="subscription_created_at",
+                math=ExperimentMetricMathType.TOTAL,
+                math_property=None,
+            ),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Populate exposure events
+        for i in range(7):
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_control_{i}",
+                properties={
+                    "$feature_flag_response": "control",
+                    feature_flag_property: "control",
+                    "$feature_flag": feature_flag.key,
+                    "$user_id": f"user_control_{i}",
+                },
+                timestamp=datetime(2023, 1, i + 1),
+            )
+
+        for i in range(9):
+            _create_event(
+                team=self.team,
+                event="$feature_flag_called",
+                distinct_id=f"user_test_{i}",
+                properties={
+                    "$feature_flag_response": "test",
+                    feature_flag_property: "test",
+                    "$feature_flag": feature_flag.key,
+                    "$user_id": f"user_test_{i}",
+                },
+                timestamp=datetime(2023, 1, i + 1),
+            )
+
+        _create_person(
+            team=self.team,
+            distinct_ids=["user_control_0"],
+            properties={"email": "john.doe@example.com"},
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["user_test_1"],
+            properties={"email": "jane.doe@example.com"},
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["user_test_2"],
+            properties={"email": "john.smith@example.com"},
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["user_test_3"],
+            properties={"email": "jane.smith@example.com"},
+        )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+
+        with freeze_time("2023-01-10"):
+            result = query_runner.calculate()
+
+        # Verify that precomputation was NOT used
+        self.assertFalse(result.is_precomputed)
+
+        # Verify results are still correct
+        assert result.variant_results is not None
+        self.assertEqual(len(result.variant_results), 1)
+
+        control_result = result.baseline
+        assert control_result is not None
+        test_result = result.variant_results[0]
+        assert test_result is not None
+
+        # Verify basic result structure
+        self.assertIsNotNone(control_result.sum)
+        self.assertIsNotNone(test_result.sum)
+        self.assertIsNotNone(control_result.denominator_sum)
+        self.assertIsNotNone(test_result.denominator_sum)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_data_warehouse_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_data_warehouse_metric.py
@@ -1134,14 +1134,64 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         # The test validates that queries with different join keys execute successfully
         # and produce ratio metric results with all required statistical fields
 
+    @parameterized.expand(
+        [
+            [
+                "mean_metric",
+                lambda usage_table, subscriptions_table: ExperimentMeanMetric(
+                    source=ExperimentDataWarehouseNode(
+                        table_name=usage_table,
+                        events_join_key="properties.$user_id",
+                        data_warehouse_join_key="userid",
+                        timestamp_field="ds",
+                        math=ExperimentMetricMathType.TOTAL,
+                        math_property=None,
+                    ),
+                ),
+                datetime(2023, 1, 31),
+                {"control_sum": 6, "test_sum": 7, "control_samples": 7, "test_samples": 9},
+            ],
+            [
+                "ratio_metric",
+                lambda usage_table, subscriptions_table: ExperimentRatioMetric(
+                    numerator=ExperimentDataWarehouseNode(
+                        table_name=usage_table,
+                        events_join_key="properties.$user_id",
+                        data_warehouse_join_key="userid",
+                        timestamp_field="ds",
+                        math=ExperimentMetricMathType.SUM,
+                        math_property="usage",
+                    ),
+                    denominator=ExperimentDataWarehouseNode(
+                        table_name=subscriptions_table,
+                        events_join_key="person.properties.email",
+                        data_warehouse_join_key="subscription_customer.customer_email",
+                        timestamp_field="subscription_created_at",
+                        math=ExperimentMetricMathType.TOTAL,
+                        math_property=None,
+                    ),
+                ),
+                datetime(2023, 1, 10),
+                {
+                    "control_sum": 650,
+                    "test_sum": 1050,
+                    "control_samples": 7,
+                    "test_samples": 9,
+                    "control_denominator": 1,
+                    "test_denominator": 3,
+                },
+            ],
+        ]
+    )
     @snapshot_clickhouse_queries
-    def test_data_warehouse_metric_skips_precomputation(self):
+    def test_data_warehouse_metric_skips_precomputation(self, name, metric_factory, end_date, expected):
         """Test that data warehouse metrics skip precomputation even when enabled"""
-        table_name = self.create_data_warehouse_table_with_usage()
+        usage_table = self.create_data_warehouse_table_with_usage()
+        subscriptions_table = self.create_data_warehouse_table_with_subscriptions()
 
         feature_flag = self.create_feature_flag()
         experiment = self.create_experiment(
-            feature_flag=feature_flag, start_date=datetime(2023, 1, 1), end_date=datetime(2023, 1, 31)
+            feature_flag=feature_flag, start_date=datetime(2023, 1, 1), end_date=end_date
         )
 
         # Enable precomputation
@@ -1150,16 +1200,7 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
 
         feature_flag_property = f"$feature/{feature_flag.key}"
 
-        metric = ExperimentMeanMetric(
-            source=ExperimentDataWarehouseNode(
-                table_name=table_name,
-                events_join_key="properties.$user_id",
-                data_warehouse_join_key="userid",
-                timestamp_field="ds",
-                math=ExperimentMetricMathType.TOTAL,
-                math_property=None,
-            ),
-        )
+        metric = metric_factory(usage_table, subscriptions_table)
         experiment_query = ExperimentQuery(
             experiment_id=experiment.id,
             kind="ExperimentQuery",
@@ -1175,7 +1216,7 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
                 _create_event(
                     team=self.team,
                     event="$feature_flag_called",
-                    distinct_id=f"distinct_{variant}_{i}",
+                    distinct_id=f"user_{variant}_{i}",
                     properties={
                         "$feature_flag_response": variant,
                         feature_flag_property: variant,
@@ -1185,10 +1226,33 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
                     timestamp=datetime(2023, 1, i + 1),
                 )
 
+        # Create persons for ratio metric denominator
+        if name == "ratio_metric":
+            _create_person(
+                team=self.team,
+                distinct_ids=["user_control_0"],
+                properties={"email": "john.doe@example.com"},
+            )
+            _create_person(
+                team=self.team,
+                distinct_ids=["user_test_1"],
+                properties={"email": "jane.doe@example.com"},
+            )
+            _create_person(
+                team=self.team,
+                distinct_ids=["user_test_2"],
+                properties={"email": "john.smith@example.com"},
+            )
+            _create_person(
+                team=self.team,
+                distinct_ids=["user_test_3"],
+                properties={"email": "jane.smith@example.com"},
+            )
+
         flush_persons_and_events()
 
         query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
-        with freeze_time("2023-01-07"):
+        with freeze_time(end_date):
             result = query_runner.calculate()
 
         # Verify that precomputation was NOT used
@@ -1203,127 +1267,13 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         test_result = result.variant_results[0]
         assert test_result is not None
 
-        self.assertEqual(control_result.sum, 6)
-        self.assertEqual(test_result.sum, 7)
-        self.assertEqual(control_result.number_of_samples, 7)
-        self.assertEqual(test_result.number_of_samples, 9)
+        # Assert exact values
+        self.assertEqual(control_result.sum, expected["control_sum"])
+        self.assertEqual(test_result.sum, expected["test_sum"])
+        self.assertEqual(control_result.number_of_samples, expected["control_samples"])
+        self.assertEqual(test_result.number_of_samples, expected["test_samples"])
 
-    @snapshot_clickhouse_queries
-    def test_ratio_metric_with_dw_skips_precomputation(self):
-        """Test that ratio metrics with data warehouse sources skip precomputation"""
-        usage_table = self.create_data_warehouse_table_with_usage()
-        subscriptions_table = self.create_data_warehouse_table_with_subscriptions()
-
-        feature_flag = self.create_feature_flag()
-        experiment = self.create_experiment(
-            feature_flag=feature_flag, start_date=datetime(2023, 1, 1), end_date=datetime(2023, 1, 10)
-        )
-
-        # Enable precomputation
-        experiment.exposure_preaggregation_enabled = True
-        experiment.save()
-
-        feature_flag_property = f"$feature/{feature_flag.key}"
-
-        metric = ExperimentRatioMetric(
-            numerator=ExperimentDataWarehouseNode(
-                table_name=usage_table,
-                events_join_key="properties.$user_id",
-                data_warehouse_join_key="userid",
-                timestamp_field="ds",
-                math=ExperimentMetricMathType.SUM,
-                math_property="usage",
-            ),
-            denominator=ExperimentDataWarehouseNode(
-                table_name=subscriptions_table,
-                events_join_key="person.properties.email",
-                data_warehouse_join_key="subscription_customer.customer_email",
-                timestamp_field="subscription_created_at",
-                math=ExperimentMetricMathType.TOTAL,
-                math_property=None,
-            ),
-        )
-
-        experiment_query = ExperimentQuery(
-            experiment_id=experiment.id,
-            kind="ExperimentQuery",
-            metric=metric,
-        )
-
-        experiment.metrics = [metric.model_dump(mode="json")]
-        experiment.save()
-
-        # Populate exposure events
-        for i in range(7):
-            _create_event(
-                team=self.team,
-                event="$feature_flag_called",
-                distinct_id=f"user_control_{i}",
-                properties={
-                    "$feature_flag_response": "control",
-                    feature_flag_property: "control",
-                    "$feature_flag": feature_flag.key,
-                    "$user_id": f"user_control_{i}",
-                },
-                timestamp=datetime(2023, 1, i + 1),
-            )
-
-        for i in range(9):
-            _create_event(
-                team=self.team,
-                event="$feature_flag_called",
-                distinct_id=f"user_test_{i}",
-                properties={
-                    "$feature_flag_response": "test",
-                    feature_flag_property: "test",
-                    "$feature_flag": feature_flag.key,
-                    "$user_id": f"user_test_{i}",
-                },
-                timestamp=datetime(2023, 1, i + 1),
-            )
-
-        _create_person(
-            team=self.team,
-            distinct_ids=["user_control_0"],
-            properties={"email": "john.doe@example.com"},
-        )
-        _create_person(
-            team=self.team,
-            distinct_ids=["user_test_1"],
-            properties={"email": "jane.doe@example.com"},
-        )
-        _create_person(
-            team=self.team,
-            distinct_ids=["user_test_2"],
-            properties={"email": "john.smith@example.com"},
-        )
-        _create_person(
-            team=self.team,
-            distinct_ids=["user_test_3"],
-            properties={"email": "jane.smith@example.com"},
-        )
-
-        flush_persons_and_events()
-
-        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
-
-        with freeze_time("2023-01-10"):
-            result = query_runner.calculate()
-
-        # Verify that precomputation was NOT used
-        self.assertFalse(result.is_precomputed)
-
-        # Verify results are still correct
-        assert result.variant_results is not None
-        self.assertEqual(len(result.variant_results), 1)
-
-        control_result = result.baseline
-        assert control_result is not None
-        test_result = result.variant_results[0]
-        assert test_result is not None
-
-        # Verify basic result structure
-        self.assertIsNotNone(control_result.sum)
-        self.assertIsNotNone(test_result.sum)
-        self.assertIsNotNone(control_result.denominator_sum)
-        self.assertIsNotNone(test_result.denominator_sum)
+        # Additional assertions for ratio metrics
+        if "control_denominator" in expected:
+            self.assertEqual(control_result.denominator_sum, expected["control_denominator"])
+            self.assertEqual(test_result.denominator_sum, expected["test_denominator"])

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/test_data_warehouse_metric.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/test_data_warehouse_metric.py
@@ -1174,7 +1174,7 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
                 datetime(2023, 1, 10),
                 {
                     "control_sum": 650,
-                    "test_sum": 1050,
+                    "test_sum": 1150,
                     "control_samples": 7,
                     "test_samples": 9,
                     "control_denominator": 1,


### PR DESCRIPTION
## Problem

Data warehouse experiment metrics fail with the error _Field not found: exposure_identifier_num_ when exposure precomputation is enabled, because the precomputed table lacks the join keys needed to link exposures to data warehouse tables.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Disable exposure precomputations for metrics with data warehouse events.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

```bash
pytest posthog/hogql_queries/experiments/test/experiment_query_runner/test_data_warehouse_metric.py
```

![cat-type](https://github.com/user-attachments/assets/889a9e23-9dc5-4f30-88bf-d43293c2622a)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
