### PR TITLE
feat(onboarding): smart prefetching for smoother step transitions

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -45,7 +45,7 @@ sqlx-cli = { pkg-path = "sqlx-cli", version = "0.8.3" } # sqlx
 postgresql = { pkg-path = "postgresql_14" , outputs = "all" } # psql
 ffmpeg = { pkg-path = "ffmpeg_5", version = "5.1.4", pkg-group = "ffmpeg" , outputs = "all" }
 protobuf = { pkg-path = "protobuf" } # protoc compiler for gRPC code generation
-ninja.pkg-path = "ninja"
+ninja = { pkg-path = "ninja" }
 emscripten = { pkg-path = "emscripten", pkg-group = "emscripten", version = "4.0.23" }
 libpthread-stubs = { pkg-path = "libpthread-stubs", pkg-group = "emscripten" }
 watchman = { pkg-path = "watchman" } # Fast file watching for Django/Celery autoreload (uses pywatchman)

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -377,6 +377,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_SESSION_REPLAY_MEDIA: 'onboarding-session-replay-media', // owner: @fercgomes #team-growth multivariate=control,screenshot,demo
     ONBOARDING_SIMPLIFIED_PRODUCT_SELECTION: 'onboarding-simplified-product-selection', // owner: @fercgomes #team-growth multivariate=control,test
     ONBOARDING_SOCIAL_PROOF_INFO: 'onboarding-social-proof-info', // owner: @fercgomes #team-growth, payload overrides social proof strings per product
+    ONBOARDING_SMART_PREFETCH: 'onboarding-smart-prefetch', // owner: #team-growth, prefetch onboarding resources to eliminate step loading multivariate=control,test
     ONBOARDING_SKIP_INSTALL_STEP: 'onboarding-skip-install-step', // owner: @rafaeelaudibert #team-growth multivariate=true
     OPTIMIZED_RELATED_GROUPS_QUERY: 'optimized-related-groups-query', // owner: @arthurdedeus #team-customer-analytics
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features

--- a/frontend/src/scenes/onboarding/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/onboardingLogic.test.ts
@@ -1,0 +1,21 @@
+import { initKeaTests } from '~/test/init'
+
+import { onboardingLogic } from './onboardingLogic'
+
+describe('onboardingLogic', () => {
+    describe('smart prefetching', () => {
+        it('does not crash when step changes and next step is unknown', async () => {
+            initKeaTests()
+
+            const logic = onboardingLogic()
+            logic.mount()
+
+            expect(() => {
+                logic.actions.setStepKey('NON_EXISTENT_STEP_KEY' as any)
+            }).not.toThrow()
+
+            logic.unmount()
+        })
+    })
+})
+

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -321,11 +321,20 @@ export const onboardingLogic = kea<onboardingLogicType>([
             sdksLogic.mount()
         },
         setStepKey: ({ stepKey }) => {
+            // This action is also used for validation (e.g. deep-linked steps).
+            if (values.isStepKeyInvalid) {
+                actions.resetStepKey()
+                return
+            }
+
             if (!values.isSmartPrefetchEnabled) {
                 return
             }
 
             const currentStepIndex = values.onboardingStepKeys.findIndex((s) => s === stepKey)
+            if (currentStepIndex === -1) {
+                return
+            }
             const nextStepKey = values.onboardingStepKeys[currentStepIndex + 1]
 
             if (!nextStepKey) {
@@ -377,11 +386,6 @@ export const onboardingLogic = kea<onboardingLogicType>([
             actions.openGlobalSetup()
         },
         setAllOnboardingSteps: () => {
-            if (values.isStepKeyInvalid) {
-                actions.resetStepKey()
-            }
-        },
-        setStepKey: () => {
             if (values.isStepKeyInvalid) {
                 actions.resetStepKey()
             }

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -2,11 +2,14 @@ import { actions, connect, kea, listeners, path, props, reducers, selectors } fr
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { globalSetupLogic } from 'lib/components/ProductSetup/globalSetupLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isKeyOf } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
+import { sdksLogic } from 'scenes/onboarding/sdks/sdksLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { inviteLogic } from 'scenes/settings/organization/inviteLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -171,6 +174,10 @@ export const onboardingLogic = kea<onboardingLogicType>([
         ],
     })),
     selectors({
+        isSmartPrefetchEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => featureFlags[FEATURE_FLAGS.ONBOARDING_SMART_PREFETCH] === 'test',
+        ],
         breadcrumbs: [
             (s) => [s.productKey, s.stepKey],
             (productKey, stepKey): Breadcrumb[] => {
@@ -297,6 +304,44 @@ export const onboardingLogic = kea<onboardingLogicType>([
                 return
             }
             actions.setProduct(availableOnboardingProducts[productKey])
+
+            if (!values.isSmartPrefetchEnabled) {
+                return
+            }
+
+            // Start onboarding-time requests immediately after the product is picked.
+            // This reduces the chance of the first step transition blocking on these.
+            billingLogic.mount()
+            billingLogic.actions.loadBilling()
+
+            inviteLogic.mount()
+            inviteLogic.actions.loadInvites()
+
+            // `sdksLogic` triggers `loadSnippetEvents()` on mount.
+            sdksLogic.mount()
+        },
+        setStepKey: ({ stepKey }) => {
+            if (!values.isSmartPrefetchEnabled) {
+                return
+            }
+
+            const currentStepIndex = values.onboardingStepKeys.findIndex((s) => s === stepKey)
+            const nextStepKey = values.onboardingStepKeys[currentStepIndex + 1]
+
+            if (!nextStepKey) {
+                return
+            }
+
+            // Step-ahead prefetching: warm up resources needed for the *next* step.
+            if (nextStepKey === OnboardingStepKey.PLANS) {
+                billingLogic.mount()
+                billingLogic.actions.loadBilling()
+            }
+
+            if (nextStepKey === OnboardingStepKey.INVITE_TEAMMATES) {
+                inviteLogic.mount()
+                inviteLogic.actions.loadInvites()
+            }
         },
         setSubscribedDuringOnboarding: ({ subscribedDuringOnboarding }) => {
             if (subscribedDuringOnboarding) {

--- a/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
+++ b/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
@@ -3,10 +3,15 @@ import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getRelativeNextPath } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { billingLogic } from 'scenes/billing/billingLogic'
 import { onboardingLogic } from 'scenes/onboarding/onboardingLogic'
+import { sdksLogic } from 'scenes/onboarding/sdks/sdksLogic'
 import { USE_CASE_OPTIONS, UseCaseOption, getRecommendedProducts } from 'scenes/onboarding/productRecommendations'
+import { inviteLogic } from 'scenes/settings/organization/inviteLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -37,7 +42,7 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
             eventUsageLogic,
             ['reportOnboardingStarted', 'reportOnboardingProductSelectionPath', 'reportOnboardingProductToggled'],
         ],
-        values: [teamLogic, ['currentTeam']],
+        values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']],
     })),
 
     actions({
@@ -165,6 +170,10 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
     })),
 
     selectors({
+        isSmartPrefetchEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => featureFlags[FEATURE_FLAGS.ONBOARDING_SMART_PREFETCH] === 'test',
+        ],
         browsingHistoryProducts: [
             (s) => [s.browsingHistory],
             (browsingHistory): ProductKey[] => mapBrowsingHistoryToProducts(browsingHistory),
@@ -322,6 +331,15 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
         },
 
         handleStartOnboarding: () => {
+            if (values.isSmartPrefetchEnabled) {
+                // Warm up any onboarding-time network calls before redirecting into a product flow.
+                // `sdksLogic` triggers `loadSnippetEvents()` on mount.
+                sdksLogic.mount()
+
+                inviteLogic.mount()
+                inviteLogic.actions.loadInvites()
+            }
+
             const nextUrl = getRelativeNextPath(router.values.searchParams['next'], location)
 
             if (nextUrl && nextUrl !== '/') {
@@ -369,7 +387,7 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
         },
     })),
 
-    afterMount(({ actions }) => {
+    afterMount(({ actions, values }) => {
         const browsingHistory = getBrowsingHistoryFromPostHog()
         if (browsingHistory.length > 0) {
             actions.setBrowsingHistory(browsingHistory)
@@ -382,5 +400,10 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
         }
 
         actions.reportOnboardingStarted('product_selection')
+
+        if (values.isSmartPrefetchEnabled) {
+            billingLogic.mount()
+            billingLogic.actions.loadBilling()
+        }
     }),
 ])

--- a/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
+++ b/frontend/src/scenes/onboarding/productSelection/productSelectionLogic.ts
@@ -9,7 +9,6 @@ import { getRelativeNextPath } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { billingLogic } from 'scenes/billing/billingLogic'
 import { onboardingLogic } from 'scenes/onboarding/onboardingLogic'
-import { sdksLogic } from 'scenes/onboarding/sdks/sdksLogic'
 import { USE_CASE_OPTIONS, UseCaseOption, getRecommendedProducts } from 'scenes/onboarding/productRecommendations'
 import { inviteLogic } from 'scenes/settings/organization/inviteLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -404,6 +403,8 @@ export const productSelectionLogic = kea<productSelectionLogicType>([
         if (values.isSmartPrefetchEnabled) {
             billingLogic.mount()
             billingLogic.actions.loadBilling()
+            inviteLogic.mount()
+            inviteLogic.actions.loadInvites()
         }
     }),
 ])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Onboarding step transitions currently trigger visible loading states (billing, SDK snippet HogQL query, and various lazy-loaded UI chunks).
This creates perceived slowness and likely increases drop-off across the flow.

## Changes

- Add `onboarding-smart-prefetch` feature flag (multivariate `control,test`) to gate smart prefetching work.
- Prefetch billing data on the product selection page (test variant only).
- Prefetch invite data + SDK snippet “has events?” HogQL query earlier in the flow (test variant only), including step-ahead prefetching based on the next onboarding step.
- Add guards so step-ahead prefetch doesn’t misbehave for unknown step keys.

## How did you test this code?

- `pnpm --filter=@posthog/frontend jest frontend/src/scenes/onboarding/onboardingLogic.test.ts`
- Manual testing still pending (agent WIP). Will add a short onboarding walkthrough recording once end-to-end dev run is complete.

## Publish to changelog?

do not publish to changelog

## Docs update

N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [POS-29](https://linear.app/posthog-team-growth/issue/POS-29/onboarding-smart-prefetching-to-eliminate-loading-times)

<div><a href="https://cursor.com/agents/bc-88e26d9e-e8c2-4bff-bb3e-cb22fcf0e26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88e26d9e-e8c2-4bff-bb3e-cb22fcf0e26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

