### PR TITLE
feat(experiments): respect team flags_persistence_default when creating experiments

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -262,17 +262,35 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(mock_report_user_action.call_args.kwargs["team"], self.team)
         self.assertIsNotNone(mock_report_user_action.call_args.kwargs["request"])
 
-    def test_creating_experiment_with_ensure_experience_continuity(self):
-        ff_key = "test-continuity-flag"
+    @parameterized.expand(
+        [
+            ("explicit_true_team_false", False, True, True),
+            ("explicit_false_team_false", False, False, False),
+            ("omitted_team_false", False, None, False),
+            ("omitted_team_true", True, None, True),
+            ("explicit_false_overrides_team_true", True, False, False),
+        ]
+    )
+    def test_creating_experiment_ensure_experience_continuity(
+        self, _name, flags_persistence_default, params_value, expected
+    ):
+        self.team.flags_persistence_default = flags_persistence_default
+        self.team.save()
+
+        ff_key = f"test-continuity-{_name}"
+        parameters: dict = {}
+        if params_value is not None:
+            parameters["ensure_experience_continuity"] = params_value
+
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",
             {
-                "name": "Test Experiment with Continuity",
+                "name": f"Test Experiment {_name}",
                 "description": "",
-                "start_date": None,  # Draft experiment
+                "start_date": None,
                 "end_date": None,
                 "feature_flag_key": ff_key,
-                "parameters": {"ensure_experience_continuity": True},
+                "parameters": parameters,
                 "filters": {
                     "events": [{"order": 0, "id": "$pageview"}],
                     "properties": [],
@@ -281,56 +299,8 @@ class TestExperimentCRUD(APILicensedTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.json()["name"], "Test Experiment with Continuity")
-        self.assertEqual(response.json()["feature_flag_key"], ff_key)
-
-        # Check that the feature flag was created with ensure_experience_continuity
         created_ff = FeatureFlag.objects.get(key=ff_key)
-        self.assertEqual(created_ff.ensure_experience_continuity, True)
-
-        # Test with ensure_experience_continuity set to False
-        ff_key_false = "test-no-continuity-flag"
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/experiments/",
-            {
-                "name": "Test Experiment without Continuity",
-                "description": "",
-                "start_date": None,
-                "end_date": None,
-                "feature_flag_key": ff_key_false,
-                "parameters": {"ensure_experience_continuity": False},
-                "filters": {
-                    "events": [{"order": 0, "id": "$pageview"}],
-                    "properties": [],
-                },
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        created_ff_false = FeatureFlag.objects.get(key=ff_key_false)
-        self.assertEqual(created_ff_false.ensure_experience_continuity, False)
-
-        # Test without specifying ensure_experience_continuity (should default to False)
-        ff_key_default = "test-default-continuity-flag"
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/experiments/",
-            {
-                "name": "Test Experiment with Default Continuity",
-                "description": "",
-                "start_date": None,
-                "end_date": None,
-                "feature_flag_key": ff_key_default,
-                "parameters": {},
-                "filters": {
-                    "events": [{"order": 0, "id": "$pageview"}],
-                    "properties": [],
-                },
-            },
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        created_ff_default = FeatureFlag.objects.get(key=ff_key_default)
-        self.assertEqual(created_ff_default.ensure_experience_continuity, False)
+        self.assertEqual(created_ff.ensure_experience_continuity, expected)
 
     def test_creating_experiment_with_rollout_percentage(self):
         ff_key = "test-rollout-flag"

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -1,3 +1,4 @@
+import { useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconBalance, IconInfo, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
@@ -12,6 +13,7 @@ import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { Link } from 'lib/lemon-ui/Link/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { alphabet, formatPercentage } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
 
 import type { Experiment, MultivariateFlagVariant } from '~/types'
 
@@ -86,6 +88,7 @@ export const VariantsPanelCreateFeatureFlag = ({
     disabled = false,
     layout = 'horizontal',
 }: VariantsPanelCreateFeatureFlagProps): JSX.Element => {
+    const { currentTeam } = useValues(teamLogic)
     const [isCustomSplit, setIsCustomSplit] = useState(false)
 
     const variants = experiment.parameters?.feature_flag_variants || [
@@ -94,7 +97,9 @@ export const VariantsPanelCreateFeatureFlag = ({
     ]
 
     const ensureExperienceContinuity =
-        (experiment.parameters as { ensure_experience_continuity?: boolean })?.ensure_experience_continuity ?? false
+        (experiment.parameters as { ensure_experience_continuity?: boolean })?.ensure_experience_continuity ??
+        currentTeam?.flags_persistence_default ??
+        false
 
     const rolloutPercentage =
         experiment.parameters?.rollout_percentage ?? NEW_EXPERIMENT.parameters.rollout_percentage ?? 100

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -376,6 +376,8 @@ class ExperimentService:
         }
         if params.get("ensure_experience_continuity") is not None:
             feature_flag_data["ensure_experience_continuity"] = params["ensure_experience_continuity"]
+        else:
+            feature_flag_data["ensure_experience_continuity"] = self.team.flags_persistence_default or False
         if create_in_folder is not None:
             feature_flag_data["_create_in_folder"] = create_in_folder
 


### PR DESCRIPTION
## Problem

When a team has "ensure continuity" (`flags_persistence_default`) enabled in project settings, new feature flags automatically default to persisting across authentication steps. However, experiments ignored this setting — their feature flags always defaulted `ensure_experience_continuity` to `false`.

## Changes

- **Backend**: `ExperimentService._ensure_feature_flag()` now falls back to `self.team.flags_persistence_default` when `ensure_experience_continuity` is not explicitly provided in experiment parameters.
- **Frontend**: `VariantsPanelCreateFeatureFlag` reads `currentTeam?.flags_persistence_default` from `teamLogic` so the persistence checkbox starts checked when the team setting is enabled.

## Testing

- Extended `test_creating_experiment_with_ensure_experience_continuity` to verify:
  - Team default `True` is applied when not explicitly provided
  - Explicit `False` overrides the team default
 - Also tested locally that on/off setting behaved as expected