### PR TITLE
feat: support slack role

### DIFF
--- a/products/conversations/backend/api/slack_oauth.py
+++ b/products/conversations/backend/api/slack_oauth.py
@@ -33,6 +33,7 @@ SUPPORTHOG_SLACK_SCOPE = ",".join(
         "groups:read",
         "reactions:read",
         "users:read",
+        "users:read.email",
     ]
 )
 

--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -196,6 +196,7 @@ class TestBackfillThreadReplies(BaseTest):
         assert comment.item_context == {
             "author_type": "customer",
             "is_private": False,
+            "from_slack": True,
             "slack_user_id": "U_BOB",
             "slack_author_name": "Bob",
             "slack_author_email": "b@x.com",

--- a/products/conversations/backend/api/tests/test_slack_team_member_detection.py
+++ b/products/conversations/backend/api/tests/test_slack_team_member_detection.py
@@ -1,0 +1,332 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.db import transaction
+
+from posthog.models.comment import Comment
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+
+from products.conversations.backend.models import Ticket
+from products.conversations.backend.models.constants import Channel
+from products.conversations.backend.slack import (
+    _backfill_thread_replies,
+    create_or_update_slack_ticket,
+    resolve_posthog_user_for_slack,
+)
+
+MODULE = "products.conversations.backend.slack"
+
+CHANNEL_ID = "C_SUPPORT"
+PARENT_TS = "1700000000.000100"
+REPLY_TS = "1700000000.000200"
+SLACK_TEAM = "T_WORKSPACE"
+
+
+def _team_member_user_info(email: str) -> dict:
+    return {"name": "Team Member", "email": email, "avatar": "https://av/team.png"}
+
+
+def _customer_user_info() -> dict:
+    return {"name": "Customer", "email": "customer@example.com", "avatar": None}
+
+
+def immediate_on_commit(func):
+    func()
+
+
+class TestResolvePosthogUserForSlack(BaseTest):
+    def test_returns_user_when_email_matches_org_member(self):
+        result = resolve_posthog_user_for_slack(self.user.email, self.team)
+        assert result is not None
+        assert result.id == self.user.id
+
+    def test_returns_none_for_non_member_email(self):
+        result = resolve_posthog_user_for_slack("stranger@example.com", self.team)
+        assert result is None
+
+    def test_returns_none_for_empty_email(self):
+        assert resolve_posthog_user_for_slack(None, self.team) is None
+        assert resolve_posthog_user_for_slack("", self.team) is None
+
+    def test_scoped_to_team_organization(self):
+        other_org = Organization.objects.create(name="Other Org")
+        other_team = Team.objects.create(organization=other_org)
+        result = resolve_posthog_user_for_slack(self.user.email, other_team)
+        assert result is None
+
+
+class TestCreateOrUpdateSlackTicketTeamMemberDetection(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.conversations_settings = {"slack_enabled": True, "slack_channel_id": CHANNEL_ID}
+        self.team.save()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_new_ticket_from_team_member_sets_support_author_type(self, _files, mock_resolve, mock_client):
+        mock_resolve.return_value = _team_member_user_info(self.user.email)
+        mock_client.return_value = MagicMock()
+
+        ticket = create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL_ID,
+            thread_ts=PARENT_TS,
+            slack_user_id="U_TEAM",
+            text="I'll create this ticket",
+            slack_team_id=SLACK_TEAM,
+        )
+
+        assert ticket is not None
+        comment = Comment.objects.get(item_id=str(ticket.id))
+        assert comment.item_context["author_type"] == "support"
+        assert comment.item_context["from_slack"] is True
+        assert comment.created_by_id == self.user.id
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_new_ticket_from_team_member_has_zero_unread_team_count(self, _files, mock_resolve, mock_client):
+        mock_resolve.return_value = _team_member_user_info(self.user.email)
+        mock_client.return_value = MagicMock()
+
+        ticket = create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL_ID,
+            thread_ts=PARENT_TS,
+            slack_user_id="U_TEAM",
+            text="Team member opens ticket",
+            slack_team_id=SLACK_TEAM,
+        )
+
+        assert ticket is not None
+        ticket.refresh_from_db()
+        assert ticket.unread_team_count == 0
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_new_ticket_from_customer_has_unread_team_count_one(self, _files, mock_resolve, mock_client):
+        mock_resolve.return_value = _customer_user_info()
+        mock_client.return_value = MagicMock()
+
+        ticket = create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL_ID,
+            thread_ts=PARENT_TS,
+            slack_user_id="U_CUST",
+            text="Help me please",
+            slack_team_id=SLACK_TEAM,
+        )
+
+        assert ticket is not None
+        ticket.refresh_from_db()
+        assert ticket.unread_team_count == 1
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_new_ticket_from_customer_sets_customer_author_type(self, _files, mock_resolve, mock_client):
+        mock_resolve.return_value = _customer_user_info()
+        mock_client.return_value = MagicMock()
+
+        ticket = create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL_ID,
+            thread_ts=PARENT_TS,
+            slack_user_id="U_CUST",
+            text="Help me",
+            slack_team_id=SLACK_TEAM,
+        )
+
+        assert ticket is not None
+        comment = Comment.objects.get(item_id=str(ticket.id))
+        assert comment.item_context["author_type"] == "customer"
+        assert comment.item_context["from_slack"] is True
+        assert comment.created_by is None
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_thread_reply_from_team_member_does_not_increment_unread_team(self, _files, mock_resolve, mock_client):
+        mock_resolve.return_value = _team_member_user_info(self.user.email)
+        mock_client.return_value = MagicMock()
+
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id=CHANNEL_ID,
+            slack_thread_ts=PARENT_TS,
+            unread_team_count=1,
+        )
+
+        create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL_ID,
+            thread_ts=PARENT_TS,
+            slack_user_id="U_TEAM",
+            text="Team member reply",
+            is_thread_reply=True,
+            slack_team_id=SLACK_TEAM,
+        )
+
+        ticket.refresh_from_db()
+        assert ticket.unread_team_count == 1  # unchanged
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_thread_reply_from_customer_increments_unread_team(self, _files, mock_resolve, mock_client):
+        mock_resolve.return_value = _customer_user_info()
+        mock_client.return_value = MagicMock()
+
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id=CHANNEL_ID,
+            slack_thread_ts=PARENT_TS,
+            unread_team_count=1,
+        )
+
+        create_or_update_slack_ticket(
+            team=self.team,
+            slack_channel_id=CHANNEL_ID,
+            thread_ts=PARENT_TS,
+            slack_user_id="U_CUST",
+            text="Customer reply",
+            is_thread_reply=True,
+            slack_team_id=SLACK_TEAM,
+        )
+
+        ticket.refresh_from_db()
+        assert ticket.unread_team_count == 2
+
+
+class TestBackfillTeamMemberDetection(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.conversations_settings = {"slack_enabled": True}
+        self.team.save()
+        self.ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id=CHANNEL_ID,
+            slack_thread_ts=PARENT_TS,
+            unread_team_count=1,
+            unread_customer_count=0,
+        )
+
+    def _mock_client(self, replies: list[dict]) -> MagicMock:
+        client = MagicMock()
+        client.conversations_replies.return_value = {"messages": replies}
+        return client
+
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_backfill_splits_unread_counts_by_author_type(self, _files, mock_resolve):
+        def resolve_side_effect(client, slack_user_id):
+            if slack_user_id == "U_TEAM":
+                return _team_member_user_info(self.user.email)
+            return _customer_user_info()
+
+        mock_resolve.side_effect = resolve_side_effect
+
+        replies = [
+            {"ts": PARENT_TS, "user": "U_CUST", "text": "parent"},
+            {"ts": "1700000000.000200", "user": "U_CUST", "text": "customer reply"},
+            {"ts": "1700000000.000300", "user": "U_TEAM", "text": "team reply"},
+            {"ts": "1700000000.000400", "user": "U_CUST", "text": "another customer reply"},
+        ]
+        client = self._mock_client(replies)
+
+        _backfill_thread_replies(client, self.team, self.ticket, CHANNEL_ID, PARENT_TS)
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.unread_team_count == 3  # 1 original + 2 customer replies
+        assert self.ticket.unread_customer_count == 1  # 1 team reply
+
+        comments = Comment.objects.filter(item_id=str(self.ticket.id)).order_by("created_at")
+        customer_comments = [c for c in comments if c.item_context["author_type"] == "customer"]
+        team_comments = [c for c in comments if c.item_context["author_type"] == "support"]
+        assert len(customer_comments) == 2
+        assert len(team_comments) == 1
+        assert team_comments[0].created_by_id == self.user.id
+
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_backfill_all_customer_messages_only_increments_unread_team(self, _files, mock_resolve):
+        mock_resolve.return_value = _customer_user_info()
+
+        replies = [
+            {"ts": PARENT_TS, "user": "U_CUST", "text": "parent"},
+            {"ts": "1700000000.000200", "user": "U_CUST", "text": "reply 1"},
+            {"ts": "1700000000.000300", "user": "U_CUST2", "text": "reply 2"},
+        ]
+        client = self._mock_client(replies)
+
+        _backfill_thread_replies(client, self.team, self.ticket, CHANNEL_ID, PARENT_TS)
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.unread_team_count == 3  # 1 original + 2 backfilled
+        assert self.ticket.unread_customer_count == 0  # no team messages
+
+
+@patch.object(transaction, "on_commit", side_effect=immediate_on_commit)
+class TestSlackEchoPreventionSignal(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.conversations_settings = {"slack_enabled": True}
+        self.team.save()
+        self.slack_ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id="",
+            distinct_id="slack-user",
+            channel_source=Channel.SLACK,
+            slack_channel_id=CHANNEL_ID,
+            slack_thread_ts=PARENT_TS,
+        )
+
+    @patch("products.conversations.backend.tasks.post_reply_to_slack.delay")
+    def test_from_slack_team_message_does_not_echo_back(self, mock_delay, _on_commit):
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.slack_ticket.id),
+            content="Team member replied in Slack",
+            created_by=self.user,
+            item_context={"author_type": "support", "is_private": False, "from_slack": True},
+        )
+
+        mock_delay.assert_not_called()
+
+    @patch("products.conversations.backend.tasks.post_reply_to_slack.delay")
+    def test_posthog_ui_team_message_does_echo_to_slack(self, mock_delay, _on_commit):
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.slack_ticket.id),
+            content="Reply from PostHog UI",
+            created_by=self.user,
+            item_context={"author_type": "support", "is_private": False},
+        )
+
+        mock_delay.assert_called_once()
+
+    @patch("products.conversations.backend.tasks.post_reply_to_slack.delay")
+    def test_from_slack_customer_message_does_not_echo(self, mock_delay, _on_commit):
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.slack_ticket.id),
+            content="Customer message from Slack",
+            item_context={"author_type": "customer", "is_private": False, "from_slack": True},
+        )
+
+        mock_delay.assert_not_called()

--- a/products/conversations/backend/api/tests/test_slack_team_member_detection.py
+++ b/products/conversations/backend/api/tests/test_slack_team_member_detection.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from django.db import transaction
 
+from parameterized import parameterized
+
 from posthog.models.comment import Comment
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
@@ -19,7 +21,6 @@ MODULE = "products.conversations.backend.slack"
 
 CHANNEL_ID = "C_SUPPORT"
 PARENT_TS = "1700000000.000100"
-REPLY_TS = "1700000000.000200"
 SLACK_TEAM = "T_WORKSPACE"
 
 
@@ -62,97 +63,66 @@ class TestCreateOrUpdateSlackTicketTeamMemberDetection(BaseTest):
         self.team.conversations_settings = {"slack_enabled": True, "slack_channel_id": CHANNEL_ID}
         self.team.save()
 
+    @parameterized.expand(
+        [
+            ("team_member", True, "support", True, 0),
+            ("customer", False, "customer", False, 1),
+        ]
+    )
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.resolve_slack_user")
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_new_ticket_from_team_member_sets_support_author_type(self, _files, mock_resolve, mock_client):
-        mock_resolve.return_value = _team_member_user_info(self.user.email)
+    def test_new_ticket_author_type_and_unread(
+        self,
+        _name,
+        is_team,
+        expected_author_type,
+        expect_created_by,
+        expected_unread,
+        _files,
+        mock_resolve,
+        mock_client,
+    ):
+        mock_resolve.return_value = _team_member_user_info(self.user.email) if is_team else _customer_user_info()
         mock_client.return_value = MagicMock()
 
         ticket = create_or_update_slack_ticket(
             team=self.team,
             slack_channel_id=CHANNEL_ID,
             thread_ts=PARENT_TS,
-            slack_user_id="U_TEAM",
-            text="I'll create this ticket",
+            slack_user_id="U_AUTHOR",
+            text="A message",
             slack_team_id=SLACK_TEAM,
         )
 
         assert ticket is not None
         comment = Comment.objects.get(item_id=str(ticket.id))
         assert isinstance(comment.item_context, dict)
-        assert comment.item_context["author_type"] == "support"
+        assert comment.item_context["author_type"] == expected_author_type
         assert comment.item_context["from_slack"] is True
-        assert comment.created_by_id == self.user.id
-
-    @patch(f"{MODULE}.get_slack_client")
-    @patch(f"{MODULE}.resolve_slack_user")
-    @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_new_ticket_from_team_member_has_zero_unread_team_count(self, _files, mock_resolve, mock_client):
-        mock_resolve.return_value = _team_member_user_info(self.user.email)
-        mock_client.return_value = MagicMock()
-
-        ticket = create_or_update_slack_ticket(
-            team=self.team,
-            slack_channel_id=CHANNEL_ID,
-            thread_ts=PARENT_TS,
-            slack_user_id="U_TEAM",
-            text="Team member opens ticket",
-            slack_team_id=SLACK_TEAM,
-        )
-
-        assert ticket is not None
+        assert (comment.created_by_id == self.user.id) == expect_created_by
         ticket.refresh_from_db()
-        assert ticket.unread_team_count == 0
+        assert ticket.unread_team_count == expected_unread
 
+    @parameterized.expand(
+        [
+            ("team_member", True, 1),
+            ("customer", False, 2),
+        ]
+    )
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.resolve_slack_user")
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_new_ticket_from_customer_has_unread_team_count_one(self, _files, mock_resolve, mock_client):
-        mock_resolve.return_value = _customer_user_info()
-        mock_client.return_value = MagicMock()
-
-        ticket = create_or_update_slack_ticket(
-            team=self.team,
-            slack_channel_id=CHANNEL_ID,
-            thread_ts=PARENT_TS,
-            slack_user_id="U_CUST",
-            text="Help me please",
-            slack_team_id=SLACK_TEAM,
-        )
-
-        assert ticket is not None
-        ticket.refresh_from_db()
-        assert ticket.unread_team_count == 1
-
-    @patch(f"{MODULE}.get_slack_client")
-    @patch(f"{MODULE}.resolve_slack_user")
-    @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_new_ticket_from_customer_sets_customer_author_type(self, _files, mock_resolve, mock_client):
-        mock_resolve.return_value = _customer_user_info()
-        mock_client.return_value = MagicMock()
-
-        ticket = create_or_update_slack_ticket(
-            team=self.team,
-            slack_channel_id=CHANNEL_ID,
-            thread_ts=PARENT_TS,
-            slack_user_id="U_CUST",
-            text="Help me",
-            slack_team_id=SLACK_TEAM,
-        )
-
-        assert ticket is not None
-        comment = Comment.objects.get(item_id=str(ticket.id))
-        assert isinstance(comment.item_context, dict)
-        assert comment.item_context["author_type"] == "customer"
-        assert comment.item_context["from_slack"] is True
-        assert comment.created_by is None
-
-    @patch(f"{MODULE}.get_slack_client")
-    @patch(f"{MODULE}.resolve_slack_user")
-    @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_thread_reply_from_team_member_does_not_increment_unread_team(self, _files, mock_resolve, mock_client):
-        mock_resolve.return_value = _team_member_user_info(self.user.email)
+    def test_thread_reply_unread_team_count(
+        self,
+        _name,
+        is_team,
+        expected_unread,
+        _files,
+        mock_resolve,
+        mock_client,
+    ):
+        mock_resolve.return_value = _team_member_user_info(self.user.email) if is_team else _customer_user_info()
         mock_client.return_value = MagicMock()
 
         ticket = Ticket.objects.create_with_number(
@@ -169,44 +139,14 @@ class TestCreateOrUpdateSlackTicketTeamMemberDetection(BaseTest):
             team=self.team,
             slack_channel_id=CHANNEL_ID,
             thread_ts=PARENT_TS,
-            slack_user_id="U_TEAM",
-            text="Team member reply",
+            slack_user_id="U_AUTHOR",
+            text="A reply",
             is_thread_reply=True,
             slack_team_id=SLACK_TEAM,
         )
 
         ticket.refresh_from_db()
-        assert ticket.unread_team_count == 1  # unchanged
-
-    @patch(f"{MODULE}.get_slack_client")
-    @patch(f"{MODULE}.resolve_slack_user")
-    @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_thread_reply_from_customer_increments_unread_team(self, _files, mock_resolve, mock_client):
-        mock_resolve.return_value = _customer_user_info()
-        mock_client.return_value = MagicMock()
-
-        ticket = Ticket.objects.create_with_number(
-            team=self.team,
-            channel_source=Channel.SLACK,
-            widget_session_id="",
-            distinct_id="",
-            slack_channel_id=CHANNEL_ID,
-            slack_thread_ts=PARENT_TS,
-            unread_team_count=1,
-        )
-
-        create_or_update_slack_ticket(
-            team=self.team,
-            slack_channel_id=CHANNEL_ID,
-            thread_ts=PARENT_TS,
-            slack_user_id="U_CUST",
-            text="Customer reply",
-            is_thread_reply=True,
-            slack_team_id=SLACK_TEAM,
-        )
-
-        ticket.refresh_from_db()
-        assert ticket.unread_team_count == 2
+        assert ticket.unread_team_count == expected_unread
 
 
 class TestBackfillTeamMemberDetection(BaseTest):
@@ -230,9 +170,39 @@ class TestBackfillTeamMemberDetection(BaseTest):
         client.conversations_replies.return_value = {"messages": replies}
         return client
 
+    @parameterized.expand(
+        [
+            (
+                "mixed_team_and_customer",
+                ["U_CUST", "U_TEAM", "U_CUST"],
+                3,
+                1,
+                2,
+                1,
+            ),
+            (
+                "all_customer",
+                ["U_CUST", "U_CUST2"],
+                3,
+                0,
+                2,
+                0,
+            ),
+        ]
+    )
     @patch(f"{MODULE}.resolve_slack_user")
     @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_backfill_splits_unread_counts_by_author_type(self, _files, mock_resolve):
+    def test_backfill_unread_counts(
+        self,
+        _name,
+        reply_users,
+        expected_unread_team,
+        expected_unread_customer,
+        expected_customer_comments,
+        expected_team_comments,
+        _files,
+        mock_resolve,
+    ):
         def resolve_side_effect(client, slack_user_id):
             if slack_user_id == "U_TEAM":
                 return _team_member_user_info(self.user.email)
@@ -240,44 +210,22 @@ class TestBackfillTeamMemberDetection(BaseTest):
 
         mock_resolve.side_effect = resolve_side_effect
 
-        replies = [
-            {"ts": PARENT_TS, "user": "U_CUST", "text": "parent"},
-            {"ts": "1700000000.000200", "user": "U_CUST", "text": "customer reply"},
-            {"ts": "1700000000.000300", "user": "U_TEAM", "text": "team reply"},
-            {"ts": "1700000000.000400", "user": "U_CUST", "text": "another customer reply"},
-        ]
+        replies = [{"ts": PARENT_TS, "user": "U_CUST", "text": "parent"}]
+        for i, user in enumerate(reply_users):
+            replies.append({"ts": f"1700000000.000{200 + i * 100}", "user": user, "text": f"reply {i}"})
         client = self._mock_client(replies)
 
         _backfill_thread_replies(client, self.team, self.ticket, CHANNEL_ID, PARENT_TS)
 
         self.ticket.refresh_from_db()
-        assert self.ticket.unread_team_count == 3  # 1 original + 2 customer replies
-        assert self.ticket.unread_customer_count == 1  # 1 team reply
+        assert self.ticket.unread_team_count == expected_unread_team
+        assert self.ticket.unread_customer_count == expected_unread_customer
 
         comments = Comment.objects.filter(item_id=str(self.ticket.id)).order_by("created_at")
         customer_comments = [c for c in comments if c.item_context["author_type"] == "customer"]
         team_comments = [c for c in comments if c.item_context["author_type"] == "support"]
-        assert len(customer_comments) == 2
-        assert len(team_comments) == 1
-        assert team_comments[0].created_by_id == self.user.id
-
-    @patch(f"{MODULE}.resolve_slack_user")
-    @patch(f"{MODULE}.extract_slack_files", return_value=[])
-    def test_backfill_all_customer_messages_only_increments_unread_team(self, _files, mock_resolve):
-        mock_resolve.return_value = _customer_user_info()
-
-        replies = [
-            {"ts": PARENT_TS, "user": "U_CUST", "text": "parent"},
-            {"ts": "1700000000.000200", "user": "U_CUST", "text": "reply 1"},
-            {"ts": "1700000000.000300", "user": "U_CUST2", "text": "reply 2"},
-        ]
-        client = self._mock_client(replies)
-
-        _backfill_thread_replies(client, self.team, self.ticket, CHANNEL_ID, PARENT_TS)
-
-        self.ticket.refresh_from_db()
-        assert self.ticket.unread_team_count == 3  # 1 original + 2 backfilled
-        assert self.ticket.unread_customer_count == 0  # no team messages
+        assert len(customer_comments) == expected_customer_comments
+        assert len(team_comments) == expected_team_comments
 
 
 @patch.object(transaction, "on_commit", side_effect=immediate_on_commit)

--- a/products/conversations/backend/api/tests/test_slack_team_member_detection.py
+++ b/products/conversations/backend/api/tests/test_slack_team_member_detection.py
@@ -80,6 +80,7 @@ class TestCreateOrUpdateSlackTicketTeamMemberDetection(BaseTest):
 
         assert ticket is not None
         comment = Comment.objects.get(item_id=str(ticket.id))
+        assert isinstance(comment.item_context, dict)
         assert comment.item_context["author_type"] == "support"
         assert comment.item_context["from_slack"] is True
         assert comment.created_by_id == self.user.id
@@ -142,6 +143,7 @@ class TestCreateOrUpdateSlackTicketTeamMemberDetection(BaseTest):
 
         assert ticket is not None
         comment = Comment.objects.get(item_id=str(ticket.id))
+        assert isinstance(comment.item_context, dict)
         assert comment.item_context["author_type"] == "customer"
         assert comment.item_context["from_slack"] is True
         assert comment.created_by is None

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -229,6 +229,10 @@ def post_slack_reply_on_team_message(sender, instance: Comment, created: bool, *
     if author_type == "customer":
         return
 
+    # Don't echo messages that originated from Slack back to Slack
+    if isinstance(item_context, dict) and item_context.get("from_slack"):
+        return
+
     # Capture values for the deferred callback
     team_id = instance.team_id
     item_id = instance.item_id

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -23,8 +23,10 @@ from PIL import Image
 from slack_sdk import WebClient
 
 from posthog.models.comment import Comment
+from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.uploaded_media import UploadedMedia, save_content_to_object_storage
+from posthog.models.user import User
 
 from .cache import get_cached_slack_user, set_cached_slack_user
 from .formatting import extract_slack_user_ids, slack_to_content_and_rich_content
@@ -126,6 +128,21 @@ def resolve_slack_user(client: WebClient, slack_user_id: str) -> dict:
     except Exception as e:
         logger.warning("slack_support_user_resolve_failed", slack_user_id=slack_user_id, error=str(e))
         return dict(_UNKNOWN_USER)
+
+
+def resolve_posthog_user_for_slack(email: str | None, team: Team) -> User | None:
+    """Match a Slack user's email to a PostHog user within the team's organization."""
+    if not email:
+        return None
+    membership = (
+        OrganizationMembership.objects.filter(
+            organization_id=team.organization_id,
+            user__email=email,
+        )
+        .select_related("user")
+        .first()
+    )
+    return membership.user if membership else None
 
 
 def get_bot_user_id(client: WebClient) -> str | None:
@@ -345,6 +362,10 @@ def create_or_update_slack_ticket(
     # Resolve Slack user info for this message author
     user_info = resolve_slack_user(client, slack_user_id)
 
+    # Check if this Slack user is a PostHog team member
+    posthog_user = resolve_posthog_user_for_slack(user_info.get("email"), team)
+    is_team_member = posthog_user is not None
+
     # Resolve in-message @mentions to display names
     mentioned_ids = extract_slack_user_ids(text, blocks)
     user_names: dict[str, str] = {}
@@ -395,9 +416,11 @@ def create_or_update_slack_ticket(
             item_id=str(ticket.id),
             content=content,
             rich_content=rich_content,
+            created_by=posthog_user,
             item_context={
-                "author_type": "customer",
+                "author_type": "support" if is_team_member else "customer",
                 "is_private": False,
+                "from_slack": True,
                 "slack_user_id": slack_user_id,
                 "slack_author_name": user_info["name"],
                 "slack_author_email": user_info.get("email"),
@@ -406,10 +429,10 @@ def create_or_update_slack_ticket(
             },
         )
 
-        # Increment unread_team_count
-        Ticket.objects.filter(id=ticket.id, team=team).update(
-            unread_team_count=F("unread_team_count") + 1,
-        )
+        if not is_team_member:
+            Ticket.objects.filter(id=ticket.id, team=team).update(
+                unread_team_count=F("unread_team_count") + 1,
+            )
 
         return ticket
 
@@ -441,7 +464,7 @@ def create_or_update_slack_ticket(
         slack_channel_id=slack_channel_id,
         slack_thread_ts=thread_ts,
         slack_team_id=slack_team_id,
-        unread_team_count=1,
+        unread_team_count=0 if is_team_member else 1,
     )
 
     Comment.objects.create(
@@ -450,9 +473,11 @@ def create_or_update_slack_ticket(
         item_id=str(ticket.id),
         content=content,
         rich_content=rich_content,
+        created_by=posthog_user,
         item_context={
-            "author_type": "customer",
+            "author_type": "support" if is_team_member else "customer",
             "is_private": False,
+            "from_slack": True,
             "slack_user_id": slack_user_id,
             "slack_author_name": user_info["name"],
             "slack_author_email": user_info.get("email"),
@@ -644,7 +669,10 @@ def _backfill_thread_replies(
     )
 
     user_cache: dict[str, dict] = {}
+    posthog_user_cache: dict[str, User | None] = {}
     comments_to_create: list[Comment] = []
+    customer_message_count = 0
+    team_message_count = 0
 
     for reply in thread_replies:
         # Match the bot/subtype filtering from handle_support_message
@@ -665,9 +693,19 @@ def _backfill_thread_replies(
             user_cache[reply_user] = resolve_slack_user(client, reply_user)
         user_info = user_cache[reply_user]
 
+        if reply_user not in posthog_user_cache:
+            posthog_user_cache[reply_user] = resolve_posthog_user_for_slack(user_info.get("email"), team)
+        posthog_user = posthog_user_cache[reply_user]
+        is_team_member = posthog_user is not None
+
         cleaned_text, rich_content = slack_to_content_and_rich_content(reply_text, reply_blocks)
         if not cleaned_text and not images:
             continue
+
+        if is_team_member:
+            team_message_count += 1
+        else:
+            customer_message_count += 1
 
         content, rich_content = _build_content_with_images(cleaned_text, rich_content, images)
 
@@ -678,9 +716,11 @@ def _backfill_thread_replies(
                 item_id=str(ticket.id),
                 content=content,
                 rich_content=rich_content,
+                created_by=posthog_user,
                 item_context={
-                    "author_type": "customer",
+                    "author_type": "support" if is_team_member else "customer",
                     "is_private": False,
+                    "from_slack": True,
                     "slack_user_id": reply_user,
                     "slack_author_name": user_info["name"],
                     "slack_author_email": user_info.get("email"),
@@ -695,12 +735,16 @@ def _backfill_thread_replies(
         # messages should not trigger activity log entries or Slack reply notifications.
         created_comments = Comment.objects.bulk_create(comments_to_create)
         last_comment = created_comments[-1]
-        Ticket.objects.filter(id=ticket.id, team=team).update(
-            unread_team_count=F("unread_team_count") + len(comments_to_create),
-            message_count=F("message_count") + len(comments_to_create),
-            last_message_at=last_comment.created_at,
-            last_message_text=(last_comment.content or "")[:500],
-        )
+        update_fields: dict[str, Any] = {
+            "message_count": F("message_count") + len(comments_to_create),
+            "last_message_at": last_comment.created_at,
+            "last_message_text": (last_comment.content or "")[:500],
+        }
+        if customer_message_count:
+            update_fields["unread_team_count"] = F("unread_team_count") + customer_message_count
+        if team_message_count:
+            update_fields["unread_customer_count"] = F("unread_customer_count") + team_message_count
+        Ticket.objects.filter(id=ticket.id, team=team).update(**update_fields)
 
     logger.info(
         "slack_support_reaction_backfill_completed",


### PR DESCRIPTION
## Problem

When we get (or backfill) messages from Slack we marked all of them as "customer".

## Changes

Check is the person is a part of an organization

