### PR TITLE
feat(dashboard-templates): new demo data for dashboard templates

### DIFF
--- a/playwright/page-models/dashboardPage.ts
+++ b/playwright/page-models/dashboardPage.ts
@@ -58,7 +58,11 @@ export class DashboardPage {
         const modal = this.page.locator('.LemonModal').filter({ hasText: 'Create a dashboard' })
         await expect(modal).toBeVisible()
 
-        const templateOption = this.page.getByTestId('create-dashboard-from-template').first()
+        // Pick a template with no variables — `.first()` can hit e.g. AARRR or Product Analytics,
+        // which open the variable picker instead of creating and never leave #newDashboard=modal.
+        const templateOption = this.page
+            .getByTestId('create-dashboard-from-template')
+            .filter({ hasText: 'Website Metrics' })
         await expect(templateOption).toBeVisible()
         await templateOption.click()
 

--- a/posthog/demo/dashboard_template_seeds/01_website_metrics.json
+++ b/posthog/demo/dashboard_template_seeds/01_website_metrics.json
@@ -1,0 +1,211 @@
+{
+    "template_name": "Website Metrics",
+    "dashboard_description": "Understand how many users are visiting your website, the most popular pages, and in which countries is your website being visited from.",
+    "dashboard_filters": {},
+    "tags": [],
+    "tiles": [
+        {
+            "name": "Website Unique Users (Total)",
+            "type": "INSIGHT",
+            "color": "blue",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "$pageview",
+                            "event": "$pageview"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-30d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "BoldNumber",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "compareFilter": {
+                        "compare": true
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "wm-1",
+                    "w": 6,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "wm-1",
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": "Shows the number of unique users over the last 30 days."
+        },
+        {
+            "name": "Top Website Pages (Overall)",
+            "type": "INSIGHT",
+            "color": "black",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "unique_session",
+                            "name": "$pageview",
+                            "event": "$pageview"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-30d",
+                        "explicitDate": false
+                    },
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$current_url",
+                                        "type": "event",
+                                        "value": "?",
+                                        "operator": "not_icontains"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsBarValue",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$current_url",
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 8,
+                    "i": "wm-2",
+                    "w": 6,
+                    "x": 0,
+                    "y": 5,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "wm-2",
+                    "w": 1,
+                    "x": 0,
+                    "y": 5,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        },
+        {
+            "name": "Website Users by Location",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "$pageview",
+                            "event": "$pageview"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-30d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "WorldMap",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$geoip_country_code",
+                        "breakdown_type": "person"
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 8,
+                    "i": "wm-3",
+                    "w": 12,
+                    "x": 0,
+                    "y": 13,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "wm-3",
+                    "w": 1,
+                    "x": 0,
+                    "y": 10,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        }
+    ],
+    "variables": [],
+    "image_url": "https://posthog.com/template_art/growth-dash.png",
+    "scope": "global"
+}

--- a/posthog/demo/dashboard_template_seeds/02_aarrr_pirate_metrics.json
+++ b/posthog/demo/dashboard_template_seeds/02_aarrr_pirate_metrics.json
@@ -1,0 +1,151 @@
+{
+    "template_name": "AARRR \u2013 Pirate Metrics",
+    "dashboard_description": "The AARRR framework, also known as \"pirate metrics\" or the AARRR funnel, is a classic framework for understanding customer behavior. Useful for marketers, product managers and growth hackers at startups.",
+    "dashboard_filters": {},
+    "tags": [],
+    "tiles": [
+        {
+            "body": "### Acquisition\n\nEdit the insights below to match your acquisition events. [Pirate metrics guide](https://posthog.com/blog/aarrr-pirate-funnel)",
+            "type": "TEXT",
+            "color": null,
+            "layouts": {
+                "sm": {
+                    "h": 4,
+                    "i": "aar-1",
+                    "w": 12,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 2,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 4,
+                    "i": "aar-1",
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 2,
+                    "minW": 1
+                }
+            }
+        },
+        {
+            "name": "Activation conversion",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "FunnelsQuery",
+                    "series": ["{SIGNED_UP}", "{LOGGED_ID}"],
+                    "dateRange": {
+                        "date_from": "-90d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "funnelsFilter": {
+                        "layout": "horizontal",
+                        "exclusions": [],
+                        "funnelVizType": "steps",
+                        "funnelOrderType": "ordered",
+                        "funnelStepReference": "total",
+                        "funnelWindowInterval": 1,
+                        "breakdownAttributionType": "first_touch",
+                        "funnelWindowIntervalUnit": "week"
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "aar-2",
+                    "w": 6,
+                    "x": 0,
+                    "y": 4,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "aar-2",
+                    "w": 1,
+                    "x": 0,
+                    "y": 4,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": "Signup to login within one week."
+        },
+        {
+            "name": "Weekly user retention",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "RetentionQuery",
+                    "dateRange": {
+                        "date_from": "-7d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "retentionFilter": {
+                        "period": "Week",
+                        "targetEntity": "{LOGGED_ID}",
+                        "retentionType": "retention_recurring",
+                        "totalIntervals": 9,
+                        "returningEntity": "{LOGGED_ID}",
+                        "retentionReference": "total"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 7,
+                    "i": "aar-3",
+                    "w": 6,
+                    "x": 6,
+                    "y": 4,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 7,
+                    "i": "aar-3",
+                    "w": 1,
+                    "x": 0,
+                    "y": 9,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": "Users who performed the login event and returned."
+        }
+    ],
+    "variables": [
+        {
+            "id": "SIGNED_UP",
+            "name": "User signed up",
+            "type": "event",
+            "default": {},
+            "required": true,
+            "description": "User signing up"
+        },
+        {
+            "id": "LOGGED_ID",
+            "name": "User logged in",
+            "type": "event",
+            "default": {},
+            "required": true,
+            "description": "A user login"
+        }
+    ],
+    "image_url": "https://posthog.com/template_art/aarrr-dash.png",
+    "scope": "global"
+}

--- a/posthog/demo/dashboard_template_seeds/03_csp_violation_reports.json
+++ b/posthog/demo/dashboard_template_seeds/03_csp_violation_reports.json
@@ -1,0 +1,213 @@
+{
+    "template_name": "CSP Violation Reports",
+    "dashboard_description": "Monitor pages violating your Content Security Policy: volume trends, directives, URLs, and recent raw events.",
+    "dashboard_filters": {
+        "date_to": null,
+        "date_from": null,
+        "properties": [],
+        "breakdown_filter": null
+    },
+    "tags": [],
+    "tiles": [
+        {
+            "name": "Violations (DAU)",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "$csp_violation",
+                            "event": "$csp_violation"
+                        }
+                    ],
+                    "interval": "day",
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "BoldNumber",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 3,
+                    "i": "csp-1",
+                    "w": 4,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 1,
+                    "minW": 1
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "csp-1",
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 1,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        },
+        {
+            "name": "Violations over time",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "total",
+                            "name": "$csp_violation",
+                            "event": "$csp_violation"
+                        }
+                    ],
+                    "interval": "day",
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 3,
+                    "i": "csp-2",
+                    "w": 8,
+                    "x": 4,
+                    "y": 0,
+                    "minH": 1,
+                    "minW": 1
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "csp-2",
+                    "w": 1,
+                    "x": 0,
+                    "y": 5,
+                    "minH": 1,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        },
+        {
+            "name": "By violated directive",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "total",
+                            "name": "$csp_violation",
+                            "event": "$csp_violation"
+                        }
+                    ],
+                    "interval": "day",
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "ActionsPie",
+                        "showLegend": true,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": true,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": true,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$csp_violated_directive",
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "csp-3",
+                    "w": 6,
+                    "x": 0,
+                    "y": 3,
+                    "minH": 1,
+                    "minW": 1
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "csp-3",
+                    "w": 1,
+                    "x": 0,
+                    "y": 10,
+                    "minH": 1,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        },
+        {
+            "name": "Recent violations",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "DataVisualizationNode",
+                "source": {
+                    "kind": "HogQLQuery",
+                    "query": "SELECT timestamp,\n       properties.$csp_violated_directive,\n       properties.$current_url\n  FROM events\n WHERE timestamp >= now() - interval 7 day\n   AND event = '$csp_violation'\n ORDER BY timestamp DESC\n LIMIT 100"
+                },
+                "display": "ActionsTable"
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "csp-4",
+                    "w": 6,
+                    "x": 6,
+                    "y": 3,
+                    "minH": 1,
+                    "minW": 1
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "csp-4",
+                    "w": 1,
+                    "x": 0,
+                    "y": 15,
+                    "minH": 1,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        }
+    ],
+    "variables": [],
+    "image_url": "https://res.cloudinary.com/dmukukwp6/image/upload/Group_9520_67a2ff6557.png",
+    "scope": "global"
+}

--- a/posthog/demo/dashboard_template_seeds/04_api_usage_metrics.json
+++ b/posthog/demo/dashboard_template_seeds/04_api_usage_metrics.json
@@ -1,0 +1,198 @@
+{
+    "template_name": "API usage metrics",
+    "dashboard_description": "Monitor programmatic API usage of data",
+    "dashboard_filters": {},
+    "tags": ["api", "monitoring"],
+    "tiles": [
+        {
+            "name": "API - number of queries",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "DataVisualizationNode",
+                "source": {
+                    "kind": "HogQLQuery",
+                    "name": null,
+                    "tags": null,
+                    "query": "select event_date, count(1) as number_of_queries\nfrom query_log\nwhere is_personal_api_key_request and event_date >= today() - interval 21 day\ngroup by event_date\norder by event_date asc",
+                    "values": null,
+                    "explain": null,
+                    "filters": {
+                        "dateRange": null,
+                        "properties": null,
+                        "filterTestAccounts": null
+                    },
+                    "version": null,
+                    "response": null,
+                    "modifiers": null,
+                    "variables": {}
+                },
+                "display": "ActionsLineGraph",
+                "chartSettings": {
+                    "xAxis": {
+                        "column": "event_date"
+                    },
+                    "yAxis": [
+                        {
+                            "column": "number_of_queries",
+                            "settings": {
+                                "formatting": {
+                                    "prefix": "",
+                                    "suffix": ""
+                                }
+                            }
+                        }
+                    ],
+                    "showLegend": true,
+                    "seriesBreakdownColumn": null
+                },
+                "tableSettings": {
+                    "conditionalFormatting": []
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "2643681",
+                    "w": 6,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 1,
+                    "minW": 1,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "2643681",
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 1,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        },
+        {
+            "name": "API - last 20 queries",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "DataVisualizationNode",
+                "source": {
+                    "kind": "HogQLQuery",
+                    "name": null,
+                    "tags": null,
+                    "query": "select event_time as finished_at, query_duration_ms, query, created_by \nfrom query_log\nwhere is_personal_api_key_request\n    and event_date = today()\norder by event_time desc\nlimit 20",
+                    "values": null,
+                    "explain": null,
+                    "filters": {
+                        "dateRange": null,
+                        "properties": null,
+                        "filterTestAccounts": null
+                    },
+                    "version": null,
+                    "response": null,
+                    "modifiers": null,
+                    "variables": {}
+                },
+                "display": "ActionsTable",
+                "chartSettings": {
+                    "xAxis": {
+                        "column": "query_start_time"
+                    },
+                    "yAxis": [
+                        {
+                            "column": "query_duration_ms",
+                            "settings": {
+                                "formatting": {
+                                    "prefix": "",
+                                    "suffix": ""
+                                }
+                            }
+                        },
+                        {
+                            "column": "created_by",
+                            "settings": {
+                                "formatting": {
+                                    "prefix": "",
+                                    "suffix": ""
+                                }
+                            }
+                        }
+                    ],
+                    "seriesBreakdownColumn": null
+                },
+                "tableSettings": {
+                    "columns": [
+                        {
+                            "column": "finished_at",
+                            "settings": {
+                                "formatting": {
+                                    "prefix": "",
+                                    "suffix": ""
+                                }
+                            }
+                        },
+                        {
+                            "column": "query_duration_ms",
+                            "settings": {
+                                "formatting": {
+                                    "prefix": "",
+                                    "suffix": ""
+                                }
+                            }
+                        },
+                        {
+                            "column": "query",
+                            "settings": {
+                                "formatting": {
+                                    "prefix": "",
+                                    "suffix": ""
+                                }
+                            }
+                        },
+                        {
+                            "column": "created_by",
+                            "settings": {
+                                "formatting": {
+                                    "prefix": "",
+                                    "suffix": ""
+                                }
+                            }
+                        }
+                    ],
+                    "conditionalFormatting": []
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "2643705",
+                    "w": 12,
+                    "x": 0,
+                    "y": 5,
+                    "minH": 1,
+                    "minW": 1,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "2643705",
+                    "w": 1,
+                    "x": 0,
+                    "y": 20,
+                    "minH": 1,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        }
+    ],
+    "variables": [],
+    "image_url": null,
+    "scope": "global",
+    "availability_contexts": []
+}

--- a/posthog/demo/dashboard_template_seeds/05_landing_pages_report.json
+++ b/posthog/demo/dashboard_template_seeds/05_landing_pages_report.json
@@ -1,0 +1,173 @@
+{
+    "template_name": "Landing Pages Report",
+    "dashboard_description": "Analyze trends on landing pages, including where users come from, browser, and device type.",
+    "dashboard_filters": {
+        "date_to": null,
+        "date_from": "-30d",
+        "properties": []
+    },
+    "tags": [],
+    "tiles": [
+        {
+            "body": "### How to use this dashboard\n\nFilter by **Current URL** to focus on specific landing pages.\n\nThis seed includes a subset of tiles from the production template.",
+            "type": "TEXT",
+            "color": null,
+            "layouts": {
+                "sm": {
+                    "h": 4,
+                    "i": "257126",
+                    "w": 12,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 2,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 6,
+                    "i": "257126",
+                    "w": 1,
+                    "x": 0,
+                    "y": 50,
+                    "minH": 2,
+                    "minW": 1
+                }
+            }
+        },
+        {
+            "name": "Unique Sessions Trend",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "unique_session",
+                            "name": "$pageview",
+                            "event": "$pageview",
+                            "custom_name": "Unique Sessions"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-30d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "ActionsAreaGraph",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": true,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 7,
+                    "i": "256443",
+                    "w": 12,
+                    "x": 0,
+                    "y": 4,
+                    "minH": 5,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "256443",
+                    "w": 1,
+                    "x": 0,
+                    "y": 20,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": "Unique sessions on landing page(s)"
+        },
+        {
+            "name": "Most Popular Landing Pages",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "unique_session",
+                            "name": "$pageview",
+                            "event": "$pageview"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-30d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "ActionsTable",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "compareFilter": {
+                        "compare": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$current_url",
+                        "breakdown_type": "event",
+                        "breakdown_normalize_url": true
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 8,
+                    "i": "256402",
+                    "w": 6,
+                    "x": 0,
+                    "y": 15,
+                    "minH": 5,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "256402",
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": "Breakdown of most popular landing pages by unique sessions"
+        }
+    ],
+    "variables": [],
+    "image_url": "https://posthog.com/template_art/website-dash.png",
+    "scope": "global",
+    "availability_contexts": null
+}

--- a/posthog/demo/dashboard_template_seeds/06_mobile_analytics.json
+++ b/posthog/demo/dashboard_template_seeds/06_mobile_analytics.json
@@ -1,0 +1,332 @@
+{
+    "template_name": "Mobile Analytics",
+    "dashboard_description": "A collection of mobile app focused insights",
+    "dashboard_filters": {
+        "date_to": null,
+        "date_from": null,
+        "properties": [
+            {
+                "key": "$lib",
+                "type": "event",
+                "value": ["posthog-ios", "posthog-android", "posthog-react-native", "posthog-flutter"],
+                "operator": "exact"
+            }
+        ]
+    },
+    "tags": [],
+    "tiles": [
+        {
+            "name": "DAU",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "All events"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-7d",
+                        "explicitDate": false
+                    },
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "type": "AND",
+                                        "values": [
+                                            {
+                                                "key": "$lib",
+                                                "type": "event",
+                                                "value": [
+                                                    "posthog-ios",
+                                                    "posthog-android",
+                                                    "posthog-react-native",
+                                                    "posthog-flutter"
+                                                ],
+                                                "operator": "exact"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$lib",
+                                        "type": "event",
+                                        "value": [
+                                            "posthog-ios",
+                                            "posthog-android",
+                                            "posthog-react-native",
+                                            "posthog-flutter"
+                                        ],
+                                        "operator": "exact"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "638548",
+                    "w": 3,
+                    "x": 6,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "638548",
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": "unique users from all events grouped by Day"
+        },
+        {
+            "name": "Adoption by country",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "total",
+                            "name": "All events"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-7d",
+                        "explicitDate": false
+                    },
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "type": "AND",
+                                        "values": [
+                                            {
+                                                "key": "$lib",
+                                                "type": "event",
+                                                "value": [
+                                                    "posthog-ios",
+                                                    "posthog-android",
+                                                    "posthog-react-native",
+                                                    "posthog-flutter"
+                                                ],
+                                                "operator": "exact"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$lib",
+                                        "type": "event",
+                                        "value": [
+                                            "posthog-ios",
+                                            "posthog-android",
+                                            "posthog-react-native",
+                                            "posthog-flutter"
+                                        ],
+                                        "operator": "exact"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "trendsFilter": {
+                        "display": "WorldMap",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$geoip_country_code",
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "638552",
+                    "w": 6,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "638552",
+                    "w": 1,
+                    "x": 0,
+                    "y": 35,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        },
+        {
+            "name": "Most common screens",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "total",
+                            "name": "$screen",
+                            "event": "$screen"
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-7d",
+                        "explicitDate": false
+                    },
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "type": "AND",
+                                        "values": [
+                                            {
+                                                "key": "$lib",
+                                                "type": "event",
+                                                "value": [
+                                                    "posthog-ios",
+                                                    "posthog-android",
+                                                    "posthog-react-native",
+                                                    "posthog-flutter"
+                                                ],
+                                                "operator": "exact"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$lib",
+                                        "type": "event",
+                                        "value": [
+                                            "posthog-ios",
+                                            "posthog-android",
+                                            "posthog-react-native",
+                                            "posthog-flutter"
+                                        ],
+                                        "operator": "exact"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsBarValue",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$screen_name",
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "638546",
+                    "w": 4,
+                    "x": 0,
+                    "y": 20,
+                    "minH": 5,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "638546",
+                    "w": 1,
+                    "x": 0,
+                    "y": 30,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": ""
+        }
+    ],
+    "variables": [],
+    "image_url": "https://posthog.com/template_art/mobile-dash.png",
+    "scope": "global",
+    "availability_contexts": null
+}

--- a/posthog/demo/dashboard_template_seeds/07_product_analytics.json
+++ b/posthog/demo/dashboard_template_seeds/07_product_analytics.json
@@ -1,0 +1,184 @@
+{
+    "template_name": "Product Analytics",
+    "dashboard_description": "High-level overview of your product including daily active users, weekly active users, retention, and growth accounting.",
+    "dashboard_filters": {},
+    "tags": [],
+    "tiles": [
+        {
+            "name": "Daily active users (DAUs)",
+            "type": "INSIGHT",
+            "color": "blue",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": ["{DAILY_ACTIVE_USER}"],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "-30d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "w": 6,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 5,
+                    "w": 1,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 3
+                }
+            },
+            "description": "Shows the number of unique users that use your app every day."
+        },
+        {
+            "name": "Weekly active users (WAUs)",
+            "type": "INSIGHT",
+            "color": "green",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": ["{WEEKLY_ACTIVE_USER}"],
+                    "interval": "week",
+                    "dateRange": {
+                        "date_from": "-90d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "w": 6,
+                    "x": 6,
+                    "y": 0,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 5,
+                    "w": 1,
+                    "x": 0,
+                    "y": 5,
+                    "minH": 5,
+                    "minW": 3
+                }
+            },
+            "description": "Shows the number of unique users that use your app every week."
+        },
+        {
+            "name": "Retention",
+            "type": "INSIGHT",
+            "color": "blue",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "RetentionQuery",
+                    "dateRange": {
+                        "date_from": "-7d",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "retentionFilter": {
+                        "period": "Week",
+                        "targetEntity": "{DAILY_ACTIVE_USER}",
+                        "retentionType": "retention_first_time",
+                        "totalIntervals": 11,
+                        "returningEntity": "{DAILY_ACTIVE_USER}"
+                    },
+                    "filterTestAccounts": false
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "w": 6,
+                    "x": 6,
+                    "y": 5,
+                    "minH": 5,
+                    "minW": 3
+                },
+                "xs": {
+                    "h": 5,
+                    "w": 1,
+                    "x": 0,
+                    "y": 10,
+                    "minH": 5,
+                    "minW": 3
+                }
+            },
+            "description": "Weekly retention of your users."
+        }
+    ],
+    "variables": [
+        {
+            "id": "DAILY_ACTIVE_USER",
+            "name": "Daily active user event",
+            "type": "event",
+            "default": {
+                "id": "$pageview",
+                "math": "dau",
+                "name": "$pageview",
+                "type": "events"
+            },
+            "required": false,
+            "description": "The event you use to define a daily active user. Defaults to pageview, but mobile apps should use an event like screenview."
+        },
+        {
+            "id": "WEEKLY_ACTIVE_USER",
+            "name": "Weekly active user event",
+            "type": "event",
+            "default": {
+                "id": "$pageview",
+                "math": "weekly_active",
+                "name": "$pageview",
+                "type": "events"
+            },
+            "required": false,
+            "description": "The event you use to define a weekly active user. Defaults to pageview, but mobile apps should use an event like screenview."
+        }
+    ],
+    "image_url": "https://posthog.com/template_art/analytics-dash.png",
+    "scope": "global",
+    "availability_contexts": null
+}

--- a/posthog/demo/dashboard_template_seeds/08_real_time_analytics.json
+++ b/posthog/demo/dashboard_template_seeds/08_real_time_analytics.json
@@ -1,0 +1,224 @@
+{
+    "template_name": "Real time analytics",
+    "dashboard_description": "Understand your site or app traffic in (near) real time.",
+    "dashboard_filters": {
+        "date_to": null,
+        "date_from": "dStart",
+        "properties": [
+            {
+                "key": "dateDiff('minute', timestamp, now()) < 30",
+                "type": "hogql",
+                "value": null
+            }
+        ]
+    },
+    "tags": [],
+    "tiles": [
+        {
+            "name": "Unique users (last 30 minutes)",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "All events",
+                            "properties": [
+                                {
+                                    "key": "dateDiff('minute', timestamp, now()) < 30",
+                                    "type": "hogql"
+                                }
+                            ]
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "dStart",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "BoldNumber",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "308997",
+                    "w": 3,
+                    "x": 3,
+                    "y": 0,
+                    "minH": 4,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "308997",
+                    "w": 1,
+                    "x": 0,
+                    "y": 25,
+                    "minH": 4,
+                    "minW": 1
+                }
+            },
+            "description": "Number of unique users recently."
+        },
+        {
+            "name": "Unique sessions (last 30 minutes)",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "unique_session",
+                            "name": "All events",
+                            "properties": [
+                                {
+                                    "key": "dateDiff('minute', timestamp, now()) < 30",
+                                    "type": "hogql"
+                                }
+                            ]
+                        }
+                    ],
+                    "interval": "hour",
+                    "dateRange": {
+                        "date_from": "dStart",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "BoldNumber",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown_type": "event"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "308996",
+                    "w": 3,
+                    "x": 0,
+                    "y": 0,
+                    "minH": 4,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "308996",
+                    "w": 1,
+                    "x": 0,
+                    "y": 30,
+                    "minH": 4,
+                    "minW": 1
+                }
+            },
+            "description": "Number of unique sessions recently, events without session IDs are excluded."
+        },
+        {
+            "name": "Unique users by location (last 30 minutes)",
+            "type": "INSIGHT",
+            "color": null,
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "All events",
+                            "properties": [
+                                {
+                                    "key": "dateDiff('minute', timestamp, now()) < 30",
+                                    "type": "hogql"
+                                }
+                            ]
+                        }
+                    ],
+                    "interval": "day",
+                    "dateRange": {
+                        "date_from": "dStart",
+                        "explicitDate": false
+                    },
+                    "properties": [],
+                    "trendsFilter": {
+                        "display": "WorldMap",
+                        "showLegend": false,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": false,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": false,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": false
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$geoip_country_code",
+                        "breakdown_type": "person"
+                    },
+                    "filterTestAccounts": true
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "h": 5,
+                    "i": "309010",
+                    "w": 6,
+                    "x": 6,
+                    "y": 5,
+                    "minH": 5,
+                    "minW": 3,
+                    "moved": false,
+                    "static": false
+                },
+                "xs": {
+                    "h": 5,
+                    "i": "309010",
+                    "w": 1,
+                    "x": 0,
+                    "y": 15,
+                    "minH": 5,
+                    "minW": 1
+                }
+            },
+            "description": "Where your recent users are from."
+        }
+    ],
+    "variables": [],
+    "image_url": "https://posthog.com/template_art/realtime-dash.png",
+    "scope": "global",
+    "availability_contexts": null
+}

--- a/posthog/demo/dashboard_template_seeds/__init__.py
+++ b/posthog/demo/dashboard_template_seeds/__init__.py
@@ -29,9 +29,9 @@ def seed_dev_dashboard_templates() -> list[str]:
 
     created: list[str] = []
     for payload in load_dashboard_template_seeds():
-        name = payload["template_name"]
-        if name is None:
-            raise ValueError(f"Dashboard template seed has a null 'template_name': {payload}")
+        name = payload.get("template_name")
+        if not name:
+            raise ValueError(f"Dashboard template seed missing or has null 'template_name': {payload}")
         exists = DashboardTemplate.objects.filter(team_id__isnull=True, template_name=name).exists()
         if exists:
             continue

--- a/posthog/demo/dashboard_template_seeds/__init__.py
+++ b/posthog/demo/dashboard_template_seeds/__init__.py
@@ -15,16 +15,12 @@ from typing import Any
 _SEED_JSON_DIR = Path(__file__).resolve().parent
 
 
-def _load_json_seed_templates() -> list[dict[str, Any]]:
+def load_dashboard_template_seeds() -> list[dict[str, Any]]:
+    """Every ``*.json`` in this directory (sorted by filename)."""
     out: list[dict[str, Any]] = []
     for path in sorted(_SEED_JSON_DIR.glob("*.json")):
         out.append(json.loads(path.read_text()))
     return out
-
-
-def iter_dashboard_template_seeds() -> list[dict[str, Any]]:
-    """Every ``*.json`` in this directory (sorted by filename)."""
-    return _load_json_seed_templates()
 
 
 def seed_dev_dashboard_templates() -> list[str]:
@@ -32,9 +28,10 @@ def seed_dev_dashboard_templates() -> list[str]:
     from posthog.models.dashboard_templates import DashboardTemplate
 
     created: list[str] = []
-    for payload in iter_dashboard_template_seeds():
+    for payload in load_dashboard_template_seeds():
         name = payload["template_name"]
-        assert name is not None
+        if name is None:
+            raise ValueError(f"Dashboard template seed has a null 'template_name': {payload}")
         exists = DashboardTemplate.objects.filter(team_id__isnull=True, template_name=name).exists()
         if exists:
             continue

--- a/posthog/demo/dashboard_template_seeds/__init__.py
+++ b/posthog/demo/dashboard_template_seeds/__init__.py
@@ -1,0 +1,54 @@
+"""Global dashboard template seeds for local dev (same idea as ``demo/legacy/*.json`` next to generators).
+
+JSON payloads live in this directory beside this package (like ``demo_people.json`` beside ``web_data_generator.py``).
+Loaded in lexicographic order; use ``01_…``, ``02_…`` filename prefixes to control order.
+
+Used by ``generate_demo_data`` and ``ensure_migration_defaults``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_SEED_JSON_DIR = Path(__file__).resolve().parent
+
+
+def _load_json_seed_templates() -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for path in sorted(_SEED_JSON_DIR.glob("*.json")):
+        out.append(json.loads(path.read_text()))
+    return out
+
+
+def iter_dashboard_template_seeds() -> list[dict[str, Any]]:
+    """Every ``*.json`` in this directory (sorted by filename)."""
+    return _load_json_seed_templates()
+
+
+def seed_dev_dashboard_templates() -> list[str]:
+    """Insert global dashboard templates if missing. Returns names of templates created."""
+    from posthog.models.dashboard_templates import DashboardTemplate
+
+    created: list[str] = []
+    for payload in iter_dashboard_template_seeds():
+        name = payload["template_name"]
+        assert name is not None
+        exists = DashboardTemplate.objects.filter(team_id__isnull=True, template_name=name).exists()
+        if exists:
+            continue
+        DashboardTemplate.objects.create(
+            team_id=None,
+            template_name=name,
+            dashboard_description=payload.get("dashboard_description"),
+            dashboard_filters=payload.get("dashboard_filters"),
+            tiles=payload.get("tiles"),
+            variables=payload.get("variables"),
+            tags=payload.get("tags") or [],
+            image_url=payload.get("image_url"),
+            scope=payload.get("scope") or DashboardTemplate.Scope.GLOBAL,
+            availability_contexts=payload.get("availability_contexts"),
+        )
+        created.append(name)
+    return created

--- a/posthog/management/commands/ensure_migration_defaults.py
+++ b/posthog/management/commands/ensure_migration_defaults.py
@@ -6,7 +6,7 @@ from typing import Any
 from django.apps import apps
 from django.core.management.base import BaseCommand
 
-from posthog.demo.dashboard_template_seeds import iter_dashboard_template_seeds, seed_dev_dashboard_templates
+from posthog.demo.dashboard_template_seeds import seed_dev_dashboard_templates
 from posthog.models.dashboard_templates import DashboardTemplate
 from posthog.models.data_color_theme import DataColorTheme
 
@@ -39,15 +39,8 @@ class Command(BaseCommand):
             create_feature_flag_template(apps, None)
             created_items.append("Dashboard template: Flagged Feature Usage")
 
-        expected_dev_templates = {p["template_name"] for p in iter_dashboard_template_seeds()}
-        have_dev_templates = set(
-            DashboardTemplate.objects.filter(
-                team_id__isnull=True, template_name__in=expected_dev_templates
-            ).values_list("template_name", flat=True)
-        )
-        if expected_dev_templates - have_dev_templates:
-            for name in seed_dev_dashboard_templates():
-                created_items.append(f"Dashboard template: {name}")
+        for name in seed_dev_dashboard_templates():
+            created_items.append(f"Dashboard template: {name}")
 
         if created_items:
             self.stdout.write("Created defaults:\n- " + "\n- ".join(created_items))

--- a/posthog/management/commands/ensure_migration_defaults.py
+++ b/posthog/management/commands/ensure_migration_defaults.py
@@ -6,6 +6,7 @@ from typing import Any
 from django.apps import apps
 from django.core.management.base import BaseCommand
 
+from posthog.demo.dashboard_template_seeds import iter_dashboard_template_seeds, seed_dev_dashboard_templates
 from posthog.models.dashboard_templates import DashboardTemplate
 from posthog.models.data_color_theme import DataColorTheme
 
@@ -37,6 +38,16 @@ class Command(BaseCommand):
         if not DashboardTemplate.objects.filter(template_name="Flagged Feature Usage", team__isnull=True).exists():
             create_feature_flag_template(apps, None)
             created_items.append("Dashboard template: Flagged Feature Usage")
+
+        expected_dev_templates = {p["template_name"] for p in iter_dashboard_template_seeds()}
+        have_dev_templates = set(
+            DashboardTemplate.objects.filter(
+                team_id__isnull=True, template_name__in=expected_dev_templates
+            ).values_list("template_name", flat=True)
+        )
+        if expected_dev_templates - have_dev_templates:
+            for name in seed_dev_dashboard_templates():
+                created_items.append(f"Dashboard template: {name}")
 
         if created_items:
             self.stdout.write("Created defaults:\n- " + "\n- ".join(created_items))

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -12,6 +12,7 @@ from django.core import exceptions
 from django.core.management.base import BaseCommand
 
 from posthog.api.person import PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES
+from posthog.demo.dashboard_template_seeds import seed_dev_dashboard_templates
 from posthog.demo.matrix import Matrix, MatrixManager
 from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.demo.products.spikegpt import SpikeGPTMatrix
@@ -212,6 +213,13 @@ class Command(BaseCommand):
             if existing_team_id != 0 and team:
                 print("Marking all quick start tasks as completed...")
                 self.complete_all_quick_start_tasks(team)
+
+            print("Seeding extra global dashboard templates (dev)...")
+            created_templates = seed_dev_dashboard_templates()
+            if created_templates:
+                print(f"Created dashboard templates: {', '.join(created_templates)}")
+            else:
+                print("Dashboard template seeds already present.")
 
             print(
                 "\nMaster project reset!\n"


### PR DESCRIPTION
## Problem

The dashboard templates we have locally are not on par with the ones we have on production (which are manually curated).

## Changes

Adds a selection of templates based on the curated ones on production.

<img width="1794" height="1750" alt="CleanShot 2026-03-24 at 12 45 34@2x" src="https://github.com/user-attachments/assets/6a8b569e-cf45-4ff0-8548-abe8f97ad6d7" />


## How did you test this code?

Locally.

## Publish to changelog?

No.