### PR TITLE
feat(logs): add "View in context" dropdown to log details and row actions

### DIFF
--- a/products/logs/frontend/components/LogsViewer/LogContextSelector/LogContextSelector.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogContextSelector/LogContextSelector.tsx
@@ -1,0 +1,56 @@
+import { useActions } from 'kea'
+import posthog from 'posthog-js'
+
+import { IconList } from '@posthog/icons'
+import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
+
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+
+import { logDetailsModalLogic } from '../LogDetailsModal/logDetailsModalLogic'
+import { logsViewerModalLogic } from '../LogsViewerModal/logsViewerModalLogic'
+import { buildContextFilters, getAvailableContexts } from './logContextUtils'
+
+interface LogContextSelectorProps {
+    log: ParsedLogMessage
+    size?: 'xsmall' | 'small'
+    noPadding?: boolean
+}
+
+export function LogContextSelector({ log, size = 'xsmall', noPadding }: LogContextSelectorProps): JSX.Element | null {
+    const { openLogsViewerModal } = useActions(logsViewerModalLogic)
+    const { closeLogDetails } = useActions(logDetailsModalLogic)
+
+    const contexts = getAvailableContexts(log)
+    if (contexts.length === 0) {
+        return null
+    }
+
+    return (
+        <LemonMenu
+            items={contexts.map((ctx) => ({
+                label: ctx.label,
+                tooltip: ctx.description,
+                onClick: () => {
+                    posthog.capture('logs context viewed', { context_type: ctx.type })
+                    closeLogDetails()
+                    const filters = buildContextFilters(log, ctx.type)
+                    openLogsViewerModal({
+                        id: `context-${log.uuid}-${ctx.type}`,
+                        fullScreen: false,
+                        initialFilters: filters,
+                    })
+                },
+            }))}
+        >
+            <LemonButton
+                size={size}
+                icon={<IconList />}
+                tooltip="View in context"
+                aria-label="View in context"
+                noPadding={noPadding ?? size === 'xsmall'}
+                className="text-muted"
+                data-attr="logs-viewer-context-selector"
+            />
+        </LemonMenu>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogContextSelector/logContextUtils.test.ts
+++ b/products/logs/frontend/components/LogsViewer/LogContextSelector/logContextUtils.test.ts
@@ -1,0 +1,113 @@
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+
+import { buildContextFilters, getAvailableContexts, LogContextType } from './logContextUtils'
+
+const makeLog = (overrides: Partial<ParsedLogMessage> = {}): ParsedLogMessage => ({
+    uuid: 'test-uuid',
+    trace_id: '',
+    span_id: '',
+    body: 'test log message',
+    attributes: {},
+    resource_attributes: {},
+    timestamp: '2026-03-24T12:00:00.000Z',
+    observed_timestamp: '2026-03-24T12:00:00.000Z',
+    severity_text: 'info',
+    severity_number: 9,
+    level: 'info',
+    instrumentation_scope: '',
+    event_name: '',
+    cleanBody: 'test log message',
+    parsedBody: null,
+    originalLog: {} as any,
+    ...overrides,
+})
+
+const makeFilterGroup = (key: string, value: string, type: PropertyFilterType): any => ({
+    type: FilterLogicalOperator.And,
+    values: [
+        {
+            type: FilterLogicalOperator.And,
+            values: [{ key, value: [value], operator: PropertyOperator.Exact, type }],
+        },
+    ],
+})
+
+describe('getAvailableContexts', () => {
+    it.each([
+        ['bare log', {}, ['surrounding_all']],
+        [
+            'with service',
+            { resource_attributes: { 'service.name': 'api' } },
+            ['surrounding_service', 'surrounding_all'],
+        ],
+        ['with trace', { trace_id: 'abc' }, ['surrounding_all', 'trace']],
+        ['with session', { attributes: { 'session.id': 's1' } }, ['surrounding_all', 'session']],
+        [
+            'all metadata',
+            { resource_attributes: { 'service.name': 'api' }, trace_id: 'abc', attributes: { 'session.id': 's1' } },
+            ['surrounding_service', 'surrounding_all', 'trace', 'session'],
+        ],
+    ])('%s → %j', (_, overrides, expectedTypes) => {
+        const types = getAvailableContexts(makeLog(overrides as any)).map((c) => c.type)
+        expect(types).toEqual(expectedTypes)
+    })
+})
+
+describe('buildContextFilters', () => {
+    const timestamp = '2026-03-24T12:00:00.000Z'
+    const log = makeLog({
+        timestamp,
+        resource_attributes: { 'service.name': 'api-server' },
+        trace_id: 'trace-abc',
+        attributes: { 'session.id': 'sess-123' },
+    })
+
+    it.each([
+        ['surrounding_service', 1],
+        ['surrounding_all', 1],
+        ['trace', 5],
+        ['session', 30],
+    ] as [LogContextType, number][])('%s sets date range with ±%d min window', (contextType, windowMinutes) => {
+        const filters = buildContextFilters(log, contextType)
+        const from = new Date(filters.dateRange!.date_from!).getTime()
+        const to = new Date(filters.dateRange!.date_to!).getTime()
+        const center = new Date(timestamp).getTime()
+        expect(from).toBe(center - windowMinutes * 60 * 1000)
+        expect(to).toBe(center + windowMinutes * 60 * 1000)
+    })
+
+    it.each([['surrounding_service'], ['surrounding_all'], ['trace'], ['session']] as [LogContextType][])(
+        '%s clears search term and severity levels',
+        (contextType) => {
+            const filters = buildContextFilters(log, contextType)
+            expect(filters.searchTerm).toBe('')
+            expect(filters.severityLevels).toEqual([])
+        }
+    )
+
+    it.each([
+        ['surrounding_service', { serviceNames: ['api-server'] }],
+        ['surrounding_all', { serviceNames: [] }],
+        ['trace', { filterGroup: makeFilterGroup('trace_id', 'trace-abc', PropertyFilterType.Log) }],
+        ['session', { filterGroup: makeFilterGroup('session.id', 'sess-123', PropertyFilterType.LogAttribute) }],
+    ] as [LogContextType, Record<string, any>][])(
+        '%s sets correct context-specific filters',
+        (contextType, expected) => {
+            const filters = buildContextFilters(log, contextType)
+            expect(filters).toEqual(expect.objectContaining(expected))
+        }
+    )
+
+    it.each([
+        ['surrounding_service with no service → empty serviceNames', 'surrounding_service', {}, { serviceNames: [] }],
+        ['session with no session_id → undefined filterGroup', 'session', {}, { filterGroup: undefined }],
+    ] as [string, LogContextType, Record<string, any>, Record<string, any>][])(
+        '%s',
+        (_, contextType, overrides, expected) => {
+            const filters = buildContextFilters(makeLog({ timestamp, ...overrides }), contextType)
+            expect(filters).toEqual(expect.objectContaining(expected))
+        }
+    )
+})

--- a/products/logs/frontend/components/LogsViewer/LogContextSelector/logContextUtils.ts
+++ b/products/logs/frontend/components/LogsViewer/LogContextSelector/logContextUtils.ts
@@ -1,0 +1,143 @@
+import { dayjs } from 'lib/dayjs'
+
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, UniversalFiltersGroup } from '~/types'
+
+import { LogsViewerFilters } from 'products/logs/frontend/components/LogsViewer/config/types'
+import { ParsedLogMessage } from 'products/logs/frontend/types'
+import { getSessionIdWithKey } from 'products/logs/frontend/utils'
+
+export type LogContextType = 'surrounding_service' | 'surrounding_all' | 'trace' | 'session'
+
+export interface LogContextOption {
+    type: LogContextType
+    label: string
+    description: string
+}
+
+const SURROUNDING_WINDOW_MINUTES = 1
+const TRACE_WINDOW_MINUTES = 5
+const SESSION_WINDOW_MINUTES = 30
+
+function getServiceName(log: ParsedLogMessage): string | null {
+    const resourceAttrs = log.resource_attributes as Record<string, unknown> | undefined
+    const serviceName = resourceAttrs?.['service.name']
+    return serviceName ? String(serviceName) : null
+}
+
+function getSessionMatch(
+    log: ParsedLogMessage
+): { key: string; value: string; source: 'attribute' | 'resource_attribute' } | null {
+    return getSessionIdWithKey(log.attributes, log.resource_attributes as Record<string, unknown> | undefined)
+}
+
+function buildDateRangeAround(timestamp: string, windowMinutes: number): { date_from: string; date_to: string } {
+    const center = dayjs(timestamp)
+    return {
+        date_from: center.subtract(windowMinutes, 'minute').toISOString(),
+        date_to: center.add(windowMinutes, 'minute').toISOString(),
+    }
+}
+
+function buildFilterGroup(key: string, value: string, propertyType: PropertyFilterType): UniversalFiltersGroup {
+    return {
+        type: FilterLogicalOperator.And,
+        values: [
+            {
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
+                        key,
+                        value: [value],
+                        operator: PropertyOperator.Exact,
+                        type: propertyType,
+                    } as any,
+                ],
+            },
+        ],
+    }
+}
+
+export function getAvailableContexts(log: ParsedLogMessage): LogContextOption[] {
+    const contexts: LogContextOption[] = []
+    const serviceName = getServiceName(log)
+
+    if (serviceName) {
+        contexts.push({
+            type: 'surrounding_service',
+            label: 'View surrounding logs',
+            description: `Logs from ${serviceName} around this time`,
+        })
+    }
+
+    contexts.push({
+        type: 'surrounding_all',
+        label: 'View all logs at this time',
+        description: 'All logs across services around this time',
+    })
+
+    if (log.trace_id) {
+        contexts.push({
+            type: 'trace',
+            label: 'View trace logs',
+            description: 'All logs sharing this trace ID',
+        })
+    }
+
+    if (getSessionMatch(log)) {
+        contexts.push({
+            type: 'session',
+            label: 'View session logs',
+            description: 'All logs from this session',
+        })
+    }
+
+    return contexts
+}
+
+export function buildContextFilters(log: ParsedLogMessage, contextType: LogContextType): Partial<LogsViewerFilters> {
+    const base: Pick<LogsViewerFilters, 'searchTerm' | 'severityLevels'> = {
+        searchTerm: '',
+        severityLevels: [],
+    }
+
+    switch (contextType) {
+        case 'surrounding_service': {
+            const serviceName = getServiceName(log)
+            return {
+                ...base,
+                dateRange: buildDateRangeAround(log.timestamp, SURROUNDING_WINDOW_MINUTES),
+                serviceNames: serviceName ? [serviceName] : [],
+            }
+        }
+        case 'surrounding_all': {
+            return {
+                ...base,
+                dateRange: buildDateRangeAround(log.timestamp, SURROUNDING_WINDOW_MINUTES),
+                serviceNames: [],
+            }
+        }
+        case 'trace': {
+            return {
+                ...base,
+                dateRange: buildDateRangeAround(log.timestamp, TRACE_WINDOW_MINUTES),
+                filterGroup: buildFilterGroup('trace_id', log.trace_id, PropertyFilterType.Log),
+            }
+        }
+        case 'session': {
+            const session = getSessionMatch(log)
+            return {
+                ...base,
+                dateRange: buildDateRangeAround(log.timestamp, SESSION_WINDOW_MINUTES),
+                filterGroup: session
+                    ? buildFilterGroup(
+                          session.key,
+                          session.value,
+                          session.source === 'attribute'
+                              ? PropertyFilterType.LogAttribute
+                              : PropertyFilterType.LogResourceAttribute
+                      )
+                    : undefined,
+            }
+        }
+    }
+}

--- a/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogDetailsModal/LogDetailsModal.tsx
@@ -11,6 +11,7 @@ import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
+import { LogContextSelector } from 'products/logs/frontend/components/LogsViewer/LogContextSelector/LogContextSelector'
 import { LogDetailsTabContent } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/Details/LogDetailsTab'
 
 import { logsViewerLogic } from '../logsViewerLogic'
@@ -108,6 +109,7 @@ export function LogDetailsModal({ timezone }: LogDetailsModalProps): JSX.Element
                                 aria-label="Copy link to log"
                                 data-attr="logs-viewer-copy-link"
                             />
+                            <LogContextSelector log={selectedLog} />
                             <LemonButton
                                 size="xsmall"
                                 icon={<IconX />}

--- a/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogRowFAB/LogRowFAB.tsx
@@ -16,6 +16,7 @@ import { IconLink } from 'lib/lemon-ui/icons'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 
+import { LogContextSelector } from 'products/logs/frontend/components/LogsViewer/LogContextSelector/LogContextSelector'
 import { logDetailsModalLogic } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal'
 import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerLogic'
 import { useCellScrollControls } from 'products/logs/frontend/components/VirtualizedLogsList/useCellScroll'
@@ -122,6 +123,7 @@ export function LogRowFAB({
                     className="text-muted"
                     data-attr="logs-viewer-copy-link"
                 />
+                <LogContextSelector log={log} noPadding />
                 {sessionId && (
                     <ViewRecordingButton
                         sessionId={sessionId}

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -102,19 +102,32 @@ export function isSessionIdKey(key: string): boolean {
     return matchesKey(key, SESSION_ID_KEYS)
 }
 
-export function getSessionIdFromLogAttributes(
+export interface SessionIdMatch {
+    key: string
+    value: string
+    source: 'attribute' | 'resource_attribute'
+}
+
+export function getSessionIdWithKey(
     attributes: Record<string, unknown> | undefined,
     resourceAttributes: Record<string, unknown> | undefined
-): string | null {
+): SessionIdMatch | null {
     for (const [key, value] of Object.entries(attributes || {})) {
         if (isSessionIdKey(key) && value) {
-            return String(value)
+            return { key, value: String(value), source: 'attribute' }
         }
     }
     for (const [key, value] of Object.entries(resourceAttributes || {})) {
         if (isSessionIdKey(key) && value) {
-            return String(value)
+            return { key, value: String(value), source: 'resource_attribute' }
         }
     }
     return null
+}
+
+export function getSessionIdFromLogAttributes(
+    attributes: Record<string, unknown> | undefined,
+    resourceAttributes: Record<string, unknown> | undefined
+): string | null {
+    return getSessionIdWithKey(attributes, resourceAttributes)?.value ?? null
 }


### PR DESCRIPTION
## Problem

Users who find a specific log via search have no way to instantly see surrounding logs in context. They have to manually copy timestamps, clear filters, and re-query - a 4-5 click process for something that should be 1 click. This was the top feedback request from the logs NPS survey.

## Changes

Adds a "View in context" dropdown to both the log detail drawer header and the row hover actions (FAB). The dropdown shows available context pivots based on the log's metadata:

- View surrounding logs: logs from the same service within ±1 min (only shown if `service.name` is present)
- **View all logs at this time**: all logs across services within ±1 min
- **View trace logs**: all logs sharing the same trace ID (only shown if `trace_id` is present)
- **View session logs**: all logs from the same session within ±30 min (only shown if `session_id` is present)

Selecting a pivot opens the existing `LogsViewerModal` with the appropriate filters pre-applied.

![image.png](https://app.graphite.com/user-attachments/assets/6d3fa373-8810-40f5-abd8-772701478d2e.png)



![image.png](https://app.graphite.com/user-attachments/assets/560aca49-74e4-41f7-a352-1a5324a30956.png)



![2026-03-24 17.17.06.gif](https://app.graphite.com/user-attachments/assets/d6ab20a9-f84e-4573-b860-0747134005f0.gif)



## How did you test this code?

- Unit tests for logContextUtils
- Manual testing for UI

## Publish to changelog?

Yes - "View in context" for logs