### PR TITLE
feat(analytics-platform): add dagster job to backfill internal/test users cohort

### DIFF
--- a/posthog/dags/backfill_internal_test_users_cohort.py
+++ b/posthog/dags/backfill_internal_test_users_cohort.py
@@ -50,10 +50,9 @@ def create_internal_test_users_cohorts_op(
         context.log.warning(f"{not_found} team IDs not found in the database, skipping")
 
     # Bulk-create all cohorts in a single INSERT.
-    # There is no unique constraint on (team_id, kind), so there's a small TOCTOU
-    # window where a user could create the cohort via the UI between our check above
-    # and this insert. That's acceptable for a one-off backfill: the worst case is a
-    # duplicate cohort row which is harmless (the UI always queries with .first()).
+    # No race condition: the INTERNAL_TEST_USERS kind can only be set by this
+    # backfill (or get_or_create_internal_test_users_cohort), not by users
+    # through the UI, so no concurrent creation can happen.
     cohorts_to_create = [
         Cohort(
             team=team,

--- a/posthog/dags/backfill_internal_test_users_cohort.py
+++ b/posthog/dags/backfill_internal_test_users_cohort.py
@@ -23,6 +23,11 @@ def create_internal_test_users_cohorts_op(
         ).values_list("team_id", flat=True)
     )
 
+    # Bulk-fetch teams that need a cohort to avoid N+1 queries
+    teams_needing_cohort = {
+        team.id: team for team in Team.objects.filter(id__in=[tid for tid in team_ids if tid not in teams_with_cohort])
+    }
+
     created = 0
     skipped = len(teams_with_cohort)
     failed = 0
@@ -31,14 +36,16 @@ def create_internal_test_users_cohorts_op(
         if team_id in teams_with_cohort:
             continue
 
+        team = teams_needing_cohort.get(team_id)
+        if team is None:
+            context.log.warning(f"Team {team_id} not found, skipping")
+            skipped += 1
+            continue
+
         try:
-            team = Team.objects.get(id=team_id)
             get_or_create_internal_test_users_cohort(team)
             created += 1
             context.log.info(f"Created internal/test users cohort for team {team_id}")
-        except Team.DoesNotExist:
-            context.log.warning(f"Team {team_id} not found, skipping")
-            skipped += 1
         except Exception as e:
             context.log.exception(f"Failed to create cohort for team {team_id}")
             capture_exception(e, {"team_id": team_id})

--- a/posthog/dags/backfill_internal_test_users_cohort.py
+++ b/posthog/dags/backfill_internal_test_users_cohort.py
@@ -1,0 +1,91 @@
+import dagster
+
+from posthog.dags.common import JobOwners
+from posthog.dags.common.ops import get_all_team_ids_op
+from posthog.exceptions_capture import capture_exception
+
+
+@dagster.op
+def create_internal_test_users_cohorts_op(
+    context: dagster.OpExecutionContext,
+    team_ids: list[int],
+) -> dict[str, int]:
+    """Create internal/test users cohort for teams that don't already have one."""
+    from posthog.models.cohort import Cohort
+    from posthog.models.cohort.cohort import CohortKind, get_or_create_internal_test_users_cohort
+    from posthog.models.team import Team
+
+    # Find teams that already have the cohort so we can skip them in bulk
+    teams_with_cohort = set(
+        Cohort.objects.filter(
+            team_id__in=team_ids,
+            kind=CohortKind.INTERNAL_TEST_USERS,
+        ).values_list("team_id", flat=True)
+    )
+
+    created = 0
+    skipped = len(teams_with_cohort)
+    failed = 0
+
+    for team_id in team_ids:
+        if team_id in teams_with_cohort:
+            continue
+
+        try:
+            team = Team.objects.get(id=team_id)
+            get_or_create_internal_test_users_cohort(team)
+            created += 1
+            context.log.info(f"Created internal/test users cohort for team {team_id}")
+        except Team.DoesNotExist:
+            context.log.warning(f"Team {team_id} not found, skipping")
+            skipped += 1
+        except Exception as e:
+            context.log.exception(f"Failed to create cohort for team {team_id}")
+            capture_exception(e, {"team_id": team_id})
+            failed += 1
+
+    context.log.info(f"Batch complete: {created} created, {skipped} skipped, {failed} failed")
+    context.add_output_metadata(
+        {
+            "batch_size": dagster.MetadataValue.int(len(team_ids)),
+            "created": dagster.MetadataValue.int(created),
+            "skipped": dagster.MetadataValue.int(skipped),
+            "failed": dagster.MetadataValue.int(failed),
+        }
+    )
+
+    return {"created": created, "skipped": skipped, "failed": failed}
+
+
+@dagster.op
+def aggregate_cohort_results_op(
+    context: dagster.OpExecutionContext,
+    results: list[dict[str, int]],
+) -> None:
+    """Aggregate results from all batches."""
+    total_created = sum(r["created"] for r in results)
+    total_skipped = sum(r["skipped"] for r in results)
+    total_failed = sum(r["failed"] for r in results)
+
+    context.log.info(f"Completed: {total_created} created, {total_skipped} skipped, {total_failed} failed")
+
+    context.add_output_metadata(
+        {
+            "total_created": dagster.MetadataValue.int(total_created),
+            "total_skipped": dagster.MetadataValue.int(total_skipped),
+            "total_failed": dagster.MetadataValue.int(total_failed),
+        }
+    )
+
+    if total_failed > 0:
+        raise Exception(f"Failed to create internal/test users cohort for {total_failed} teams")
+
+
+@dagster.job(
+    description="Creates internal/test users cohort for all teams that don't already have one",
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value},
+)
+def backfill_internal_test_users_cohort_job():
+    team_ids = get_all_team_ids_op()
+    results = team_ids.map(create_internal_test_users_cohorts_op)
+    aggregate_cohort_results_op(results.collect())

--- a/posthog/dags/backfill_internal_test_users_cohort.py
+++ b/posthog/dags/backfill_internal_test_users_cohort.py
@@ -3,6 +3,9 @@ import dagster
 from posthog.dags.common import JobOwners
 from posthog.dags.common.ops import get_all_team_ids_op
 from posthog.exceptions_capture import capture_exception
+from posthog.models.cohort import Cohort
+from posthog.models.cohort.cohort import CohortKind, get_or_create_internal_test_users_cohort
+from posthog.models.team import Team
 
 
 @dagster.op
@@ -11,9 +14,6 @@ def create_internal_test_users_cohorts_op(
     team_ids: list[int],
 ) -> dict[str, int]:
     """Create internal/test users cohort for teams that don't already have one."""
-    from posthog.models.cohort import Cohort
-    from posthog.models.cohort.cohort import CohortKind, get_or_create_internal_test_users_cohort
-    from posthog.models.team import Team
 
     # Find teams that already have the cohort so we can skip them in bulk
     teams_with_cohort = set(

--- a/posthog/dags/backfill_internal_test_users_cohort.py
+++ b/posthog/dags/backfill_internal_test_users_cohort.py
@@ -2,10 +2,29 @@ import dagster
 
 from posthog.dags.common import JobOwners
 from posthog.dags.common.ops import get_all_team_ids_op
-from posthog.exceptions_capture import capture_exception
 from posthog.models.cohort import Cohort
-from posthog.models.cohort.cohort import CohortKind, get_or_create_internal_test_users_cohort
+from posthog.models.cohort.cohort import INTERNAL_TEST_USERS_COHORT_NAME, CohortKind
 from posthog.models.team import Team
+
+# Standard filter: matches people with $internal_or_test_user set to true
+_INTERNAL_TEST_USERS_FILTERS: dict = {
+    "properties": {
+        "type": "OR",
+        "values": [
+            {
+                "type": "AND",
+                "values": [
+                    {
+                        "key": "$internal_or_test_user",
+                        "type": "person",
+                        "value": [True],
+                        "operator": "exact",
+                    }
+                ],
+            }
+        ],
+    }
+}
 
 
 @dagster.op
@@ -23,45 +42,44 @@ def create_internal_test_users_cohorts_op(
         ).values_list("team_id", flat=True)
     )
 
-    # Bulk-fetch teams that need a cohort to avoid N+1 queries
-    teams_needing_cohort = {
-        team.id: team for team in Team.objects.filter(id__in=[tid for tid in team_ids if tid not in teams_with_cohort])
-    }
+    # Bulk-fetch only teams that need a cohort
+    teams_needing_cohort = list(Team.objects.filter(id__in=[tid for tid in team_ids if tid not in teams_with_cohort]))
 
-    created = 0
-    skipped = len(teams_with_cohort)
-    failed = 0
+    not_found = len(team_ids) - len(teams_with_cohort) - len(teams_needing_cohort)
+    if not_found > 0:
+        context.log.warning(f"{not_found} team IDs not found in the database, skipping")
 
-    for team_id in team_ids:
-        if team_id in teams_with_cohort:
-            continue
+    # Bulk-create all cohorts in a single INSERT.
+    # There is no unique constraint on (team_id, kind), so there's a small TOCTOU
+    # window where a user could create the cohort via the UI between our check above
+    # and this insert. That's acceptable for a one-off backfill: the worst case is a
+    # duplicate cohort row which is harmless (the UI always queries with .first()).
+    cohorts_to_create = [
+        Cohort(
+            team=team,
+            name=INTERNAL_TEST_USERS_COHORT_NAME,
+            description="People who are internal team members or test users. Used for filtering out internal traffic from analytics.",
+            is_static=False,
+            kind=CohortKind.INTERNAL_TEST_USERS,
+            filters=_INTERNAL_TEST_USERS_FILTERS,
+        )
+        for team in teams_needing_cohort
+    ]
 
-        team = teams_needing_cohort.get(team_id)
-        if team is None:
-            context.log.warning(f"Team {team_id} not found, skipping")
-            skipped += 1
-            continue
+    created_cohorts = Cohort.objects.bulk_create(cohorts_to_create)
+    created = len(created_cohorts)
+    skipped = len(teams_with_cohort) + not_found
 
-        try:
-            get_or_create_internal_test_users_cohort(team)
-            created += 1
-            context.log.info(f"Created internal/test users cohort for team {team_id}")
-        except Exception as e:
-            context.log.exception(f"Failed to create cohort for team {team_id}")
-            capture_exception(e, {"team_id": team_id})
-            failed += 1
-
-    context.log.info(f"Batch complete: {created} created, {skipped} skipped, {failed} failed")
+    context.log.info(f"Batch complete: {created} created, {skipped} skipped")
     context.add_output_metadata(
         {
             "batch_size": dagster.MetadataValue.int(len(team_ids)),
             "created": dagster.MetadataValue.int(created),
             "skipped": dagster.MetadataValue.int(skipped),
-            "failed": dagster.MetadataValue.int(failed),
         }
     )
 
-    return {"created": created, "skipped": skipped, "failed": failed}
+    return {"created": created, "skipped": skipped}
 
 
 @dagster.op
@@ -72,20 +90,15 @@ def aggregate_cohort_results_op(
     """Aggregate results from all batches."""
     total_created = sum(r["created"] for r in results)
     total_skipped = sum(r["skipped"] for r in results)
-    total_failed = sum(r["failed"] for r in results)
 
-    context.log.info(f"Completed: {total_created} created, {total_skipped} skipped, {total_failed} failed")
+    context.log.info(f"Completed: {total_created} created, {total_skipped} skipped")
 
     context.add_output_metadata(
         {
             "total_created": dagster.MetadataValue.int(total_created),
             "total_skipped": dagster.MetadataValue.int(total_skipped),
-            "total_failed": dagster.MetadataValue.int(total_failed),
         }
     )
-
-    if total_failed > 0:
-        raise Exception(f"Failed to create internal/test users cohort for {total_failed} teams")
 
 
 @dagster.job(

--- a/posthog/dags/locations/analytics_platform.py
+++ b/posthog/dags/locations/analytics_platform.py
@@ -1,6 +1,7 @@
 import dagster
 
 from posthog.dags import sessions, sessions_v1_cleanup
+from posthog.dags.backfill_internal_test_users_cohort import backfill_internal_test_users_cohort_job
 from posthog.dags.sessions import (
     experimental_sessions_backfill_job,
     experimental_sessions_v3_backfill,
@@ -11,6 +12,11 @@ from . import resources
 
 defs = dagster.Definitions(
     assets=[sessions.sessions_v3_backfill, sessions.sessions_v3_backfill_replay, experimental_sessions_v3_backfill],
-    jobs=[sessions_backfill_job, sessions_v1_cleanup.sessions_v1_cleanup_job, experimental_sessions_backfill_job],
+    jobs=[
+        sessions_backfill_job,
+        sessions_v1_cleanup.sessions_v1_cleanup_job,
+        experimental_sessions_backfill_job,
+        backfill_internal_test_users_cohort_job,
+    ],
     resources=resources,
 )


### PR DESCRIPTION
## Problem

Teams created before #51852 don't have the internal/test users cohort (identified by `kind=internal_test_users`). We need a way to backfill this cohort for all existing teams.

## Changes

- Added a new Dagster job `backfill_internal_test_users_cohort_job` that iterates through all teams in batches and creates the internal/test users cohort for teams that don't already have one
- Uses the existing `get_all_team_ids_op` for batching and the existing `get_or_create_internal_test_users_cohort` function for cohort creation
- Registered the job in the `analytics_platform` Dagster location

## How did you test this code?

Ran the dagster job locally and it succeeded:

<img width="1340" height="824" alt="Screenshot 2026-03-24 at 17 59 59" src="https://github.com/user-attachments/assets/e3a2b1c1-86f4-4d32-97ff-2717af83adaa" />


## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Authored by Claude Opus 4.6 via Claude Code.