### PR TITLE
chore(batch-exports): Clean up old feature flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -238,7 +238,6 @@ export const FEATURE_FLAGS = {
     ALERTS_ANOMALY_DETECTION: 'alerts-anomaly-detection', // owner: @andrewm4894
     ALERTS_INLINE_NOTIFICATIONS: 'alerts-inline-notifications', // owner: @vdekrijger
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
-    BATCH_EXPORT_NEW_LOGS: 'batch-export-new-logs', // owner: #team-batch-exports
     BATCH_EXPORTS_AZURE_BLOB: 'azure-blob-batch-exports', // owner: #team-batch-exports
     BATCH_EXPORTS_DATABRICKS: 'databricks-batch-exports', // owner: @rossgray #team-batch-exports
     BATCH_EXPORTS_BIGQUERY_INTEGRATION: 'batch-exports-bigquery-integration', // owner: @tomasfarias #team-batch-exports

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -238,7 +238,6 @@ export const FEATURE_FLAGS = {
     ALERTS_ANOMALY_DETECTION: 'alerts-anomaly-detection', // owner: @andrewm4894
     ALERTS_INLINE_NOTIFICATIONS: 'alerts-inline-notifications', // owner: @vdekrijger
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
-    BATCH_EXPORTS_DATABRICKS: 'databricks-batch-exports', // owner: @rossgray #team-batch-exports
     BATCH_EXPORTS_BIGQUERY_INTEGRATION: 'batch-exports-bigquery-integration', // owner: @tomasfarias #team-batch-exports
     BACKFILL_WORKFLOWS_DESTINATION: 'backfill-workflows-destination', // owner: #team-batch-exports
     BING_ADS_SOURCE: 'bing-ads-source', // owner: @jabahamondes #team-web-analytics

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -238,7 +238,6 @@ export const FEATURE_FLAGS = {
     ALERTS_ANOMALY_DETECTION: 'alerts-anomaly-detection', // owner: @andrewm4894
     ALERTS_INLINE_NOTIFICATIONS: 'alerts-inline-notifications', // owner: @vdekrijger
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion
-    BATCH_EXPORTS_AZURE_BLOB: 'azure-blob-batch-exports', // owner: #team-batch-exports
     BATCH_EXPORTS_DATABRICKS: 'databricks-batch-exports', // owner: @rossgray #team-batch-exports
     BATCH_EXPORTS_BIGQUERY_INTEGRATION: 'batch-exports-bigquery-integration', // owner: @tomasfarias #team-batch-exports
     BACKFILL_WORKFLOWS_DESTINATION: 'backfill-workflows-destination', // owner: #team-batch-exports

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.tsx
@@ -15,7 +15,6 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { LemonDivider, LemonSkeleton } from '@posthog/lemon-ui'
 
-import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { NotFound } from 'lib/components/NotFound'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -31,7 +30,6 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { BATCH_EXPORT_SERVICE_NAMES, BatchExportService, Breadcrumb } from '~/types'
 
-import { PipelineNodeLogs } from '../legacy-plugins/PipelineNodeLogs'
 import { BatchExportConfigFormLogicProps, batchExportConfigFormLogic } from './batchExportConfigFormLogic'
 import { BatchExportConfiguration } from './BatchExportConfiguration'
 import {
@@ -41,8 +39,7 @@ import {
 import { RenderBatchExportIcon } from './BatchExportIcon'
 import type { batchExportSceneLogicType } from './BatchExportSceneType'
 import { BatchExportsMetrics } from './BatchExportsMetrics'
-import { normalizeBatchExportService } from './utils'
-import { humanizeBatchExportName } from './utils'
+import { humanizeBatchExportName, normalizeBatchExportService } from './utils'
 
 const BATCH_EXPORT_SCENE_TABS = ['configuration', 'metrics', 'logs', 'runs', 'backfills'] as const
 export type BatchExportSceneTab = (typeof BATCH_EXPORT_SCENE_TABS)[number]
@@ -247,14 +244,12 @@ function BatchExportSceneContentInner({
                   label: 'Logs',
                   key: 'logs',
                   content: (
-                      <FlaggedFeature flag="batch-export-new-logs" fallback={<PipelineNodeLogs id={id} />}>
-                          <LogsViewer
-                              sourceType="batch_exports"
-                              sourceId={id}
-                              instanceLabel="run"
-                              defaultFilters={{ levels: ['LOG', 'INFO', 'WARN', 'ERROR'] }}
-                          />
-                      </FlaggedFeature>
+                      <LogsViewer
+                          sourceType="batch_exports"
+                          sourceId={id}
+                          instanceLabel="run"
+                          defaultFilters={{ levels: ['LOG', 'INFO', 'WARN', 'ERROR'] }}
+                      />
                   ),
               }
             : null,

--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -139,13 +139,9 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                 // HTTP is currently only used for Cloud to Cloud migrations and shouldn't be accessible to users
                 const httpEnabled =
                     featureFlags[FEATURE_FLAGS.BATCH_EXPORTS_POSTHOG_HTTP] || user?.is_impersonated || user?.is_staff
-                // Databricks is currently behind a feature flag
-                const databricksEnabled = featureFlags[FEATURE_FLAGS.BATCH_EXPORTS_DATABRICKS]
 
-                const services = BATCH_EXPORT_SERVICE_NAMES.filter(
-                    (service) =>
-                        (httpEnabled ? true : service !== ('HTTP' as const)) &&
-                        (databricksEnabled ? true : service !== ('Databricks' as const))
+                const services = BATCH_EXPORT_SERVICE_NAMES.filter((service) =>
+                    httpEnabled ? true : service !== ('HTTP' as const)
                 )
 
                 return services.map(

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -1049,28 +1049,8 @@ def databricks_integration(team, user):
     )
 
 
-@pytest.fixture
-def enable_databricks(team):
-    with mock.patch(
-        "posthog.batch_exports.http.posthoganalytics.feature_enabled", return_value=True
-    ) as feature_enabled:
-        yield
-        feature_enabled.assert_any_call(
-            "databricks-batch-exports",
-            str(team.uuid),
-            groups={"organization": str(team.organization.id)},
-            group_properties={
-                "organization": {
-                    "id": str(team.organization.id),
-                    "created_at": team.organization.created_at,
-                }
-            },
-            send_feature_flag_events=False,
-        )
-
-
 def test_creating_databricks_batch_export_using_integration(
-    client: HttpClient, temporal, organization, team, user, databricks_integration, enable_databricks
+    client: HttpClient, temporal, organization, team, user, databricks_integration
 ):
     """Test that we can create a Databricks batch export using an integration.
 
@@ -1113,40 +1093,6 @@ def test_creating_databricks_batch_export_using_integration(
     assert schedule.schedule.spec.intervals[0].every == dt.timedelta(hours=1)
     assert isinstance(schedule.schedule.action, ScheduleActionStartWorkflow)
     assert schedule.schedule.action.workflow == "databricks-export"
-
-
-def test_creating_databricks_batch_export_fails_if_feature_flag_is_not_enabled(
-    client: HttpClient, temporal, organization, team, user, databricks_integration
-):
-    """Test that creating a Databricks batch export fails if the feature flag is not enabled."""
-
-    destination_data = {
-        "type": "Databricks",
-        "config": {
-            "http_path": "my-http-path",
-            "catalog": "my-catalog",
-            "schema": "my-schema",
-            "table_name": "my-table-name",
-        },
-        "integration": databricks_integration.id,
-    }
-
-    batch_export_data = {
-        "name": "my-databricks-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
-    client.force_login(user)
-
-    response = create_batch_export(
-        client,
-        team.pk,
-        batch_export_data,
-    )
-
-    assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
-    assert "The Databricks destination is not enabled for this team." in response.json()["detail"]
 
 
 def test_creating_databricks_batch_export_fails_if_integration_is_missing(

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -1096,7 +1096,7 @@ def test_creating_databricks_batch_export_using_integration(
 
 
 def test_creating_databricks_batch_export_fails_if_integration_is_missing(
-    client: HttpClient, temporal, organization, team, user, enable_databricks
+    client: HttpClient, temporal, organization, team, user
 ):
     """Test that creating a Databricks batch export fails if the integration is missing.
 
@@ -1136,7 +1136,7 @@ def test_creating_databricks_batch_export_fails_if_integration_is_missing(
 
 
 def test_creating_databricks_batch_export_fails_if_integration_is_invalid(
-    client: HttpClient, temporal, organization, team, user, enable_databricks
+    client: HttpClient, temporal, organization, team, user
 ):
     """Test that creating a Databricks batch export fails if the integration is invalid.
 
@@ -1228,7 +1228,7 @@ def test_creating_databricks_batch_export_fails_if_integration_does_not_exist(
 
 
 def test_creating_databricks_batch_export_fails_if_integration_is_not_the_correct_type(
-    client: HttpClient, temporal, organization, team, user, enable_databricks
+    client: HttpClient, temporal, organization, team, user
 ):
     """Test that creating a Databricks batch export fails if the integration is not the correct type.
 

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -1327,41 +1327,6 @@ def test_creating_databricks_batch_export_fails_if_integration_is_not_the_correc
     assert response.json()["detail"] == "Integration is not a Databricks integration."
 
 
-def test_creating_azure_blob_batch_export_fails_if_feature_flag_is_not_enabled(
-    client: HttpClient,
-    team,
-    user,
-):
-    """Test that creating an Azure Blob batch export fails if the feature flag is not enabled."""
-    destination_data = {
-        "type": "AzureBlob",
-        "config": {
-            "container_name": "test-container",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-azure-blob-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
-    client.force_login(user)
-
-    with mock.patch(
-        "posthog.batch_exports.http.posthoganalytics.feature_enabled",
-        return_value=False,
-    ):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
-
-    assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
-    assert "Azure Blob Storage batch exports are not enabled for this team." in response.json()["detail"]
-
-
 @pytest.fixture
 def azure_blob_integration(team, user):
     """Create an Azure Blob integration."""
@@ -1398,15 +1363,11 @@ def test_creating_azure_blob_batch_export_using_integration(
 
     client.force_login(user)
 
-    with mock.patch(
-        "posthog.batch_exports.http.posthoganalytics.feature_enabled",
-        return_value=True,
-    ):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
+    response = create_batch_export(
+        client,
+        team.pk,
+        batch_export_data,
+    )
 
     assert response.status_code == status.HTTP_201_CREATED, response.json()
 

--- a/posthog/api/test/batch_exports/test_test.py
+++ b/posthog/api/test/batch_exports/test_test.py
@@ -409,29 +409,8 @@ def databricks_integration(team, user):
     )
 
 
-@pytest.fixture
-def enable_databricks(team):
-    with unittest.mock.patch(
-        "posthog.batch_exports.http.posthoganalytics.feature_enabled",
-        return_value=True,
-    ) as feature_enabled:
-        yield
-        feature_enabled.assert_called_once_with(
-            "databricks-batch-exports",
-            str(team.uuid),
-            groups={"organization": str(team.organization.id)},
-            group_properties={
-                "organization": {
-                    "id": str(team.organization.id),
-                    "created_at": team.organization.created_at,
-                }
-            },
-            send_feature_flag_events=False,
-        )
-
-
 def test_can_run_databricks_test_step_for_new_destination(
-    client: HttpClient, organization, team, user, databricks_integration, enable_databricks
+    client: HttpClient, organization, team, user, databricks_integration
 ):
     destination_data = {
         "type": "Databricks",

--- a/posthog/api/test/batch_exports/test_test.py
+++ b/posthog/api/test/batch_exports/test_test.py
@@ -470,7 +470,6 @@ def test_integration_is_required_for_databricks_destination_tests(
     organization,
     team,
     user,
-    enable_databricks,
 ):
     destination_data = {
         "type": "Databricks",

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -3,7 +3,6 @@ import typing as t
 import datetime as dt
 
 import pytest
-from unittest import mock
 
 from django.conf import settings
 from django.test.client import Client as HttpClient
@@ -811,16 +810,6 @@ def databricks_integration_2(team, user):
     )
 
 
-@pytest.fixture
-def enable_databricks(team):
-    """Enable the Databricks batch exports feature flag to be able to run the test."""
-    with mock.patch(
-        "posthog.batch_exports.http.posthoganalytics.feature_enabled",
-        return_value=True,
-    ):
-        yield
-
-
 def test_can_update_batch_export_with_integration(
     client: HttpClient,
     temporal,
@@ -829,7 +818,6 @@ def test_can_update_batch_export_with_integration(
     user,
     databricks_integration,
     databricks_integration_2,
-    enable_databricks,
 ):
     """Test we can update a batch export with an integration (for example Databricks)."""
 
@@ -901,7 +889,6 @@ def test_can_update_batch_export_with_integration_to_none(
     team,
     user,
     databricks_integration,
-    enable_databricks,
 ):
     """Test we cannot update a batch export that requires an integration to None."""
 

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -716,21 +716,6 @@ class BatchExportSerializer(serializers.ModelSerializer):
 
         if destination_type == BatchExportDestination.Destination.DATABRICKS:
             team_id = self.context["team_id"]
-            team = Team.objects.get(id=team_id)
-
-            if not posthoganalytics.feature_enabled(
-                "databricks-batch-exports",
-                str(team.uuid),
-                groups={"organization": str(team.organization.id)},
-                group_properties={
-                    "organization": {
-                        "id": str(team.organization.id),
-                        "created_at": team.organization.created_at,
-                    }
-                },
-                send_feature_flag_events=False,
-            ):
-                raise PermissionDenied("The Databricks destination is not enabled for this team.")
 
             # validate the Integration is valid (this is mandatory for Databricks batch exports)
             integration: Integration | None = destination_attrs.get("integration")

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -757,21 +757,6 @@ class BatchExportSerializer(serializers.ModelSerializer):
 
         if destination_type == BatchExportDestination.Destination.AZURE_BLOB:
             team_id = self.context["team_id"]
-            team = Team.objects.get(id=team_id)
-
-            if not posthoganalytics.feature_enabled(
-                "azure-blob-batch-exports",
-                str(team.uuid),
-                groups={"organization": str(team.organization.id)},
-                group_properties={
-                    "organization": {
-                        "id": str(team.organization.id),
-                        "created_at": team.organization.created_at,
-                    }
-                },
-                send_feature_flag_events=False,
-            ):
-                raise PermissionDenied("Azure Blob Storage batch exports are not enabled for this team.")
 
             # validate the Integration is valid (this is mandatory for Azure Blob batch exports)
             integration = destination_attrs.get("integration")


### PR DESCRIPTION
## Problem

We still reference a number of feature flags in batch exports, even though these have been rolled out to 100% of users/orgs for a while.

## Changes

Remove feature flags and code using them.

## How did you test this code?

- Relying on automated test suite
- Started local stack and browsed around a bit

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
