### PR TITLE
fix(remote-config): update on disable

### DIFF
--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -515,8 +515,9 @@ def site_app_saved(sender, instance: "PluginConfig", created, **kwargs):
 
 
 @receiver(post_save, sender=HogFunction)
-def site_function_saved(sender, instance: "HogFunction", created, **kwargs):
-    if instance.enabled and instance.type in ("site_destination", "site_app"):
+@receiver(post_delete, sender=HogFunction)
+def site_function_changed(sender, instance: "HogFunction", **kwargs):
+    if instance.type in ("site_destination", "site_app"):
         transaction.on_commit(lambda: _update_team_remote_config(instance.team_id))
 
 

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -587,6 +587,13 @@ class TestRemoteConfigCaching(_RemoteConfigBase):
 
 
 class TestRemoteConfigJS(_RemoteConfigBase):
+    def _run_remote_config_on_commit_synchronously(self):
+        from posthog.tasks.remote_config import update_team_remote_config
+
+        return patch("posthog.models.remote_config.transaction.on_commit", side_effect=lambda fn: fn()), patch(
+            "posthog.models.remote_config._update_team_remote_config", side_effect=update_team_remote_config
+        )
+
     def test_renders_js_including_config(self):
         # NOTE: This is a very basic test to check that the JS is rendered correctly
         # It doesn't check the actual contents of the JS, as that changes often but checks some general things
@@ -708,6 +715,53 @@ class TestRemoteConfigJS(_RemoteConfigBase):
 
         js = self.remote_config.get_config_js_via_token(self.team.api_token)
         assert str(site_destination.id) not in js
+
+    @patch("posthog.cdp.site_functions.transpile", side_effect=mock_transpile)
+    def test_disabling_site_functions_updates_remote_config(self, mock_transpile_fn):
+        site_app = HogFunction.objects.create(
+            name="Site app",
+            type=HogFunctionType.SITE_APP,
+            team=self.team,
+            enabled=True,
+        )
+
+        self.sync_remote_config()
+
+        js = self.remote_config.get_config_js_via_token(self.team.api_token)
+        assert str(site_app.id) in js
+
+        on_commit_patch, update_remote_config_patch = self._run_remote_config_on_commit_synchronously()
+        with on_commit_patch, update_remote_config_patch:
+            site_app.enabled = False
+            site_app.save()
+
+        self.remote_config.refresh_from_db()
+
+        js = self.remote_config.get_config_js_via_token(self.team.api_token)
+        assert str(site_app.id) not in js
+
+    @patch("posthog.cdp.site_functions.transpile", side_effect=mock_transpile)
+    def test_deleting_site_functions_updates_remote_config(self, mock_transpile_fn):
+        site_app = HogFunction.objects.create(
+            name="Site app",
+            type=HogFunctionType.SITE_APP,
+            team=self.team,
+            enabled=True,
+        )
+
+        self.sync_remote_config()
+
+        js = self.remote_config.get_config_js_via_token(self.team.api_token)
+        assert str(site_app.id) in js
+
+        on_commit_patch, update_remote_config_patch = self._run_remote_config_on_commit_synchronously()
+        with on_commit_patch, update_remote_config_patch:
+            site_app.delete()
+
+        self.remote_config.refresh_from_db()
+
+        js = self.remote_config.get_config_js_via_token(self.team.api_token)
+        assert str(site_app.id) not in js
 
 
 class TestRemoteConfigRaceCondition(_RemoteConfigBase):


### PR DESCRIPTION
## Problem

The `HogFunction` signal only refreshed remote config when the saved instance was still enabled, so disabling a notification bar (`enabled=False`) skipped the refresh entirely. That left stale data in `config.js` until
  some unrelated refresh or the daily `sync_all_remote_configs` job in `posthog/tasks/scheduled.py:547`

## Changes

Site-app HogFunctions now trigger remote-config refresh on save and delete, including the disable path. 

## How did you test this code?

New tests in `posthog/models/test/test_remote_config.py`

## Publish to changelog?

no
## Docs update
no