### PR TITLE
fix(tracing): fix nodejs trace precision being too low

### DIFF
--- a/nodejs/src/common/tracing/tracing-utils.ts
+++ b/nodejs/src/common/tracing/tracing-utils.ts
@@ -30,6 +30,14 @@ const logTime = (startTime: number, statsKey: string, error?: any): void => {
     })
 }
 
+function getHighResTimestamp(): HrTime {
+    // performance.timeOrigin: absolute start time of the process
+    // performance.now(): high-res relative time since process start
+    const epochMillis = performance.timeOrigin + performance.now()
+    const seconds = Math.floor(epochMillis / 1000)
+    const nanos = Math.round((epochMillis % 1000) * 1_000_000)
+    return [seconds, nanos]
+}
 /**
  * Wraps a function in an OpenTelemetry tracing span.
  */
@@ -40,19 +48,24 @@ export function withTracingSpan<T>(
     fn: () => Promise<T>
 ): Promise<T> {
     const _tracer = typeof tracer === 'string' ? trace.getTracer(tracer) : tracer
-    return _tracer.startActiveSpan(name, { kind: SpanKind.CLIENT, attributes: attrs }, async (span) => {
-        try {
-            const out = await fn()
-            span.setStatus({ code: SpanStatusCode.OK })
-            return out
-        } catch (e: any) {
-            span.recordException(e)
-            span.setStatus({ code: SpanStatusCode.ERROR, message: e?.message })
-            throw e
-        } finally {
-            span.end()
+    const startHrTime = getHighResTimestamp()
+    return _tracer.startActiveSpan(
+        name,
+        { kind: SpanKind.CLIENT, attributes: attrs, startTime: startHrTime },
+        async (span) => {
+            try {
+                const out = await fn()
+                span.setStatus({ code: SpanStatusCode.OK })
+                return out
+            } catch (e: any) {
+                span.recordException(e)
+                span.setStatus({ code: SpanStatusCode.ERROR, message: e?.message })
+                throw e
+            } finally {
+                span.end(getHighResTimestamp())
+            }
         }
-    })
+    )
 }
 
 /**

--- a/nodejs/src/common/tracing/tracing-utils.ts
+++ b/nodejs/src/common/tracing/tracing-utils.ts
@@ -1,4 +1,4 @@
-import { Attributes, SpanKind, SpanStatusCode, Tracer, trace } from '@opentelemetry/api'
+import { Attributes, HrTime, SpanKind, SpanStatusCode, Tracer, trace } from '@opentelemetry/api'
 import { Histogram, Summary, exponentialBuckets } from 'prom-client'
 
 import { defaultConfig } from '~/config/config'

--- a/products/tracing/frontend/TraceFlameChart.tsx
+++ b/products/tracing/frontend/TraceFlameChart.tsx
@@ -53,15 +53,19 @@ function buildSpanTree(spans: Span[]): SpanNode[] {
     return roots
 }
 
+function sortChildren(nodes: SpanNode[]): SpanNode[] {
+    return [...nodes].sort((a, b) => parseTimestampUs(a.span.timestamp) - parseTimestampUs(b.span.timestamp))
+}
+
 function flattenTree(nodes: SpanNode[]): SpanNode[] {
     const result: SpanNode[] = []
     function walk(node: SpanNode): void {
         result.push(node)
-        for (const child of node.children) {
+        for (const child of sortChildren(node.children)) {
             walk(child)
         }
     }
-    for (const root of nodes) {
+    for (const root of sortChildren(nodes)) {
         walk(root)
     }
     return result
@@ -91,8 +95,8 @@ function parseTimestampUs(iso: string): number {
     if (dot === -1) {
         return ms * 1_000
     }
-    // Find the end of fractional digits (before 'Z' or '+'/'-' timezone)
-    const fracEnd = iso.search(/[Z+-]/i)
+    // Find the end of fractional digits (before 'Z')
+    const fracEnd = iso.search(/[Z+-](\d\d:\d\d)?$/i)
     if (fracEnd === -1) {
         return ms * 1_000
     }
@@ -236,9 +240,9 @@ function SpanDetailPanel({ span }: { span: Span }): JSX.Element {
                     </>
                 )}
                 <span className="text-muted font-medium">Start</span>
-                <span className="font-mono">{new Date(span.timestamp).toISOString()}</span>
+                <span className="font-mono">{span.timestamp}</span>
                 <span className="text-muted font-medium">End</span>
-                <span className="font-mono">{new Date(span.end_time).toISOString()}</span>
+                <span className="font-mono">{span.end_time}</span>
             </div>
         </div>
     )

--- a/products/tracing/frontend/TraceFlameChart.tsx
+++ b/products/tracing/frontend/TraceFlameChart.tsx
@@ -68,14 +68,41 @@ function flattenTree(nodes: SpanNode[]): SpanNode[] {
 }
 
 export function formatDuration(durationNano: number): string {
-    const ms = durationNano / 1_000_000
-    if (ms < 0.1) {
-        return `${(ms * 1000).toFixed(0)}\u00B5s`
+    const us = durationNano / 1_000
+    if (us < 100) {
+        return `${us.toFixed(1)}\u00B5s`
     }
+    const ms = us / 1_000
     if (ms < 1000) {
-        return `${ms.toFixed(1)}ms`
+        return `${ms.toFixed(ms < 10 ? 2 : 1)}ms`
     }
     return `${(ms / 1000).toFixed(2)}s`
+}
+
+/**
+ * Parse an ISO 8601 timestamp string to microseconds since epoch.
+ * `Date.getTime()` only gives millisecond resolution, losing sub-ms
+ * precision from timestamps like "2024-01-15T10:30:00.123456Z".
+ */
+function parseTimestampUs(iso: string): number {
+    const ms = new Date(iso).getTime()
+    // Extract fractional seconds beyond milliseconds
+    const dot = iso.indexOf('.')
+    if (dot === -1) {
+        return ms * 1_000
+    }
+    // Find the end of fractional digits (before 'Z' or '+'/'-' timezone)
+    const fracEnd = iso.search(/[Z+-]/i)
+    if (fracEnd === -1) {
+        return ms * 1_000
+    }
+    const fracStr = iso.slice(dot + 1, fracEnd)
+    // Pad or truncate to 6 digits (microseconds)
+    const padded = fracStr.padEnd(6, '0').slice(0, 6)
+    const totalUs = parseInt(padded, 10)
+    // ms already includes the first 3 fractional digits, so add the remaining sub-ms part
+    const subMsUs = totalUs % 1_000
+    return ms * 1_000 + subMsUs
 }
 
 function buildServiceColorMap(spans: Span[]): Map<string, number> {
@@ -85,18 +112,18 @@ function buildServiceColorMap(spans: Span[]): Map<string, number> {
     return map
 }
 
-/** Generate evenly spaced tick marks for the timeline */
-function getTimelineTicks(durationMs: number): number[] {
-    if (durationMs <= 0) {
+/** Generate evenly spaced tick marks for the timeline (in microseconds) */
+function getTimelineTicks(durationUs: number): number[] {
+    if (durationUs <= 0) {
         return []
     }
     const targetTickCount = 5
-    const rawInterval = durationMs / targetTickCount
+    const rawInterval = durationUs / targetTickCount
     const magnitude = Math.pow(10, Math.floor(Math.log10(rawInterval)))
     const niceIntervals = [1, 2, 5, 10]
     const interval = niceIntervals.find((n) => n * magnitude >= rawInterval)! * magnitude
     const ticks: number[] = []
-    for (let t = interval; t < durationMs; t += interval) {
+    for (let t = interval; t < durationUs; t += interval) {
         ticks.push(t)
     }
     return ticks
@@ -230,9 +257,9 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
         if (spans.length === 0) {
             return []
         }
-        const timestamps = spans.map((s) => new Date(s.timestamp).getTime())
-        const endTimes = spans.map((s) => new Date(s.end_time).getTime())
-        const start = Math.min(...timestamps)
+        const startTimes = spans.map((s) => parseTimestampUs(s.timestamp))
+        const endTimes = spans.map((s) => parseTimestampUs(s.timestamp) + s.duration_nano / 1_000)
+        const start = Math.min(...startTimes)
         const end = Math.max(...endTimes)
         const duration = end - start
         if (duration <= 0) {
@@ -240,8 +267,9 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
         }
         const points = new Set<number>()
         for (const s of spans) {
-            points.add(((new Date(s.timestamp).getTime() - start) / duration) * 100)
-            points.add(((new Date(s.end_time).getTime() - start) / duration) * 100)
+            const spanStartUs = parseTimestampUs(s.timestamp)
+            points.add(((spanStartUs - start) / duration) * 100)
+            points.add(((spanStartUs + s.duration_nano / 1_000 - start) / duration) * 100)
         }
         return [...points].sort((a, b) => a - b)
     }, [spans])
@@ -284,14 +312,14 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
         return <div className="text-muted p-4">No spans in this trace</div>
     }
 
-    const timestamps = spans.map((s) => new Date(s.timestamp).getTime())
-    const endTimes = spans.map((s) => new Date(s.end_time).getTime())
-    const traceStart = Math.min(...timestamps)
-    const traceEnd = Math.max(...endTimes)
-    const traceDurationMs = traceEnd - traceStart
-    const ticks = getTimelineTicks(traceDurationMs)
+    const startTimesUs = spans.map((s) => parseTimestampUs(s.timestamp))
+    const endTimesUs = spans.map((s) => parseTimestampUs(s.timestamp) + s.duration_nano / 1_000)
+    const traceStartUs = Math.min(...startTimesUs)
+    const traceEndUs = Math.max(...endTimesUs)
+    const traceDurationUs = traceEndUs - traceStartUs
+    const ticks = getTimelineTicks(traceDurationUs)
 
-    const cursorTimeMs = cursorPct !== null ? (cursorPct / 100) * traceDurationMs : null
+    const cursorTimeUs = cursorPct !== null ? (cursorPct / 100) * traceDurationUs : null
 
     return (
         <div
@@ -319,33 +347,33 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
                 </div>
                 <div className="relative grow h-7" ref={timelineRef}>
                     {(cursorPct === null || cursorPct > 5) && (
-                        <span className="absolute left-1 top-1/2 -translate-y-1/2 text-[10px] text-muted">0ms</span>
+                        <span className="absolute left-1 top-1/2 -translate-y-1/2 text-[10px] text-muted">0</span>
                     )}
                     {ticks
-                        .filter((tickMs) => {
-                            const pct = (tickMs / traceDurationMs) * 100
+                        .filter((tickUs) => {
+                            const pct = (tickUs / traceDurationUs) * 100
                             return pct > 5 && pct < 90
                         })
-                        .map((tickMs) => {
-                            const pct = (tickMs / traceDurationMs) * 100
+                        .map((tickUs) => {
+                            const pct = (tickUs / traceDurationUs) * 100
                             return (
                                 <span
-                                    key={tickMs}
+                                    key={tickUs}
                                     className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 text-[10px] text-muted"
                                     // eslint-disable-next-line react/forbid-dom-props
                                     style={{ left: `${pct}%` }}
                                 >
-                                    {formatDuration(tickMs * 1_000_000)}
+                                    {formatDuration(tickUs * 1_000)}
                                 </span>
                             )
                         })}
                     {(cursorPct === null || cursorPct < 95) && (
                         <span className="absolute right-1 top-1/2 -translate-y-1/2 text-[10px] text-muted">
-                            {formatDuration(traceDurationMs * 1_000_000)}
+                            {formatDuration(traceDurationUs * 1_000)}
                         </span>
                     )}
                     {/* Cursor time label in header */}
-                    {cursorPct !== null && cursorTimeMs !== null && (
+                    {cursorPct !== null && cursorTimeUs !== null && (
                         <span
                             className={`absolute bottom-0 text-[10px] font-mono font-medium pointer-events-none ${
                                 cursorPct < 50 ? 'translate-x-1' : '-translate-x-full -ml-1'
@@ -353,7 +381,7 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
                             // eslint-disable-next-line react/forbid-dom-props
                             style={{ left: `${cursorPct}%` }}
                         >
-                            {formatDuration(cursorTimeMs * 1_000_000)}
+                            {formatDuration(cursorTimeUs * 1_000)}
                         </span>
                     )}
                 </div>
@@ -362,11 +390,12 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
             {/* Span rows */}
             {flatSpans.map((node) => {
                 const { span } = node
-                const spanStart = new Date(span.timestamp).getTime()
-                const spanEnd = new Date(span.end_time).getTime()
-                const leftPct = traceDurationMs > 0 ? ((spanStart - traceStart) / traceDurationMs) * 100 : 0
-                const widthPct =
-                    traceDurationMs > 0 ? Math.max(((spanEnd - spanStart) / traceDurationMs) * 100, 0.3) : 100
+                const spanStartUs = parseTimestampUs(span.timestamp)
+                const spanDurationUs = span.duration_nano / 1_000
+                const leftPct =
+                    traceDurationUs > 0 ? Math.max(((spanStartUs - traceStartUs) / traceDurationUs) * 100, 0) : 0
+                const rawWidthPct = traceDurationUs > 0 ? (spanDurationUs / traceDurationUs) * 100 : 100
+                const widthPct = Math.max(Math.min(rawWidthPct, 100 - leftPct), 0.3)
 
                 const isError = span.status_code === 2
                 const seriesIndex = serviceColorMap.get(span.service_name) ?? 0
@@ -420,11 +449,11 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
                                 style={{ height: ROW_HEIGHT - 8 }}
                             >
                                 {/* Grid lines */}
-                                {ticks.map((tickMs) => {
-                                    const pct = (tickMs / traceDurationMs) * 100
+                                {ticks.map((tickUs) => {
+                                    const pct = (tickUs / traceDurationUs) * 100
                                     return (
                                         <span
-                                            key={tickMs}
+                                            key={tickUs}
                                             className="absolute top-0 bottom-0 border-l border-border"
                                             // eslint-disable-next-line react/forbid-dom-props
                                             style={{ left: `${pct}%` }}

--- a/products/tracing/frontend/TraceFlameChart.tsx
+++ b/products/tracing/frontend/TraceFlameChart.tsx
@@ -256,27 +256,30 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
     const tree = useMemo(() => buildSpanTree(spans), [spans])
     const flatSpans = useMemo(() => flattenTree(tree), [tree])
 
+    const { traceStartUs, traceDurationUs } = useMemo(() => {
+        if (spans.length === 0) {
+            return { traceStartUs: 0, traceDurationUs: 0 }
+        }
+        const startTimesUs = spans.map((s) => parseTimestampUs(s.timestamp))
+        const endTimesUs = spans.map((s) => parseTimestampUs(s.timestamp) + s.duration_nano / 1_000)
+        const traceStartUs = Math.min(...startTimesUs)
+        const traceEndUs = Math.max(...endTimesUs)
+        return { traceStartUs, traceDurationUs: traceEndUs - traceStartUs }
+    }, [spans])
+
     // Pre-compute snap points (span start/end as percentages of trace duration)
     const snapPointsPct = useMemo(() => {
-        if (spans.length === 0) {
-            return []
-        }
-        const startTimes = spans.map((s) => parseTimestampUs(s.timestamp))
-        const endTimes = spans.map((s) => parseTimestampUs(s.timestamp) + s.duration_nano / 1_000)
-        const start = Math.min(...startTimes)
-        const end = Math.max(...endTimes)
-        const duration = end - start
-        if (duration <= 0) {
+        if (traceDurationUs <= 0) {
             return []
         }
         const points = new Set<number>()
         for (const s of spans) {
             const spanStartUs = parseTimestampUs(s.timestamp)
-            points.add(((spanStartUs - start) / duration) * 100)
-            points.add(((spanStartUs + s.duration_nano / 1_000 - start) / duration) * 100)
+            points.add(((spanStartUs - traceStartUs) / traceDurationUs) * 100)
+            points.add(((spanStartUs + s.duration_nano / 1_000 - traceStartUs) / traceDurationUs) * 100)
         }
         return [...points].sort((a, b) => a - b)
-    }, [spans])
+    }, [spans, traceStartUs, traceDurationUs])
 
     const SNAP_THRESHOLD_PX = 6
 
@@ -316,11 +319,6 @@ export function TraceFlameChart({ spans }: TraceFlameChartProps): JSX.Element {
         return <div className="text-muted p-4">No spans in this trace</div>
     }
 
-    const startTimesUs = spans.map((s) => parseTimestampUs(s.timestamp))
-    const endTimesUs = spans.map((s) => parseTimestampUs(s.timestamp) + s.duration_nano / 1_000)
-    const traceStartUs = Math.min(...startTimesUs)
-    const traceEndUs = Math.max(...endTimesUs)
-    const traceDurationUs = traceEndUs - traceStartUs
     const ticks = getTimelineTicks(traceDurationUs)
 
     const cursorTimeUs = cursorPct !== null ? (cursorPct / 100) * traceDurationUs : null


### PR DESCRIPTION
## Problem

traces generated from our nodejs services only have millisecond precision, not microsecond

## Changes

fix nodejs trace generation to use high precision timestamps - also fix various frontend issues with tracing relating to this

## How did you test this code?
locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
