### PR TITLE
refactor: move most ingestion warnings to outputs

### DIFF
--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.integration.test.ts
@@ -9,6 +9,7 @@ import { createTestTeam } from '../../../../tests/helpers/team'
 import { InternalPerson, PropertyUpdateOperation } from '../../../types'
 import { parseJSON } from '../../../utils/json-parse'
 import { AI_EVENTS_OUTPUT, EVENTS_OUTPUT } from '../../analytics/outputs'
+import { INGESTION_WARNINGS_OUTPUT } from '../../common/outputs'
 import { IngestionOutputs } from '../../outputs/ingestion-outputs'
 import { newPipelineBuilder } from '../../pipelines/builders'
 import { createContext } from '../../pipelines/helpers'
@@ -82,6 +83,10 @@ function buildPipeline(configOverrides: Partial<AiEventSubpipelineConfig> = {}) 
             [AI_EVENTS_OUTPUT]: {
                 topic: 'ai_events_topic',
                 producer: { produce: mockProduce } as any,
+            },
+            [INGESTION_WARNINGS_OUTPUT]: {
+                topic: 'ingestion_warnings_topic',
+                producer: { queueMessages: jest.fn().mockResolvedValue(undefined) } as any,
             },
         }),
         teamManager: {

--- a/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.ts
+++ b/nodejs/src/ingestion/ai/pipelines/ai-event-subpipeline.ts
@@ -11,6 +11,7 @@ import { GroupTypeManager } from '../../../worker/ingestion/group-type-manager'
 import { BatchWritingGroupStore } from '../../../worker/ingestion/groups/batch-writing-group-store'
 import { PersonsStore } from '../../../worker/ingestion/persons/persons-store'
 import { AiEventOutput, EVENTS_OUTPUT, EventOutput } from '../../analytics/outputs'
+import { IngestionWarningsOutput } from '../../common/outputs'
 import { createCreateEventStep } from '../../event-processing/create-event-step'
 import { createEmitEventStep } from '../../event-processing/emit-event-step'
 import { EventPipelineRunnerOptions } from '../../event-processing/event-pipeline-options'
@@ -36,7 +37,7 @@ export interface AiEventSubpipelineInput {
 
 export interface AiEventSubpipelineConfig {
     options: EventPipelineRunnerOptions
-    outputs: IngestionOutputs<EventOutput | AiEventOutput>
+    outputs: IngestionOutputs<EventOutput | AiEventOutput | IngestionWarningsOutput>
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
@@ -117,7 +118,6 @@ export function createAiEventSubpipeline<TInput extends AiEventSubpipelineInput,
             topHog(
                 createEmitEventStep({
                     outputs,
-                    kafkaProducer,
                     groupId,
                 }),
                 [

--- a/nodejs/src/ingestion/analytics/config/outputs.ts
+++ b/nodejs/src/ingestion/analytics/config/outputs.ts
@@ -2,7 +2,9 @@ import {
     KAFKA_CLICKHOUSE_AI_EVENTS_JSON,
     KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
     KAFKA_EVENTS_JSON,
+    KAFKA_INGESTION_WARNINGS,
 } from '../../../config/kafka-topics'
+import { INGESTION_WARNINGS_OUTPUT } from '../../common/outputs'
 import { IngestionOutputDefinition } from '../../outputs/resolver'
 import { AI_EVENTS_OUTPUT, EVENTS_OUTPUT, HEATMAPS_OUTPUT } from '../outputs'
 import { DEFAULT_PRODUCER, ProducerName } from './producers'
@@ -26,5 +28,11 @@ export const INGESTION_OUTPUT_DEFINITIONS: Record<string, IngestionOutputDefinit
         defaultProducerName: DEFAULT_PRODUCER,
         producerOverrideEnvVar: 'INGESTION_OUTPUT_HEATMAPS_PRODUCER',
         topicOverrideEnvVar: 'INGESTION_OUTPUT_HEATMAPS_TOPIC',
+    },
+    [INGESTION_WARNINGS_OUTPUT]: {
+        defaultTopic: KAFKA_INGESTION_WARNINGS,
+        defaultProducerName: DEFAULT_PRODUCER,
+        producerOverrideEnvVar: 'INGESTION_OUTPUT_INGESTION_WARNINGS_PRODUCER',
+        topicOverrideEnvVar: 'INGESTION_OUTPUT_INGESTION_WARNINGS_TOPIC',
     },
 }

--- a/nodejs/src/ingestion/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/event-subpipeline.ts
@@ -9,6 +9,7 @@ import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { createCreateEventStep } from '../event-processing/create-event-step'
 import { createEmitEventStep } from '../event-processing/emit-event-step'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
@@ -35,7 +36,7 @@ export interface EventSubpipelineInput {
 
 export interface EventSubpipelineConfig {
     options: EventPipelineRunnerOptions
-    outputs: IngestionOutputs<EventOutput | HeatmapsOutput>
+    outputs: IngestionOutputs<EventOutput | HeatmapsOutput | IngestionWarningsOutput>
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     hogTransformer: HogTransformerService
@@ -113,7 +114,6 @@ export function createEventSubpipeline<TInput extends EventSubpipelineInput, TCo
             topHog(
                 createEmitEventStep({
                     outputs,
-                    kafkaProducer,
                     groupId,
                 }),
                 [

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -10,6 +10,7 @@ import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { CookielessManager } from '../cookieless/cookieless-manager'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
 import { createFlushBatchStoresStep } from '../event-processing/flush-batch-stores-step'
@@ -43,7 +44,7 @@ export interface JoinedIngestionPipelineConfig {
     personsPrefetchEnabled: boolean
     cdpHogWatcherSampleRate: number
     groupId: string
-    outputs: IngestionOutputs<EventOutput | AiEventOutput | HeatmapsOutput>
+    outputs: IngestionOutputs<EventOutput | AiEventOutput | HeatmapsOutput | IngestionWarningsOutput>
     splitAiEventsConfig: SplitAiEventsStepConfig
     perDistinctIdOptions: EventPipelineRunnerOptions
 }
@@ -219,7 +220,7 @@ export function createJoinedIngestionPipeline<
                                     })
                                 )
                         )
-                        .handleIngestionWarnings(kafkaProducer)
+                        .handleIngestionWarnings(outputs)
                 )
         )
         .handleResults(pipelineConfig)

--- a/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/per-distinct-id-pipeline.ts
@@ -9,6 +9,7 @@ import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writ
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
 import { AI_EVENT_TYPES } from '../ai'
 import { AiEventSubpipelineInput, createAiEventSubpipeline } from '../ai/pipelines/ai-event-subpipeline'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
 import { SplitAiEventsStepConfig } from '../event-processing/split-ai-events-step'
 import { IngestionOutputs } from '../outputs/ingestion-outputs'
@@ -29,7 +30,7 @@ export type PerDistinctIdPipelineInput = EventSubpipelineInput &
 
 export interface PerDistinctIdPipelineConfig {
     options: EventPipelineRunnerOptions
-    outputs: IngestionOutputs<EventOutput | AiEventOutput | HeatmapsOutput>
+    outputs: IngestionOutputs<EventOutput | AiEventOutput | HeatmapsOutput | IngestionWarningsOutput>
     splitAiEventsConfig: SplitAiEventsStepConfig
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager

--- a/nodejs/src/ingestion/analytics/testing-ai-event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/testing-ai-event-subpipeline.ts
@@ -2,9 +2,9 @@ import { Message } from 'node-rdkafka'
 
 import { PluginEvent } from '~/plugin-scaffold'
 
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
 import { createProcessAiEventStep } from '../ai/pipelines/steps/process-ai-event-step'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { createCreateEventStep } from '../event-processing/create-event-step'
 import { createDisablePersonProcessingWithFakePersonStep } from '../event-processing/disable-person-processing-with-fake-person-step'
 import { createEmitEventStep } from '../event-processing/emit-event-step'
@@ -22,8 +22,7 @@ export interface TestingAiEventSubpipelineInput {
 }
 
 export interface TestingAiEventSubpipelineConfig {
-    outputs: IngestionOutputs<EventOutput>
-    kafkaProducer: KafkaProducerWrapper
+    outputs: IngestionOutputs<EventOutput | IngestionWarningsOutput>
     groupId: string
 }
 
@@ -31,7 +30,7 @@ export function createTestingAiEventSubpipeline<TInput extends TestingAiEventSub
     builder: StartPipelineBuilder<TInput, TContext>,
     config: TestingAiEventSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { outputs, kafkaProducer, groupId } = config
+    const { outputs, groupId } = config
 
     // Compared to ai-event-subpipeline.ts:
     // CHANGED: createNormalizeProcessPersonFlagStep → createDisablePersonProcessingWithFakePersonStep
@@ -47,5 +46,5 @@ export function createTestingAiEventSubpipeline<TInput extends TestingAiEventSub
         .pipe(createProcessAiEventStep())
         .pipe(createPrepareEventStep())
         .pipe(createCreateEventStep(EVENTS_OUTPUT))
-        .pipe(createEmitEventStep({ outputs, kafkaProducer, groupId }))
+        .pipe(createEmitEventStep({ outputs, groupId }))
 }

--- a/nodejs/src/ingestion/analytics/testing-event-subpipeline.ts
+++ b/nodejs/src/ingestion/analytics/testing-event-subpipeline.ts
@@ -2,8 +2,8 @@ import { Message } from 'node-rdkafka'
 
 import { PluginEvent } from '~/plugin-scaffold'
 
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, Team } from '../../types'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { createCreateEventStep } from '../event-processing/create-event-step'
 import { createDisablePersonProcessingWithFakePersonStep } from '../event-processing/disable-person-processing-with-fake-person-step'
 import { createEmitEventStep } from '../event-processing/emit-event-step'
@@ -22,8 +22,7 @@ export interface TestingEventSubpipelineInput {
 }
 
 export interface TestingEventSubpipelineConfig {
-    outputs: IngestionOutputs<EventOutput | HeatmapsOutput>
-    kafkaProducer: KafkaProducerWrapper
+    outputs: IngestionOutputs<EventOutput | HeatmapsOutput | IngestionWarningsOutput>
     groupId: string
 }
 
@@ -31,7 +30,7 @@ export function createTestingEventSubpipeline<TInput extends TestingEventSubpipe
     builder: StartPipelineBuilder<TInput, TContext>,
     config: TestingEventSubpipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { outputs, kafkaProducer, groupId } = config
+    const { outputs, groupId } = config
 
     // Compared to event-subpipeline.ts:
     // CHANGED: createNormalizeProcessPersonFlagStep → createDisablePersonProcessingWithFakePersonStep
@@ -50,7 +49,6 @@ export function createTestingEventSubpipeline<TInput extends TestingEventSubpipe
         .pipe(
             createEmitEventStep({
                 outputs,
-                kafkaProducer,
                 groupId,
             })
         )

--- a/nodejs/src/ingestion/analytics/testing-joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/testing-joined-ingestion-pipeline.ts
@@ -4,6 +4,7 @@ import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Team } from '../../types'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { TeamManager } from '../../utils/team-manager'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { BatchPipelineBuilder } from '../pipelines/builders/batch-pipeline-builders'
 import { OkResultWithContext } from '../pipelines/filter-map-batch-pipeline'
@@ -24,7 +25,7 @@ import { createTestingPreTeamPreprocessingSubpipeline } from './testing-pre-team
 export interface TestingJoinedIngestionPipelineConfig {
     dlqTopic: string
     groupId: string
-    outputs: IngestionOutputs<EventOutput | HeatmapsOutput>
+    outputs: IngestionOutputs<EventOutput | HeatmapsOutput | IngestionWarningsOutput>
 }
 
 export interface TestingJoinedIngestionPipelineDeps {
@@ -96,7 +97,6 @@ export function createTestingJoinedIngestionPipeline<
 
     const perEventConfig: TestingPerDistinctIdPipelineConfig = {
         outputs,
-        kafkaProducer,
         groupId,
     }
 
@@ -128,7 +128,7 @@ export function createTestingJoinedIngestionPipeline<
                                 )
                                 .gather()
                         )
-                        .handleIngestionWarnings(kafkaProducer)
+                        .handleIngestionWarnings(outputs)
                 )
         )
         .handleResults(pipelineConfig)

--- a/nodejs/src/ingestion/analytics/testing-per-distinct-id-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/testing-per-distinct-id-pipeline.ts
@@ -1,8 +1,8 @@
 import { Message } from 'node-rdkafka'
 
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Team } from '../../types'
 import { AI_EVENT_TYPES } from '../ai'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { PipelineBuilder, StartPipelineBuilder } from '../pipelines/builders/pipeline-builders'
 import {
@@ -20,8 +20,7 @@ export type TestingPerDistinctIdPipelineInput = TestingEventSubpipelineInput &
     TestingAiEventSubpipelineInput
 
 export interface TestingPerDistinctIdPipelineConfig {
-    outputs: IngestionOutputs<EventOutput | HeatmapsOutput>
-    kafkaProducer: KafkaProducerWrapper
+    outputs: IngestionOutputs<EventOutput | HeatmapsOutput | IngestionWarningsOutput>
     groupId: string
 }
 
@@ -46,7 +45,7 @@ export function createTestingPerDistinctIdPipeline<TInput extends TestingPerDist
     builder: StartPipelineBuilder<TInput, TContext>,
     config: TestingPerDistinctIdPipelineConfig
 ): PipelineBuilder<TInput, void, TContext> {
-    const { outputs, kafkaProducer, groupId } = config
+    const { outputs, groupId } = config
 
     return builder.retry(
         (e) =>
@@ -61,14 +60,12 @@ export function createTestingPerDistinctIdPipeline<TInput extends TestingPerDist
                     .branch('ai', (b) =>
                         createTestingAiEventSubpipeline(b, {
                             outputs,
-                            kafkaProducer,
                             groupId,
                         })
                     )
                     .branch('event', (b) =>
                         createTestingEventSubpipeline(b, {
                             outputs,
-                            kafkaProducer,
                             groupId,
                         })
                     )

--- a/nodejs/src/ingestion/common/ingestion-warnings.ts
+++ b/nodejs/src/ingestion/common/ingestion-warnings.ts
@@ -72,7 +72,9 @@ export async function emitIngestionWarning(
 
     if (emitted) {
         return outputs
-            .queueMessages(INGESTION_WARNINGS_OUTPUT, [{ value: serializeIngestionWarning(teamId, type, details) }])
+            .queueMessages(INGESTION_WARNINGS_OUTPUT, [
+                { value: Buffer.from(serializeIngestionWarning(teamId, type, details)) },
+            ])
             .then(() => true)
             .catch((error: unknown) => {
                 logger.warn('⚠️', 'Failed to produce ingestion warning', { error, team_id: teamId, type, details })

--- a/nodejs/src/ingestion/common/ingestion-warnings.ts
+++ b/nodejs/src/ingestion/common/ingestion-warnings.ts
@@ -1,0 +1,83 @@
+import { Counter } from 'prom-client'
+
+import { KAFKA_INGESTION_WARNINGS } from '../../config/kafka-topics'
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { TeamId, TimestampFormat } from '../../types'
+import { logger } from '../../utils/logger'
+import { IngestionWarningLimiter } from '../../utils/token-bucket'
+import { castTimestampOrNow } from '../../utils/utils'
+import { IngestionOutputs } from '../outputs/ingestion-outputs'
+import { INGESTION_WARNINGS_OUTPUT, IngestionWarningsOutput } from './outputs'
+
+export const ingestionWarningCounter = new Counter({
+    name: 'ingestion_warnings_total',
+    help: 'Total number of ingestion warnings by type and emission status',
+    labelNames: ['type', 'emitted'],
+})
+
+function serializeIngestionWarning(teamId: TeamId, type: string, details: Record<string, any>): string {
+    return JSON.stringify({
+        team_id: teamId,
+        type: type,
+        source: 'plugin-server',
+        details: JSON.stringify(details),
+        timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
+    })
+}
+
+function shouldEmitWarning(teamId: TeamId, type: string, debounce?: { key?: string; alwaysSend?: boolean }): boolean {
+    const limiterKey = `${teamId}:${type}:${debounce?.key || ''}`
+    return !!debounce?.alwaysSend || IngestionWarningLimiter.consume(limiterKey, 1)
+}
+
+/**
+ * Legacy wrapper — uses hardcoded KAFKA_INGESTION_WARNINGS topic and a raw producer.
+ * Prefer emitIngestionWarning with outputs in new pipeline code.
+ */
+export async function captureIngestionWarning(
+    kafkaProducer: KafkaProducerWrapper,
+    teamId: TeamId,
+    type: string,
+    details: Record<string, any>,
+    debounce?: { key?: string; alwaysSend?: boolean }
+): Promise<boolean> {
+    const emitted = shouldEmitWarning(teamId, type, debounce)
+    ingestionWarningCounter.inc({ type, emitted: emitted.toString() })
+
+    if (emitted) {
+        return kafkaProducer
+            .queueMessages({
+                topic: KAFKA_INGESTION_WARNINGS,
+                messages: [{ value: serializeIngestionWarning(teamId, type, details) }],
+            })
+            .then(() => true)
+            .catch((error: unknown) => {
+                logger.warn('⚠️', 'Failed to produce ingestion warning', { error, team_id: teamId, type, details })
+                return false
+            })
+    }
+    return Promise.resolve(false)
+}
+
+/** Produce an ingestion warning through the outputs abstraction. */
+export async function emitIngestionWarning(
+    outputs: IngestionOutputs<IngestionWarningsOutput>,
+    teamId: TeamId,
+    type: string,
+    details: Record<string, any>,
+    debounce?: { key?: string; alwaysSend?: boolean }
+): Promise<boolean> {
+    const emitted = shouldEmitWarning(teamId, type, debounce)
+    ingestionWarningCounter.inc({ type, emitted: emitted.toString() })
+
+    if (emitted) {
+        return outputs
+            .queueMessages(INGESTION_WARNINGS_OUTPUT, [{ value: serializeIngestionWarning(teamId, type, details) }])
+            .then(() => true)
+            .catch((error: unknown) => {
+                logger.warn('⚠️', 'Failed to produce ingestion warning', { error, team_id: teamId, type, details })
+                return false
+            })
+    }
+    return Promise.resolve(false)
+}

--- a/nodejs/src/ingestion/common/outputs.ts
+++ b/nodejs/src/ingestion/common/outputs.ts
@@ -1,2 +1,5 @@
 export const EVENTS_OUTPUT = 'events' as const
 export type EventOutput = typeof EVENTS_OUTPUT
+
+export const INGESTION_WARNINGS_OUTPUT = 'ingestion_warnings' as const
+export type IngestionWarningsOutput = typeof INGESTION_WARNINGS_OUTPUT

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.ts
@@ -7,7 +7,8 @@ import { TeamManager } from '~/utils/team-manager'
 import { GroupTypeManager } from '~/worker/ingestion/group-type-manager'
 import { PersonRepository } from '~/worker/ingestion/persons/repositories/person-repository'
 
-import { EVENTS_OUTPUT, EventOutput } from '../common/outputs'
+import { KAFKA_INGESTION_WARNINGS } from '../../config/kafka-topics'
+import { EVENTS_OUTPUT, EventOutput, INGESTION_WARNINGS_OUTPUT, IngestionWarningsOutput } from '../common/outputs'
 import {
     createApplyEventRestrictionsStep,
     createOverflowLaneTTLRefreshStep,
@@ -114,10 +115,14 @@ export function createErrorTrackingPipeline(
     const topHogWrapper = createTopHogWrapper(topHog)
 
     // Create outputs configuration for the emit step
-    const outputs = new IngestionOutputs<EventOutput>({
+    const outputs = new IngestionOutputs<EventOutput | IngestionWarningsOutput>({
         [EVENTS_OUTPUT]: {
             topic: outputTopic,
             producer: kafkaProducer,
+        },
+        [INGESTION_WARNINGS_OUTPUT]: {
+            topic: KAFKA_INGESTION_WARNINGS,
+            producer: ingestionWarningProducer,
         },
     })
 
@@ -200,7 +205,6 @@ export function createErrorTrackingPipeline(
                                                 topHogWrapper(
                                                     createEmitEventStep({
                                                         outputs,
-                                                        kafkaProducer,
                                                         groupId,
                                                     }),
                                                     [
@@ -216,7 +220,7 @@ export function createErrorTrackingPipeline(
                                             )
                                     )
                             )
-                            .handleIngestionWarnings(ingestionWarningProducer)
+                            .handleIngestionWarnings(outputs)
                 )
         )
         .handleResults(pipelineConfig)

--- a/nodejs/src/ingestion/event-processing/emit-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.test.ts
@@ -5,12 +5,12 @@ import { createTestEventHeaders } from '../../../tests/helpers/event-headers'
 import { createTestMessage } from '../../../tests/helpers/kafka-message'
 import { createMockIngestionOutputs } from '../../../tests/helpers/mock-ingestion-outputs'
 import { ingestionLagGauge, ingestionLagHistogram } from '../../common/metrics'
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, ISOTimestamp, ProcessedEvent, ProjectId } from '../../types'
 import { MessageSizeTooLarge } from '../../utils/db/error'
 import { eventProcessedAndIngestedCounter } from '../../worker/ingestion/event-pipeline/metrics'
-import { captureIngestionWarning } from '../../worker/ingestion/utils'
 import { EVENTS_OUTPUT, EventOutput } from '../analytics/outputs'
+import { emitIngestionWarning } from '../common/ingestion-warnings'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { isOkResult } from '../pipelines/results'
 import {
@@ -21,9 +21,8 @@ import {
     serializeEvent,
 } from './emit-event-step'
 
-// Mock the utils module
-jest.mock('../../worker/ingestion/utils', () => ({
-    captureIngestionWarning: jest.fn().mockResolvedValue(undefined),
+jest.mock('../common/ingestion-warnings', () => ({
+    emitIngestionWarning: jest.fn().mockResolvedValue(undefined),
 }))
 
 // Mock the metrics module
@@ -47,14 +46,13 @@ jest.mock('~/common/metrics', () => ({
     },
 }))
 
-const mockCaptureIngestionWarning = jest.mocked(captureIngestionWarning)
+const mockEmitIngestionWarning = jest.mocked(emitIngestionWarning)
 const mockEventProcessedAndIngestedCounter = jest.mocked(eventProcessedAndIngestedCounter)
 const mockIngestionLagGauge = jest.mocked(ingestionLagGauge)
 const mockIngestionLagHistogram = jest.mocked(ingestionLagHistogram)
 
 describe('emit-event-step', () => {
-    let mockOutputs: jest.Mocked<IngestionOutputs<EventOutput>>
-    let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
+    let mockOutputs: jest.Mocked<IngestionOutputs<EventOutput | IngestionWarningsOutput>>
     let config: EmitEventStepConfig<EventOutput>
     let mockProcessedEvent: ProcessedEvent
     let mockHeaders: EventHeaders
@@ -65,12 +63,10 @@ describe('emit-event-step', () => {
         mockMessage = createTestMessage()
         jest.clearAllMocks()
 
-        mockOutputs = createMockIngestionOutputs<EventOutput>()
-        mockKafkaProducer = {} as any
+        mockOutputs = createMockIngestionOutputs<EventOutput | IngestionWarningsOutput>()
 
         config = {
             outputs: mockOutputs,
-            kafkaProducer: mockKafkaProducer,
             groupId: 'test-group-id',
         }
 
@@ -147,7 +143,7 @@ describe('emit-event-step', () => {
             // Execute the side effect to test error handling
             await result.sideEffects[0]
 
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledWith(mockKafkaProducer, 1, 'message_size_too_large', {
+            expect(mockEmitIngestionWarning).toHaveBeenCalledWith(mockOutputs, 1, 'message_size_too_large', {
                 eventUuid: 'test-uuid',
                 distinctId: 'test-distinct-id',
             })
@@ -169,7 +165,7 @@ describe('emit-event-step', () => {
 
             // Execute the side effect to test error handling
             await expect(result.sideEffects[0]).rejects.toThrow('Generic Kafka error')
-            expect(mockCaptureIngestionWarning).not.toHaveBeenCalled()
+            expect(mockEmitIngestionWarning).not.toHaveBeenCalled()
             // Metric should not be incremented when there's an error
             expect(mockEventProcessedAndIngestedCounter.inc).not.toHaveBeenCalled()
         })

--- a/nodejs/src/ingestion/event-processing/emit-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.ts
@@ -2,13 +2,13 @@ import { DateTime } from 'luxon'
 import { Message } from 'node-rdkafka'
 
 import { ingestionLagGauge, ingestionLagHistogram } from '../../common/metrics'
-import { KafkaProducerWrapper } from '../../kafka/producer'
 import { EventHeaders, ProcessedEvent, RawKafkaEvent, TimestampFormat } from '../../types'
 import { MessageSizeTooLarge } from '../../utils/db/error'
 import { safeClickhouseString } from '../../utils/db/utils'
 import { castTimestampOrNow, castTimestampToClickhouseFormat } from '../../utils/utils'
 import { eventProcessedAndIngestedCounter } from '../../worker/ingestion/event-pipeline/metrics'
-import { captureIngestionWarning } from '../../worker/ingestion/utils'
+import { emitIngestionWarning } from '../common/ingestion-warnings'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
@@ -19,8 +19,7 @@ export interface EventToEmit<O extends string> {
 }
 
 export interface EmitEventStepConfig<O extends string> {
-    outputs: IngestionOutputs<O>
-    kafkaProducer: KafkaProducerWrapper
+    outputs: IngestionOutputs<O | IngestionWarningsOutput>
     groupId: string
 }
 
@@ -69,15 +68,10 @@ export function createEmitEventStep<O extends string, T extends EmitEventStepInp
                     // Some messages end up significantly larger than the original
                     // after plugin processing, person & group enrichment, etc.
                     if (error instanceof MessageSizeTooLarge) {
-                        await captureIngestionWarning(
-                            config.kafkaProducer,
-                            serialized.team_id,
-                            'message_size_too_large',
-                            {
-                                eventUuid: serialized.uuid,
-                                distinctId: serialized.distinct_id,
-                            }
-                        )
+                        await emitIngestionWarning(outputs, serialized.team_id, 'message_size_too_large', {
+                            eventUuid: serialized.uuid,
+                            distinctId: serialized.distinct_id,
+                        })
                     } else {
                         throw error
                     }

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -36,6 +36,7 @@ import {
     createJoinedIngestionPipeline,
 } from './analytics'
 import { AiEventOutput, EventOutput, HeatmapsOutput } from './analytics/outputs'
+import { IngestionWarningsOutput } from './common/outputs'
 import { IngestionConsumerConfig } from './config'
 import { CookielessManager } from './cookieless/cookieless-manager'
 import { parseSplitAiEventsConfig } from './event-processing/split-ai-events-step'
@@ -58,7 +59,7 @@ export interface IngestionConsumerDeps {
     redisPool: RedisPool
     kafkaProducer: KafkaProducerWrapper
     kafkaMetricsProducer: KafkaProducerWrapper
-    outputs: IngestionOutputs<EventOutput | AiEventOutput | HeatmapsOutput>
+    outputs: IngestionOutputs<EventOutput | AiEventOutput | HeatmapsOutput | IngestionWarningsOutput>
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository

--- a/nodejs/src/ingestion/ingestion-testing-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-testing-consumer.ts
@@ -2,6 +2,7 @@ import { Message } from 'node-rdkafka'
 
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
+import { KAFKA_INGESTION_WARNINGS } from '../config/kafka-topics'
 import { KafkaConsumer } from '../kafka/consumer'
 import { KafkaProducerWrapper } from '../kafka/producer'
 import { HealthCheckResult, HealthCheckResultError, PluginServerService, PluginsServerConfig } from '../types'
@@ -16,6 +17,7 @@ import {
     TestingJoinedIngestionPipelineInput,
     createTestingJoinedIngestionPipeline,
 } from './analytics/testing-joined-ingestion-pipeline'
+import { INGESTION_WARNINGS_OUTPUT } from './common/outputs'
 import { latestOffsetTimestampGauge } from './ingestion-consumer'
 import { IngestionOutputs } from './outputs/ingestion-outputs'
 import { BatchPipeline } from './pipelines/batch-pipeline.interface'
@@ -98,6 +100,10 @@ export class IngestionTestingConsumer {
             },
             [HEATMAPS_OUTPUT]: {
                 topic: this.config.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
+                producer: this.kafkaProducer!,
+            },
+            [INGESTION_WARNINGS_OUTPUT]: {
+                topic: KAFKA_INGESTION_WARNINGS,
                 producer: this.kafkaProducer!,
             },
         })

--- a/nodejs/src/ingestion/pipelines/builders/batch-pipeline-builders.ts
+++ b/nodejs/src/ingestion/pipelines/builders/batch-pipeline-builders.ts
@@ -1,7 +1,8 @@
 import { Message } from 'node-rdkafka'
 
-import { KafkaProducerWrapper } from '../../../kafka/producer'
 import { PromiseScheduler } from '../../../utils/promise-scheduler'
+import { IngestionWarningsOutput } from '../../common/outputs'
+import { IngestionOutputs } from '../../outputs/ingestion-outputs'
 import { BaseBatchPipeline, BatchProcessingStep } from '../base-batch-pipeline'
 import { BatchPipeline } from '../batch-pipeline.interface'
 import { BatchRetryOptions, withBatchRetry } from '../batch-retry'
@@ -228,8 +229,8 @@ export class TeamAwareBatchPipelineBuilder<
     }
 
     handleIngestionWarnings(
-        kafkaProducer: KafkaProducerWrapper
+        outputs: IngestionOutputs<IngestionWarningsOutput>
     ): BatchPipelineBuilder<TInput, TOutput, CInput, COutput> {
-        return new BatchPipelineBuilder(new IngestionWarningHandlingBatchPipeline(kafkaProducer, this.pipeline))
+        return new BatchPipelineBuilder(new IngestionWarningHandlingBatchPipeline(outputs, this.pipeline))
     }
 }

--- a/nodejs/src/ingestion/pipelines/docs/09-ingestion-warnings.test.ts
+++ b/nodejs/src/ingestion/pipelines/docs/09-ingestion-warnings.test.ts
@@ -43,9 +43,11 @@
  * ignored and never sent to Kafka. Always ensure `handleIngestionWarnings()`
  * is called within a `teamAware()` block to process warnings.
  */
+import { createMockIngestionOutputs } from '../../../../tests/helpers/mock-ingestion-outputs'
 import { createTestTeam } from '../../../../tests/helpers/team'
 import { Team } from '../../../types'
 import { PromiseScheduler } from '../../../utils/promise-scheduler'
+import { IngestionWarningsOutput } from '../../common/outputs'
 import { newBatchPipelineBuilder } from '../builders'
 import { createContext } from '../helpers'
 import { PipelineWarning } from '../pipeline.interface'
@@ -235,9 +237,7 @@ describe('Handling Ingestion Warnings', () => {
      * Use `handleSideEffects()` to execute the warning side effects.
      */
     it('handleIngestionWarnings converts warnings to side effects', async () => {
-        const mockKafkaProducer = {
-            queueMessages: jest.fn().mockResolvedValue(undefined),
-        }
+        const mockOutputs = createMockIngestionOutputs<IngestionWarningsOutput>()
         const promiseScheduler = new PromiseScheduler()
 
         interface Event {
@@ -256,7 +256,7 @@ describe('Handling Ingestion Warnings', () => {
         const pipeline = newBatchPipelineBuilder<Event, { team: Team }>()
             .pipeBatch(createWarningStep())
             .teamAware((builder) => builder)
-            .handleIngestionWarnings(mockKafkaProducer as any)
+            .handleIngestionWarnings(mockOutputs)
             .handleSideEffects(promiseScheduler, { await: true })
             .build()
 
@@ -268,8 +268,8 @@ describe('Handling Ingestion Warnings', () => {
         // Warnings are cleared after handling
         expect(results![0].context.warnings).toEqual([])
 
-        // Side effects were executed (warning sent to Kafka)
-        expect(mockKafkaProducer.queueMessages).toHaveBeenCalled()
+        // Side effects were executed (warning sent to Kafka via outputs)
+        expect(mockOutputs.queueMessages).toHaveBeenCalled()
     })
 
     /**
@@ -277,9 +277,7 @@ describe('Handling Ingestion Warnings', () => {
      * Both the original side effects and warning side effects are executed.
      */
     it('handleIngestionWarnings preserves existing side effects', async () => {
-        const mockKafkaProducer = {
-            queueMessages: jest.fn().mockResolvedValue(undefined),
-        }
+        const mockOutputs = createMockIngestionOutputs<IngestionWarningsOutput>()
         const promiseScheduler = new PromiseScheduler()
 
         const sideEffectLog: string[] = []
@@ -304,7 +302,7 @@ describe('Handling Ingestion Warnings', () => {
         const pipeline = newBatchPipelineBuilder<Event, { team: Team }>()
             .pipeBatch(createStepWithBothSideEffectsAndWarnings())
             .teamAware((builder) => builder)
-            .handleIngestionWarnings(mockKafkaProducer as any)
+            .handleIngestionWarnings(mockOutputs)
             .handleSideEffects(promiseScheduler, { await: true })
             .build()
 
@@ -316,8 +314,8 @@ describe('Handling Ingestion Warnings', () => {
         // Original side effect executed
         expect(sideEffectLog).toContain('processed: click')
 
-        // Warning side effect executed (sent to Kafka)
-        expect(mockKafkaProducer.queueMessages).toHaveBeenCalled()
+        // Warning side effect executed (sent to Kafka via outputs)
+        expect(mockOutputs.queueMessages).toHaveBeenCalled()
     })
 })
 

--- a/nodejs/src/ingestion/pipelines/docs/12-filter-map.test.ts
+++ b/nodejs/src/ingestion/pipelines/docs/12-filter-map.test.ts
@@ -19,9 +19,11 @@
 import { Message } from 'node-rdkafka'
 
 import { createTestMessage } from '../../../../tests/helpers/kafka-message'
+import { createMockIngestionOutputs } from '../../../../tests/helpers/mock-ingestion-outputs'
 import { createTestTeam } from '../../../../tests/helpers/team'
 import { Team } from '../../../types'
 import { PromiseScheduler } from '../../../utils/promise-scheduler'
+import { IngestionWarningsOutput } from '../../common/outputs'
 import { newBatchPipelineBuilder } from '../builders'
 import { createContext } from '../helpers'
 import { PipelineWarning } from '../pipeline.interface'
@@ -131,7 +133,7 @@ describe('Filter Map', () => {
                 (b) =>
                     b
                         .teamAware((b) => b.pipeBatch(createProcessEventStep()).gather())
-                        .handleIngestionWarnings(mockKafkaProducer as any)
+                        .handleIngestionWarnings(createMockIngestionOutputs<IngestionWarningsOutput>())
             )
             // Handle all results (both from subpipeline and passed-through non-OK) once at the end
             .messageAware((builder) => builder)

--- a/nodejs/src/ingestion/pipelines/docs/12-filter-map.test.ts
+++ b/nodejs/src/ingestion/pipelines/docs/12-filter-map.test.ts
@@ -182,8 +182,8 @@ describe('Filter Map', () => {
 
         // Ingestion warning was produced for deprecated event via outputs
         expect(mockWarningOutputs.queueMessages).toHaveBeenCalledTimes(1)
-        expect(mockWarningOutputs.queueMessages).toHaveBeenCalledWith(INGESTION_WARNINGS_OUTPUT, [
-            expect.objectContaining({ value: expect.stringContaining('"type":"deprecated_event"') }),
-        ])
+        expect(mockWarningOutputs.queueMessages.mock.calls[0][0]).toBe(INGESTION_WARNINGS_OUTPUT)
+        const warningValue = mockWarningOutputs.queueMessages.mock.calls[0][1][0].value!.toString()
+        expect(warningValue).toContain('"type":"deprecated_event"')
     })
 })

--- a/nodejs/src/ingestion/pipelines/docs/12-filter-map.test.ts
+++ b/nodejs/src/ingestion/pipelines/docs/12-filter-map.test.ts
@@ -23,7 +23,7 @@ import { createMockIngestionOutputs } from '../../../../tests/helpers/mock-inges
 import { createTestTeam } from '../../../../tests/helpers/team'
 import { Team } from '../../../types'
 import { PromiseScheduler } from '../../../utils/promise-scheduler'
-import { IngestionWarningsOutput } from '../../common/outputs'
+import { INGESTION_WARNINGS_OUTPUT, IngestionWarningsOutput } from '../../common/outputs'
 import { newBatchPipelineBuilder } from '../builders'
 import { createContext } from '../helpers'
 import { PipelineWarning } from '../pipeline.interface'
@@ -43,6 +43,7 @@ describe('Filter Map', () => {
         const processedEvents: Array<{ eventName: string; teamId: number }> = []
         const producedMessages: any[] = []
         const promiseScheduler = new PromiseScheduler()
+        const mockWarningOutputs = createMockIngestionOutputs<IngestionWarningsOutput>()
         const mockKafkaProducer = {
             produce: jest.fn((msg) => {
                 producedMessages.push(msg)
@@ -133,7 +134,7 @@ describe('Filter Map', () => {
                 (b) =>
                     b
                         .teamAware((b) => b.pipeBatch(createProcessEventStep()).gather())
-                        .handleIngestionWarnings(createMockIngestionOutputs<IngestionWarningsOutput>())
+                        .handleIngestionWarnings(mockWarningOutputs)
             )
             // Handle all results (both from subpipeline and passed-through non-OK) once at the end
             .messageAware((builder) => builder)
@@ -179,8 +180,10 @@ describe('Filter Map', () => {
         // Redirect was called for the overflow event
         expect(topics).toContain('overflow-topic')
 
-        // Ingestion warning was produced for deprecated event
-        const warningTopics = topics.filter((t: string) => t.includes('ingestion_warnings'))
-        expect(warningTopics).toHaveLength(1)
+        // Ingestion warning was produced for deprecated event via outputs
+        expect(mockWarningOutputs.queueMessages).toHaveBeenCalledTimes(1)
+        expect(mockWarningOutputs.queueMessages).toHaveBeenCalledWith(INGESTION_WARNINGS_OUTPUT, [
+            expect.objectContaining({ value: expect.stringContaining('"type":"deprecated_event"') }),
+        ])
     })
 })

--- a/nodejs/src/ingestion/pipelines/docs/13-conventions.test.ts
+++ b/nodejs/src/ingestion/pipelines/docs/13-conventions.test.ts
@@ -32,11 +32,13 @@
 import { Message } from 'node-rdkafka'
 
 import { createTestMessage } from '../../../../tests/helpers/kafka-message'
+import { createMockIngestionOutputs } from '../../../../tests/helpers/mock-ingestion-outputs'
 import { createTestTeam } from '../../../../tests/helpers/team'
 import { KafkaProducerWrapper } from '../../../kafka/producer'
 import { Team } from '../../../types'
 import { parseJSON } from '../../../utils/json-parse'
 import { PromiseScheduler } from '../../../utils/promise-scheduler'
+import { IngestionWarningsOutput } from '../../common/outputs'
 import { newBatchPipelineBuilder, newPipelineBuilder } from '../builders'
 import { PipelineBuilder, StartPipelineBuilder } from '../builders/pipeline-builders'
 import { createContext } from '../helpers'
@@ -482,7 +484,7 @@ describe('Pipeline Phases', () => {
                                                 group.sequentially((b) => createProcessingSubpipeline(b))
                                             )
                                     )
-                                    .handleIngestionWarnings(mockKafkaProducer)
+                                    .handleIngestionWarnings(createMockIngestionOutputs<IngestionWarningsOutput>())
                         )
                 )
                 .handleResults(pipelineConfig)

--- a/nodejs/src/ingestion/pipelines/ingestion-warning-handling-batch-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/ingestion-warning-handling-batch-pipeline.test.ts
@@ -1,13 +1,15 @@
 import { Message } from 'node-rdkafka'
 
-import { KafkaProducerWrapper } from '../../kafka/producer'
+import { createMockIngestionOutputs } from '../../../tests/helpers/mock-ingestion-outputs'
 import { Team } from '../../types'
-import * as utils from '../../worker/ingestion/utils'
+import * as ingestionWarnings from '../common/ingestion-warnings'
+import { IngestionWarningsOutput } from '../common/outputs'
+import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { createContext, createNewBatchPipeline } from './helpers'
 import { IngestionWarningHandlingBatchPipeline } from './ingestion-warning-handling-batch-pipeline'
 import { ok } from './results'
 
-jest.mock('../../worker/ingestion/utils')
+jest.mock('../common/ingestion-warnings')
 
 function createTestMessage(overrides: Partial<Message> = {}): Message {
     return {
@@ -50,16 +52,13 @@ function createTestTeam(overrides: Partial<Team> = {}): Team {
 }
 
 describe('IngestionWarningHandlingBatchPipeline', () => {
-    let mockKafkaProducer: jest.Mocked<KafkaProducerWrapper>
-    let mockCaptureIngestionWarning: jest.MockedFunction<typeof utils.captureIngestionWarning>
+    let mockOutputs: jest.Mocked<IngestionOutputs<IngestionWarningsOutput>>
+    let mockEmitIngestionWarning: jest.MockedFunction<typeof ingestionWarnings.emitIngestionWarning>
 
     beforeEach(() => {
-        mockKafkaProducer = {
-            queueMessages: jest.fn(),
-        } as any
-
-        mockCaptureIngestionWarning = jest.fn().mockResolvedValue(true)
-        ;(utils.captureIngestionWarning as any) = mockCaptureIngestionWarning
+        mockOutputs = createMockIngestionOutputs<IngestionWarningsOutput>()
+        mockEmitIngestionWarning = jest.fn().mockResolvedValue(true)
+        ;(ingestionWarnings.emitIngestionWarning as any) = mockEmitIngestionWarning
     })
 
     describe('basic functionality', () => {
@@ -82,7 +81,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             ]
 
             const rootPipeline = createNewBatchPipeline<{ message: Message; team: Team }, { team: Team }>().build()
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, rootPipeline)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, rootPipeline)
 
             pipeline.feed(batch)
             const results = await pipeline.next()
@@ -100,18 +99,18 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                     team,
                 })
             )
-            expect(mockCaptureIngestionWarning).not.toHaveBeenCalled()
+            expect(mockEmitIngestionWarning).not.toHaveBeenCalled()
         })
 
         it('should handle empty batch', async () => {
             const rootPipeline = createNewBatchPipeline<{ message: Message; team: Team }, { team: Team }>().build()
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, rootPipeline)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, rootPipeline)
 
             pipeline.feed([])
             const results = await pipeline.next()
 
             expect(results).toEqual(null)
-            expect(mockCaptureIngestionWarning).not.toHaveBeenCalled()
+            expect(mockEmitIngestionWarning).not.toHaveBeenCalled()
         })
     })
 
@@ -132,7 +131,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             ]
 
             const rootPipeline = createNewBatchPipeline<{ message: Message; team: Team }, { team: Team }>().build()
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, rootPipeline)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, rootPipeline)
 
             pipeline.feed(batch)
             const results = await pipeline.next()
@@ -141,20 +140,20 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             expect(results![0].context.warnings).toEqual([])
             expect(results![0].context.sideEffects).toHaveLength(2)
 
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledTimes(2)
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledWith(
-                mockKafkaProducer,
+            expect(mockEmitIngestionWarning).toHaveBeenCalledTimes(2)
+            expect(mockEmitIngestionWarning).toHaveBeenCalledWith(
+                mockOutputs,
                 team.id,
                 'test_warning',
                 { field: 'value' },
-                { alwaysSend: undefined }
+                { key: undefined, alwaysSend: undefined }
             )
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledWith(
-                mockKafkaProducer,
+            expect(mockEmitIngestionWarning).toHaveBeenCalledWith(
+                mockOutputs,
                 team.id,
                 'another_warning',
                 { error: 'something' },
-                { alwaysSend: undefined }
+                { key: undefined, alwaysSend: undefined }
             )
         })
 
@@ -171,17 +170,17 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             ]
 
             const rootPipeline = createNewBatchPipeline<{ message: Message; team: Team }, { team: Team }>().build()
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, rootPipeline)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, rootPipeline)
 
             pipeline.feed(batch)
             const results = await pipeline.next()
 
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledWith(
-                mockKafkaProducer,
+            expect(mockEmitIngestionWarning).toHaveBeenCalledWith(
+                mockOutputs,
                 team.id,
                 'critical_warning',
                 { urgent: true },
-                { alwaysSend: true }
+                { key: undefined, alwaysSend: true }
             )
             expect(results![0].context.warnings).toEqual([])
         })
@@ -203,7 +202,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             ]
 
             const rootPipeline = createNewBatchPipeline<{ message: Message; team: Team }, { team: Team }>().build()
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, rootPipeline)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, rootPipeline)
 
             pipeline.feed(batch)
             const results = await pipeline.next()
@@ -247,26 +246,20 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             ]
 
             const rootPipeline = createNewBatchPipeline<{ message: Message; team: Team }, { team: Team }>().build()
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, rootPipeline)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, rootPipeline)
 
             pipeline.feed(batch)
             const results = await pipeline.next()
 
             expect(results).toHaveLength(3)
-
-            // First item: 1 warning converted to side effect
             expect(results![0].context.warnings).toEqual([])
             expect(results![0].context.sideEffects).toHaveLength(1)
-
-            // Second item: no warnings, no side effects
             expect(results![1].context.warnings).toEqual([])
             expect(results![1].context.sideEffects).toHaveLength(0)
-
-            // Third item: 2 warnings converted to side effects
             expect(results![2].context.warnings).toEqual([])
             expect(results![2].context.sideEffects).toHaveLength(2)
 
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledTimes(3)
+            expect(mockEmitIngestionWarning).toHaveBeenCalledTimes(3)
         })
 
         it('should handle multiple items with different teams', async () => {
@@ -288,24 +281,24 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             ]
 
             const rootPipeline = createNewBatchPipeline<{ message: Message; team: Team }, { team: Team }>().build()
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, rootPipeline)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, rootPipeline)
 
             pipeline.feed(batch)
             await pipeline.next()
 
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledWith(
-                mockKafkaProducer,
+            expect(mockEmitIngestionWarning).toHaveBeenCalledWith(
+                mockOutputs,
                 team1.id,
                 'warning_team1',
                 { team: 1 },
-                { alwaysSend: undefined }
+                { key: undefined, alwaysSend: undefined }
             )
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledWith(
-                mockKafkaProducer,
+            expect(mockEmitIngestionWarning).toHaveBeenCalledWith(
+                mockOutputs,
                 team2.id,
                 'warning_team2',
                 { team: 2 },
-                { alwaysSend: undefined }
+                { key: undefined, alwaysSend: undefined }
             )
         })
     })
@@ -320,21 +313,11 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             const team = createTestTeam()
 
             const batch = [
-                createContext(ok({ message: messages[0], team }), {
-                    message: messages[0],
-                    team,
-                }),
-                createContext(ok({ message: messages[1], team }), {
-                    message: messages[1],
-                    team,
-                }),
-                createContext(ok({ message: messages[2], team }), {
-                    message: messages[2],
-                    team,
-                }),
+                createContext(ok({ message: messages[0], team }), { message: messages[0], team }),
+                createContext(ok({ message: messages[1], team }), { message: messages[1], team }),
+                createContext(ok({ message: messages[2], team }), { message: messages[2], team }),
             ]
 
-            // Create a previous pipeline that adds warnings
             const previousPipeline = {
                 feed: jest.fn(),
                 next: jest.fn().mockResolvedValue([
@@ -356,7 +339,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
                 ]),
             }
 
-            const pipeline = new IngestionWarningHandlingBatchPipeline(mockKafkaProducer, previousPipeline as any)
+            const pipeline = new IngestionWarningHandlingBatchPipeline(mockOutputs, previousPipeline as any)
 
             pipeline.feed(batch)
             const results = await pipeline.next()
@@ -369,7 +352,7 @@ describe('IngestionWarningHandlingBatchPipeline', () => {
             expect(results![1].context.warnings).toEqual([])
             expect(results![2].context.warnings).toEqual([])
 
-            expect(mockCaptureIngestionWarning).toHaveBeenCalledTimes(2)
+            expect(mockEmitIngestionWarning).toHaveBeenCalledTimes(2)
         })
     })
 })

--- a/nodejs/src/ingestion/pipelines/ingestion-warning-handling-batch-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ingestion-warning-handling-batch-pipeline.ts
@@ -1,5 +1,6 @@
-import { KafkaProducerWrapper } from '../../kafka/producer'
-import { captureIngestionWarning } from '../../worker/ingestion/utils'
+import { emitIngestionWarning } from '../common/ingestion-warnings'
+import { IngestionWarningsOutput } from '../common/outputs'
+import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { BatchPipeline, BatchPipelineResultWithContext } from './batch-pipeline.interface'
 import { TeamIdContext } from './builders/batch-pipeline-builders'
 
@@ -11,7 +12,7 @@ export class IngestionWarningHandlingBatchPipeline<
 > implements BatchPipeline<TInput, TOutput, CInput, COutput>
 {
     constructor(
-        private kafkaProducer: KafkaProducerWrapper,
+        private outputs: IngestionOutputs<IngestionWarningsOutput>,
         private previousPipeline: BatchPipeline<TInput, TOutput, CInput, COutput>
     ) {}
 
@@ -28,8 +29,8 @@ export class IngestionWarningHandlingBatchPipeline<
         return results.map((resultWithContext) => {
             if (resultWithContext.context.warnings && resultWithContext.context.warnings.length > 0) {
                 const warningPromises = resultWithContext.context.warnings.map((warning) =>
-                    captureIngestionWarning(
-                        this.kafkaProducer,
+                    emitIngestionWarning(
+                        this.outputs,
                         resultWithContext.context.team.id,
                         warning.type,
                         warning.details,

--- a/nodejs/src/ingestion/pipelines/pipelines.integration.test.ts
+++ b/nodejs/src/ingestion/pipelines/pipelines.integration.test.ts
@@ -1,7 +1,9 @@
 import { Message } from 'node-rdkafka'
 import { v4 } from 'uuid'
 
+import { createMockIngestionOutputs } from '../../../tests/helpers/mock-ingestion-outputs'
 import { ProjectId, Team } from '../../types'
+import { IngestionWarningsOutput } from '../common/outputs'
 import { BatchProcessingStep } from './base-batch-pipeline'
 import { newBatchPipelineBuilder } from './builders'
 import { createBatch, createNewPipeline, createUnwrapper } from './helpers'
@@ -1796,7 +1798,7 @@ describe('Pipeline Integration Tests', () => {
                                             .gather()
                                             .pipeBatch(batchStep)
                                     )
-                                    .handleIngestionWarnings(mockKafkaProducer)
+                                    .handleIngestionWarnings(createMockIngestionOutputs<IngestionWarningsOutput>())
                         )
                 )
                 .handleResults(pipelineConfig)

--- a/nodejs/src/ingestion/session_replay/session-replay-pipeline.ts
+++ b/nodejs/src/ingestion/session_replay/session-replay-pipeline.ts
@@ -1,5 +1,6 @@
 import { Message } from 'node-rdkafka'
 
+import { KAFKA_INGESTION_WARNINGS } from '../../config/kafka-topics'
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { ParsedMessageData } from '../../session-recording/kafka/types'
 import { SessionBatchManager } from '../../session-recording/sessions/session-batch-manager'
@@ -8,7 +9,9 @@ import { TeamService } from '../../session-replay/shared/teams/team-service'
 import { ValueMatcher } from '../../types'
 import { EventIngestionRestrictionManager } from '../../utils/event-ingestion-restrictions'
 import { PromiseScheduler } from '../../utils/promise-scheduler'
+import { INGESTION_WARNINGS_OUTPUT, IngestionWarningsOutput } from '../common/outputs'
 import { createApplyEventRestrictionsStep, createParseHeadersStep } from '../event-preprocessing'
+import { IngestionOutputs } from '../outputs/ingestion-outputs'
 import { BatchPipelineUnwrapper } from '../pipelines/batch-pipeline-unwrapper'
 import { newBatchPipelineBuilder } from '../pipelines/builders'
 import { TopHogRegistry, createTopHogWrapper, sum, timer } from '../pipelines/extensions/tophog'
@@ -72,6 +75,13 @@ export function createSessionReplayPipeline(
         sessionBatchManager,
         isDebugLoggingEnabled,
     } = config
+
+    const outputs = new IngestionOutputs<IngestionWarningsOutput>({
+        [INGESTION_WARNINGS_OUTPUT]: {
+            topic: KAFKA_INGESTION_WARNINGS,
+            producer: ingestionWarningProducer,
+        },
+    })
 
     const pipelineConfig: PipelineConfig = {
         kafkaProducer,
@@ -150,7 +160,7 @@ export function createSessionReplayPipeline(
                                     )
                                     .gather()
                             )
-                            .handleIngestionWarnings(ingestionWarningProducer)
+                            .handleIngestionWarnings(outputs)
                 )
         )
         .handleResults(pipelineConfig)

--- a/nodejs/src/worker/ingestion/utils.ts
+++ b/nodejs/src/worker/ingestion/utils.ts
@@ -1,21 +1,18 @@
 import { DateTime } from 'luxon'
-import { Counter } from 'prom-client'
 
 import { PluginEvent, ProcessedPluginEvent } from '~/plugin-scaffold'
 
-import { KafkaProducerWrapper, TopicMessage } from '../../kafka/producer'
-import { PipelineEvent, TeamId, TimestampFormat } from '../../types'
+import { TopicMessage } from '../../kafka/producer'
+import { PipelineEvent, TimestampFormat } from '../../types'
 import { safeClickhouseString } from '../../utils/db/utils'
-import { logger } from '../../utils/logger'
-import { IngestionWarningLimiter } from '../../utils/token-bucket'
-import { UUIDT, castTimestampOrNow, castTimestampToClickhouseFormat } from '../../utils/utils'
-import { KAFKA_EVENTS_DEAD_LETTER_QUEUE, KAFKA_INGESTION_WARNINGS } from './../../config/kafka-topics'
+import { UUIDT, castTimestampToClickhouseFormat } from '../../utils/utils'
+import { KAFKA_EVENTS_DEAD_LETTER_QUEUE } from './../../config/kafka-topics'
 
-export const ingestionWarningCounter = new Counter({
-    name: 'ingestion_warnings_total',
-    help: 'Total number of ingestion warnings by type and emission status',
-    labelNames: ['type', 'emitted'],
-})
+export {
+    ingestionWarningCounter,
+    captureIngestionWarning,
+    emitIngestionWarning,
+} from '../../ingestion/common/ingestion-warnings'
 
 function getClickhouseTimestampOrNull(isoTimestamp?: string): string | null {
     return isoTimestamp
@@ -64,57 +61,4 @@ export function generateEventDeadLetterQueueMessage(
             },
         ],
     }
-}
-
-// These get displayed under Data Management > Ingestion Warnings
-// These warnings get displayed to end users. Make sure these errors are actionable and useful for them and
-// also update IngestionWarningsView.tsx to display useful context.
-export async function captureIngestionWarning(
-    kafkaProducer: KafkaProducerWrapper,
-    teamId: TeamId,
-    type: string,
-    details: Record<string, any>,
-    /**
-     * captureIngestionWarning will debounce calls using team id and type as the key
-     * you can provide additional config in debounce.key to add to that key
-     * for example to debounce by specific user id you can use debounce: { key: user_id }
-     *
-     * if alwaysSend is true, the message will be sent regardless of the debounce key
-     * you can use this when a message is rare enough or important enough that it should always be sent
-     */
-    debounce?: { key?: string; alwaysSend?: boolean }
-): Promise<boolean> {
-    const limiter_key = `${teamId}:${type}:${debounce?.key || ''}`
-    const shouldEmit = !!debounce?.alwaysSend || IngestionWarningLimiter.consume(limiter_key, 1)
-
-    ingestionWarningCounter.inc({ type, emitted: shouldEmit.toString() })
-
-    if (shouldEmit) {
-        return kafkaProducer
-            .queueMessages({
-                topic: KAFKA_INGESTION_WARNINGS,
-                messages: [
-                    {
-                        value: JSON.stringify({
-                            team_id: teamId,
-                            type: type,
-                            source: 'plugin-server',
-                            details: JSON.stringify(details),
-                            timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
-                        }),
-                    },
-                ],
-            })
-            .then(() => true)
-            .catch((error) => {
-                logger.warn('⚠️', 'Failed to produce ingestion warning', {
-                    error,
-                    team_id: teamId,
-                    type,
-                    details,
-                })
-                return false
-            })
-    }
-    return Promise.resolve(false)
 }

--- a/nodejs/tests/helpers/ingestion-outputs.ts
+++ b/nodejs/tests/helpers/ingestion-outputs.ts
@@ -2,8 +2,10 @@ import {
     KAFKA_CLICKHOUSE_AI_EVENTS_JSON,
     KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
     KAFKA_EVENTS_JSON,
+    KAFKA_INGESTION_WARNINGS,
 } from '../../src/config/kafka-topics'
 import { AI_EVENTS_OUTPUT, EVENTS_OUTPUT, HEATMAPS_OUTPUT } from '../../src/ingestion/analytics/outputs'
+import { INGESTION_WARNINGS_OUTPUT } from '../../src/ingestion/common/outputs'
 import { IngestionOutputs } from '../../src/ingestion/outputs/ingestion-outputs'
 import { KafkaProducerWrapper } from '../../src/kafka/producer'
 
@@ -12,5 +14,6 @@ export function createTestIngestionOutputs(kafkaProducer: KafkaProducerWrapper) 
         [EVENTS_OUTPUT]: { topic: KAFKA_EVENTS_JSON, producer: kafkaProducer },
         [AI_EVENTS_OUTPUT]: { topic: KAFKA_CLICKHOUSE_AI_EVENTS_JSON, producer: kafkaProducer },
         [HEATMAPS_OUTPUT]: { topic: KAFKA_CLICKHOUSE_HEATMAP_EVENTS, producer: kafkaProducer },
+        [INGESTION_WARNINGS_OUTPUT]: { topic: KAFKA_INGESTION_WARNINGS, producer: kafkaProducer },
     })
 }


### PR DESCRIPTION
## Problem

We're moving Kafka event production to the outputs abstraction to allow us to produce to different Kafka clusters.

## Changes

- Moves the handle ingestion warnings pipeline step to use outputs
- Removes kafka producer from emit events step and uses outputs to send the ingestion warnings

## How did you test this code?

- Updated existing tests
- Integration tests
- Will check on dev / overflow