### PR TITLE
feat(phrocs): Add sort shortcut + scroll arrows

### DIFF
--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -61,6 +61,8 @@ You typically run phrocs via `hogli dev` rather than directly.
 | `r`    | Restart selected process                        |
 | `s`    | Stop selected process                           |
 | `c`    | Enter copy mode                                 |
+| `i`    | Show process info in pager                      |
+| `o`    | Sort processes by <name/CPU/RAM/status>         |
 | `/`    | Enter search mode                               |
 | `esc`  | Exit copy and search modes                      |
 | `?`    | Toggle full help                                |

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"log"
+	"sort"
 	"strings"
 
 	"charm.land/bubbles/v2/help"
@@ -21,6 +22,31 @@ const (
 	focusOutput
 	focusContainers
 )
+
+type SortMode int
+
+const (
+	SortName SortMode = iota
+	SortCPU
+	SortRAM
+	SortStatus
+	sortModeCount // sentinel for cycling
+)
+
+func (s SortMode) String() string {
+	switch s {
+	case SortName:
+		return "name"
+	case SortCPU:
+		return "CPU"
+	case SortRAM:
+		return "RAM"
+	case SortStatus:
+		return "status"
+	default:
+		return "name"
+	}
+}
 
 type Model struct {
 	mgr *process.Manager
@@ -46,6 +72,7 @@ type Model struct {
 	services       []*process.Process
 	servicesCursor int
 	servicesOffset int
+	sortMode       SortMode
 
 	// Docker container sidebar (visible when docker-compose proc is selected)
 	containers         []docker.DockerContainer
@@ -165,11 +192,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case process.StatusMsg:
 		m.dbg("status: proc=%s status=%s", msg.Name, msg.Status)
+		// Capture the active name before re-fetching so sortServices
+		// can restore the cursor to the same process.
+		activeName := ""
+		if p := m.activeProc(); p != nil {
+			activeName = p.Name
+		}
 		// Re-fetch the process slice so status icons refresh on next render
 		m.services = m.mgr.Procs()
-		if m.servicesCursor >= len(m.services) {
-			m.servicesCursor = max(0, len(m.services)-1)
+		// Restore cursor to the same process in the new (unsorted) slice
+		m.servicesCursor = 0
+		for i, p := range m.services {
+			if p.Name == activeName {
+				m.servicesCursor = i
+				break
+			}
 		}
+		m.sortServices()
 		m.ensureSidebarCursorVisible()
 
 	// Container-related messages only relevant in docker mode
@@ -411,4 +450,62 @@ func (m Model) buildContent() string {
 		return ""
 	}
 	return strings.Join(p.Lines(), "\n")
+}
+
+// statusSortOrder returns a numeric rank for sorting by status.
+// Running/pending processes sort first, crashed last.
+func statusSortOrder(s process.Status) int {
+	switch s {
+	case process.StatusRunning:
+		return 0
+	case process.StatusPending:
+		return 1
+	case process.StatusCrashed:
+		return 2
+	case process.StatusStopped:
+		return 3
+	case process.StatusDone:
+		return 4
+	default:
+		return 5
+	}
+}
+
+// sortServices re-sorts m.services by the current sortMode, preserving
+// the cursor on the same process.
+func (m *Model) sortServices() {
+	if len(m.services) == 0 {
+		return
+	}
+	activeName := ""
+	if m.servicesCursor < len(m.services) {
+		activeName = m.services[m.servicesCursor].Name
+	}
+
+	sort.SliceStable(m.services, func(i, j int) bool {
+		a, b := m.services[i], m.services[j]
+		switch m.sortMode {
+		case SortCPU:
+			return a.CPUPercent() > b.CPUPercent()
+		case SortRAM:
+			return a.MemRSSMB() > b.MemRSSMB()
+		case SortStatus:
+			sa, sb := statusSortOrder(a.Status()), statusSortOrder(b.Status())
+			if sa != sb {
+				return sa < sb
+			}
+			return a.Name < b.Name
+		default: // SortName
+			return a.Name < b.Name
+		}
+	})
+
+	// Restore cursor to the same process
+	for i, p := range m.services {
+		if p.Name == activeName {
+			m.servicesCursor = i
+			break
+		}
+	}
+	m.ensureSidebarCursorVisible()
 }

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -209,7 +209,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.sortServices()
-		m.ensureSidebarCursorVisible()
 
 	// Container-related messages only relevant in docker mode
 	case docker.ContainerListMsg:
@@ -453,7 +452,7 @@ func (m Model) buildContent() string {
 }
 
 // statusSortOrder returns a numeric rank for sorting by status.
-// Running/pending processes sort first, crashed last.
+// Running/pending processes sort first, done last.
 func statusSortOrder(s process.Status) int {
 	switch s {
 	case process.StatusRunning:
@@ -484,6 +483,7 @@ func (m *Model) sortServices() {
 
 	sort.SliceStable(m.services, func(i, j int) bool {
 		a, b := m.services[i], m.services[j]
+
 		switch m.sortMode {
 		case SortCPU:
 			return a.CPUPercent() > b.CPUPercent()
@@ -495,7 +495,14 @@ func (m *Model) sortServices() {
 				return sa < sb
 			}
 			return a.Name < b.Name
-		default: // SortName
+		default:
+			// Always place info at the top of the list
+			if a.Name == "info" {
+				return true
+			}
+			if b.Name == "info" {
+				return false
+			}
 			return a.Name < b.Name
 		}
 	})

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -600,3 +600,126 @@ func TestGotoTop_clearsAtBottom(t *testing.T) {
 		t.Error("home key should set atBottom=false")
 	}
 }
+
+// ── Sorting ──────────────────────────────────────────────────────────────────
+
+func serviceNames(m Model) []string {
+	names := make([]string, len(m.services))
+	for i, p := range m.services {
+		names[i] = p.Name
+	}
+	return names
+}
+
+func TestSort_defaultIsName(t *testing.T) {
+	m := readyModel(t, "frontend", "backend", "celery")
+	got := serviceNames(m)
+	want := []string{"backend", "celery", "frontend"}
+	for i, n := range got {
+		if n != want[i] {
+			t.Errorf("index %d: got %q, want %q (full: %v)", i, n, want[i], got)
+		}
+	}
+}
+
+func TestSort_cycleWithO(t *testing.T) {
+	m := readyModel(t, "backend", "frontend")
+	if m.sortMode != SortName {
+		t.Fatalf("initial sort mode: got %v, want SortName", m.sortMode)
+	}
+	m = update(m, keypress('o'))
+	if m.sortMode != SortCPU {
+		t.Errorf("after first o: got %v, want SortCPU", m.sortMode)
+	}
+	m = update(m, keypress('o'))
+	if m.sortMode != SortRAM {
+		t.Errorf("after second o: got %v, want SortRAM", m.sortMode)
+	}
+	m = update(m, keypress('o'))
+	if m.sortMode != SortStatus {
+		t.Errorf("after third o: got %v, want SortStatus", m.sortMode)
+	}
+	m = update(m, keypress('o'))
+	if m.sortMode != SortName {
+		t.Errorf("after fourth o: got %v, want SortName (wrap)", m.sortMode)
+	}
+}
+
+func TestSort_cursorPreservedAcrossModes(t *testing.T) {
+	m := readyModel(t, "alpha", "beta", "gamma")
+	// Select "gamma" (last in alphabetical order)
+	m = update(m, keypress('j'))
+	m = update(m, keypress('j'))
+	if m.services[m.servicesCursor].Name != "gamma" {
+		t.Fatalf("cursor should be on gamma, got %s", m.services[m.servicesCursor].Name)
+	}
+	// Cycle sort — cursor should stay on gamma
+	m = update(m, keypress('o'))
+	if m.services[m.servicesCursor].Name != "gamma" {
+		t.Errorf("after sort cycle, cursor should stay on gamma, got %s", m.services[m.servicesCursor].Name)
+	}
+}
+
+func TestSort_cursorPreservedOnStatusMsg(t *testing.T) {
+	m := readyModel(t, "alpha", "beta", "gamma")
+	// After init+sort, order is alphabetical: alpha, beta, gamma.
+	// Navigate to the last entry.
+	m = update(m, keypress('j'))
+	m = update(m, keypress('j'))
+	selected := m.services[m.servicesCursor].Name
+	if selected != "gamma" {
+		t.Fatalf("cursor should be on gamma, got %s (order: %v)", selected, serviceNames(m))
+	}
+	// StatusMsg re-fetches and re-sorts — cursor should stay on gamma
+	m = update(m, process.StatusMsg{Name: "alpha", Status: process.StatusRunning})
+	if m.services[m.servicesCursor].Name != "gamma" {
+		t.Errorf("after StatusMsg, cursor should stay on gamma, got %s", m.services[m.servicesCursor].Name)
+	}
+}
+
+func TestSort_statusOrder(t *testing.T) {
+	// All test processes start as StatusStopped since we don't call Start().
+	// With equal statuses, status sort falls back to alphabetical.
+	m := readyModel(t, "gamma", "alpha", "beta")
+	m.sortMode = SortStatus
+	m.sortServices()
+
+	got := serviceNames(m)
+	want := []string{"alpha", "beta", "gamma"}
+	for i, n := range got {
+		if n != want[i] {
+			t.Errorf("status sort index %d: got %q, want %q (full: %v)", i, n, want[i], got)
+		}
+	}
+}
+
+func TestSort_statusSortOrder(t *testing.T) {
+	// Verify the rank function directly
+	tests := []struct {
+		status process.Status
+		want   int
+	}{
+		{process.StatusRunning, 0},
+		{process.StatusPending, 1},
+		{process.StatusCrashed, 2},
+		{process.StatusStopped, 3},
+		{process.StatusDone, 4},
+	}
+	for i, tt := range tests {
+		got := statusSortOrder(tt.status)
+		if got != tt.want {
+			t.Errorf("statusSortOrder(%v): got %d, want %d (index %d)", tt.status, got, tt.want, i)
+		}
+	}
+}
+
+func TestSort_infoSortsAlphabetically(t *testing.T) {
+	m := readyModel(t, "info", "backend", "alpha")
+	got := serviceNames(m)
+	want := []string{"alpha", "backend", "info"}
+	for i, n := range got {
+		if n != want[i] {
+			t.Errorf("index %d: got %q, want %q (full: %v)", i, n, want[i], got)
+		}
+	}
+}

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -716,7 +716,7 @@ func TestSort_statusSortOrder(t *testing.T) {
 func TestSort_infoSortsAlphabetically(t *testing.T) {
 	m := readyModel(t, "info", "backend", "alpha")
 	got := serviceNames(m)
-	want := []string{"alpha", "backend", "info"}
+	want := []string{"info", "alpha", "backend"}
 	for i, n := range got {
 		if n != want[i] {
 			t.Errorf("index %d: got %q, want %q (full: %v)", i, n, want[i], got)

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -22,6 +22,7 @@ type keyMap struct {
 	Backspace  key.Binding
 	Hedgehog   key.Binding
 	Info       key.Binding
+	Sort       key.Binding
 	LazyDocker key.Binding
 	ProcViewer key.Binding
 }
@@ -104,6 +105,10 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("i"),
 			key.WithHelp("i:", "info"),
 		),
+		Sort: key.NewBinding(
+			key.WithKeys("o"),
+			key.WithHelp("o:", "sort"),
+		),
 		LazyDocker: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("d:", "lazydocker"),
@@ -118,12 +123,12 @@ func defaultKeyMap() keyMap {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.NextProc, k.NextPane, k.Search, k.CopyMode, k.Restart, k.Stop, k.Quit, k.Help}
+	return []key.Binding{k.NextProc, k.NextPane, k.Search, k.CopyMode, k.Sort, k.Restart, k.Stop, k.Quit, k.Help}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.NextProc, k.PrevProc},
+		{k.NextProc, k.PrevProc, k.Sort},
 		{k.ScrollUp, k.ScrollDown},
 		{k.GotoTop, k.GotoBottom},
 		{k.NextPane, k.PrevPane, k.LazyDocker, k.ProcViewer},

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -304,6 +304,11 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		m.applyCopyStyle()
 		m.dbg("copy mode: enter at line %d", m.copyCursor)
 
+	case key.Matches(msg, m.keys.Sort):
+		m.sortMode = (m.sortMode + 1) % SortMode(sortModeCount)
+		m.sortServices()
+		m.dbg("sort: %s", m.sortMode)
+
 	case key.Matches(msg, m.keys.Info):
 		m.infoMode = true
 		m.refreshInfoContent()

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -51,9 +51,14 @@ func (m Model) renderHeader() string {
 		}
 	}
 
-	spacerW := max(m.width-lipgloss.Width(stripesStyle)-lipgloss.Width(brand)-lipgloss.Width(procInfo)-lipgloss.Width(meta), 0)
+	var sortInfo string
+	if m.sortMode != SortName {
+		sortInfo = headerMetaStyle.Render(fmt.Sprintf("sort:%s", m.sortMode))
+	}
+
+	spacerW := max(m.width-lipgloss.Width(stripesStyle)-lipgloss.Width(brand)-lipgloss.Width(sortInfo)-lipgloss.Width(procInfo)-lipgloss.Width(meta)-1, 0)
 	spacer := lipgloss.NewStyle().Width(spacerW).Render("")
-	return lipgloss.JoinHorizontal(lipgloss.Top, stripesStyle, brand, spacer, procInfo, "•", meta)
+	return lipgloss.JoinHorizontal(lipgloss.Top, stripesStyle, brand, spacer, sortInfo, procInfo, "•", meta)
 }
 
 func (m Model) renderSidebar() string {
@@ -67,8 +72,19 @@ func (m Model) renderSidebar() string {
 	start := min(max(m.servicesOffset, 0), max(0, len(m.services)-1))
 	end := min(len(m.services), start+h)
 
+	canScrollUp := start > 0
+	canScrollDown := end < len(m.services)
+
+	visibleH := m.sidebarVisibleItems()
+	visibleEnd := min(len(m.services), start+visibleH)
+
 	var rows []string
-	for i := start; i < end; i++ {
+
+	if canScrollUp {
+		rows = append(rows, scrollArrowStyle.Width(innerW).Render("▲"))
+	}
+
+	for i := start; i < visibleEnd; i++ {
 		p := m.services[i]
 		status := p.Status()
 		iconChar := statusIconChar(status)
@@ -85,8 +101,12 @@ func (m Model) renderSidebar() string {
 		rows = append(rows, renderSidebarRow(iconChar, name, iconColor, i == m.servicesCursor, cpuPct, innerW))
 	}
 
+	if canScrollDown {
+		rows = append(rows, scrollArrowStyle.Width(innerW).Render("▼"))
+	}
+
 	// Pad remaining rows so the sidebar border extends the full height
-	for i := end - start; i < h; i++ {
+	for len(rows) < h {
 		rows = append(rows, procInactiveStyle.Width(innerW).Render(""))
 	}
 
@@ -103,11 +123,35 @@ func (m Model) sidebarHeight() int {
 	return max(h, 1)
 }
 
+// sidebarVisibleItems returns how many process rows fit in the sidebar,
+// accounting for scroll arrow indicators that consume a row each.
+func (m Model) sidebarVisibleItems() int {
+	h := m.sidebarHeight()
+	if len(m.services) <= h {
+		return h
+	}
+
+	start := min(max(m.servicesOffset, 0), max(0, len(m.services)-1))
+	end := min(len(m.services), start+h)
+
+	canScrollUp := start > 0
+	canScrollDown := end < len(m.services)
+
+	if canScrollUp {
+		h--
+	}
+	if canScrollDown {
+		h--
+	}
+
+	return max(h, 1)
+}
+
 // Keep selected process row within the visible
 // sidebar window by adjusting servicesOffset
 func (m *Model) ensureSidebarCursorVisible() {
-	h := m.sidebarHeight()
-	if len(m.services) <= h {
+	h := m.sidebarVisibleItems()
+	if len(m.services) <= m.sidebarHeight() {
 		m.servicesOffset = 0
 		return
 	}

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -53,7 +53,7 @@ func (m Model) renderHeader() string {
 
 	var sortInfo string
 	if m.sortMode != SortName {
-		sortInfo = headerMetaStyle.Render(fmt.Sprintf("sort:%s", m.sortMode))
+		sortInfo = headerMetaStyle.Render(fmt.Sprintf("▼ %s", m.sortMode))
 	}
 
 	spacerW := max(m.width-lipgloss.Width(stripesStyle)-lipgloss.Width(brand)-lipgloss.Width(sortInfo)-lipgloss.Width(procInfo)-lipgloss.Width(meta)-1, 0)
@@ -70,12 +70,7 @@ func (m Model) renderSidebar() string {
 	// Determine the vertical slice of the services list to render based
 	// on the current cursor position and servicesOffset
 	start := min(max(m.servicesOffset, 0), max(0, len(m.services)-1))
-	end := min(len(m.services), start+h)
-
-	canScrollUp := start > 0
-	canScrollDown := end < len(m.services)
-
-	visibleH := m.sidebarVisibleItems()
+	canScrollUp, canScrollDown, visibleH := m.sidebarScrollState()
 	visibleEnd := min(len(m.services), start+visibleH)
 
 	var rows []string
@@ -123,34 +118,36 @@ func (m Model) sidebarHeight() int {
 	return max(h, 1)
 }
 
-// sidebarVisibleItems returns how many process rows fit in the sidebar,
-// accounting for scroll arrow indicators that consume a row each.
-func (m Model) sidebarVisibleItems() int {
+// sidebarScrollState computes whether scroll arrows are needed and how many
+// process rows fit. Arrows are derived from offset and list length only,
+// avoiding the circular dependency where arrow visibility depends on visible
+// count which depends on arrow visibility.
+func (m Model) sidebarScrollState() (canScrollUp, canScrollDown bool, visibleH int) {
 	h := m.sidebarHeight()
-	if len(m.services) <= h {
-		return h
+	n := len(m.services)
+	if n <= h {
+		return false, false, h
 	}
 
-	start := min(max(m.servicesOffset, 0), max(0, len(m.services)-1))
-	end := min(len(m.services), start+h)
-
-	canScrollUp := start > 0
-	canScrollDown := end < len(m.services)
-
+	start := min(max(m.servicesOffset, 0), max(0, n-1))
+	canScrollUp = start > 0
+	// Tentatively deduct one row for the up arrow
+	avail := h
 	if canScrollUp {
-		h--
+		avail--
 	}
+	// Check whether the remaining rows can show everything from start onward
+	canScrollDown = start+avail < n
 	if canScrollDown {
-		h--
+		avail--
 	}
-
-	return max(h, 1)
+	return canScrollUp, canScrollDown, max(avail, 1)
 }
 
 // Keep selected process row within the visible
 // sidebar window by adjusting servicesOffset
 func (m *Model) ensureSidebarCursorVisible() {
-	h := m.sidebarVisibleItems()
+	_, _, h := m.sidebarScrollState()
 	if len(m.services) <= m.sidebarHeight() {
 		m.servicesOffset = 0
 		return

--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -81,6 +81,11 @@ var (
 				PaddingLeft(1).
 				Foreground(colorGrey)
 
+	scrollArrowStyle = lipgloss.NewStyle().
+				PaddingLeft(1).
+				Foreground(colorGrey).
+				Align(lipgloss.Center)
+
 	// Footer
 	footerStyle = lipgloss.NewStyle().
 			Foreground(colorGrey).


### PR DESCRIPTION
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Add o key to cycle sidebar sort order: Name → CPU → RAM → Status (header shows sort:mode when not default)        
- Add ▲/▼ scroll indicators to the sidebar when the process list overflows                                              

<img width="870" height="300" alt="Screenshot 2026-03-24 at 1 24 43 PM" src="https://github.com/user-attachments/assets/d70f65a7-361b-4cf6-87a1-d4812934a607" />

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

skip-inkeep-docs

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
