### PR TITLE
fix(workflows): Attribute email open and click metrics to workflow email actions

### DIFF
--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -13,10 +13,10 @@ import { KAFKA_APP_METRICS_2 } from '~/config/kafka-topics'
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 import { closeHub, createHub } from '~/utils/db/hub'
-import { UUIDT } from '~/utils/utils'
 
 import { Hub, Team } from '../../../types'
 import { PIXEL_GIF } from './email-tracking.service'
+import { generateEmailTrackingCode } from './helpers/tracking-code'
 
 describe('EmailTrackingService', () => {
     let hub: Hub
@@ -56,7 +56,49 @@ describe('EmailTrackingService', () => {
         })
 
         describe('handleEmailTrackingRedirect', () => {
-            it('should redirect to the target url and track the click metric', async () => {
+            it('should redirect to the target url and track the click metric via ph_id', async () => {
+                const phId = generateEmailTrackingCode({
+                    functionId: hogFunction.id,
+                    id: invocationId,
+                    teamId: team.id,
+                })
+                const res = await supertest(app).get(`/public/m/redirect?ph_id=${phId}&target=https://example.com`)
+                expect(res.status).toBe(302)
+                expect(res.headers.location).toBe('https://example.com')
+
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+                expect(messages[0].value).toMatchObject({
+                    app_source: 'hog_function',
+                    app_source_id: hogFunction.id,
+                    instance_id: invocationId,
+                    metric_kind: 'email',
+                    metric_name: 'email_link_clicked',
+                    team_id: team.id,
+                    count: 1,
+                })
+            })
+
+            it('should use actionId as instance_id for click metric when present in ph_id', async () => {
+                const actionNodeId = 'action_function_email_abc123'
+                const phId = generateEmailTrackingCode({
+                    functionId: hogFunction.id,
+                    id: invocationId,
+                    teamId: team.id,
+                    state: { actionId: actionNodeId },
+                })
+                const res = await supertest(app).get(`/public/m/redirect?ph_id=${phId}&target=https://example.com`)
+                expect(res.status).toBe(302)
+
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+                expect(messages[0].value).toMatchObject({
+                    instance_id: actionNodeId,
+                    metric_name: 'email_link_clicked',
+                })
+            })
+
+            it('should redirect to the target url and track the click metric via legacy ph_fn_id/ph_inv_id', async () => {
                 const res = await supertest(app).get(
                     `/public/m/redirect?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}&target=https://example.com`
                 )
@@ -77,15 +119,18 @@ describe('EmailTrackingService', () => {
             })
 
             it('should return 404 if the target is not provided', async () => {
-                const res = await supertest(app).get(
-                    `/public/m/redirect?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}`
-                )
+                const phId = generateEmailTrackingCode({
+                    functionId: hogFunction.id,
+                    id: invocationId,
+                    teamId: team.id,
+                })
+                const res = await supertest(app).get(`/public/m/redirect?ph_id=${phId}`)
                 expect(res.status).toBe(404)
             })
 
             it('should redirect even if the tracking code is invalid', async () => {
                 const res = await supertest(app).get(
-                    `/public/m/redirect?ph_fn_id=invalid-function-id&ph_inv_id=invalid-invocation-id&target=https://example.com`
+                    `/public/m/redirect?ph_id=invalid-tracking-code&target=https://example.com`
                 )
                 expect(res.status).toBe(302)
                 expect(res.headers.location).toBe('https://example.com')
@@ -96,7 +141,50 @@ describe('EmailTrackingService', () => {
         })
 
         describe('email tracking pixel', () => {
-            it('should return a 200 and a gif image, tracking the open metric', async () => {
+            it('should return a 200 and a gif image, tracking the open metric via ph_id', async () => {
+                const phId = generateEmailTrackingCode({
+                    functionId: hogFunction.id,
+                    id: invocationId,
+                    teamId: team.id,
+                })
+                const res = await supertest(app).get(`/public/m/pixel?ph_id=${phId}`)
+                expect(res.status).toBe(200)
+                expect(res.headers['content-type']).toBe('image/gif')
+                expect(res.body).toEqual(PIXEL_GIF)
+
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+                expect(messages[0].value).toMatchObject({
+                    app_source: 'hog_function',
+                    app_source_id: hogFunction.id,
+                    instance_id: invocationId,
+                    metric_kind: 'email',
+                    metric_name: 'email_opened',
+                    team_id: team.id,
+                    count: 1,
+                })
+            })
+
+            it('should use actionId as instance_id for open metric when present in ph_id', async () => {
+                const actionNodeId = 'action_function_email_abc123'
+                const phId = generateEmailTrackingCode({
+                    functionId: hogFunction.id,
+                    id: invocationId,
+                    teamId: team.id,
+                    state: { actionId: actionNodeId },
+                })
+                const res = await supertest(app).get(`/public/m/pixel?ph_id=${phId}`)
+                expect(res.status).toBe(200)
+
+                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                expect(messages).toHaveLength(1)
+                expect(messages[0].value).toMatchObject({
+                    instance_id: actionNodeId,
+                    metric_name: 'email_opened',
+                })
+            })
+
+            it('should return a 200 and a gif image, tracking the open metric via legacy ph_fn_id/ph_inv_id', async () => {
                 const res = await supertest(app).get(
                     `/public/m/pixel?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}`
                 )
@@ -118,7 +206,7 @@ describe('EmailTrackingService', () => {
             })
 
             it('should return a 200 even if the tracking code is invalid', async () => {
-                const res = await supertest(app).get(`/public/m/pixel?ph_fn_id=${new UUIDT()}&ph_inv_id=${new UUIDT()}`)
+                const res = await supertest(app).get(`/public/m/pixel?ph_id=invalid-tracking-code`)
                 expect(res.status).toBe(200)
                 expect(res.headers['content-type']).toBe('image/gif')
                 expect(res.body).toEqual(PIXEL_GIF)

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -13,7 +13,11 @@ import { HogFunctionManagerService } from '../managers/hog-function-manager.serv
 import { RecipientsManagerService } from '../managers/recipients-manager.service'
 import { HogFunctionMonitoringService } from '../monitoring/hog-function-monitoring.service'
 import { SesWebhookHandler } from './helpers/ses'
-import { generateEmailTrackingCode, generateEmailTrackingPixelUrl } from './helpers/tracking-code'
+import {
+    generateEmailTrackingCode,
+    generateEmailTrackingPixelUrl,
+    parseEmailTrackingCode,
+} from './helpers/tracking-code'
 
 export const PIXEL_GIF = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64')
 const LINK_REGEX =
@@ -32,7 +36,9 @@ const emailTrackingErrorsCounter = new Counter({
 })
 
 export const generateTrackingRedirectUrl = (
-    invocation: Pick<CyclotronJobInvocationHogFunction, 'functionId' | 'id' | 'teamId'>,
+    invocation: Pick<CyclotronJobInvocationHogFunction, 'functionId' | 'id' | 'teamId'> & {
+        state?: { actionId?: string }
+    },
     targetUrl: string
 ): string => {
     return `${defaultConfig.CDP_EMAIL_TRACKING_URL}/public/m/redirect?ph_id=${generateEmailTrackingCode(invocation)}&target=${encodeURIComponent(targetUrl)}`
@@ -69,11 +75,13 @@ export class EmailTrackingService {
     public async trackMetric({
         functionId,
         invocationId,
+        actionId,
         metricName,
         source,
     }: {
         functionId?: string
         invocationId?: string
+        actionId?: string
         metricName: MinimalAppMetric['metric_name']
         source: 'direct' | 'ses'
     }): Promise<void> {
@@ -110,7 +118,7 @@ export class EmailTrackingService {
             {
                 team_id: teamId,
                 app_source_id: appSourceId,
-                instance_id: invocationId,
+                instance_id: actionId || invocationId,
                 metric_name: metricName,
                 metric_kind: 'email',
                 count: 1,
@@ -144,6 +152,7 @@ export class EmailTrackingService {
                 await this.trackMetric({
                     functionId: metric.functionId,
                     invocationId: metric.invocationId,
+                    actionId: metric.actionId,
                     metricName: metric.metricName,
                     source: 'ses',
                 })
@@ -189,15 +198,35 @@ export class EmailTrackingService {
         }
     }
 
-    public async handleEmailTrackingPixel(req: ModifiedRequest, res: express.Response): Promise<void> {
-        // NOTE: this is somewhat naieve. We should expand with UA checking for things like apple's tracking prevention etc.
-        const { ph_fn_id, ph_inv_id } = req.query
+    private parseTrackingParams(query: Record<string, any>): {
+        functionId?: string
+        invocationId?: string
+        actionId?: string
+    } {
+        // Support both combined ph_id format and legacy separate params
+        if (query.ph_id) {
+            const parsed = parseEmailTrackingCode(query.ph_id as string)
+            return {
+                functionId: parsed?.functionId,
+                invocationId: parsed?.invocationId,
+                actionId: parsed?.actionId,
+            }
+        }
+        return {
+            functionId: query.ph_fn_id as string | undefined,
+            invocationId: query.ph_inv_id as string | undefined,
+        }
+    }
 
-        // Track the value
+    // NOTE: this is somewhat naieve. We should expand with UA checking for things like apple's tracking prevention etc.
+    public async handleEmailTrackingPixel(req: ModifiedRequest, res: express.Response): Promise<void> {
+        const { functionId, invocationId, actionId } = this.parseTrackingParams(req.query)
+
         try {
             await this.trackMetric({
-                functionId: ph_fn_id as string,
-                invocationId: ph_inv_id as string,
+                functionId,
+                invocationId,
+                actionId,
                 metricName: 'email_opened',
                 source: 'direct',
             })
@@ -210,18 +239,19 @@ export class EmailTrackingService {
     }
 
     public async handleEmailTrackingRedirect(req: ModifiedRequest, res: express.Response): Promise<void> {
-        const { ph_fn_id, ph_inv_id, target } = req.query
+        const { functionId, invocationId, actionId } = this.parseTrackingParams(req.query)
+        const { target } = req.query
 
         if (!target) {
             res.status(404).send('Not found')
             return
         }
 
-        // Track the value
         try {
             await this.trackMetric({
-                functionId: ph_fn_id as string,
-                invocationId: ph_inv_id as string,
+                functionId,
+                invocationId,
+                actionId,
                 metricName: 'email_link_clicked',
                 source: 'direct',
             })

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -276,7 +276,7 @@ describe('EmailService', () => {
             const emails = await mailDevAPI.getEmails()
             expect(emails).toHaveLength(1)
             expect(emails[0].html).toEqual(
-                `<body>Hi! <a href="http://localhost:8010/public/m/redirect?ph_id=ZnVuY3Rpb24tMTppbnZvY2F0aW9uLTE6Mg&target=https%3A%2F%2Fexample.com">Click me</a><img src="http://localhost:8010/public/m/pixel?ph_id=ZnVuY3Rpb24tMTppbnZvY2F0aW9uLTE6Mg" style="display: none;" /></body>`
+                `<body>Hi! <a href="http://localhost:8010/public/m/redirect?ph_id=ZnVuY3Rpb24tMTppbnZvY2F0aW9uLTE6Mjo&target=https%3A%2F%2Fexample.com">Click me</a><img src="http://localhost:8010/public/m/pixel?ph_id=ZnVuY3Rpb24tMTppbnZvY2F0aW9uLTE6Mjo" style="display: none;" /></body>`
             )
         })
     })
@@ -354,7 +354,7 @@ describe('EmailService', () => {
                   "EmailTags": [
                     {
                       "Name": "ph_id",
-                      "Value": "ZnVuY3Rpb24tMTppbnZvY2F0aW9uLTE6Mg",
+                      "Value": "ZnVuY3Rpb24tMTppbnZvY2F0aW9uLTE6Mjo",
                     },
                   ],
                   "FeedbackForwardingEmailAddress": "test@posthog-test.com",

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -312,6 +312,7 @@ export class SesWebhookHandler {
         metrics?: {
             functionId?: string
             invocationId?: string
+            actionId?: string
             metricName: MinimalAppMetric['metric_name']
         }[]
         optOutRecipients?: {
@@ -364,6 +365,7 @@ export class SesWebhookHandler {
         const metrics: {
             functionId?: string
             invocationId?: string
+            actionId?: string
             metricName: MinimalAppMetric['metric_name']
         }[] = []
         const optOutRecipients: {
@@ -374,7 +376,7 @@ export class SesWebhookHandler {
         for (const rec of records) {
             logger.info('[SesWebhookHandler] processing record', { rec })
             const tags = rec.mail.tags
-            const { functionId, invocationId, teamId } = parseEmailTrackingCode(tags?.ph_id?.[0] || '') || {}
+            const { functionId, invocationId, teamId, actionId } = parseEmailTrackingCode(tags?.ph_id?.[0] || '') || {}
 
             if (!functionId && !invocationId) {
                 logger.error('[SesWebhookHandler] handleWebhook: No functionId or invocationId found', { rec })
@@ -382,7 +384,7 @@ export class SesWebhookHandler {
             }
 
             const metricName = EVENT_TYPE_TO_METRIC_NAME[rec.eventType]
-            metrics.push({ functionId, invocationId, metricName })
+            metrics.push({ functionId, invocationId, actionId, metricName })
 
             // Opt out recipients on permanent bounces
             if (teamId && rec.eventType === 'Bounce' && rec.bounce.bounceType === 'Permanent') {

--- a/nodejs/src/cdp/services/messaging/helpers/tracking-code.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/tracking-code.ts
@@ -20,28 +20,33 @@ function fromBase64UrlSafe(b64url: string) {
 
 export const parseEmailTrackingCode = (
     encodedTrackingCode: string
-): { functionId: string; invocationId: string; teamId: string } | null => {
+): { functionId: string; invocationId: string; teamId: string; actionId?: string } | null => {
     const decodedTrackingCode = fromBase64UrlSafe(encodedTrackingCode)
     try {
-        const [functionId, invocationId, teamId] = decodedTrackingCode.split(':')
+        const [functionId, invocationId, teamId, actionId] = decodedTrackingCode.split(':')
         if (!functionId || !invocationId) {
             return null
         }
-        return { functionId, invocationId, teamId }
+        return { functionId, invocationId, teamId, actionId: actionId || undefined }
     } catch {
         return null
     }
 }
 
 export const generateEmailTrackingCode = (
-    invocation: Pick<CyclotronJobInvocationHogFunction, 'functionId' | 'id' | 'teamId'>
+    invocation: Pick<CyclotronJobInvocationHogFunction, 'functionId' | 'id' | 'teamId'> & {
+        state?: { actionId?: string }
+    }
 ): string => {
     // Generate a base64 encoded string free of equal signs
-    return toBase64UrlSafe(`${invocation.functionId}:${invocation.id}:${invocation.teamId}`)
+    const actionId = invocation.state?.actionId ?? ''
+    return toBase64UrlSafe(`${invocation.functionId}:${invocation.id}:${invocation.teamId}:${actionId}`)
 }
 
 export const generateEmailTrackingPixelUrl = (
-    invocation: Pick<CyclotronJobInvocationHogFunction, 'functionId' | 'id' | 'teamId'>
+    invocation: Pick<CyclotronJobInvocationHogFunction, 'functionId' | 'id' | 'teamId'> & {
+        state?: { actionId?: string }
+    }
 ): string => {
     return `${defaultConfig.CDP_EMAIL_TRACKING_URL}/public/m/pixel?ph_id=${generateEmailTrackingCode(invocation)}`
 }


### PR DESCRIPTION
## Problem

We got reports (e.g. [here](https://posthoghelp.zendesk.com/agent/tickets/53916) or [here](https://posthog.slack.com/archives/C0AMDJGKNDD/p1774256197377939)) that email "Opened" and "Clicked" columns show 0 in the workflow metrics overview table, even though SES webhook data confirms opens and clicks are being tracked in ClickHouse.

Email engagement metrics from SES webhooks are stored with per-run invocation IDs as `instance_id`, but the overview table groups by action node IDs (e.g. `action_function_email_65c395f5-...`). Since these don't match, opens and clicks never appear in the correct row.

## Changes

- **Include `actionId` in the email tracking code**: The base64 tracking code embedded in emails now encodes `functionId:invocationId:teamId:actionId` (previously just `functionId:invocationId:teamId`). This is backwards compatible - old 3-field codes still parse correctly with `actionId` as `undefined`.
- **Use `actionId` as `instance_id` for engagement metrics**: `trackMetric` now uses `actionId || invocationId` as the `instance_id`, matching how `email_sent` already stores metrics (via `email.service.ts:112`). This ensures opens/clicks appear in the same row as sent/delivered in the overview table.
- **Fix direct pixel/redirect handlers**: Added `parseTrackingParams` that decodes the `ph_id` query param via `parseEmailTrackingCode`, with fallback to legacy `ph_fn_id`/`ph_inv_id` params. Both `handleEmailTrackingPixel` and `handleEmailTrackingRedirect` now use this method.
- **Pass `actionId` through SES webhook path**: The SES webhook handler now extracts and forwards `actionId` from the tracking code so SES-originated engagement metrics also get correct attribution.

## How did you test this code?

- Ran all email tracking tests (18 tests across `email-tracking.service.test.ts` and `ses.test.ts`) and all email service tests (30 tests in `email.service.test.ts`) - all pass
- Verified the new `ph_id` format tests fail against the old code (confirming they catch the bug)
- Verified the legacy `ph_fn_id`/`ph_inv_id` tests still pass (backwards compatibility)
- Manually tested against local dev environment: hit the pixel and redirect endpoints with a real workflow's tracking code, confirmed metrics appeared in ClickHouse with the correct `instance_id` matching the action node ID
- Queried production ClickHouse (EU) to confirm existing `email_opened` data exists for the reporting customer but was stored with invocation IDs as `instance_id`

## Publish to changelog?

No