### PR TITLE
chore(flags): migrate super_groups flags key (phase 1)

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -459,6 +459,11 @@ class FeatureFlagFiltersSchemaSerializer(serializers.Serializer):
         required=False,
         help_text="Additional super condition groups used by experiments.",
     )
+    feature_enrollment = serializers.BooleanField(
+        required=False,
+        allow_null=True,
+        help_text="Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.",
+    )
 
 
 property_help_text = "Filter events by event property, person property, cohort, groups and more."

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1350,6 +1350,8 @@ class FeatureFlagSerializer(
         self._update_filters(validated_data)
 
         # TRICKY: Update super_groups if key is changing, since the super groups depend on the key name.
+        # Note: feature_enrollment is a boolean and doesn't need updating on key change —
+        # the enrollment property key ($feature_enrollment/{flag_key}) is derived at evaluation time.
         if validated_key and validated_key != old_key:
             filters = validated_data.get("filters", instance.filters) or {}
             validated_data["filters"] = self._update_super_groups_for_key_change(validated_key, old_key, filters)

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -179,6 +179,10 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
         return self.get_filters().get("super_groups", []) or []
 
     @property
+    def has_feature_enrollment(self) -> bool:
+        return bool(self.get_filters().get("feature_enrollment", False))
+
+    @property
     def holdout(self):
         return self.get_filters().get("holdout", None)
 

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -122,6 +122,7 @@ class EarlyAccessFeatureSerializer(serializers.ModelSerializer):
                 serialized_data_filters = {
                     **related_feature_flag.filters,
                     "super_groups": None,
+                    "feature_enrollment": None,
                     "groups": [{"properties": [], "rollout_percentage": 100}],
                 }
 
@@ -154,6 +155,7 @@ class EarlyAccessFeatureSerializer(serializers.ModelSerializer):
                 serialized_data_filters = {
                     **related_feature_flag.filters,
                     "super_groups": super_conditions(related_feature_flag_key),
+                    "feature_enrollment": True,
                 }
 
                 serializer = FeatureFlagSerializer(
@@ -165,12 +167,13 @@ class EarlyAccessFeatureSerializer(serializers.ModelSerializer):
                 serializer.is_valid(raise_exception=True)
                 serializer.save()
         elif stage is not None and (stage not in EarlyAccessFeature.ActiveStage):
-            # Remove super_groups when leaving an active stage (including moving to CONCEPT)
+            # Remove super_groups and feature_enrollment when leaving an active stage (including moving to CONCEPT)
             related_feature_flag = instance.feature_flag
             if related_feature_flag:
                 related_feature_flag.filters = {
                     **related_feature_flag.filters,
                     "super_groups": None,
+                    "feature_enrollment": None,
                 }
                 related_feature_flag.save()
 
@@ -290,6 +293,7 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
                 serialized_data_filters = {
                     **feature_flag.filters,
                     "super_groups": super_conditions(feature_flag_key),
+                    "feature_enrollment": True,
                 }
 
                 serializer = FeatureFlagSerializer(
@@ -309,6 +313,7 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
 
             if validated_data.get("stage") in EarlyAccessFeature.ActiveStage:
                 filters["super_groups"] = super_conditions(feature_flag_key)
+                filters["feature_enrollment"] = True
 
             feature_flag_serializer = FeatureFlagSerializer(
                 data={
@@ -347,6 +352,7 @@ class EarlyAccessFeatureViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             related_feature_flag.filters = {
                 **related_feature_flag.filters,
                 "super_groups": None,
+                "feature_enrollment": None,
             }
             related_feature_flag.save()
 

--- a/products/early_access_features/backend/api.py
+++ b/products/early_access_features/backend/api.py
@@ -307,7 +307,7 @@ class EarlyAccessFeatureSerializerCreateOnly(EarlyAccessFeatureSerializer):
         else:
             feature_flag_key = slugify(validated_data["name"])
 
-            filters = {
+            filters: dict[str, Any] = {
                 "groups": default_condition,
             }
 

--- a/products/early_access_features/backend/apps.py
+++ b/products/early_access_features/backend/apps.py
@@ -33,6 +33,7 @@ class EarlyAccessFeaturesConfig(AppConfig):
             if feature_flag:
                 filters = dict(feature_flag.filters or {})
                 filters["super_groups"] = None
+                filters["feature_enrollment"] = None
                 feature_flag.filters = filters
                 feature_flag.save(update_fields=["filters"])
 

--- a/products/early_access_features/backend/test/test_early_access_feature.py
+++ b/products/early_access_features/backend/test/test_early_access_feature.py
@@ -39,8 +39,9 @@ class TestEarlyAccessFeature(APIBaseTest):
         assert response_data["stage"] == "concept"
         assert response_data["feature_flag"]["key"] == "hick-bondoogling"
         assert response_data["feature_flag"]["active"]
-        # CONCEPT stage should NOT have super_groups - users can opt-in but flag won't be enabled
+        # CONCEPT stage should NOT have super_groups or feature_enrollment
         assert not response_data["feature_flag"]["filters"].get("super_groups", None)
+        assert not response_data["feature_flag"]["filters"].get("feature_enrollment", None)
         assert len(response_data["feature_flag"]["filters"]["groups"]) == 1
         assert response_data["feature_flag"]["filters"]["groups"][0]["rollout_percentage"] == 0
         assert isinstance(response_data["created_at"], str)
@@ -60,9 +61,10 @@ class TestEarlyAccessFeature(APIBaseTest):
 
         assert response.status_code == status.HTTP_201_CREATED, response_data
         assert response_data["stage"] == "alpha"
-        # ALPHA stage should have super_groups - flag is enabled for opted-in users
+        # ALPHA stage should have super_groups and feature_enrollment - flag is enabled for opted-in users
         assert response_data["feature_flag"]["filters"].get("super_groups", None)
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
 
     @parameterized.expand(
         [
@@ -86,6 +88,7 @@ class TestEarlyAccessFeature(APIBaseTest):
 
         assert response.status_code == status.HTTP_201_CREATED, response_data
         assert not response_data["feature_flag"]["filters"].get("super_groups", None)
+        assert not response_data["feature_flag"]["filters"].get("feature_enrollment", None)
 
         feature_id = response_data["id"]
 
@@ -101,6 +104,7 @@ class TestEarlyAccessFeature(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK, response_data
         assert response_data["stage"] == target_stage
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
 
     @parameterized.expand(
         [
@@ -117,6 +121,7 @@ class TestEarlyAccessFeature(APIBaseTest):
         response_data = response.json()
         assert response.status_code == status.HTTP_201_CREATED, response_data
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
 
         feature_id = response_data["id"]
 
@@ -135,8 +140,10 @@ class TestEarlyAccessFeature(APIBaseTest):
         assert response_data["stage"] == EarlyAccessFeature.Stage.GENERAL_AVAILABILITY
         if expect_super_groups:
             assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+            assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
         else:
             assert not response_data["feature_flag"]["filters"].get("super_groups")
+            assert not response_data["feature_flag"]["filters"].get("feature_enrollment")
             assert response_data["feature_flag"]["filters"]["groups"] == expected_groups
 
     def test_demote_alpha_to_concept_removes_super_groups(self):
@@ -154,6 +161,7 @@ class TestEarlyAccessFeature(APIBaseTest):
 
         assert response.status_code == status.HTTP_201_CREATED, response_data
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
 
         feature_id = response_data["id"]
 
@@ -168,8 +176,9 @@ class TestEarlyAccessFeature(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK, response_data
         assert response_data["stage"] == EarlyAccessFeature.Stage.CONCEPT
-        # CONCEPT should not have super_groups
+        # CONCEPT should not have super_groups or feature_enrollment
         assert not response_data["feature_flag"]["filters"].get("super_groups", None)
+        assert not response_data["feature_flag"]["filters"].get("feature_enrollment", None)
 
     def test_archive(self):
         response = self.client.post(
@@ -185,6 +194,7 @@ class TestEarlyAccessFeature(APIBaseTest):
 
         assert response.status_code == status.HTTP_201_CREATED, response_data
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
 
         feature_id = response_data["id"]
 
@@ -200,6 +210,7 @@ class TestEarlyAccessFeature(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK, response_data
         assert response_data["stage"] == EarlyAccessFeature.Stage.ARCHIVED
         assert not response_data["feature_flag"]["filters"].get("super_groups", None)
+        assert not response_data["feature_flag"]["filters"].get("feature_enrollment", None)
 
     def test_update_doesnt_remove_super_condition(self):
         response = self.client.post(
@@ -215,6 +226,7 @@ class TestEarlyAccessFeature(APIBaseTest):
 
         assert response.status_code == status.HTTP_201_CREATED, response_data
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
 
         feature_id = response_data["id"]
 
@@ -231,6 +243,7 @@ class TestEarlyAccessFeature(APIBaseTest):
         assert response_data["stage"] == EarlyAccessFeature.Stage.BETA
         assert response_data["description"] == "Something else!"
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
 
     def test_we_dont_delete_existing_flag_information_when_creating_early_access_feature(self):
         flag = FeatureFlag.objects.create(
@@ -288,6 +301,7 @@ class TestEarlyAccessFeature(APIBaseTest):
                         "rollout_percentage": 100,
                     }
                 ],
+                "feature_enrollment": True,
             },
         )
 
@@ -348,6 +362,7 @@ class TestEarlyAccessFeature(APIBaseTest):
         assert response_data["feature_flag"]["key"] == "hick-bondoogling"
         assert response_data["feature_flag"]["active"]
         assert len(response_data["feature_flag"]["filters"]["super_groups"]) == 1
+        assert response_data["feature_flag"]["filters"]["feature_enrollment"] is True
         assert len(response_data["feature_flag"]["filters"]["groups"]) == 1
         assert response_data["feature_flag"]["filters"]["groups"][0]["rollout_percentage"] == 0
         assert isinstance(response_data["created_at"], str)
@@ -399,6 +414,7 @@ class TestEarlyAccessFeature(APIBaseTest):
                     }
                 ],
                 "super_groups": None,
+                "feature_enrollment": None,
             },
         )
 

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -654,6 +654,11 @@ export interface FeatureFlagFiltersSchemaApi {
     payloads?: FeatureFlagFiltersSchemaApiPayloads
     /** Additional super condition groups used by experiments. */
     super_groups?: FeatureFlagFiltersSchemaApiSuperGroupsItem[]
+    /**
+     * Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.
+     * @nullable
+     */
+    feature_enrollment?: boolean | null
 }
 
 export interface FeatureFlagCreateRequestSchemaApi {

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -797,6 +797,11 @@ export interface FeatureFlagFiltersSchemaApi {
     payloads?: FeatureFlagFiltersSchemaApiPayloads
     /** Additional super condition groups used by experiments. */
     super_groups?: FeatureFlagFiltersSchemaApiSuperGroupsItem[]
+    /**
+     * Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.
+     * @nullable
+     */
+    feature_enrollment?: boolean | null
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15099,6 +15099,11 @@ export namespace Schemas {
       payloads?: FeatureFlagFiltersSchemaPayloads;
       /** Additional super condition groups used by experiments. */
       super_groups?: FeatureFlagFiltersSchemaSuperGroupsItem[];
+      /**
+       * Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.
+       * @nullable
+       */
+      feature_enrollment?: boolean | null;
     }
 
     export interface FeatureFlagCreateRequestSchema {

--- a/services/mcp/src/generated/feature_flags/api.ts
+++ b/services/mcp/src/generated/feature_flags/api.ts
@@ -351,6 +351,12 @@ export const FeatureFlagsCreateBody = /* @__PURE__ */ zod.object({
                 .array(zod.record(zod.string(), zod.unknown()))
                 .optional()
                 .describe('Additional super condition groups used by experiments.'),
+            feature_enrollment: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.'
+                ),
         })
         .optional()
         .describe('Feature flag targeting configuration.'),
@@ -662,6 +668,12 @@ export const FeatureFlagsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 .array(zod.record(zod.string(), zod.unknown()))
                 .optional()
                 .describe('Additional super condition groups used by experiments.'),
+            feature_enrollment: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.'
+                ),
         })
         .optional()
         .describe('Feature flag targeting configuration.'),

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -351,6 +351,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                 .array(zod.record(zod.string(), zod.unknown()))
                 .optional()
                 .describe('Additional super condition groups used by experiments.'),
+            feature_enrollment: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.'
+                ),
         })
         .nullish()
         .describe(
@@ -1088,6 +1094,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                 .array(zod.record(zod.string(), zod.unknown()))
                 .optional()
                 .describe('Additional super condition groups used by experiments.'),
+            feature_enrollment: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}.'
+                ),
         })
         .nullish()
         .describe(

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/create-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/create-feature-flag.json
@@ -26,6 +26,17 @@
                     ],
                     "description": "Group type index for group-based feature flags."
                 },
+                "feature_enrollment": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}."
+                },
                 "groups": {
                     "description": "Release condition groups for the feature flag.",
                     "items": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/survey-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/survey-create.json
@@ -591,6 +591,17 @@
                             ],
                             "description": "Group type index for group-based feature flags."
                         },
+                        "feature_enrollment": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}."
+                        },
                         "groups": {
                             "description": "Release condition groups for the feature flag.",
                             "items": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/survey-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/survey-update.json
@@ -714,6 +714,17 @@
                             ],
                             "description": "Group type index for group-based feature flags."
                         },
+                        "feature_enrollment": {
+                            "anyOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}."
+                        },
                         "groups": {
                             "description": "Release condition groups for the feature flag.",
                             "items": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/update-feature-flag.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/update-feature-flag.json
@@ -26,6 +26,17 @@
                     ],
                     "description": "Group type index for group-based feature flags."
                 },
+                "feature_enrollment": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Whether this flag has early access feature enrollment enabled. When true, the flag is evaluated against the person property $feature_enrollment/{flag_key}."
+                },
                 "groups": {
                     "description": "Release condition groups for the feature flag.",
                     "items": {


### PR DESCRIPTION
Part of #47929 

## Summary

Phase 1 of the `super_groups` → `feature_enrollment` migration. This PR adds dual-writing so that every place that writes `super_groups` into feature flag filters now also writes `feature_enrollment: true` (or clears it alongside `super_groups`).

This is a backwards-compatible change, since no code reads `feature_enrollment` yet. The new field is purely additive, preparing for Phase 2 where the flag service will start reading it.

### Changes by file

**`posthog/api/documentation.py`**
- Added `feature_enrollment` boolean field to `FeatureFlagFiltersSchemaDef` so it appears in the OpenAPI spec.

**`posthog/models/feature_flag/feature_flag.py`**
- Added `has_feature_enrollment` property that reads `filters.get("feature_enrollment", False)`. Existing `super_conditions` property kept for now (legacy readers still active).

**`products/early_access_features/backend/api.py`**
- All 5 write sites in `EarlyAccessFeatureSerializer` now dual-write:
  - Promote to active stage (update) → sets `feature_enrollment: True`
  - GA rollout_to_all → clears `feature_enrollment`
  - Demote/archive → clears `feature_enrollment`
  - Create with active stage (existing flag + new flag) → sets `feature_enrollment: True`
  - Destroy → clears `feature_enrollment`

**`products/early_access_features/backend/apps.py`**
- `_pre_delete` hook now also clears `feature_enrollment` when clearing `super_groups`.

**`posthog/api/feature_flag.py`**
- Added comment to `_update_super_groups_for_key_change` noting that `feature_enrollment` is key-independent and doesn't need updating on flag key rename.

**`products/early_access_features/backend/test/test_early_access_feature.py`**
- All relevant tests now assert `feature_enrollment` presence/absence alongside `super_groups` assertions.

## Test plan

- [x] All 28 early access feature tests pass
- [x] `test_updating_feature_flag_key_updates_super_groups` passes