### PR TITLE
fix(dev): Dont run post checkout if flox isn't setup

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -269,6 +269,9 @@ elif [[ -n "$_flox_rustc_ver" ]]; then
   done_step "Rust toolchain (rustc ${_flox_rustc_ver})"
 fi
 
+# Share a single Cargo target dir so worktrees skip redundant linking
+export CARGO_TARGET_DIR="$HOME/.cargo/target"
+
 # ── Summary ─────────────────────────────────────────────────────────
 _activation_end=$(date +%s)
 _activation_time=$(( _activation_end - _activation_start ))

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -9,12 +9,16 @@
 
 # Bootstrap husky + lint-staged so pre-commit hooks work in worktrees
 # pnpm may come from flox, corepack, brew, etc. — add flox bin to PATH if available
-MAIN_REPO="$(cd "$(dirname "$0")/.." && pwd)"
-for p in "$MAIN_REPO/.flox/run"/*/bin; do
-    [ -d "$p" ] && export PATH="$p:$PATH"
-done
+if command -v flox > /dev/null 2>&1 && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
+    MAIN_REPO="$(cd "$(dirname "$0")/.." && pwd)"
+    for p in "$MAIN_REPO/.flox/run"/*/bin; do
+        [ -d "$p" ] && export PATH="$p:$PATH"
+    done
 
-if [ ! -d node_modules/.pnpm ]; then
-    echo "husky: worktree detected, bootstrapping with pnpm install ..."
-    pnpm install --frozen-lockfile --filter=.
+    if [ ! -d node_modules/.pnpm ]; then
+        echo "husky: worktree detected, bootstrapping with pnpm install ..."
+        pnpm install --frozen-lockfile --filter=.
+    fi
+else
+    echo "no flox setup, skipping husky setup"
 fi

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -9,16 +9,19 @@
 
 # Bootstrap husky + lint-staged so pre-commit hooks work in worktrees
 # pnpm may come from flox, corepack, brew, etc. — add flox bin to PATH if available
-if command -v flox > /dev/null 2>&1 && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then
-    MAIN_REPO="$(cd "$(dirname "$0")/.." && pwd)"
+MAIN_REPO="$(cd "$(dirname "$0")/.." && pwd)"
+if [ -d "$MAIN_REPO/.flox/run" ]; then
     for p in "$MAIN_REPO/.flox/run"/*/bin; do
         [ -d "$p" ] && export PATH="$p:$PATH"
     done
+fi
 
-    if [ ! -d node_modules/.pnpm ]; then
-        echo "husky: worktree detected, bootstrapping with pnpm install ..."
-        pnpm install --frozen-lockfile --filter=.
-    fi
-else
-    echo "no flox setup, skipping husky setup"
+if ! command -v pnpm > /dev/null 2>&1; then
+    echo "husky: pnpm not found, skipping worktree bootstrap"
+    exit 0
+fi
+
+if [ ! -d node_modules/.pnpm ]; then
+    echo "husky: worktree detected, bootstrapping with pnpm install ..."
+    pnpm install --frozen-lockfile --filter=.
 fi


### PR DESCRIPTION
## Problem
- post-checkout assumes flox is setup and running/activated, though not everyone uses it 

## Changes
skip this post-checkout pnpm stuff if flox isn't actively used

