### PR TITLE
chore: Cleanup related persons experiment

### DIFF
--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -4,8 +4,6 @@ from typing import Optional, Union
 
 from django.utils.timezone import now
 
-import posthoganalytics
-
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import Team
@@ -52,6 +50,7 @@ class RelatedActorsQuery:
         group_type_indexes = list(
             GroupTypeMapping.objects.filter(project_id=self.team.project_id)
             .exclude(group_type_index=self.group_type_index)
+            .order_by("group_type_index")
             .values_list("group_type_index", flat=True)
         )
 
@@ -64,46 +63,14 @@ class RelatedActorsQuery:
                 results.extend(self._query_related_groups_control(index))
         return results
 
-    def _is_test_variant(self) -> bool:
-        flag_result = posthoganalytics.get_feature_flag(
-            "optimized-related-people-query",
-            str(self.team.uuid),
-            groups={"organization": str(self.team.organization.id), "project": str(self.team.uuid)},
-        )
-        return flag_result == "test"  # type: ignore[comparison-overlap]
-
     def _query_related_people(self) -> list[SerializedPerson]:
         if not self.is_aggregating_by_groups:
             return []
-
-        if self._is_test_variant():
-            tag_queries(name="optimized-related-people-test")
-            person_ids = self._query_related_people_optimized()
-        else:
-            tag_queries(name="optimized-related-people-control")
-            person_ids = self._query_related_people_control()
-
+        tag_queries(name="related-people")
+        person_ids = self._query_related_people_ids()
         return get_serialized_people(self.team, person_ids)
 
-    def _query_related_people_control(self) -> list:
-        # :KLUDGE: We need to fetch distinct_id + person properties to be able to link to user properly.
-        return self._take_first(
-            # nosemgrep: clickhouse-injection-taint - internal SQL fragments, values parameterized
-            sync_execute(
-                f"""
-            SELECT DISTINCT {self.DISTINCT_ID_TABLE_ALIAS}.person_id
-            FROM events e
-            {self._distinct_ids_join}
-            WHERE team_id = %(team_id)s
-              AND timestamp > %(after)s
-              AND timestamp < %(before)s
-              AND {self._filter_clause}
-            """,
-                self._params,
-            )
-        )
-
-    def _query_related_people_optimized(self) -> list:
+    def _query_related_people_ids(self) -> list:
         return self._take_first(
             # nosemgrep: clickhouse-injection-taint - internal SQL fragments, values parameterized
             sync_execute(

--- a/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_related_actors_query.ambr
@@ -2,32 +2,6 @@
 # name: TestRelatedGroupsQuery.test_control_query
   '''
   
-  SELECT DISTINCT $group_1 AS group_key
-  FROM events e
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 99999
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
-  JOIN
-    (SELECT group_key
-     FROM groups
-     WHERE team_id = 99999
-       AND group_type_index = 1
-     GROUP BY group_key) groups ON $group_1 = groups.group_key
-  WHERE team_id = 99999
-    AND timestamp > '2024-12-01T12:00:00.000000'
-    AND timestamp < '2025-03-01T12:00:00.000000'
-    AND group_key != ''
-    AND pdi.person_id = '00000000-0000-4000-8000-000000000000'
-  ORDER BY group_key
-  '''
-# ---
-# name: TestRelatedGroupsQuery.test_control_query.1
-  '''
-  
   SELECT DISTINCT $group_0 AS group_key
   FROM events e
   JOIN
@@ -51,32 +25,10 @@
   ORDER BY group_key
   '''
 # ---
-# name: TestRelatedGroupsQuery.test_optimized_query
+# name: TestRelatedGroupsQuery.test_control_query.1
   '''
   
-  SELECT DISTINCT group_type_index,
-                  group_key
-  FROM groups
-  WHERE team_id = 99999
-    AND group_type_index IN [1, 0]
-    AND (group_type_index,
-         group_key) IN
-      (SELECT tuples.1 AS group_type_index,
-              tuples.2 AS group_key
-       FROM events e ARRAY
-       JOIN arrayFilter(x -> x.2 != '', [(toUInt8(1), e.$group_1), (toUInt8(0), e.$group_0)]) AS tuples
-       WHERE team_id = 99999
-         AND e.timestamp > '2024-12-01T12:00:00.000000'
-         AND e.timestamp < '2025-03-01T12:00:00.000000'
-         AND e.person_id = '00000000-0000-4000-8000-000000000000' )
-  ORDER BY group_type_index,
-           group_key
-  '''
-# ---
-# name: TestRelatedPersonsQuery.test_query_related_people_control
-  '''
-  
-  SELECT DISTINCT pdi.person_id
+  SELECT DISTINCT $group_1 AS group_key
   FROM events e
   JOIN
     (SELECT distinct_id,
@@ -85,17 +37,6 @@
      WHERE team_id = 99999
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
-  WHERE team_id = 99999
-    AND timestamp > '2024-12-01T12:00:00.000000'
-    AND timestamp < '2025-03-01T12:00:00.000000'
-    AND $group_0 = 'org:1'
-  '''
-# ---
-# name: TestRelatedPersonsQuery.test_query_related_people_control.1
-  '''
-  
-  SELECT DISTINCT $group_1 AS group_key
-  FROM events e
   JOIN
     (SELECT group_key
      FROM groups
@@ -106,11 +47,33 @@
     AND timestamp > '2024-12-01T12:00:00.000000'
     AND timestamp < '2025-03-01T12:00:00.000000'
     AND group_key != ''
-    AND $group_0 = 'org:1'
+    AND pdi.person_id = '00000000-0000-4000-8000-000000000000'
   ORDER BY group_key
   '''
 # ---
-# name: TestRelatedPersonsQuery.test_query_related_people_optimized
+# name: TestRelatedGroupsQuery.test_optimized_query
+  '''
+  
+  SELECT DISTINCT group_type_index,
+                  group_key
+  FROM groups
+  WHERE team_id = 99999
+    AND group_type_index IN [0, 1]
+    AND (group_type_index,
+         group_key) IN
+      (SELECT tuples.1 AS group_type_index,
+              tuples.2 AS group_key
+       FROM events e ARRAY
+       JOIN arrayFilter(x -> x.2 != '', [(toUInt8(0), e.$group_0), (toUInt8(1), e.$group_1)]) AS tuples
+       WHERE team_id = 99999
+         AND e.timestamp > '2024-12-01T12:00:00.000000'
+         AND e.timestamp < '2025-03-01T12:00:00.000000'
+         AND e.person_id = '00000000-0000-4000-8000-000000000000' )
+  ORDER BY group_type_index,
+           group_key
+  '''
+# ---
+# name: TestRelatedPersonsQuery.test_query_related_people
   '''
   
   SELECT DISTINCT argMax(person_id, version) AS person_id
@@ -127,7 +90,7 @@
   HAVING argMax(is_deleted, version) = 0
   '''
 # ---
-# name: TestRelatedPersonsQuery.test_query_related_people_optimized.1
+# name: TestRelatedPersonsQuery.test_query_related_people.1
   '''
   
   SELECT DISTINCT $group_1 AS group_key

--- a/ee/clickhouse/queries/test/test_related_actors_query.py
+++ b/ee/clickhouse/queries/test/test_related_actors_query.py
@@ -12,7 +12,6 @@ from posthog.test.base import (
     flush_persons_and_events,
     snapshot_clickhouse_queries,
 )
-from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -23,7 +22,6 @@ from posthog.models.group.util import create_group
 
 from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
 
-PATH = "ee.clickhouse.queries.related_actors_query"
 RECENT_DATE = datetime(2025, 2, 15, 12, 0, 0)
 
 
@@ -103,8 +101,7 @@ class TestRelatedPersonsQuery(BaseRelatedActorsTest):
         return RelatedActorsQuery(team=self.team, group_type_index=0, id="org:1").run()
 
     @snapshot_clickhouse_queries
-    @patch(f"{PATH}.posthoganalytics.get_feature_flag", return_value="control")
-    def test_query_related_people_control(self, _):
+    def test_query_related_people(self):
         results = self.run_query()
 
         assert len(results) == 2
@@ -112,21 +109,7 @@ class TestRelatedPersonsQuery(BaseRelatedActorsTest):
         assert str(self.person.uuid) in ids
         assert str(self.another_person.uuid) in ids
 
-    @snapshot_clickhouse_queries
-    @patch(f"{PATH}.posthoganalytics.get_feature_flag", return_value="test")
-    def test_query_related_people_optimized(self, _):
-        results = self.run_query()
-
-        assert len(results) == 2
-        ids = self.get_ids_from_results(results)
-        assert str(self.person.uuid) in ids
-        assert str(self.another_person.uuid) in ids
-
-    @parameterized.expand(["control", "test"])
-    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
-    def test_returns_related_people(self, variant, mock_flag):
-        mock_flag.return_value = variant
-
+    def test_returns_related_people(self):
         results = self.run_query()
 
         assert len(results) == 2
@@ -136,10 +119,7 @@ class TestRelatedPersonsQuery(BaseRelatedActorsTest):
         assert str(self.unrelated_person.uuid) not in ids
         assert str(self.old_related_person.uuid) not in ids
 
-    @parameterized.expand(["control", "test"])
-    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
-    def test_excludes_deleted_person_mapping(self, variant, mock_flag):
-        mock_flag.return_value = variant
+    def test_excludes_deleted_person_mapping(self):
         self._insert_pdi2_row("user2", str(self.another_person.uuid), version=100, is_deleted=1)
 
         results = self.run_query()
@@ -147,10 +127,7 @@ class TestRelatedPersonsQuery(BaseRelatedActorsTest):
         ids = self.get_ids_from_results(results)
         assert str(self.another_person.uuid) not in ids
 
-    @parameterized.expand(["control", "test"])
-    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
-    def test_reassigned_distinct_id_resolves_to_new_person(self, variant, mock_flag):
-        mock_flag.return_value = variant
+    def test_reassigned_distinct_id_resolves_to_new_person(self):
         new_person = _create_person(distinct_ids=["new_user"], team=self.team, uuid=uuid4())
         flush_persons_and_events()
         self._insert_pdi2_row("user1", str(new_person.uuid), version=100)
@@ -161,10 +138,7 @@ class TestRelatedPersonsQuery(BaseRelatedActorsTest):
         assert str(new_person.uuid) in ids
         assert str(self.person.uuid) not in ids
 
-    @parameterized.expand(["control", "test"])
-    @patch(f"{PATH}.posthoganalytics.get_feature_flag")
-    def test_multiple_distinct_ids_same_person_deduped(self, variant, mock_flag):
-        mock_flag.return_value = variant
+    def test_multiple_distinct_ids_same_person_deduped(self):
         self._insert_pdi2_row("user2", str(self.person.uuid), version=100)
 
         results = self.run_query()

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
@@ -2,19 +2,18 @@
 # name: GroupsViewSetTestCase.test_related_groups
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT pdi.person_id
-  FROM events e
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 99999
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
+  SELECT DISTINCT argMax(person_id, version) AS person_id
+  FROM person_distinct_id2
   WHERE team_id = 99999
-    AND timestamp > '2021-02-09T00:00:00.000000'
-    AND timestamp < '2021-05-10T00:00:00.000000'
-    AND $group_0 = '0::0'
+    AND distinct_id IN
+      (SELECT distinct_id
+       FROM events
+       WHERE team_id = 99999
+         AND timestamp > '2021-02-09T00:00:00.000000'
+         AND timestamp < '2021-05-10T00:00:00.000000'
+         AND $group_0 = '0::0' )
+  GROUP BY distinct_id
+  HAVING argMax(is_deleted, version) = 0
   '''
 # ---
 # name: GroupsViewSetTestCase.test_related_groups.1


### PR DESCRIPTION
## Problem

The `optimized-related-people-query` feature flag experiment has concluded — the optimized variant won. The control path (joining `events → person_distinct_id` via subquery) and the feature flag check are dead code that should be removed.

The related **groups** experiment (`OPTIMIZED_RELATED_GROUPS_QUERY`) is still ongoing and is intentionally left untouched.

## Changes

- Removed the `_is_test_variant()` method and its `posthoganalytics.get_feature_flag` call from `RelatedActorsQuery`
- Removed the control path `_query_related_people_control()` — the optimized `person_distinct_id2` query is now the only path
- Renamed `_query_related_people_optimized` → `_query_related_people_ids` since it's no longer contrasted with a control
- De-parameterized people tests (removed control/test matrix) and removed the mock patches

## How did you test this code?

Unit tests passing, manually in the UI

## Publish to changelog?

No

## Docs update

N/A