### PR TITLE
fix(actions): show proper error when saving action with empty name

### DIFF
--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -204,6 +204,14 @@ class ActionSerializer(
         if attrs.get("pinned_at") == "":
             attrs["pinned_at"] = None
 
+        # Check for empty name - this must come before uniqueness check
+        name = attrs.get("name")
+        if name is not None and not name.strip():
+            raise serializers.ValidationError(
+                {"name": "This field may not be blank."},
+                code="blank",
+            )
+
         if "name" in attrs:
             colliding_action_ids = list(
                 Action.objects.filter(name=attrs["name"], deleted=False, **include_args)

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -137,6 +137,46 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         self.assertEqual(Action.objects.count(), count)
 
+    def test_cant_create_action_with_empty_name(self, *args):
+        count = Action.objects.count()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            {"name": ""},
+            headers={"origin": "http://testserver"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "blank",
+                "detail": "This field may not be blank.",
+                "attr": "name",
+            },
+        )
+        self.assertEqual(Action.objects.count(), count)
+
+    def test_cant_create_action_with_whitespace_only_name(self, *args):
+        count = Action.objects.count()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            {"name": "   "},
+            headers={"origin": "http://testserver"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "blank",
+                "detail": "This field may not be blank.",
+                "attr": "name",
+            },
+        )
+        self.assertEqual(Action.objects.count(), count)
+
     @freeze_time("2021-12-12")
     @patch("posthog.api.action.report_user_action")
     def test_update_action(self, patch_capture, *args):

--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -116,6 +116,10 @@ export const actionEditLogic = kea<actionEditLogicType>([
 
                         return { ...updatedAction }
                     }
+                    if (response.code === 'blank' && response.attr === 'name') {
+                        lemonToast.error('Action name cannot be empty.')
+                        return { ...updatedAction }
+                    }
                     throw response
                 }
 


### PR DESCRIPTION
## Summary

- Adds validation in `ActionSerializer.validate()` to check for blank/empty action names before checking uniqueness
- Returns a proper "This field may not be blank" error with code "blank" instead of incorrectly triggering the uniqueness check
- Updates frontend to handle the new error code and show "Action name cannot be empty" toast

## Problem

When saving an action with an empty name, if another action with an empty name already existed, the user would see "Action with this name already exists" - a confusing error message that didn't match the actual problem.

## Test plan

- [x] Added test `test_cant_create_action_with_empty_name` 
- [x] Added test `test_cant_create_action_with_whitespace_only_name`
- [x] Existing test `test_cant_create_action_with_the_same_name` still passes

https://claude.ai/code/session_017dRZTyCVuyx3bMH4iuoy85