### PR TITLE
feat: add llm_context URL to Stripe app manifest

### DIFF
--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -89,7 +89,8 @@
     "account_configuration_schema": "{\"type\":\"object\",\"properties\":{\"region\":{\"type\":\"string\",\"enum\":[\"US\",\"EU\"],\"description\":\"Which PostHog region to connect the Stripe account to\"}},\"required\":[\"region\"],\"additionalProperties\":false}",
     "deep_link_purposes": [
       "dashboard"
-    ]
+    ],
+    "llm_context": "https://posthog.com/stripe/llm-context.md"
   },
   "ui_extension": {
     "views": [


### PR DESCRIPTION
## Problem

PostHog is a provider in [Stripe Projects](https://docs.stripe.com/projects) but doesn't have an `llm_context` URL configured. When developers provision PostHog via `stripe projects add posthog`, AI coding agents get no guidance on how to integrate it.

Currently only 5/10 Stripe Projects providers have this set. PostHog and Supabase are among the 5 that don't. The providers with the best context (Clerk, Neon, Vercel) use dedicated post-provisioning files rather than their general llms.txt.

Context: [Slack thread](https://posthog.slack.com/archives/C0AAZGWD83A/p1773846180847469) where Rami from Stripe explained the field.

## Changes

Adds `"llm_context": "https://posthog.com/stripe/llm-context.md"` to the `provisioning` section of `stripe-app.json`.

Placement confirmed by the [APP 0.1d provider integration guide](https://github.com/agentic-provisioning/posthog-spec/blob/master/integration_guide_provider.md) which shows `llm_context` as an optional field under `provisioning`.

The context file itself is in a separate PR: [PostHog/posthog.com#15932](https://github.com/PostHog/posthog.com/pull/15932). It provides post-provisioning guidance modeled after [Clerk's context file](https://integrations.clerk.com/stripe/llm.md) (the best of the current providers): credential explanation, wizard command, framework quickstarts, product overview.

## How did you test this code

- Verified JSON is valid
- Confirmed field placement against [APP 0.1d spec](https://github.com/agentic-provisioning/posthog-spec/blob/master/integration_guide_provider.md) (`llm_context` goes under `provisioning`)
- Cross-referenced with `stripe projects llm-context --json` output from other providers (Clerk, Neon, Vercel)
- The context file URL will work once PostHog/posthog.com#15932 is merged and deployed

## Changelog

No

🤖 Generated with [Claude Code](https://claude.com/claude-code)