### PR TITLE
feat(events): add minmax index on $session_id_uuid column

### DIFF
--- a/posthog/clickhouse/migrations/0222_add_session_id_uuid_minmax_index.py
+++ b/posthog/clickhouse/migrations/0222_add_session_id_uuid_minmax_index.py
@@ -1,0 +1,18 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+ADD_MINMAX_INDEX_SHARDED_EVENTS = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `minmax_$session_id_uuid` `$session_id_uuid`
+TYPE minmax
+GRANULARITY 1
+"""
+
+operations = [
+    run_sql_with_exceptions(
+        ADD_MINMAX_INDEX_SHARDED_EVENTS,
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0221_error_tracking_events_test_table
+0222_add_session_id_uuid_minmax_index

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -4096,6 +4096,7 @@
       , INDEX `minmax_$group_4` `$group_4` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$window_id` `$window_id` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$session_id` `$session_id` TYPE minmax GRANULARITY 1
+      , INDEX `minmax_$session_id_uuid` `$session_id_uuid` TYPE minmax GRANULARITY 1
       ,             properties_group_custom Map(String, String)
               MATERIALIZED mapSort(
                   mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'epik', 'qclid', 'sccid', 'irclid', '_kx'),
@@ -6806,6 +6807,7 @@
       , INDEX `minmax_$group_4` `$group_4` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$window_id` `$window_id` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$session_id` `$session_id` TYPE minmax GRANULARITY 1
+      , INDEX `minmax_$session_id_uuid` `$session_id_uuid` TYPE minmax GRANULARITY 1
       ,             properties_group_custom Map(String, String)
               MATERIALIZED mapSort(
                   mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'epik', 'qclid', 'sccid', 'irclid', '_kx'),

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -149,6 +149,7 @@ EVENTS_TABLE_MATERIALIZED_COLUMNS = f"""
     , INDEX `minmax_$group_4` `$group_4` TYPE minmax GRANULARITY 1
     , INDEX `minmax_$window_id` `$window_id` TYPE minmax GRANULARITY 1
     , INDEX `minmax_$session_id` `$session_id` TYPE minmax GRANULARITY 1
+    , INDEX `minmax_$session_id_uuid` `$session_id_uuid` TYPE minmax GRANULARITY 1
     , {", ".join(property_groups.get_create_table_pieces("sharded_events"))}
 """
 


### PR DESCRIPTION
## Problem

Queries filtering on `$session_id_uuid` scan more data than necessary because there is no data skipping index on that column. The existing minmax indexes cover `$session_id` (the string column) but not the UUID variant.

## Changes

- Add ClickHouse migration `0222` that creates a minmax index on `$session_id_uuid` for `sharded_events`
- Add the index to the table definition in `sql.py` so newly created tables include it
- The migration intentionally does **not** materialize the index — that will be done separately

## How did you test this code?

This PR was authored by an AI agent. No manual testing was performed. The migration follows the same pattern as existing minmax index migrations (e.g., `0185`, `0220`). Schema snapshot was updated to match.

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Co-authored by Claude Opus 4.6 in Claude Code. The migration pattern was derived from existing minmax index migrations in the codebase.