### PR TITLE
chore(ingestion): add wrap batch step for metrics

### DIFF
--- a/nodejs/src/ingestion/pipelines/batch-retry.test.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.test.ts
@@ -1,4 +1,5 @@
 import { BatchProcessingStep } from './base-batch-pipeline'
+import { withBatchRetry } from './batch-retry'
 import { newBatchPipelineBuilder } from './builders'
 import { createContext } from './helpers'
 import { drop, isDlqResult, isDropResult, isOkResult, ok } from './results'
@@ -149,5 +150,28 @@ describe('withBatchRetry', () => {
         // Other results should be processed
         expect(isOkResult(results![1].result) && results![1].result.value).toBe('4')
         expect(isOkResult(results![2].result) && results![2].result.value).toBe('6')
+    })
+
+    it('preserves the step name for metrics', () => {
+        const myNamedStep: BatchProcessingStep<number, string> = function myNamedStep(values) {
+            return Promise.resolve(values.map((v) => ok(String(v))))
+        }
+
+        const wrapped = withBatchRetry(myNamedStep)
+
+        // The wrapped function should preserve the original step name
+        expect(wrapped.name).toBe('myNamedStep')
+    })
+
+    it('uses variable name for arrow functions assigned to variables', () => {
+        // JavaScript infers the name from the variable assignment
+        const myArrowStep: BatchProcessingStep<number, string> = (values) => {
+            return Promise.resolve(values.map((v) => ok(String(v))))
+        }
+
+        const wrapped = withBatchRetry(myArrowStep)
+
+        // Arrow functions assigned to variables get their name from the variable
+        expect(wrapped.name).toBe('myArrowStep')
     })
 })

--- a/nodejs/src/ingestion/pipelines/batch-retry.test.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.test.ts
@@ -152,26 +152,19 @@ describe('withBatchRetry', () => {
         expect(isOkResult(results![2].result) && results![2].result.value).toBe('6')
     })
 
-    it('preserves the step name for metrics', () => {
-        const myNamedStep: BatchProcessingStep<number, string> = function myNamedStep(values) {
-            return Promise.resolve(values.map((v) => ok(String(v))))
-        }
+    // Declare steps outside it.each to preserve inferred names from variable assignment
+    const myNamedStep: BatchProcessingStep<number, string> = function myNamedStep(values) {
+        return Promise.resolve(values.map((v) => ok(String(v))))
+    }
+    const myArrowStep: BatchProcessingStep<number, string> = (values) => {
+        return Promise.resolve(values.map((v) => ok(String(v))))
+    }
 
-        const wrapped = withBatchRetry(myNamedStep)
-
-        // The wrapped function should preserve the original step name
-        expect(wrapped.name).toBe('myNamedStep')
-    })
-
-    it('uses variable name for arrow functions assigned to variables', () => {
-        // JavaScript infers the name from the variable assignment
-        const myArrowStep: BatchProcessingStep<number, string> = (values) => {
-            return Promise.resolve(values.map((v) => ok(String(v))))
-        }
-
-        const wrapped = withBatchRetry(myArrowStep)
-
-        // Arrow functions assigned to variables get their name from the variable
-        expect(wrapped.name).toBe('myArrowStep')
+    it.each([
+        { description: 'named function expression', step: myNamedStep, expectedName: 'myNamedStep' },
+        { description: 'arrow function assigned to variable', step: myArrowStep, expectedName: 'myArrowStep' },
+    ])('preserves step name for $description', ({ step, expectedName }) => {
+        const wrapped = withBatchRetry(step)
+        expect(wrapped.name).toBe(expectedName)
     })
 })

--- a/nodejs/src/ingestion/pipelines/batch-retry.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { retryIfRetriable } from '../../utils/retries'
 import { BatchProcessingStep } from './base-batch-pipeline'
+import { wrapBatchStep } from './extensions/helpers'
 import { dlq } from './results'
 
 export interface BatchRetryOptions {
@@ -26,11 +27,10 @@ export function withBatchRetry<T, U>(
     step: BatchProcessingStep<T, U>,
     options: BatchRetryOptions = {}
 ): BatchProcessingStep<T, U> {
-    const stepName = step.name || 'anonymousBatchStep'
-
-    return async (values: T[]) => {
+    return wrapBatchStep(step, async (values, s) => {
+        const stepName = s.name || 'anonymousBatchStep'
         try {
-            return await retryIfRetriable(() => step(values), options.tries ?? 3, options.sleepMs ?? 100)
+            return await retryIfRetriable(() => s(values), options.tries ?? 3, options.sleepMs ?? 100)
         } catch (error) {
             const isRetriable = (error as any)?.isRetriable
 
@@ -48,5 +48,5 @@ export function withBatchRetry<T, U>(
 
             throw error
         }
-    }
+    })
 }

--- a/nodejs/src/ingestion/pipelines/batch-retry.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.ts
@@ -2,7 +2,6 @@ import { logger } from '../../utils/logger'
 import { captureException } from '../../utils/posthog'
 import { retryIfRetriable } from '../../utils/retries'
 import { BatchProcessingStep } from './base-batch-pipeline'
-import { wrapBatchStep } from './extensions/helpers'
 import { dlq } from './results'
 
 export interface BatchRetryOptions {
@@ -27,14 +26,13 @@ export function withBatchRetry<T, U>(
     step: BatchProcessingStep<T, U>,
     options: BatchRetryOptions = {}
 ): BatchProcessingStep<T, U> {
-    return wrapBatchStep(step, async (values, s) => {
-        const stepName = s.name || 'anonymousBatchStep'
+    const wrappedStep: BatchProcessingStep<T, U> = async (values: T[]) => {
         try {
-            return await retryIfRetriable(() => s(values), options.tries ?? 3, options.sleepMs ?? 100)
+            return await retryIfRetriable(() => step(values), options.tries ?? 3, options.sleepMs ?? 100)
         } catch (error) {
             const isRetriable = (error as any)?.isRetriable
 
-            logger.error('🔥', `Batch step ${stepName} failed`, {
+            logger.error('🔥', `Batch step ${step.name} failed`, {
                 error: error instanceof Error ? error.message : String(error),
                 stack: (error as Error).stack,
                 batchSize: values.length,
@@ -48,5 +46,8 @@ export function withBatchRetry<T, U>(
 
             throw error
         }
-    })
+    }
+
+    Object.defineProperty(wrappedStep, 'name', { value: step.name })
+    return wrappedStep
 }

--- a/nodejs/src/ingestion/pipelines/extensions/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/extensions/helpers.ts
@@ -1,4 +1,3 @@
-import type { BatchProcessingStep } from '../base-batch-pipeline'
 import type { PipelineResult } from '../results'
 import type { ProcessingStep } from '../steps'
 
@@ -8,14 +7,5 @@ export function wrapStep<T, U>(
 ): ProcessingStep<T, U> {
     const wrappedStep: ProcessingStep<T, U> = (input) => wrapper(input, step)
     Object.defineProperty(wrappedStep, 'name', { value: step.name })
-    return wrappedStep
-}
-
-export function wrapBatchStep<T, U>(
-    step: BatchProcessingStep<T, U>,
-    wrapper: (inputs: T[], step: BatchProcessingStep<T, U>) => Promise<PipelineResult<U>[]>
-): BatchProcessingStep<T, U> {
-    const wrappedStep: BatchProcessingStep<T, U> = (inputs) => wrapper(inputs, step)
-    Object.defineProperty(wrappedStep, 'name', { value: step.name || 'anonymousBatchStep' })
     return wrappedStep
 }

--- a/nodejs/src/ingestion/pipelines/extensions/helpers.ts
+++ b/nodejs/src/ingestion/pipelines/extensions/helpers.ts
@@ -1,3 +1,4 @@
+import type { BatchProcessingStep } from '../base-batch-pipeline'
 import type { PipelineResult } from '../results'
 import type { ProcessingStep } from '../steps'
 
@@ -7,5 +8,14 @@ export function wrapStep<T, U>(
 ): ProcessingStep<T, U> {
     const wrappedStep: ProcessingStep<T, U> = (input) => wrapper(input, step)
     Object.defineProperty(wrappedStep, 'name', { value: step.name })
+    return wrappedStep
+}
+
+export function wrapBatchStep<T, U>(
+    step: BatchProcessingStep<T, U>,
+    wrapper: (inputs: T[], step: BatchProcessingStep<T, U>) => Promise<PipelineResult<U>[]>
+): BatchProcessingStep<T, U> {
+    const wrappedStep: BatchProcessingStep<T, U> = (inputs) => wrapper(inputs, step)
+    Object.defineProperty(wrappedStep, 'name', { value: step.name || 'anonymousBatchStep' })
     return wrappedStep
 }


### PR DESCRIPTION
## Problem

batch retry pipeline is returning an anonymous step - so metrics aren't getting tagged appropriately. add a batch step wrapper so we label the step right.