### PR TITLE
fix(storybook): disable source maps in CI to fix Cloudflare Pages OOM

### DIFF
--- a/common/storybook/.storybook/main.ts
+++ b/common/storybook/.storybook/main.ts
@@ -52,6 +52,12 @@ const config: StorybookConfig = {
         options: { builder: { useSWC: true } },
     },
 
+    build: {
+        test: {
+            disableSourcemaps: !!process.env.CI,
+        },
+    },
+
     docs: {
         autodocs: 'tag',
     },


### PR DESCRIPTION
## Problem

The Cloudflare Pages Storybook build sometimes fails at ~90% during webpack's `SourceMapDevToolPlugin` phase with `Resource temporarily unavailable (os error 11)` ([example](https://github.com/PostHog/posthog/runs/68415816212)). 

The build generates source maps for hundreds of story bundles and exhausts the container's fixed resources. Do we want these sourcemaps in the production storybook deploy? 😓 

Our CloudFlare build config does not use `--test` and by default will include sourcemaps:
<img width="752" height="158" alt="Screenshot 2026-03-24 at 3 31 07 PM" src="https://github.com/user-attachments/assets/b1de35dd-c3de-4204-87d8-8e176ecb1038" />

CF Pages has no option to increase build resources ([docs](https://developers.cloudflare.com/pages/platform/limits/)).

## Changes

Disable source map generation in CI using Storybook's native [`build.test.disableSourcemaps`](https://storybook.js.org/docs/api/main-config/main-config-build) config, gated on `process.env.CI` (set automatically by CF Pages).

Follows the same pattern already used for the webpack cache setting in `main.ts` line 32.