### PR TITLE
feat: add ingestion outputs metrics

### DIFF
--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.test.ts
@@ -117,7 +117,7 @@ describe('createExtractHeatmapDataStep', () => {
                 expect.arrayContaining([
                     expect.objectContaining({
                         key: '018eebf3-cb48-750b-bfad-36409ea6f2b2',
-                        value: expect.any(String),
+                        value: expect.any(Buffer),
                     }),
                 ])
             )
@@ -125,7 +125,7 @@ describe('createExtractHeatmapDataStep', () => {
             const queuedMessages = mockOutputs.queueMessages.mock.calls[0][1]
             expect(queuedMessages).toHaveLength(2)
 
-            const firstMessage = parseJSON(queuedMessages[0].value as string)
+            const firstMessage = parseJSON(queuedMessages[0].value!.toString())
             expect(firstMessage).toMatchObject({
                 type: 'mousemove',
                 x: 64, // 1020 / 16
@@ -156,7 +156,7 @@ describe('createExtractHeatmapDataStep', () => {
             const queuedMessages = mockOutputs.queueMessages.mock.calls[0][1]
             expect(queuedMessages).toHaveLength(2)
 
-            const urls = queuedMessages.map((msg: any) => parseJSON(msg.value as string).current_url)
+            const urls = queuedMessages.map((msg: any) => parseJSON(msg.value!.toString()).current_url)
             expect(urls).toContain('http://localhost:3000/')
             expect(urls).toContain('http://localhost:3000/about')
         })
@@ -178,12 +178,12 @@ describe('createExtractHeatmapDataStep', () => {
             expect(queuedMessages).toHaveLength(3) // 2 original + 1 scroll depth
 
             const scrollDepthMessage = queuedMessages.find((msg: any) => {
-                const parsed = parseJSON(msg.value as string)
+                const parsed = parseJSON(msg.value!.toString())
                 return parsed.type === 'scrolldepth'
             })
 
             expect(scrollDepthMessage).toBeDefined()
-            const scrollData = parseJSON(scrollDepthMessage!.value as string)
+            const scrollData = parseJSON(scrollDepthMessage!.value!.toString())
             expect(scrollData).toMatchObject({
                 type: 'scrolldepth',
                 x: 0,
@@ -214,7 +214,7 @@ describe('createExtractHeatmapDataStep', () => {
             expect(queuedMessages).toHaveLength(1) // Only scroll depth, no heatmap data
 
             const scrollDepthMessage = queuedMessages[0]
-            const scrollData = parseJSON(scrollDepthMessage.value as string)
+            const scrollData = parseJSON(scrollDepthMessage.value!.toString())
             expect(scrollData).toMatchObject({
                 type: 'scrolldepth',
                 x: 0,
@@ -421,7 +421,7 @@ describe('createExtractHeatmapDataStep', () => {
             expect(mockOutputs.queueMessages).toHaveBeenCalledTimes(1)
 
             const queuedMessages = mockOutputs.queueMessages.mock.calls[0][1]
-            const message = parseJSON(queuedMessages[0].value as string)
+            const message = parseJSON(queuedMessages[0].value!.toString())
 
             expect(message.x).toBe(10) // 160 / 16
             expect(message.y).toBe(20) // 320 / 16

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
@@ -45,7 +45,7 @@ export function createExtractHeatmapDataStep<TInput extends ExtractHeatmapDataSt
                         HEATMAPS_OUTPUT,
                         heatmapEvents.map((rawEvent) => ({
                             key: eventUuid,
-                            value: JSON.stringify(rawEvent),
+                            value: Buffer.from(JSON.stringify(rawEvent)),
                         }))
                     )
                 )

--- a/nodejs/src/ingestion/outputs/index.ts
+++ b/nodejs/src/ingestion/outputs/index.ts
@@ -1,4 +1,5 @@
 export { IngestionOutputs, IngestionOutput } from './ingestion-outputs'
+export { IngestionOutputMessage } from './types'
 export { IngestionOutputDefinition, resolveIngestionOutputs } from './resolver'
 export { AllowedConfigKey, getProducerConfig } from './kafka-producer-config'
 export { KafkaProducerRegistry } from './kafka-producer-registry'

--- a/nodejs/src/ingestion/outputs/ingestion-outputs.test.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-outputs.test.ts
@@ -166,11 +166,11 @@ describe('IngestionOutputs', () => {
                 events: { topic: 'clickhouse_events', producer },
             })
 
-            await outputs.queueMessages('events', [{ value: 'msg1' }, { value: 'msg2' }])
+            await outputs.queueMessages('events', [{ value: Buffer.from('msg1') }, { value: Buffer.from('msg2') }])
 
             expect(producer.queueMessages).toHaveBeenCalledWith({
                 topic: 'clickhouse_events',
-                messages: [{ value: 'msg1' }, { value: 'msg2' }],
+                messages: [{ value: Buffer.from('msg1') }, { value: Buffer.from('msg2') }],
             })
         })
     })

--- a/nodejs/src/ingestion/outputs/ingestion-outputs.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-outputs.ts
@@ -1,4 +1,4 @@
-import { KafkaProducerWrapper, MessageKey, MessageWithoutTopic } from '../../kafka/producer'
+import { KafkaProducerWrapper, MessageKey } from '../../kafka/producer'
 import { logger } from '../../utils/logger'
 import {
     ingestionOutputsBatchSize,
@@ -6,16 +6,7 @@ import {
     ingestionOutputsLatency,
     ingestionOutputsMessageValueBytes,
 } from './metrics'
-
-// Buffer.byteLength is O(n) for strings but O(1) for Buffers.
-// Most callers pass Buffers, so this is cheap in practice.
-// TODO: refactor message type to only accept Buffers, then simplify to value.length.
-function messageValueBytes(value: string | Buffer | null): number {
-    if (value === null) {
-        return 0
-    }
-    return typeof value === 'string' ? Buffer.byteLength(value) : value.length
-}
+import { IngestionOutputMessage } from './types'
 
 /** A resolved output: the Kafka topic and the producer to write to it. */
 export interface IngestionOutput {
@@ -41,14 +32,13 @@ export class IngestionOutputs<O extends string> {
      * @param output - The output name to produce to.
      * @param message - The message to produce. Key is required for partitioning.
      */
-    async produce(output: O, message: Omit<MessageWithoutTopic, 'key'> & { key: MessageKey }): Promise<void> {
+    async produce(output: O, message: IngestionOutputMessage & { key: MessageKey }): Promise<void> {
         const { topic, producer } = this.outputs[output]
-        const value = typeof message.value === 'string' ? Buffer.from(message.value) : message.value
-        ingestionOutputsMessageValueBytes.observe({ output }, messageValueBytes(message.value))
+        ingestionOutputsMessageValueBytes.observe({ output }, message.value?.length ?? 0)
         ingestionOutputsBatchSize.observe({ output, method: 'produce' }, 1)
         const end = ingestionOutputsLatency.startTimer({ output, method: 'produce' })
         try {
-            return await producer.produce({ ...message, topic, value })
+            return await producer.produce({ ...message, topic })
         } catch (error) {
             ingestionOutputsErrors.inc({ output, method: 'produce' })
             throw error
@@ -65,10 +55,10 @@ export class IngestionOutputs<O extends string> {
      * @param output - The output name to produce to.
      * @param messages - The messages to produce.
      */
-    async queueMessages(output: O, messages: MessageWithoutTopic[]): Promise<void> {
+    async queueMessages(output: O, messages: IngestionOutputMessage[]): Promise<void> {
         const { topic, producer } = this.outputs[output]
         for (const m of messages) {
-            ingestionOutputsMessageValueBytes.observe({ output }, messageValueBytes(m.value))
+            ingestionOutputsMessageValueBytes.observe({ output }, m.value?.length ?? 0)
         }
         ingestionOutputsBatchSize.observe({ output, method: 'queueMessages' }, messages.length)
         const end = ingestionOutputsLatency.startTimer({ output, method: 'queueMessages' })

--- a/nodejs/src/ingestion/outputs/ingestion-outputs.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-outputs.ts
@@ -36,15 +36,7 @@ export class IngestionOutputs<O extends string> {
         const { topic, producer } = this.outputs[output]
         ingestionOutputsMessageValueBytes.observe({ output }, message.value?.length ?? 0)
         ingestionOutputsBatchSize.observe({ output, method: 'produce' }, 1)
-        const end = ingestionOutputsLatency.startTimer({ output, method: 'produce' })
-        try {
-            return await producer.produce({ ...message, topic })
-        } catch (error) {
-            ingestionOutputsErrors.inc({ output, method: 'produce' })
-            throw error
-        } finally {
-            end()
-        }
+        return this.withMetrics(output, 'produce', () => producer.produce({ ...message, topic }))
     }
 
     /**
@@ -61,11 +53,15 @@ export class IngestionOutputs<O extends string> {
             ingestionOutputsMessageValueBytes.observe({ output }, m.value?.length ?? 0)
         }
         ingestionOutputsBatchSize.observe({ output, method: 'queueMessages' }, messages.length)
-        const end = ingestionOutputsLatency.startTimer({ output, method: 'queueMessages' })
+        return this.withMetrics(output, 'queueMessages', () => producer.queueMessages({ topic, messages }))
+    }
+
+    private async withMetrics<T>(output: O, method: string, fn: () => Promise<T>): Promise<T> {
+        const end = ingestionOutputsLatency.startTimer({ output, method })
         try {
-            return await producer.queueMessages({ topic, messages })
+            return await fn()
         } catch (error) {
-            ingestionOutputsErrors.inc({ output, method: 'queueMessages' })
+            ingestionOutputsErrors.inc({ output, method })
             throw error
         } finally {
             end()

--- a/nodejs/src/ingestion/outputs/ingestion-outputs.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-outputs.ts
@@ -1,5 +1,21 @@
 import { KafkaProducerWrapper, MessageKey, MessageWithoutTopic } from '../../kafka/producer'
 import { logger } from '../../utils/logger'
+import {
+    ingestionOutputsBatchSize,
+    ingestionOutputsErrors,
+    ingestionOutputsLatency,
+    ingestionOutputsMessageValueBytes,
+} from './metrics'
+
+// Buffer.byteLength is O(n) for strings but O(1) for Buffers.
+// Most callers pass Buffers, so this is cheap in practice.
+// TODO: refactor message type to only accept Buffers, then simplify to value.length.
+function messageValueBytes(value: string | Buffer | null): number {
+    if (value === null) {
+        return 0
+    }
+    return typeof value === 'string' ? Buffer.byteLength(value) : value.length
+}
 
 /** A resolved output: the Kafka topic and the producer to write to it. */
 export interface IngestionOutput {
@@ -28,7 +44,17 @@ export class IngestionOutputs<O extends string> {
     async produce(output: O, message: Omit<MessageWithoutTopic, 'key'> & { key: MessageKey }): Promise<void> {
         const { topic, producer } = this.outputs[output]
         const value = typeof message.value === 'string' ? Buffer.from(message.value) : message.value
-        return producer.produce({ ...message, topic, value })
+        ingestionOutputsMessageValueBytes.observe({ output }, messageValueBytes(message.value))
+        ingestionOutputsBatchSize.observe({ output, method: 'produce' }, 1)
+        const end = ingestionOutputsLatency.startTimer({ output, method: 'produce' })
+        try {
+            return await producer.produce({ ...message, topic, value })
+        } catch (error) {
+            ingestionOutputsErrors.inc({ output, method: 'produce' })
+            throw error
+        } finally {
+            end()
+        }
     }
 
     /**
@@ -41,7 +67,19 @@ export class IngestionOutputs<O extends string> {
      */
     async queueMessages(output: O, messages: MessageWithoutTopic[]): Promise<void> {
         const { topic, producer } = this.outputs[output]
-        return producer.queueMessages({ topic, messages })
+        for (const m of messages) {
+            ingestionOutputsMessageValueBytes.observe({ output }, messageValueBytes(m.value))
+        }
+        ingestionOutputsBatchSize.observe({ output, method: 'queueMessages' }, messages.length)
+        const end = ingestionOutputsLatency.startTimer({ output, method: 'queueMessages' })
+        try {
+            return await producer.queueMessages({ topic, messages })
+        } catch (error) {
+            ingestionOutputsErrors.inc({ output, method: 'queueMessages' })
+            throw error
+        } finally {
+            end()
+        }
     }
 
     /**

--- a/nodejs/src/ingestion/outputs/metrics.ts
+++ b/nodejs/src/ingestion/outputs/metrics.ts
@@ -1,0 +1,32 @@
+import { Counter, Histogram } from 'prom-client'
+
+export const ingestionOutputsMessageValueBytes = new Histogram({
+    name: 'ingestion_outputs_message_value_bytes',
+    help: 'Approximate value size in bytes per message produced to ingestion outputs',
+    labelNames: ['output'],
+    // 128B, 256B, 512B, 1KB, 2KB, 4KB, 8KB, 16KB, 32KB, 64KB, 128KB, 256KB, 512KB, 1MB, 2MB, 4MB, 8MB, 16MB, 32MB, 64MB
+    buckets: [
+        128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304,
+        8388608, 16777216, 33554432, 67108864,
+    ],
+})
+
+export const ingestionOutputsLatency = new Histogram({
+    name: 'ingestion_outputs_latency_seconds',
+    help: 'Latency of produce/queueMessages calls to ingestion outputs',
+    labelNames: ['output', 'method'],
+    buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+})
+
+export const ingestionOutputsErrors = new Counter({
+    name: 'ingestion_outputs_errors_total',
+    help: 'Total number of produce/queueMessages errors on ingestion outputs',
+    labelNames: ['output', 'method'],
+})
+
+export const ingestionOutputsBatchSize = new Histogram({
+    name: 'ingestion_outputs_batch_size',
+    help: 'Number of messages per produce/queueMessages call',
+    labelNames: ['output', 'method'],
+    buckets: [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000],
+})

--- a/nodejs/src/ingestion/outputs/resolver.test.ts
+++ b/nodejs/src/ingestion/outputs/resolver.test.ts
@@ -61,10 +61,10 @@ describe('resolveIngestionOutputs', () => {
 
         expect(registry.getProducer).toHaveBeenCalledWith('PRIMARY')
 
-        await outputs.queueMessages('events', [{ value: 'test' }])
+        await outputs.queueMessages('events', [{ value: Buffer.from('test') }])
         expect(producer.queueMessages).toHaveBeenCalledWith({
             topic: 'clickhouse_events',
-            messages: [{ value: 'test' }],
+            messages: [{ value: Buffer.from('test') }],
         })
     })
 
@@ -75,10 +75,10 @@ describe('resolveIngestionOutputs', () => {
 
         const outputs = await resolveIngestionOutputs(registry, testDefinitions)
 
-        await outputs.queueMessages('events', [{ value: 'test' }])
+        await outputs.queueMessages('events', [{ value: Buffer.from('test') }])
         expect(producer.queueMessages).toHaveBeenCalledWith({
             topic: 'custom_events_topic',
-            messages: [{ value: 'test' }],
+            messages: [{ value: Buffer.from('test') }],
         })
     })
 
@@ -89,10 +89,10 @@ describe('resolveIngestionOutputs', () => {
 
         const outputs = await resolveIngestionOutputs(registry, testDefinitions)
 
-        await outputs.queueMessages('ai_events', [{ value: 'test' }])
+        await outputs.queueMessages('ai_events', [{ value: Buffer.from('test') }])
         expect(producer.queueMessages).toHaveBeenCalledWith({
             topic: 'clickhouse_ai_events',
-            messages: [{ value: 'test' }],
+            messages: [{ value: Buffer.from('test') }],
         })
     })
 
@@ -106,7 +106,7 @@ describe('resolveIngestionOutputs', () => {
 
         expect(registry.getProducer).toHaveBeenCalledWith('SECONDARY')
 
-        await outputs.queueMessages('events', [{ value: 'test' }])
+        await outputs.queueMessages('events', [{ value: Buffer.from('test') }])
         expect(secondary.queueMessages).toHaveBeenCalledTimes(1)
         expect(primary.queueMessages).not.toHaveBeenCalled()
     })
@@ -119,7 +119,7 @@ describe('resolveIngestionOutputs', () => {
 
         const outputs = await resolveIngestionOutputs(registry, testDefinitions)
 
-        await outputs.queueMessages('ai_events', [{ value: 'test' }])
+        await outputs.queueMessages('ai_events', [{ value: Buffer.from('test') }])
         expect(primary.queueMessages).toHaveBeenCalledTimes(1)
         expect(secondary.queueMessages).not.toHaveBeenCalled()
     })

--- a/nodejs/src/ingestion/outputs/types.ts
+++ b/nodejs/src/ingestion/outputs/types.ts
@@ -1,0 +1,8 @@
+import { MessageKey } from '../../kafka/producer'
+
+/** A Kafka message with a Buffer value, used by IngestionOutputs. */
+export type IngestionOutputMessage = {
+    value: Buffer | null
+    key?: MessageKey
+    headers?: Record<string, string>
+}


### PR DESCRIPTION
## Problem

Would be great to have more observability for ingestion outputs.

## Changes

Adds a couple of metrics for the outputs:
- latency
- batch size
- errors
- payload size

## How did you test this code?

Just adding metrics