### PR TITLE
fix: skip coupons_overview API call for non-admin users

### DIFF
--- a/frontend/src/scenes/coupons/couponLogic.ts
+++ b/frontend/src/scenes/coupons/couponLogic.ts
@@ -35,7 +35,7 @@ export const couponLogic = kea<couponLogicType>([
             billingLogic,
             ['billing', 'billingLoading'],
         ],
-        actions: [billingLogic, ['loadBillingSuccess']],
+        actions: [billingLogic, ['loadBillingSuccess'], organizationLogic, ['loadCurrentOrganizationSuccess']],
     })),
     actions({
         setClaimed: (claimed: boolean) => ({ claimed }),
@@ -46,7 +46,7 @@ export const couponLogic = kea<couponLogicType>([
             null as CouponsOverview | null,
             {
                 loadCouponsOverview: async () => {
-                    if (!values.isAdminOrOwner) {
+                    if (values.isAdminOrOwner === false && values.currentOrganization) {
                         return null
                     }
                     return await api.get('api/billing/coupons/overview')
@@ -118,6 +118,11 @@ export const couponLogic = kea<couponLogicType>([
             // kea-forms errors() is a selector that only recalculates when form state changes.
             // Since we depend on external billing state, we force recalculation by re-setting a form value.
             actions.setCouponValue('code', values.coupon.code)
+        },
+        loadCurrentOrganizationSuccess: () => {
+            if (!values.couponsOverview && values.isAdminOrOwner) {
+                actions.loadCouponsOverview()
+            }
         },
     })),
     afterMount(({ actions }) => {

--- a/frontend/src/scenes/coupons/couponLogic.ts
+++ b/frontend/src/scenes/coupons/couponLogic.ts
@@ -41,11 +41,14 @@ export const couponLogic = kea<couponLogicType>([
         setClaimed: (claimed: boolean) => ({ claimed }),
         setClaimedDetails: (details: any) => ({ details }),
     }),
-    loaders(() => ({
+    loaders(({ values }) => ({
         couponsOverview: [
             null as CouponsOverview | null,
             {
                 loadCouponsOverview: async () => {
+                    if (!values.isAdminOrOwner) {
+                        return null
+                    }
                     return await api.get('api/billing/coupons/overview')
                 },
             },


### PR DESCRIPTION
## Problem

Member-level Vercel SSO users visiting the billing page trigger a `coupons_overview` API call. The billing service rejects this with 403 (requires admin), which PostHog doesn't handle gracefully - it throws a 500. 132 occurrences in the last 7 days.

## Changes

Skip the `loadCouponsOverview` API call in `couponLogic` when the user isn't an admin or owner. The logic already connects to `organizationLogic.isAdminOrOwner` - just needed a guard before the API call.

Members see the billing page normally, just without the coupons banner (which they can't act on anyway).

## How did you test this?

- [x] Verified `couponLogic` already has `isAdminOrOwner` from `organizationLogic`
- [x] `activeCoupons` selector returns `[]` when `couponsOverview` is null, so the UI handles it cleanly
- [x] The billing page loading spinner won't block since `couponsOverviewLoading` resolves immediately for non-admins

## Changelog

No - bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)