### PR TITLE
feat(flags): verify evaluation_metadata presence in flags cache

### DIFF
--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -382,7 +382,7 @@ def verify_team_flags(
     # Check if evaluation_metadata is present in cached data.
     # Entries written before evaluation_metadata was added won't have it,
     # and the Rust service needs it for flag dependency evaluation.
-    if "evaluation_metadata" not in cached_data:
+    if not cached_data or "evaluation_metadata" not in cached_data:
         return {
             "status": "mismatch",
             "issue": "MISSING_EVALUATION_METADATA",
@@ -391,7 +391,7 @@ def verify_team_flags(
         }
 
     # Extract cached flags
-    cached_flags = cached_data.get("flags", []) if cached_data else []
+    cached_flags = cached_data.get("flags", [])
 
     # Compare flags by ID
     db_flags_by_id = {flag["id"]: flag for flag in db_flags}

--- a/posthog/models/feature_flag/flags_cache.py
+++ b/posthog/models/feature_flag/flags_cache.py
@@ -379,6 +379,17 @@ def verify_team_flags(
             "db_data": db_data,
         }
 
+    # Check if evaluation_metadata is present in cached data.
+    # Entries written before evaluation_metadata was added won't have it,
+    # and the Rust service needs it for flag dependency evaluation.
+    if "evaluation_metadata" not in cached_data:
+        return {
+            "status": "mismatch",
+            "issue": "MISSING_EVALUATION_METADATA",
+            "details": "Cache entry missing evaluation_metadata",
+            "db_data": db_data,
+        }
+
     # Extract cached flags
     cached_flags = cached_data.get("flags", []) if cached_data else []
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1603,7 +1603,7 @@ class TestManagementCommands(BaseTest):
 
         # Simulate a pre-evaluation_metadata cache entry by removing the key
         cached_data, _source = flags_hypercache.get_from_cache_with_source(self.team)
-        self.assertIsNotNone(cached_data)
+        assert cached_data is not None
         del cached_data["evaluation_metadata"]
         flags_hypercache.set_cache_value(self.team, cached_data)
 

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1588,6 +1588,32 @@ class TestManagementCommands(BaseTest):
         self.assertIsInstance(result["db_data"], dict)
         self.assertIn("flags", result["db_data"])
 
+    def test_verify_detects_missing_evaluation_metadata(self):
+        from posthog.models.feature_flag.flags_cache import update_flags_cache, verify_team_flags
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="test-flag",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+        )
+
+        # Warm the cache normally (includes evaluation_metadata)
+        update_flags_cache(self.team)
+
+        # Simulate a pre-evaluation_metadata cache entry by removing the key
+        cached_data, _source = flags_hypercache.get_from_cache_with_source(self.team)
+        self.assertIsNotNone(cached_data)
+        del cached_data["evaluation_metadata"]
+        flags_hypercache.set_cache_value(self.team, cached_data)
+
+        result = verify_team_flags(self.team)
+
+        self.assertEqual(result["status"], "mismatch")
+        self.assertEqual(result["issue"], "MISSING_EVALUATION_METADATA")
+        self.assertIn("db_data", result)
+        self.assertIn("evaluation_metadata", result["db_data"])
+
     @override_settings(FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=0)
     def test_verify_fix_failures_reported(self):
         """Test that fix failures are properly reported."""


### PR DESCRIPTION
## Problem

The flags HyperCache recently gained `evaluation_metadata` (dependency stages, missing deps, transitive deps), but the verification task (`verify_team_flags`) doesn't check for its presence. Cache entries written before this field was added silently lack it, leaving the Rust flags service without dependency information.

I recently ran `python manage.py warm_flags_cache` in prod-us and prod-eu, so I'm pretty confident every cache entry is good. But this would give me 100% confidence.

## Changes

- Add an `evaluation_metadata` presence check in `verify_team_flags` that returns a `MISSING_EVALUATION_METADATA` mismatch, triggering the existing auto-fix path to rebuild the entry
- Add a test that simulates a pre-`evaluation_metadata` cache entry and verifies detection

## How did you test this code?

- New test `test_verify_detects_missing_evaluation_metadata` covers the detection path
- All 21 existing verify-related tests pass without regressions

## Publish to changelog?

no