### PR TITLE
feat(dashboard-insights): ensure order of duplicated insights is always after the original item

### DIFF
--- a/frontend/src/scenes/dashboard/tileLayouts.test.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.test.ts
@@ -1,6 +1,6 @@
 import { Layout, LayoutItem } from 'react-grid-layout'
 
-import { calculateDuplicateLayout, calculateLayouts } from 'scenes/dashboard/tileLayouts'
+import { calculateDuplicateLayout, calculateLayouts, sortTilesByLayout } from 'scenes/dashboard/tileLayouts'
 
 import { DashboardLayoutSize, DashboardTile, QueryBasedInsightModel, TileLayout } from '~/types'
 
@@ -133,5 +133,19 @@ describe('calculateDuplicateLayout', () => {
 
         expect(result.duplicateLayouts.sm).toEqual({ x: 6, y: 0, w: 6, h: 5 })
         expect((result.duplicateLayouts as any).xs).toBeUndefined()
+    })
+
+    describe('sortTilesByLayout', () => {
+        it('tiebreaks by tile id ascending when sm positions match', () => {
+            const a = {
+                id: 1,
+                layouts: { sm: { x: 0, y: 0, w: 6, h: 5 } },
+            } as unknown as DashboardTile<QueryBasedInsightModel>
+            const b = {
+                id: 2,
+                layouts: { sm: { x: 0, y: 0, w: 6, h: 5 } },
+            } as unknown as DashboardTile<QueryBasedInsightModel>
+            expect(sortTilesByLayout([b, a], 'sm')).toEqual([a, b])
+        })
     })
 })

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -102,10 +102,15 @@ export const sortTilesByLayout = (
         const bx = b.layouts?.[col]?.x ?? 0
         const by = b.layouts?.[col]?.y ?? 0
 
-        if (ay < by || (ay == by && ax < bx)) {
-            return -1
-        } else if (ay > by || (ay == by && ax > bx)) {
-            return 1
+        if (ay !== by) {
+            return ay < by ? -1 : 1
+        }
+        if (ax !== bx) {
+            return ax < bx ? -1 : 1
+        }
+        // Deterministic order when positions match (e.g. duplicate tile): older tile first
+        if (a.id != null && b.id != null && a.id !== b.id) {
+            return a.id < b.id ? -1 : 1
         }
         return 0
     })

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -530,7 +530,10 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
         return dashboard
 
-    def _deep_duplicate_tiles(self, dashboard: Dashboard, existing_tile: DashboardTile) -> None:
+    def _deep_duplicate_tiles(
+        self, dashboard: Dashboard, existing_tile: DashboardTile, duplicate_layouts: dict | None = None
+    ) -> None:
+        layouts = duplicate_layouts if duplicate_layouts is not None else existing_tile.layouts
         if existing_tile.insight:
             new_data = {
                 **InsightSerializer(existing_tile.insight, context=self.context).data,
@@ -551,7 +554,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             DashboardTile.objects.create(
                 dashboard=dashboard,
                 insight=insight,
-                layouts=existing_tile.layouts,
+                layouts=layouts,
                 color=existing_tile.color,
                 filters_overrides=existing_tile.filters_overrides,
                 show_description=existing_tile.show_description,
@@ -570,7 +573,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             DashboardTile.objects.create(
                 dashboard=dashboard,
                 text=text,
-                layouts=existing_tile.layouts,
+                layouts=layouts,
                 color=existing_tile.color,
                 filters_overrides=existing_tile.filters_overrides,
                 show_description=existing_tile.show_description,
@@ -589,7 +592,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             DashboardTile.objects.create(
                 dashboard=dashboard,
                 button_tile=button_tile,
-                layouts=existing_tile.layouts,
+                layouts=layouts,
                 color=existing_tile.color,
                 filters_overrides=existing_tile.filters_overrides,
                 show_description=existing_tile.show_description,
@@ -667,8 +670,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
         for tile_data in duplicate_tiles:
             # nosemgrep: idor-lookup-without-team (scoped via parent viewset get_queryset)
             existing_tile = DashboardTile.objects.get(dashboard=instance, id=tile_data["id"])
-            existing_tile.layouts = tile_data.get("layouts", {})
-            self._deep_duplicate_tiles(instance, existing_tile)
+            self._deep_duplicate_tiles(instance, existing_tile, tile_data.get("layouts", {}))
 
         if "request" in self.context:
             report_user_action(
@@ -1153,13 +1155,7 @@ class DashboardsViewSet(
 
         layout_size = self._get_layout_size_from_request(request)
 
-        sorted_tiles = sorted(
-            tiles,
-            key=lambda tile: (
-                tile.layouts.get(layout_size, {}).get("y", 100),
-                tile.layouts.get(layout_size, {}).get("x", 100),
-            ),
-        )
+        sorted_tiles = DashboardTile.sort_tiles_by_layout(tiles, layout_size)
 
         # Async generator that handles progressive tile serialization and streaming
         async def async_tile_stream_generator() -> AsyncGenerator[bytes, None]:

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1099,6 +1099,9 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         new_tile = next(t for t in tiles if t["id"] != original_tile.id)
         assert new_tile["layouts"] == expected_layouts
 
+        tile_ids_in_response_order = [t["id"] for t in tiles]
+        assert tile_ids_in_response_order.index(original_tile.id) < tile_ids_in_response_order.index(new_tile["id"])
+
     def test_dashboard_duplication_can_duplicate_tiles_without_editing_name_if_there_is_none(self) -> None:
         existing_dashboard = Dashboard.objects.create(team=self.team, name="existing dashboard", created_by=self.user)
         self.dashboard_api.create_insight({"dashboards": [existing_dashboard.pk], "name": None})

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -222,12 +222,17 @@ class DashboardTile(models.Model):
     def sort_tiles_by_layout(
         tiles: list["DashboardTile"] | QuerySet["DashboardTile"], layout_size: str = "sm"
     ) -> list["DashboardTile"]:
-        """Sort tiles by their layout position (y, then x)."""
+        """Sort tiles by their layout position (y, then x, then tile pk ascending).
+
+        The pk tiebreaker keeps order stable when positions match (e.g. duplicate insight workflow)
+        so the original tile always sorts before the copy so that we have less likelihood of breaking dashboard layout orders
+        """
         return sorted(
             tiles,
             key=lambda tile: (
                 tile.layouts.get(layout_size, {}).get("y", 100),
                 tile.layouts.get(layout_size, {}).get("x", 100),
+                tile.pk,
             ),
         )
 

--- a/posthog/models/test/test_dashboard_tile_model.py
+++ b/posthog/models/test/test_dashboard_tile_model.py
@@ -46,3 +46,16 @@ class TestDashboardTileModel(APIBaseTest):
                     text = Text.objects.create(team=self.team, body="I am a text")
                     tile = DashboardTile.objects.create(dashboard=self.dashboard, text=text, **invalid_text_tile_field)
                     tile.clean()
+
+    def test_sort_tiles_by_layout_tiebreaks_by_pk_when_positions_match(self) -> None:
+        """Same (y, x) must sort deterministically so duplicate tiles never flap before the original."""
+        dashboard = Dashboard.objects.create(team=self.team, name="sort tiebreak", created_by=self.user)
+        insight_a = Insight.objects.create(team=self.team, short_id="aaaaaa", name="a")
+        insight_b = Insight.objects.create(team=self.team, short_id="bbbbbb", name="b")
+        same_sm = {"sm": {"x": 0, "y": 0, "w": 6, "h": 5}}
+        tile_lower_pk = DashboardTile.objects.create(dashboard=dashboard, insight=insight_a, layouts=same_sm)
+        tile_higher_pk = DashboardTile.objects.create(dashboard=dashboard, insight=insight_b, layouts=same_sm)
+        assert tile_lower_pk.pk < tile_higher_pk.pk
+
+        sorted_tiles = DashboardTile.sort_tiles_by_layout([tile_higher_pk, tile_lower_pk], "sm")
+        assert sorted_tiles == [tile_lower_pk, tile_higher_pk]


### PR DESCRIPTION
## Problem

When duplicating insights, it can appear

Closes #28519

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
