### PR TITLE
fix(web-analytics): Reduce live dashboard lag under high event volume

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
@@ -119,6 +119,7 @@ describe('LiveMetricsSlidingWindow', () => {
             window.addDataPoint(toUnixSeconds(relativeTime(-30 * MINUTE)), 'user-old', { pageviews: 1 })
             tickMinute()
             window.addDataPoint(toUnixSeconds(relativeTime(-1 * MINUTE)), 'user-new', { pageviews: 1 })
+            window.prune()
 
             expect(window.getSortedBuckets()).toHaveLength(1)
         })
@@ -450,6 +451,7 @@ describe('LiveMetricsSlidingWindow', () => {
                 pageviews: 1,
                 device: { deviceId: 'device-3', deviceType: 'Desktop' },
             })
+            window.prune()
 
             const breakdown = window.getDeviceBreakdown()
             expect(getDeviceCount(breakdown, 'Mobile')).toBe(1)
@@ -476,6 +478,7 @@ describe('LiveMetricsSlidingWindow', () => {
                 pageviews: 1,
                 device: { deviceId: 'device-2', deviceType: 'Desktop' },
             })
+            window.prune()
 
             const breakdown = window.getDeviceBreakdown()
             expect(getDeviceCount(breakdown, 'Mobile')).toBe(1)
@@ -552,6 +555,7 @@ describe('LiveMetricsSlidingWindow', () => {
             tickMinute()
 
             window.addDataPoint(toUnixSeconds(relativeTime(MINUTE)), 'user-3', { pageviews: 1 })
+            window.prune()
 
             expect(window.getTotalUniqueUsers()).toBe(2)
             expect(window.getSortedBuckets()).toHaveLength(2)
@@ -568,6 +572,7 @@ describe('LiveMetricsSlidingWindow', () => {
             tickMinute()
 
             window.addDataPoint(toUnixSeconds(relativeTime(MINUTE)), 'user-2', { pageviews: 1 })
+            window.prune()
 
             expect(window.getTotalUniqueUsers()).toBe(2)
         })
@@ -624,6 +629,7 @@ describe('LiveMetricsSlidingWindow', () => {
             tickMinute()
 
             window.addGeoDataPoint(toUnixSeconds(relativeTime(MINUTE)), 'GB', 'user-3')
+            window.prune()
 
             const breakdown = window.getCountryBreakdown()
             expect(getCountryCount(breakdown, 'US')).toBe(1)
@@ -641,6 +647,7 @@ describe('LiveMetricsSlidingWindow', () => {
             tickMinute()
 
             window.addGeoDataPoint(toUnixSeconds(relativeTime(MINUTE)), 'US', 'user-2')
+            window.prune()
 
             const breakdown = window.getCountryBreakdown()
             expect(getCountryCount(breakdown, 'US')).toBe(2)

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
@@ -43,8 +43,6 @@ export class LiveMetricsSlidingWindow {
         if (data.browser) {
             this.addBrowserToBucket(bucket, data.browser.browserType, data.browser.deviceId)
         }
-
-        this.prune()
     }
 
     addGeoDataPoint(eventTs: number, countryCode: string, distinctId: string): void {
@@ -53,7 +51,6 @@ export class LiveMetricsSlidingWindow {
         }
         const bucket = this.getOrCreateBucket(eventTs)
         this.addCountryToBucket(bucket, countryCode, distinctId)
-        this.prune()
     }
 
     extendBucketData(eventTs: number, data: SlidingWindowBucket): void {
@@ -98,8 +95,6 @@ export class LiveMetricsSlidingWindow {
                 }
             }
         }
-
-        this.prune()
     }
 
     private addUserToBucket(bucket: SlidingWindowBucket, userId: string): void {
@@ -208,7 +203,7 @@ export class LiveMetricsSlidingWindow {
         }
     }
 
-    private prune(): void {
+    prune(): void {
         const nowTs = Date.now() / 1000
         const threshold = nowTs - this.windowSizeSeconds
         for (const [ts, bucket] of this.buckets.entries()) {

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -34,8 +34,8 @@ import {
 const ERROR_TOAST_ID = 'live-pageviews-error'
 const RECONNECT_TOAST_ID = 'live-pageviews-reconnect'
 const BUCKET_WINDOW_MINUTES = 30
-const BATCH_FLUSH_INTERVAL_MS = 300
-const BATCH_SIZE_THRESHOLD = 10
+const BATCH_FLUSH_INTERVAL_MS = 500
+const BATCH_SIZE_THRESHOLD = 50
 const COOKIELESS_TRANSFORM_PREFIX = 'cookieless_transform'
 const COOKIELESS_TRANSFORM_SEPARATOR = '|||'
 
@@ -64,6 +64,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     for (const { timestamp, bucket } of buckets) {
                         existingWindow.extendBucketData(timestamp / 1000, bucket)
                     }
+                    existingWindow.prune()
                     return existingWindow
                 },
                 addEvents: (window, { events, newerThan }) => {
@@ -95,16 +96,18 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                         }
                     }
 
+                    window.prune()
                     return window
                 },
                 addGeoEvents: (window, { events }) => {
                     const nowTs = Date.now() / 1000
                     for (const event of events) {
                         if (event.countryCode) {
-                            const distinctId = event.distinctId!
+                            const distinctId = event.distinctId
                             window.addGeoDataPoint(nowTs, event.countryCode, distinctId)
                         }
                     }
+                    window.prune()
                     return window
                 },
             },
@@ -164,6 +167,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
 
                 return result
             },
+            { resultEqualityCheck: equal },
         ],
         deviceBreakdown: [
             (s) => [s.slidingWindow, s.windowVersion],
@@ -178,6 +182,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
         countryBreakdown: [
             (s) => [s.slidingWindow, s.windowVersion],
             (slidingWindow: LiveMetricsSlidingWindow): CountryBreakdownItem[] => slidingWindow.getCountryBreakdown(),
+            { resultEqualityCheck: equal },
         ],
         topPaths: [
             (s) => [s.slidingWindow, s.windowVersion],
@@ -313,15 +318,27 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             const url = new URL(`${host}/events`)
             url.searchParams.append('geo', 'true')
 
+            cache.geoBatch = [] as LiveGeoEvent[]
+            cache.lastGeoBatchTime = performance.now()
+
             cache.geoConnection = createStreamConnection({
                 url,
                 token,
                 onMessage: (data) => {
                     try {
                         const geoData = JSON.parse(data) as LiveGeoEvent
-                        actions.addGeoEvents([geoData])
+                        if (geoData.countryCode && geoData.distinctId) {
+                            cache.geoBatch.push(geoData)
+                        }
                     } catch (ex) {
                         console.error('Failed to parse geo event:', ex)
+                    }
+
+                    const timeSinceLastBatch = performance.now() - cache.lastGeoBatchTime
+                    if (cache.geoBatch.length >= BATCH_SIZE_THRESHOLD || timeSinceLastBatch > BATCH_FLUSH_INTERVAL_MS) {
+                        actions.addGeoEvents(cache.geoBatch)
+                        cache.geoBatch = []
+                        cache.lastGeoBatchTime = performance.now()
                     }
                 },
                 onError: (error) => {


### PR DESCRIPTION
## Problem
The Livestream service is publishing a lot more events per second after the refactor causing the Live tab to slowdown / lag. 
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Increase the batch size and increase the flush interval.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
