### PR TITLE
fix(workflows): Make action created_at/updated_at optional in Zod schema

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/types.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.test.ts
@@ -1,0 +1,44 @@
+import { HogFlowActionSchema } from './types'
+
+describe('HogFlowActionSchema', () => {
+    it.each([
+        [
+            'trigger',
+            {
+                id: 'trigger_node',
+                name: 'Trigger',
+                type: 'trigger',
+                description: '',
+                config: {
+                    type: 'event',
+                    filters: {
+                        events: [{ id: '$pageview', name: '$pageview', type: 'events' }],
+                    },
+                },
+            },
+        ],
+        [
+            'exit',
+            {
+                id: 'exit_node',
+                name: 'Exit',
+                type: 'exit',
+                description: '',
+                config: { reason: 'Default exit' },
+            },
+        ],
+        [
+            'function',
+            {
+                id: 'action_function_abc123',
+                name: 'Send webhook',
+                type: 'function',
+                description: '',
+                config: { template_id: 'template-webhook', inputs: {} },
+            },
+        ],
+    ])('validates %s action without created_at/updated_at', (_label, action) => {
+        const result = HogFlowActionSchema.safeParse(action)
+        expect(result.success).toBe(true)
+    })
+})

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -24,8 +24,8 @@ const _commonActionFields = {
     name: z.string(),
     description: z.string(),
     on_error: z.enum(['continue', 'abort']).optional().nullable(),
-    created_at: z.number(),
-    updated_at: z.number(),
+    created_at: z.number().optional(),
+    updated_at: z.number().optional(),
     filters: ActionFiltersSchema.optional().nullable(),
     output_variable: z // The Hogflow-level variable to store the output of this action into
         .union([


### PR DESCRIPTION
## Problem

A [customer reported](https://posthoghelp.zendesk.com/agent/tickets/53868) that their workflow's Trigger and Exit blocks show yellow exclamation marks indicating they need further configuration, but there is no indication in the configuration panel of what's wrong. The issue affects any workflow where the trigger or exit actions were stored without `created_at`/`updated_at` fields in the actions JSON. The backend DRF serializer treats these fields as optional (`required=False`), but the frontend Zod schema required them, causing a silent validation failure with no user-facing error message.

## Changes

- Made `created_at` and `updated_at` optional in the `HogFlowActionSchema` Zod schema (`z.number().optional()`), aligning with the backend serializer's `required=False` contract
- Added regression tests that verify trigger, exit, and function actions validate successfully without these fields

### Screenshots

**Before:**

<img width="1663" height="1171" alt="Screenshot 2026-03-25 at 0 19 22" src="https://github.com/user-attachments/assets/a2e31779-a2bd-442c-876c-ed8d14c31504" />

**After:**

<img width="1676" height="1191" alt="Screenshot 2026-03-25 at 0 23 56" src="https://github.com/user-attachments/assets/d0604982-d8c5-4526-afc4-a4c9969b2007" />

## How did you test this code?

- Reproduced the issue locally by inserting a workflow with missing timestamps on trigger/exit actions directly into the DB, confirmed yellow badges appeared
- Verified the fix removes the false validation errors
- Unit tests: parameterized tests covering trigger, exit, and function actions without `created_at`/`updated_at`

## Publish to changelog?

No
