### PR TITLE
feat(clickhouse): fix TCP/HTTP incompatibilities and add shadow mode

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -1,4 +1,6 @@
 import os
+import re
+import types
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -18,6 +20,8 @@ from clickhouse_pool import ChPool
 from posthog.clickhouse.workload import Workload
 from posthog.settings import data_stores
 from posthog.utils import patchable
+
+_INSERT_RE = re.compile(r"INSERT\s+INTO\s+(\S+)\s*\(([^)]+)\)\s*VALUES", re.IGNORECASE)
 
 
 class NodeRole(StrEnum):
@@ -125,11 +129,18 @@ class ProxyClient:
         types_check=False,
         columnar=False,
     ):
+        # Avoid mutating caller's settings dict; handle None
+        settings = {**(settings or {})}
         if query_id:
             settings["query_id"] = query_id
+
+        # INSERT with row data (list/tuple/generator) needs clickhouse_connect.insert(),
+        # not query(). query() is for SELECT statements.
+        if isinstance(params, (list, tuple, types.GeneratorType)) and params:
+            return self._execute_insert(query, params, settings)
+
         result = self._client.query(query=query, parameters=params, settings=settings, column_oriented=columnar)
 
-        # we must play with result summary here
         written_rows = int(result.summary.get("written_rows", 0))
         if written_rows > 0:
             return written_rows
@@ -138,7 +149,28 @@ class ProxyClient:
             return result.result_set, column_types_driver_format
         return result.result_set
 
-    # Implement methods for session managment: https://peps.python.org/pep-0343/ so ProxyClient can be used in all places a clickhouse_driver.Client is.
+    def _execute_insert(self, query: str, params, settings: dict):
+        """Route INSERT with row data through clickhouse_connect.insert()."""
+        match = _INSERT_RE.search(query)
+        if not match:
+            result = self._client.command(query, settings=settings)
+            return result if isinstance(result, int) else 0
+
+        table_name = match.group(1)
+        column_names = [c.strip() for c in match.group(2).split(",")]
+
+        if isinstance(params, types.GeneratorType):
+            params = list(params)
+        if params and isinstance(params[0], dict):
+            data = [[row.get(col) for col in column_names] for row in params]
+        else:
+            data = [list(row) if not isinstance(row, (list, tuple)) else row for row in params]
+
+        summary = self._client.insert(
+            table=table_name, data=data, column_names=column_names, settings=settings
+        )
+        return summary.written_rows
+
     def __enter__(self):
         return self
 

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -16,7 +16,7 @@ import sqlparse
 import structlog
 from clickhouse_driver import Client as SyncClient
 from opentelemetry import trace
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram
 
 from posthog.clickhouse.client.connection import (
     ClickHouseUser,
@@ -57,6 +57,19 @@ QUERY_ERROR_COUNTER = Counter(
     "clickhouse_query_failure",
     "Query execution failure signal is dispatched when a query fails.",
     labelnames=["exception_type", "query_type", "workload", "chargeable"],
+)
+
+SHADOW_MODE_COUNTER = Counter(
+    "posthog_clickhouse_shadow_mode_queries_total",
+    "Shadow mode query comparison results.",
+    labelnames=["result"],
+)
+
+SHADOW_MODE_LATENCY = Histogram(
+    "posthog_clickhouse_shadow_mode_latency_seconds",
+    "Query latency by protocol during shadow mode.",
+    labelnames=["protocol"],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
 )
 
 InsertParams = Union[list, tuple, types.GeneratorType]
@@ -391,7 +404,108 @@ def sync_execute(
         if app_settings.SHELL_PLUS_PRINT_SQL:
             print("Execution time: %.6fs" % (execution_time,))  # noqa T201
 
+    # Shadow mode: re-execute SELECT queries on HTTP and compare results.
+    # Only runs when TCP is the primary path and shadow mode is enabled.
+    if (
+        app_settings.CLICKHOUSE_HTTP_SHADOW_MODE
+        and not app_settings.CLICKHOUSE_USE_HTTP
+        and not isinstance(prepared_args, (list, tuple, types.GeneratorType))
+        and "INSERT INTO" not in prepared_sql.upper()
+        and sync_client is None
+    ):
+        SHADOW_MODE_LATENCY.labels(protocol="tcp").observe(execution_time)
+        _run_shadow_http_query(
+            prepared_sql=prepared_sql,
+            prepared_args=prepared_args,
+            settings=settings,
+            with_column_types=with_column_types,
+            query_id=query_id,
+            tcp_result=result,
+            workload=workload,
+            team_id=team_id,
+            readonly=readonly,
+            ch_user=ch_user,
+        )
+
     return result
+
+
+def _run_shadow_http_query(
+    *,
+    prepared_sql,
+    prepared_args,
+    settings,
+    with_column_types,
+    query_id,
+    tcp_result,
+    workload,
+    team_id,
+    readonly,
+    ch_user,
+):
+    """Execute the same query on HTTP and compare with the TCP result.
+
+    Never raises — all errors are caught and logged. The TCP result is always
+    the one returned to the caller.
+    """
+    from posthog.clickhouse.client.connection import get_http_client, get_kwargs_for_client
+
+    shadow_logger = structlog.get_logger("clickhouse.shadow_mode")
+    try:
+        kwargs = get_kwargs_for_client(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user)
+        shadow_start = perf_counter()
+        with get_http_client(**kwargs) as http_client:
+            http_result = http_client.execute(
+                prepared_sql,
+                params=prepared_args,
+                settings=settings,
+                with_column_types=with_column_types,
+                query_id=f"shadow_{query_id}" if query_id else None,
+            )
+        shadow_duration = perf_counter() - shadow_start
+        SHADOW_MODE_LATENCY.labels(protocol="http").observe(shadow_duration)
+
+        # Compare results
+        tcp_rows = tcp_result
+        http_rows = http_result
+        tcp_col_types = None
+        http_col_types = None
+
+        if with_column_types and isinstance(tcp_result, tuple):
+            tcp_rows, tcp_col_types = tcp_result
+            if isinstance(http_result, tuple):
+                http_rows, http_col_types = http_result
+
+        tcp_row_count = len(tcp_rows) if isinstance(tcp_rows, list) else 0
+        http_row_count = len(http_rows) if isinstance(http_rows, list) else 0
+
+        if tcp_row_count != http_row_count:
+            SHADOW_MODE_COUNTER.labels(result="mismatch").inc()
+            shadow_logger.warning(
+                "shadow_mode_row_count_mismatch",
+                tcp_rows=tcp_row_count,
+                http_rows=http_row_count,
+                query=prepared_sql[:200],
+            )
+        elif tcp_col_types and http_col_types and tcp_col_types != http_col_types:
+            SHADOW_MODE_COUNTER.labels(result="mismatch").inc()
+            shadow_logger.warning(
+                "shadow_mode_column_type_mismatch",
+                tcp_types=str(tcp_col_types[:5]),
+                http_types=str(http_col_types[:5]),
+                query=prepared_sql[:200],
+            )
+        else:
+            SHADOW_MODE_COUNTER.labels(result="match").inc()
+
+    except Exception as e:
+        SHADOW_MODE_COUNTER.labels(result="error").inc()
+        shadow_logger.warning(
+            "shadow_mode_http_error",
+            error=str(e),
+            error_type=type(e).__name__,
+            query=prepared_sql[:200],
+        )
 
 
 def query_with_columns(

--- a/posthog/clickhouse/client/test/test_http_migration.py
+++ b/posthog/clickhouse/client/test/test_http_migration.py
@@ -5,14 +5,12 @@ to the TCP client (clickhouse-driver) for all query patterns used in PostHog.
 """
 
 import uuid
-from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
 
 import pytest
+from unittest.mock import MagicMock, patch
 
 from posthog.clickhouse.client.connection import ProxyClient, get_http_client
 from posthog.clickhouse.client.execute import sync_execute
-
 
 # ── ProxyClient unit tests ──────────────────────────────────────────────────
 
@@ -162,7 +160,7 @@ class TestProxyClientInsert:
         mock_client.command.return_value = 3
 
         proxy = ProxyClient(mock_client)
-        result = proxy.execute(
+        proxy.execute(
             "INSERT INTO t SELECT number FROM numbers(3)",
             params=[],
             settings={},

--- a/posthog/clickhouse/client/test/test_http_migration.py
+++ b/posthog/clickhouse/client/test/test_http_migration.py
@@ -1,0 +1,312 @@
+"""Tests for HTTP protocol migration compatibility.
+
+Validates that ProxyClient (HTTP via clickhouse-connect) behaves identically
+to the TCP client (clickhouse-driver) for all query patterns used in PostHog.
+"""
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from posthog.clickhouse.client.connection import ProxyClient, get_http_client
+from posthog.clickhouse.client.execute import sync_execute
+
+
+# ── ProxyClient unit tests ──────────────────────────────────────────────────
+
+
+class TestProxyClientSelectQueries:
+    def test_execute_select_returns_result_set(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = [(1,), (2,), (3,)]
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("SELECT number FROM numbers(3)", settings={})
+
+        assert result == [(1,), (2,), (3,)]
+
+    def test_execute_with_column_types(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = [("Alice", 30), ("Bob", 25)]
+
+        mock_name_type = MagicMock()
+        mock_name_type.name = "String"
+        mock_age_type = MagicMock()
+        mock_age_type.name = "UInt32"
+
+        mock_result.column_names = ["name", "age"]
+        mock_result.column_types = [mock_name_type, mock_age_type]
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result_set, column_types = proxy.execute(
+            "SELECT name, age FROM t", with_column_types=True, settings={}
+        )
+
+        assert result_set == [("Alice", 30), ("Bob", 25)]
+        assert column_types == [("name", "String"), ("age", "UInt32")]
+
+    def test_execute_empty_result(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = []
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("SELECT 1 WHERE 0", settings={})
+
+        assert result == []
+
+
+class TestProxyClientQueryId:
+    def test_query_id_creates_new_settings_dict(self):
+        """query_id should not mutate the caller's settings dict."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = []
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        original_settings = {"max_threads": 4}
+        proxy.execute("SELECT 1", query_id="test-123", settings=original_settings)
+
+        # Original dict must NOT be mutated
+        assert "query_id" not in original_settings
+        # But the query should have received the query_id
+        call_settings = mock_client.query.call_args.kwargs["settings"]
+        assert call_settings["query_id"] == "test-123"
+
+    def test_query_id_with_none_settings(self):
+        """query_id with settings=None should not crash."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = []
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        proxy.execute("SELECT 1", query_id="test-456", settings=None)
+
+        call_settings = mock_client.query.call_args.kwargs["settings"]
+        assert call_settings["query_id"] == "test-456"
+
+
+class TestProxyClientInsert:
+    def test_insert_command_returns_written_rows_from_summary(self):
+        """INSERT ... SELECT returns written_rows from response summary."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "5"}
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("INSERT INTO t SELECT number FROM numbers(5)", settings={})
+
+        assert result == 5
+
+    def test_insert_with_dict_rows(self):
+        """Batch INSERT with list of dicts should use client.insert()."""
+        mock_client = MagicMock()
+        mock_summary = MagicMock()
+        mock_summary.written_rows = 2
+        mock_client.insert.return_value = mock_summary
+
+        proxy = ProxyClient(mock_client)
+        data = [
+            {"id": "abc", "name": "Alice", "age": 30},
+            {"id": "def", "name": "Bob", "age": 25},
+        ]
+        result = proxy.execute(
+            "INSERT INTO users (id, name, age) VALUES",
+            params=data,
+            settings={},
+        )
+
+        assert result == 2
+        mock_client.insert.assert_called_once()
+        call_kwargs = mock_client.insert.call_args.kwargs
+        assert call_kwargs["table"] == "users"
+        assert call_kwargs["column_names"] == ["id", "name", "age"]
+        assert call_kwargs["data"] == [["abc", "Alice", 30], ["def", "Bob", 25]]
+
+    def test_insert_with_tuple_rows(self):
+        """Batch INSERT with list of tuples should use client.insert()."""
+        mock_client = MagicMock()
+        mock_summary = MagicMock()
+        mock_summary.written_rows = 2
+        mock_client.insert.return_value = mock_summary
+
+        proxy = ProxyClient(mock_client)
+        data = [(1, "Alice"), (2, "Bob")]
+        result = proxy.execute(
+            "INSERT INTO users (id, name) VALUES",
+            params=data,
+            settings={},
+        )
+
+        assert result == 2
+        mock_client.insert.assert_called_once()
+
+    def test_insert_without_column_spec_falls_back_to_command(self):
+        """INSERT without explicit columns falls back to command()."""
+        mock_client = MagicMock()
+        mock_client.command.return_value = 3
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute(
+            "INSERT INTO t SELECT number FROM numbers(3)",
+            params=[],
+            settings={},
+        )
+
+        # Empty list should not trigger batch insert path
+        # (empty list is falsy in Python)
+        mock_client.query.assert_called_once()
+
+
+class TestProxyClientContextManager:
+    def test_context_manager_protocol(self):
+        mock_client = MagicMock()
+        proxy = ProxyClient(mock_client)
+
+        with proxy as p:
+            assert p is proxy
+
+
+# ── Integration tests (require ClickHouse) ──────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestHttpClientIntegration:
+    def test_select_via_http(self):
+        """Basic SELECT works through HTTP ProxyClient."""
+        with get_http_client() as client:
+            result = client.execute("SELECT 1 AS n, 'hello' AS s", settings={})
+        assert result == [(1, "hello")]
+
+    def test_select_with_column_types_via_http(self):
+        """Column type metadata matches between TCP and HTTP."""
+        query = "SELECT toUInt64(1) AS n, 'hello' AS s"
+
+        tcp_result = sync_execute(query, with_column_types=True)
+        with get_http_client() as client:
+            http_result = client.execute(query, with_column_types=True, settings={})
+
+        tcp_rows, tcp_types = tcp_result
+        http_rows, http_types = http_result
+
+        assert tcp_rows == http_rows
+        # Column names should match
+        assert [name for name, _ in tcp_types] == [name for name, _ in http_types]
+
+    def test_insert_via_http_command(self):
+        """INSERT ... SELECT works through HTTP."""
+        table = f"_test_http_insert_{uuid.uuid4().hex[:8]}"
+        sync_execute(f"CREATE TABLE {table} (n UInt64) ENGINE = Memory")
+        try:
+            with get_http_client() as client:
+                result = client.execute(
+                    f"INSERT INTO {table} SELECT number FROM numbers(5)", settings={}
+                )
+            assert result == 5
+
+            rows = sync_execute(f"SELECT count() FROM {table}")
+            assert rows[0][0] == 5
+        finally:
+            sync_execute(f"DROP TABLE IF EXISTS {table}")
+
+    def test_batch_insert_with_dicts_via_http(self):
+        """Batch INSERT with dict rows works through HTTP ProxyClient."""
+        table = f"_test_http_batch_{uuid.uuid4().hex[:8]}"
+        sync_execute(f"CREATE TABLE {table} (id String, value UInt64) ENGINE = Memory")
+        try:
+            with get_http_client() as client:
+                data = [
+                    {"id": "a", "value": 1},
+                    {"id": "b", "value": 2},
+                    {"id": "c", "value": 3},
+                ]
+                result = client.execute(
+                    f"INSERT INTO {table} (id, value) VALUES",
+                    params=data,
+                    settings={},
+                )
+            assert result == 3
+
+            rows = sync_execute(f"SELECT id, value FROM {table} ORDER BY value")
+            assert rows == [("a", 1), ("b", 2), ("c", 3)]
+        finally:
+            sync_execute(f"DROP TABLE IF EXISTS {table}")
+
+
+# ── Shadow mode tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestShadowMode:
+    def test_shadow_mode_runs_http_query(self, settings):
+        """When shadow mode is on, HTTP query runs alongside TCP."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = False
+
+        result = sync_execute("SELECT 1 AS n")
+        # Primary (TCP) result is returned correctly
+        assert result == [(1,)]
+
+    def test_shadow_mode_does_not_affect_tcp_result_on_http_error(self, settings):
+        """HTTP errors in shadow mode don't affect the TCP result."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = False
+
+        with patch(
+            "posthog.clickhouse.client.execute.get_http_client",
+            side_effect=Exception("HTTP connection failed"),
+        ):
+            result = sync_execute("SELECT 42 AS n")
+            assert result == [(42,)]
+
+    def test_shadow_mode_skips_insert_queries(self, settings):
+        """INSERT queries are never shadowed."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = False
+
+        table = f"_test_shadow_insert_{uuid.uuid4().hex[:8]}"
+        sync_execute(f"CREATE TABLE {table} (n UInt64) ENGINE = Memory")
+        try:
+            with patch(
+                "posthog.clickhouse.client.execute._run_shadow_http_query"
+            ) as mock_shadow:
+                sync_execute(f"INSERT INTO {table} SELECT number FROM numbers(3)")
+                mock_shadow.assert_not_called()
+        finally:
+            sync_execute(f"DROP TABLE IF EXISTS {table}")
+
+    def test_shadow_mode_off_by_default(self, settings):
+        """Shadow mode doesn't run when CLICKHOUSE_HTTP_SHADOW_MODE is False."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = False
+
+        with patch(
+            "posthog.clickhouse.client.execute._run_shadow_http_query"
+        ) as mock_shadow:
+            sync_execute("SELECT 1")
+            mock_shadow.assert_not_called()
+
+    def test_shadow_mode_skipped_when_http_is_primary(self, settings):
+        """Shadow mode doesn't run when HTTP is already the primary path."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = True
+
+        with patch(
+            "posthog.clickhouse.client.execute._run_shadow_http_query"
+        ) as mock_shadow:
+            sync_execute("SELECT 1")
+            mock_shadow.assert_not_called()

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -295,6 +295,10 @@ with suppress(Exception):
     as_json = json.loads(os.getenv("CLICKHOUSE_USE_HTTP_PER_TEAM", "[]"))
     CLICKHOUSE_USE_HTTP_PER_TEAM = {int(v) for v in as_json}
 
+# Shadow mode: execute every SELECT query on both TCP and HTTP, compare results,
+# log discrepancies. TCP result is always returned. Enable in dev/staging first.
+CLICKHOUSE_HTTP_SHADOW_MODE: bool = get_from_env("CLICKHOUSE_HTTP_SHADOW_MODE", False, type_cast=str_to_bool)
+
 QUERYSERVICE_HOST: str = get_from_env("QUERYSERVICE_HOST", CLICKHOUSE_HOST)
 QUERYSERVICE_SECURE: bool = get_from_env("QUERYSERVICE_SECURE", CLICKHOUSE_SECURE, type_cast=str_to_bool)
 QUERYSERVICE_VERIFY: bool = get_from_env("QUERYSERVICE_VERIFY", CLICKHOUSE_VERIFY, type_cast=str_to_bool)


### PR DESCRIPTION
## Summary

Fixes three incompatibilities in `ProxyClient` (HTTP via `clickhouse-connect`) that would break queries when `CLICKHOUSE_USE_HTTP=true`, and adds a shadow mode for safe validation before flipping the default.

**Prerequisite for**: ClickHouse Query Gateway (#51799)
**Related**: PR #51718 (closed, folded into gateway PR), [RFC #1043](https://github.com/PostHog/requests-for-comments-internal/pull/1043)

### Incompatibilities fixed

1. **Batch INSERT with row data** (Critical) — `ProxyClient.execute()` now detects INSERT queries with list/tuple/generator args and routes through `client.insert()` instead of `client.query()`, which can't handle row data. Affects `cohort/util.py:insert_static_cohort` and any caller passing list args to `sync_execute`.

2. **Settings dict mutation** (Medium) — `ProxyClient.execute()` no longer mutates the caller's settings dict when adding `query_id`. Also handles `settings=None` without crashing.

3. **Shadow mode** (`CLICKHOUSE_HTTP_SHADOW_MODE`) — when enabled, every SELECT query runs on both TCP and HTTP. Results are compared (row count, column types), discrepancies logged via structlog, and Prometheus metrics emitted. TCP result is always returned. Shadow errors never affect the primary path.

### New Prometheus metrics

- `posthog_clickhouse_shadow_mode_queries_total{result=match|mismatch|error}`
- `posthog_clickhouse_shadow_mode_latency_seconds{protocol=tcp|http}`

### Monitoring

ClickHouse system.query_log:
```sql
SELECT query_id, type, query_duration_ms, read_rows, result_rows
FROM system.query_log
WHERE query_id LIKE 'shadow_%'
ORDER BY event_time DESC LIMIT 100
```

Grafana PromQL:
```promql
# Shadow mode discrepancy rate
rate(posthog_clickhouse_shadow_mode_queries_total{result="mismatch"}[5m])
/ rate(posthog_clickhouse_shadow_mode_queries_total[5m])

# HTTP vs TCP latency comparison
histogram_quantile(0.99, rate(posthog_clickhouse_shadow_mode_latency_seconds_bucket{protocol="http"}[5m]))
```

### Rollout plan

1. Dev/staging: Set `CLICKHOUSE_HTTP_SHADOW_MODE=true`
2. Monitor shadow mode metrics for mismatches and errors
3. Fix any discrepancies found
4. Flip `CLICKHOUSE_USE_HTTP=true` once shadow mode shows zero mismatches for 7+ days
5. Remove shadow mode, proceed to gateway rollout

## Test plan

- [x] 10 unit tests for ProxyClient fixes (SELECT, INSERT with dicts/tuples, query_id, context manager)
- [x] 4 integration tests (require ClickHouse: SELECT, column types, INSERT command, batch INSERT)
- [x] 5 shadow mode tests (runs HTTP alongside TCP, error isolation, INSERT skip, off-by-default)
- [x] Existing test_connection.py and test_tracing.py still pass (23/23)