### PR TITLE
fix(web-analytics): Decrease live Web Analytics refresh

### DIFF
--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
@@ -188,6 +188,8 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map([
                     ['Mobile', new Set(['device-1', 'device-2', 'device-3'])],
                     ['Desktop', new Set(['device-4', 'device-5'])],
@@ -200,6 +202,8 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map([
                     ['Mobile', new Set(['device-6', 'device-7', 'device-8'])],
                     ['Desktop', new Set(['device-9', 'device-10', 'device-11'])],
@@ -222,6 +226,8 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map([['Mobile', new Set(['device-1', 'device-2'])]]),
                 paths: new Map(),
                 browsers: new Map(),
@@ -230,6 +236,8 @@ describe('LiveMetricsSlidingWindow', () => {
             })
             window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map([['Mobile', new Set(['device-1', 'device-3'])]]),
                 paths: new Map(),
                 browsers: new Map(),
@@ -251,6 +259,8 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map([
                     ['Mobile', new Set(['device-1', 'device-2', 'device-3'])],
                     ['Desktop', new Set(['device-4', 'device-5', 'device-6', 'device-7'])],
@@ -276,6 +286,8 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map(),
                 paths: new Map([
                     ['/home', 10],
@@ -288,6 +300,8 @@ describe('LiveMetricsSlidingWindow', () => {
             })
             window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map(),
                 paths: new Map([
                     ['/home', 5],
@@ -317,6 +331,8 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map(),
                 paths: new Map([
                     ['/pricing', 20],
@@ -373,6 +389,8 @@ describe('LiveMetricsSlidingWindow', () => {
 
             window.extendBucketData(minuteStart, {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map(),
                 paths: new Map(),
                 browsers: new Map(),
@@ -381,6 +399,8 @@ describe('LiveMetricsSlidingWindow', () => {
             })
             window.extendBucketData(minuteStart, {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map(),
                 paths: new Map(),
                 browsers: new Map(),
@@ -673,6 +693,191 @@ describe('LiveMetricsSlidingWindow', () => {
             expect(breakdown[0]).toEqual({ country: 'US', count: 3, percentage: 50 })
             expect(breakdown[1]).toEqual({ country: 'GB', count: 2, percentage: expect.closeTo(33.33, 1) })
             expect(breakdown[2]).toEqual({ country: 'DE', count: 1, percentage: expect.closeTo(16.67, 1) })
+        })
+    })
+
+    describe('incremental totalPageviews', () => {
+        it('tracks pageviews incrementally via addDataPoint', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-1', { pageviews: 3 })
+            expect(window.getTotalPageviews()).toBe(3)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-4 * MINUTE)), 'user-2', { pageviews: 7 })
+            expect(window.getTotalPageviews()).toBe(10)
+        })
+
+        it('tracks pageviews incrementally via extendBucketData', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
+                pageviews: 10,
+                newUserCount: 0,
+                returningUserCount: 0,
+                devices: new Map(),
+                browsers: new Map(),
+                paths: new Map(),
+                uniqueUsers: new Set(),
+                countries: new Map<string, Set<string>>(),
+            })
+
+            expect(window.getTotalPageviews()).toBe(10)
+        })
+
+        it('decrements totalPageviews when buckets are pruned', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-30 * MINUTE)), 'user-1', { pageviews: 5 })
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-2', { pageviews: 10 })
+
+            expect(window.getTotalPageviews()).toBe(15)
+
+            tickMinute()
+            window.prune()
+
+            expect(window.getTotalPageviews()).toBe(10)
+        })
+    })
+
+    describe('incremental globalPathCounts', () => {
+        it('tracks paths incrementally via addDataPoint', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-1', { pageviews: 1, pathname: '/home' })
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-2', { pageviews: 1, pathname: '/home' })
+            window.addDataPoint(toUnixSeconds(relativeTime(-4 * MINUTE)), 'user-3', {
+                pageviews: 1,
+                pathname: '/about',
+            })
+
+            const topPaths = window.getTopPaths(10)
+            expect(topPaths).toEqual([
+                { path: '/home', views: 2 },
+                { path: '/about', views: 1 },
+            ])
+        })
+
+        it('decrements path counts when buckets are pruned', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-30 * MINUTE)), 'user-1', {
+                pageviews: 1,
+                pathname: '/old-page',
+            })
+            window.addDataPoint(toUnixSeconds(relativeTime(-30 * MINUTE)), 'user-2', {
+                pageviews: 1,
+                pathname: '/home',
+            })
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-3', {
+                pageviews: 1,
+                pathname: '/home',
+            })
+
+            expect(window.getTopPaths(10)).toEqual([
+                { path: '/home', views: 2 },
+                { path: '/old-page', views: 1 },
+            ])
+
+            tickMinute()
+            window.prune()
+
+            expect(window.getTopPaths(10)).toEqual([{ path: '/home', views: 1 }])
+        })
+
+        it('tracks paths incrementally via extendBucketData', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
+                pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
+                devices: new Map(),
+                browsers: new Map(),
+                paths: new Map([
+                    ['/home', 10],
+                    ['/about', 5],
+                ]),
+                uniqueUsers: new Set(),
+                countries: new Map<string, Set<string>>(),
+            })
+
+            expect(window.getTopPaths(10)).toEqual([
+                { path: '/home', views: 10 },
+                { path: '/about', views: 5 },
+            ])
+        })
+    })
+
+    describe('incremental new/returning user counts', () => {
+        it('classifies first-time users as new', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-1', { pageviews: 1 })
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-2', { pageviews: 1 })
+
+            const buckets = window.getSortedBuckets()
+            expect(buckets[0][1].newUserCount).toBe(2)
+            expect(buckets[0][1].returningUserCount).toBe(0)
+        })
+
+        it('classifies users seen in earlier buckets as returning', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-1', { pageviews: 1 })
+            window.addDataPoint(toUnixSeconds(relativeTime(-4 * MINUTE)), 'user-1', { pageviews: 1 })
+            window.addDataPoint(toUnixSeconds(relativeTime(-4 * MINUTE)), 'user-2', { pageviews: 1 })
+
+            const buckets = window.getSortedBuckets()
+            expect(buckets[0][1].newUserCount).toBe(1)
+            expect(buckets[0][1].returningUserCount).toBe(0)
+            expect(buckets[1][1].newUserCount).toBe(1)
+            expect(buckets[1][1].returningUserCount).toBe(1)
+        })
+
+        it('does not double-count duplicate users in same bucket', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-1', { pageviews: 1 })
+            window.addDataPoint(toUnixSeconds(relativeTime(-5 * MINUTE)), 'user-1', { pageviews: 1 })
+
+            const buckets = window.getSortedBuckets()
+            expect(buckets[0][1].newUserCount).toBe(1)
+            expect(buckets[0][1].returningUserCount).toBe(0)
+            expect(buckets[0][1].uniqueUsers.size).toBe(1)
+        })
+
+        it('classifies users from extendBucketData correctly', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+
+            window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
+                pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
+                devices: new Map(),
+                browsers: new Map(),
+                paths: new Map(),
+                uniqueUsers: new Set(['user-1', 'user-2']),
+                countries: new Map<string, Set<string>>(),
+            })
+
+            window.extendBucketData(toUnixSeconds(relativeTime(-4 * MINUTE)), {
+                pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
+                devices: new Map(),
+                browsers: new Map(),
+                paths: new Map(),
+                uniqueUsers: new Set(['user-1', 'user-3']),
+                countries: new Map<string, Set<string>>(),
+            })
+
+            const buckets = window.getSortedBuckets()
+            // user-1 and user-2 are new in the first bucket
+            expect(buckets[0][1].newUserCount).toBe(2)
+            expect(buckets[0][1].returningUserCount).toBe(0)
+            // user-1 is returning, user-3 is new in the second bucket
+            expect(buckets[1][1].newUserCount).toBe(1)
+            expect(buckets[1][1].returningUserCount).toBe(1)
         })
     })
 })

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
@@ -10,6 +10,10 @@ export class LiveMetricsSlidingWindow {
     private browserBucketCounts = new Map<string, Map<string, number>>()
     private countryBucketCounts = new Map<string, Map<string, number>>()
 
+    // Incrementally-maintained aggregates
+    private _totalPageviews = 0
+    private _globalPathCounts = new Map<string, number>()
+
     constructor(windowSizeMinutes: number) {
         this.windowSizeSeconds = windowSizeMinutes * 60
     }
@@ -30,10 +34,12 @@ export class LiveMetricsSlidingWindow {
 
         if (data.pageviews) {
             bucket.pageviews += data.pageviews
+            this._totalPageviews += data.pageviews
         }
 
         if (data.pathname) {
             bucket.paths.set(data.pathname, (bucket.paths.get(data.pathname) || 0) + 1)
+            this._globalPathCounts.set(data.pathname, (this._globalPathCounts.get(data.pathname) || 0) + 1)
         }
 
         if (data.device) {
@@ -64,6 +70,7 @@ export class LiveMetricsSlidingWindow {
 
         if (data.pageviews) {
             bucket.pageviews += data.pageviews
+            this._totalPageviews += data.pageviews
         }
 
         if (data.devices) {
@@ -85,6 +92,7 @@ export class LiveMetricsSlidingWindow {
         if (data.paths) {
             for (const [path, count] of data.paths) {
                 bucket.paths.set(path, (bucket.paths.get(path) || 0) + count)
+                this._globalPathCounts.set(path, (this._globalPathCounts.get(path) || 0) + count)
             }
         }
 
@@ -100,7 +108,16 @@ export class LiveMetricsSlidingWindow {
     private addUserToBucket(bucket: SlidingWindowBucket, userId: string): void {
         if (!bucket.uniqueUsers.has(userId)) {
             bucket.uniqueUsers.add(userId)
-            this.userBucketCounts.set(userId, (this.userBucketCounts.get(userId) || 0) + 1)
+
+            const prevCount = this.userBucketCounts.get(userId) || 0
+            this.userBucketCounts.set(userId, prevCount + 1)
+
+            // Classify as new or returning based on whether we've seen this user globally
+            if (prevCount > 0) {
+                bucket.returningUserCount++
+            } else {
+                bucket.newUserCount++
+            }
         }
     }
 
@@ -203,6 +220,17 @@ export class LiveMetricsSlidingWindow {
         }
     }
 
+    private removePathsFromTracking(bucket: SlidingWindowBucket): void {
+        for (const [path, count] of bucket.paths) {
+            const globalCount = this._globalPathCounts.get(path) || 0
+            if (globalCount <= count) {
+                this._globalPathCounts.delete(path)
+            } else {
+                this._globalPathCounts.set(path, globalCount - count)
+            }
+        }
+    }
+
     prune(): void {
         const nowTs = Date.now() / 1000
         const threshold = nowTs - this.windowSizeSeconds
@@ -212,6 +240,8 @@ export class LiveMetricsSlidingWindow {
                 this.removeItemsFromTracking(bucket.devices, this.deviceBucketCounts)
                 this.removeItemsFromTracking(bucket.browsers, this.browserBucketCounts)
                 this.removeCountriesFromTracking(bucket)
+                this.removePathsFromTracking(bucket)
+                this._totalPageviews -= bucket.pageviews
                 this.buckets.delete(ts)
             }
         }
@@ -222,11 +252,7 @@ export class LiveMetricsSlidingWindow {
     }
 
     getTotalPageviews(): number {
-        let total = 0
-        for (const bucket of this.buckets.values()) {
-            total += bucket.pageviews
-        }
-        return total
+        return this._totalPageviews
     }
 
     getDeviceBreakdown(): { device: string; count: number; percentage: number }[] {
@@ -301,13 +327,7 @@ export class LiveMetricsSlidingWindow {
     }
 
     getTopPaths(limit: number): { path: string; views: number }[] {
-        const aggregates = new Map<string, number>()
-        for (const bucket of this.buckets.values()) {
-            for (const [path, count] of bucket.paths) {
-                aggregates.set(path, (aggregates.get(path) || 0) + count)
-            }
-        }
-        return [...aggregates.entries()]
+        return [...this._globalPathCounts.entries()]
             .map(([path, views]) => ({ path, views }))
             .sort((a, b) => b.views - a.views)
             .slice(0, limit)
@@ -348,6 +368,8 @@ export class LiveMetricsSlidingWindow {
         if (!bucket) {
             bucket = {
                 pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
                 devices: new Map<string, Set<string>>(),
                 browsers: new Map<string, Set<string>>(),
                 paths: new Map<string, number>(),

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
@@ -26,6 +26,8 @@ export interface PathItem {
 
 export interface SlidingWindowBucket {
     pageviews: number
+    newUserCount: number
+    returningUserCount: number
     devices: Map<string, Set<string>>
     browsers: Map<string, Set<string>>
     paths: Map<string, number>

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWorldMap.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWorldMap.tsx
@@ -1,7 +1,7 @@
 import '~/scenes/insights/views/WorldMap/WorldMap.scss'
 
 import { useActions, useValues } from 'kea'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import { gradateColor } from 'lib/utils'
 import { countryVectors } from 'scenes/insights/views/WorldMap/countryVectors'
@@ -13,6 +13,48 @@ const SATURATION_FLOOR = 0.3
 const HEAT_BRIGHTNESS_FACTOR = 0.8
 const HEAT_HUE_ROTATION_DEG = 180
 const HEAT_TRANSITION_DURATION = '0.15s'
+
+interface CountryPathProps {
+    countryCode: string
+    countryElement: JSX.Element
+    fill: string | undefined
+    heat: number
+    mapColor: string
+    onMouseEnter: (countryCode: string, e: React.MouseEvent) => void
+    onMouseMove: (e: React.MouseEvent) => void
+    onMouseLeave: () => void
+}
+
+const CountryPath = React.memo(
+    ({
+        countryCode,
+        countryElement,
+        fill,
+        heat,
+        mapColor,
+        onMouseEnter,
+        onMouseMove,
+        onMouseLeave,
+    }: CountryPathProps): JSX.Element => {
+        return React.cloneElement(countryElement, {
+            key: countryCode,
+            style: {
+                color: fill,
+                '--world-map-hover': mapColor,
+                cursor: fill ? 'pointer' : undefined,
+                filter:
+                    heat > 0
+                        ? `brightness(${1 + heat * HEAT_BRIGHTNESS_FACTOR}) saturate(${1 + heat}) hue-rotate(${heat * HEAT_HUE_ROTATION_DEG}deg)`
+                        : undefined,
+                transition: `filter ${HEAT_TRANSITION_DURATION} ease-out`,
+            },
+            onMouseEnter: (e: React.MouseEvent) => onMouseEnter(countryCode, e),
+            onMouseMove,
+            onMouseLeave,
+        })
+    }
+)
+CountryPath.displayName = 'CountryPath'
 
 interface LiveWorldMapProps {
     data: CountryBreakdownItem[]
@@ -28,18 +70,20 @@ export const LiveWorldMap = ({ data, totalEvents }: LiveWorldMapProps): JSX.Elem
         updateCountryData(data, totalEvents)
     }, [data, totalEvents, updateCountryData])
 
-    const handleMouseEnter = (countryCode: string, e: React.MouseEvent): void => {
-        showTooltip(countryCode)
-        updateTooltipCoordinates(e.clientX, e.clientY)
-    }
+    const handleMouseEnter = useCallback(
+        (countryCode: string, e: React.MouseEvent): void => {
+            showTooltip(countryCode)
+            updateTooltipCoordinates(e.clientX, e.clientY)
+        },
+        [showTooltip, updateTooltipCoordinates]
+    )
 
-    const handleMouseMove = (e: React.MouseEvent): void => {
-        updateTooltipCoordinates(e.clientX, e.clientY)
-    }
-
-    const handleMouseLeave = (): void => {
-        hideTooltip()
-    }
+    const handleMouseMove = useCallback(
+        (e: React.MouseEvent): void => {
+            updateTooltipCoordinates(e.clientX, e.clientY)
+        },
+        [updateTooltipCoordinates]
+    )
 
     return (
         <div className="relative">
@@ -56,24 +100,20 @@ export const LiveWorldMap = ({ data, totalEvents }: LiveWorldMapProps): JSX.Elem
                     }
                     const count = countryCodeToCount[countryCode] || 0
                     const fill = count > 0 ? gradateColor(mapColor, count / maxCount, SATURATION_FLOOR) : undefined
-                    const heat = countryHeat[countryCode] || 0
 
-                    return React.cloneElement(countryElement, {
-                        key: countryCode,
-                        style: {
-                            color: fill,
-                            '--world-map-hover': mapColor,
-                            cursor: count > 0 ? 'pointer' : undefined,
-                            filter:
-                                heat > 0
-                                    ? `brightness(${1 + heat * HEAT_BRIGHTNESS_FACTOR}) saturate(${1 + heat}) hue-rotate(${heat * HEAT_HUE_ROTATION_DEG}deg)`
-                                    : undefined,
-                            transition: `filter ${HEAT_TRANSITION_DURATION} ease-out`,
-                        },
-                        onMouseEnter: (e: React.MouseEvent) => handleMouseEnter(countryCode, e),
-                        onMouseMove: handleMouseMove,
-                        onMouseLeave: handleMouseLeave,
-                    })
+                    return (
+                        <CountryPath
+                            key={countryCode}
+                            countryCode={countryCode}
+                            countryElement={countryElement}
+                            fill={fill}
+                            heat={countryHeat[countryCode] || 0}
+                            mapColor={mapColor}
+                            onMouseEnter={handleMouseEnter}
+                            onMouseMove={handleMouseMove}
+                            onMouseLeave={hideTooltip}
+                        />
+                    )
                 })}
             </svg>
             {tooltipData && tooltipPosition && (

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -3,7 +3,9 @@ import { actions, connect, events, kea, listeners, path, reducers, selectors } f
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { hashCodeForString } from 'lib/utils'
 import { liveEventsHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
@@ -41,7 +43,7 @@ const COOKIELESS_TRANSFORM_SEPARATOR = '|||'
 export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType>([
     path(['scenes', 'web-analytics', 'livePageviewsLogic']),
     connect(() => ({
-        values: [teamLogic, ['currentTeam']],
+        values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']],
     })),
     actions(() => ({
         addEvents: (events: LiveEvent[], newerThan: Date) => ({ events, newerThan }),
@@ -196,6 +198,9 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
         pauseStream: () => {
             cache.eventsConnection?.abort()
             cache.geoConnection?.abort()
+            cache.batch = []
+            cache.geoBatch = []
+            stopFlushInterval(cache as FlushCache)
         },
         resumeStream: () => {
             if (cache.hasInitialized) {
@@ -204,10 +209,13 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     autoClose: 2000,
                 })
             }
+            startFlushInterval(cache as FlushCache, actions as FlushActions, values as FlushValues)
             actions.loadInitialData()
         },
         loadInitialData: async () => {
             actions.setIsLoading(true)
+
+            const geoEnabled = !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_MAP]
 
             try {
                 const now = Date.now()
@@ -219,9 +227,15 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 cache.newerThan = handoff
 
                 actions.updateConnection()
-                actions.updateGeoConnection()
+                if (geoEnabled) {
+                    actions.updateGeoConnection()
+                } else {
+                    cache.geoConnection?.abort()
+                    cache.geoConnection = null
+                    cache.geoBatch = []
+                }
                 const [usersPageviewsResponse, deviceResponse, browserResponse, pathsResponse, geoResponse] =
-                    await loadQueryData(dateFrom, handoff)
+                    await loadQueryData(dateFrom, handoff, geoEnabled)
 
                 const bucketMap = new Map<number, SlidingWindowBucket>()
 
@@ -229,7 +243,9 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 addBreakdownDataToBuckets(deviceResponse, bucketMap, (b) => b.devices)
                 addBreakdownDataToBuckets(browserResponse, bucketMap, (b) => b.browsers)
                 addPathDataToBuckets(pathsResponse, bucketMap)
-                addGeoDataToBuckets(geoResponse, bucketMap)
+                if (geoResponse) {
+                    addGeoDataToBuckets(geoResponse, bucketMap)
+                }
 
                 actions.setInitialData([...bucketMap.entries()].map(([timestamp, bucket]) => ({ timestamp, bucket })))
             } catch (error) {
@@ -321,25 +337,13 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             })
         },
     })),
-    events(({ actions, cache }) => ({
+    events(({ actions, values, cache }) => ({
         afterMount: () => {
             cache.batch = [] as LiveEvent[]
             cache.geoBatch = [] as LiveGeoEvent[]
 
             actions.loadInitialData()
-
-            // Flush both event and geo batches on a fixed interval
-            // to cap kea dispatches at a predictable rate regardless of event volume
-            cache.flushInterval = setInterval(() => {
-                if (cache.batch.length > 0) {
-                    actions.addEvents(cache.batch, cache.newerThan)
-                    cache.batch = []
-                }
-                if (cache.geoBatch.length > 0) {
-                    actions.addGeoEvents(cache.geoBatch)
-                    cache.geoBatch = []
-                }
-            }, FLUSH_INTERVAL_MS)
+            startFlushInterval(cache as FlushCache, actions as FlushActions, values as FlushValues)
 
             // Ensures that our graph continues to update and old data "falls off"
             // even if new events aren't coming in
@@ -356,9 +360,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
         beforeUnmount: () => {
             cache.eventsConnection?.abort()
             cache.geoConnection?.abort()
-            if (cache.flushInterval) {
-                clearInterval(cache.flushInterval)
-            }
+            stopFlushInterval(cache as FlushCache)
             if (cache.minuteTickTimeout) {
                 clearTimeout(cache.minuteTickTimeout)
             }
@@ -366,10 +368,54 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
     })),
 ])
 
+interface FlushCache {
+    batch: LiveEvent[]
+    geoBatch: LiveGeoEvent[]
+    newerThan: Date
+    flushInterval: ReturnType<typeof setInterval> | null
+}
+
+interface FlushActions {
+    addEvents: (events: LiveEvent[], newerThan: Date) => void
+    addGeoEvents: (events: LiveGeoEvent[]) => void
+}
+
+interface FlushValues {
+    featureFlags: Record<string, string | boolean | undefined>
+}
+
+const stopFlushInterval = (cache: FlushCache): void => {
+    if (cache.flushInterval) {
+        clearInterval(cache.flushInterval)
+        cache.flushInterval = null
+    }
+}
+
+// Flush both event and geo batches on a fixed interval
+// to cap kea dispatches at a predictable rate regardless of event volume
+const startFlushInterval = (cache: FlushCache, actions: FlushActions, values: FlushValues): void => {
+    if (cache.flushInterval) {
+        return
+    }
+    cache.flushInterval = setInterval(() => {
+        if (cache.batch.length > 0) {
+            actions.addEvents(cache.batch, cache.newerThan)
+            cache.batch = []
+        }
+        if (cache.geoBatch.length > 0 && values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_MAP]) {
+            actions.addGeoEvents(cache.geoBatch)
+            cache.geoBatch = []
+        }
+    }, FLUSH_INTERVAL_MS)
+}
+
 const loadQueryData = async (
     dateFrom: Date,
-    dateTo: Date
-): Promise<[HogQLQueryResponse, HogQLQueryResponse, HogQLQueryResponse, TrendsQueryResponse, HogQLQueryResponse]> => {
+    dateTo: Date,
+    includeGeo: boolean
+): Promise<
+    [HogQLQueryResponse, HogQLQueryResponse, HogQLQueryResponse, TrendsQueryResponse, HogQLQueryResponse | null]
+> => {
     const usersPageviewsQuery: HogQLQuery = {
         kind: NodeKind.HogQLQuery,
         query: `SELECT
@@ -489,7 +535,7 @@ const loadQueryData = async (
         performQuery(deviceQuery),
         performQuery(browserQuery),
         performQuery(pathsQuery),
-        performQuery(geoQuery),
+        includeGeo ? performQuery(geoQuery) : Promise.resolve(null),
     ])
 }
 

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -34,8 +34,7 @@ import {
 const ERROR_TOAST_ID = 'live-pageviews-error'
 const RECONNECT_TOAST_ID = 'live-pageviews-reconnect'
 const BUCKET_WINDOW_MINUTES = 30
-const BATCH_FLUSH_INTERVAL_MS = 500
-const BATCH_SIZE_THRESHOLD = 50
+const FLUSH_INTERVAL_MS = 300
 const COOKIELESS_TRANSFORM_PREFIX = 'cookieless_transform'
 const COOKIELESS_TRANSFORM_SEPARATOR = '|||'
 
@@ -112,13 +111,19 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 },
             },
         ],
-        windowVersion: [
+        eventsVersion: [
             0,
             {
                 setInitialData: (v) => v + 1,
                 addEvents: (v) => v + 1,
-                addGeoEvents: (v) => v + 1,
                 tickCurrentMinute: (v) => v + 1,
+            },
+        ],
+        geoVersion: [
+            0,
+            {
+                setInitialData: (v) => v + 1,
+                addGeoEvents: (v) => v + 1,
             },
         ],
         isLoading: [
@@ -130,37 +135,22 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
     }),
     selectors({
         chartData: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): ChartDataPoint[] => {
                 const bucketMap = new Map(slidingWindow.getSortedBuckets())
                 const result: ChartDataPoint[] = []
-                const seenUsers = new Set<string>()
 
                 const currentBucketTs = Math.floor(Date.now() / 60000) * 60
                 for (let i = BUCKET_WINDOW_MINUTES - 1; i >= 0; i--) {
                     const ts = currentBucketTs - i * 60
                     const bucket = bucketMap.get(ts)
 
-                    let newUsers = 0
-                    let returningUsers = 0
-
-                    if (bucket) {
-                        for (const userId of bucket.uniqueUsers) {
-                            if (seenUsers.has(userId)) {
-                                returningUsers++
-                            } else {
-                                newUsers++
-                                seenUsers.add(userId)
-                            }
-                        }
-                    }
-
                     result.push({
                         minute: dayjs.unix(ts).format('HH:mm'),
                         timestamp: ts * 1000,
                         users: bucket?.uniqueUsers.size ?? 0,
-                        newUsers,
-                        returningUsers,
+                        newUsers: bucket?.newUserCount ?? 0,
+                        returningUsers: bucket?.returningUserCount ?? 0,
                         pageviews: bucket?.pageviews ?? 0,
                     })
                 }
@@ -170,35 +160,35 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             { resultEqualityCheck: equal },
         ],
         deviceBreakdown: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): DeviceBreakdownItem[] => slidingWindow.getDeviceBreakdown(),
             { resultEqualityCheck: equal },
         ],
         browserBreakdown: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): BrowserBreakdownItem[] => slidingWindow.getBrowserBreakdown(6),
             { resultEqualityCheck: equal },
         ],
         countryBreakdown: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.geoVersion],
             (slidingWindow: LiveMetricsSlidingWindow): CountryBreakdownItem[] => slidingWindow.getCountryBreakdown(),
             { resultEqualityCheck: equal },
         ],
         topPaths: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): PathItem[] => slidingWindow.getTopPaths(10),
             { resultEqualityCheck: equal },
         ],
         totalPageviews: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalPageviews(),
         ],
         totalUniqueVisitors: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalUniqueUsers(),
         ],
         totalBrowsers: [
-            (s) => [s.slidingWindow, s.windowVersion],
+            (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalBrowsers(),
         ],
     }),
@@ -266,8 +256,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             const url = new URL(`${host}/events`)
             url.searchParams.append('columns', '$pathname,$device_type,$device_id,$browser,$ip,$raw_user_agent')
 
-            cache.batch = [] as LiveEvent[]
-            cache.lastBatchTime = performance.now()
+            cache.batch = cache.batch ?? ([] as LiveEvent[])
 
             cache.eventsConnection = createStreamConnection({
                 url,
@@ -281,13 +270,6 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                         cache.batch.push(eventData)
                     } catch (ex) {
                         console.error(ex)
-                    }
-
-                    const timeSinceLastBatch = performance.now() - cache.lastBatchTime
-                    if (cache.batch.length >= BATCH_SIZE_THRESHOLD || timeSinceLastBatch > BATCH_FLUSH_INTERVAL_MS) {
-                        actions.addEvents(cache.batch, cache.newerThan)
-                        cache.batch = []
-                        cache.lastBatchTime = performance.now()
                     }
                 },
                 onError: (error) => {
@@ -318,8 +300,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             const url = new URL(`${host}/events`)
             url.searchParams.append('geo', 'true')
 
-            cache.geoBatch = [] as LiveGeoEvent[]
-            cache.lastGeoBatchTime = performance.now()
+            cache.geoBatch = cache.geoBatch ?? ([] as LiveGeoEvent[])
 
             cache.geoConnection = createStreamConnection({
                 url,
@@ -333,13 +314,6 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     } catch (ex) {
                         console.error('Failed to parse geo event:', ex)
                     }
-
-                    const timeSinceLastBatch = performance.now() - cache.lastGeoBatchTime
-                    if (cache.geoBatch.length >= BATCH_SIZE_THRESHOLD || timeSinceLastBatch > BATCH_FLUSH_INTERVAL_MS) {
-                        actions.addGeoEvents(cache.geoBatch)
-                        cache.geoBatch = []
-                        cache.lastGeoBatchTime = performance.now()
-                    }
                 },
                 onError: (error) => {
                     console.error('Geo stream error:', error)
@@ -349,7 +323,23 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
     })),
     events(({ actions, cache }) => ({
         afterMount: () => {
+            cache.batch = [] as LiveEvent[]
+            cache.geoBatch = [] as LiveGeoEvent[]
+
             actions.loadInitialData()
+
+            // Flush both event and geo batches on a fixed interval
+            // to cap kea dispatches at a predictable rate regardless of event volume
+            cache.flushInterval = setInterval(() => {
+                if (cache.batch.length > 0) {
+                    actions.addEvents(cache.batch, cache.newerThan)
+                    cache.batch = []
+                }
+                if (cache.geoBatch.length > 0) {
+                    actions.addGeoEvents(cache.geoBatch)
+                    cache.geoBatch = []
+                }
+            }, FLUSH_INTERVAL_MS)
 
             // Ensures that our graph continues to update and old data "falls off"
             // even if new events aren't coming in
@@ -366,6 +356,9 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
         beforeUnmount: () => {
             cache.eventsConnection?.abort()
             cache.geoConnection?.abort()
+            if (cache.flushInterval) {
+                clearInterval(cache.flushInterval)
+            }
             if (cache.minuteTickTimeout) {
                 clearTimeout(cache.minuteTickTimeout)
             }
@@ -590,6 +583,8 @@ const getOrCreateBucket = (map: Map<number, SlidingWindowBucket>, timestamp: num
 const createEmptyBucket = (): SlidingWindowBucket => {
     return {
         pageviews: 0,
+        newUserCount: 0,
+        returningUserCount: 0,
         devices: new Map<string, Set<string>>(),
         browsers: new Map<string, Set<string>>(),
         paths: new Map<string, number>(),

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
@@ -166,7 +166,7 @@ export const liveWorldMapLogic = kea<liveWorldMapLogicType>([
             if (hasNewActivity) {
                 const heat = computeHeat(lastActivity)
                 actions.setCountryHeat(heat)
-                startHeatInterval(cache, actions)
+                startHeatInterval(cache as HeatCache, actions as Pick<typeof actions, 'setCountryHeat'>)
             }
         },
     })),
@@ -176,7 +176,7 @@ export const liveWorldMapLogic = kea<liveWorldMapLogicType>([
             cache.lastActivity = {}
         },
         beforeUnmount: () => {
-            stopHeatInterval(cache)
+            stopHeatInterval(cache as HeatCache)
         },
     })),
 ])
@@ -196,11 +196,15 @@ function computeHeat(lastActivity: Record<string, number>): Record<string, numbe
     return heat
 }
 
+interface HeatCache {
+    lastActivity: Record<string, number>
+    heatInterval: ReturnType<typeof setInterval> | null
+}
+
 // Only run the heat decay interval while there are active heat values.
 // Stops automatically when all heat has decayed to 0.
 function startHeatInterval(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cache: Record<string, any>,
+    cache: HeatCache,
     actions: { setCountryHeat: (heat: Record<string, number>) => void }
 ): void {
     if (cache.heatInterval) {
@@ -209,7 +213,7 @@ function startHeatInterval(
     cache.heatInterval = setInterval(() => {
         const heat = computeHeat(cache.lastActivity || {})
         if (Object.keys(heat).length === 0) {
-            stopHeatInterval(cache)
+            stopHeatInterval(cache as HeatCache)
             actions.setCountryHeat({})
             return
         }
@@ -217,8 +221,7 @@ function startHeatInterval(
     }, HEAT_UPDATE_INTERVAL_MS)
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function stopHeatInterval(cache: Record<string, any>): void {
+function stopHeatInterval(cache: HeatCache): void {
     if (cache.heatInterval) {
         clearInterval(cache.heatInterval)
         cache.heatInterval = null

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWorldMapLogic.tsx
@@ -147,12 +147,14 @@ export const liveWorldMapLogic = kea<liveWorldMapLogicType>([
             const isInitialLoad = !cache.initialized
             cache.initialized = true
 
+            let hasNewActivity = false
             if (!isInitialLoad) {
                 for (const item of data) {
                     if (item.country) {
                         const prevCount = prevCounts[item.country] || 0
                         if (item.count > prevCount) {
                             lastActivity[item.country] = now
+                            hasNewActivity = true
                         }
                     }
                 }
@@ -161,23 +163,20 @@ export const liveWorldMapLogic = kea<liveWorldMapLogicType>([
             cache.lastActivity = lastActivity
             cache.prevCounts = Object.fromEntries(data.map((item: CountryBreakdownItem) => [item.country, item.count]))
 
-            actions.setCountryHeat(computeHeat(lastActivity))
+            if (hasNewActivity) {
+                const heat = computeHeat(lastActivity)
+                actions.setCountryHeat(heat)
+                startHeatInterval(cache, actions)
+            }
         },
     })),
-    events(({ actions, cache }) => ({
+    events(({ cache }) => ({
         afterMount: () => {
             cache.prevCounts = {}
             cache.lastActivity = {}
-
-            cache.heatInterval = setInterval(() => {
-                const heat = computeHeat(cache.lastActivity || {})
-                actions.setCountryHeat(heat)
-            }, HEAT_UPDATE_INTERVAL_MS)
         },
         beforeUnmount: () => {
-            if (cache.heatInterval) {
-                clearInterval(cache.heatInterval)
-            }
+            stopHeatInterval(cache)
         },
     })),
 ])
@@ -195,4 +194,33 @@ function computeHeat(lastActivity: Record<string, number>): Record<string, numbe
     }
 
     return heat
+}
+
+// Only run the heat decay interval while there are active heat values.
+// Stops automatically when all heat has decayed to 0.
+function startHeatInterval(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cache: Record<string, any>,
+    actions: { setCountryHeat: (heat: Record<string, number>) => void }
+): void {
+    if (cache.heatInterval) {
+        return
+    }
+    cache.heatInterval = setInterval(() => {
+        const heat = computeHeat(cache.lastActivity || {})
+        if (Object.keys(heat).length === 0) {
+            stopHeatInterval(cache)
+            actions.setCountryHeat({})
+            return
+        }
+        actions.setCountryHeat(heat)
+    }, HEAT_UPDATE_INTERVAL_MS)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function stopHeatInterval(cache: Record<string, any>): void {
+    if (cache.heatInterval) {
+        clearInterval(cache.heatInterval)
+        cache.heatInterval = null
+    }
 }


### PR DESCRIPTION
## Problem
The Web Analytics Live dashboard is laggy under high event volume.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes	
- Replace per-message batch thresholds with a fixed 300ms flush interval for both SSE streams
- Split single `windowVersion` into `eventsVersion` + `geoVersion` so geo updates don't recompute event selectors
- Maintain `totalPageviews`, path counts, and new/returning user counts incrementally instead of recomputing from scratch
- Only run world map heat decay interval while heat is active
- Memoize individual country SVG elements so only changed countries re-render

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
