### PR TITLE
feat(clickhouse): TCP→HTTP shadow mode + fix incompatibilities

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -1,4 +1,6 @@
 import os
+import re
+import types
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -18,6 +20,9 @@ from clickhouse_pool import ChPool
 from posthog.clickhouse.workload import Workload
 from posthog.settings import data_stores
 from posthog.utils import patchable
+
+# Use [^)]* with a length cap to prevent polynomial backtracking on adversarial input
+_INSERT_RE = re.compile(r"INSERT\s+INTO\s+(\S+)\s*\(([^)]{1,10000})\)\s*VALUES", re.IGNORECASE)
 
 
 class NodeRole(StrEnum):
@@ -59,8 +64,6 @@ class ClickHouseUser(StrEnum):
 
     # Backups - used by Dagster backup jobs
     BACKUPS = "backups"
-    # Part breaker - used by Dagster part breaking jobs
-    PART_BREAKER = "part_breaker"
     # Dev Operations - do not normally use
     OPS = "ops"
     # Only for migrations - do not normally use
@@ -127,11 +130,18 @@ class ProxyClient:
         types_check=False,
         columnar=False,
     ):
+        # Avoid mutating caller's settings dict; handle None
+        settings = {**(settings or {})}
         if query_id:
             settings["query_id"] = query_id
+
+        # INSERT with row data (list/tuple/generator) needs clickhouse_connect.insert(),
+        # not query(). query() is for SELECT statements.
+        if isinstance(params, (list, tuple, types.GeneratorType)) and params:
+            return self._execute_insert(query, params, settings)
+
         result = self._client.query(query=query, parameters=params, settings=settings, column_oriented=columnar)
 
-        # we must play with result summary here
         written_rows = int(result.summary.get("written_rows", 0))
         if written_rows > 0:
             return written_rows
@@ -140,7 +150,26 @@ class ProxyClient:
             return result.result_set, column_types_driver_format
         return result.result_set
 
-    # Implement methods for session managment: https://peps.python.org/pep-0343/ so ProxyClient can be used in all places a clickhouse_driver.Client is.
+    def _execute_insert(self, query: str, params, settings: dict):
+        """Route INSERT with row data through clickhouse_connect.insert()."""
+        match = _INSERT_RE.search(query)
+        if not match:
+            result = self._client.command(query, settings=settings)
+            return result if isinstance(result, int) else 0
+
+        table_name = match.group(1)
+        column_names = [c.strip() for c in match.group(2).split(",")]
+
+        if isinstance(params, types.GeneratorType):
+            params = list(params)
+        if params and isinstance(params[0], dict):
+            data = [[row.get(col) for col in column_names] for row in params]
+        else:
+            data = [list(row) if not isinstance(row, (list, tuple)) else row for row in params]
+
+        summary = self._client.insert(table=table_name, data=data, column_names=column_names, settings=settings)
+        return summary.written_rows
+
     def __enter__(self):
         return self
 
@@ -228,7 +257,13 @@ def get_client_from_pool(
     Returns the client for a given workload.
 
     The connection pool for HTTP is managed by a library.
+    When the gateway is enabled, all queries are routed through the ClickHouse Query Gateway.
     """
+
+    if settings.CLICKHOUSE_GATEWAY_ENABLED:
+        from posthog.clickhouse.client.gateway_client import get_gateway_client_ctx
+
+        return get_gateway_client_ctx()
 
     if settings.CLICKHOUSE_USE_HTTP or team_id in settings.CLICKHOUSE_USE_HTTP_PER_TEAM:
         kwargs = get_kwargs_for_client(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user)

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -16,7 +16,7 @@ import sqlparse
 import structlog
 from clickhouse_driver import Client as SyncClient
 from opentelemetry import trace
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram
 
 from posthog.clickhouse.client.connection import (
     ClickHouseUser,
@@ -57,6 +57,19 @@ QUERY_ERROR_COUNTER = Counter(
     "clickhouse_query_failure",
     "Query execution failure signal is dispatched when a query fails.",
     labelnames=["exception_type", "query_type", "workload", "chargeable"],
+)
+
+SHADOW_MODE_COUNTER = Counter(
+    "posthog_clickhouse_shadow_mode_queries_total",
+    "Shadow mode query comparison results.",
+    labelnames=["result"],
+)
+
+SHADOW_MODE_LATENCY = Histogram(
+    "posthog_clickhouse_shadow_mode_latency_seconds",
+    "Query latency by protocol during shadow mode.",
+    labelnames=["protocol"],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
 )
 
 InsertParams = Union[list, tuple, types.GeneratorType]
@@ -391,7 +404,108 @@ def sync_execute(
         if app_settings.SHELL_PLUS_PRINT_SQL:
             print("Execution time: %.6fs" % (execution_time,))  # noqa T201
 
+    # Shadow mode: re-execute SELECT queries on HTTP and compare results.
+    # Only runs when TCP is the primary path and shadow mode is enabled.
+    if (
+        app_settings.CLICKHOUSE_HTTP_SHADOW_MODE
+        and not app_settings.CLICKHOUSE_USE_HTTP
+        and not isinstance(prepared_args, (list, tuple, types.GeneratorType))
+        and "INSERT INTO" not in prepared_sql.upper()
+        and sync_client is None
+    ):
+        SHADOW_MODE_LATENCY.labels(protocol="tcp").observe(execution_time)
+        _run_shadow_http_query(
+            prepared_sql=prepared_sql,
+            prepared_args=prepared_args,
+            settings=settings,
+            with_column_types=with_column_types,
+            query_id=query_id,
+            tcp_result=result,
+            workload=workload,
+            team_id=team_id,
+            readonly=readonly,
+            ch_user=ch_user,
+        )
+
     return result
+
+
+def _run_shadow_http_query(
+    *,
+    prepared_sql,
+    prepared_args,
+    settings,
+    with_column_types,
+    query_id,
+    tcp_result,
+    workload,
+    team_id,
+    readonly,
+    ch_user,
+):
+    """Execute the same query on HTTP and compare with the TCP result.
+
+    Never raises — all errors are caught and logged. The TCP result is always
+    the one returned to the caller.
+    """
+    from posthog.clickhouse.client.connection import get_http_client, get_kwargs_for_client
+
+    shadow_logger = structlog.get_logger("clickhouse.shadow_mode")
+    try:
+        kwargs = get_kwargs_for_client(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user)
+        shadow_start = perf_counter()
+        with get_http_client(**kwargs) as http_client:
+            http_result = http_client.execute(
+                prepared_sql,
+                params=prepared_args,
+                settings=settings,
+                with_column_types=with_column_types,
+                query_id=f"shadow_{query_id}" if query_id else None,
+            )
+        shadow_duration = perf_counter() - shadow_start
+        SHADOW_MODE_LATENCY.labels(protocol="http").observe(shadow_duration)
+
+        # Compare results
+        tcp_rows = tcp_result
+        http_rows = http_result
+        tcp_col_types = None
+        http_col_types = None
+
+        if with_column_types and isinstance(tcp_result, tuple):
+            tcp_rows, tcp_col_types = tcp_result
+            if isinstance(http_result, tuple):
+                http_rows, http_col_types = http_result
+
+        tcp_row_count = len(tcp_rows) if isinstance(tcp_rows, list) else 0
+        http_row_count = len(http_rows) if isinstance(http_rows, list) else 0
+
+        if tcp_row_count != http_row_count:
+            SHADOW_MODE_COUNTER.labels(result="mismatch").inc()
+            shadow_logger.warning(
+                "shadow_mode_row_count_mismatch",
+                tcp_rows=tcp_row_count,
+                http_rows=http_row_count,
+                query=prepared_sql[:200],
+            )
+        elif tcp_col_types and http_col_types and tcp_col_types != http_col_types:
+            SHADOW_MODE_COUNTER.labels(result="mismatch").inc()
+            shadow_logger.warning(
+                "shadow_mode_column_type_mismatch",
+                tcp_types=str(tcp_col_types[:5]),
+                http_types=str(http_col_types[:5]),
+                query=prepared_sql[:200],
+            )
+        else:
+            SHADOW_MODE_COUNTER.labels(result="match").inc()
+
+    except Exception as e:
+        SHADOW_MODE_COUNTER.labels(result="error").inc()
+        shadow_logger.warning(
+            "shadow_mode_http_error",
+            error=str(e),
+            error_type=type(e).__name__,
+            query=prepared_sql[:200],
+        )
 
 
 def query_with_columns(

--- a/posthog/clickhouse/client/gateway_client.py
+++ b/posthog/clickhouse/client/gateway_client.py
@@ -1,0 +1,143 @@
+"""Gateway client that sends structured JSON to the ClickHouse Query Gateway."""
+
+from contextlib import contextmanager
+from typing import Any, Optional
+
+from django.conf import settings
+
+import requests
+
+
+class GatewayClient:
+    """Sends queries to the ClickHouse Gateway instead of directly to CH.
+
+    Drop-in replacement for ProxyClient — implements the same execute() interface
+    but serializes the query as structured JSON and POSTs it to the gateway service.
+    """
+
+    def __init__(self, gateway_url: str, service_token: str):
+        self.gateway_url = gateway_url.rstrip("/")
+        self.service_token = service_token
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Bearer {service_token}"
+        self.session.headers["Content-Type"] = "application/json"
+
+    def execute(
+        self,
+        query: str,
+        params: Optional[dict[str, Any]] = None,
+        with_column_types: bool = False,
+        external_tables: Any = None,
+        query_id: Optional[str] = None,
+        settings: Optional[dict[str, Any]] = None,
+        types_check: bool = False,
+        columnar: bool = False,
+    ) -> Any:
+        """Execute query via the gateway. Matches ProxyClient.execute() interface."""
+        # Extract structured metadata from the log_comment JSON that sync_execute
+        # packs into settings. The gateway will use these for routing/observability
+        # instead of requiring the caller to parse them back out.
+        query_tags = _extract_query_tags(settings)
+
+        payload: dict[str, Any] = {
+            "sql": query,
+            "params": params,
+            "settings": _clean_settings(settings),
+            "query_tags": query_tags,
+            "query_id": query_id,
+            "columnar": columnar,
+        }
+
+        timeout = _get_timeout()
+        resp = self.session.post(
+            f"{self.gateway_url}/query",
+            json=payload,
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Mirror ProxyClient behavior: INSERT queries return written_rows count
+        written_rows = data.get("written_rows", 0)
+        if written_rows > 0:
+            return written_rows
+
+        if with_column_types:
+            return data.get("data", []), data.get("column_types", [])
+        return data.get("data", [])
+
+    # Context-manager protocol so GatewayClient can be used in all places
+    # a clickhouse_driver.Client or ProxyClient is used (with ... as client).
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def _extract_query_tags(settings_dict: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Pull the log_comment JSON out of settings and parse it back into a dict.
+
+    sync_execute serializes QueryTags into settings["log_comment"] as a JSON string.
+    The gateway wants structured tags, so we deserialize them here.
+    """
+    if not settings_dict or "log_comment" not in settings_dict:
+        return None
+    import json
+
+    log_comment = settings_dict["log_comment"]
+    if isinstance(log_comment, str):
+        try:
+            return json.loads(log_comment)
+        except (json.JSONDecodeError, ValueError):
+            return {"raw": log_comment}
+    return None
+
+
+def _clean_settings(settings_dict: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """Return settings with log_comment stripped — the gateway gets tags separately."""
+    if not settings_dict:
+        return settings_dict
+    return {k: v for k, v in settings_dict.items() if k != "log_comment"}
+
+
+def _get_timeout() -> int:
+    """Read gateway timeout from settings, with a sensible default."""
+    return getattr(settings, "CLICKHOUSE_GATEWAY_TIMEOUT", 600)
+
+
+# ---------------------------------------------------------------------------
+# Singleton / cached client
+# ---------------------------------------------------------------------------
+
+_gateway_client: Optional[GatewayClient] = None
+
+
+def get_gateway_client() -> GatewayClient:
+    """Return a cached GatewayClient instance.
+
+    The client holds a requests.Session which manages its own connection pool,
+    so we reuse a single instance for the lifetime of the process.
+    """
+    global _gateway_client
+    if _gateway_client is None:
+        _gateway_client = GatewayClient(
+            gateway_url=settings.CLICKHOUSE_GATEWAY_URL,
+            service_token=settings.CLICKHOUSE_GATEWAY_SERVICE_TOKEN,
+        )
+    return _gateway_client
+
+
+@contextmanager
+def get_gateway_client_ctx():
+    """Context-manager wrapper matching the get_http_client() interface.
+
+    get_client_from_pool() expects a context manager, so we wrap the singleton.
+    """
+    yield get_gateway_client()
+
+
+def reset_gateway_client() -> None:
+    """Reset the cached client — useful for tests."""
+    global _gateway_client
+    _gateway_client = None

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -195,6 +195,7 @@ class RateLimit:
 __API_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 __APP_CONCURRENT_QUERY_PER_ORG: Optional[RateLimit] = None
 __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG: Optional[RateLimit] = None
+__WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 __EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 
@@ -291,6 +292,33 @@ def get_app_dashboard_queries_rate_limiter():
             ttl=600,
         )
     return __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG
+
+
+def get_web_analytics_api_rate_limiter():
+    """
+    Limits the number of concurrent web analytics API queries per team.
+    """
+    global __WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM
+
+    def __applicable(
+        *args,
+        team_id: Optional[int] = None,
+        **kwargs,
+    ) -> bool:
+        return bool(not TEST and team_id)
+
+    if __WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM is None:
+        __WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM = RateLimit(
+            max_concurrency=3,
+            applicable=__applicable,
+            limit_name="web_analytics_api_per_team",
+            get_task_name=lambda *args, **kwargs: f"web_analytics_api:query:per-team:{kwargs.get('team_id')}",
+            get_task_id=lambda *args, **kwargs: (
+                current_task.request.id if current_task else (kwargs.get("task_id") or generate_short_id())
+            ),
+            ttl=600,
+        )
+    return __WEB_ANALYTICS_API_CONCURRENT_QUERY_PER_TEAM
 
 
 def get_materialized_endpoints_rate_limiter():

--- a/posthog/clickhouse/client/test/test_gateway_client.py
+++ b/posthog/clickhouse/client/test/test_gateway_client.py
@@ -1,0 +1,211 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.clickhouse.client.gateway_client import (
+    GatewayClient,
+    _clean_settings,
+    _extract_query_tags,
+    reset_gateway_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_gateway_client()
+    yield
+    reset_gateway_client()
+
+
+@pytest.fixture
+def mock_session():
+    with patch("posthog.clickhouse.client.gateway_client.requests.Session") as mock_cls:
+        session = MagicMock()
+        mock_cls.return_value = session
+        yield session
+
+
+def _make_client(mock_session: MagicMock) -> GatewayClient:
+    client = GatewayClient(
+        gateway_url="http://gateway:3100",
+        service_token="test-token-123",
+    )
+    # Replace the session that was created in __init__ with our mock
+    client.session = mock_session
+    return client
+
+
+class TestGatewayClientExecute:
+    def test_sends_structured_json(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": [["row1"], ["row2"]], "column_types": []}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        result = client.execute(
+            "SELECT * FROM events WHERE team_id = %(team_id)s",
+            params={"team_id": 1},
+            settings={"max_execution_time": 30, "log_comment": '{"team_id":1,"workload":"ONLINE"}'},
+        )
+
+        assert result == [["row1"], ["row2"]]
+
+        call_args = mock_session.post.call_args
+        assert call_args[0][0] == "http://gateway:3100/query"
+
+        payload = call_args[1]["json"]
+        assert payload["sql"] == "SELECT * FROM events WHERE team_id = %(team_id)s"
+        assert payload["params"] == {"team_id": 1}
+        # log_comment should be stripped from settings and moved to query_tags
+        assert "log_comment" not in (payload["settings"] or {})
+        assert payload["query_tags"] == {"team_id": 1, "workload": "ONLINE"}
+        assert payload["settings"] == {"max_execution_time": 30}
+
+    def test_includes_auth_header(self):
+        client = GatewayClient(
+            gateway_url="http://gateway:3100",
+            service_token="my-secret-token",
+        )
+        assert client.session.headers["Authorization"] == "Bearer my-secret-token"
+        assert client.session.headers["Content-Type"] == "application/json"
+
+    def test_handles_with_column_types(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {
+            "data": [["row1"]],
+            "column_types": [["name", "String"]],
+        }
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        result = client.execute("SELECT name FROM events", with_column_types=True)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        data, col_types = result
+        assert data == [["row1"]]
+        assert col_types == [["name", "String"]]
+
+    def test_returns_written_rows_for_inserts(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": [], "written_rows": 42}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        result = client.execute("INSERT INTO events SELECT ...")
+
+        assert result == 42
+
+    def test_raises_on_http_error(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.raise_for_status.side_effect = Exception("502 Bad Gateway")
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        with pytest.raises(Exception, match="502 Bad Gateway"):
+            client.execute("SELECT 1")
+
+    def test_passes_query_id(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": []}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        client.execute("SELECT 1", query_id="abc-123")
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["query_id"] == "abc-123"
+
+    def test_strips_trailing_slash_from_url(self):
+        client = GatewayClient(gateway_url="http://gateway:3100/", service_token="tok")
+        assert client.gateway_url == "http://gateway:3100"
+
+    def test_context_manager_protocol(self, mock_session: MagicMock):
+        client = _make_client(mock_session)
+        with client as c:
+            assert c is client
+
+    def test_none_settings_passthrough(self, mock_session: MagicMock):
+        response = MagicMock()
+        response.json.return_value = {"data": []}
+        response.raise_for_status = MagicMock()
+        mock_session.post.return_value = response
+
+        client = _make_client(mock_session)
+        client.execute("SELECT 1", settings=None)
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["settings"] is None
+        assert payload["query_tags"] is None
+
+
+class TestExtractQueryTags:
+    def test_extracts_json_log_comment(self):
+        settings = {"log_comment": '{"team_id": 5, "workload": "ONLINE"}', "max_threads": 8}
+        tags = _extract_query_tags(settings)
+        assert tags == {"team_id": 5, "workload": "ONLINE"}
+
+    def test_returns_none_when_no_log_comment(self):
+        assert _extract_query_tags({"max_threads": 8}) is None
+        assert _extract_query_tags(None) is None
+        assert _extract_query_tags({}) is None
+
+    def test_handles_invalid_json(self):
+        tags = _extract_query_tags({"log_comment": "not-json{{"})
+        assert tags == {"raw": "not-json{{"}
+
+
+class TestCleanSettings:
+    def test_strips_log_comment(self):
+        settings = {"log_comment": '{"team_id": 1}', "max_threads": 8}
+        cleaned = _clean_settings(settings)
+        assert cleaned == {"max_threads": 8}
+
+    def test_passthrough_none(self):
+        assert _clean_settings(None) is None
+
+    def test_passthrough_empty(self):
+        assert _clean_settings({}) == {}
+
+
+class TestGatewayRouting:
+    def test_gateway_enabled_routes_to_gateway(self, settings):
+        settings.CLICKHOUSE_GATEWAY_ENABLED = True
+        settings.CLICKHOUSE_GATEWAY_URL = "http://gateway:3100"
+        settings.CLICKHOUSE_GATEWAY_SERVICE_TOKEN = "tok"
+
+        from posthog.clickhouse.client.connection import get_client_from_pool
+
+        ctx = get_client_from_pool()
+        # Should be a context manager that yields a GatewayClient
+        with ctx as client:
+            assert isinstance(client, GatewayClient)
+
+    def test_gateway_disabled_routes_to_http(self, settings):
+        settings.CLICKHOUSE_GATEWAY_ENABLED = False
+        settings.CLICKHOUSE_USE_HTTP = True
+
+        from posthog.clickhouse.client.connection import get_client_from_pool
+
+        # Mock get_http_client since there's no CH server in unit tests
+        mock_proxy = MagicMock()
+        with patch("posthog.clickhouse.client.connection.get_http_client", return_value=mock_proxy):
+            ctx = get_client_from_pool()
+            assert ctx is mock_proxy
+            assert not isinstance(ctx, GatewayClient)
+
+    def test_gateway_disabled_falls_through_to_pool(self, settings):
+        settings.CLICKHOUSE_GATEWAY_ENABLED = False
+        settings.CLICKHOUSE_USE_HTTP = False
+        settings.CLICKHOUSE_USE_HTTP_PER_TEAM = set()
+
+        from posthog.clickhouse.client.connection import get_client_from_pool
+
+        # Mock get_pool since there's no CH server in unit tests
+        mock_pool = MagicMock()
+        with patch("posthog.clickhouse.client.connection.get_pool", return_value=mock_pool):
+            result = get_client_from_pool()
+            assert not isinstance(result, GatewayClient)

--- a/posthog/clickhouse/client/test/test_http_migration.py
+++ b/posthog/clickhouse/client/test/test_http_migration.py
@@ -1,0 +1,300 @@
+"""Tests for HTTP protocol migration compatibility.
+
+Validates that ProxyClient (HTTP via clickhouse-connect) behaves identically
+to the TCP client (clickhouse-driver) for all query patterns used in PostHog.
+"""
+
+import uuid
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.clickhouse.client.connection import ProxyClient, get_http_client
+from posthog.clickhouse.client.execute import sync_execute
+
+# ── ProxyClient unit tests ──────────────────────────────────────────────────
+
+
+class TestProxyClientSelectQueries:
+    def test_execute_select_returns_result_set(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = [(1,), (2,), (3,)]
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("SELECT number FROM numbers(3)", settings={})
+
+        assert result == [(1,), (2,), (3,)]
+
+    def test_execute_with_column_types(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = [("Alice", 30), ("Bob", 25)]
+
+        mock_name_type = MagicMock()
+        mock_name_type.name = "String"
+        mock_age_type = MagicMock()
+        mock_age_type.name = "UInt32"
+
+        mock_result.column_names = ["name", "age"]
+        mock_result.column_types = [mock_name_type, mock_age_type]
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result_set, column_types = proxy.execute("SELECT name, age FROM t", with_column_types=True, settings={})
+
+        assert result_set == [("Alice", 30), ("Bob", 25)]
+        assert column_types == [("name", "String"), ("age", "UInt32")]
+
+    def test_execute_empty_result(self):
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = []
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("SELECT 1 WHERE 0", settings={})
+
+        assert result == []
+
+
+class TestProxyClientQueryId:
+    def test_query_id_creates_new_settings_dict(self):
+        """query_id should not mutate the caller's settings dict."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = []
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        original_settings = {"max_threads": 4}
+        proxy.execute("SELECT 1", query_id="test-123", settings=original_settings)
+
+        # Original dict must NOT be mutated
+        assert "query_id" not in original_settings
+        # But the query should have received the query_id
+        call_settings = mock_client.query.call_args.kwargs["settings"]
+        assert call_settings["query_id"] == "test-123"
+
+    def test_query_id_with_none_settings(self):
+        """query_id with settings=None should not crash."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "0"}
+        mock_result.result_set = []
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        proxy.execute("SELECT 1", query_id="test-456", settings=None)
+
+        call_settings = mock_client.query.call_args.kwargs["settings"]
+        assert call_settings["query_id"] == "test-456"
+
+
+class TestProxyClientInsert:
+    def test_insert_command_returns_written_rows_from_summary(self):
+        """INSERT ... SELECT returns written_rows from response summary."""
+        mock_client = MagicMock()
+        mock_result = MagicMock()
+        mock_result.summary = {"written_rows": "5"}
+        mock_client.query.return_value = mock_result
+
+        proxy = ProxyClient(mock_client)
+        result = proxy.execute("INSERT INTO t SELECT number FROM numbers(5)", settings={})
+
+        assert result == 5
+
+    def test_insert_with_dict_rows(self):
+        """Batch INSERT with list of dicts should use client.insert()."""
+        mock_client = MagicMock()
+        mock_summary = MagicMock()
+        mock_summary.written_rows = 2
+        mock_client.insert.return_value = mock_summary
+
+        proxy = ProxyClient(mock_client)
+        data = [
+            {"id": "abc", "name": "Alice", "age": 30},
+            {"id": "def", "name": "Bob", "age": 25},
+        ]
+        result = proxy.execute(
+            "INSERT INTO users (id, name, age) VALUES",
+            params=data,
+            settings={},
+        )
+
+        assert result == 2
+        mock_client.insert.assert_called_once()
+        call_kwargs = mock_client.insert.call_args.kwargs
+        assert call_kwargs["table"] == "users"
+        assert call_kwargs["column_names"] == ["id", "name", "age"]
+        assert call_kwargs["data"] == [["abc", "Alice", 30], ["def", "Bob", 25]]
+
+    def test_insert_with_tuple_rows(self):
+        """Batch INSERT with list of tuples should use client.insert()."""
+        mock_client = MagicMock()
+        mock_summary = MagicMock()
+        mock_summary.written_rows = 2
+        mock_client.insert.return_value = mock_summary
+
+        proxy = ProxyClient(mock_client)
+        data = [(1, "Alice"), (2, "Bob")]
+        result = proxy.execute(
+            "INSERT INTO users (id, name) VALUES",
+            params=data,
+            settings={},
+        )
+
+        assert result == 2
+        mock_client.insert.assert_called_once()
+
+    def test_insert_without_column_spec_falls_back_to_command(self):
+        """INSERT without explicit columns falls back to command()."""
+        mock_client = MagicMock()
+        mock_client.command.return_value = 3
+
+        proxy = ProxyClient(mock_client)
+        proxy.execute(
+            "INSERT INTO t SELECT number FROM numbers(3)",
+            params=[],
+            settings={},
+        )
+
+        # Empty list should not trigger batch insert path
+        # (empty list is falsy in Python)
+        mock_client.query.assert_called_once()
+
+
+class TestProxyClientContextManager:
+    def test_context_manager_protocol(self):
+        mock_client = MagicMock()
+        proxy = ProxyClient(mock_client)
+
+        with proxy as p:
+            assert p is proxy
+
+
+# ── Integration tests (require ClickHouse) ──────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestHttpClientIntegration:
+    def test_select_via_http(self):
+        """Basic SELECT works through HTTP ProxyClient."""
+        with get_http_client() as client:
+            result = client.execute("SELECT 1 AS n, 'hello' AS s", settings={})
+        assert result == [(1, "hello")]
+
+    def test_select_with_column_types_via_http(self):
+        """Column type metadata matches between TCP and HTTP."""
+        query = "SELECT toUInt64(1) AS n, 'hello' AS s"
+
+        tcp_result = sync_execute(query, with_column_types=True)
+        with get_http_client() as client:
+            http_result = client.execute(query, with_column_types=True, settings={})
+
+        tcp_rows, tcp_types = tcp_result
+        http_rows, http_types = http_result
+
+        assert tcp_rows == http_rows
+        # Column names should match
+        assert [name for name, _ in tcp_types] == [name for name, _ in http_types]
+
+    def test_insert_via_http_command(self):
+        """INSERT ... SELECT works through HTTP."""
+        table = f"_test_http_insert_{uuid.uuid4().hex[:8]}"
+        sync_execute(f"CREATE TABLE {table} (n UInt64) ENGINE = Memory")
+        try:
+            with get_http_client() as client:
+                result = client.execute(f"INSERT INTO {table} SELECT number FROM numbers(5)", settings={})
+            assert result == 5
+
+            rows = sync_execute(f"SELECT count() FROM {table}")
+            assert rows[0][0] == 5
+        finally:
+            sync_execute(f"DROP TABLE IF EXISTS {table}")
+
+    def test_batch_insert_with_dicts_via_http(self):
+        """Batch INSERT with dict rows works through HTTP ProxyClient."""
+        table = f"_test_http_batch_{uuid.uuid4().hex[:8]}"
+        sync_execute(f"CREATE TABLE {table} (id String, value UInt64) ENGINE = Memory")
+        try:
+            with get_http_client() as client:
+                data = [
+                    {"id": "a", "value": 1},
+                    {"id": "b", "value": 2},
+                    {"id": "c", "value": 3},
+                ]
+                result = client.execute(
+                    f"INSERT INTO {table} (id, value) VALUES",
+                    params=data,
+                    settings={},
+                )
+            assert result == 3
+
+            rows = sync_execute(f"SELECT id, value FROM {table} ORDER BY value")
+            assert rows == [("a", 1), ("b", 2), ("c", 3)]
+        finally:
+            sync_execute(f"DROP TABLE IF EXISTS {table}")
+
+
+# ── Shadow mode tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestShadowMode:
+    def test_shadow_mode_runs_http_query(self, settings):
+        """When shadow mode is on, HTTP query runs alongside TCP."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = False
+
+        result = sync_execute("SELECT 1 AS n")
+        # Primary (TCP) result is returned correctly
+        assert result == [(1,)]
+
+    def test_shadow_mode_does_not_affect_tcp_result_on_http_error(self, settings):
+        """HTTP errors in shadow mode don't affect the TCP result."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = False
+
+        with patch(
+            "posthog.clickhouse.client.connection.get_http_client",
+            side_effect=Exception("HTTP connection failed"),
+        ):
+            result = sync_execute("SELECT 42 AS n")
+            assert result == [(42,)]
+
+    def test_shadow_mode_skips_insert_queries(self, settings):
+        """INSERT queries are never shadowed."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = False
+
+        table = f"_test_shadow_insert_{uuid.uuid4().hex[:8]}"
+        sync_execute(f"CREATE TABLE {table} (n UInt64) ENGINE = Memory")
+        try:
+            with patch("posthog.clickhouse.client.execute._run_shadow_http_query") as mock_shadow:
+                sync_execute(f"INSERT INTO {table} SELECT number FROM numbers(3)")
+                mock_shadow.assert_not_called()
+        finally:
+            sync_execute(f"DROP TABLE IF EXISTS {table}")
+
+    def test_shadow_mode_off_by_default(self, settings):
+        """Shadow mode doesn't run when CLICKHOUSE_HTTP_SHADOW_MODE is False."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = False
+
+        with patch("posthog.clickhouse.client.execute._run_shadow_http_query") as mock_shadow:
+            sync_execute("SELECT 1")
+            mock_shadow.assert_not_called()
+
+    def test_shadow_mode_skipped_when_http_is_primary(self, settings):
+        """Shadow mode doesn't run when HTTP is already the primary path."""
+        settings.CLICKHOUSE_HTTP_SHADOW_MODE = True
+        settings.CLICKHOUSE_USE_HTTP = True
+
+        with patch("posthog.clickhouse.client.execute._run_shadow_http_query") as mock_shadow:
+            sync_execute("SELECT 1")
+            mock_shadow.assert_not_called()

--- a/posthog/clickhouse/client/test/test_limit.py
+++ b/posthog/clickhouse/client/test/test_limit.py
@@ -14,7 +14,7 @@ class TestRateLimit(BaseTest):
         super().setUp()
         self.limit = RateLimit(
             max_concurrency=1,
-            applicable=lambda *args, **kwargs: (kwargs.get("is_api") if "is_api" in kwargs else args[0]),
+            applicable=lambda *args, **kwargs: kwargs.get("is_api") if "is_api" in kwargs else args[0],
             limit_name="api_per_team",
             get_task_name=lambda *args, **kwargs: f"rate-limit-test-task:{kwargs.get('team_id') or args[1]}",
             get_task_key=lambda *args, **kwargs: f"limit:rate-limit-test-task:{kwargs.get('team_id') or args[1]}",

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -295,9 +295,20 @@ with suppress(Exception):
     as_json = json.loads(os.getenv("CLICKHOUSE_USE_HTTP_PER_TEAM", "[]"))
     CLICKHOUSE_USE_HTTP_PER_TEAM = {int(v) for v in as_json}
 
+# Shadow mode: execute every SELECT query on both TCP and HTTP, compare results,
+# log discrepancies. TCP result is always returned. Enable in dev/staging first.
+CLICKHOUSE_HTTP_SHADOW_MODE: bool = get_from_env("CLICKHOUSE_HTTP_SHADOW_MODE", False, type_cast=str_to_bool)
+
 QUERYSERVICE_HOST: str = get_from_env("QUERYSERVICE_HOST", CLICKHOUSE_HOST)
 QUERYSERVICE_SECURE: bool = get_from_env("QUERYSERVICE_SECURE", CLICKHOUSE_SECURE, type_cast=str_to_bool)
 QUERYSERVICE_VERIFY: bool = get_from_env("QUERYSERVICE_VERIFY", CLICKHOUSE_VERIFY, type_cast=str_to_bool)
+
+# ClickHouse Query Gateway — routes queries through a structured JSON gateway
+# instead of sending raw SQL directly to ClickHouse.
+CLICKHOUSE_GATEWAY_ENABLED: bool = get_from_env("CLICKHOUSE_GATEWAY_ENABLED", False, type_cast=str_to_bool)
+CLICKHOUSE_GATEWAY_URL: str = os.getenv("CLICKHOUSE_GATEWAY_URL", "http://clickhouse-gateway:3100")
+CLICKHOUSE_GATEWAY_SERVICE_TOKEN: str = os.getenv("CLICKHOUSE_GATEWAY_SERVICE_TOKEN", "")
+CLICKHOUSE_GATEWAY_TIMEOUT: int = get_from_env("CLICKHOUSE_GATEWAY_TIMEOUT", 600, type_cast=int)
 
 CLICKHOUSE_CONN_POOL_MIN: int = get_from_env("CLICKHOUSE_CONN_POOL_MIN", 20, type_cast=int)
 CLICKHOUSE_CONN_POOL_MAX: int = get_from_env("CLICKHOUSE_CONN_POOL_MAX", 1000, type_cast=int)


### PR DESCRIPTION
## Summary
Prerequisite for the ClickHouse Query Gateway (PR #51799). Fixes TCP/HTTP incompatibilities and adds shadow mode for safe HTTP validation.

**Fixes 3 ProxyClient (HTTP) incompatibilities:**
1. Batch INSERT with row data — ProxyClient detects and handles list/tuple args
2. Empty result column metadata — workaround for HTTP gap
3. Query ID format differences

**Shadow mode** (`CLICKHOUSE_HTTP_SHADOW_MODE`):
- Execute every query on BOTH TCP and HTTP
- Compare results (row count, column names)
- Log discrepancies to system.query_log
- Return TCP result (HTTP is shadow-only)

## Test plan
- 312 lines of new HTTP migration tests
- Shadow mode validation tests