### PR TITLE
refactor(ActionFilterRow): extract ActionFilterRowMenu

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -7,8 +7,7 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { useCallback, useState } from 'react'
 
-import { IconCopy, IconEllipsis, IconFilter, IconGroupIntersect, IconPencil, IconTrash } from '@posthog/icons'
-import { LemonBadge, LemonCheckbox, LemonDivider, LemonMenu } from '@posthog/lemon-ui'
+import { IconCopy, IconFilter, IconGroupIntersect, IconPencil, IconTrash } from '@posthog/icons'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { HogQLEditor } from 'lib/components/HogQLEditor/HogQLEditor'
@@ -51,6 +50,7 @@ import {
     PropertyOperator,
 } from '~/types'
 
+import { ActionFilterRowMenu } from './ActionFilterRowMenu'
 import { getValue, taxonomicFilterGroupTypeToEntityType } from './actionFilterRowUtils'
 import { MathSelector } from './MathSelector'
 import type { ActionFilterRowProps } from './types'
@@ -155,8 +155,6 @@ export function ActionFilterRow({
     const canCombine = showCombine && !singleFilter && filter.type !== EntityTypes.DATA_WAREHOUSE
 
     const [isHogQLDropdownVisible, setIsHogQLDropdownVisible] = useState(false)
-    const [isMenuVisible, setIsMenuVisible] = useState(false)
-
     const {
         setNodeRef,
         attributes: { 'aria-disabled': _, ...attributes },
@@ -412,7 +410,6 @@ export function ActionFilterRow({
             data-attr={`show-prop-rename-${index}`}
             noPadding={!enablePopup}
             onClick={() => {
-                setIsMenuVisible(false)
                 selectFilter(filter)
                 onRenameClick()
             }}
@@ -430,7 +427,6 @@ export function ActionFilterRow({
             data-attr={`show-prop-duplicate-${index}`}
             noPadding={!enablePopup}
             onClick={() => {
-                setIsMenuVisible(false)
                 duplicateFilter(filter)
             }}
             fullWidth={enablePopup}
@@ -466,7 +462,6 @@ export function ActionFilterRow({
             data-attr={`delete-prop-filter-${index}`}
             noPadding={!enablePopup}
             onClick={() => {
-                setIsMenuVisible(false)
                 onClose()
             }}
             fullWidth={enablePopup}
@@ -692,107 +687,34 @@ export function ActionFilterRow({
                                     <>
                                         {!hideFilter && propertyFiltersButton}
                                         {canCombine && combineInlineButton}
-                                        <div className="relative">
-                                            <LemonMenu
-                                                placement={isTrendsContext ? 'bottom-end' : 'bottom-start'}
-                                                visible={isMenuVisible}
-                                                closeOnClickInside={false}
-                                                onVisibilityChange={setIsMenuVisible}
-                                                items={[
-                                                    // MathSelector for funnels only (trends shows it inline)
-                                                    ...(isFunnelContext
-                                                        ? [
-                                                              {
-                                                                  label: () => (
-                                                                      <>
-                                                                          <MathSelector
-                                                                              math={math}
-                                                                              mathGroupTypeIndex={mathGroupTypeIndex}
-                                                                              index={index}
-                                                                              onMathSelect={onMathSelect}
-                                                                              disabled={readOnly}
-                                                                              style={{
-                                                                                  maxWidth: '100%',
-                                                                                  width: 'initial',
-                                                                              }}
-                                                                              mathAvailability={mathAvailability}
-                                                                              trendsDisplayCategory={
-                                                                                  trendsDisplayCategory
-                                                                              }
-                                                                              query={query || {}}
-                                                                          />
-                                                                          <LemonDivider />
-                                                                      </>
-                                                                  ),
-                                                              },
-                                                          ]
-                                                        : []),
-                                                    // Optional step checkbox for funnels only
-                                                    ...(isFunnelContext && index > 0
-                                                        ? [
-                                                              {
-                                                                  label: () => (
-                                                                      <>
-                                                                          <Tooltip title="Optional steps show conversion rates from the last mandatory step, but are not necessary to move to the next step in the funnel">
-                                                                              <div className="px-2 py-1">
-                                                                                  <LemonCheckbox
-                                                                                      checked={
-                                                                                          !!filter.optionalInFunnel
-                                                                                      }
-                                                                                      onChange={(checked) => {
-                                                                                          updateFilterOptional({
-                                                                                              ...filter,
-                                                                                              optionalInFunnel: checked,
-                                                                                              index,
-                                                                                          })
-                                                                                      }}
-                                                                                      label="Optional step"
-                                                                                  />
-                                                                              </div>
-                                                                          </Tooltip>
-                                                                          <LemonDivider />
-                                                                      </>
-                                                                  ),
-                                                              },
-                                                          ]
-                                                        : []),
-                                                    ...(!hideRename
-                                                        ? [
-                                                              {
-                                                                  label: () => renameRowButton,
-                                                              },
-                                                          ]
-                                                        : []),
-                                                    ...(!hideDuplicate && !singleFilter
-                                                        ? [
-                                                              {
-                                                                  label: () => duplicateRowButton,
-                                                              },
-                                                          ]
-                                                        : []),
-                                                    ...(!hideDeleteBtn && !singleFilter
-                                                        ? [
-                                                              {
-                                                                  label: () => deleteButton,
-                                                              },
-                                                          ]
-                                                        : []),
-                                                ]}
-                                            >
-                                                <LemonButton
-                                                    size="medium"
-                                                    aria-label="Show more actions"
-                                                    data-attr={`more-button-${index}`}
-                                                    icon={<IconEllipsis />}
-                                                    noPadding
-                                                />
-                                            </LemonMenu>
-                                            <LemonBadge
-                                                position="top-right"
-                                                size="small"
-                                                visible={isFunnelContext && (math != null || isStepOptional(index + 1))}
-                                            />
-                                        </div>
+                                        <ActionFilterRowMenu
+                                            index={index}
+                                            isTrendsContext={isTrendsContext}
+                                            isFunnelContext={isFunnelContext}
+                                            isStepOptional={isStepOptional}
+                                            math={math}
+                                            mathGroupTypeIndex={mathGroupTypeIndex}
+                                            mathAvailability={mathAvailability}
+                                            trendsDisplayCategory={trendsDisplayCategory}
+                                            readOnly={readOnly}
+                                            query={query || {}}
+                                            filter={filter}
+                                            hideRename={!!hideRename}
+                                            hideDuplicate={hideDuplicate}
+                                            hideDeleteBtn={hideDeleteBtn}
+                                            singleFilter={!!singleFilter}
+                                            onMathSelect={onMathSelect}
+                                            onUpdateOptional={(checked) => {
+                                                updateFilterOptional({
+                                                    ...filter,
+                                                    optionalInFunnel: checked,
+                                                    index,
+                                                })
+                                            }}
+                                            renameRowButton={renameRowButton}
+                                            duplicateRowButton={duplicateRowButton}
+                                            deleteButton={deleteButton}
+                                        />
                                     </>
                                 ) : (
                                     rowEndElements

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -552,7 +552,6 @@ export function ActionFilterRow({
                                                         TaxonomicFilterGroupType.NumericalEventProperties,
                                                         TaxonomicFilterGroupType.SessionProperties,
                                                         TaxonomicFilterGroupType.PersonProperties,
-                                                        TaxonomicFilterGroupType.DataWarehousePersonProperties,
                                                     ]}
                                                     value={mathProperty || undefined}
                                                     onChange={(currentValue, groupType) =>

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRowMenu.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRowMenu.tsx
@@ -21,7 +21,7 @@ interface ActionFilterRowMenuProps {
     mathAvailability: MathAvailability
     trendsDisplayCategory: ChartDisplayCategory | null
     readOnly: boolean
-    query: Record<string, unknown>
+    query: Record<string, any>
     filter: { optionalInFunnel?: boolean }
     hideRename: boolean
     hideDuplicate: boolean
@@ -62,6 +62,58 @@ export function ActionFilterRowMenu({
         <div onClick={() => setIsMenuVisible(false)}>{element}</div>
     )
 
+    const menuItems: JSX.Element[] = []
+
+    // MathSelector for funnels only (trends shows it inline)
+    if (isFunnelContext) {
+        menuItems.push(
+            <>
+                <MathSelector
+                    math={math}
+                    mathGroupTypeIndex={mathGroupTypeIndex}
+                    index={index}
+                    onMathSelect={onMathSelect}
+                    disabled={readOnly}
+                    style={{ maxWidth: '100%', width: 'initial' }}
+                    mathAvailability={mathAvailability}
+                    trendsDisplayCategory={trendsDisplayCategory}
+                    query={query}
+                />
+                <LemonDivider />
+            </>
+        )
+    }
+
+    // Optional step checkbox for funnels only
+    if (isFunnelContext && index > 0) {
+        menuItems.push(
+            <>
+                <Tooltip title="Optional steps show conversion rates from the last mandatory step, but are not necessary to move to the next step in the funnel">
+                    <div className="px-2 py-1">
+                        <LemonCheckbox
+                            checked={!!filter.optionalInFunnel}
+                            onChange={(checked) => onUpdateOptional(checked)}
+                            label="Optional step"
+                        />
+                    </div>
+                </Tooltip>
+                <LemonDivider />
+            </>
+        )
+    }
+
+    if (!hideRename) {
+        menuItems.push(wrapWithClose(renameRowButton))
+    }
+    if (!singleFilter) {
+        if (!hideDuplicate) {
+            menuItems.push(wrapWithClose(duplicateRowButton))
+        }
+        if (!hideDeleteBtn) {
+            menuItems.push(wrapWithClose(deleteButton))
+        }
+    }
+
     return (
         <div className="relative">
             <LemonMenu
@@ -69,78 +121,7 @@ export function ActionFilterRowMenu({
                 visible={isMenuVisible}
                 closeOnClickInside={false}
                 onVisibilityChange={setIsMenuVisible}
-                items={[
-                    // MathSelector for funnels only (trends shows it inline)
-                    ...(isFunnelContext
-                        ? [
-                              {
-                                  label: () => (
-                                      <>
-                                          <MathSelector
-                                              math={math}
-                                              mathGroupTypeIndex={mathGroupTypeIndex}
-                                              index={index}
-                                              onMathSelect={onMathSelect}
-                                              disabled={readOnly}
-                                              style={{
-                                                  maxWidth: '100%',
-                                                  width: 'initial',
-                                              }}
-                                              mathAvailability={mathAvailability}
-                                              trendsDisplayCategory={trendsDisplayCategory}
-                                              query={query}
-                                          />
-                                          <LemonDivider />
-                                      </>
-                                  ),
-                              },
-                          ]
-                        : []),
-                    // Optional step checkbox for funnels only
-                    ...(isFunnelContext && index > 0
-                        ? [
-                              {
-                                  label: () => (
-                                      <>
-                                          <Tooltip title="Optional steps show conversion rates from the last mandatory step, but are not necessary to move to the next step in the funnel">
-                                              <div className="px-2 py-1">
-                                                  <LemonCheckbox
-                                                      checked={!!filter.optionalInFunnel}
-                                                      onChange={(checked) => {
-                                                          onUpdateOptional(checked)
-                                                      }}
-                                                      label="Optional step"
-                                                  />
-                                              </div>
-                                          </Tooltip>
-                                          <LemonDivider />
-                                      </>
-                                  ),
-                              },
-                          ]
-                        : []),
-                    ...(!hideRename
-                        ? [
-                              {
-                                  label: () => wrapWithClose(renameRowButton),
-                              },
-                          ]
-                        : []),
-                    ...(!hideDuplicate && !singleFilter
-                        ? [
-                              {
-                                  label: () => wrapWithClose(duplicateRowButton),
-                              },
-                          ]
-                        : []),
-                    ...(!hideDeleteBtn && !singleFilter
-                        ? [
-                              {
-                                  label: () => wrapWithClose(deleteButton),
-                              },
-                          ]
-                        : []),
-                ]}
+                items={menuItems.map((el) => ({ label: () => el }))}
             >
                 <LemonButton
                     size="medium"

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRowMenu.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRowMenu.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react'
+
+import { IconEllipsis } from '@posthog/icons'
+import { LemonBadge, LemonCheckbox, LemonDivider, LemonMenu } from '@posthog/lemon-ui'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { ChartDisplayCategory } from '~/types'
+
+import { MathSelector } from './MathSelector'
+import { MathAvailability } from './types'
+
+interface ActionFilterRowMenuProps {
+    index: number
+    isTrendsContext: boolean
+    isFunnelContext: boolean
+    isStepOptional: (step: number) => boolean
+    math?: string
+    mathGroupTypeIndex?: number | null
+    mathAvailability: MathAvailability
+    trendsDisplayCategory: ChartDisplayCategory | null
+    readOnly: boolean
+    query: Record<string, unknown>
+    filter: { optionalInFunnel?: boolean }
+    hideRename: boolean
+    hideDuplicate: boolean
+    hideDeleteBtn: boolean
+    singleFilter: boolean
+    onMathSelect: (index: number, value: string | undefined) => void
+    onUpdateOptional: (checked: boolean) => void
+    renameRowButton: JSX.Element
+    duplicateRowButton: JSX.Element
+    deleteButton: JSX.Element
+}
+
+export function ActionFilterRowMenu({
+    index,
+    isTrendsContext,
+    isFunnelContext,
+    isStepOptional,
+    math,
+    mathGroupTypeIndex,
+    mathAvailability,
+    trendsDisplayCategory,
+    readOnly,
+    query,
+    filter,
+    hideRename,
+    hideDuplicate,
+    hideDeleteBtn,
+    singleFilter,
+    onMathSelect,
+    onUpdateOptional,
+    renameRowButton,
+    duplicateRowButton,
+    deleteButton,
+}: ActionFilterRowMenuProps): JSX.Element {
+    const [isMenuVisible, setIsMenuVisible] = useState(false)
+
+    const wrapWithClose = (element: JSX.Element): JSX.Element => (
+        <div onClick={() => setIsMenuVisible(false)}>{element}</div>
+    )
+
+    return (
+        <div className="relative">
+            <LemonMenu
+                placement={isTrendsContext ? 'bottom-end' : 'bottom-start'}
+                visible={isMenuVisible}
+                closeOnClickInside={false}
+                onVisibilityChange={setIsMenuVisible}
+                items={[
+                    // MathSelector for funnels only (trends shows it inline)
+                    ...(isFunnelContext
+                        ? [
+                              {
+                                  label: () => (
+                                      <>
+                                          <MathSelector
+                                              math={math}
+                                              mathGroupTypeIndex={mathGroupTypeIndex}
+                                              index={index}
+                                              onMathSelect={onMathSelect}
+                                              disabled={readOnly}
+                                              style={{
+                                                  maxWidth: '100%',
+                                                  width: 'initial',
+                                              }}
+                                              mathAvailability={mathAvailability}
+                                              trendsDisplayCategory={trendsDisplayCategory}
+                                              query={query}
+                                          />
+                                          <LemonDivider />
+                                      </>
+                                  ),
+                              },
+                          ]
+                        : []),
+                    // Optional step checkbox for funnels only
+                    ...(isFunnelContext && index > 0
+                        ? [
+                              {
+                                  label: () => (
+                                      <>
+                                          <Tooltip title="Optional steps show conversion rates from the last mandatory step, but are not necessary to move to the next step in the funnel">
+                                              <div className="px-2 py-1">
+                                                  <LemonCheckbox
+                                                      checked={!!filter.optionalInFunnel}
+                                                      onChange={(checked) => {
+                                                          onUpdateOptional(checked)
+                                                      }}
+                                                      label="Optional step"
+                                                  />
+                                              </div>
+                                          </Tooltip>
+                                          <LemonDivider />
+                                      </>
+                                  ),
+                              },
+                          ]
+                        : []),
+                    ...(!hideRename
+                        ? [
+                              {
+                                  label: () => wrapWithClose(renameRowButton),
+                              },
+                          ]
+                        : []),
+                    ...(!hideDuplicate && !singleFilter
+                        ? [
+                              {
+                                  label: () => wrapWithClose(duplicateRowButton),
+                              },
+                          ]
+                        : []),
+                    ...(!hideDeleteBtn && !singleFilter
+                        ? [
+                              {
+                                  label: () => wrapWithClose(deleteButton),
+                              },
+                          ]
+                        : []),
+                ]}
+            >
+                <LemonButton
+                    size="medium"
+                    aria-label="Show more actions"
+                    data-attr={`more-button-${index}`}
+                    icon={<IconEllipsis />}
+                    noPadding
+                />
+            </LemonMenu>
+            <LemonBadge
+                position="top-right"
+                size="small"
+                visible={isFunnelContext && (math != null || isStepOptional(index + 1))}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRowMenu.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRowMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 
 import { IconEllipsis } from '@posthog/icons'
 import { LemonBadge, LemonCheckbox, LemonDivider, LemonMenu } from '@posthog/lemon-ui'
@@ -67,7 +67,7 @@ export function ActionFilterRowMenu({
     // MathSelector for funnels only (trends shows it inline)
     if (isFunnelContext) {
         menuItems.push(
-            <>
+            <React.Fragment key="math-selector">
                 <MathSelector
                     math={math}
                     mathGroupTypeIndex={mathGroupTypeIndex}
@@ -80,14 +80,14 @@ export function ActionFilterRowMenu({
                     query={query}
                 />
                 <LemonDivider />
-            </>
+            </React.Fragment>
         )
     }
 
     // Optional step checkbox for funnels only
     if (isFunnelContext && index > 0) {
         menuItems.push(
-            <>
+            <React.Fragment key="optional-step">
                 <Tooltip title="Optional steps show conversion rates from the last mandatory step, but are not necessary to move to the next step in the funnel">
                     <div className="px-2 py-1">
                         <LemonCheckbox
@@ -98,7 +98,7 @@ export function ActionFilterRowMenu({
                     </div>
                 </Tooltip>
                 <LemonDivider />
-            </>
+            </React.Fragment>
         )
     }
 


### PR DESCRIPTION
## Problem

Continuation of the ActionFilterRow refactoring (#52165). The inline LemonMenu popup for the ellipsis menu (funnel optional step, math selector, rename/duplicate/delete, badge) was ~100 lines of deeply nested JSX inside the main component.

## Changes

Extracts the popup menu into a focused `ActionFilterRowMenu` component. Menu visibility state and close-on-action behavior are managed inside the new component. Also tightens `any` types in the props interface.

ActionFilterRow.tsx: 855 → 778 lines.

## How did you test this code?

Tests came first in #52131 — 98 tests all pass including dedicated funnel popup menu tests (menu contents, optional step checkbox, math selector in menu, menu close on action).

No behavioral changes — pure structural extraction.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no