### PR TITLE
chore(llma): pin pyod to exact version 2.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dependencies = [
     "psycopg[binary]==3.2.4",
     "pyarrow==18.1.0",
     "pydantic~=2.12.0",
-    "pyod~=2.0.0",
+    "pyod==2.0.7",
     "pyjwt~=2.10.0",
     "pymssql==2.3.5",
     "pymysql==1.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -5325,7 +5325,7 @@ requires-dist = [
     { name = "pymongo", specifier = "==4.13.2" },
     { name = "pymssql", specifier = "==2.3.5" },
     { name = "pymysql", specifier = "==1.1.1" },
-    { name = "pyod", specifier = "~=2.0.0" },
+    { name = "pyod", specifier = "==2.0.7" },
     { name = "pyroscope-io", specifier = "~=0.8.8" },
     { name = "python-dateutil", specifier = "~=2.9.0" },
     { name = "python-snappy", specifier = "~=0.7.3" },


### PR DESCRIPTION
## Summary

- Pin `pyod` from `~=2.0.0` (any 2.0.x) to `==2.0.7` (exact version) to reduce supply chain risk
- Prevents unexpected updates from introducing breaking changes or compromised releases
- No functional changes — this is the version already resolved in `uv.lock`

## Test plan

- [ ] CI passes (no dependency changes, just pinning the already-used version)

https://claude.ai/code/session_01CvGbTcpoTE6WAWhcKuBzDP