### PR TITLE
feat(experiments): throttle metric queries with rolling concurrency limit

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -1021,45 +1021,26 @@ describe('experimentLogic', () => {
     })
 
     describe('getDisplayOrderedIndices', () => {
-        it('returns identity order when orderedUuids is null', () => {
-            const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }]
-            expect(getDisplayOrderedIndices(metrics, null)).toEqual([0, 1, 2])
-        })
-
-        it('returns identity order when orderedUuids is undefined', () => {
-            const metrics = [{ uuid: 'a' }, { uuid: 'b' }]
-            expect(getDisplayOrderedIndices(metrics, undefined)).toEqual([0, 1])
-        })
-
-        it('returns identity order when orderedUuids is empty', () => {
-            const metrics = [{ uuid: 'a' }, { uuid: 'b' }]
-            expect(getDisplayOrderedIndices(metrics, [])).toEqual([0, 1])
-        })
-
-        it('reorders indices according to orderedUuids', () => {
-            const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }]
-            expect(getDisplayOrderedIndices(metrics, ['c', 'a', 'b'])).toEqual([2, 0, 1])
-        })
-
-        it('appends metrics missing from orderedUuids at the end', () => {
-            const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }, { uuid: 'd' }]
-            expect(getDisplayOrderedIndices(metrics, ['c', 'a'])).toEqual([2, 0, 1, 3])
-        })
-
-        it('ignores orderedUuids entries not present in metrics', () => {
-            const metrics = [{ uuid: 'a' }, { uuid: 'b' }]
-            expect(getDisplayOrderedIndices(metrics, ['x', 'b', 'y', 'a'])).toEqual([1, 0])
-        })
-
-        it('handles metrics without uuids', () => {
-            const metrics = [{ uuid: 'a' }, {}, { uuid: 'c' }]
-            expect(getDisplayOrderedIndices(metrics, ['c', 'a'])).toEqual([2, 0, 1])
+        it.each([
+            ['null orderedUuids — identity order', [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }], null, [0, 1, 2]],
+            ['undefined orderedUuids — identity order', [{ uuid: 'a' }, { uuid: 'b' }], undefined, [0, 1]],
+            ['empty orderedUuids — identity order', [{ uuid: 'a' }, { uuid: 'b' }], [], [0, 1]],
+            ['reorders by orderedUuids', [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }], ['c', 'a', 'b'], [2, 0, 1]],
+            [
+                'appends missing metrics at end',
+                [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }, { uuid: 'd' }],
+                ['c', 'a'],
+                [2, 0, 1, 3],
+            ],
+            ['ignores uuids not in metrics', [{ uuid: 'a' }, { uuid: 'b' }], ['x', 'b', 'y', 'a'], [1, 0]],
+            ['handles metrics without uuids', [{ uuid: 'a' }, {}, { uuid: 'c' }], ['c', 'a'], [2, 0, 1]],
+        ])('%s', (_desc, metrics, orderedUuids, expected) => {
+            expect(getDisplayOrderedIndices(metrics, orderedUuids)).toEqual(expected)
         })
 
         it('returns all indices exactly once', () => {
             const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }, { uuid: 'd' }, { uuid: 'e' }]
-            const result = getDisplayOrderedIndices(metrics, ['d', 'b'])
-            expect(result.sort()).toEqual([0, 1, 2, 3, 4])
+            expect(getDisplayOrderedIndices(metrics, ['d', 'b']).sort()).toEqual([0, 1, 2, 3, 4])
         })
     })
 })

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -13,7 +13,7 @@ import { Breakdown, ExperimentMetric, ExperimentMetricType, NodeKind } from '~/q
 import { initKeaTests } from '~/test/init'
 import { Experiment } from '~/types'
 
-import { ExperimentSavedMetric, ExperimentWarning, experimentLogic } from './experimentLogic'
+import { ExperimentSavedMetric, ExperimentWarning, experimentLogic, getDisplayOrderedIndices } from './experimentLogic'
 
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
     lemonToast: {
@@ -1017,6 +1017,49 @@ describe('experimentLogic', () => {
         ])('$desc → $expected', ({ overrides, expected }) => {
             logic.actions.setExperiment(createExperiment(overrides))
             expect(logic.values.experimentWarning).toEqual(expected)
+        })
+    })
+
+    describe('getDisplayOrderedIndices', () => {
+        it('returns identity order when orderedUuids is null', () => {
+            const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }]
+            expect(getDisplayOrderedIndices(metrics, null)).toEqual([0, 1, 2])
+        })
+
+        it('returns identity order when orderedUuids is undefined', () => {
+            const metrics = [{ uuid: 'a' }, { uuid: 'b' }]
+            expect(getDisplayOrderedIndices(metrics, undefined)).toEqual([0, 1])
+        })
+
+        it('returns identity order when orderedUuids is empty', () => {
+            const metrics = [{ uuid: 'a' }, { uuid: 'b' }]
+            expect(getDisplayOrderedIndices(metrics, [])).toEqual([0, 1])
+        })
+
+        it('reorders indices according to orderedUuids', () => {
+            const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }]
+            expect(getDisplayOrderedIndices(metrics, ['c', 'a', 'b'])).toEqual([2, 0, 1])
+        })
+
+        it('appends metrics missing from orderedUuids at the end', () => {
+            const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }, { uuid: 'd' }]
+            expect(getDisplayOrderedIndices(metrics, ['c', 'a'])).toEqual([2, 0, 1, 3])
+        })
+
+        it('ignores orderedUuids entries not present in metrics', () => {
+            const metrics = [{ uuid: 'a' }, { uuid: 'b' }]
+            expect(getDisplayOrderedIndices(metrics, ['x', 'b', 'y', 'a'])).toEqual([1, 0])
+        })
+
+        it('handles metrics without uuids', () => {
+            const metrics = [{ uuid: 'a' }, {}, { uuid: 'c' }]
+            expect(getDisplayOrderedIndices(metrics, ['c', 'a'])).toEqual([2, 0, 1])
+        })
+
+        it('returns all indices exactly once', () => {
+            const metrics = [{ uuid: 'a' }, { uuid: 'b' }, { uuid: 'c' }, { uuid: 'd' }, { uuid: 'e' }]
+            const result = getDisplayOrderedIndices(metrics, ['d', 'b'])
+            expect(result.sort()).toEqual([0, 1, 2, 3, 4])
         })
     })
 })

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -14,6 +14,7 @@ import { addProjectIdIfMissing } from 'lib/utils/router-utils'
 import { showApprovalRequiredToast } from 'scenes/approvals/ApprovalRequiredBanner'
 import { dispatchChangeRequestCreated } from 'scenes/approvals/utils'
 import { billingLogic } from 'scenes/billing/billingLogic'
+import { runWithLimit } from 'scenes/dashboard/dashboardUtils'
 import {
     hasMultipleVariantsActive,
     hasZeroRollout,
@@ -195,6 +196,7 @@ interface MetricLoadingConfig {
     isPrimary: boolean
     isRetry: boolean
     metricIndexOffset: number
+    orderedUuids?: string[] | null
     onSetLegacyResults: (
         results: (
             | CachedLegacyExperimentQueryResponse
@@ -267,6 +269,53 @@ function classifyError(
     return 'unknown'
 }
 
+/**
+ * Returns metric indices in display order. Metrics whose UUID appears in
+ * orderedUuids come first (in that order), followed by any remaining metrics
+ * in their original array position. Each entry is the original index into the
+ * metrics array so callers can write results to the correct positional slot.
+ */
+export function getDisplayOrderedIndices(
+    metrics: { uuid?: string }[],
+    orderedUuids: string[] | null | undefined
+): number[] {
+    if (!orderedUuids || orderedUuids.length === 0) {
+        return metrics.map((_, i) => i)
+    }
+
+    const uuidToIndex = new Map<string, number>()
+    for (let i = 0; i < metrics.length; i++) {
+        const uuid = metrics[i].uuid
+        if (uuid) {
+            uuidToIndex.set(uuid, i)
+        }
+    }
+
+    const ordered: number[] = []
+    const seen = new Set<number>()
+
+    for (const uuid of orderedUuids) {
+        const idx = uuidToIndex.get(uuid)
+        if (idx !== undefined && !seen.has(idx)) {
+            ordered.push(idx)
+            seen.add(idx)
+        }
+    }
+
+    for (let i = 0; i < metrics.length; i++) {
+        if (!seen.has(i)) {
+            ordered.push(i)
+        }
+    }
+
+    return ordered
+}
+
+// Max concurrent metric queries to avoid overwhelming the celery queue's
+// per-team concurrency limit (10). Using runWithLimit instead of Promise.all
+// prevents mass rejections and retry churn when experiments have many metrics.
+const METRIC_QUERY_CONCURRENCY_LIMIT = 10
+
 const loadMetrics = async ({
     metrics,
     experimentId,
@@ -276,6 +325,7 @@ const loadMetrics = async ({
     isPrimary,
     isRetry,
     metricIndexOffset,
+    orderedUuids,
     onSetLegacyResults,
     onSetResults,
     onSetErrors,
@@ -294,11 +344,16 @@ const loadMetrics = async ({
     let erroredCount = 0
     let cachedCount = 0
 
-    await Promise.all(
-        metrics.map(async (metric, index) => {
+    // Build tasks in display order so higher-priority metrics get dispatched first,
+    // but each task writes to its original index so the UI stays consistent.
+    const displayOrder = getDisplayOrderedIndices(metrics, orderedUuids)
+
+    const tasks = displayOrder.map((originalIndex) => {
+        const metric = metrics[originalIndex]
+        return async (): Promise<void> => {
             let response: any = null
             const startTime = performance.now()
-            const metricIndex = metricIndexOffset + index
+            const metricIndex = metricIndexOffset + originalIndex
             const metricKind = metric.kind || 'unknown'
 
             try {
@@ -332,17 +387,17 @@ const loadMetrics = async ({
                     const typedResponse = convertToTypedExperimentResponse(response as CachedExperimentQueryResponse)
                     if (typedResponse) {
                         if (isLegacyExperimentResponse(typedResponse)) {
-                            legacyResults[index] = {
+                            legacyResults[originalIndex] = {
                                 ...typedResponse,
                                 fakeInsightId: Math.random().toString(36).substring(2, 15),
                             } as CachedLegacyExperimentQueryResponse & { fakeInsightId: string }
                         } else if (isNewExperimentResponse(typedResponse)) {
-                            results[index] = typedResponse
+                            results[originalIndex] = typedResponse
                         }
                     }
                 } else {
                     // For trends/funnels queries, keep original response
-                    legacyResults[index] = {
+                    legacyResults[originalIndex] = {
                         ...response,
                         fakeInsightId: Math.random().toString(36).substring(2, 15),
                     } as (CachedExperimentTrendsQueryResponse | CachedExperimentFunnelsQueryResponse) & {
@@ -386,7 +441,7 @@ const loadMetrics = async ({
                 const queryId = response?.query_status?.id || error.queryId || null
                 const errorType = classifyError(errorDetail, errorMessage, errorCode, statusCode)
 
-                currentErrors[index] = {
+                currentErrors[originalIndex] = {
                     detail: errorDetail,
                     statusCode,
                     hasDiagnostics,
@@ -426,12 +481,14 @@ const loadMetrics = async ({
                     status_code: statusCode,
                 })
 
-                legacyResults[index] = null
+                legacyResults[originalIndex] = null
                 onSetLegacyResults([...legacyResults])
                 onSetResults([...results])
             }
-        })
-    )
+        }
+    })
+
+    await runWithLimit(tasks, METRIC_QUERY_CONCURRENCY_LIMIT)
 
     return { successfulCount, erroredCount, cachedCount }
 }
@@ -1934,6 +1991,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 isPrimary: true,
                 isRetry: false,
                 metricIndexOffset: 0,
+                orderedUuids: values.experiment?.primary_metrics_ordered_uuids,
                 onSetLegacyResults: actions.setLegacyPrimaryMetricsResults,
                 onSetResults: actions.setPrimaryMetricsResults,
                 onSetErrors: actions.setPrimaryMetricsResultsErrors,
@@ -1972,6 +2030,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 isPrimary: false,
                 isRetry: false,
                 metricIndexOffset: 0,
+                orderedUuids: values.experiment?.secondary_metrics_ordered_uuids,
                 onSetLegacyResults: actions.setLegacySecondaryMetricsResults,
                 onSetResults: actions.setSecondaryMetricsResults,
                 onSetErrors: actions.setSecondaryMetricsResultsErrors,


### PR DESCRIPTION
## Problem

Experiments fire all metric queries (sometimes up to 50) simultaneously via `Promise.all`. Each query goes through Celery's `process_query_task`, which has a per-team concurrency limit of 10 slots (Redis sorted set, no waiting queue). When all 50 hit at once, 40 get `ConcurrencyLimitExceeded` and enter a retry loop with exponential backoff. Meanwhile, the frontend's 606-second polling timeout ticks from when `pollForResults` starts - not from when Celery actually executes the query - so retried queries burn through most of their timeout budget just waiting to be accepted.

## Changes

Replace `Promise.all(metrics.map(...))` with `runWithLimit(tasks, 10)` - a rolling window concurrency limiter already used by dashboards (`dashboardUtils.ts`). It dispatches up to 10 queries at a time and starts the next one as soon as any finishes.

Tasks are built in display order (using `primary_metrics_ordered_uuids` / `secondary_metrics_ordered_uuids`), so the metrics the user sees first are queried first. Each task captures its original array index and writes results back to that position, so ordering is purely a dispatch concern - no arrays are reordered.

Added `getDisplayOrderedIndices` helper with 8 tests covering reordering, missing UUIDs, metrics without UUIDs, and the all-indices-exactly-once invariant.

## How did you test this code?

All 44 experiment tests pass (36 existing + 8 new for `getDisplayOrderedIndices`).