### PR TITLE
fix(cdp): normalize github destination repo values

### DIFF
--- a/frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx
@@ -6,6 +6,7 @@ import { LemonInputSelect, LemonInputSelectOption } from '@posthog/lemon-ui'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { githubIntegrationLogic } from './githubIntegrationLogic'
+import { normalizeGitHubRepositoryValue } from './githubUtils'
 
 export type GitHubRepositoryPickerProps = {
     integrationId: number
@@ -23,7 +24,7 @@ export const GitHubRepositoryPicker = ({
     return (
         <LemonInputSelect
             onChange={(val) => onChange?.(val[0] ?? null)}
-            value={value ? [value] : []}
+            value={value ? [normalizeGitHubRepositoryValue(value) ?? value] : []}
             mode="single"
             data-attr="select-github-repository"
             placeholder="Select a repository..."
@@ -58,7 +59,7 @@ export function useRepositories(integrationId: number): { options: LemonInputSel
         loadRepositories()
     }, [loadRepositories])
 
-    const options = useMemo(() => repositories.map((r) => ({ key: r.full_name, label: r.full_name })), [repositories])
+    const options = useMemo(() => repositories.map((r) => ({ key: r.name, label: r.full_name })), [repositories])
 
     return { options, loading: repositoriesLoading }
 }

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -15,6 +15,7 @@ import { IconBranch } from 'lib/lemon-ui/icons'
 
 import { CyclotronJobInputSchemaType, IntegrationType } from '~/types'
 
+import { getGitHubInstallationSettingsUrl } from './githubUtils'
 import { integrationsLogic } from './integrationsLogic'
 
 export function IntegrationView({
@@ -39,6 +40,7 @@ export function IntegrationView({
     const isGitHub = integration.kind === 'github'
     const repositories = isGitHub ? getGitHubRepositories(integration.id) : []
     const refreshedAtTimestamp = integration.config?.refreshed_at || null
+    const githubInstallationUrl = isGitHub ? getGitHubInstallationSettingsUrl(integration.config) : null
 
     useEffect(() => {
         if (isGitHub) {
@@ -116,12 +118,8 @@ export function IntegrationView({
                                         type="secondary"
                                         icon={<IconGear />}
                                         onClick={() => {
-                                            const installationId = integration.config?.installation_id
-                                            if (installationId) {
-                                                window.open(
-                                                    `https://github.com/settings/installations/${installationId}`,
-                                                    '_blank'
-                                                )
+                                            if (githubInstallationUrl) {
+                                                window.open(githubInstallationUrl, '_blank')
                                             }
                                         }}
                                         tooltip="Manage repository access on GitHub"
@@ -138,12 +136,8 @@ export function IntegrationView({
                                         type="secondary"
                                         icon={<IconGear />}
                                         onClick={() => {
-                                            const installationId = integration.config?.installation_id
-                                            if (installationId) {
-                                                window.open(
-                                                    `https://github.com/settings/installations/${installationId}`,
-                                                    '_blank'
-                                                )
+                                            if (githubInstallationUrl) {
+                                                window.open(githubInstallationUrl, '_blank')
                                             }
                                         }}
                                         tooltip="Configure repository access"

--- a/frontend/src/lib/integrations/githubUtils.test.ts
+++ b/frontend/src/lib/integrations/githubUtils.test.ts
@@ -1,0 +1,39 @@
+import { getGitHubInstallationSettingsUrl, normalizeGitHubRepositoryValue } from './githubUtils'
+
+describe('githubUtils', () => {
+    describe('getGitHubInstallationSettingsUrl', () => {
+        it('builds the organization-scoped installation URL for org installations', () => {
+            expect(
+                getGitHubInstallationSettingsUrl({
+                    installation_id: '115652094',
+                    account: {
+                        type: 'Organization',
+                        name: 'peakcloudoy',
+                    },
+                })
+            ).toEqual('https://github.com/organizations/peakcloudoy/settings/installations/115652094')
+        })
+
+        it('falls back to the user installation URL for non-org installations', () => {
+            expect(
+                getGitHubInstallationSettingsUrl({
+                    installation_id: '115652094',
+                    account: {
+                        type: 'User',
+                        name: 'masa',
+                    },
+                })
+            ).toEqual('https://github.com/settings/installations/115652094')
+        })
+    })
+
+    describe('normalizeGitHubRepositoryValue', () => {
+        it('keeps plain repository names unchanged', () => {
+            expect(normalizeGitHubRepositoryValue('posthog')).toEqual('posthog')
+        })
+
+        it('extracts the repository name from a legacy owner/repo value', () => {
+            expect(normalizeGitHubRepositoryValue('PostHog/posthog')).toEqual('posthog')
+        })
+    })
+})

--- a/frontend/src/lib/integrations/githubUtils.ts
+++ b/frontend/src/lib/integrations/githubUtils.ts
@@ -1,0 +1,32 @@
+type GitHubInstallationConfig = {
+    installation_id?: string | number | null
+    account?: {
+        type?: string | null
+        name?: string | null
+    } | null
+} | null
+
+export function getGitHubInstallationSettingsUrl(config?: GitHubInstallationConfig): string | null {
+    const installationId = config?.installation_id
+    if (!installationId) {
+        return null
+    }
+
+    const accountType = config?.account?.type
+    const accountName = config?.account?.name
+
+    if (accountType === 'Organization' && accountName) {
+        return `https://github.com/organizations/${encodeURIComponent(accountName)}/settings/installations/${installationId}`
+    }
+
+    return `https://github.com/settings/installations/${installationId}`
+}
+
+export function normalizeGitHubRepositoryValue(value?: string | null): string | null {
+    if (!value) {
+        return null
+    }
+
+    const repositoryParts = value.split('/', 2)
+    return repositoryParts.length === 2 ? repositoryParts[1] : value
+}

--- a/nodejs/src/cdp/templates/_destinations/github/github.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/github/github.template.test.ts
@@ -1,0 +1,52 @@
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './github.template'
+
+describe('github template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('uses the integration owner when the repository input is just the repo name', async () => {
+        const response = await tester.invoke({
+            github_installation: {
+                account: {
+                    name: 'PostHog',
+                },
+                access_token: 'github-token',
+            },
+            repository: 'posthog',
+            title: 'Issue title',
+            description: 'Issue description',
+            posthog_issue_id: 'issue-123',
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchObject({
+            url: 'https://api.github.com/repos/PostHog/posthog/issues',
+        })
+    })
+
+    it('uses the owner from a legacy owner/repo repository value', async () => {
+        const response = await tester.invoke({
+            github_installation: {
+                account: {
+                    name: 'PostHog',
+                },
+                access_token: 'github-token',
+            },
+            repository: 'peakcloudoy/varaus',
+            title: 'Issue title',
+            description: 'Issue description',
+            posthog_issue_id: 'issue-123',
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toEqual(false)
+        expect(response.invocation.queueParameters).toMatchObject({
+            url: 'https://api.github.com/repos/peakcloudoy/varaus/issues',
+        })
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/github/github.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/github/github.template.ts
@@ -12,6 +12,12 @@ export const template: HogFunctionTemplate = {
     code_language: 'hog',
     code: `let owner := inputs.github_installation.account.name
 let repo := inputs.repository
+let repositoryParts := splitByString('/', inputs.repository, 2)
+
+if (length(repositoryParts) = 2) {
+    owner := repositoryParts[1]
+    repo := repositoryParts[2]
+}
 
 if (not owner) {
     throw Error('Owner is required')

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2187,9 +2187,10 @@ class GitHubIntegration:
 
         org = self.organization()
         access_token = self.integration.sensitive_config["access_token"]
+        repository_path = repository if "/" in repository else f"{org}/{repository}"
 
         response = requests.post(
-            f"https://api.github.com/repos/{org}/{repository}/issues",
+            f"https://api.github.com/repos/{repository_path}/issues",
             json={"title": title, "body": body},
             headers={
                 "Accept": "application/vnd.github+json",

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -788,6 +788,44 @@ class TestGitHubIntegrationModel(BaseTest):
         assert repos == []
         assert mock_get.call_count == 2
 
+    @patch("posthog.models.integration.requests.post")
+    def test_create_issue_accepts_plain_repository_name(self, mock_post):
+        integration = self.create_integration(
+            {"installation_id": "INSTALL", "account": {"name": "PostHog"}},
+            {"access_token": "ACCESS_TOKEN"},
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"number": 123}
+        mock_post.return_value = mock_response
+
+        response = GitHubIntegration(integration).create_issue(
+            {"title": "Issue title", "body": "Issue body", "repository": "posthog"}
+        )
+
+        assert response == {"number": 123, "repository": "posthog"}
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == "https://api.github.com/repos/PostHog/posthog/issues"
+
+    @patch("posthog.models.integration.requests.post")
+    def test_create_issue_accepts_legacy_owner_repo_repository_value(self, mock_post):
+        integration = self.create_integration(
+            {"installation_id": "INSTALL", "account": {"name": "PostHog"}},
+            {"access_token": "ACCESS_TOKEN"},
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"number": 123}
+        mock_post.return_value = mock_response
+
+        response = GitHubIntegration(integration).create_issue(
+            {"title": "Issue title", "body": "Issue body", "repository": "peakcloudoy/varaus"}
+        )
+
+        assert response == {"number": 123, "repository": "peakcloudoy/varaus"}
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == "https://api.github.com/repos/peakcloudoy/varaus/issues"
+
 
 class TestDatabricksIntegrationModel(BaseTest):
     @patch("posthog.models.integration.socket.socket")


### PR DESCRIPTION
## Problem

GitHub issue destinations were saving repository selections as `owner/repo`, but the runtime expected just `repo`. That caused duplicated owner paths and 404s when creating issues. Organization installs were also linking to the wrong GitHub settings URL.

Related ticket: https://posthoghelp.zendesk.com/agent/tickets/53265 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55476)

## Changes

- store GitHub repository selections canonically while still showing `owner/repo` in the picker
- keep legacy saved `owner/repo` values working in both execution paths
- send organization installs to the correct GitHub settings URL
- add focused regression coverage for repository normalization and installation URL generation

## How did you test this code?

- `pytest posthog/models/test/test_integration_model.py -k "create_issue_accepts or list_repositories"`
- `pnpm --filter=@posthog/frontend exec jest --runInBand --watchman=false src/lib/integrations/githubUtils.test.ts`
- added `nodejs/src/cdp/templates/_destinations/github/github.template.test.ts`
- I could not run the new nodejs Jest test locally because the available Node runtime does not match the compiled `re2` native module in this environment

## Publish to changelog?

no

## Docs update

No docs update needed.
