### PR TITLE
fix(hogql): null comparisons

### DIFF
--- a/common/hogql_parser/HogQLLexer.h
+++ b/common/hogql_parser/HogQLLexer.h
@@ -89,7 +89,7 @@ public:
           /* consume to EOL or EOF */
           while (true) {
               ch = _input->LA(i);
-              if (ch == 0 || ch == '\n' || ch == '\r')
+              if (ch <= 0 || ch == '\n' || ch == '\r')
                   break;
               ++i;
           }

--- a/common/hogql_parser/package.json
+++ b/common/hogql_parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogql-parser",
-    "version": "1.3.32",
+    "version": "1.3.34",
     "description": "WebAssembly HogQL Parser - Parse HogQL queries in JavaScript/TypeScript",
     "keywords": [
         "antlr4",

--- a/common/hogql_parser/parser_json.cpp
+++ b/common/hogql_parser/parser_json.cpp
@@ -1770,7 +1770,7 @@ class HogQLParseTreeJSONConverter : public HogQLParserBaseVisitor {
     null_constant["value"] = nullptr;
     json["right"] = std::move(null_constant);
     json["op"] = ctx->NOT() ? "!=" : "==";
-    json["null_comparison_style"] = "is";
+    json["is_null_comparison_style"] = true;
     return json;
   }
 

--- a/common/hogql_parser/parser_json.cpp
+++ b/common/hogql_parser/parser_json.cpp
@@ -1770,6 +1770,7 @@ class HogQLParseTreeJSONConverter : public HogQLParserBaseVisitor {
     null_constant["value"] = nullptr;
     json["right"] = std::move(null_constant);
     json["op"] = ctx->NOT() ? "!=" : "==";
+    json["null_comparison_style"] = "is";
     return json;
   }
 

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.32",
+    version="1.3.33",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.33",
+    version="1.3.34",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
         "@posthog/docs-onboarding": "workspace:*",
         "@posthog/esbuilder": "workspace:*",
         "@posthog/hedgehog-mode": "^0.0.48",
-        "@posthog/hogql-parser": "1.3.32",
+        "@posthog/hogql-parser": "1.3.34",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "^0.36.6",
         "@posthog/mosaic": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,8 +587,8 @@ importers:
         specifier: ^0.0.48
         version: 0.0.48(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/hogql-parser':
-        specifier: 1.3.32
-        version: 1.3.32
+        specifier: 1.3.34
+        version: 1.3.34
       '@posthog/hogvm':
         specifier: workspace:*
         version: link:../common/hogvm/typescript
@@ -8106,8 +8106,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/hogql-parser@1.3.32':
-    resolution: {integrity: sha512-vE0ppfD9DkJtIQmfMZM6Rkl2GevQSUBg8X8tsqGOGuYXdMTTY34GFYx0Y6HgNYJcBUGC4DqgxiypChN+osRkjw==}
+  '@posthog/hogql-parser@1.3.34':
+    resolution: {integrity: sha512-1v/ExDG+HrG2940IyPcOQLbwkxQ4EzUO7hueT+m4QoBnIc0PFeUO2g20lLD0/t5qDHQffAZ5QaZkw7/nIDDhCQ==}
 
   '@posthog/icons@0.36.4':
     resolution: {integrity: sha512-xnusbGNz/5vSMUWdEViWuai7D/gxiMZSDDnP6s/acndMqzN+W4asPUgUNnTUps7OyAS1IKaO9zxhdikFrtooJA==}
@@ -29401,7 +29401,7 @@ snapshots:
     transitivePeerDependencies:
       - prop-types
 
-  '@posthog/hogql-parser@1.3.32': {}
+  '@posthog/hogql-parser@1.3.34': {}
 
   '@posthog/icons@0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -789,7 +789,7 @@ class CompareOperation(Expr):
     right: Expr
     op: CompareOperationOp
     type: Optional[ConstantType] = None
-    null_comparison_style: Literal["is"] | None = None
+    is_null_comparison_style: bool = False
 
 
 @dataclass(kw_only=True)

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -789,7 +789,7 @@ class CompareOperation(Expr):
     right: Expr
     op: CompareOperationOp
     type: Optional[ConstantType] = None
-    is_null_comparison_style: bool = False
+    is_null_comparison_style: Optional[bool] = None
 
 
 @dataclass(kw_only=True)

--- a/posthog/hogql/ast.py
+++ b/posthog/hogql/ast.py
@@ -789,6 +789,7 @@ class CompareOperation(Expr):
     right: Expr
     op: CompareOperationOp
     type: Optional[ConstantType] = None
+    null_comparison_style: Literal["is"] | None = None
 
 
 @dataclass(kw_only=True)

--- a/posthog/hogql/grammar/HogQLLexer.cpp.g4
+++ b/posthog/hogql/grammar/HogQLLexer.cpp.g4
@@ -30,7 +30,7 @@ void skipWsAndComments(std::size_t& i) {
         /* consume to EOL or EOF */
         while (true) {
             ch = _input->LA(i);
-            if (ch == 0 || ch == '\n' || ch == '\r')
+            if (ch <= 0 || ch == '\n' || ch == '\r')
                 break;
             ++i;
         }

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -1066,7 +1066,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
             left=self.visit(ctx.columnExpr()),
             right=ast.Constant(value=None),
             op=ast.CompareOperationOp.NotEq if ctx.NOT() else ast.CompareOperationOp.Eq,
-            null_comparison_style="is",
+            is_null_comparison_style=True,
         )
 
     def visitColumnExprIsDistinctFrom(self, ctx: HogQLParser.ColumnExprIsDistinctFromContext):

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -1066,6 +1066,7 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
             left=self.visit(ctx.columnExpr()),
             right=ast.Constant(value=None),
             op=ast.CompareOperationOp.NotEq if ctx.NOT() else ast.CompareOperationOp.Eq,
+            null_comparison_style="is",
         )
 
     def visitColumnExprIsDistinctFrom(self, ctx: HogQLParser.ColumnExprIsDistinctFromContext):

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -222,6 +222,15 @@ class PostgresPrinter(HogQLPrinter):
         else:
             right = self.visit(node.right)
 
+        if (
+            node.null_comparison_style == "is"
+            and isinstance(node.right, ast.Constant)
+            and node.right.value is None
+            and node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.NotEq)
+        ):
+            not_kw = " NOT" if node.op == ast.CompareOperationOp.NotEq else ""
+            return f"({left} IS{not_kw} NULL)"
+
         return self._get_compare_op(node.op, left, right)
 
     def _get_compare_op(self, op: ast.CompareOperationOp, left: str, right: str) -> str:

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -223,7 +223,7 @@ class PostgresPrinter(HogQLPrinter):
             right = self.visit(node.right)
 
         if (
-            node.null_comparison_style == "is"
+            node.is_null_comparison_style
             and isinstance(node.right, ast.Constant)
             and node.right.value is None
             and node.op in (ast.CompareOperationOp.Eq, ast.CompareOperationOp.NotEq)

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4442,11 +4442,16 @@ class TestPostgresPrinter(BaseTest):
             dialect,
         )[0]
 
-    def test_null_comparisons_in_postgres(self):
-        self.assertEqual(self._expr("event is null"), "(events.event IS NULL)")
-        self.assertEqual(self._expr("event is not null"), "(events.event IS NOT NULL)")
-        self.assertEqual(self._expr("event = null"), "(events.event = NULL)")
-        self.assertEqual(self._expr("event != null"), "(events.event != NULL)")
+    @parameterized.expand(
+        [
+            ("is_null", "event is null", "(events.event IS NULL)"),
+            ("is_not_null", "event is not null", "(events.event IS NOT NULL)"),
+            ("eq_null", "event = null", "(events.event = NULL)"),
+            ("neq_null", "event != null", "(events.event != NULL)"),
+        ]
+    )
+    def test_null_comparisons_in_postgres(self, _name: str, expr: str, expected: str):
+        self.assertEqual(self._expr(expr), expected)
 
     @parameterized.expand(
         [

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4442,6 +4442,12 @@ class TestPostgresPrinter(BaseTest):
             dialect,
         )[0]
 
+    def test_null_comparisons_in_postgres(self):
+        self.assertEqual(self._expr("event is null"), "(events.event IS NULL)")
+        self.assertEqual(self._expr("event is not null"), "(events.event IS NOT NULL)")
+        self.assertEqual(self._expr("event = null"), "(events.event = NULL)")
+        self.assertEqual(self._expr("event != null"), "(events.event != NULL)")
+
     @parameterized.expand(
         [
             (

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -635,7 +635,7 @@ def parser_test_factory(backend: HogQLParserBackend):
                     left=ast.Constant(value=1),
                     right=ast.Constant(value=None),
                     op=ast.CompareOperationOp.Eq,
-                    null_comparison_style="is",
+                    is_null_comparison_style=True,
                 ),
             )
             self.assertEqual(
@@ -644,7 +644,7 @@ def parser_test_factory(backend: HogQLParserBackend):
                     left=ast.Constant(value=1),
                     right=ast.Constant(value=None),
                     op=ast.CompareOperationOp.NotEq,
-                    null_comparison_style="is",
+                    is_null_comparison_style=True,
                 ),
             )
 

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -635,6 +635,7 @@ def parser_test_factory(backend: HogQLParserBackend):
                     left=ast.Constant(value=1),
                     right=ast.Constant(value=None),
                     op=ast.CompareOperationOp.Eq,
+                    null_comparison_style="is",
                 ),
             )
             self.assertEqual(
@@ -643,6 +644,7 @@ def parser_test_factory(backend: HogQLParserBackend):
                     left=ast.Constant(value=1),
                     right=ast.Constant(value=None),
                     op=ast.CompareOperationOp.NotEq,
+                    null_comparison_style="is",
                 ),
             )
 

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -541,6 +541,7 @@ class CloningVisitor(Visitor[Any]):
             left=self.visit(node.left),
             right=self.visit(node.right),
             op=node.op,
+            null_comparison_style=node.null_comparison_style,
         )
 
     def visit_not(self, node: ast.Not):

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -541,7 +541,7 @@ class CloningVisitor(Visitor[Any]):
             left=self.visit(node.left),
             right=self.visit(node.right),
             op=node.op,
-            null_comparison_style=node.null_comparison_style,
+            is_null_comparison_style=node.is_null_comparison_style,
         )
 
     def visit_not(self, node: ast.Not):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "grimp==3.13",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.32",
+    "hogql-parser==1.3.34",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",
     "kafka-python==2.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2894,14 +2894,14 @@ wheels = [
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.32"
+version = "1.3.34"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/bc/4dc786fd500d82640f25721d27167636c86dc1796e78fb88525c009b7e54/hogql_parser-1.3.32.tar.gz", hash = "sha256:2874520348752251bdb38bd65063626caaa5732f6fd917820cb3ac08df1d774c", size = 85924, upload-time = "2026-03-24T08:47:56.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c5/260320b7b5653cd9d341fe6ac4a63cc730cc06cf95c158f5d1f3c243f4a4/hogql_parser-1.3.34.tar.gz", hash = "sha256:245ff247af61871a0918a37589c40b481bc814d4ca837b263baf992fb1bd0c2e", size = 85924, upload-time = "2026-03-25T09:24:03.838Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/1a/5c17453e0df08f2259bfae3cd365536c4b0f4b8d8c81d1898807b5ba5567/hogql_parser-1.3.32-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2a10050230c64842338bba10e0acf02d22f233b6be57b451e260d966f54ab8aa", size = 646380, upload-time = "2026-03-24T08:47:40.601Z" },
-    { url = "https://files.pythonhosted.org/packages/58/e0/b11fbdb8c3c74a76ec2b9021a8452810380578ce701046e7020857811604/hogql_parser-1.3.32-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:ab0aa02b1be12e9b42d98d0098acdad903bfd99eb0281cd9b4756bf60e93b4ea", size = 651502, upload-time = "2026-03-24T08:47:42.561Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a2/87f49afbd49e0da7988b1e533e41ee8352b7f5091374a7b38790cd70ee22/hogql_parser-1.3.32-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1c9745ccd1ace3b99a4b0460f595f7a0cc5edc482a51574099ed54061465dea3", size = 4874979, upload-time = "2026-03-24T08:47:44.57Z" },
-    { url = "https://files.pythonhosted.org/packages/98/35/51ba6726b28be74443bdabac7c0ef62038fcc83259be56ec00ad379658eb/hogql_parser-1.3.32-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2845187d0201e143fa9bd7edc6bd9c228500a22a9252d21ebe0f7a681bf30075", size = 4984092, upload-time = "2026-03-24T08:47:46.876Z" },
+    { url = "https://files.pythonhosted.org/packages/30/35/6d5a0ec3ff77ad4dcc9f98ac85e770c760503b7da38b6c4efe5b2e8556d5/hogql_parser-1.3.34-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d51d548e983419ef5f03ef102bd1f582ad7596120f9af20be195b0f8c385352f", size = 646329, upload-time = "2026-03-25T09:23:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/93/5115a94326d525651a6d689f48e03dcae40c7677da41b947b5742f6ac0d6/hogql_parser-1.3.34-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:11834d039be10c589453733b1d38baf26a61a1c5a4d5b2f5183dcbb14d5ba7f1", size = 651591, upload-time = "2026-03-25T09:23:50.738Z" },
+    { url = "https://files.pythonhosted.org/packages/50/7a/de2a468aa8343465ed2c7fb2f32dd97c0ce820cf24dd0732e592782d69cd/hogql_parser-1.3.34-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e5168f4e65481207f990f5289a0be1c20d1892b3b16807f68c897864f37c4f7f", size = 4875400, upload-time = "2026-03-25T09:23:52.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/23/93ba23fac7f48f068f8b7e80834753ab1fb4615fe89954a9ddd7280b39fa/hogql_parser-1.3.34-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:41a1922049b9a57d37f33027c48fccc167e9b8c12c5425af55544fdf4ab75a30", size = 4984882, upload-time = "2026-03-25T09:23:55.257Z" },
 ]
 
 [[package]]
@@ -5271,7 +5271,7 @@ requires-dist = [
     { name = "grimp", specifier = "==3.13" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.32" },
+    { name = "hogql-parser", specifier = "==1.3.34" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },
     { name = "kafka-python", specifier = "==2.3.0" },


### PR DESCRIPTION
## Problem

Postgres printer currently converts `IS [NOT] NULL` into `= NULL / != NULL`. These are not equivalent, `IS [NOT] NULL` must be preserved, while other `= / !=` comparisons should remain unchanged.

## Changes

Preserve null-comparison style in AST from both parsers.

## How did you test this code?

Unit tests

## Publish to changelog?

No