### PR TITLE
fix(subscriptions): add dashboard relation to exported asset query

### DIFF
--- a/posthog/temporal/subscriptions/activities.py
+++ b/posthog/temporal/subscriptions/activities.py
@@ -162,7 +162,7 @@ async def deliver_subscription(inputs: DeliverSubscriptionInputs) -> None:
     assets_by_id = await database_sync_to_async(
         lambda: {
             a.id: a
-            for a in ExportedAsset.objects_including_ttl_deleted.select_related("insight").filter(
+            for a in ExportedAsset.objects_including_ttl_deleted.select_related("insight", "dashboard").filter(
                 pk__in=inputs.exported_asset_ids
             )
         },


### PR DESCRIPTION
## Problem

After merging the [subscription flow refactor](https://github.com/PostHog/posthog/pull/51649) I noticed that a subset of our subscriptions started to fail. After inspecting the stack trace in temporal ([example](https://cloud.temporal.io/namespaces/posthog-prod-eu.usz2o/workflows/process-subscription-3270/019d2434-5c6e-7da2-8845-cff54b3f8526/timeline)), it turned out that the Slack `deliver_subscription` path has a call chain which invokes the dashboard. E.g.: `_block_for_asset` calls `asset.get_public_content_url()` → `self.filename` → `self.dashboard`, and as a result Django tries a lazy FK load, which is forbidden in an async context.

This PR fixes it by lazy loading the dashboard as well so that it no longer needs to do the lazy FK load.

## Changes

Added "dashboard" to the select_related call so it's eagerly loaded with the initial query, avoiding the lazy load entirely.

## How did you test this code?

:white_check_mark: CI is passing

## Publish to changelog?

No

## Docs update

No