### PR TITLE
fix(phrocs): reset stdin in pipe fallback to prevent fd 0 closure

### DIFF
--- a/tools/phrocs/internal/process/proc.go
+++ b/tools/phrocs/internal/process/proc.go
@@ -353,6 +353,11 @@ func (p *Process) startWithPipe(cmd *exec.Cmd, send func(tea.Msg)) error {
 	// before failing. For the pipe path we only need Setpgid so Stop() can
 	// kill the full process tree via Kill(-pid, SIGTERM).
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// pty.Start also sets Stdin/Stdout/Stderr to the (now-closed) tty slave.
+	// Reset them so the child gets /dev/null for stdin and our pipe for output.
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
 
 	pr, pw, err := os.Pipe()
 	if err != nil {


### PR DESCRIPTION
## Problem

`celery-worker`  exited for me with `exit 0`. No errors, just a clean exit. Had Claude churn on the problem for a bit and found this issue. It's likely related to my terminal setup (kitty + zellij). Anyways, Claude think there still should be a fallback path that works here, and that the fix is legit.

When `pty.Start()` fails, phrocs falls back to `startWithPipe`. The fallback resets `SysProcAttr` and reassigns `Stdout`/`Stderr` to the pipe, but never resets `Stdin` — which still references the now-closed PTY slave file. The closed file's `Fd()` returns `-1`, which Go's `forkExec` interprets as "close fd 0 in the child".

This causes Python child processes to start with `sys.stdin = None`, which silently breaks celery's click-based CLI: `worker_main()` returns `None` instead of blocking, and the process exits with code 0 without ever starting the worker.

## Changes

Reset `cmd.Stdin`, `cmd.Stdout`, and `cmd.Stderr` to `nil` at the top of `startWithPipe`, before assigning the pipe. This ensures the child gets `/dev/null` for stdin and the pipe for output.

## Testing

1. `hogli start --phrocs`
2. Verify celery-worker reaches `ready` state and shows the celery banner + "Connected to redis" in logs