### PR TITLE
fix(trends): do not prefix empty formula nodes

### DIFF
--- a/frontend/src/scenes/insights/summarizeInsight.test.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.test.ts
@@ -243,6 +243,30 @@ describe('summarizing insights', () => {
             expect(result).toEqual('(A + B) / 100 on A. Pageview unique users & B. Random action count')
         })
 
+        it('does not prefix with an empty formula node label', () => {
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [
+                    {
+                        kind: NodeKind.EventsNode,
+                        event: '$pageview',
+                        name: '$pageview',
+                        math: BaseMathType.TotalCount,
+                    },
+                ],
+                trendsFilter: {
+                    formulaNodes: [{ formula: '', custom_name: '' }],
+                },
+            }
+
+            const result = summarizeInsight(
+                { kind: NodeKind.InsightVizNode, source: query } as InsightVizNode,
+                summaryContext
+            )
+
+            expect(result).toEqual('Pageview count')
+        })
+
         it('summarizes a user-based Funnels insight with 3 steps', () => {
             const query: FunnelsQuery = {
                 kind: NodeKind.FunnelsQuery,

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -152,8 +152,14 @@ export function summarizeInsightQuery(query: InsightQueryNode, context: SummaryC
             summary = `${query.trendsFilter.formula} on ${summary}`
         }
         if (query.trendsFilter?.formulaNodes) {
-            const formulas = query.trendsFilter?.formulaNodes.map((node) => node.custom_name || node.formula).join(', ')
-            summary = `${formulas} on ${summary}`
+            const formulas = query.trendsFilter.formulaNodes
+                .map((node) => node.custom_name?.trim() || node.formula?.trim())
+                .filter((formula): formula is string => !!formula)
+                .join(', ')
+
+            if (formulas) {
+                summary = `${formulas} on ${summary}`
+            }
         }
 
         return summary


### PR DESCRIPTION
## Problem

Trends insights with empty formula nodes would show up as " on Pageview count" in the UI.

## Changes

Ignores empty formula nodes when deriving the name from the query.

## How did you test this code?

Verified behaviour manually before and after this change