### PR TITLE
chore(cli): bump version to 0.7.4

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.7.4
+
+- fix: create per-UUID ZIP for dSYM uploads
+
 # 0.7.3
 
 - feat: enable symbol set compression

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.7.3"
+version = "0.7.4"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",


### PR DESCRIPTION
## Problem

The CLI needs a new release to include the per-UUID ZIP fix for dSYM uploads (#52067).

## Changes

- Bump CLI version from 0.7.3 to 0.7.4
- Add changelog entry for the dSYM per-UUID ZIP fix

## How did you test this code?

Version bump only, no logic changes.

## Publish to changelog?

no