### PR TITLE
feat(funnels): add extended person properties support to correlated properties

### DIFF
--- a/frontend/src/lib/components/PropertySelect/PropertySelect.stories.tsx
+++ b/frontend/src/lib/components/PropertySelect/PropertySelect.stories.tsx
@@ -32,7 +32,9 @@ const meta: Meta<typeof PropertySelect> = {
 }
 export default meta
 
-const Template: StoryFn<typeof PropertySelect> = (props: Partial<PropertySelectProps>) => {
+const Template: StoryFn<typeof PropertySelect> = (
+    props: Partial<Omit<PropertySelectProps, 'taxonomicFilterGroup' | 'taxonomicFilterGroups'>>
+) => {
     const [selectedProperties, setSelectProperties] = useState<string[]>([
         '$initial_geoip_postal_code',
         '$initial_geoip_latitude',

--- a/frontend/src/lib/components/PropertySelect/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertySelect/PropertySelect.tsx
@@ -18,7 +18,8 @@ export interface PropertySelectProps {
     onChange: (names: string[]) => void
     selectedProperties: string[]
     sortable?: boolean
-    taxonomicFilterGroup: TaxonomicFilterGroupType.PersonProperties | TaxonomicFilterGroupType.EventProperties
+    taxonomicFilterGroup?: TaxonomicFilterGroupType.PersonProperties | TaxonomicFilterGroupType.EventProperties
+    taxonomicFilterGroups?: TaxonomicFilterGroupType[]
     disabledReason?: string | null
 }
 
@@ -56,10 +57,12 @@ export const PropertySelect = ({
     addText,
     sortable = false,
     taxonomicFilterGroup,
+    taxonomicFilterGroups,
     disabledReason,
 }: PropertySelectProps): JSX.Element => {
     const [open, setOpen] = useState<boolean>(false)
     const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 1 } }))
+    const resolvedTaxonomicFilterGroups = taxonomicFilterGroups ?? (taxonomicFilterGroup ? [taxonomicFilterGroup] : [])
 
     const handleChange = (name: string): void => {
         onChange(Array.from(new Set(selectedProperties.concat([name]))))
@@ -121,7 +124,7 @@ export const PropertySelect = ({
                                 handleChange(value as string)
                                 setOpen(false)
                             }}
-                            taxonomicGroupTypes={[taxonomicFilterGroup]}
+                            taxonomicGroupTypes={resolvedTaxonomicFilterGroups}
                         />
                     }
                 >

--- a/frontend/src/lib/components/PropertySelect/PropertySelect.tsx
+++ b/frontend/src/lib/components/PropertySelect/PropertySelect.tsx
@@ -13,15 +13,25 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
 import { Popover } from 'lib/lemon-ui/Popover/Popover'
 
-export interface PropertySelectProps {
+type PropertySelectBaseProps = {
     addText: string
     onChange: (names: string[]) => void
     selectedProperties: string[]
     sortable?: boolean
-    taxonomicFilterGroup?: TaxonomicFilterGroupType.PersonProperties | TaxonomicFilterGroupType.EventProperties
-    taxonomicFilterGroups?: TaxonomicFilterGroupType[]
     disabledReason?: string | null
 }
+
+export type PropertySelectProps = PropertySelectBaseProps &
+    (
+        | {
+              taxonomicFilterGroup: TaxonomicFilterGroupType.PersonProperties | TaxonomicFilterGroupType.EventProperties
+              taxonomicFilterGroups?: never
+          }
+        | {
+              taxonomicFilterGroups: TaxonomicFilterGroupType[]
+              taxonomicFilterGroup?: never
+          }
+    )
 
 const SortableProperty = ({
     name,

--- a/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
@@ -151,7 +151,10 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
                                 overlay={
                                     <div className="p-4">
                                         <PropertySelect
-                                            taxonomicFilterGroup={TaxonomicFilterGroupType.PersonProperties}
+                                            taxonomicFilterGroups={[
+                                                TaxonomicFilterGroupType.PersonProperties,
+                                                TaxonomicFilterGroupType.DataWarehousePersonProperties,
+                                            ]}
                                             onChange={setPropertyNames}
                                             selectedProperties={
                                                 propertyNames.length === 1 && propertyNames[0] === '$all'

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -661,6 +661,81 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             10,
         )
 
+    @freeze_time("2019-12-31")
+    def test_funnel_correlation_with_extended_person_property_name(self):
+        filters = {
+            "events": [
+                {"id": "user signed up", "type": "events", "order": 0},
+                {"id": "paid", "type": "events", "order": 1},
+            ],
+            "insight": INSIGHT_FUNNELS,
+            "date_from": "2020-01-01",
+            "date_to": "2020-01-14",
+            "funnel_correlation_type": "properties",
+        }
+
+        for i in range(3):
+            _create_person(
+                distinct_ids=[f"dw_user_success_{i}"],
+                team_id=self.team.pk,
+                properties={"customer_profile.plan": "enterprise"},
+            )
+            _create_event(
+                team=self.team,
+                event="user signed up",
+                distinct_id=f"dw_user_success_{i}",
+                timestamp="2020-01-02T14:00:00Z",
+            )
+            _create_event(
+                team=self.team,
+                event="paid",
+                distinct_id=f"dw_user_success_{i}",
+                timestamp="2020-01-04T14:00:00Z",
+            )
+
+        for i in range(3):
+            _create_person(
+                distinct_ids=[f"dw_user_dropoff_{i}"],
+                team_id=self.team.pk,
+                properties={"customer_profile.plan": "free"},
+            )
+            _create_event(
+                team=self.team,
+                event="user signed up",
+                distinct_id=f"dw_user_dropoff_{i}",
+                timestamp="2020-01-02T14:00:00Z",
+            )
+
+        result, _ = self._get_events_for_filters(
+            filters,
+            funnelCorrelationType=FunnelCorrelationResultsType.PROPERTIES,
+            funnelCorrelationNames=["customer_profile.plan"],
+        )
+
+        correlation_rows = {
+            row["event"]: {k: v for k, v in row.items() if k != "odds_ratio"}
+            for row in result
+            if row["event"] != "$overall"
+        }
+
+        self.assertEqual(
+            correlation_rows,
+            {
+                "customer_profile.plan::enterprise": {
+                    "event": "customer_profile.plan::enterprise",
+                    "success_count": 3,
+                    "failure_count": 0,
+                    "correlation_type": "success",
+                },
+                "customer_profile.plan::free": {
+                    "event": "customer_profile.plan::free",
+                    "success_count": 0,
+                    "failure_count": 3,
+                    "correlation_type": "failure",
+                },
+            },
+        )
+
     # TODO: Delete this test when moved to person-on-events
     @also_test_with_materialized_columns(
         event_properties=[], person_properties=["$browser"], verify_no_jsonextract=False


### PR DESCRIPTION
## Problem

Correlated properties of funnel insights did not support extended person properties.

## Changes

Now they do.

## How did you test this code?

Tried with a local example:

![Screenshot 2026-03-25 at 11.33.07.png](https://app.graphite.com/user-attachments/assets/9b57a4c3-f79a-4826-ba75-3e26f6558f9f.png)

