### PR TITLE
feat(logs): add logs-saved-views feature flag and integrate into API and frontend

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -337,6 +337,7 @@ export const FEATURE_FLAGS = {
     LOGS_SETTINGS_RETENTION: 'logs-settings-retention', // owner: #team-logs
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
+    LOGS_SAVED_VIEWS: 'logs-saved-views', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
     MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics

--- a/products/logs/backend/test/test_views_api.py
+++ b/products/logs/backend/test/test_views_api.py
@@ -1,4 +1,5 @@
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -15,6 +16,9 @@ class TestLogsViewAPI(APIBaseTest):
     def setUp(self):
         super().setUp()
         self.base_url = f"/api/environments/{self.team.pk}/logs/views/"
+        self._ff_patcher = patch("posthoganalytics.feature_enabled", return_value=True)
+        self._ff_patcher.start()
+        self.addCleanup(self._ff_patcher.stop)
 
     def _valid_payload(self, **overrides) -> dict:
         defaults = {
@@ -194,6 +198,13 @@ class TestLogsViewAPI(APIBaseTest):
         client = APIClient()
         response = client.get(self.base_url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    # --- Feature flag ---
+
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_returns_403_when_feature_flag_disabled(self, _mock_feature_enabled):
+        response = self.client.get(self.base_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     # --- Pinned ---
 

--- a/products/logs/backend/views_api.py
+++ b/products/logs/backend/views_api.py
@@ -5,6 +5,7 @@ from rest_framework import serializers, viewsets
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.permissions import PostHogFeatureFlagPermission
 
 from products.logs.backend.models import LogsView
 
@@ -49,6 +50,8 @@ class LogsViewViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     queryset = LogsView.objects.all().order_by("-created_at")
     serializer_class = LogsViewSerializer
     lookup_field = "short_id"
+    posthog_feature_flag = "logs-saved-views"
+    permission_classes = [PostHogFeatureFlagPermission]
 
     def safely_get_queryset(self, queryset: Any) -> Any:
         queryset = queryset.filter(team_id=self.team_id)

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconBookmark, IconGear } from '@posthog/icons'
+import { IconGear } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTabs } from '@posthog/lemon-ui'
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -15,8 +15,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
-import { logsViewsListLogic } from 'products/logs/frontend/components/LogsViews/logsViewsListLogic'
-import { SavedViewsModal } from 'products/logs/frontend/components/LogsViews/SavedViewsModal'
+import { SavedViewsButton } from 'products/logs/frontend/components/LogsViews/SavedViewsButton'
 import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPrompt/logsIngestionLogic'
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 
@@ -57,6 +56,7 @@ const LogsSceneContent = (): JSX.Element => {
                 actions={
                     <>
                         {hasLogs && <LogsSceneFeedbackButton />}
+                        <SavedViewsButton id={tabId} />
                         <LemonButton size="small" type="secondary" icon={<IconGear />} onClick={openLogsSettings}>
                             Settings
                         </LemonButton>
@@ -89,7 +89,6 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const { tabId, activeTab } = useValues(logsSceneLogic)
     const { setActiveTab } = useActions(logsSceneLogic)
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
-    const { openModal } = useActions(logsViewsListLogic({ id: tabId }))
 
     return (
         <>
@@ -101,13 +100,10 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 actions={
                     <>
                         {hasLogs && <LogsSceneFeedbackButton />}
-                        <LemonButton size="small" type="secondary" icon={<IconBookmark />} onClick={openModal}>
-                            Saved views
-                        </LemonButton>
+                        <SavedViewsButton id={tabId} />
                     </>
                 }
             />
-            <SavedViewsModal id={tabId} />
             {teamHasLogsCheckFailed && (
                 <LemonBanner
                     type="info"

--- a/products/logs/frontend/components/LogsViews/SavedViewsButton.tsx
+++ b/products/logs/frontend/components/LogsViews/SavedViewsButton.tsx
@@ -1,0 +1,33 @@
+import { useActions } from 'kea'
+
+import { IconBookmark } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+
+import { logsViewsListLogic } from './logsViewsListLogic'
+import { LogsViewsLogicProps } from './logsViewsLogic'
+import { SavedViewsModal } from './SavedViewsModal'
+
+function SavedViewsButtonInner({ id }: LogsViewsLogicProps): JSX.Element {
+    const { openModal } = useActions(logsViewsListLogic({ id }))
+
+    return (
+        <>
+            <LemonButton size="small" type="secondary" icon={<IconBookmark />} onClick={openModal}>
+                Saved views
+            </LemonButton>
+            <SavedViewsModal id={id} />
+        </>
+    )
+}
+
+export function SavedViewsButton({ id }: LogsViewsLogicProps): JSX.Element | null {
+    const enabled = useFeatureFlag('LOGS_SAVED_VIEWS')
+
+    if (!enabled) {
+        return null
+    }
+
+    return <SavedViewsButtonInner id={id} />
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Saved views were gated behind the logs-tabbed-view feature flag meaning it couldn't be rolled out seperately.

## Changes

Gates the saved views feature behind it's own feature flag so it can be rolled out independently of the tabbed view feature.

- adds a feature flag
- protects frontend and api with the feature flag

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- updated unit tests & manual ui testing

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->