### PR TITLE
fix: Prevent 'slow' tasks from increasing queue depth in temporal

### DIFF
--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -109,8 +109,8 @@ async def create_schedule_all_subscriptions_schedule(client: Client):
         ),
         spec=ScheduleSpec(cron_expressions=["55 * * * *"]),  # Run at minute 55 of every hour
         # ALLOW_ALL: if a previous run is still executing, start the new one anyway.
-        # Safe because child workflows use idempotent IDs (process-subscription-{id})
-        # so Temporal rejects duplicate starts for the same subscription.
+        # Safe because child workflows use deterministic IDs (process-subscription-{id})
+        # and Temporal guarantees no two open workflows can share the same ID.
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
     )
 

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -14,6 +14,8 @@ from temporalio.client import (
     ScheduleAlreadyRunningError,
     ScheduleCalendarSpec,
     ScheduleIntervalSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
     ScheduleRange,
     ScheduleSpec,
 )
@@ -106,6 +108,10 @@ async def create_schedule_all_subscriptions_schedule(client: Client):
             task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
         ),
         spec=ScheduleSpec(cron_expressions=["55 * * * *"]),  # Run at minute 55 of every hour
+        # ALLOW_ALL: if a previous run is still executing, start the new one anyway.
+        # Safe because child workflows use idempotent IDs (process-subscription-{id})
+        # so Temporal rejects duplicate starts for the same subscription.
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
     )
 
     if await a_schedule_exists(client, "schedule-all-subscriptions-schedule"):

--- a/posthog/temporal/subscriptions/workflows.py
+++ b/posthog/temporal/subscriptions/workflows.py
@@ -6,7 +6,7 @@ import traceback
 
 import temporalio.common
 import temporalio.workflow
-from temporalio.exceptions import ActivityError, ApplicationError
+from temporalio.exceptions import ActivityError, ApplicationError, WorkflowAlreadyStartedError
 
 from posthog.event_usage import EventSource
 from posthog.slo.types import SloOutcome
@@ -132,9 +132,9 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
         )
 
         # Fan-out child workflows — one per subscription, fully isolated.
-        # Idempotent ID (no run_id suffix) prevents duplicate deliveries when
-        # schedule runs overlap: if the previous run's child is still executing,
-        # Temporal rejects the duplicate start and we log it below.
+        # Deterministic ID (no run_id suffix) prevents duplicate deliveries when
+        # schedule runs overlap: Temporal guarantees no two open workflows can
+        # share the same ID, so a still-running child rejects the duplicate start.
         tasks = []
         for sub_id in subscription_ids:
             task = temporalio.workflow.execute_child_workflow(
@@ -153,11 +153,19 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
             failed_ids = []
             for sub_id, result in zip(subscription_ids, results):
                 if isinstance(result, BaseException):
-                    failed_ids.append(sub_id)
-                    temporalio.workflow.logger.warning(
-                        "process_subscription.child_workflow_error",
-                        extra={"subscription_id": sub_id, "error": str(result)},
-                    )
+                    if isinstance(result, WorkflowAlreadyStartedError):
+                        # A previous schedule run's child is still processing this
+                        # subscription — not a failure, just skip it.
+                        temporalio.workflow.logger.info(
+                            "process_subscription.already_running",
+                            extra={"subscription_id": sub_id},
+                        )
+                    else:
+                        failed_ids.append(sub_id)
+                        temporalio.workflow.logger.warning(
+                            "process_subscription.child_workflow_error",
+                            extra={"subscription_id": sub_id, "error": str(result)},
+                        )
 
             if failed_ids:
                 raise ApplicationError(


### PR DESCRIPTION
## Problem

The subscription scheduling workflow can encounter issues when a previous run is still executing and a new scheduled run attempts to start. This can lead to scheduling conflicts or missed executions as by default, temporal will "skip" the new workflow if something is already in flight.

[Docs](https://docs.temporal.io/schedule#overlap-policy)

## Changes

Added `ScheduleOverlapPolicy.ALLOW_ALL` to the subscription schedule configuration, allowing new scheduled runs to start even if previous runs are still executing. This is safe because child workflows use idempotent IDs (`process-subscription-{id}`), ensuring Temporal automatically rejects duplicate starts for the same subscription ([docs](https://docs.temporal.io/workflow-execution/workflowid-runid#workflow-id-reuse-policy)).

- This seemed the safest approach to avoid delaying the deliveries for users who are waiting on their subscription "in the new batch" (which is a drawback of the buffered options), whilst giving a lot of additional time to the activities in flight. Additionally cancelling whatever was in flight does not seem right as it means that the subscription won't potentially be picked up until the next delivery date (depending on how we cancel/terminate it), and otherwise it might cause us to do additional work / create infinite loops if a subscription consequently takes >1hr to process, as it would get terminated and then restart from 0 again with the 1hr processing, ad infinitum. 

## How did you test this code?

Will closely monitor post release, and tested ni the UI over here:

[In flight run](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/schedule-all-subscriptions-schedule-2026-03-25T07%3A55%3A00Zv2/019d24c1-3393-784a-a7b0-39779c7e5b5a/timeline)

[New run, ran without issues](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/schedule-all-subscriptions-schedule-2026-03-25T11%3A55%3A00Z/019d24d9-1742-753a-9904-b1c2fb30b7a1/timeline)

## Publish to changelog?

No

## Docs update

No docs update needed for this internal scheduling configuration change.