### PR TITLE
chore: Bump temporalio

### DIFF
--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--server-root-ca-cert",
-            default=settings.TEMPORAL_CLIENT_ROOT_CA,
+            default=None,
             help="Optional root server CA cert",
         )
         parser.add_argument(

--- a/posthog/management/commands/get_temporal_workflow_count.py
+++ b/posthog/management/commands/get_temporal_workflow_count.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--server-root-ca-cert",
-            default=settings.TEMPORAL_CLIENT_ROOT_CA,
+            default=None,
             help="Optional root server CA cert",
         )
         parser.add_argument(

--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -367,7 +367,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--server-root-ca-cert",
-            default=settings.TEMPORAL_CLIENT_ROOT_CA,
+            default=None,
             help="Optional root server CA cert",
         )
         parser.add_argument(

--- a/posthog/management/commands/start_temporal_workflow.py
+++ b/posthog/management/commands/start_temporal_workflow.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--server-root-ca-cert",
-            default=settings.TEMPORAL_CLIENT_ROOT_CA,
+            default=None,
             help="Optional root server CA cert",
         )
         parser.add_argument(

--- a/posthog/temporal/ai/video_segment_clustering/activities/a2_fetch_segments.py
+++ b/posthog/temporal/ai/video_segment_clustering/activities/a2_fetch_segments.py
@@ -91,7 +91,10 @@ async def fetch_segments_activity(inputs: FetchSegmentsActivityInputs) -> FetchS
         )
 
     distinct_ids = list({s.distinct_id for s in segments if s.distinct_id})
-    storage_key = generate_storage_key(inputs.team_id, activity.info().workflow_run_id, name="segments")
+    workflow_run_id = activity.info().workflow_run_id
+    assert workflow_run_id  # Will always be defined if this activity was started by a workflow
+
+    storage_key = generate_storage_key(inputs.team_id, workflow_run_id, name="segments")
     await store_fetch_result(storage_key, segments, distinct_ids)
 
     return FetchSegmentsResult(storage_key=storage_key, document_count=len(segments))

--- a/posthog/temporal/common/client.py
+++ b/posthog/temporal/common/client.py
@@ -17,10 +17,10 @@ async def connect(
     host: str,
     port: int | str,
     namespace: str,
-    server_root_ca_cert: str | None = None,
     client_cert: str | None = None,
     client_key: str | None = None,
     runtime: Runtime | None = None,
+    server_root_ca_cert: str | None = None,
     settings: Any | None = django_settings,
     use_pydantic_converter: bool = False,
 ) -> Client:

--- a/posthog/temporal/common/client.py
+++ b/posthog/temporal/common/client.py
@@ -25,12 +25,14 @@ async def connect(
     use_pydantic_converter: bool = False,
 ) -> Client:
     tls: TLSConfig | bool = False
-    if server_root_ca_cert and client_cert and client_key:
+    if client_cert and client_key:
         tls = TLSConfig(
-            server_root_ca_cert=bytes(server_root_ca_cert, "utf-8"),
             client_cert=bytes(client_cert, "utf-8"),
             client_private_key=bytes(client_key, "utf-8"),
         )
+
+        if server_root_ca_cert:
+            tls.server_root_ca_cert = bytes(server_root_ca_cert, "utf-8")
 
     data_converter = pydantic_data_converter if use_pydantic_converter else temporalio.converter.default()
 
@@ -58,7 +60,6 @@ async def sync_connect() -> Client:
         django_settings.TEMPORAL_HOST,
         django_settings.TEMPORAL_PORT,
         django_settings.TEMPORAL_NAMESPACE,
-        django_settings.TEMPORAL_CLIENT_ROOT_CA,
         django_settings.TEMPORAL_CLIENT_CERT,
         django_settings.TEMPORAL_CLIENT_KEY,
     )
@@ -71,7 +72,6 @@ async def async_connect() -> Client:
         django_settings.TEMPORAL_HOST,
         django_settings.TEMPORAL_PORT,
         django_settings.TEMPORAL_NAMESPACE,
-        django_settings.TEMPORAL_CLIENT_ROOT_CA,
         django_settings.TEMPORAL_CLIENT_CERT,
         django_settings.TEMPORAL_CLIENT_KEY,
     )

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -715,7 +715,7 @@ def configure_default_ssl_context():
     return context
 
 
-def get_temporal_activity_context() -> dict[str, str | int]:
+def get_temporal_activity_context() -> dict[str, str | int | None]:
     """Return activity context variables from Temporal.
 
     More specifically, the context variables coming from Temporal are:
@@ -737,7 +737,7 @@ def get_temporal_activity_context() -> dict[str, str | int]:
     if activity_info is None:
         return {}
 
-    ctx: dict[str, str | int] = {
+    ctx: dict[str, str | int | None] = {
         "activity_id": activity_info.activity_id,
         "activity_type": activity_info.activity_type,
         "attempt": activity_info.attempt,
@@ -751,7 +751,7 @@ def get_temporal_activity_context() -> dict[str, str | int]:
     return ctx
 
 
-def get_temporal_workflow_context() -> dict[str, str | int]:
+def get_temporal_workflow_context() -> dict[str, str | int | None]:
     """Return workflow context variables from Temporal.
 
     More specifically, the context variables coming from Temporal are:
@@ -770,7 +770,7 @@ def get_temporal_workflow_context() -> dict[str, str | int]:
     if workflow_info is None:
         return {}
 
-    ctx: dict[str, str | int] = {
+    ctx: dict[str, str | int | None] = {
         "attempt": workflow_info.attempt,
         "task_queue": workflow_info.task_queue,
         "workflow_id": workflow_info.workflow_id,

--- a/posthog/temporal/common/shutdown.py
+++ b/posthog/temporal/common/shutdown.py
@@ -16,7 +16,13 @@ class WorkerShuttingDownError(Exception):
     """
 
     def __init__(
-        self, activity_id: str, activity_type: str, task_queue: str, attempt: int, workflow_id: str, workflow_type: str
+        self,
+        activity_id: str,
+        activity_type: str,
+        task_queue: str,
+        attempt: int,
+        workflow_id: str | None,
+        workflow_type: str | None,
     ):
         self.activity_id = activity_id
         self.activity_type = activity_type

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -258,9 +258,9 @@ async def create_worker(
         host,
         port,
         namespace,
-        server_root_ca_cert,
-        client_cert,
-        client_key,
+        server_root_ca_cert=server_root_ca_cert,
+        client_cert=client_cert,
+        client_key=client_key,
         runtime=runtime,
         use_pydantic_converter=use_pydantic_converter,
     )

--- a/posthog/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/temporalio.py
@@ -106,7 +106,6 @@ async def _get_temporal_client(config: TemporalIOSourceConfig) -> Client:
         host=config.host,
         port=config.port,
         namespace=config.namespace,
-        server_root_ca_cert=config.server_client_root_ca,
         client_cert=config.client_certificate,
         client_key=config.client_private_key,
         settings=FakeSettings(config.encryption_key)

--- a/posthog/temporal/data_modeling/activities/create_data_modeling_job.py
+++ b/posthog/temporal/data_modeling/activities/create_data_modeling_job.py
@@ -51,6 +51,10 @@ async def create_data_modeling_job_activity(inputs: CreateDataModelingJobInputs)
     workflow_id = activity.info().workflow_id
     workflow_run_id = activity.info().workflow_run_id
 
+    # Will always be defined if this activity was started by a workflow
+    assert workflow_id
+    assert workflow_run_id
+
     job_id = await _create_data_modeling_job(inputs, workflow_id, workflow_run_id)
     await logger.ainfo(f"Created DataModelingJob {job_id} for node {inputs.node_id}")
     return job_id

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -1362,6 +1362,10 @@ async def create_job_model_activity(inputs: CreateJobModelInputs) -> str:
     workflow_id = temporalio.activity.info().workflow_id
     workflow_run_id = temporalio.activity.info().workflow_run_id
 
+    # Will always be defined if this activity was started by a workflow
+    assert workflow_id
+    assert workflow_run_id
+
     if len(inputs.select) != 0:
         label = inputs.select[0].label
         saved_query = await get_saved_query(team, label)

--- a/posthog/temporal/session_replay/session_summary/activities/patterns.py
+++ b/posthog/temporal/session_replay/session_summary/activities/patterns.py
@@ -297,6 +297,8 @@ async def _generate_patterns_assignments(
     # TODO: Replace later by splitting `_generate_patterns_assignments` into separate activity
     temporal_client = await async_connect()
     info = temporalio.activity.info()
+    assert info.workflow_id  # Will always be defined if this activity was started by a workflow
+
     workflow_handle = temporal_client.get_workflow_handle(info.workflow_id, run_id=info.workflow_run_id)
     # Send initial progress
     await workflow_handle.signal("update_pattern_assignments_progress", 0)

--- a/posthog/temporal/tests/conftest.py
+++ b/posthog/temporal/tests/conftest.py
@@ -102,7 +102,6 @@ async def temporal_client():
         settings.TEMPORAL_HOST,
         settings.TEMPORAL_PORT,
         settings.TEMPORAL_NAMESPACE,
-        settings.TEMPORAL_CLIENT_ROOT_CA,
         settings.TEMPORAL_CLIENT_CERT,
         settings.TEMPORAL_CLIENT_KEY,
     )

--- a/posthog/temporal/tests/session_replay/session_summary/test_summarize_session.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_summarize_session.py
@@ -291,7 +291,7 @@ class TestSummarizeSingleSessionStreamWorkflow:
             async with Worker(
                 activity_environment.client,
                 task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
-                workflows=AI_WORKFLOWS + SESSION_SUMMARY_WORKFLOWS,
+                workflows=[*AI_WORKFLOWS, *SESSION_SUMMARY_WORKFLOWS],
                 activities=[stream_llm_single_session_summary_activity, fetch_session_data_activity],
                 workflow_runner=UnsandboxedWorkflowRunner(),
             ) as worker:

--- a/posthog/temporal/tests/session_replay/session_summary/test_summarize_session_group.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_summarize_session_group.py
@@ -1043,7 +1043,7 @@ class TestSummarizeSessionGroupWorkflow:
                 async with Worker(
                     activity_environment.client,
                     task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
-                    workflows=AI_WORKFLOWS + SESSION_SUMMARY_WORKFLOWS,
+                    workflows=[*AI_WORKFLOWS, *SESSION_SUMMARY_WORKFLOWS],
                     activities=[
                         get_llm_single_session_summary_activity,
                         extract_session_group_patterns_activity,

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -682,7 +682,6 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             settings.TEMPORAL_HOST,
             settings.TEMPORAL_PORT,
             settings.TEMPORAL_NAMESPACE,
-            settings.TEMPORAL_CLIENT_ROOT_CA,
             settings.TEMPORAL_CLIENT_CERT,
             settings.TEMPORAL_CLIENT_KEY,
         )

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -761,7 +761,6 @@ async def pause_batch_export_over_failure_threshold(batch_export_id: str) -> boo
         settings.TEMPORAL_HOST,
         settings.TEMPORAL_PORT,
         settings.TEMPORAL_NAMESPACE,
-        settings.TEMPORAL_CLIENT_ROOT_CA,
         settings.TEMPORAL_CLIENT_CERT,
         settings.TEMPORAL_CLIENT_KEY,
     )
@@ -788,7 +787,6 @@ async def cancel_running_backfills(batch_export_id: str) -> int:
         settings.TEMPORAL_HOST,
         settings.TEMPORAL_PORT,
         settings.TEMPORAL_NAMESPACE,
-        settings.TEMPORAL_CLIENT_ROOT_CA,
         settings.TEMPORAL_CLIENT_CERT,
         settings.TEMPORAL_CLIENT_KEY,
     )

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -136,7 +136,6 @@ async def temporal_client():
         settings.TEMPORAL_HOST,
         settings.TEMPORAL_PORT,
         settings.TEMPORAL_NAMESPACE,
-        settings.TEMPORAL_CLIENT_ROOT_CA,
         settings.TEMPORAL_CLIENT_CERT,
         settings.TEMPORAL_CLIENT_KEY,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ dependencies = [
     "statshog==1.0.6",
     "stripe==12.2.0",
     "structlog==25.4.0",
-    "temporalio==1.14.1",
+    "temporalio==1.24.0",
     "tenacity==9.1.2",
     "tiktoken==0.9.*",
     "tldextract~=5.1",

--- a/uv.lock
+++ b/uv.lock
@@ -4071,14 +4071,14 @@ wheels = [
 
 [[package]]
 name = "nexus-rpc"
-version = "1.1.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/66/540687556bd28cf1ec370cc6881456203dfddb9dab047b8979c6865b5984/nexus_rpc-1.1.0.tar.gz", hash = "sha256:d65ad6a2f54f14e53ebe39ee30555eaeb894102437125733fb13034a04a44553", size = 77383, upload-time = "2025-07-07T19:03:58.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/2f/9e9d0dcaa4c6ffa22b7aa31069a8a264c753ff8027b36af602cce038c92f/nexus_rpc-1.1.0-py3-none-any.whl", hash = "sha256:d1b007af2aba186a27e736f8eaae39c03aed05b488084ff6c3d1785c9ba2ad38", size = 27743, upload-time = "2025-07-07T19:03:57.556Z" },
+    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
 ]
 
 [[package]]
@@ -5384,7 +5384,7 @@ requires-dist = [
     { name = "stripe", specifier = "==12.2.0" },
     { name = "structlog", specifier = "==25.4.0" },
     { name = "tbb", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==2022.3.1" },
-    { name = "temporalio", specifier = "==1.14.1" },
+    { name = "temporalio", specifier = "==1.24.0" },
     { name = "tenacity", specifier = "==9.1.2" },
     { name = "tiktoken", specifier = "==0.9.*" },
     { name = "tldextract", specifier = "~=5.1" },
@@ -7258,7 +7258,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.14.1"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -7266,13 +7266,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/23/ef5ed581d26112e21c4a6d4ddc2c4eaa5700c0d70b53b07566553e9b7d90/temporalio-1.14.1.tar.gz", hash = "sha256:b240cf56f64add65beb75bd18aa854ac35bdc2505097af5af1e235d611190a9d", size = 1607639, upload-time = "2025-07-10T20:56:43.485Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b1/7d9b3104ab7994e7d49e765b92495aaff44810b1e066c874c284a93ebd55/temporalio-1.24.0.tar.gz", hash = "sha256:e534e2e71b4a721193ec4ff3dae521146d093554bd47a64f5605d4ca33e56718", size = 2040485, upload-time = "2026-03-23T15:33:33.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/66/6dc4f5a647a9901cf19e012c442173574babdc879ccaf4cb166662a23ef0/temporalio-1.14.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ebde00b59af72e512e5837445e4b5b8aa445431d57a71bbeb57a5ba8a93ac8be", size = 12508009, upload-time = "2025-07-10T20:56:30.653Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dc/654ebcc92c658180576127ac6dc047fab43b7730f39df4439645e91577fb/temporalio-1.14.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:3c21cff8fdc60fbcc9acd91e6c119b0b5f9de7671fe806459f00d68bd4ecae78", size = 12091653, upload-time = "2025-07-10T20:56:33.199Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/58/7fc3a7bde275c059e42d0279c54e8e66642b67be8eda21b31347f4277186/temporalio-1.14.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f984b503ae741213fe71128d6193076f3267691561ff3c55dbe798f92e6ee1b", size = 12451995, upload-time = "2025-07-10T20:56:36.055Z" },
-    { url = "https://files.pythonhosted.org/packages/98/12/14f6a7a1f4aebb7d846469f5c1cd165cce55b793ded6ce5fc315bd83e28f/temporalio-1.14.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:830cb1a820624a5e64f6c874b5aca6ad9eb841295407dd2011074159a2d28bdb", size = 12688904, upload-time = "2025-07-10T20:56:38.501Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/ed/c09f1ca41d5ed9f9a777a0ddd5bc225f8300bab8b42bc6751195566706fb/temporalio-1.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:ad4e6a16b42bb34aebec62fb8bbe8f64643d8268ed6d7db337dfe98a76799bb0", size = 12758696, upload-time = "2025-07-10T20:56:41.266Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/30517c21d6155bce1c3dc0e420db48da0231230dbc683f40ab6d5fe22b37/temporalio-1.24.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7f11e7b4f4d09bafba499b43188353e23dc128b1fe3f3160014476e3dce70760", size = 12223918, upload-time = "2026-03-23T15:33:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d0/11aa103bde794524008c1850a84e06cde98698395ca1f8b12e1bd2390aa8/temporalio-1.24.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:5cff75a0ca922575b808a7fca1b0de38f6eea061f49e026664b8be9d5bb06ab8", size = 11708887, upload-time = "2026-03-23T15:33:11.67Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f4/774b56100e6bb94e3757ec96fb5c2bc62d42defc7d6de0ee35a12273827a/temporalio-1.24.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee7c13b6724dd0c304aa846aecf6da72a8550f4ade40a0a7f6dcc1c92ef35710", size = 12028303, upload-time = "2026-03-23T15:33:18.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/91/c05d0e9c2432fe8b1ea0d6fae321866ee49a320ad5e494e6ec9424ca5c28/temporalio-1.24.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa71b9bfa42f951dd04ade97ce7f92ecedee8903047b4b41b122bb8cbd87a337", size = 12375155, upload-time = "2026-03-23T15:33:24.234Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/97/5c939e4609c164c8690a3b5a135eb828d531de8ef63ff447a2a439c0b0fb/temporalio-1.24.0-cp310-abi3-win_amd64.whl", hash = "sha256:52f6833647eceddbebcc376e2ea663a9f73b2b3a42675f503aeb27c98fd4daeb", size = 12720174, upload-time = "2026-03-23T15:33:30.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

We want tracing in Temporal workers. Temporal now offers a "new approach (recommended)" to do tracing using an `OpenTelemetryPlugin` whereas the old way using an interceptor has been labelled as "legacy approach". However, this plugin is only available in newer versions of the SDK. 

I don't want to implement tracing using some legacy feature that will likely get removed, so let's bump the SDK.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Bump temporalio to 1.24.0.

Remove `server_root_ca_cert` as a default parameter: Starting from sdk version 1.18, the native certificate store is no longer loaded by default when `server_root_ca_cert` is set (see: https://redirect.github.com/temporalio/sdk-core/pull/1007). We need that to validate Temporal Cloud's own server cert, so we remove `server_root_ca_cert`.

Turns out we don't need that setting: We misunderstood `server_root_ca_cert` to mean our own CA cert, when it is in fact the CA cert used to validate the server's certificate (this makes total sense as our root CA cert is already uploaded to the server so that they can verify our own client certs). In previous versions of the sdk all certs were loaded regardless, so everything still worked. 

Anyways, the solution is to just not pass `server_root_ca_cert` ever. So, I've made the default `None` and generally excluded it from calls. Kept the setting around in case we ever decide to self-host our own temporal server and we then will need that.

There is a second breaking change: `activity.info()` can now return certain properties as `None`, like `workflow_id` and `workflow_run_id`. This is because Temporal is gearing up to support activities outside of workflows. We don't care about this feature, but it does mean we need additional assertions wherever we read stuff from `activity.info()`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran unit tests, deployed to dev, ran batch exports in dev. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

no
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
