### PR TITLE
fix: Add optional chaining for `sourceQuery.source`

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -69,7 +69,7 @@ export const variablesLogic = kea<variablesLogicType>([
     })),
     propsChanged(({ props, actions, values }) => {
         if (props.sourceQuery) {
-            const variables = Object.values(props.sourceQuery?.source.variables ?? {})
+            const variables = Object.values(props.sourceQuery?.source?.variables ?? {})
 
             if (variables.length) {
                 variables.forEach((variable) => {
@@ -172,7 +172,7 @@ export const variablesLogic = kea<variablesLogicType>([
     }),
     selectors({
         queryVariableCodeNames: [
-            (s) => [s.editorQuery, (_, props) => props.sourceQuery?.source.query],
+            (s) => [s.editorQuery, (_, props) => props.sourceQuery?.source?.query],
             (editorQuery, sourceQuery): string[] => {
                 const matches = getVariablesFromQuery(editorQuery ?? sourceQuery ?? '')
                 return Array.from(new Set(matches.filter((match): match is string => Boolean(match))))


### PR DESCRIPTION
## Problem

Causing https://us.posthog.com/project/2/error_tracking/019d21d4-f3da-7d73-8c01-bd08f092e33b. It looks like this was introduced in #52054.

I've reproduced this by switching between two SQL editor tabs which are both on the visualization tab, but can't currently explain why exactly it happens (guessing maybe something with Kea mounting/unmounting logics).

## Changes

Add optional chaining as a defensive fix.