### PR TITLE
feat(cymbal): add php frame support

### DIFF
--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         java::RawJavaFrame,
         js::RawJSFrame,
         node::RawNodeFrame,
+        php::RawPHPFrame,
         python::RawPythonFrame,
         ruby::RawRubyFrame,
     },
@@ -43,6 +44,8 @@ pub enum RawFrame {
     JavaScriptNode(RawNodeFrame),
     #[serde(rename = "go")]
     Go(RawGoFrame),
+    #[serde(rename = "php")]
+    Php(RawPHPFrame),
     #[serde(rename = "hermes")]
     Hermes(RawHermesFrame),
     #[serde(rename = "java")]
@@ -84,6 +87,7 @@ impl RawFrame {
                 to_vec(frame.resolve(team_id, catalog, debug_images).await),
                 "apple",
             ),
+            RawFrame::Php(frame) => (to_vec(Ok(frame.into())), "php"),
             RawFrame::Python(frame) => (to_vec(Ok(frame.into())), "python"),
             RawFrame::Ruby(frame) => (to_vec(Ok(frame.into())), "ruby"),
             RawFrame::Custom(frame) => (to_vec(Ok(frame.into())), "custom"),
@@ -142,6 +146,7 @@ impl RawFrame {
             RawFrame::Java(frame) => frame.symbol_set_ref(),
             // Frames with no symbol sets
             RawFrame::Python(_)
+            | RawFrame::Php(_)
             | RawFrame::Ruby(_)
             | RawFrame::Go(_)
             | RawFrame::Dart(_)
@@ -154,6 +159,7 @@ impl RawFrame {
         let hash_id = match self {
             RawFrame::JavaScriptWeb(raw) | RawFrame::LegacyJS(raw) => raw.frame_id(),
             RawFrame::JavaScriptNode(raw) => raw.frame_id(),
+            RawFrame::Php(raw) => raw.frame_id(),
             RawFrame::Python(raw) => raw.frame_id(),
             RawFrame::Ruby(raw) => raw.frame_id(),
             RawFrame::Go(raw) => raw.frame_id(),

--- a/rust/cymbal/src/langs/mod.rs
+++ b/rust/cymbal/src/langs/mod.rs
@@ -8,6 +8,7 @@ pub mod hermes;
 pub mod java;
 pub mod js;
 pub mod node;
+pub mod php;
 pub mod python;
 pub mod ruby;
 pub mod utils;

--- a/rust/cymbal/src/langs/php.rs
+++ b/rust/cymbal/src/langs/php.rs
@@ -1,0 +1,104 @@
+use common_types::error_tracking::FrameId;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+
+use crate::{
+    frames::{Context, ContextLine, Frame},
+    langs::CommonFrameMetadata,
+};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RawPHPFrame {
+    #[serde(rename = "abs_path")]
+    pub path: Option<String>,
+    pub context_line: Option<String>,
+    pub filename: Option<String>,
+    pub function: Option<String>,
+    pub lineno: Option<u32>,
+    #[serde(default)]
+    pub pre_context: Vec<String>,
+    #[serde(default)]
+    pub post_context: Vec<String>,
+    #[serde(flatten)]
+    pub meta: CommonFrameMetadata,
+}
+
+impl RawPHPFrame {
+    pub fn frame_id(&self) -> String {
+        let mut hasher = Sha512::new();
+        self.context_line
+            .as_ref()
+            .inspect(|c| hasher.update(c.as_bytes()));
+        self.filename
+            .as_ref()
+            .inspect(|f| hasher.update(f.as_bytes()));
+        self.function
+            .as_ref()
+            .inspect(|f| hasher.update(f.as_bytes()));
+        hasher.update(self.lineno.unwrap_or_default().to_be_bytes());
+        self.pre_context
+            .iter()
+            .chain(self.post_context.iter())
+            .for_each(|line| {
+                hasher.update(line.as_bytes());
+            });
+        format!("{:x}", hasher.finalize())
+    }
+
+    pub fn get_context(&self) -> Option<Context> {
+        let context_line = self.context_line.as_ref()?;
+        let lineno = self.lineno?;
+
+        let line = ContextLine::new(lineno, context_line);
+
+        let before = self
+            .pre_context
+            .iter()
+            .rev()
+            .enumerate()
+            .map(|(i, line)| ContextLine::new_rel(lineno, -(i as i32) - 1, line.clone()))
+            .collect();
+        let after = self
+            .post_context
+            .iter()
+            .enumerate()
+            .map(|(i, line)| ContextLine::new_rel(lineno, (i as i32) + 1, line.clone()))
+            .collect();
+        Some(Context {
+            before,
+            line,
+            after,
+        })
+    }
+
+    fn mangled_name(&self) -> String {
+        self.function
+            .clone()
+            .unwrap_or_else(|| "<unknown>".to_string())
+    }
+}
+
+impl From<&RawPHPFrame> for Frame {
+    fn from(raw: &RawPHPFrame) -> Self {
+        Frame {
+            frame_id: FrameId::placeholder(),
+            mangled_name: raw.mangled_name(),
+            line: raw.lineno,
+            column: None,
+            source: raw.filename.clone(),
+            in_app: raw.meta.in_app,
+            resolved_name: raw.function.clone(),
+            lang: "php".to_string(),
+            resolved: true,
+            resolve_failure: None,
+
+            junk_drawer: None,
+            context: raw.get_context(),
+            release: None,
+            synthetic: raw.meta.synthetic,
+            suspicious: false,
+            module: None,
+            code_variables: None,
+        }
+    }
+}

--- a/rust/cymbal/tests/static/php_err_props.json
+++ b/rust/cymbal/tests/static/php_err_props.json
@@ -1,0 +1,34 @@
+{
+  "$exception_list": [
+    {
+      "type": "RuntimeException",
+      "value": "boom",
+      "stacktrace": {
+        "type": "raw",
+        "frames": [
+          {
+            "platform": "php",
+            "filename": "ExceptionCapture.php",
+            "abs_path": "/app/lib/ExceptionCapture.php",
+            "lineno": 42,
+            "function": "PostHog\\ExceptionCapture::buildParsedException",
+            "in_app": true,
+            "context_line": "throw new \\RuntimeException('boom');",
+            "pre_context": [
+              "try {",
+              "    $throwLine = __LINE__ + 1;"
+            ],
+            "post_context": [
+              "} catch (\\RuntimeException $e) {",
+              "    return [$e, $throwLine];"
+            ]
+          },
+          {
+            "platform": "php",
+            "in_app": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/rust/cymbal/tests/types.rs
+++ b/rust/cymbal/tests/types.rs
@@ -84,41 +84,8 @@ fn node_exceptions() {
 
 #[test]
 fn php_exceptions() {
-    let props: RawErrProps = serde_json::from_str(
-        r#"{
-            "$exception_list": [{
-                "type": "RuntimeException",
-                "value": "boom",
-                "stacktrace": {
-                    "type": "raw",
-                    "frames": [
-                        {
-                            "platform": "php",
-                            "filename": "ExceptionCapture.php",
-                            "abs_path": "/app/lib/ExceptionCapture.php",
-                            "lineno": 42,
-                            "function": "PostHog\\ExceptionCapture::buildParsedException",
-                            "in_app": true,
-                            "context_line": "throw new \\RuntimeException('boom');",
-                            "pre_context": [
-                                "try {",
-                                "    $throwLine = __LINE__ + 1;"
-                            ],
-                            "post_context": [
-                                "} catch (\\RuntimeException $e) {",
-                                "    return [$e, $throwLine];"
-                            ]
-                        },
-                        {
-                            "platform": "php",
-                            "in_app": false
-                        }
-                    ]
-                }
-            }]
-        }"#,
-    )
-    .unwrap();
+    let props: RawErrProps =
+        serde_json::from_str(include_str!("./static/php_err_props.json")).unwrap();
 
     let frames = props
         .exception_list
@@ -146,7 +113,19 @@ fn php_exceptions() {
         frames[0].resolved_name.as_deref(),
         Some("PostHog\\ExceptionCapture::buildParsedException")
     );
-    assert_eq!(frames[0].context.as_ref().unwrap().line.number, 42);
+    let context = frames[0].context.as_ref().unwrap();
+    assert_eq!(context.line.number, 42);
+    assert_eq!(context.line.line, "throw new \\RuntimeException('boom');");
+    assert_eq!(context.before.len(), 2);
+    assert_eq!(context.before[0].number, 41);
+    assert_eq!(context.before[0].line, "    $throwLine = __LINE__ + 1;");
+    assert_eq!(context.before[1].number, 40);
+    assert_eq!(context.before[1].line, "try {");
+    assert_eq!(context.after.len(), 2);
+    assert_eq!(context.after[0].number, 43);
+    assert_eq!(context.after[0].line, "} catch (\\RuntimeException $e) {");
+    assert_eq!(context.after[1].number, 44);
+    assert_eq!(context.after[1].line, "    return [$e, $throwLine];");
     assert_eq!(frames[1].mangled_name, "<unknown>");
     assert_eq!(frames[1].resolved_name, None);
 }

--- a/rust/cymbal/tests/types.rs
+++ b/rust/cymbal/tests/types.rs
@@ -81,3 +81,72 @@ fn node_exceptions() {
 
     assert_eq!(frames.len(), 4);
 }
+
+#[test]
+fn php_exceptions() {
+    let props: RawErrProps = serde_json::from_str(
+        r#"{
+            "$exception_list": [{
+                "type": "RuntimeException",
+                "value": "boom",
+                "stacktrace": {
+                    "type": "raw",
+                    "frames": [
+                        {
+                            "platform": "php",
+                            "filename": "ExceptionCapture.php",
+                            "abs_path": "/app/lib/ExceptionCapture.php",
+                            "lineno": 42,
+                            "function": "PostHog\\ExceptionCapture::buildParsedException",
+                            "in_app": true,
+                            "context_line": "throw new \\RuntimeException('boom');",
+                            "pre_context": [
+                                "try {",
+                                "    $throwLine = __LINE__ + 1;"
+                            ],
+                            "post_context": [
+                                "} catch (\\RuntimeException $e) {",
+                                "    return [$e, $throwLine];"
+                            ]
+                        },
+                        {
+                            "platform": "php",
+                            "in_app": false
+                        }
+                    ]
+                }
+            }]
+        }"#,
+    )
+    .unwrap();
+
+    let frames = props
+        .exception_list
+        .iter()
+        .map(|e| e.stack.clone().unwrap())
+        .flat_map(|t| {
+            let Stacktrace::Raw { frames } = t else {
+                panic!("Expected a Raw stacktrace")
+            };
+            frames
+        })
+        .map(|f| {
+            let RawFrame::Php(f) = f else {
+                panic!("Expected a PHP frame")
+            };
+            let f: Frame = (&f).into();
+            f
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0].lang, "php");
+    assert_eq!(frames[0].source.as_deref(), Some("ExceptionCapture.php"));
+    assert_eq!(
+        frames[0].resolved_name.as_deref(),
+        Some("PostHog\\ExceptionCapture::buildParsedException")
+    );
+    assert_eq!(frames[0].context.as_ref().unwrap().line.number, 42);
+    assert_eq!(frames[1].mangled_name, "<unknown>");
+    assert_eq!(frames[1].resolved_name, None);
+}


### PR DESCRIPTION
## Problem

posthog-php now emits PHP exception stack frames with `platform: "php"`, including PHP-specific raw frame details like `abs_path` and sometimes sparse internal frames. Cymbal did not understand that platform yet, so those events could not be deserialized and processed natively.

## Changes

- add a dedicated PHP raw frame type in Cymbal
- wire `platform: "php"` into raw frame deserialization, frame resolution, metrics tagging, and raw frame IDs
- map PHP frames into Cymbal `Frame`s with source context support
- tolerate sparse PHP frames that omit `filename` or `function`
- add regression coverage for the posthog-php payload shape

## How did you test this code?

- `cargo fmt --package cymbal --check`
- `cargo test -p cymbal --test types -- --nocapture`
- `cargo test -p cymbal`

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored in Codex. Compared the in-progress posthog-php exception payload changes with existing Cymbal language handlers, mirrored the Ruby-style raw-frame handling where appropriate, then added targeted regression coverage and ran the Cymbal test suite.
