### PR TITLE
fix(workflows): Remove direct pixel/redirect metric recording to prevent double counting with SES webhooks

### DIFF
--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -650,14 +650,14 @@ export class CdpApi {
 
     private getEmailTrackingPixel =
         () =>
-        async (req: ModifiedRequest, res: express.Response): Promise<any> => {
-            await this.emailTrackingService.handleEmailTrackingPixel(req, res)
+        (req: ModifiedRequest, res: express.Response): any => {
+            this.emailTrackingService.handleEmailTrackingPixel(req, res)
         }
 
     private getEmailTrackingRedirect =
         () =>
-        async (req: ModifiedRequest, res: express.Response): Promise<any> => {
-            await this.emailTrackingService.handleEmailTrackingRedirect(req, res)
+        (req: ModifiedRequest, res: express.Response): any => {
+            this.emailTrackingService.handleEmailTrackingRedirect(req, res)
         }
 
     private generatePreferencesToken =

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -55,8 +55,11 @@ describe('EmailTrackingService', () => {
             server.close()
         })
 
+        // Metrics are tracked via SES webhooks, not the direct pixel/redirect handlers,
+        // to avoid double counting. These tests verify the handlers still serve correct
+        // responses without recording metrics.
         describe('handleEmailTrackingRedirect', () => {
-            it('should redirect to the target url and track the click metric via ph_id', async () => {
+            it('should redirect to the target url without recording metrics', async () => {
                 const phId = generateEmailTrackingCode({
                     functionId: hogFunction.id,
                     id: invocationId,
@@ -67,55 +70,7 @@ describe('EmailTrackingService', () => {
                 expect(res.headers.location).toBe('https://example.com')
 
                 const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(messages).toHaveLength(1)
-                expect(messages[0].value).toMatchObject({
-                    app_source: 'hog_function',
-                    app_source_id: hogFunction.id,
-                    instance_id: invocationId,
-                    metric_kind: 'email',
-                    metric_name: 'email_link_clicked',
-                    team_id: team.id,
-                    count: 1,
-                })
-            })
-
-            it('should use actionId as instance_id for click metric when present in ph_id', async () => {
-                const actionNodeId = 'action_function_email_abc123'
-                const phId = generateEmailTrackingCode({
-                    functionId: hogFunction.id,
-                    id: invocationId,
-                    teamId: team.id,
-                    state: { actionId: actionNodeId },
-                })
-                const res = await supertest(app).get(`/public/m/redirect?ph_id=${phId}&target=https://example.com`)
-                expect(res.status).toBe(302)
-
-                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(messages).toHaveLength(1)
-                expect(messages[0].value).toMatchObject({
-                    instance_id: actionNodeId,
-                    metric_name: 'email_link_clicked',
-                })
-            })
-
-            it('should redirect to the target url and track the click metric via legacy ph_fn_id/ph_inv_id', async () => {
-                const res = await supertest(app).get(
-                    `/public/m/redirect?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}&target=https://example.com`
-                )
-                expect(res.status).toBe(302)
-                expect(res.headers.location).toBe('https://example.com')
-
-                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(messages).toHaveLength(1)
-                expect(messages[0].value).toMatchObject({
-                    app_source: 'hog_function',
-                    app_source_id: hogFunction.id,
-                    instance_id: invocationId,
-                    metric_kind: 'email',
-                    metric_name: 'email_link_clicked',
-                    team_id: team.id,
-                    count: 1,
-                })
+                expect(messages).toHaveLength(0)
             })
 
             it('should return 404 if the target is not provided', async () => {
@@ -127,21 +82,10 @@ describe('EmailTrackingService', () => {
                 const res = await supertest(app).get(`/public/m/redirect?ph_id=${phId}`)
                 expect(res.status).toBe(404)
             })
-
-            it('should redirect even if the tracking code is invalid', async () => {
-                const res = await supertest(app).get(
-                    `/public/m/redirect?ph_id=invalid-tracking-code&target=https://example.com`
-                )
-                expect(res.status).toBe(302)
-                expect(res.headers.location).toBe('https://example.com')
-
-                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(messages).toHaveLength(0)
-            })
         })
 
         describe('email tracking pixel', () => {
-            it('should return a 200 and a gif image, tracking the open metric via ph_id', async () => {
+            it('should return a gif image without recording metrics', async () => {
                 const phId = generateEmailTrackingCode({
                     functionId: hogFunction.id,
                     id: invocationId,
@@ -153,56 +97,7 @@ describe('EmailTrackingService', () => {
                 expect(res.body).toEqual(PIXEL_GIF)
 
                 const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(messages).toHaveLength(1)
-                expect(messages[0].value).toMatchObject({
-                    app_source: 'hog_function',
-                    app_source_id: hogFunction.id,
-                    instance_id: invocationId,
-                    metric_kind: 'email',
-                    metric_name: 'email_opened',
-                    team_id: team.id,
-                    count: 1,
-                })
-            })
-
-            it('should use actionId as instance_id for open metric when present in ph_id', async () => {
-                const actionNodeId = 'action_function_email_abc123'
-                const phId = generateEmailTrackingCode({
-                    functionId: hogFunction.id,
-                    id: invocationId,
-                    teamId: team.id,
-                    state: { actionId: actionNodeId },
-                })
-                const res = await supertest(app).get(`/public/m/pixel?ph_id=${phId}`)
-                expect(res.status).toBe(200)
-
-                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(messages).toHaveLength(1)
-                expect(messages[0].value).toMatchObject({
-                    instance_id: actionNodeId,
-                    metric_name: 'email_opened',
-                })
-            })
-
-            it('should return a 200 and a gif image, tracking the open metric via legacy ph_fn_id/ph_inv_id', async () => {
-                const res = await supertest(app).get(
-                    `/public/m/pixel?ph_fn_id=${hogFunction.id}&ph_inv_id=${invocationId}`
-                )
-                expect(res.status).toBe(200)
-                expect(res.headers['content-type']).toBe('image/gif')
-                expect(res.body).toEqual(PIXEL_GIF)
-
-                const messages = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(messages).toHaveLength(1)
-                expect(messages[0].value).toMatchObject({
-                    app_source: 'hog_function',
-                    app_source_id: hogFunction.id,
-                    instance_id: invocationId,
-                    metric_kind: 'email',
-                    metric_name: 'email_opened',
-                    team_id: team.id,
-                    count: 1,
-                })
+                expect(messages).toHaveLength(0)
             })
 
             it('should return a 200 even if the tracking code is invalid', async () => {

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -5,7 +5,6 @@ import { ModifiedRequest } from '~/api/router'
 import { CyclotronJobInvocationHogFunction, MinimalAppMetric } from '~/cdp/types'
 import { defaultConfig } from '~/config/config'
 import { parseJSON } from '~/utils/json-parse'
-import { captureException } from '~/utils/posthog'
 
 import { logger } from '../../../utils/logger'
 import { HogFlowManagerService } from '../hogflows/hogflow-manager.service'
@@ -218,46 +217,22 @@ export class EmailTrackingService {
         }
     }
 
-    // NOTE: this is somewhat naieve. We should expand with UA checking for things like apple's tracking prevention etc.
-    public async handleEmailTrackingPixel(req: ModifiedRequest, res: express.Response): Promise<void> {
-        const { functionId, invocationId, actionId } = this.parseTrackingParams(req.query)
-
-        try {
-            await this.trackMetric({
-                functionId,
-                invocationId,
-                actionId,
-                metricName: 'email_opened',
-                source: 'direct',
-            })
-        } catch (error) {
-            logger.error('[EmailTrackingService] handleEmailTrackingPixel: Error tracking open metric', { error })
-            captureException(error)
-        }
-
+    // Metrics are not recorded here because SES webhooks already track opens.
+    // Recording here would double-count. The pixel is still served so email
+    // clients that load it get a valid response.
+    public handleEmailTrackingPixel(_req: ModifiedRequest, res: express.Response): void {
         res.status(200).set('Content-Type', 'image/gif').send(PIXEL_GIF)
     }
 
-    public async handleEmailTrackingRedirect(req: ModifiedRequest, res: express.Response): Promise<void> {
-        const { functionId, invocationId, actionId } = this.parseTrackingParams(req.query)
+    // Metrics are not recorded here because SES webhooks already track clicks.
+    // Recording here would double-count. The redirect still works so users
+    // reach their destination.
+    public handleEmailTrackingRedirect(req: ModifiedRequest, res: express.Response): void {
         const { target } = req.query
 
         if (!target) {
             res.status(404).send('Not found')
             return
-        }
-
-        try {
-            await this.trackMetric({
-                functionId,
-                invocationId,
-                actionId,
-                metricName: 'email_link_clicked',
-                source: 'direct',
-            })
-        } catch (error) {
-            logger.error('[EmailTrackingService] handleEmailTrackingRedirect: Error tracking metric', { error })
-            captureException(error)
         }
 
         res.redirect(target as string)


### PR DESCRIPTION
## Problem

After merging [#52210](https://github.com/PostHog/posthog/pull/52210), email open and click metrics are being double counted. Both the SES webhook handler and our custom tracking pixel/redirect handlers now record the same events, inflating the numbers (e.g. 42 opens shown for 24 emails sent).

This happens because SES fires its own Open/Click webhook events AND the email client loads our tracking pixel/follows our redirect - each path independently records a metric. On localhost this wasn't happening as maildev doesn't send any webhooks like SES does.

## Changes

- Removed metric recording from `handleEmailTrackingPixel` and `handleEmailTrackingRedirect` - these handlers now only serve the gif and redirect respectively, without calling `trackMetric`. SES webhooks remain the sole source of open/click metrics.
- Updated `cdp-api.ts` callers to match the now-synchronous handler signatures.
- Updated tests to verify handlers return correct responses without producing Kafka messages.

## How did you test this code?

- All email tracking, SES webhook, and email service tests pass (45 total)
- Observed the double counting in production after the previous PR merged, confirmed the inflated numbers match the expected 2x pattern

## Publish to changelog?

No