### PR TITLE
fix(data-warehouse): restore Z suffix for Klaviyo datetime

### DIFF
--- a/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -30,7 +30,7 @@ def _format_datetime_z(dt: datetime) -> str:
     Klaviyo rejects the +00:00 UTC offset format produced by isoformat(),
     so we must use the Z suffix instead.
     """
-    utc_dt = dt.astimezone(UTC)
+    utc_dt = dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
     return utc_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
 

--- a/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -24,12 +24,22 @@ class KlaviyoResumeConfig:
     next_url: str
 
 
+def _format_datetime_z(dt: datetime) -> str:
+    """Format a datetime as ISO 8601 with Z suffix, which Klaviyo's API requires.
+
+    Klaviyo rejects the +00:00 UTC offset format produced by isoformat(),
+    so we must use the Z suffix instead.
+    """
+    utc_dt = dt.astimezone(UTC)
+    return utc_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
 def _format_incremental_value(value: Any) -> str:
-    """Format incremental field value as ISO string for Klaviyo API filters."""
+    """Format incremental field value for Klaviyo API filters."""
     if isinstance(value, datetime):
-        return value.isoformat()
+        return _format_datetime_z(value)
     if isinstance(value, date):
-        return datetime.combine(value, datetime.min.time()).isoformat()
+        return _format_datetime_z(datetime.combine(value, datetime.min.time(), tzinfo=UTC))
     return str(value)
 
 

--- a/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -7,7 +7,7 @@ from posthog.temporal.data_imports.sources.klaviyo.klaviyo import (
     _build_initial_params,
     _format_incremental_value,
 )
-from posthog.temporal.data_imports.sources.klaviyo.settings import KLAVIYO_ENDPOINTS
+from posthog.temporal.data_imports.sources.klaviyo.settings import KLAVIYO_ENDPOINTS, KlaviyoEndpointConfig
 
 
 class TestFormatIncrementalValue:
@@ -60,7 +60,7 @@ class TestBuildFilter:
         ]
     )
     def test_build_filter(
-        self, _name: str, config: object, field: str | None, value: str | None, expected: str | None
+        self, _name: str, config: KlaviyoEndpointConfig, field: str | None, value: str | None, expected: str | None
     ) -> None:
         assert _build_filter(config, field, value) == expected
 

--- a/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -33,25 +33,36 @@ class TestFormatIncrementalValue:
 
 
 class TestBuildFilter:
-    def test_incremental_only(self) -> None:
-        config = KLAVIYO_ENDPOINTS["events"]
-        result = _build_filter(config, "datetime", "2026-03-04T02:58:14.000Z")
-        assert result == "greater-than(datetime,2026-03-04T02:58:14.000Z)"
-
-    def test_base_filter_only(self) -> None:
-        config = KLAVIYO_ENDPOINTS["email_campaigns"]
-        result = _build_filter(config, None, None)
-        assert result == "equals(messages.channel,'email')"
-
-    def test_combined_base_and_incremental(self) -> None:
-        config = KLAVIYO_ENDPOINTS["email_campaigns"]
-        result = _build_filter(config, "updated_at", "2026-03-04T02:58:14.000Z")
-        assert result == "and(equals(messages.channel,'email'),greater-than(updated_at,2026-03-04T02:58:14.000Z))"
-
-    def test_no_filter(self) -> None:
-        config = KLAVIYO_ENDPOINTS["metrics"]
-        result = _build_filter(config, None, None)
-        assert result is None
+    @parameterized.expand(
+        [
+            (
+                "incremental_only",
+                KLAVIYO_ENDPOINTS["events"],
+                "datetime",
+                "2026-03-04T02:58:14.000Z",
+                "greater-than(datetime,2026-03-04T02:58:14.000Z)",
+            ),
+            (
+                "base_filter_only",
+                KLAVIYO_ENDPOINTS["email_campaigns"],
+                None,
+                None,
+                "equals(messages.channel,'email')",
+            ),
+            (
+                "combined_base_and_incremental",
+                KLAVIYO_ENDPOINTS["email_campaigns"],
+                "updated_at",
+                "2026-03-04T02:58:14.000Z",
+                "and(equals(messages.channel,'email'),greater-than(updated_at,2026-03-04T02:58:14.000Z))",
+            ),
+            ("no_filter", KLAVIYO_ENDPOINTS["metrics"], None, None, None),
+        ]
+    )
+    def test_build_filter(
+        self, _name: str, config: object, field: str | None, value: str | None, expected: str | None
+    ) -> None:
+        assert _build_filter(config, field, value) == expected
 
 
 class TestBuildInitialParams:

--- a/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -1,0 +1,79 @@
+from datetime import UTC, date, datetime
+
+from parameterized import parameterized
+
+from posthog.temporal.data_imports.sources.klaviyo.klaviyo import (
+    _build_filter,
+    _build_initial_params,
+    _format_incremental_value,
+)
+from posthog.temporal.data_imports.sources.klaviyo.settings import KLAVIYO_ENDPOINTS
+
+
+class TestFormatIncrementalValue:
+    @parameterized.expand(
+        [
+            ("utc_datetime", datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC), "2026-03-04T02:58:14.000Z"),
+            (
+                "datetime_with_microseconds",
+                datetime(2026, 1, 15, 10, 30, 45, 123456, tzinfo=UTC),
+                "2026-01-15T10:30:45.123Z",
+            ),
+            ("naive_datetime", datetime(2026, 3, 4, 2, 58, 14), "2026-03-04T02:58:14.000Z"),
+            ("date_value", date(2026, 3, 4), "2026-03-04T00:00:00.000Z"),
+            ("string_passthrough", "some-cursor-value", "some-cursor-value"),
+        ]
+    )
+    def test_format_incremental_value(self, _name: str, value: object, expected: str) -> None:
+        assert _format_incremental_value(value) == expected
+
+    def test_no_plus_zero_offset_in_output(self) -> None:
+        result = _format_incremental_value(datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC))
+        assert "+00:00" not in result
+
+
+class TestBuildFilter:
+    def test_incremental_only(self) -> None:
+        config = KLAVIYO_ENDPOINTS["events"]
+        result = _build_filter(config, "datetime", "2026-03-04T02:58:14.000Z")
+        assert result == "greater-than(datetime,2026-03-04T02:58:14.000Z)"
+
+    def test_base_filter_only(self) -> None:
+        config = KLAVIYO_ENDPOINTS["email_campaigns"]
+        result = _build_filter(config, None, None)
+        assert result == "equals(messages.channel,'email')"
+
+    def test_combined_base_and_incremental(self) -> None:
+        config = KLAVIYO_ENDPOINTS["email_campaigns"]
+        result = _build_filter(config, "updated_at", "2026-03-04T02:58:14.000Z")
+        assert result == "and(equals(messages.channel,'email'),greater-than(updated_at,2026-03-04T02:58:14.000Z))"
+
+    def test_no_filter(self) -> None:
+        config = KLAVIYO_ENDPOINTS["metrics"]
+        result = _build_filter(config, None, None)
+        assert result is None
+
+
+class TestBuildInitialParams:
+    def test_events_incremental_uses_z_suffix(self) -> None:
+        config = KLAVIYO_ENDPOINTS["events"]
+        params = _build_initial_params(
+            config,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            incremental_field="datetime",
+        )
+        assert "+00:00" not in params["filter"]
+        assert params["filter"] == "greater-than(datetime,2026-03-04T02:58:14.000Z)"
+
+    def test_lookback_window_uses_z_suffix(self) -> None:
+        config = KLAVIYO_ENDPOINTS["events"]
+        params = _build_initial_params(
+            config,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=None,
+            incremental_field="datetime",
+        )
+        assert "filter" in params
+        assert "+00:00" not in params["filter"]
+        assert params["filter"].endswith("Z)")


### PR DESCRIPTION
## Problem

Klaviyo data warehouse syncs configured as "append by date" re-import the entire dataset on every run instead of just new records, creating exact duplicates and inflating data warehouse usage.

The root cause is a regression introduced in #50629 (make Klaviyo source resumable, Mar 11). That PR branched from before #49890 (Z suffix fix, Mar 5) and rewrote `klaviyo.py` without carrying over the fix. This reverted `_format_incremental_value` to using `datetime.isoformat()`, which produces the `+00:00` UTC offset format that Klaviyo's API rejects.

As a result, the incremental datetime filter (`greater-than(datetime,...)`) is malformed on every subsequent sync, causing either a 400 Bad Request or the filter being silently ignored. Since append mode does a pure append with no deduplication on primary keys, any re-fetched data creates exact duplicates.

## Changes

- Restores `_format_datetime_z()` helper that formats datetimes with the `Z` suffix (e.g. `2026-03-04T02:58:14.000Z` instead of `2026-03-04T02:58:14+00:00`)
- Updates `_format_incremental_value` to use it for both `datetime` and `date` inputs
- Adds regression tests for `_format_incremental_value`, `_build_filter`, and `_build_initial_params` to prevent this from being lost again

## How did you test this code?

I haven't manually tested this, however, I did the following:

- Verified the fix logic directly by running the formatting functions against all input types (UTC datetime, datetime with microseconds, naive datetime, date, string passthrough)
- All produce Z suffix format, none contain `+00:00`
- Added parameterized test suite covering the formatting, filter building, and initial params construction

## Publish to changelog?

No

## Docs update

No

## 🤖 LLM context

Co-authored by Claude Code. 
