### PR TITLE
feat: Add new SLO dashboard based on our SLo package

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/dashboards.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/dashboards.tf
@@ -1,0 +1,6 @@
+resource "posthog_dashboard" "slo_monitoring" {
+  name        = "SLO Monitoring"
+  description = "Rolling success rates and burn rates for SLO-tracked operations. Uses slo_operation_completed events. Burn rate of 1.0 = consuming error budget at planned rate."
+  pinned      = true
+  tags        = ["managed-by:terraform", "slo"]
+}

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -1,0 +1,343 @@
+locals {
+  # ===========================================================================
+  # SLO operation config. Add new operations here to auto-generate insights.
+  # Each operation must emit slo_operation_completed events with matching
+  # properties.operation value (see posthog/slo/types.py:SloOperation).
+  # ===========================================================================
+  slo_operations = {
+    subscription_delivery = {
+      name    = "Subscription deliveries"
+      slo     = 99.95 # error budget = 0.05%
+      regions = ["US", "EU"]
+    }
+  }
+
+  # ---------------------------------------------------------------------------
+  # Flatten: {operation}_{region} for burn rate + duration per region.
+  # ---------------------------------------------------------------------------
+  slo_operation_regions = merge([
+    for op_key, op in local.slo_operations : {
+      for region in op.regions :
+      "${op_key}_${lower(region)}" => {
+        name      = op.name
+        slo       = op.slo
+        operation = op_key
+        region    = region
+      }
+    }
+  ]...)
+
+  # ---------------------------------------------------------------------------
+  # Burn rate query template (hourly granularity, 4 windows).
+  # Placeholders: {{OPERATION}}, {{REGION}}, {{ERROR_BUDGET}}
+  # ---------------------------------------------------------------------------
+  slo_burn_rate_query = <<-SQL
+    WITH hourly AS (
+        SELECT
+            toStartOfHour(timestamp) AS hour,
+            count() AS total,
+            countIf(properties.outcome = 'failure') AS failures
+        FROM events
+        WHERE event = 'slo_operation_completed'
+          AND properties.operation = '{{OPERATION}}'
+          AND properties.region = '{{REGION}}'
+          AND timestamp >= now() - INTERVAL 35 DAY
+        GROUP BY hour
+    ),
+    hour_range AS (
+        SELECT toStartOfHour(now()) - INTERVAL number HOUR AS hour FROM numbers(840)
+    ),
+    base AS (
+        SELECT
+            h.hour AS hour,
+            coalesce(hourly.total, 0) AS total,
+            coalesce(hourly.failures, 0) AS failures
+        FROM hour_range AS h
+        LEFT JOIN hourly ON h.hour = hourly.hour
+    ),
+    rolling AS (
+        SELECT
+            hour,
+            total AS t1h,
+            failures AS f1h,
+            sum(total) OVER w24h AS t24h,
+            sum(failures) OVER w24h AS f24h,
+            sum(total) OVER w7d AS t7d,
+            sum(failures) OVER w7d AS f7d,
+            sum(total) OVER w28d AS t28d,
+            sum(failures) OVER w28d AS f28d
+        FROM base
+        WINDOW
+            w24h AS (ORDER BY hour ASC ROWS BETWEEN 23 PRECEDING AND CURRENT ROW),
+            w7d  AS (ORDER BY hour ASC ROWS BETWEEN 167 PRECEDING AND CURRENT ROW),
+            w28d AS (ORDER BY hour ASC ROWS BETWEEN 671 PRECEDING AND CURRENT ROW)
+    )
+    SELECT hour AS time, metric, value
+    FROM (
+        SELECT
+            hour,
+            ['Burn rate 1h', 'Burn rate 24h', 'Burn rate 7d', 'Burn rate 28d'] AS metrics,
+            [
+                round(if(t1h  > 0, (f1h  / t1h)  / {{ERROR_BUDGET}}, 0), 2),
+                round(if(t24h > 0, (f24h / t24h) / {{ERROR_BUDGET}}, 0), 2),
+                round(if(t7d  > 0, (f7d  / t7d)  / {{ERROR_BUDGET}}, 0), 2),
+                round(if(t28d > 0, (f28d / t28d) / {{ERROR_BUDGET}}, 0), 2)
+            ] AS vals
+        FROM rolling
+        WHERE hour >= now() - INTERVAL 7 DAY
+    )
+    ARRAY JOIN metrics AS metric, vals AS value
+    ORDER BY time ASC, metric ASC
+    LIMIT 5000
+  SQL
+
+  # ---------------------------------------------------------------------------
+  # Duration percentile query template (daily granularity, p50/p95/p99 in seconds).
+  # Placeholders: {{OPERATION}}, {{REGION}}
+  # ---------------------------------------------------------------------------
+  slo_duration_query = <<-SQL
+    WITH daily AS (
+        SELECT
+            toDate(timestamp) AS date,
+            quantile(0.50)(toFloat(properties.duration_ms)) / 1000 AS p50,
+            quantile(0.95)(toFloat(properties.duration_ms)) / 1000 AS p95,
+            quantile(0.99)(toFloat(properties.duration_ms)) / 1000 AS p99
+        FROM events
+        WHERE event = 'slo_operation_completed'
+          AND properties.operation = '{{OPERATION}}'
+          AND properties.region = '{{REGION}}'
+          AND properties.duration_ms IS NOT NULL
+          AND timestamp >= now() - INTERVAL 28 DAY
+        GROUP BY date
+    ),
+    date_range AS (
+        SELECT toDate(now()) - number AS date FROM numbers(28)
+    ),
+    base AS (
+        SELECT
+            d.date AS date,
+            daily.p50,
+            daily.p95,
+            daily.p99
+        FROM date_range AS d
+        LEFT JOIN daily ON d.date = daily.date
+    )
+    SELECT date AS day, metric, value
+    FROM (
+        SELECT
+            date,
+            ['p50', 'p95', 'p99'] AS metrics,
+            [
+                round(coalesce(p50, 0), 1),
+                round(coalesce(p95, 0), 1),
+                round(coalesce(p99, 0), 1)
+            ] AS vals
+        FROM base
+    )
+    ARRAY JOIN metrics AS metric, vals AS value
+    ORDER BY day ASC, metric ASC
+    LIMIT 500
+  SQL
+
+}
+
+# ---------------------------------------------------------------------------
+# Burn rate insights (one per operation, auto-generated).
+# ---------------------------------------------------------------------------
+resource "posthog_insight" "slo_burn_rate" {
+  for_each = local.slo_operation_regions
+
+  name        = "SLO: Burn Rates - ${each.value.name} (${each.value.slo}%) — ${each.value.region}"
+  description = "[Investigate failures with AI](/ai?ask=Investigate+${each.value.operation}+failures+in+${each.value.region}+region+slo_operation_completed+events+last+24h)"
+  query_json = jsonencode({
+    kind = "DataVisualizationNode"
+    source = {
+      kind = "HogQLQuery"
+      query = replace(
+        replace(
+          replace(local.slo_burn_rate_query, "{{OPERATION}}", each.value.operation),
+          "{{REGION}}", each.value.region),
+        "{{ERROR_BUDGET}}", tostring((100 - each.value.slo) / 100)
+      )
+    }
+    display = "ActionsLineGraph"
+    chartSettings = {
+      xAxis = { column = "time" }
+      yAxis = [
+        {
+          column   = "value"
+          settings = { formatting = { prefix = "", suffix = "" } }
+        }
+      ]
+      seriesBreakdownColumn = "metric"
+      showLegend            = true
+      goalLines = [
+        { label = "Budget rate", value = 1.0 }
+      ]
+    }
+    tableSettings = {
+      columns = [
+        { column = "time", settings = { formatting = { prefix = "", suffix = "" } } },
+        { column = "metric", settings = { formatting = { prefix = "", suffix = "" } } },
+        { column = "value", settings = { formatting = { prefix = "", suffix = "" } } },
+      ]
+    }
+  })
+
+  dashboard_ids = [posthog_dashboard.slo_monitoring.id]
+  tags          = ["managed-by:terraform", "slo"]
+}
+
+# ---------------------------------------------------------------------------
+# Duration percentile insights (one per operation, auto-generated).
+# ---------------------------------------------------------------------------
+resource "posthog_insight" "slo_duration" {
+  for_each = local.slo_operation_regions
+
+  name        = "SLO: Duration - ${each.value.name} — ${each.value.region}"
+  description = ""
+  query_json = jsonencode({
+    kind = "DataVisualizationNode"
+    source = {
+      kind  = "HogQLQuery"
+      query = replace(
+        replace(local.slo_duration_query, "{{OPERATION}}", each.value.operation),
+        "{{REGION}}", each.value.region)
+    }
+    display = "ActionsAreaGraph"
+    chartSettings = {
+      xAxis = { column = "day" }
+      yAxis = [
+        {
+          column = "value"
+          settings = {
+            display    = { color = "#1d4aff", label = "", trendLine = false, displayType = "auto", yAxisPosition = "left" }
+            formatting = { style = "number", prefix = "", suffix = "s" }
+          }
+        }
+      ]
+      seriesBreakdownColumn = "metric"
+    }
+    tableSettings = {
+      columns = [
+        { column = "day", settings = { formatting = { prefix = "", suffix = "" } } },
+        { column = "metric", settings = { formatting = { prefix = "", suffix = "" } } },
+        { column = "value", settings = { formatting = { style = "number", prefix = "", suffix = "s" } } },
+      ]
+    }
+  })
+
+  dashboard_ids = [posthog_dashboard.slo_monitoring.id]
+  tags          = ["managed-by:terraform", "slo"]
+}
+
+# ---------------------------------------------------------------------------
+# Combined 28d success rate (all operations on one chart).
+# ---------------------------------------------------------------------------
+resource "posthog_insight" "slo_success_rate" {
+  name        = "SLO: 28d Success Rate"
+  description = ""
+  query_json = jsonencode({
+    kind = "DataVisualizationNode"
+    source = {
+      kind  = "HogQLQuery"
+      query = <<-SQL
+        WITH daily AS (
+            SELECT
+                toDate(timestamp) AS date,
+                properties.operation AS operation,
+                count() AS total,
+                countIf(properties.outcome = 'failure') AS failures
+            FROM events
+            WHERE event = 'slo_operation_completed'
+              AND timestamp >= now() - INTERVAL 56 DAY
+            GROUP BY date, operation
+        ),
+        date_range AS (
+            SELECT toDate(now()) - number AS date FROM numbers(28)
+        ),
+        operations AS (
+            SELECT DISTINCT operation FROM daily
+        ),
+        base AS (
+            SELECT
+                d.date AS date,
+                o.operation AS operation,
+                coalesce(daily.total, 0) AS total,
+                coalesce(daily.failures, 0) AS failures
+            FROM date_range AS d
+            CROSS JOIN operations AS o
+            LEFT JOIN daily ON d.date = daily.date AND o.operation = daily.operation
+        ),
+        rolling AS (
+            SELECT
+                date,
+                operation,
+                sum(total) OVER (PARTITION BY operation ORDER BY date ASC ROWS BETWEEN 27 PRECEDING AND CURRENT ROW) AS t28,
+                sum(failures) OVER (PARTITION BY operation ORDER BY date ASC ROWS BETWEEN 27 PRECEDING AND CURRENT ROW) AS f28
+            FROM base
+        )
+        SELECT
+            date AS day,
+            operation,
+            round(if(t28 > 0, (t28 - f28) / t28 * 100, 100), 2) AS success_rate
+        FROM rolling
+        ORDER BY date ASC, operation ASC
+        LIMIT 500
+      SQL
+    }
+    display = "ActionsLineGraph"
+    chartSettings = {
+      xAxis = { column = "day" }
+      yAxis = [
+        {
+          column   = "success_rate"
+          settings = { formatting = { prefix = "", suffix = "%" } }
+        }
+      ]
+      seriesBreakdownColumn = "operation"
+      showLegend            = true
+    }
+    tableSettings = {
+      columns = [
+        { column = "day", settings = { formatting = { prefix = "", suffix = "" } } },
+        { column = "operation", settings = { formatting = { prefix = "", suffix = "" } } },
+        { column = "success_rate", settings = { formatting = { prefix = "", suffix = "%" } } },
+      ]
+    }
+  })
+
+  dashboard_ids = [posthog_dashboard.slo_monitoring.id]
+  tags          = ["managed-by:terraform", "slo"]
+}
+
+# ---------------------------------------------------------------------------
+# 28d volume summary table (all operations, includes SLO target).
+# ---------------------------------------------------------------------------
+resource "posthog_insight" "slo_volume" {
+  name        = "SLO: 28d Volume by Operation"
+  description = ""
+  query_json = jsonencode({
+    kind = "DataVisualizationNode"
+    source = {
+      kind  = "HogQLQuery"
+      query = <<-SQL
+        SELECT
+            properties.operation AS operation,
+            properties.region AS region,
+            count() AS total,
+            countIf(properties.outcome = 'success') AS successes,
+            countIf(properties.outcome = 'failure') AS failures,
+            round(countIf(properties.outcome = 'success') / count() * 100, 2) AS success_rate
+        FROM events
+        WHERE event = 'slo_operation_completed'
+          AND timestamp >= now() - INTERVAL 28 DAY
+        GROUP BY operation, region
+        ORDER BY operation, region
+      SQL
+    }
+  })
+
+  dashboard_ids = [posthog_dashboard.slo_monitoring.id]
+  tags          = ["managed-by:terraform", "slo"]
+}

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -28,9 +28,12 @@ locals {
   ]...)
 
   # Row budgets for queries (with 2x margin for safety).
-  slo_burn_rate_limit      = 168 * 4 * 2            # 7 days * 24h * 4 metrics * margin
-  slo_duration_limit       = 28 * 3 * 2             # 28 days * 3 percentiles * margin
-  slo_success_rate_limit   = length(local.slo_operations) * 28 * 2  # 28 days * N operations * margin
+  slo_burn_rate_limit    = 168 * 4 * 2 # 7 days * 24h * 4 metrics * margin
+  slo_duration_limit     = 28 * 3 * 2  # 28 days * 3 percentiles * margin
+  slo_success_rate_limit = length(local.slo_operations) * 28 * 2
+
+  # Explicit operation list for the success rate query (avoids DISTINCT drift).
+  slo_operation_list = join(", ", [for k, _ in local.slo_operations : "'${k}'"])
 
   # ---------------------------------------------------------------------------
   # Burn rate query template (hourly granularity, 4 windows).
@@ -255,6 +258,7 @@ resource "posthog_insight" "slo_success_rate" {
                 countIf(properties.outcome = 'failure') AS failures
             FROM events
             WHERE event = 'slo_operation_completed'
+              AND properties.operation IN (${local.slo_operation_list})
               AND timestamp >= now() - INTERVAL 56 DAY
             GROUP BY date, operation
         ),
@@ -262,7 +266,7 @@ resource "posthog_insight" "slo_success_rate" {
             SELECT toDate(now()) - number AS date FROM numbers(28)
         ),
         operations AS (
-            SELECT DISTINCT operation FROM daily
+            SELECT arrayJoin([${local.slo_operation_list}]) AS operation
         ),
         base AS (
             SELECT

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -27,6 +27,11 @@ locals {
     }
   ]...)
 
+  # Row budgets for queries (with 2x margin for safety).
+  slo_burn_rate_limit      = 168 * 4 * 2            # 7 days * 24h * 4 metrics * margin
+  slo_duration_limit       = 28 * 3 * 2             # 28 days * 3 percentiles * margin
+  slo_success_rate_limit   = length(local.slo_operations) * 28 * 2  # 28 days * N operations * margin
+
   # ---------------------------------------------------------------------------
   # Burn rate query template (hourly granularity, 4 windows).
   # Placeholders: {{OPERATION}}, {{REGION}}, {{ERROR_BUDGET}}
@@ -78,17 +83,17 @@ locals {
             hour,
             ['Burn rate 1h', 'Burn rate 24h', 'Burn rate 7d', 'Burn rate 28d'] AS metrics,
             [
-                round(if(t1h  > 0, (f1h  / t1h)  / {{ERROR_BUDGET}}, 0), 2),
-                round(if(t24h > 0, (f24h / t24h) / {{ERROR_BUDGET}}, 0), 2),
-                round(if(t7d  > 0, (f7d  / t7d)  / {{ERROR_BUDGET}}, 0), 2),
-                round(if(t28d > 0, (f28d / t28d) / {{ERROR_BUDGET}}, 0), 2)
+                if(t1h  > 0, round((f1h  / t1h)  / {{ERROR_BUDGET}}, 2), NULL),
+                if(t24h > 0, round((f24h / t24h) / {{ERROR_BUDGET}}, 2), NULL),
+                if(t7d  > 0, round((f7d  / t7d)  / {{ERROR_BUDGET}}, 2), NULL),
+                if(t28d > 0, round((f28d / t28d) / {{ERROR_BUDGET}}, 2), NULL)
             ] AS vals
         FROM rolling
         WHERE hour >= now() - INTERVAL 7 DAY
     )
     ARRAY JOIN metrics AS metric, vals AS value
     ORDER BY time ASC, metric ASC
-    LIMIT 5000
+    LIMIT ${local.slo_burn_rate_limit}
   SQL
 
   # ---------------------------------------------------------------------------
@@ -128,15 +133,15 @@ locals {
             date,
             ['p50', 'p95', 'p99'] AS metrics,
             [
-                round(coalesce(p50, 0), 1),
-                round(coalesce(p95, 0), 1),
-                round(coalesce(p99, 0), 1)
+                round(p50, 1),
+                round(p95, 1),
+                round(p99, 1)
             ] AS vals
         FROM base
     )
     ARRAY JOIN metrics AS metric, vals AS value
     ORDER BY day ASC, metric ASC
-    LIMIT 500
+    LIMIT ${local.slo_duration_limit}
   SQL
 
 }
@@ -280,10 +285,10 @@ resource "posthog_insight" "slo_success_rate" {
         SELECT
             date AS day,
             operation,
-            round(if(t28 > 0, (t28 - f28) / t28 * 100, 100), 2) AS success_rate
+            if(t28 > 0, round((t28 - f28) / t28 * 100, 2), NULL) AS success_rate
         FROM rolling
         ORDER BY date ASC, operation ASC
-        LIMIT 500
+        LIMIT ${local.slo_success_rate_limit}
       SQL
     }
     display = "ActionsLineGraph"

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -53,7 +53,7 @@ locals {
         GROUP BY hour
     ),
     hour_range AS (
-        SELECT toStartOfHour(now()) - INTERVAL number HOUR AS hour FROM numbers(840)
+        SELECT toStartOfHour(now()) - INTERVAL number HOUR AS hour FROM numbers(841)
     ),
     base AS (
         SELECT

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
@@ -1,0 +1,86 @@
+resource "posthog_dashboard_layout" "slo_monitoring" {
+  dashboard_id = posthog_dashboard.slo_monitoring.id
+  tiles = concat(
+    # Row 0: Success rate (wide) + volume table (narrow).
+    [
+      {
+        insight_id = posthog_insight.slo_success_rate.id
+        layouts_json = jsonencode({
+          sm = {
+            h = 5, i = "success_rate", w = 8, x = 0, y = 0
+            minH = 2, minW = 2, moved = false, static = false
+          }
+        })
+      },
+      {
+        insight_id = posthog_insight.slo_volume.id
+        layouts_json = jsonencode({
+          sm = {
+            h = 5, i = "volume", w = 4, x = 8, y = 0
+            minH = 2, minW = 2, moved = false, static = false
+          }
+        })
+      },
+      {
+        text_body = "**Success rate** is a 28-day rolling window showing the percentage of successful operations. **Burn rate** measures how fast you're consuming your error budget — 1.0 means you're spending at the sustainable rate, >1.0 means you'll exhaust it before the window ends. **Duration** shows p50/p95/p99 operation latency in seconds."
+        layouts_json = jsonencode({
+          sm = {
+            h = 1, i = "text", w = 12, x = 0, y = 5
+            minH = 1, minW = 1, moved = false, static = false
+          }
+        })
+      },
+    ],
+    # Per-operation section: header + burn rates by region (row 1) + durations by region (row 2).
+    # Each operation block is: 1 (header) + 3 (burn rates) + 3 (durations) = 7 units tall.
+    flatten([
+      for op_idx, op_key in sort(keys(local.slo_operations)) :
+      concat(
+        # Section header
+        [
+          {
+            text_body = "### ${local.slo_operations[op_key].name} (SLO: ${local.slo_operations[op_key].slo}%)"
+            layouts_json = jsonencode({
+              sm = {
+                h = 1, i = "header_${op_key}", w = 12, x = 0, y = 6 + op_idx * 7
+                minH = 1, minW = 1, moved = false, static = false
+              }
+            })
+          },
+        ],
+        # Burn rate tiles for each region (side by side, h=3)
+        [
+          for reg_idx, region in local.slo_operations[op_key].regions :
+          {
+            insight_id = posthog_insight.slo_burn_rate["${op_key}_${lower(region)}"].id
+            layouts_json = jsonencode({
+              sm = {
+                h = 3, i = "burn_${op_key}_${lower(region)}"
+                w = floor(12 / length(local.slo_operations[op_key].regions))
+                x = reg_idx * floor(12 / length(local.slo_operations[op_key].regions))
+                y = 7 + op_idx * 7
+                minH = 2, minW = 2, moved = false, static = false
+              }
+            })
+          }
+        ],
+        # Duration tiles for each region (side by side, h=3)
+        [
+          for reg_idx, region in local.slo_operations[op_key].regions :
+          {
+            insight_id = posthog_insight.slo_duration["${op_key}_${lower(region)}"].id
+            layouts_json = jsonencode({
+              sm = {
+                h = 3, i = "dur_${op_key}_${lower(region)}"
+                w = floor(12 / length(local.slo_operations[op_key].regions))
+                x = reg_idx * floor(12 / length(local.slo_operations[op_key].regions))
+                y = 10 + op_idx * 7
+                minH = 2, minW = 2, moved = false, static = false
+              }
+            })
+          }
+        ],
+      )
+    ]),
+  )
+}

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/terragrunt.hcl
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/terragrunt.hcl
@@ -1,0 +1,29 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+include "region" {
+  path   = "../../../terragrunt.hcl"
+  expose = true
+}
+
+include "project" {
+  path   = "../../terragrunt.hcl"
+  expose = true
+}
+
+# Read team-level config for shared inputs and generate blocks
+locals {
+  team_config = read_terragrunt_config("${get_terragrunt_dir()}/../terragrunt.hcl")
+}
+
+# Generate team variables from parent config
+generate "variables_team" {
+  path      = "variables_team.tf"
+  if_exists = "overwrite"
+  contents  = file("${get_terragrunt_dir()}/../variables_team.tf.tpl")
+}
+
+# Merge team-level inputs
+inputs = local.team_config.inputs


### PR DESCRIPTION
## Problem

The analytics platform team needs comprehensive SLO (Service Level Objective) monitoring capabilities to track service reliability and performance across different operations and regions. This infrastructure provides automated dashboards and insights for monitoring burn rates, success rates, and operation durations.

## Changes

- **SLO Dashboard Creation**: Added a PostHog dashboard named "SLO Monitoring" with appropriate tags and pinned status
- **Automated Insight Generation**: Created a configurable system that auto-generates insights for SLO operations defined in local configuration
- **Burn Rate Monitoring**: Implemented burn rate calculations across multiple time windows (1h, 24h, 7d, 28d) with error budget tracking
- **Duration Tracking**: Added percentile-based duration monitoring (p50, p95, p99) for operation latency analysis
- **Success Rate Visualization**: Created combined 28-day rolling success rate charts for all operations
- **Volume Analytics**: Added operation volume breakdown tables showing total requests, successes, failures, and success rates by region
- **Dashboard Layout**: Configured responsive dashboard layout with organized sections for overview metrics and per-operation details
- **Initial Configuration**: Set up monitoring for subscription delivery operations across US and EU regions with 99.95% SLO target

The system uses `slo_operation_completed` events and provides AI-powered failure investigation links for quick troubleshooting.

## How did you test this code?

Worked with the MCP in order to generate a "as close as automaitcally possible" dashboard over here: https://us.posthog.com/project/2/dashboard/1396561 (there are a few gaps as I only have 1 operation emitted atm and the MCP can't yet create text items). Even though there are gaps, this should give a rough idea of how this will look.

The speculative TF plan looks solid [link](https://github.com/PostHog/posthog/actions/runs/23540540661/job/68527031644?pr=52244)

## Publish to changelog?

No - this is internal infrastructure setup.

## Docs update

No.