### PR TITLE
feat(logs): track user actions for logs alerts and views

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.event_usage import report_user_action
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
@@ -133,6 +134,32 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         return queryset.filter(team_id=self.team_id)
+
+    def _track(self, event: str, instance: LogsAlertConfiguration) -> None:
+        report_user_action(
+            self.request.user,
+            event,
+            {
+                "id": str(instance.id),
+                "name": instance.name,
+                "enabled": instance.enabled,
+                "threshold_count": instance.threshold_count,
+                "threshold_operator": instance.threshold_operator,
+                "window_minutes": instance.window_minutes,
+            },
+            team=self.team,
+            request=self.request,
+        )
+
+    def perform_create(self, serializer) -> None:
+        self._track("logs alert created", serializer.save())
+
+    def perform_update(self, serializer) -> None:
+        self._track("logs alert updated", serializer.save())
+
+    def perform_destroy(self, instance: LogsAlertConfiguration) -> None:
+        self._track("logs alert deleted", instance)
+        super().perform_destroy(instance)
 
 
 @mutable_receiver(model_activity_signal, sender=LogsAlertConfiguration)

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -17,7 +17,7 @@ from posthog.schema import DateRange, LogAttributesQuery, LogsQuery, LogValuesQu
 
 from posthog.api.mixins import PydanticModelMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.event_usage import get_request_analytics_properties
+from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import User
 from posthog.models.exported_asset import ExportedAsset
@@ -216,6 +216,23 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             }
             next_cursor = base64.b64encode(json.dumps(cursor_data).encode("utf-8")).decode("utf-8")
 
+        if not live_logs_checkpoint:
+            report_user_action(
+                request.user,
+                "logs query executed",
+                {
+                    "results_count": len(results),
+                    "has_more": has_more,
+                    "has_search_term": bool(query_data.get("searchTerm")),
+                    "has_filter_group": bool(query_data.get("filterGroup")),
+                    "severity_levels_count": len(query_data.get("severityLevels", [])),
+                    "service_names_count": len(query_data.get("serviceNames", [])),
+                    "is_paginated": bool(after_cursor),
+                },
+                team=self.team,
+                request=request,
+            )
+
         return Response(
             {
                 "query": query,
@@ -247,6 +264,21 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             analytics_props=get_request_analytics_properties(request),
         )
         assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
+
+        report_user_action(
+            request.user,
+            "logs sparkline queried",
+            {
+                "has_search_term": bool(query_data.get("searchTerm")),
+                "has_filter_group": bool(query_data.get("filterGroup")),
+                "severity_levels_count": len(query_data.get("severityLevels", [])),
+                "service_names_count": len(query_data.get("serviceNames", [])),
+                "breakdown_by": query_data.get("sparklineBreakdownBy"),
+            },
+            team=self.team,
+            request=request,
+        )
+
         return Response(response.results, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["GET"], required_scopes=["logs:read"])
@@ -366,6 +398,13 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         cache_key = f"team:{self.team.id}:has_logs"
         cached = cache.get(cache_key)
         if cached is True:
+            report_user_action(
+                request.user,
+                "logs has_logs checked",
+                {"has_logs": True},
+                team=self.team,
+                request=request,
+            )
             return Response({"hasLogs": True}, status=status.HTTP_200_OK)
 
         runner = HasLogsQueryRunner(self.team)
@@ -374,6 +413,14 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         # Only cache positive results (once you have logs, you always have logs)
         if has_logs:
             cache.set(cache_key, True, int(dt.timedelta(days=7).total_seconds()))
+
+        report_user_action(
+            request.user,
+            "logs has_logs checked",
+            {"has_logs": has_logs},
+            team=self.team,
+            request=request,
+        )
 
         return Response({"hasLogs": has_logs}, status=status.HTTP_200_OK)
 
@@ -399,6 +446,19 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         )
 
         export_asset.delay(asset.id)
+
+        report_user_action(
+            request.user,
+            "logs export requested",
+            {
+                "export_id": asset.id,
+                "columns_count": len(columns),
+                "has_search_term": bool(query_data.get("searchTerm")),
+                "service_names_count": len(query_data.get("serviceNames", [])),
+            },
+            team=self.team,
+            request=request,
+        )
 
         return Response(
             {

--- a/products/logs/backend/explain.py
+++ b/products/logs/backend/explain.py
@@ -29,6 +29,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.client.connection import Workload
+from posthog.event_usage import report_user_action
 from posthog.models import Team
 from posthog.rate_limit import (
     LLMAnalyticsSummarizationBurstThrottle,
@@ -310,6 +311,16 @@ class LogExplainViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                         uuid=uuid,
                         team_id=self.team_id,
                     )
+                    report_user_action(
+                        request.user,
+                        "logs explain requested",
+                        {
+                            "force_refresh": False,
+                            "cached": True,
+                        },
+                        team=self.team,
+                        request=request,
+                    )
                     return Response(cached_result, status=status.HTTP_200_OK)
 
             log_data = fetch_log_by_uuid(self.team, uuid, timestamp)
@@ -325,6 +336,17 @@ class LogExplainViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 uuid=uuid,
                 team_id=self.team_id,
                 force_refresh=force_refresh,
+            )
+
+            report_user_action(
+                request.user,
+                "logs explain requested",
+                {
+                    "force_refresh": force_refresh,
+                    "cached": False,
+                },
+                team=self.team,
+                request=request,
             )
 
             return Response(result, status=status.HTTP_200_OK)

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -37,7 +37,8 @@ class TestLogsAlertAPI(APIBaseTest):
 
     # --- CRUD ---
 
-    def test_create(self):
+    @patch("products.logs.backend.alerts_api.report_user_action")
+    def test_create(self, mock_report):
         data = self._create_via_api()
         assert data["name"] == "High error rate"
         assert data["threshold_count"] == 10
@@ -45,6 +46,11 @@ class TestLogsAlertAPI(APIBaseTest):
         assert data["enabled"] is True
         assert data["created_by"]["id"] == self.user.pk
         assert data["filters"] == {"severityLevels": ["error"]}
+
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs alert created"
+        assert mock_report.call_args[0][2]["name"] == "High error rate"
+        assert mock_report.call_args[0][2]["threshold_count"] == 10
 
     def test_list(self):
         self._create_via_api(name="Alert 1")
@@ -75,8 +81,10 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["name"] == "Renamed"
 
-    def test_partial_update(self):
+    @patch("products.logs.backend.alerts_api.report_user_action")
+    def test_partial_update(self, mock_report):
         created = self._create_via_api()
+        mock_report.reset_mock()
 
         response = self.client.patch(
             f"{self.base_url}{created['id']}/",
@@ -86,12 +94,22 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["name"] == "Patched"
 
-    def test_delete(self):
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs alert updated"
+        assert mock_report.call_args[0][2]["name"] == "Patched"
+
+    @patch("products.logs.backend.alerts_api.report_user_action")
+    def test_delete(self, mock_report):
         created = self._create_via_api()
+        mock_report.reset_mock()
 
         response = self.client.delete(f"{self.base_url}{created['id']}/")
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not LogsAlertConfiguration.objects.filter(pk=created["id"]).exists()
+
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs alert deleted"
+        assert mock_report.call_args[0][2]["name"] == "High error rate"
 
     # --- Team isolation ---
 

--- a/products/logs/backend/test/test_explain.py
+++ b/products/logs/backend/test/test_explain.py
@@ -279,7 +279,8 @@ class TestLogExplainAPI(ClickhouseTestMixin, APIBaseTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_successful_explanation(self):
+    @patch("products.logs.backend.explain.report_user_action")
+    def test_successful_explanation(self, mock_report):
         self.organization.is_ai_data_processing_approved = True
         self.organization.save()
 
@@ -314,7 +315,12 @@ class TestLogExplainAPI(ClickhouseTestMixin, APIBaseTest):
         assert len(data["probable_causes"]) == 1
         assert len(data["immediate_actions"]) == 1
 
-    def test_caches_result(self):
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs explain requested"
+        assert mock_report.call_args[0][2]["cached"] is False
+
+    @patch("products.logs.backend.explain.report_user_action")
+    def test_caches_result(self, mock_report):
         self.organization.is_ai_data_processing_approved = True
         self.organization.save()
 
@@ -345,6 +351,9 @@ class TestLogExplainAPI(ClickhouseTestMixin, APIBaseTest):
             assert response1.status_code == status.HTTP_200_OK
             assert mock_client.chat.completions.create.call_count == 1
 
+            assert mock_report.call_args[0][1] == "logs explain requested"
+            assert mock_report.call_args[0][2]["cached"] is False
+
             # Second request should use cache
             response2 = self.client.post(
                 f"/api/environments/{self.team.id}/logs/explainLogWithAI/",
@@ -352,6 +361,9 @@ class TestLogExplainAPI(ClickhouseTestMixin, APIBaseTest):
             )
             assert response2.status_code == status.HTTP_200_OK
             assert mock_client.chat.completions.create.call_count == 1  # Still 1, used cache
+
+            assert mock_report.call_count == 2
+            assert mock_report.call_args[0][2]["cached"] is True
 
     def test_force_refresh_bypasses_cache(self):
         self.organization.is_ai_data_processing_approved = True

--- a/products/logs/backend/test/test_has_logs_query_runner.py
+++ b/products/logs/backend/test/test_has_logs_query_runner.py
@@ -124,7 +124,10 @@ class TestHasLogsAPI(ClickhouseTestMixin, APIBaseTest):
             """)
 
         # First call should hit the database and cache the result
-        with patch("products.logs.backend.api.HasLogsQueryRunner") as mock_runner:
+        with (
+            patch("products.logs.backend.api.HasLogsQueryRunner") as mock_runner,
+            patch("products.logs.backend.api.report_user_action") as mock_report,
+        ):
             mock_runner.return_value.run.return_value = True
 
             response = self.client.get(f"/api/projects/{self.team.id}/logs/has_logs")
@@ -132,11 +135,17 @@ class TestHasLogsAPI(ClickhouseTestMixin, APIBaseTest):
             self.assertEqual(response.json(), {"hasLogs": True})
             self.assertEqual(mock_runner.return_value.run.call_count, 1)
 
+            assert mock_report.call_args[0][1] == "logs has_logs checked"
+            assert mock_report.call_args[0][2]["has_logs"] is True
+
             # Second call should use cache, not hit the runner again
             response = self.client.get(f"/api/projects/{self.team.id}/logs/has_logs")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(response.json(), {"hasLogs": True})
             self.assertEqual(mock_runner.return_value.run.call_count, 1)
+
+            # Tracking should fire on both cached and uncached paths
+            assert mock_report.call_count == 2
 
     def test_has_logs_api_does_not_cache_negative_results(self):
         cache.clear()

--- a/products/logs/backend/test/test_logs_export.py
+++ b/products/logs/backend/test/test_logs_export.py
@@ -15,8 +15,9 @@ def _minimal_query_data() -> dict:
 
 
 class TestLogsExportEndpoint(APIBaseTest):
+    @patch("products.logs.backend.api.report_user_action")
     @patch("products.logs.backend.api.export_asset")
-    def test_export_creates_asset_with_correct_context(self, mock_export_asset):
+    def test_export_creates_asset_with_correct_context(self, mock_export_asset, mock_report):
         response = self.client.post(
             f"/api/projects/{self.team.pk}/logs/export/",
             data={
@@ -35,6 +36,10 @@ class TestLogsExportEndpoint(APIBaseTest):
         assert asset.export_context["source"]["kind"] == "LogsQuery"
         assert asset.export_context["columns"] == ["timestamp", "body"]
         mock_export_asset.delay.assert_called_once_with(asset.id)
+
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs export requested"
+        assert mock_report.call_args[0][2]["columns_count"] == 2
 
     @parameterized.expand(
         [

--- a/products/logs/backend/test/test_views_api.py
+++ b/products/logs/backend/test/test_views_api.py
@@ -35,13 +35,19 @@ class TestLogsViewAPI(APIBaseTest):
 
     # --- CRUD ---
 
-    def test_create(self):
+    @patch("products.logs.backend.views_api.report_user_action")
+    def test_create(self, mock_report):
         data = self._create_via_api()
         assert data["name"] == "Error logs"
         assert data["filters"] == {"severityLevels": ["error", "fatal"]}
         assert data["pinned"] is False
         assert data["short_id"] is not None
         assert data["created_by"]["id"] == self.user.pk
+
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs view created"
+        assert mock_report.call_args[0][2]["name"] == "Error logs"
+        assert mock_report.call_args[0][2]["has_filters"] is True
 
     def test_list(self):
         self._create_via_api(name="View 1")
@@ -61,8 +67,10 @@ class TestLogsViewAPI(APIBaseTest):
         assert response.json()["short_id"] == created["short_id"]
         assert response.json()["name"] == "Error logs"
 
-    def test_partial_update(self):
+    @patch("products.logs.backend.views_api.report_user_action")
+    def test_partial_update(self, mock_report):
         created = self._create_via_api()
+        mock_report.reset_mock()
 
         response = self.client.patch(
             f"{self.base_url}{created['short_id']}/",
@@ -71,6 +79,10 @@ class TestLogsViewAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["name"] == "Renamed view"
+
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs view updated"
+        assert mock_report.call_args[0][2]["name"] == "Renamed view"
 
     def test_partial_update_preserves_filters(self):
         created = self._create_via_api(filters={"severityLevels": ["error"], "serviceNames": ["api"]})
@@ -84,12 +96,18 @@ class TestLogsViewAPI(APIBaseTest):
         assert response.json()["name"] == "Just rename"
         assert response.json()["filters"] == {"severityLevels": ["error"], "serviceNames": ["api"]}
 
-    def test_delete(self):
+    @patch("products.logs.backend.views_api.report_user_action")
+    def test_delete(self, mock_report):
         created = self._create_via_api()
+        mock_report.reset_mock()
 
         response = self.client.delete(f"{self.base_url}{created['short_id']}/")
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not LogsView.objects.filter(pk=created["id"]).exists()
+
+        mock_report.assert_called_once()
+        assert mock_report.call_args[0][1] == "logs view deleted"
+        assert mock_report.call_args[0][2]["name"] == "Error logs"
 
     # --- Filters are optional ---
 

--- a/products/logs/backend/views_api.py
+++ b/products/logs/backend/views_api.py
@@ -5,6 +5,7 @@ from rest_framework import serializers, viewsets
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.event_usage import report_user_action
 from posthog.permissions import PostHogFeatureFlagPermission
 
 from products.logs.backend.models import LogsView
@@ -57,3 +58,28 @@ class LogsViewViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         queryset = queryset.filter(team_id=self.team_id)
         queryset = queryset.select_related("created_by")
         return queryset
+
+    def _track(self, event: str, instance: LogsView) -> None:
+        report_user_action(
+            self.request.user,
+            event,
+            {
+                "id": str(instance.id),
+                "short_id": instance.short_id,
+                "name": instance.name,
+                "pinned": instance.pinned,
+                "has_filters": bool(instance.filters),
+            },
+            team=self.team,
+            request=self.request,
+        )
+
+    def perform_create(self, serializer) -> None:
+        self._track("logs view created", serializer.save())
+
+    def perform_update(self, serializer) -> None:
+        self._track("logs view updated", serializer.save())
+
+    def perform_destroy(self, instance: LogsView) -> None:
+        self._track("logs view deleted", instance)
+        super().perform_destroy(instance)


### PR DESCRIPTION
## Problem

As we ramp up our AI tooling for APM/Logs we'll need to see usage broken down by usage source (user, api. mcp e.t.c.)

## Changes

Added comprehensive user action tracking across the logs product:

**Logs API endpoints:**

- Track `logs query executed` with query metadata (results count, filters, pagination status)
- Track `logs sparkline queried` with breakdown and filter information
- Track `logs has_logs checked` with availability status
- Track `logs export requested` with export details and query parameters

**Logs alerts management:**

- Track `logs alert created`, `logs alert updated`, and `logs alert deleted` with alert configuration details (threshold, operator, window, enabled status)

**Logs views management:**

- Track `logs view created`, `logs view updated`, and `logs view deleted` with view metadata (name, pinned status, filter presence)

**Logs explain feature:**

- Track `logs explain requested` with cache status and force refresh flag

All tracking includes relevant context properties to enable detailed usage analysis and breakdown by different usage sources.

## How did you test this code?

Code review and validation of tracking implementation patterns. The tracking follows existing PostHog conventions using `report_user_action` with appropriate event names and property structures.

## Publish to changelog?

No