### PR TITLE
fix(replay): fall back to unhashed js when hashed CDN asset is missing

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -90,7 +90,7 @@ export function copyIndexHtml(
             } catch (error) {
                 console.error('Error loading chunk: "' + file + '"')
                 console.error(error)
-                if (file !== ${JSON.stringify(jsFileFallback)}) {
+                if (file === ${JSON.stringify(jsFile)} && file !== ${JSON.stringify(jsFileFallback)}) {
                     await import((window.JS_URL || '') + '/static/' + ${JSON.stringify(jsFileFallback)})
                 }
             }

--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -82,6 +82,7 @@ export function copyIndexHtml(
     const cssFile =
         relativeFiles.length > 0 ? relativeFiles.find((e) => e.endsWith('.css')) : `${entry}.css?t=${buildId}`
 
+    const jsFileFallback = `${entry}.js`
     const scriptCode = `
         window.ESBUILD_LOAD_SCRIPT = async function (file) {
             try {
@@ -89,6 +90,9 @@ export function copyIndexHtml(
             } catch (error) {
                 console.error('Error loading chunk: "' + file + '"')
                 console.error(error)
+                if (file !== ${JSON.stringify(jsFileFallback)}) {
+                    await import((window.JS_URL || '') + '/static/' + ${JSON.stringify(jsFileFallback)})
+                }
             }
         }
         window.ESBUILD_LOAD_SCRIPT(${JSON.stringify(jsFile)})


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Problem:
Shared links show blank pages on Cloud. The hashed JS files are missing from the S3 bucket, returning 403. Root cause is the upload-assets job intermittently failing.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Falls back to the unhashed exporter.js (already uploaded by createHashlessEntrypoints) when the hashed file fails to load. Happy path unchanged; fallback may serve a slightly stale version (up to 24h CDN TTL).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
