### PR TITLE
fix(workflows): Remove SES Send/Delivery webhook metrics to prevent triple counting email_sent

### DIFF
--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -217,6 +217,7 @@ export class EmailTrackingService {
         }
     }
 
+    // NOTE: this is somewhat naieve. We should expand with UA checking for things like apple's tracking prevention etc.
     // Metrics are not recorded here because SES webhooks already track opens.
     // Recording here would double-count. The pixel is still served so email
     // clients that load it get a valid response.

--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -57,24 +57,18 @@ describe('SesWebhookHandler', () => {
         expect(result.metrics?.[0].metricName).toBe('email_link_clicked')
     })
 
-    it('parses a raw Delivery event', async () => {
-        const body = [
-            {
-                eventType: 'Delivery',
-                mail: baseMail,
-                delivery: {
-                    processingTimeMillis: 1000,
-                    smtpResponse: '250 OK',
-                    reportingMTA: 'mta',
-                    timestamp: '2025-10-03T12:03:00Z',
-                    recipients: ['to@example.com'],
-                },
-            },
-        ]
-        const result = await handler.handleWebhook({ body, headers: {} })
-        expect(result.status).toBe(200)
-        expect(result.metrics?.[0].metricName).toBe('email_sent')
-    })
+    it.each([
+        ['Send', {}],
+        ['Delivery', { delivery: { timestamp: '2025-10-03T12:03:00Z' } }],
+    ] as const)(
+        'skips %s events (email_sent is recorded synchronously, not from webhooks)',
+        async (eventType, extra) => {
+            const body = [{ eventType, mail: baseMail, ...extra }]
+            const result = await handler.handleWebhook({ body, headers: {} })
+            expect(result.status).toBe(200)
+            expect(result.metrics).toHaveLength(0)
+        }
+    )
 
     it('parses a raw Bounce event and returns opt-out recipients for permanent bounces', async () => {
         const body = [

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -143,16 +143,15 @@ const SesEventBatchSchema = z.array(SesEventRecordSchema)
 
 export type SesEventRecord = z.infer<typeof SesEventRecordSchema>
 
-const EVENT_TYPE_TO_METRIC_NAME: Record<SesEventRecord['eventType'], MinimalAppMetric['metric_name']> = {
+// email_sent is recorded synchronously in email.service.ts when the email is sent,
+// so we don't record it again from SES Send/Delivery webhooks to avoid double counting.
+const EVENT_TYPE_TO_METRIC_NAME: Partial<Record<SesEventRecord['eventType'], MinimalAppMetric['metric_name']>> = {
     Open: 'email_opened',
     Click: 'email_link_clicked',
-    // Delivery: 'email_sent',
     Bounce: 'email_bounced',
     Complaint: 'email_blocked',
     RenderingFailure: 'email_failed',
-    Send: 'email_sent',
     Reject: 'email_failed',
-    Delivery: 'email_sent',
 }
 
 export class SesWebhookHandler {
@@ -384,7 +383,9 @@ export class SesWebhookHandler {
             }
 
             const metricName = EVENT_TYPE_TO_METRIC_NAME[rec.eventType]
-            metrics.push({ functionId, invocationId, actionId, metricName })
+            if (metricName) {
+                metrics.push({ functionId, invocationId, actionId, metricName })
+            }
 
             // Opt out recipients on permanent bounces
             if (teamId && rec.eventType === 'Bounce' && rec.bounce.bounceType === 'Permanent') {


### PR DESCRIPTION
## Problem

Every email sent through workflows is counted 3x in the "Emails sent" metric. This happens because `email_sent` is recorded from three sources: once synchronously when the email is sent (`email.service.ts`), once from the SES `Send` webhook, and once from the SES `Delivery` webhook. A workflow that sends 6 emails shows 18 in the metrics.

<img width="2347" height="779" alt="Screenshot 2026-03-25 at 14 50 48" src="https://github.com/user-attachments/assets/3a45962a-5cd8-49a2-aaed-501f267afefa" />

## Changes

- Removed `Send` and `Delivery` from the SES webhook event-to-metric mapping. `email_sent` is already recorded synchronously in `email.service.ts` when the email is sent, so the webhook events are redundant.
- Added a guard to skip SES events that don't have a metric mapping (Send, Delivery, DeliveryDelay) instead of pushing undefined metric names.
- Restored a NOTE comment about email client tracking prevention that was accidentally removed in a prior PR.

## How did you test this code?

- Confirmed the 3x counting in production (6 emails showing as 18 sent)
- All email tracking, SES webhook, and email service tests pass
- Updated the Delivery event test to verify it no longer produces metrics

## Publish to changelog?

No