### PR TITLE
fix(modeling): 15min schedules sync daily by mistake

### DIFF
--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -36,6 +36,7 @@ def _short_interval_spec(entity_id: uuid.UUID, interval: timedelta, timezone: st
         calendars=[
             ScheduleCalendarSpec(
                 comment=f"Every {base_min}th minute in the {interval_mins}min interval window (bucketed)",
+                hour=[ScheduleRange(start=0, end=23)],
                 minute=[ScheduleRange(start=m, end=m) for m in mins],
             )
         ],

--- a/products/data_modeling/backend/test/test_schedule.py
+++ b/products/data_modeling/backend/test/test_schedule.py
@@ -36,6 +36,12 @@ class TestShortIntervalSpec:
         spec = build_schedule_spec(uuid.uuid4(), timedelta(hours=1))
         assert len(spec.calendars[0].minute) == 1
 
+    def test_15min_runs_every_hour(self):
+        spec = build_schedule_spec(uuid.uuid4(), timedelta(minutes=15))
+        assert len(spec.calendars[0].hour) == 1
+        assert spec.calendars[0].hour[0].start == 0
+        assert spec.calendars[0].hour[0].end == 23
+
     def test_15min_minutes_are_spaced_15_apart(self):
         spec = build_schedule_spec(uuid.uuid4(), timedelta(minutes=15))
         mins = sorted(r.start for r in spec.calendars[0].minute)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

15 mins != 15 mins

## Changes

15 mins == 15 mins

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

unit test

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->