### PR TITLE
fix(error-tracking): improve issue list presentation

### DIFF
--- a/products/error_tracking/frontend/components/Indicators.tsx
+++ b/products/error_tracking/frontend/components/Indicators.tsx
@@ -31,7 +31,10 @@ export const LabelIndicator = React.forwardRef<HTMLDivElement, LabelIndicatorPro
 ): JSX.Element {
     return (
         <Tooltip title={tooltip} placement={tooltipPlacement}>
-            <div ref={ref} className={clsx('flex items-center cursor-help', className, sizeVariants[size])}>
+            <div
+                ref={ref}
+                className={clsx('flex items-center', tooltip && 'cursor-help', className, sizeVariants[size])}
+            >
                 <LemonBadge status={intent} size="small" />
                 <div>{label}</div>
             </div>

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -32,7 +32,7 @@ export const IssueListTitleHeader = ({
     const allSelected = results.length == selectedIssueIds.length && selectedIssueIds.length > 0
 
     return (
-        <div className="flex gap-2 items-center">
+        <div className="flex gap-3 items-center -ml-1">
             <LemonCheckbox
                 checked={allSelected}
                 onChange={() => (allSelected ? setSelectedIssueIds([]) : setSelectedIssueIds(results.map((r) => r.id)))}
@@ -106,8 +106,8 @@ export const IssueListTitleColumn = (props: {
     }, [dateRange, filterGroup, filterTestAccounts, searchQuery, record.last_seen, record.id])
 
     return (
-        <div className="flex items-start gap-x-2 group my-1 [--line-height:1.3rem]">
-            <LemonCheckbox className="h-(--line-height)" checked={checked} onChange={handleSelectionChange} />
+        <div className="flex items-start gap-x-2 group my-1 [--line-height:1.3rem] -ml-2">
+            <LemonCheckbox className="h-(--line-height) mx-1" checked={checked} onChange={handleSelectionChange} />
             <div className="flex flex-col gap-[2px]">
                 <IssueTitle record={record} issueUrl={issueUrl} runtime={runtime} />
                 <div

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -124,6 +124,7 @@ export const IssueListTitleColumn = (props: {
                 )}
                 <IssueMetadata
                     record={record}
+                    orderBy={orderBy}
                     onStatusChange={(status) => updateIssueStatus(record.id, status)}
                     onAssigneeChange={(assignee) => updateIssueAssignee(record.id, assignee)}
                 />
@@ -162,10 +163,12 @@ const IssueTitle = ({
 
 const IssueMetadata = ({
     record,
+    orderBy,
     onStatusChange,
     onAssigneeChange,
 }: {
     record: ErrorTrackingIssue
+    orderBy: string
     onStatusChange: (status: ErrorTrackingIssue['status']) => void
     onAssigneeChange: (assignee: ErrorTrackingIssue['assignee']) => void
 }): JSX.Element => (
@@ -189,12 +192,21 @@ const IssueMetadata = ({
             )}
         </AssigneeSelect>
         <CustomSeparator />
-        <TZLabel time={record.first_seen} className="border-dotted border-b text-xs ml-1" delayMs={750} />
-        <IconChevronRight className="text-quaternary mx-1" />
+        {orderBy === 'first_seen' && (
+            <>
+                <TZLabel
+                    time={record.first_seen}
+                    className="border-dotted border-b text-xs ml-1"
+                    suffix="old"
+                    delayMs={750}
+                />
+                <IconChevronRight className="text-quaternary mx-0.5" fontSize="0.75rem" />
+            </>
+        )}
         {record.last_seen ? (
-            <TZLabel time={record.last_seen} className="border-dotted border-b text-xs" delayMs={750} />
+            <TZLabel time={record.last_seen} className="border-dotted border-b text-xs ml-1" delayMs={750} />
         ) : (
-            <LemonSkeleton />
+            <LemonSkeleton className="ml-1" />
         )}
     </div>
 )

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -42,45 +42,63 @@ export const IssueListTitleHeader = ({
     )
 }
 
-export const IssueListTitleColumn = <T extends ErrorTrackingIssue | ErrorTrackingCorrelatedIssue>(props: {
-    results: T[]
+/** Resolve which issue IDs should be toggled, supporting shift-click range selection. */
+function getShiftClickIds(
+    results: { id: string }[],
+    recordIndex: number,
+    recordId: string,
+    shiftKeyHeld: boolean,
+    previouslyCheckedRecordIndex: number | null
+): string[] {
+    if (!shiftKeyHeld || previouslyCheckedRecordIndex === null) {
+        return [recordId]
+    }
+    const start = Math.min(previouslyCheckedRecordIndex, recordIndex)
+    const end = Math.max(previouslyCheckedRecordIndex, recordIndex) + 1
+    return results.slice(start, end).map((r) => r.id)
+}
+
+export const IssueListTitleColumn = (props: {
+    results: (ErrorTrackingIssue | ErrorTrackingCorrelatedIssue)[]
     record: unknown
     recordIndex: number
 }): JSX.Element => {
+    const record = props.record as ErrorTrackingIssue
+    const { recordIndex, results } = props
     const { selectedIssueIds, shiftKeyHeld, previouslyCheckedRecordIndex } = useValues(bulkSelectLogic)
     const { setSelectedIssueIds, setPreviouslyCheckedRecordIndex } = useActions(bulkSelectLogic)
     const { updateIssueAssignee, updateIssueStatus } = useActions(issueActionsLogic)
     const { dateRange, filterGroup, filterTestAccounts, searchQuery } = useValues(issueFiltersLogic)
     const { orderBy } = useValues(issueQueryOptionsLogic)
 
-    const record = props.record as ErrorTrackingIssue
     const checked = selectedIssueIds.includes(record.id)
     const runtime = getRuntimeFromLib(record.library)
-    const recordIndex = props.recordIndex
 
-    const onChange = (newValue: boolean): void => {
-        const includedIds: string[] = []
-
-        if (!shiftKeyHeld || previouslyCheckedRecordIndex === null) {
-            includedIds.push(record.id)
-        } else {
-            const start = Math.min(previouslyCheckedRecordIndex, recordIndex)
-            const end = Math.max(previouslyCheckedRecordIndex, recordIndex) + 1
-            includedIds.push(...props.results.slice(start, end).map((r) => r.id))
-        }
-
+    const handleSelectionChange = (newValue: boolean): void => {
+        const idsToToggle = getShiftClickIds(
+            results,
+            recordIndex,
+            record.id,
+            shiftKeyHeld,
+            previouslyCheckedRecordIndex
+        )
         setPreviouslyCheckedRecordIndex(recordIndex)
         setSelectedIssueIds(
             newValue
-                ? [...new Set([...selectedIssueIds, ...includedIds])]
-                : selectedIssueIds.filter((id) => !includedIds.includes(id))
+                ? [...new Set([...selectedIssueIds, ...idsToToggle])]
+                : selectedIssueIds.filter((id) => !idsToToggle.includes(id))
         )
     }
 
+    // Keep params in sync between listing and details views
     const issueUrl = useMemo(() => {
         const params: Params = {}
-        // We want to keep params in sync between listing and details views
-        updateFilterSearchParams(params, { dateRange, filterGroup, filterTestAccounts, searchQuery })
+        updateFilterSearchParams(params, {
+            dateRange,
+            filterGroup,
+            filterTestAccounts,
+            searchQuery,
+        })
         return urls.errorTrackingIssue(record.id, {
             timestamp: record.last_seen,
             ...params,
@@ -88,83 +106,97 @@ export const IssueListTitleColumn = <T extends ErrorTrackingIssue | ErrorTrackin
     }, [dateRange, filterGroup, filterTestAccounts, searchQuery, record.last_seen, record.id])
 
     return (
-        <div className="flex items-start gap-x-2 group my-1">
-            <LemonCheckbox className="h-[1rem]" checked={checked} onChange={onChange} />
-
-            <div className="flex flex-col gap-[3px]">
-                <Link
-                    className="flex-1 pr-12"
-                    to={issueUrl}
-                    onClick={() => {
-                        const issueLogic = errorTrackingIssueSceneLogic({ id: record.id, timestamp: record.last_seen })
-                        issueLogic.mount()
-                        issueLogic.actions.setIssue(record)
-                    }}
+        <div className="flex items-start gap-x-2 group my-1 [--line-height:1.3rem]">
+            <LemonCheckbox className="h-(--line-height)" checked={checked} onChange={handleSelectionChange} />
+            <div className="flex flex-col gap-[2px]">
+                <IssueTitle record={record} issueUrl={issueUrl} runtime={runtime} />
+                <div
+                    title={record.description || undefined}
+                    className="font-medium line-clamp-1 text-[var(--gray-8)] h-(--line-height)"
                 >
-                    <div className="flex items-center h-[1rem] gap-2">
-                        <RuntimeIcon className="shrink-0" runtime={runtime} fontSize="0.7rem" />
-                        <span className="font-semibold text-[0.9rem] line-clamp-1">
-                            {record.name || 'Unknown Type'}
-                        </span>
-                    </div>
-                </Link>
-                <div title={record.description || undefined} className="font-medium line-clamp-1 text-[var(--gray-8)]">
                     {record.description}
                 </div>
-                <div className="line-clamp-1 text-[var(--gray-8)] italic">
-                    {record.function}
-                    {record.source ? <> in {sourceDisplay(record.source)}</> : <></>}
-                </div>
-                <div className="flex items-center text-secondary">
-                    <IssueStatusSelect
-                        status={record.status}
-                        onChange={(status) => updateIssueStatus(record.id, status)}
-                    />
-                    <CustomSeparator />
-                    <AssigneeSelect
-                        assignee={record.assignee}
-                        onChange={(assignee) => updateIssueAssignee(record.id, assignee)}
-                    >
-                        {(anyAssignee) => (
-                            <div
-                                className="flex items-center hover:bg-fill-button-tertiary-hover p-[0.1rem] rounded cursor-pointer"
-                                role="button"
-                            >
-                                <AssigneeIconDisplay assignee={anyAssignee} size="xsmall" />
-                                <AssigneeLabelDisplay
-                                    assignee={anyAssignee}
-                                    className="ml-1 text-xs text-secondary"
-                                    size="xsmall"
-                                />
-                                <IconChevronDown />
-                            </div>
-                        )}
-                    </AssigneeSelect>
-                    <CustomSeparator />
-                    {orderBy === 'first_seen' && (
-                        <>
-                            <TZLabel
-                                time={record.first_seen}
-                                className="border-dotted border-b text-xs ml-1"
-                                suffix="old"
-                                delayMs={750}
-                            />
-                            <IconChevronRight className="text-quaternary mx-0.5" fontSize="0.75rem" />
-                        </>
-                    )}
-                    {record.last_seen ? (
-                        <TZLabel
-                            time={record.last_seen}
-                            className="border-dotted border-b text-xs ml-1"
-                            delayMs={750}
-                        />
-                    ) : (
-                        <LemonSkeleton className="ml-1" />
-                    )}
-                </div>
+                {(record.function || record.source) && (
+                    <div className="line-clamp-1 text-[var(--gray-6)] italic font-light h-(--line-height)">
+                        {record.function}
+                        {record.source ? <> in {sourceDisplay(record.source)}</> : <></>}
+                    </div>
+                )}
+                <IssueMetadata
+                    record={record}
+                    onStatusChange={(status) => updateIssueStatus(record.id, status)}
+                    onAssigneeChange={(assignee) => updateIssueAssignee(record.id, assignee)}
+                />
             </div>
         </div>
     )
 }
+
+const IssueTitle = ({
+    record,
+    issueUrl,
+    runtime,
+}: {
+    record: ErrorTrackingIssue
+    issueUrl: string
+    runtime: string | undefined
+}): JSX.Element => (
+    <Link
+        className="flex-1 pr-12 text-[0.9rem]"
+        to={issueUrl}
+        onClick={() => {
+            const issueLogic = errorTrackingIssueSceneLogic({
+                id: record.id,
+                timestamp: record.last_seen,
+            })
+            issueLogic.mount()
+            issueLogic.actions.setIssue(record)
+        }}
+    >
+        <div className="flex items-center gap-2 h-(--line-height)">
+            <RuntimeIcon className="shrink-0" runtime={runtime} fontSize="0.7rem" />
+            <span className="font-semibold line-clamp-1">{record.name || 'Unknown Type'}</span>
+        </div>
+    </Link>
+)
+
+const IssueMetadata = ({
+    record,
+    onStatusChange,
+    onAssigneeChange,
+}: {
+    record: ErrorTrackingIssue
+    onStatusChange: (status: ErrorTrackingIssue['status']) => void
+    onAssigneeChange: (assignee: ErrorTrackingIssue['assignee']) => void
+}): JSX.Element => (
+    <div className="flex items-center text-secondary h-[calc(var(--line-height)*1.3)]">
+        <IssueStatusSelect status={record.status} onChange={onStatusChange} />
+        <CustomSeparator />
+        <AssigneeSelect assignee={record.assignee} onChange={onAssigneeChange}>
+            {(anyAssignee) => (
+                <div
+                    className="flex items-center hover:bg-fill-button-tertiary-hover p-[0.1rem] rounded cursor-pointer"
+                    role="button"
+                >
+                    <AssigneeIconDisplay assignee={anyAssignee} size="xsmall" />
+                    <AssigneeLabelDisplay
+                        assignee={anyAssignee}
+                        className="ml-1 text-xs text-secondary"
+                        size="xsmall"
+                    />
+                    <IconChevronDown />
+                </div>
+            )}
+        </AssigneeSelect>
+        <CustomSeparator />
+        <TZLabel time={record.first_seen} className="border-dotted border-b text-xs ml-1" delayMs={750} />
+        <IconChevronRight className="text-quaternary mx-1" />
+        {record.last_seen ? (
+            <TZLabel time={record.last_seen} className="border-dotted border-b text-xs" delayMs={750} />
+        ) : (
+            <LemonSkeleton />
+        )}
+    </div>
+)
 
 export const CustomSeparator = (): JSX.Element => <IconMinus className="text-quaternary rotate-90" />

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -106,8 +106,10 @@ export const IssueListTitleColumn = (props: {
     }, [dateRange, filterGroup, filterTestAccounts, searchQuery, record.last_seen, record.id])
 
     return (
-        <div className="flex gap-x-2 group my-1 [--line-height:1.3rem]">
-            <LemonCheckbox className="self-center" checked={checked} onChange={handleSelectionChange} />
+        <div className="flex items-start gap-x-2 group my-1 [--line-height:1.3rem]">
+            <div className="flex justify-center w-6 shrink-0 h-(--line-height)">
+                <LemonCheckbox checked={checked} onChange={handleSelectionChange} />
+            </div>
             <div className="flex flex-col gap-[2px]">
                 <IssueTitle record={record} issueUrl={issueUrl} runtime={runtime} />
                 <div

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { IconChevronDown, IconChevronRight, IconMinus } from '@posthog/icons'
 import { LemonCheckbox, LemonSkeleton, Link } from '@posthog/lemon-ui'
 
+import { ErrorTrackingRuntime } from 'lib/components/Errors/types'
 import { getRuntimeFromLib } from 'lib/components/Errors/utils'
 import { TZLabel } from 'lib/components/TZLabel'
 import { Params } from 'scenes/sceneTypes'
@@ -140,7 +141,7 @@ const IssueTitle = ({
 }: {
     record: ErrorTrackingIssue
     issueUrl: string
-    runtime: string | undefined
+    runtime: ErrorTrackingRuntime
 }): JSX.Element => (
     <Link
         className="flex-1 pr-12 text-[0.9rem]"

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -107,9 +107,7 @@ export const IssueListTitleColumn = (props: {
 
     return (
         <div className="flex items-start gap-x-2 group my-1 [--line-height:1.3rem]">
-            <div className="flex justify-center w-6 shrink-0 h-(--line-height)">
-                <LemonCheckbox checked={checked} onChange={handleSelectionChange} />
-            </div>
+            <LemonCheckbox className="h-(--line-height)" checked={checked} onChange={handleSelectionChange} />
             <div className="flex flex-col gap-[2px]">
                 <IssueTitle record={record} issueUrl={issueUrl} runtime={runtime} />
                 <div

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -106,8 +106,8 @@ export const IssueListTitleColumn = (props: {
     }, [dateRange, filterGroup, filterTestAccounts, searchQuery, record.last_seen, record.id])
 
     return (
-        <div className="flex items-start gap-x-2 group my-1 [--line-height:1.3rem]">
-            <LemonCheckbox className="h-(--line-height)" checked={checked} onChange={handleSelectionChange} />
+        <div className="flex gap-x-2 group my-1 [--line-height:1.3rem]">
+            <LemonCheckbox className="self-center" checked={checked} onChange={handleSelectionChange} />
             <div className="flex flex-col gap-[2px]">
                 <IssueTitle record={record} issueUrl={issueUrl} runtime={runtime} />
                 <div


### PR DESCRIPTION
## Problem

The issue list rows in Error tracking had some visual rough edges: the function/source line showed even when empty, `cursor-help` appeared on indicators without tooltips, and the row component was a single large function that was hard to follow.

## Changes

- Extract `IssueTitle`, `IssueMetadata`, and `getShiftClickIds` into focused sub-components for readability
- Conditionally render the function/source line only when data exists
- Use a CSS custom property (`--line-height`) for consistent row element sizing
- Only apply `cursor-help` on `LabelIndicator` when a tooltip is actually present

Before: 
<img width="710" height="105" alt="image" src="https://github.com/user-attachments/assets/1869dee3-8284-494a-b781-9b15f609db29" />

After:
<img width="605" height="115" alt="image" src="https://github.com/user-attachments/assets/6da9b982-7ae4-47d7-8df2-2343fe380b65" />