### PR TITLE
fix: Release hash retrieval

### DIFF
--- a/posthog/slo/events.py
+++ b/posthog/slo/events.py
@@ -1,8 +1,7 @@
-import os
-
 import posthoganalytics
 from prometheus_client import Counter, Histogram
 
+from posthog.git import get_git_commit_short
 from posthog.slo.types import SloCompletedProperties, SloStartedProperties
 
 OPERATION_STARTED_COUNTER = Counter(
@@ -51,7 +50,7 @@ def emit_slo_started(
     extra_properties: dict | None = None,
 ) -> None:
     all_properties = properties.to_dict()
-    all_properties["deploy_sha"] = os.environ.get("COMMIT_SHA")
+    all_properties["deploy_sha"] = get_git_commit_short()
     if extra_properties:
         all_properties.update(extra_properties)
 
@@ -72,7 +71,7 @@ def emit_slo_completed(
     extra_properties: dict | None = None,
 ) -> None:
     all_properties = properties.to_dict()
-    all_properties["deploy_sha"] = os.environ.get("COMMIT_SHA")
+    all_properties["deploy_sha"] = get_git_commit_short()
     if extra_properties:
         all_properties.update(extra_properties)
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

This PR fixes the release hash calculation for the SLO metrics so that it's aligned with the other locations in the codebase.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

See above.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

CI passing.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

No

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
