### PR TITLE
fix(experiments): escape query for debug.

### DIFF
--- a/posthog/clickhouse/client/escape.py
+++ b/posthog/clickhouse/client/escape.py
@@ -93,3 +93,32 @@ def escape_param_for_clickhouse(param: Any) -> str:
         timezone="UTC",
     )
     return escape_param(param, context=context)
+
+
+def substitute_params_for_display(query: str, params: dict[str, Any]) -> str:
+    """
+    Substitute query parameters for display/debug purposes.
+
+    This function is for generating SQL output shown to users in debug panels.
+    Parameters marked with '_sensitive' suffix are replaced with '[HIDDEN]'.
+
+    DO NOT use this function for query execution - use substitute_params instead.
+
+    Args:
+        query: SQL query string with %(param_name)s placeholders
+        params: Dictionary of parameter values
+
+    Returns:
+        Query string with parameters substituted
+    """
+    if not isinstance(params, dict):
+        raise ValueError("Parameters are expected in dict form")
+
+    escaped = {}
+    for key, value in params.items():
+        if key.endswith("_sensitive"):
+            escaped[key] = "'[HIDDEN]'"
+        else:
+            escaped[key] = escape_param_for_clickhouse(value)
+
+    return query % escaped

--- a/posthog/clickhouse/client/test/test_escape.py
+++ b/posthog/clickhouse/client/test/test_escape.py
@@ -1,0 +1,114 @@
+import pytest
+
+from parameterized import parameterized
+
+from posthog.clickhouse.client.escape import substitute_params, substitute_params_for_display
+
+
+class TestSubstituteParams:
+    @parameterized.expand(
+        [
+            (
+                "basic values",
+                "SELECT * FROM table WHERE id = %(id)s AND name = %(name)s",
+                {"id": 123, "name": "test"},
+                ["123", "'test'"],
+            ),
+            (
+                "sensitive values not redacted in execution mode",
+                "SELECT * FROM s3(%(url)s, %(key)s, %(secret_sensitive)s)",
+                {
+                    "url": "s3://bucket/path",
+                    "key": "AKIAIOSFODNN7EXAMPLE",
+                    "secret_sensitive": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                },
+                ["AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"],
+            ),
+        ]
+    )
+    def test_substitute_params(self, _name, query, params, expected_in_result):
+        result = substitute_params(query, params)
+        for expected in expected_in_result:
+            assert expected in result
+
+    def test_substitute_params_raises_error_for_non_dict(self):
+        with pytest.raises(ValueError, match="Parameters are expected in dict form"):
+            substitute_params("SELECT 1", [1, 2, 3])
+
+
+class TestSubstituteParamsForDisplay:
+    @parameterized.expand(
+        [
+            (
+                "basic values",
+                "SELECT * FROM table WHERE id = %(id)s AND name = %(name)s",
+                {"id": 123, "name": "test"},
+                ["123", "'test'"],
+                [],
+                0,
+            ),
+            (
+                "s3 parameters",
+                "SELECT * FROM s3(%(url)s, %(access_key_sensitive)s, %(access_secret_sensitive)s)",
+                {
+                    "url": "s3://bucket/path",
+                    "access_key_sensitive": "AKIAIOSFODNN7EXAMPLE",
+                    "access_secret_sensitive": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                },
+                ["s3://bucket/path", "[HIDDEN]"],
+                ["AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"],
+                2,
+            ),
+            (
+                "azure blob parameters",
+                "SELECT * FROM azureBlobStorage(%(storage_url)s, %(container)s, %(access_key_sensitive)s, %(access_secret_sensitive)s)",
+                {
+                    "storage_url": "https://account.blob.core.windows.net",
+                    "container": "my-container",
+                    "access_key_sensitive": "account-name",
+                    "access_secret_sensitive": "super-secret-key",
+                },
+                ["https://account.blob.core.windows.net", "my-container", "[HIDDEN]"],
+                ["account-name", "super-secret-key"],
+                2,
+            ),
+            (
+                "all parameters marked",
+                "SELECT * FROM table WHERE key1 = %(key1_sensitive)s AND key2 = %(key2_sensitive)s",
+                {"key1_sensitive": "secret1", "key2_sensitive": "secret2"},
+                ["[HIDDEN]"],
+                ["secret1", "secret2"],
+                2,
+            ),
+            (
+                "no marked parameters",
+                "SELECT * FROM table WHERE id = %(id)s AND status = %(status)s",
+                {"id": 42, "status": "active"},
+                ["42", "'active'"],
+                ["[HIDDEN]"],
+                0,
+            ),
+        ]
+    )
+    def test_substitute_params_for_display(
+        self, _name, query, params, expected_in_result, not_expected_in_result, hidden_count
+    ):
+        result = substitute_params_for_display(query, params)
+
+        for expected in expected_in_result:
+            assert expected in result, f"Expected '{expected}' in result"
+
+        for not_expected in not_expected_in_result:
+            assert not_expected not in result, f"Did not expect '{not_expected}' in result"
+
+        assert result.count("[HIDDEN]") == hidden_count, f"Expected {hidden_count} [HIDDEN] occurrences"
+
+    def test_substitute_params_for_display_raises_error_for_non_dict(self):
+        with pytest.raises(ValueError, match="Parameters are expected in dict form"):
+            substitute_params_for_display("SELECT 1", [1, 2, 3])  # type: ignore
+
+    def test_substitute_params_for_display_empty_params(self):
+        query = "SELECT * FROM table"
+        params: dict[str, str] = {}
+        result = substitute_params_for_display(query, params)
+        assert result == query

--- a/posthog/hogql_queries/experiments/test/test_experiment_utils.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_utils.py
@@ -1027,13 +1027,13 @@ class TestGetExperimentQueryDebug:
         assert "SELECT" in clickhouse_sql
 
     @pytest.mark.django_db
-    def test_uses_display_substitution(self, team):
-        """Test that function uses substitute_params_for_display."""
-        from unittest.mock import patch
+    def test_masks_sensitive_parameters(self, team):
+        """Test that parameters marked _sensitive are masked as [HIDDEN] in output."""
+        from unittest.mock import MagicMock, patch
 
         from posthog.hogql import ast
+        from posthog.hogql.context import HogQLContext
 
-        # Create a simple query
         select_query = ast.SelectQuery(
             select=[ast.Constant(value=1)],
             select_from=ast.JoinExpr(
@@ -1041,14 +1041,29 @@ class TestGetExperimentQueryDebug:
             ),
         )
 
-        # Patch substitute_params_for_display to verify it's called
-        with patch("posthog.hogql_queries.experiments.utils.substitute_params_for_display") as mock_display:
-            mock_display.return_value = "SELECT 1 FROM events WHERE key = '[HIDDEN]'"
+        # Mock the executor's generate_clickhouse_sql to return params with _sensitive suffix
+        with patch("posthog.hogql_queries.experiments.utils.HogQLQueryExecutor") as mock_executor_class:
+            mock_executor = MagicMock()
+            mock_executor_class.return_value = mock_executor
+            mock_executor.hogql = "SELECT 1"
+
+            # Simulate query with sensitive parameters
+            mock_context = HogQLContext()
+            mock_context.values = {
+                "hogql_val_0": "s3://bucket/path",
+                "hogql_val_1_sensitive": "SECRETKEY123",
+                "hogql_val_2_sensitive": "SECRETTOKEN456",
+            }
+            mock_executor.generate_clickhouse_sql.return_value = (
+                "SELECT * FROM s3(%(hogql_val_0)s, %(hogql_val_1_sensitive)s, %(hogql_val_2_sensitive)s)",
+                mock_context,
+            )
 
             hogql, clickhouse_sql = get_experiment_query_debug(select_query, team)
 
-            # Verify that substitute_params_for_display was called (not the unsafe substitute_params)
-            mock_display.assert_called_once()
-
-            # Verify the result is what was returned by our mock
-            assert clickhouse_sql == "SELECT 1 FROM events WHERE key = '[HIDDEN]'"
+            # Verify URL is visible
+            assert "s3://bucket/path" in clickhouse_sql
+            # Verify secrets are hidden
+            assert "SECRETKEY123" not in clickhouse_sql
+            assert "SECRETTOKEN456" not in clickhouse_sql
+            assert clickhouse_sql.count("[HIDDEN]") == 2

--- a/posthog/hogql_queries/experiments/test/test_experiment_utils.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_utils.py
@@ -20,6 +20,7 @@ from posthog.schema import (
 from posthog.hogql_queries.experiments.breakdown_injector import BREAKDOWN_NULL_STRING_LABEL
 from posthog.hogql_queries.experiments.utils import (
     aggregate_variants_across_breakdowns,
+    get_experiment_query_debug,
     get_variant_result,
     get_variant_results,
     validate_variant_result,
@@ -994,3 +995,60 @@ class TestValidateVariantResult:
         # Should have NOT_ENOUGH_EXPOSURES validation failure
         assert result.validation_failures is not None
         assert ExperimentStatsValidationFailure.NOT_ENOUGH_EXPOSURES in result.validation_failures
+
+
+class TestGetExperimentQueryDebug:
+    """Tests for get_experiment_query_debug() which generates debug SQL."""
+
+    @pytest.mark.django_db
+    def test_generates_hogql_and_clickhouse_sql(self, team):
+        """Test that function generates both HogQL and ClickHouse SQL."""
+        from posthog.hogql import ast
+
+        # Create a simple query with a table that would use sensitive params
+        select_query = ast.SelectQuery(
+            select=[ast.Constant(value=1)],
+            select_from=ast.JoinExpr(
+                table=ast.Field(chain=["events"]),
+            ),
+        )
+
+        hogql, clickhouse_sql = get_experiment_query_debug(select_query, team)
+
+        # HogQL should be generated
+        assert hogql is not None
+        assert len(hogql) > 0
+
+        # ClickHouse SQL should be generated
+        assert clickhouse_sql is not None
+        assert len(clickhouse_sql) > 0
+
+        # Basic sanity check - should contain SQL keywords
+        assert "SELECT" in clickhouse_sql
+
+    @pytest.mark.django_db
+    def test_uses_display_substitution(self, team):
+        """Test that function uses substitute_params_for_display."""
+        from unittest.mock import patch
+
+        from posthog.hogql import ast
+
+        # Create a simple query
+        select_query = ast.SelectQuery(
+            select=[ast.Constant(value=1)],
+            select_from=ast.JoinExpr(
+                table=ast.Field(chain=["events"]),
+            ),
+        )
+
+        # Patch substitute_params_for_display to verify it's called
+        with patch("posthog.hogql_queries.experiments.utils.substitute_params_for_display") as mock_display:
+            mock_display.return_value = "SELECT 1 FROM events WHERE key = '[HIDDEN]'"
+
+            hogql, clickhouse_sql = get_experiment_query_debug(select_query, team)
+
+            # Verify that substitute_params_for_display was called (not the unsafe substitute_params)
+            mock_display.assert_called_once()
+
+            # Verify the result is what was returned by our mock
+            assert clickhouse_sql == "SELECT 1 FROM events WHERE key = '[HIDDEN]'"

--- a/posthog/hogql_queries/experiments/utils.py
+++ b/posthog/hogql_queries/experiments/utils.py
@@ -23,7 +23,7 @@ from posthog.hogql import ast
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import HogQLQueryExecutor
 
-from posthog.clickhouse.client.escape import substitute_params
+from posthog.clickhouse.client.escape import substitute_params_for_display
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
 from posthog.models import Team
 
@@ -54,7 +54,7 @@ def get_experiment_query_debug(experiment_query_ast: ast.SelectQuery, team: Team
         modifiers=create_default_modifiers_for_team(team),
     )
     clickhouse_sql_with_params, clickhouse_context_with_values = executor.generate_clickhouse_sql()
-    clickhouse_sql = substitute_params(clickhouse_sql_with_params, clickhouse_context_with_values.values)
+    clickhouse_sql = substitute_params_for_display(clickhouse_sql_with_params, clickhouse_context_with_values.values)
     return (executor.hogql, clickhouse_sql)
 
 


### PR DESCRIPTION
## Problem

Queries for debug are not escaped.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Escape them.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
