### PR TITLE
feat(replay): add session-level sentiment scoring to video summary

### DIFF
--- a/ee/hogai/session_summaries/session/output_data.py
+++ b/ee/hogai/session_summaries/session/output_data.py
@@ -175,6 +175,32 @@ class IntermediateSessionSummarySerializer(RawSessionSummarySerializer):
     )
 
 
+class SentimentSignalSerializer(serializers.Serializer):
+    signal_type = serializers.ChoiceField(
+        choices=[
+            "rage_click",
+            "repeated_error",
+            "backtracking",
+            "long_pause",
+            "abandonment",
+            "dead_click",
+            "confusion_loop",
+            "error_cascade",
+            "other",
+        ],
+        required=True,
+    )
+    segment_index = serializers.IntegerField(min_value=0, required=True)
+    description = serializers.CharField(max_length=10_000, required=True)
+    intensity = serializers.FloatField(min_value=0, max_value=1, required=True)
+
+
+class SessionSentimentSerializer(serializers.Serializer):
+    frustration_score = serializers.FloatField(min_value=0, max_value=1, required=True)
+    outcome = serializers.ChoiceField(choices=["successful", "friction", "frustrated", "blocked"], required=True)
+    sentiment_signals = SentimentSignalSerializer(many=True, required=False, allow_empty=True)
+
+
 class SessionSummarySerializer(IntermediateSessionSummarySerializer):
     """
     Session summary enriched with metadata, expected to be used in the final summary.
@@ -183,6 +209,7 @@ class SessionSummarySerializer(IntermediateSessionSummarySerializer):
     key_actions = serializers.ListField(
         child=EnrichedSegmentKeyActionsSerializer(), required=False, allow_empty=True, allow_null=True
     )
+    sentiment = SessionSentimentSerializer(required=False, allow_null=True)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         """

--- a/ee/hogai/session_summaries/session/output_data.py
+++ b/ee/hogai/session_summaries/session/output_data.py
@@ -4,11 +4,6 @@ from typing import Any
 import structlog
 from rest_framework import serializers
 
-from posthog.temporal.ai.session_summary.types.sentiment_constants import (
-    SENTIMENT_OUTCOME_TYPES,
-    SENTIMENT_SIGNAL_TYPES,
-)
-
 from ee.hogai.session_summaries import SummaryValidationError
 from ee.hogai.session_summaries.constants import HALLUCINATED_EVENTS_MIN_RATIO
 from ee.hogai.session_summaries.utils import (
@@ -181,7 +176,20 @@ class IntermediateSessionSummarySerializer(RawSessionSummarySerializer):
 
 
 class SentimentSignalSerializer(serializers.Serializer):
-    signal_type = serializers.ChoiceField(choices=list(SENTIMENT_SIGNAL_TYPES), required=True)
+    signal_type = serializers.ChoiceField(
+        choices=[
+            "rage_click",
+            "repeated_error",
+            "backtracking",
+            "long_pause",
+            "abandonment",
+            "dead_click",
+            "confusion_loop",
+            "error_cascade",
+            "other",
+        ],
+        required=True,
+    )
     segment_index = serializers.IntegerField(min_value=0, required=True)
     description = serializers.CharField(max_length=10_000, required=True)
     intensity = serializers.FloatField(min_value=0, max_value=1, required=True)
@@ -189,7 +197,7 @@ class SentimentSignalSerializer(serializers.Serializer):
 
 class SessionSentimentSerializer(serializers.Serializer):
     frustration_score = serializers.FloatField(min_value=0, max_value=1, required=True)
-    outcome = serializers.ChoiceField(choices=list(SENTIMENT_OUTCOME_TYPES), required=True)
+    outcome = serializers.ChoiceField(choices=["successful", "friction", "frustrated", "blocked"], required=True)
     sentiment_signals = SentimentSignalSerializer(many=True, required=False, allow_empty=True)
 
 

--- a/ee/hogai/session_summaries/session/output_data.py
+++ b/ee/hogai/session_summaries/session/output_data.py
@@ -4,7 +4,10 @@ from typing import Any
 import structlog
 from rest_framework import serializers
 
-from posthog.temporal.ai.session_summary.types.video import SENTIMENT_OUTCOME_TYPES, SENTIMENT_SIGNAL_TYPES
+from posthog.temporal.ai.session_summary.types.sentiment_constants import (
+    SENTIMENT_OUTCOME_TYPES,
+    SENTIMENT_SIGNAL_TYPES,
+)
 
 from ee.hogai.session_summaries import SummaryValidationError
 from ee.hogai.session_summaries.constants import HALLUCINATED_EVENTS_MIN_RATIO

--- a/ee/hogai/session_summaries/session/output_data.py
+++ b/ee/hogai/session_summaries/session/output_data.py
@@ -4,6 +4,8 @@ from typing import Any
 import structlog
 from rest_framework import serializers
 
+from posthog.temporal.ai.session_summary.types.video import SENTIMENT_OUTCOME_TYPES, SENTIMENT_SIGNAL_TYPES
+
 from ee.hogai.session_summaries import SummaryValidationError
 from ee.hogai.session_summaries.constants import HALLUCINATED_EVENTS_MIN_RATIO
 from ee.hogai.session_summaries.utils import (
@@ -176,20 +178,7 @@ class IntermediateSessionSummarySerializer(RawSessionSummarySerializer):
 
 
 class SentimentSignalSerializer(serializers.Serializer):
-    signal_type = serializers.ChoiceField(
-        choices=[
-            "rage_click",
-            "repeated_error",
-            "backtracking",
-            "long_pause",
-            "abandonment",
-            "dead_click",
-            "confusion_loop",
-            "error_cascade",
-            "other",
-        ],
-        required=True,
-    )
+    signal_type = serializers.ChoiceField(choices=list(SENTIMENT_SIGNAL_TYPES), required=True)
     segment_index = serializers.IntegerField(min_value=0, required=True)
     description = serializers.CharField(max_length=10_000, required=True)
     intensity = serializers.FloatField(min_value=0, max_value=1, required=True)
@@ -197,7 +186,7 @@ class SentimentSignalSerializer(serializers.Serializer):
 
 class SessionSentimentSerializer(serializers.Serializer):
     frustration_score = serializers.FloatField(min_value=0, max_value=1, required=True)
-    outcome = serializers.ChoiceField(choices=["successful", "friction", "frustrated", "blocked"], required=True)
+    outcome = serializers.ChoiceField(choices=list(SENTIMENT_OUTCOME_TYPES), required=True)
     sentiment_signals = SentimentSignalSerializer(many=True, required=False, allow_empty=True)
 
 

--- a/ee/hogai/session_summaries/tests/conftest.py
+++ b/ee/hogai/session_summaries/tests/conftest.py
@@ -307,6 +307,7 @@ def get_mock_enriched_llm_json_response(session_id: str) -> dict[str, Any]:
             "description": "Concise session outcome description focusing on conversion attempts, feature usage, and critical issues",
             "success": True,
         },
+        "sentiment": None,
     }
 
 

--- a/ee/hogai/session_summaries/tests/test_output_data.py
+++ b/ee/hogai/session_summaries/tests/test_output_data.py
@@ -622,6 +622,110 @@ class TestSessionSummarySerializerValidation:
         assert "segments[0].name" in serializer.errors
         assert "session_outcome.success" in serializer.errors
 
+    def test_valid_summary_with_sentiment(self) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = {
+            "frustration_score": 0.3,
+            "outcome": "friction",
+            "sentiment_signals": [
+                {
+                    "signal_type": "repeated_error",
+                    "segment_index": 0,
+                    "description": "User hit the same validation error twice",
+                    "intensity": 0.4,
+                },
+            ],
+        }
+        serializer = SessionSummarySerializer(data=data)
+        assert serializer.is_valid()
+
+    def test_valid_summary_without_sentiment(self) -> None:
+        data = _get_valid_summary_data()
+        assert "sentiment" not in data
+        serializer = SessionSummarySerializer(data=data)
+        assert serializer.is_valid()
+
+    def test_valid_summary_with_null_sentiment(self) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = None
+        serializer = SessionSummarySerializer(data=data)
+        assert serializer.is_valid()
+
+    def test_sentiment_with_empty_signals(self) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = {
+            "frustration_score": 0.0,
+            "outcome": "successful",
+            "sentiment_signals": [],
+        }
+        serializer = SessionSummarySerializer(data=data)
+        assert serializer.is_valid()
+
+    @pytest.mark.parametrize("outcome", ["successful", "friction", "frustrated", "blocked"])
+    def test_sentiment_valid_outcome_values(self, outcome: str) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = {
+            "frustration_score": 0.5,
+            "outcome": outcome,
+            "sentiment_signals": [],
+        }
+        serializer = SessionSummarySerializer(data=data)
+        assert serializer.is_valid()
+
+    def test_sentiment_invalid_outcome(self) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = {
+            "frustration_score": 0.5,
+            "outcome": "unknown",
+            "sentiment_signals": [],
+        }
+        serializer = SessionSummarySerializer(data=data)
+        assert not serializer.is_valid()
+
+    def test_sentiment_frustration_score_out_of_range(self) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = {
+            "frustration_score": 1.5,
+            "outcome": "frustrated",
+            "sentiment_signals": [],
+        }
+        serializer = SessionSummarySerializer(data=data)
+        assert not serializer.is_valid()
+
+    def test_sentiment_signal_invalid_type(self) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = {
+            "frustration_score": 0.5,
+            "outcome": "friction",
+            "sentiment_signals": [
+                {
+                    "signal_type": "invalid_type",
+                    "segment_index": 0,
+                    "description": "Something happened",
+                    "intensity": 0.5,
+                },
+            ],
+        }
+        serializer = SessionSummarySerializer(data=data)
+        assert not serializer.is_valid()
+
+    def test_sentiment_signal_intensity_out_of_range(self) -> None:
+        data = _get_valid_summary_data()
+        data["sentiment"] = {
+            "frustration_score": 0.5,
+            "outcome": "friction",
+            "sentiment_signals": [
+                {
+                    "signal_type": "rage_click",
+                    "segment_index": 0,
+                    "description": "Rage clicking on button",
+                    "intensity": 2.0,
+                },
+            ],
+        }
+        serializer = SessionSummarySerializer(data=data)
+        assert not serializer.is_valid()
+
     def test_validation_correctly_identifies_error_position_in_arrays(self) -> None:
         data = {
             "segments": [

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -452,7 +452,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/posthog/temporal/session_replay/session_summary/activities/a4_consolidate_video_segments.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a4_consolidate_video_segments.py
@@ -16,6 +16,7 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.temporal.session_replay.session_summary.types.video import (
     ConsolidatedVideoAnalysis,
+    SentimentOutcomeType,
     SessionSentiment,
     VideoSegmentOutput,
     VideoSummarySingleSessionInputs,
@@ -168,20 +169,21 @@ def _validate_and_clamp_sentiment(analysis: ConsolidatedVideoAnalysis) -> Consol
 
     valid_signals = [s for s in sentiment.sentiment_signals if s.segment_index in valid_indices]
 
-    if sentiment.outcome == "successful":
-        score = min(score, 0.2)
-    elif sentiment.outcome == "friction":
-        score = max(score, 0.2)
-    elif sentiment.outcome == "frustrated":
-        score = max(score, 0.5)
-    elif sentiment.outcome == "blocked":
-        score = max(score, 0.75)
-
     n_confused = sum(1 for s in analysis.segments if s.confusion_detected)
     n_blocked = sum(1 for s in analysis.segments if s.exception == "blocking")
     if len(analysis.segments) > 0:
         signal_floor = min((n_confused + n_blocked * 2) / len(analysis.segments), 1.0)
         score = max(score, signal_floor * 0.5)
+
+    OUTCOME_SCORE_FLOORS: dict[SentimentOutcomeType, float] = {
+        "successful": 0.0,
+        "friction": 0.2,
+        "frustrated": 0.5,
+        "blocked": 0.75,
+    }
+
+    outcome_floor = OUTCOME_SCORE_FLOORS.get(sentiment.outcome, 0.0)
+    score = max(score, outcome_floor)
 
     clamped_sentiment = SessionSentiment(
         frustration_score=round(max(0.0, min(1.0, score)), 4),

--- a/posthog/temporal/session_replay/session_summary/activities/a4_consolidate_video_segments.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a4_consolidate_video_segments.py
@@ -16,7 +16,6 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.temporal.session_replay.session_summary.types.video import (
     ConsolidatedVideoAnalysis,
-    SentimentOutcomeType,
     SessionSentiment,
     VideoSegmentOutput,
     VideoSummarySingleSessionInputs,
@@ -175,7 +174,7 @@ def _validate_and_clamp_sentiment(analysis: ConsolidatedVideoAnalysis) -> Consol
         signal_floor = min((n_confused + n_blocked * 2) / len(analysis.segments), 1.0)
         score = max(score, signal_floor * 0.5)
 
-    OUTCOME_SCORE_FLOORS: dict[SentimentOutcomeType, float] = {
+    OUTCOME_SCORE_FLOORS: dict[str, float] = {
         "successful": 0.0,
         "friction": 0.2,
         "frustrated": 0.5,

--- a/posthog/temporal/session_replay/session_summary/activities/a4_consolidate_video_segments.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a4_consolidate_video_segments.py
@@ -16,6 +16,7 @@ from temporalio.exceptions import ApplicationError
 
 from posthog.temporal.session_replay.session_summary.types.video import (
     ConsolidatedVideoAnalysis,
+    SessionSentiment,
     VideoSegmentOutput,
     VideoSummarySingleSessionInputs,
 )
@@ -77,12 +78,18 @@ async def consolidate_video_segments_activity(
             trace_id=trace_id,
         )
 
+        consolidated_analysis = _validate_and_clamp_sentiment(consolidated_analysis)
+
         logger.debug(
             f"Consolidated {len(raw_segments)} raw segments into {len(consolidated_analysis.segments)} semantic segments",
             session_id=inputs.session_id,
             raw_count=len(raw_segments),
             consolidated_count=len(consolidated_analysis.segments),
             session_success=consolidated_analysis.session_outcome.success,
+            frustration_score=consolidated_analysis.sentiment.frustration_score
+            if consolidated_analysis.sentiment
+            else None,
+            outcome=consolidated_analysis.sentiment.outcome if consolidated_analysis.sentiment else None,
             signals_type="session-summaries",
         )
 
@@ -146,6 +153,45 @@ async def _call_llm_to_consolidate_segments(
     raise RuntimeError("Unreachable")
 
 
+def _validate_and_clamp_sentiment(analysis: ConsolidatedVideoAnalysis) -> ConsolidatedVideoAnalysis:
+    """Validate and clamp sentiment fields for consistency with segment-level signals.
+
+    Ensures the LLM-produced frustration_score aligns with the stated outcome and
+    observed segment flags. Drops signals referencing non-existent segments.
+    """
+    if not analysis.sentiment:
+        return analysis
+
+    sentiment = analysis.sentiment
+    score = sentiment.frustration_score
+    valid_indices = set(range(len(analysis.segments)))
+
+    valid_signals = [s for s in sentiment.sentiment_signals if s.segment_index in valid_indices]
+
+    if sentiment.outcome == "successful":
+        score = min(score, 0.2)
+    elif sentiment.outcome == "friction":
+        score = max(score, 0.2)
+    elif sentiment.outcome == "frustrated":
+        score = max(score, 0.5)
+    elif sentiment.outcome == "blocked":
+        score = max(score, 0.75)
+
+    n_confused = sum(1 for s in analysis.segments if s.confusion_detected)
+    n_blocked = sum(1 for s in analysis.segments if s.exception == "blocking")
+    if len(analysis.segments) > 0:
+        signal_floor = min((n_confused + n_blocked * 2) / len(analysis.segments), 1.0)
+        score = max(score, signal_floor * 0.5)
+
+    clamped_sentiment = SessionSentiment(
+        frustration_score=round(max(0.0, min(1.0, score)), 4),
+        outcome=sentiment.outcome,
+        sentiment_signals=valid_signals,
+    )
+
+    return analysis.model_copy(update={"sentiment": clamped_sentiment})
+
+
 CONSOLIDATION_PROMPT = """
 You are summarizing a user's journey through a product session for PMs, developers, and analysts who want to understand what the user did and whether anything needs attention.
 
@@ -178,6 +224,19 @@ fix_suggestions:
 - Each needs: issue, evidence (exact error or observed behavior), suggestion.
 - Only include when grounded in something specific. Empty list is fine.
 
+Sentiment scoring:
+- Produce a `sentiment` object with:
+  - `frustration_score`: float 0.0-1.0. Based on observable evidence only. 0.0 = entirely smooth session, 1.0 = severe, persistent frustration. Most sessions should land 0.1-0.4. Reserve >0.7 for persistent, unresolved issues.
+  - `outcome`: "successful" if no significant friction, "friction" if some issues but user recovered, "frustrated" if repeated issues or visible confusion, "blocked" if user couldn't proceed.
+  - `sentiment_signals`: list of specific observed signals. Each has:
+    - `signal_type`: one of rage_click, repeated_error, backtracking, long_pause, abandonment, dead_click, confusion_loop, error_cascade, other.
+    - `segment_index`: which segment the signal occurred in.
+    - `description`: 1 sentence about what was observed.
+    - `intensity`: 0.0-1.0 severity of this individual signal.
+- The frustration_score should be roughly consistent with the signals. A session with no signals should score near 0. A session with multiple high-intensity signals should score high.
+- Do not infer frustration from normal behavior. Pausing to read is not frustration. Repeatedly clicking a broken button is.
+- Empty sentiment_signals list is fine if the session was smooth.
+
 Raw segments:
 {segments_text}
 
@@ -194,4 +253,6 @@ Style:
 Rules:
 - Time ranges must not overlap and should cover the full session.
 - One segment_outcome per segment with a brief narrative summary.
+- frustration_score and each signal intensity must be between 0.0 and 1.0 inclusive.
+- outcome must be exactly one of: successful, friction, frustrated, blocked.
 """

--- a/posthog/temporal/session_replay/session_summary/activities/a6_store_video_session_summary.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a6_store_video_session_summary.py
@@ -357,12 +357,17 @@ def _convert_video_segments_to_session_summary(
         "success": analysis.session_outcome.success,
     }
 
-    return {
+    result: dict = {
         "segments": summary_segments,
         "key_actions": key_actions,
         "segment_outcomes": segment_outcomes,
         "session_outcome": session_outcome,
     }
+
+    if analysis.sentiment is not None:
+        result["sentiment"] = analysis.sentiment.model_dump()
+
+    return result
 
 
 def _find_closest_event(

--- a/posthog/temporal/session_replay/session_summary/types/video.py
+++ b/posthog/temporal/session_replay/session_summary/types/video.py
@@ -135,6 +135,43 @@ class VideoFixSuggestion(BaseModel):
     suggestion: str = Field(description="Actionable fix or improvement")
 
 
+class SentimentSignal(BaseModel):
+    """A specific observation that contributed to the session frustration score."""
+
+    model_config = ConfigDict(frozen=True)
+
+    signal_type: Literal[
+        "rage_click",
+        "repeated_error",
+        "backtracking",
+        "long_pause",
+        "abandonment",
+        "dead_click",
+        "confusion_loop",
+        "error_cascade",
+        "other",
+    ] = Field(description="Category of the observed frustration signal")
+    segment_index: int = Field(description="Index of the segment where the signal was observed")
+    description: str = Field(description="Brief description of the observed signal")
+    intensity: float = Field(ge=0.0, le=1.0, description="How severe this signal is (0=mild, 1=extreme)")
+
+
+class SessionSentiment(BaseModel):
+    """Session-level sentiment scoring derived from video analysis."""
+
+    model_config = ConfigDict(frozen=True)
+
+    frustration_score: float = Field(
+        ge=0.0, le=1.0, description="Overall frustration score (0.0=smooth session, 1.0=extremely frustrated)"
+    )
+    outcome: Literal["successful", "friction", "frustrated", "blocked"] = Field(
+        description="How the session went: successful (no friction), friction (issues but recovered), frustrated (repeated issues, visible confusion), blocked (couldn't proceed)"
+    )
+    sentiment_signals: list[SentimentSignal] = Field(
+        default_factory=list, description="Evidence signals backing the frustration score"
+    )
+
+
 class ConsolidatedVideoAnalysis(BaseModel):
     """Complete output from video segment consolidation including segments, outcomes, and session-level analysis."""
 
@@ -146,4 +183,7 @@ class ConsolidatedVideoAnalysis(BaseModel):
     fix_suggestions: list[VideoFixSuggestion] = Field(
         default_factory=list,
         description="Actionable fix suggestions grounded in observed issues — only include if there is clear evidence",
+    )
+    sentiment: SessionSentiment | None = Field(
+        default=None, description="Session-level sentiment scoring with evidence signals"
     )

--- a/posthog/temporal/session_replay/session_summary/types/video.py
+++ b/posthog/temporal/session_replay/session_summary/types/video.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from posthog.schema import ReplayInactivityPeriod
 
+from posthog.temporal.ai.session_summary.types.sentiment_constants import SentimentOutcomeType, SentimentSignalType
+
 from ee.hogai.session_summaries.session.summarize_session import ExtraSummaryContext
 
 
@@ -133,35 +135,6 @@ class VideoFixSuggestion(BaseModel):
     issue: str = Field(description="What went wrong — specific error, failure, or friction point")
     evidence: str = Field(description="What was observed: exact error message, failed action, or user behavior")
     suggestion: str = Field(description="Actionable fix or improvement")
-
-
-SENTIMENT_SIGNAL_TYPES = (
-    "rage_click",
-    "repeated_error",
-    "backtracking",
-    "long_pause",
-    "abandonment",
-    "dead_click",
-    "confusion_loop",
-    "error_cascade",
-    "other",
-)
-
-SENTIMENT_OUTCOME_TYPES = ("successful", "friction", "frustrated", "blocked")
-
-SentimentSignalType = Literal[
-    "rage_click",
-    "repeated_error",
-    "backtracking",
-    "long_pause",
-    "abandonment",
-    "dead_click",
-    "confusion_loop",
-    "error_cascade",
-    "other",
-]
-
-SentimentOutcomeType = Literal["successful", "friction", "frustrated", "blocked"]
 
 
 class SentimentSignal(BaseModel):

--- a/posthog/temporal/session_replay/session_summary/types/video.py
+++ b/posthog/temporal/session_replay/session_summary/types/video.py
@@ -4,8 +4,6 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from posthog.schema import ReplayInactivityPeriod
 
-from posthog.temporal.ai.session_summary.types.sentiment_constants import SentimentOutcomeType, SentimentSignalType
-
 from ee.hogai.session_summaries.session.summarize_session import ExtraSummaryContext
 
 
@@ -142,7 +140,17 @@ class SentimentSignal(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    signal_type: SentimentSignalType = Field(description="Category of the observed frustration signal")
+    signal_type: Literal[
+        "rage_click",
+        "repeated_error",
+        "backtracking",
+        "long_pause",
+        "abandonment",
+        "dead_click",
+        "confusion_loop",
+        "error_cascade",
+        "other",
+    ] = Field(description="Category of the observed frustration signal")
     segment_index: int = Field(description="Index of the segment where the signal was observed")
     description: str = Field(description="Brief description of the observed signal")
     intensity: float = Field(ge=0.0, le=1.0, description="How severe this signal is (0=mild, 1=extreme)")
@@ -156,7 +164,7 @@ class SessionSentiment(BaseModel):
     frustration_score: float = Field(
         ge=0.0, le=1.0, description="Overall frustration score (0.0=smooth session, 1.0=extremely frustrated)"
     )
-    outcome: SentimentOutcomeType = Field(
+    outcome: Literal["successful", "friction", "frustrated", "blocked"] = Field(
         description="How the session went: successful (no friction), friction (issues but recovered), frustrated (repeated issues, visible confusion), blocked (couldn't proceed)"
     )
     sentiment_signals: list[SentimentSignal] = Field(

--- a/posthog/temporal/session_replay/session_summary/types/video.py
+++ b/posthog/temporal/session_replay/session_summary/types/video.py
@@ -135,22 +135,41 @@ class VideoFixSuggestion(BaseModel):
     suggestion: str = Field(description="Actionable fix or improvement")
 
 
+SENTIMENT_SIGNAL_TYPES = (
+    "rage_click",
+    "repeated_error",
+    "backtracking",
+    "long_pause",
+    "abandonment",
+    "dead_click",
+    "confusion_loop",
+    "error_cascade",
+    "other",
+)
+
+SENTIMENT_OUTCOME_TYPES = ("successful", "friction", "frustrated", "blocked")
+
+SentimentSignalType = Literal[
+    "rage_click",
+    "repeated_error",
+    "backtracking",
+    "long_pause",
+    "abandonment",
+    "dead_click",
+    "confusion_loop",
+    "error_cascade",
+    "other",
+]
+
+SentimentOutcomeType = Literal["successful", "friction", "frustrated", "blocked"]
+
+
 class SentimentSignal(BaseModel):
     """A specific observation that contributed to the session frustration score."""
 
     model_config = ConfigDict(frozen=True)
 
-    signal_type: Literal[
-        "rage_click",
-        "repeated_error",
-        "backtracking",
-        "long_pause",
-        "abandonment",
-        "dead_click",
-        "confusion_loop",
-        "error_cascade",
-        "other",
-    ] = Field(description="Category of the observed frustration signal")
+    signal_type: SentimentSignalType = Field(description="Category of the observed frustration signal")
     segment_index: int = Field(description="Index of the segment where the signal was observed")
     description: str = Field(description="Brief description of the observed signal")
     intensity: float = Field(ge=0.0, le=1.0, description="How severe this signal is (0=mild, 1=extreme)")
@@ -164,7 +183,7 @@ class SessionSentiment(BaseModel):
     frustration_score: float = Field(
         ge=0.0, le=1.0, description="Overall frustration score (0.0=smooth session, 1.0=extremely frustrated)"
     )
-    outcome: Literal["successful", "friction", "frustrated", "blocked"] = Field(
+    outcome: SentimentOutcomeType = Field(
         description="How the session went: successful (no friction), friction (issues but recovered), frustrated (repeated issues, visible confusion), blocked (couldn't proceed)"
     )
     sentiment_signals: list[SentimentSignal] = Field(

--- a/posthog/temporal/tests/ai/test_validate_and_clamp_sentiment.py
+++ b/posthog/temporal/tests/ai/test_validate_and_clamp_sentiment.py
@@ -1,0 +1,148 @@
+import pytest
+
+from parameterized import parameterized
+
+from posthog.temporal.ai.session_summary.activities.a4_consolidate_video_segments import _validate_and_clamp_sentiment
+from posthog.temporal.ai.session_summary.types.video import (
+    ConsolidatedVideoAnalysis,
+    ConsolidatedVideoSegment,
+    SentimentSignal,
+    SessionSentiment,
+    VideoSegmentOutcome,
+    VideoSessionOutcome,
+)
+
+
+def _make_segment(
+    *,
+    success: bool = True,
+    confusion_detected: bool = False,
+    abandonment_detected: bool = False,
+    exception: str | None = None,
+) -> ConsolidatedVideoSegment:
+    return ConsolidatedVideoSegment(
+        title="Test segment",
+        start_time="0:00",
+        end_time="1:00",
+        description="Test",
+        success=success,
+        confusion_detected=confusion_detected,
+        abandonment_detected=abandonment_detected,
+        exception=exception,
+    )
+
+
+def _make_analysis(
+    *,
+    segments: list[ConsolidatedVideoSegment] | None = None,
+    frustration_score: float = 0.5,
+    outcome: str = "friction",
+    sentiment_signals: list[SentimentSignal] | None = None,
+    sentiment: SessionSentiment | None = "auto",
+) -> ConsolidatedVideoAnalysis:
+    if segments is None:
+        segments = [_make_segment()]
+
+    if sentiment == "auto":
+        sentiment = SessionSentiment(
+            frustration_score=frustration_score,
+            outcome=outcome,
+            sentiment_signals=sentiment_signals or [],
+        )
+
+    return ConsolidatedVideoAnalysis(
+        segments=segments,
+        session_outcome=VideoSessionOutcome(success=True, description="Test"),
+        segment_outcomes=[
+            VideoSegmentOutcome(segment_index=i, success=s.success, summary="Test") for i, s in enumerate(segments)
+        ],
+        sentiment=sentiment,
+    )
+
+
+class TestValidateAndClampSentiment:
+    def test_returns_unchanged_when_no_sentiment(self):
+        analysis = _make_analysis(sentiment=None)
+        result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is None
+
+    @parameterized.expand(
+        [
+            ("successful_passes_through_high", "successful", 0.9, 0.9),
+            ("successful_passes_through_low", "successful", 0.1, 0.1),
+            ("friction_floors_at_0_2", "friction", 0.05, 0.2),
+            ("friction_keeps_high", "friction", 0.4, 0.4),
+            ("frustrated_floors_at_0_5", "frustrated", 0.1, 0.5),
+            ("frustrated_keeps_high", "frustrated", 0.8, 0.8),
+            ("blocked_floors_at_0_75", "blocked", 0.1, 0.75),
+            ("blocked_keeps_high", "blocked", 0.95, 0.95),
+        ]
+    )
+    def test_outcome_clamps_score(self, _name, outcome, input_score, expected):
+        analysis = _make_analysis(frustration_score=input_score, outcome=outcome)
+        result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment.frustration_score == pytest.approx(expected, abs=0.01)
+        assert result.sentiment.outcome == outcome
+
+    def test_drops_signals_with_invalid_segment_index(self):
+        signals = [
+            SentimentSignal(signal_type="rage_click", segment_index=0, description="Valid", intensity=0.8),
+            SentimentSignal(signal_type="dead_click", segment_index=5, description="Invalid", intensity=0.5),
+            SentimentSignal(signal_type="backtracking", segment_index=99, description="Way out", intensity=0.3),
+        ]
+        analysis = _make_analysis(
+            segments=[_make_segment()], sentiment_signals=signals, outcome="friction", frustration_score=0.3
+        )
+        result = _validate_and_clamp_sentiment(analysis)
+        assert len(result.sentiment.sentiment_signals) == 1
+        assert result.sentiment.sentiment_signals[0].signal_type == "rage_click"
+
+    def test_keeps_all_valid_signals(self):
+        signals = [
+            SentimentSignal(signal_type="rage_click", segment_index=0, description="First", intensity=0.8),
+            SentimentSignal(signal_type="dead_click", segment_index=1, description="Second", intensity=0.5),
+        ]
+        analysis = _make_analysis(
+            segments=[_make_segment(), _make_segment()],
+            sentiment_signals=signals,
+            outcome="frustrated",
+            frustration_score=0.6,
+        )
+        result = _validate_and_clamp_sentiment(analysis)
+        assert len(result.sentiment.sentiment_signals) == 2
+
+    def test_confusion_detected_raises_floor(self):
+        analysis = _make_analysis(
+            segments=[_make_segment(confusion_detected=True)],
+            frustration_score=0.0,
+            outcome="successful",
+        )
+        result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment.frustration_score >= 0.5
+
+    def test_blocking_exception_raises_floor(self):
+        analysis = _make_analysis(
+            segments=[_make_segment(exception="blocking")],
+            frustration_score=0.0,
+            outcome="successful",
+        )
+        result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment.frustration_score >= 0.5
+
+    def test_multiple_segments_dilute_signal_floor(self):
+        segments = [_make_segment(confusion_detected=True), _make_segment(), _make_segment(), _make_segment()]
+        analysis = _make_analysis(segments=segments, frustration_score=0.0, outcome="successful")
+        result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment.frustration_score == pytest.approx(0.125, abs=0.01)
+
+    def test_combined_confusion_and_blocking(self):
+        segments = [_make_segment(confusion_detected=True, exception="blocking"), _make_segment()]
+        analysis = _make_analysis(segments=segments, frustration_score=0.1, outcome="friction")
+        result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment.frustration_score >= 0.5
+
+    def test_score_always_in_valid_range(self):
+        for outcome in ["successful", "friction", "frustrated", "blocked"]:
+            analysis = _make_analysis(frustration_score=1.0, outcome=outcome)
+            result = _validate_and_clamp_sentiment(analysis)
+            assert 0.0 <= result.sentiment.frustration_score <= 1.0

--- a/posthog/temporal/tests/ai/test_validate_and_clamp_sentiment.py
+++ b/posthog/temporal/tests/ai/test_validate_and_clamp_sentiment.py
@@ -2,8 +2,10 @@ import pytest
 
 from parameterized import parameterized
 
-from posthog.temporal.ai.session_summary.activities.a4_consolidate_video_segments import _validate_and_clamp_sentiment
-from posthog.temporal.ai.session_summary.types.video import (
+from posthog.temporal.session_replay.session_summary.activities.a4_consolidate_video_segments import (
+    _validate_and_clamp_sentiment,
+)
+from posthog.temporal.session_replay.session_summary.types.video import (
     ConsolidatedVideoAnalysis,
     ConsolidatedVideoSegment,
     SentimentSignal,

--- a/posthog/temporal/tests/ai/test_validate_and_clamp_sentiment.py
+++ b/posthog/temporal/tests/ai/test_validate_and_clamp_sentiment.py
@@ -12,6 +12,8 @@ from posthog.temporal.ai.session_summary.types.video import (
     VideoSessionOutcome,
 )
 
+_SENTINEL = object()
+
 
 def _make_segment(
     *,
@@ -38,17 +40,20 @@ def _make_analysis(
     frustration_score: float = 0.5,
     outcome: str = "friction",
     sentiment_signals: list[SentimentSignal] | None = None,
-    sentiment: SessionSentiment | None = "auto",
+    sentiment: SessionSentiment | None | object = _SENTINEL,
 ) -> ConsolidatedVideoAnalysis:
     if segments is None:
         segments = [_make_segment()]
 
-    if sentiment == "auto":
-        sentiment = SessionSentiment(
+    resolved_sentiment: SessionSentiment | None
+    if sentiment is _SENTINEL:
+        resolved_sentiment = SessionSentiment(
             frustration_score=frustration_score,
             outcome=outcome,
             sentiment_signals=sentiment_signals or [],
         )
+    else:
+        resolved_sentiment = sentiment  # type: ignore[assignment]
 
     return ConsolidatedVideoAnalysis(
         segments=segments,
@@ -56,7 +61,7 @@ def _make_analysis(
         segment_outcomes=[
             VideoSegmentOutcome(segment_index=i, success=s.success, summary="Test") for i, s in enumerate(segments)
         ],
-        sentiment=sentiment,
+        sentiment=resolved_sentiment,
     )
 
 
@@ -81,6 +86,7 @@ class TestValidateAndClampSentiment:
     def test_outcome_clamps_score(self, _name, outcome, input_score, expected):
         analysis = _make_analysis(frustration_score=input_score, outcome=outcome)
         result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is not None
         assert result.sentiment.frustration_score == pytest.approx(expected, abs=0.01)
         assert result.sentiment.outcome == outcome
 
@@ -94,6 +100,7 @@ class TestValidateAndClampSentiment:
             segments=[_make_segment()], sentiment_signals=signals, outcome="friction", frustration_score=0.3
         )
         result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is not None
         assert len(result.sentiment.sentiment_signals) == 1
         assert result.sentiment.sentiment_signals[0].signal_type == "rage_click"
 
@@ -109,6 +116,7 @@ class TestValidateAndClampSentiment:
             frustration_score=0.6,
         )
         result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is not None
         assert len(result.sentiment.sentiment_signals) == 2
 
     def test_confusion_detected_raises_floor(self):
@@ -118,6 +126,7 @@ class TestValidateAndClampSentiment:
             outcome="successful",
         )
         result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is not None
         assert result.sentiment.frustration_score >= 0.5
 
     def test_blocking_exception_raises_floor(self):
@@ -127,22 +136,26 @@ class TestValidateAndClampSentiment:
             outcome="successful",
         )
         result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is not None
         assert result.sentiment.frustration_score >= 0.5
 
     def test_multiple_segments_dilute_signal_floor(self):
         segments = [_make_segment(confusion_detected=True), _make_segment(), _make_segment(), _make_segment()]
         analysis = _make_analysis(segments=segments, frustration_score=0.0, outcome="successful")
         result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is not None
         assert result.sentiment.frustration_score == pytest.approx(0.125, abs=0.01)
 
     def test_combined_confusion_and_blocking(self):
         segments = [_make_segment(confusion_detected=True, exception="blocking"), _make_segment()]
         analysis = _make_analysis(segments=segments, frustration_score=0.1, outcome="friction")
         result = _validate_and_clamp_sentiment(analysis)
+        assert result.sentiment is not None
         assert result.sentiment.frustration_score >= 0.5
 
     def test_score_always_in_valid_range(self):
         for outcome in ["successful", "friction", "frustrated", "blocked"]:
             analysis = _make_analysis(frustration_score=1.0, outcome=outcome)
             result = _validate_and_clamp_sentiment(analysis)
+            assert result.sentiment is not None
             assert 0.0 <= result.sentiment.frustration_score <= 1.0


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Session replay summaries detect confusion, errors, and abandonment per-segment but don't produce a queryable session-level score, would be nice to add it on for later features like showing most frustrated/successful replays upfront

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Add sentiment scoring (frustration_score + outcome bucket + evidence signals) to the a4 consolidation step with deterministic clamping, DRF serializers for storage, and backward-compatible persistence through a6.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
