### PR TITLE
fix: query trace_log across all cluster nodes for profiling results

### DIFF
--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -251,13 +251,13 @@ class DebugCHQueries(viewsets.ViewSet):
                 SELECT
                     arrayStringConcat(arrayMap(x -> demangle(addressToSymbol(x)), trace), ';') AS stack,
                     count() AS samples
-                FROM system.trace_log
+                FROM clusterAllReplicas(%(cluster)s, system, trace_log)
                 WHERE query_id = %(query_id)s AND trace_type = 'CPU'
                 GROUP BY trace
                 HAVING stack != ''
                 SETTINGS allow_introspection_functions=1
                 """,
-                {"query_id": profile_query_id},
+                {"query_id": profile_query_id, "cluster": CLICKHOUSE_CLUSTER},
             )
         except Exception:
             raise exceptions.ValidationError(

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -255,7 +255,7 @@ class DebugCHQueries(viewsets.ViewSet):
                 WHERE query_id = %(query_id)s AND trace_type = 'CPU'
                 GROUP BY trace
                 HAVING stack != ''
-                SETTINGS allow_introspection_functions=1
+                SETTINGS allow_introspection_functions=1, skip_unavailable_shards=1
                 """,
                 {"query_id": profile_query_id, "cluster": CLICKHOUSE_CLUSTER},
             )


### PR DESCRIPTION
## Problem

The query profiling feature queries `system.trace_log` to collect CPU trace data, but on multi-shard ClickHouse clusters the profiled query may execute on a different node than the one polled for results. 

## Changes

Use `clusterAllReplicas()` 

## How did you test this code?

- will need to verify in prod as local is just a single shard

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code (Opus 4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)