### PR TITLE
chore(cdp): Exclude warehouse hog functions from the API

### DIFF
--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -475,6 +475,8 @@ class HogFunctionViewSet(
         return HogFunctionSerializer
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        queryset = queryset.exclude(type=HogFunctionType.WAREHOUSE_SOURCE_WEBHOOK.value)
+
         if not (self.action == "partial_update" and self.request.data.get("deleted") is False):
             # We only want to include deleted functions if we are un-deleting them
             queryset = queryset.filter(deleted=False)

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1200,6 +1200,30 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?type=destination,transformation")
         assert len(response.json()["results"]) == 2
 
+    def test_warehouse_source_webhook_excluded(self, *args):
+        destination = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={**EXAMPLE_FULL},
+        )
+        assert destination.status_code == status.HTTP_201_CREATED
+
+        webhook_func = HogFunction.objects.create(
+            team=self.team,
+            name="Webhook Source",
+            type="warehouse_source_webhook",
+            hog="return event",
+        )
+
+        # List should not include warehouse_source_webhook functions
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+        ids = [r["id"] for r in response.json()["results"]]
+        assert str(webhook_func.id) not in ids
+        assert len(response.json()["results"]) == 1
+
+        # Detail should return 404
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/{webhook_func.id}/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     def test_list_with_enabled_filter(self, *args):
         response_destination = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",


### PR DESCRIPTION
## Changes
- Dont allow viewing/editing of warehouse type hog functions - this should all be done via the managed sources UI instead

## How did you test this code?
Unit test

## Publish to changelog?
Nah
