### PR TITLE
feat: instrument alert checks with SLO events

### DIFF
--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -1,3 +1,4 @@
+import time
 import traceback
 from collections import defaultdict
 from collections.abc import Callable
@@ -22,6 +23,8 @@ from posthog.models import AlertConfiguration, User
 from posthog.models.alert import AlertCheck
 from posthog.ph_client import ph_scoped_capture
 from posthog.schema_migrations.upgrade_manager import upgrade_query
+from posthog.slo.events import emit_slo_completed, emit_slo_started
+from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome, SloStartedProperties
 from posthog.tasks.alerts.trends import check_trends_alert, check_trends_alert_with_detector
 from posthog.tasks.alerts.utils import (
     WRAPPER_NODE_KINDS,
@@ -171,13 +174,18 @@ def check_alerts_task() -> None:
         ),
     )
 
-    grouped_by_team = defaultdict(list)
+    grouped_by_team: defaultdict[int, list[tuple[str, int, str | None]]] = defaultdict(list)
     for alert in sorted_alerts:
-        grouped_by_team[alert.team].append(alert.id)
+        grouped_by_team[alert.team_id].append((str(alert.id), alert.team_id, alert.calculation_interval))
 
-    for alert_ids in grouped_by_team.values():
+    for alert_data in grouped_by_team.values():
         # We chain the task execution to prevent queries *for a single team* running at the same time
-        chain(*(check_alert_task.si(str(alert_id)).set(expires=expire_after) for alert_id in alert_ids))()
+        chain(
+            *(
+                check_alert_task.si(alert_id, team_id, calculation_interval).set(expires=expire_after)
+                for alert_id, team_id, calculation_interval in alert_data
+            )
+        )()
 
 
 @shared_task(
@@ -186,9 +194,43 @@ def check_alerts_task() -> None:
     expires=60 * 60,
 )
 # @limit_concurrency(5)  Concurrency controlled by CeleryQueue.ALERTS for now
-def check_alert_task(alert_id: str) -> None:
-    with ph_scoped_capture() as capture_ph_event:
-        check_alert(alert_id, capture_ph_event)
+def check_alert_task(alert_id: str, team_id: int = 0, calculation_interval: str | None = None) -> None:
+    emit_slo_started(
+        distinct_id=alert_id,
+        properties=SloStartedProperties(
+            area=SloArea.ANALYTIC_PLATFORM,
+            operation=SloOperation.ALERT_CHECK,
+            team_id=team_id,
+            resource_id=alert_id,
+        ),
+        extra_properties={"calculation_interval": calculation_interval},
+    )
+    outcome = SloOutcome.FAILURE
+    started_at = time.monotonic()
+    error_extra: dict | None = None
+    try:
+        with ph_scoped_capture() as capture_ph_event:
+            check_alert(alert_id, capture_ph_event)
+        outcome = SloOutcome.SUCCESS
+    except Exception as exc:
+        error_extra = {
+            "error_type": type(exc).__name__,
+            "error_message": str(exc),
+        }
+        raise
+    finally:
+        emit_slo_completed(
+            distinct_id=alert_id,
+            properties=SloCompletedProperties(
+                area=SloArea.ANALYTIC_PLATFORM,
+                operation=SloOperation.ALERT_CHECK,
+                team_id=team_id,
+                resource_id=alert_id,
+                outcome=outcome,
+                duration_ms=(time.monotonic() - started_at) * 1000,
+            ),
+            extra_properties={"calculation_interval": calculation_interval, **(error_extra or {})},
+        )
 
 
 @retry(

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -195,20 +195,20 @@ def check_alerts_task() -> None:
 )
 # @limit_concurrency(5)  Concurrency controlled by CeleryQueue.ALERTS for now
 def check_alert_task(alert_id: str, team_id: int = 0, calculation_interval: str | None = None) -> None:
-    emit_slo_started(
-        distinct_id=alert_id,
-        properties=SloStartedProperties(
-            area=SloArea.ANALYTIC_PLATFORM,
-            operation=SloOperation.ALERT_CHECK,
-            team_id=team_id,
-            resource_id=alert_id,
-        ),
-        extra_properties={"calculation_interval": calculation_interval},
-    )
     outcome = SloOutcome.FAILURE
     started_at = time.monotonic()
     error_extra: dict | None = None
     try:
+        emit_slo_started(
+            distinct_id=alert_id,
+            properties=SloStartedProperties(
+                area=SloArea.ANALYTIC_PLATFORM,
+                operation=SloOperation.ALERT_CHECK,
+                team_id=team_id,
+                resource_id=alert_id,
+            ),
+            extra_properties={"calculation_interval": calculation_interval},
+        )
         with ph_scoped_capture() as capture_ph_event:
             check_alert(alert_id, capture_ph_event)
         outcome = SloOutcome.SUCCESS

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -26,7 +26,7 @@ from posthog.models import AlertConfiguration, User
 from posthog.models.alert import AlertCheck, AlertSubscription
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.organization import Organization, OrganizationMembership
-from posthog.slo.types import SloArea, SloOperation, SloOutcome, SloStartedProperties
+from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome, SloStartedProperties
 from posthog.tasks.alerts.checks import check_alert, check_alert_task, check_alerts_task
 from posthog.tasks.alerts.utils import send_notifications_for_breaches
 from posthog.tasks.test.utils_email_tests import mock_email_messages
@@ -1176,15 +1176,15 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
     @patch("posthog.tasks.alerts.checks.check_alert")
     def test_slo_emits_correct_events(
         self,
-        _name,
-        side_effect,
-        calculation_interval,
-        expected_outcome,
-        expected_error_extra,
-        mock_check_alert,
-        mock_slo_started,
-        mock_slo_completed,
-    ):
+        _name: str,
+        side_effect: Exception | None,
+        calculation_interval: str,
+        expected_outcome: SloOutcome,
+        expected_error_extra: dict | None,
+        mock_check_alert: MagicMock,
+        mock_slo_started: MagicMock,
+        mock_slo_completed: MagicMock,
+    ) -> None:
         mock_check_alert.return_value = None
         mock_check_alert.side_effect = side_effect
 
@@ -1204,25 +1204,29 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
             ),
             extra_properties={"calculation_interval": calculation_interval},
         )
-        mock_slo_completed.assert_called_once()
-        completed_props = mock_slo_completed.call_args.kwargs["properties"]
-        assert completed_props.outcome == expected_outcome
-        assert completed_props.duration_ms is not None
-        assert completed_props.duration_ms >= 0
-        completed_extra = mock_slo_completed.call_args.kwargs["extra_properties"]
-        assert completed_extra["calculation_interval"] == calculation_interval
-        if expected_error_extra:
-            for key, value in expected_error_extra.items():
-                assert completed_extra[key] == value
-        else:
-            assert "error_type" not in completed_extra
+        mock_slo_completed.assert_called_once_with(
+            distinct_id=self.alert_id,
+            properties=SloCompletedProperties(
+                area=SloArea.ANALYTIC_PLATFORM,
+                operation=SloOperation.ALERT_CHECK,
+                team_id=self.team.id,
+                resource_id=self.alert_id,
+                outcome=expected_outcome,
+                duration_ms=mock_slo_completed.call_args.kwargs["properties"].duration_ms,
+            ),
+            extra_properties={
+                "calculation_interval": calculation_interval,
+                **(expected_error_extra or {}),
+            },
+        )
+        assert mock_slo_completed.call_args.kwargs["properties"].duration_ms >= 0
 
     @patch("posthog.tasks.alerts.checks.check_alert_task")
-    def test_check_alerts_task_passes_team_id_to_check_alert_task(self, mock_task):
+    def test_check_alerts_task_passes_team_id_to_check_alert_task(self, mock_task: MagicMock) -> None:
         # check_alert_task.si(...) returns a signature; we need to capture what .si is called with
         captured_si_args: list[tuple] = []
 
-        def fake_si(*args, **kwargs):
+        def fake_si(*args: object, **kwargs: object) -> MagicMock:
             captured_si_args.append(args)
             sig = MagicMock()
             sig.set.return_value = sig

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -26,7 +26,8 @@ from posthog.models import AlertConfiguration, User
 from posthog.models.alert import AlertCheck, AlertSubscription
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.organization import Organization, OrganizationMembership
-from posthog.tasks.alerts.checks import check_alert
+from posthog.slo.types import SloArea, SloOperation, SloOutcome, SloStartedProperties
+from posthog.tasks.alerts.checks import check_alert, check_alert_task, check_alerts_task
 from posthog.tasks.alerts.utils import send_notifications_for_breaches
 from posthog.tasks.test.utils_email_tests import mock_email_messages
 
@@ -1127,3 +1128,117 @@ class TestGetSubscribedUsersEmails(APIBaseTest):
 
         emails = self.alert.get_subscribed_users_emails()
         assert emails == []
+
+
+class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin):
+    def setUp(self) -> None:
+        super().setUp()
+        dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
+        query_dict = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            trendsFilter=TrendsFilter(display=ChartDisplayType.BOLD_NUMBER),
+        ).model_dump()
+        insight = dashboard_api.create_insight(data={"name": "insight", "query": query_dict})[1]
+        alert_resp = self.client.post(
+            f"/api/projects/{self.team.id}/alerts",
+            data={
+                "name": "slo test alert",
+                "insight": insight["id"],
+                "subscribed_users": [self.user.id],
+                "calculation_interval": "hourly",
+                "config": {"type": "TrendsAlertConfig", "series_index": 0},
+                "condition": {"type": "absolute_value"},
+                "threshold": {"configuration": {"type": "absolute", "bounds": {}}},
+            },
+        ).json()
+        self.alert_id = alert_resp["id"]
+
+    @parameterized.expand(
+        [
+            (
+                "success",
+                None,
+                "hourly",
+                SloOutcome.SUCCESS,
+                None,
+            ),
+            (
+                "failure",
+                RuntimeError("CH failure"),
+                "daily",
+                SloOutcome.FAILURE,
+                {"error_type": "RuntimeError", "error_message": "CH failure"},
+            ),
+        ]
+    )
+    @patch("posthog.tasks.alerts.checks.emit_slo_completed")
+    @patch("posthog.tasks.alerts.checks.emit_slo_started")
+    @patch("posthog.tasks.alerts.checks.check_alert")
+    def test_slo_emits_correct_events(
+        self,
+        _name,
+        side_effect,
+        calculation_interval,
+        expected_outcome,
+        expected_error_extra,
+        mock_check_alert,
+        mock_slo_started,
+        mock_slo_completed,
+    ):
+        mock_check_alert.return_value = None
+        mock_check_alert.side_effect = side_effect
+
+        if side_effect is not None:
+            with pytest.raises(type(side_effect)):
+                check_alert_task(self.alert_id, self.team.id, calculation_interval)
+        else:
+            check_alert_task(self.alert_id, self.team.id, calculation_interval)
+
+        mock_slo_started.assert_called_once_with(
+            distinct_id=self.alert_id,
+            properties=SloStartedProperties(
+                area=SloArea.ANALYTIC_PLATFORM,
+                operation=SloOperation.ALERT_CHECK,
+                team_id=self.team.id,
+                resource_id=self.alert_id,
+            ),
+            extra_properties={"calculation_interval": calculation_interval},
+        )
+        mock_slo_completed.assert_called_once()
+        completed_props = mock_slo_completed.call_args.kwargs["properties"]
+        assert completed_props.outcome == expected_outcome
+        assert completed_props.duration_ms is not None
+        assert completed_props.duration_ms >= 0
+        completed_extra = mock_slo_completed.call_args.kwargs["extra_properties"]
+        assert completed_extra["calculation_interval"] == calculation_interval
+        if expected_error_extra:
+            for key, value in expected_error_extra.items():
+                assert completed_extra[key] == value
+        else:
+            assert "error_type" not in completed_extra
+
+    @patch("posthog.tasks.alerts.checks.check_alert_task")
+    def test_check_alerts_task_passes_team_id_to_check_alert_task(self, mock_task):
+        # check_alert_task.si(...) returns a signature; we need to capture what .si is called with
+        captured_si_args: list[tuple] = []
+
+        def fake_si(*args, **kwargs):
+            captured_si_args.append(args)
+            sig = MagicMock()
+            sig.set.return_value = sig
+            return sig
+
+        mock_task.si = fake_si
+
+        check_alerts_task()
+
+        # check_alerts_task queries all due alerts across all teams; find the one for our alert
+        matching = [
+            (alert_id, team_id, interval)
+            for alert_id, team_id, interval in captured_si_args
+            if alert_id == self.alert_id
+        ]
+        assert len(matching) == 1, f"Expected our alert to be scheduled once, got: {matching}"
+        _, team_id, interval = matching[0]
+        assert team_id == self.team.id
+        assert interval == "hourly"

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -27,7 +27,7 @@ from posthog.models.alert import AlertCheck, AlertSubscription
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome, SloStartedProperties
-from posthog.tasks.alerts.checks import check_alert, check_alert_task, check_alerts_task
+from posthog.tasks.alerts.checks import check_alert, check_alert_task
 from posthog.tasks.alerts.utils import send_notifications_for_breaches
 from posthog.tasks.test.utils_email_tests import mock_email_messages
 
@@ -1220,29 +1220,3 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
             },
         )
         assert mock_slo_completed.call_args.kwargs["properties"].duration_ms >= 0
-
-    @patch("posthog.tasks.alerts.checks.check_alert_task")
-    def test_check_alerts_task_passes_team_id_to_check_alert_task(self, mock_task: MagicMock) -> None:
-        # check_alert_task.si(...) returns a signature; we need to capture what .si is called with
-        captured_si_args: list[tuple] = []
-
-        def fake_si(*args: object, **kwargs: object) -> MagicMock:
-            captured_si_args.append(args)
-            sig = MagicMock()
-            sig.set.return_value = sig
-            return sig
-
-        mock_task.si = fake_si
-
-        check_alerts_task()
-
-        # check_alerts_task queries all due alerts across all teams; find the one for our alert
-        matching = [
-            (alert_id, team_id, interval)
-            for alert_id, team_id, interval in captured_si_args
-            if alert_id == self.alert_id
-        ]
-        assert len(matching) == 1, f"Expected our alert to be scheduled once, got: {matching}"
-        _, team_id, interval = matching[0]
-        assert team_id == self.team.id
-        assert interval == "hourly"

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -10,6 +10,11 @@ locals {
       slo     = 99.95 # error budget = 0.05%
       regions = ["US", "EU"]
     }
+    alert_check = {
+      name    = "Alert checks"
+      slo     = 99.95 # error budget = 0.05%
+      regions = ["US", "EU"]
+    }
   }
 
   # ---------------------------------------------------------------------------
@@ -181,7 +186,7 @@ resource "posthog_insight" "slo_burn_rate" {
       seriesBreakdownColumn = "metric"
       showLegend            = true
       goalLines = [
-        { label = "Budget rate", value = 1.0 }
+        { label = "Budget rate", value = 1.0, position = "start" }
       ]
     }
     tableSettings = {

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/layouts.tf
@@ -31,32 +31,50 @@ resource "posthog_dashboard_layout" "slo_monitoring" {
         })
       },
     ],
-    # Per-region rows: burn rate (left) + duration (right), h=3 each.
-    # Sorted by operation then region. Each row is 3 units tall.
-    # y starts at 6 (after success rate h=5 + text h=1).
-    [
-      for idx, key in sort(keys(local.slo_operation_regions)) :
-      {
-        insight_id = posthog_insight.slo_burn_rate[key].id
-        layouts_json = jsonencode({
-          sm = {
-            h = 3, i = "burn_${key}", w = 6, x = 0, y = 6 + idx * 3
-            minH = 2, minW = 2, moved = false, static = false
+    # Per-operation sections: header + burn rate (left) + duration (right) per region.
+    # Each section: header (h=1) + N regions * row_height (h=3).
+    # Base y = 6 (after success rate h=5 + text h=1).
+    # NOTE: y offset formula assumes all operations have the same number of regions.
+    flatten([
+      for op_idx, op_key in sort(keys(local.slo_operations)) : concat(
+        # Section header
+        [{
+          text_body = "## ${local.slo_operations[op_key].name}"
+          layouts_json = jsonencode({
+            sm = {
+              h = 1, i = "header_${op_key}", w = 12, x = 0,
+              y = 6 + op_idx * (1 + length(local.slo_operations[op_key].regions) * 3)
+              minH = 1, minW = 1, moved = false, static = false
+            }
+          })
+        }],
+        # Burn rate tiles (left half)
+        [
+          for reg_idx, region in sort(local.slo_operations[op_key].regions) : {
+            insight_id = posthog_insight.slo_burn_rate["${op_key}_${lower(region)}"].id
+            layouts_json = jsonencode({
+              sm = {
+                h = 3, i = "burn_${op_key}_${lower(region)}", w = 6, x = 0,
+                y = 6 + op_idx * (1 + length(local.slo_operations[op_key].regions) * 3) + 1 + reg_idx * 3
+                minH = 2, minW = 2, moved = false, static = false
+              }
+            })
           }
-        })
-      }
-    ],
-    [
-      for idx, key in sort(keys(local.slo_operation_regions)) :
-      {
-        insight_id = posthog_insight.slo_duration[key].id
-        layouts_json = jsonencode({
-          sm = {
-            h = 3, i = "dur_${key}", w = 6, x = 6, y = 6 + idx * 3
-            minH = 2, minW = 2, moved = false, static = false
+        ],
+        # Duration tiles (right half)
+        [
+          for reg_idx, region in sort(local.slo_operations[op_key].regions) : {
+            insight_id = posthog_insight.slo_duration["${op_key}_${lower(region)}"].id
+            layouts_json = jsonencode({
+              sm = {
+                h = 3, i = "dur_${op_key}_${lower(region)}", w = 6, x = 6,
+                y = 6 + op_idx * (1 + length(local.slo_operations[op_key].regions) * 3) + 1 + reg_idx * 3
+                minH = 2, minW = 2, moved = false, static = false
+              }
+            })
           }
-        })
-      }
-    ],
+        ],
+      )
+    ]),
   )
 }


### PR DESCRIPTION
## Problem

Alert checks have no SLO instrumentation — we can't measure success rates, failure rates, or durations.
The existing SLO monitoring dashboard only tracks subscription deliveries.

This is the beginning of additional upcoming changes in order to improve the reliability of the alerts. 

## Changes

- Wrap `check_alert_task` with `slo_operation_started` / `slo_operation_completed` events, mirroring the
  pattern used for subscription deliveries
- Thread `team_id` and `calculation_interval` from `check_alerts_task` fan-out to avoid extra DB queries
  at the task boundary
- Add `alert_check` as a new operation in the SLO monitoring terraform module (`slo-monitoring/insights.tf`),
  which auto-generates burn rate, duration, and success rate insights for both US and EU regions
- Add section headers per operation in the dashboard layout
- Move budget rate goal line to start of chart

## How did you test this code?

✅ Parameterized unit tests for SLO event emission (success + failure paths)

✅ Ran a test script to confirm the output:

```python
  """
  E2E smoke test for alert check SLO instrumentation.

  Verifies the full flow: check_alert_task emits slo_operation_started
  and slo_operation_completed events with correct properties, for both
  success and failure paths.

  Uses Django test infrastructure but exercises the real code path
  (no mocking of SLO emit functions — only check_alert and ph_scoped_capture
  are mocked to avoid needing ClickHouse data and PostHog client).
  """

  import os
  import sys
  import time

  os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")

  import django

  django.setup()

  from unittest.mock import MagicMock, patch

  # Capture all posthoganalytics.capture calls
  captured_events: list[dict] = []
  original_capture = None


  def fake_capture(distinct_id, event, properties=None, **kwargs):
      captured_events.append(
          {"distinct_id": distinct_id, "event": event, "properties": properties or {}}
      )


  def run_success_path():
      """Simulate a successful alert check and verify SLO events."""
      captured_events.clear()

      with (
          patch("posthog.slo.events.posthoganalytics.capture", side_effect=fake_capture),
          patch("posthog.tasks.alerts.checks.check_alert") as mock_check,
          patch("posthog.tasks.alerts.checks.ph_scoped_capture") as mock_ph,
      ):
          mock_check.return_value = None
          mock_ph.return_value.__enter__ = MagicMock(return_value=lambda *a, **k: None)
          mock_ph.return_value.__exit__ = MagicMock(return_value=False)

          from posthog.tasks.alerts.checks import check_alert_task

          check_alert_task("test-alert-123", team_id=42, calculation_interval="hourly")

      print("=== SUCCESS PATH ===")
      print(f"Events captured: {len(captured_events)}")
      assert len(captured_events) == 2, f"Expected 2 events, got {len(captured_events)}"

      started = captured_events[0]
      completed = captured_events[1]

      print(f"\n1. {started['event']}")
      print(f"   distinct_id: {started['distinct_id']}")
      for k, v in sorted(started["properties"].items()):
          print(f"   {k}: {v}")

      assert started["event"] == "slo_operation_started"
      assert started["properties"]["operation"] == "alert_check"
      assert started["properties"]["area"] == "analytic-platform"
      assert started["properties"]["team_id"] == 42
      assert started["properties"]["resource_id"] == "test-alert-123"
      assert started["properties"]["calculation_interval"] == "hourly"

      print(f"\n2. {completed['event']}")
      print(f"   distinct_id: {completed['distinct_id']}")
      for k, v in sorted(completed["properties"].items()):
          print(f"   {k}: {v}")

      assert completed["event"] == "slo_operation_completed"
      assert completed["properties"]["operation"] == "alert_check"
      assert completed["properties"]["outcome"] == "success"
      assert completed["properties"]["team_id"] == 42
      assert completed["properties"]["resource_id"] == "test-alert-123"
      assert completed["properties"]["calculation_interval"] == "hourly"
      assert completed["properties"]["duration_ms"] >= 0
      assert "error_type" not in completed["properties"]

      print("\n   PASS")


  def run_failure_path():
      """Simulate a failing alert check and verify SLO events."""
      captured_events.clear()

      with (
          patch("posthog.slo.events.posthoganalytics.capture", side_effect=fake_capture),
          patch(
              "posthog.tasks.alerts.checks.check_alert",
              side_effect=RuntimeError("ClickHouse timeout"),
          ),
          patch("posthog.tasks.alerts.checks.ph_scoped_capture") as mock_ph,
      ):
          mock_ph.return_value.__enter__ = MagicMock(return_value=lambda *a, **k: None)
          mock_ph.return_value.__exit__ = MagicMock(return_value=False)

          from posthog.tasks.alerts.checks import check_alert_task

          try:
              check_alert_task("test-alert-456", team_id=99, calculation_interval="daily")
          except RuntimeError:
              pass  # Expected

      print("\n=== FAILURE PATH ===")
      print(f"Events captured: {len(captured_events)}")
      assert len(captured_events) == 2, f"Expected 2 events, got {len(captured_events)}"

      started = captured_events[0]
      completed = captured_events[1]

      print(f"\n1. {started['event']}")
      print(f"   distinct_id: {started['distinct_id']}")
      for k, v in sorted(started["properties"].items()):
          print(f"   {k}: {v}")

      assert started["event"] == "slo_operation_started"
      assert started["properties"]["operation"] == "alert_check"
      assert started["properties"]["calculation_interval"] == "daily"

      print(f"\n2. {completed['event']}")
      print(f"   distinct_id: {completed['distinct_id']}")
      for k, v in sorted(completed["properties"].items()):
          print(f"   {k}: {v}")

      assert completed["event"] == "slo_operation_completed"
      assert completed["properties"]["outcome"] == "failure"
      assert completed["properties"]["error_type"] == "RuntimeError"
      assert completed["properties"]["error_message"] == "ClickHouse timeout"
      assert completed["properties"]["calculation_interval"] == "daily"
      assert completed["properties"]["duration_ms"] >= 0

      print("\n   PASS")


  def run_prometheus_metrics():
      """Verify Prometheus counters are incremented."""
      from posthog.slo.events import (
          OPERATION_COMPLETED_COUNTER,
          OPERATION_DURATION,
          OPERATION_STARTED_COUNTER,
      )

      started_before = OPERATION_STARTED_COUNTER.labels(
          area="analytic-platform", operation="alert_check"
      )._value.get()
      completed_before = OPERATION_COMPLETED_COUNTER.labels(
          area="analytic-platform", operation="alert_check", outcome="success"
      )._value.get()

      with (
          patch("posthog.slo.events.posthoganalytics.capture"),
          patch("posthog.tasks.alerts.checks.check_alert") as mock_check,
          patch("posthog.tasks.alerts.checks.ph_scoped_capture") as mock_ph,
      ):
          mock_check.return_value = None
          mock_ph.return_value.__enter__ = MagicMock(return_value=lambda *a, **k: None)
          mock_ph.return_value.__exit__ = MagicMock(return_value=False)

          from posthog.tasks.alerts.checks import check_alert_task

          check_alert_task("test-alert-789", team_id=1, calculation_interval="weekly")

      started_after = OPERATION_STARTED_COUNTER.labels(
          area="analytic-platform", operation="alert_check"
      )._value.get()
      completed_after = OPERATION_COMPLETED_COUNTER.labels(
          area="analytic-platform", operation="alert_check", outcome="success"
      )._value.get()

      print("\n=== PROMETHEUS METRICS ===")
      print(f"   slo_operation_started (alert_check): {started_before} -> {started_after}")
      print(f"   slo_operation_completed (alert_check, success): {completed_before} -> {completed_after}")

      assert started_after == started_before + 1, "Started counter not incremented"
      assert completed_after == completed_before + 1, "Completed counter not incremented"

      print("\n   PASS")


  if __name__ == "__main__":
      run_success_path()
      run_failure_path()
      run_prometheus_metrics()
      print("\n=== ALL PASSED ===")
```

**Output:**

```bash
  === SUCCESS PATH ===
  Events captured: 2

  1. slo_operation_started
     distinct_id: test-alert-123
     area: analytic-platform
     calculation_interval: hourly
     deploy_sha: ead69d7b466
     operation: alert_check
     resource_id: test-alert-123
     team_id: 42

  2. slo_operation_completed
     distinct_id: test-alert-123
     area: analytic-platform
     calculation_interval: hourly
     deploy_sha: ead69d7b466
     duration_ms: 30.04937500008964
     operation: alert_check
     outcome: success
     resource_id: test-alert-123
     team_id: 42

     PASS

  === FAILURE PATH ===
  Events captured: 2

  1. slo_operation_started
     distinct_id: test-alert-456
     area: analytic-platform
     calculation_interval: daily
     deploy_sha: ead69d7b466
     operation: alert_check
     resource_id: test-alert-456
     team_id: 99

  2. slo_operation_completed
     distinct_id: test-alert-456
     area: analytic-platform
     calculation_interval: daily
     deploy_sha: ead69d7b466
     duration_ms: 17.789499997888925
     error_message: ClickHouse timeout
     error_type: RuntimeError
     operation: alert_check
     outcome: failure
     resource_id: test-alert-456
     team_id: 99

     PASS

  === PROMETHEUS METRICS ===
     slo_operation_started (alert_check): 2.0 -> 3.0
     slo_operation_completed (alert_check, success): 1.0 -> 2.0

     PASS

  === ALL PASSED ===
```

## Publish to changelog?

No

## Docs update

N/A