### PR TITLE
chore(): have Claude to write permissions changes to settings.local.json instead of settings.json

### DIFF
--- a/.claude/hooks/migrate-permissions.sh
+++ b/.claude/hooks/migrate-permissions.sh
@@ -68,8 +68,13 @@ except Exception:
     os.unlink(tmp_path)
     sys.exit(1)
 
-# Remove permissions from settings.json atomically
-del settings['permissions']
+# Remove only the migrated allow list from settings.json
+perms = settings.get('permissions', {})
+perms.pop('allow', None)
+if perms:
+    settings['permissions'] = perms
+else:
+    settings.pop('permissions', None)
 fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix='.json')
 try:
     with os.fdopen(fd, 'w') as f:

--- a/.claude/hooks/migrate-permissions.sh
+++ b/.claude/hooks/migrate-permissions.sh
@@ -17,11 +17,16 @@ if ! mkdir "$LOCKFILE" 2>/dev/null; then
 fi
 trap 'rmdir "$LOCKFILE" 2>/dev/null' EXIT
 
+
+export SETTINGS_PATH="$SETTINGS"
+export LOCAL_PATH="$LOCAL"
+
 python3 -c "
 import json, sys, os, tempfile
 
-settings_path = '$SETTINGS'
-local_path = '$LOCAL'
+settings_path = os.environ['SETTINGS_PATH']
+local_path = os.environ['LOCAL_PATH']
+
 
 # Read settings.json
 try:

--- a/.claude/hooks/migrate-permissions.sh
+++ b/.claude/hooks/migrate-permissions.sh
@@ -64,7 +64,7 @@ try:
         json.dump(local, f, indent=2)
         f.write('\n')
     os.replace(tmp_path, local_path)
-except:
+except Exception:
     os.unlink(tmp_path)
     sys.exit(1)
 

--- a/.claude/hooks/migrate-permissions.sh
+++ b/.claude/hooks/migrate-permissions.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# Migrates permissions from settings.json to settings.local.json.
+# The CLI's "Always allow" button writes to settings.json, but we want
+# personal permissions in settings.local.json so they don't get committed.
+#
+# Triggered by ConfigChange hook, so must handle concurrent invocations
+# and avoid corrupting settings.local.json.
+
+SETTINGS="$CLAUDE_PROJECT_DIR/.claude/settings.json"
+LOCAL="$CLAUDE_PROJECT_DIR/.claude/settings.local.json"
+LOCKFILE="$CLAUDE_PROJECT_DIR/.claude/.migrate-permissions.lock"
+
+# Use mkdir as an atomic lock (works on macOS and Linux)
+if ! mkdir "$LOCKFILE" 2>/dev/null; then
+    exit 0
+fi
+trap 'rmdir "$LOCKFILE" 2>/dev/null' EXIT
+
+python3 -c "
+import json, sys, os, tempfile
+
+settings_path = '$SETTINGS'
+local_path = '$LOCAL'
+
+# Read settings.json
+try:
+    with open(settings_path) as f:
+        settings = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    sys.exit(0)
+
+# Check if there are permissions to migrate
+allow = settings.get('permissions', {}).get('allow', [])
+if not allow:
+    sys.exit(0)
+
+# Read settings.local.json — abort if it exists but can't be parsed
+if os.path.exists(local_path):
+    try:
+        with open(local_path) as f:
+            local = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        # File exists but is corrupt or being written — don't risk losing data
+        sys.exit(1)
+else:
+    local = {}
+
+# Merge allow lists, deduplicate while preserving order
+local_perms = local.setdefault('permissions', {})
+existing = local_perms.get('allow', [])
+seen = set(existing)
+for entry in allow:
+    if entry not in seen:
+        existing.append(entry)
+        seen.add(entry)
+local_perms['allow'] = existing
+
+# Write settings.local.json atomically via temp file
+dir_path = os.path.dirname(local_path)
+fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix='.json')
+try:
+    with os.fdopen(fd, 'w') as f:
+        json.dump(local, f, indent=2)
+        f.write('\n')
+    os.replace(tmp_path, local_path)
+except:
+    os.unlink(tmp_path)
+    sys.exit(1)
+
+# Remove permissions from settings.json atomically
+del settings['permissions']
+fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix='.json')
+try:
+    with os.fdopen(fd, 'w') as f:
+        json.dump(settings, f, indent=2)
+        f.write('\n')
+    os.replace(tmp_path, settings_path)
+except:
+    os.unlink(tmp_path)
+    sys.exit(1)
+"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,16 @@
                     }
                 ]
             }
+        ],
+        "ConfigChange": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/migrate-permissions.sh"
+                    }
+                ]
+            }
         ]
     },
     "enabledPlugins": {

--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ CLAUDE.local.md
 # Ignore file for clearing demo data on local
 posthog/management/commands/clear_demo_data.py
 
-# Ignore Claude Code settings
+.claude/tmp*.json
 .claude/settings.local.json
 .claude/settings.local.json.tmp
 .claude/.migrate-permissions.lock

--- a/.gitignore
+++ b/.gitignore
@@ -139,9 +139,9 @@ CLAUDE.local.md
 # Ignore file for clearing demo data on local
 posthog/management/commands/clear_demo_data.py
 
-.claude/tmp*.json
+# Ignore Claude Code settings
 .claude/settings.local.json
-.claude/settings.local.json.tmp
+.claude/tmp*.json
 .claude/.migrate-permissions.lock
 .claude/worktrees/
 

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,8 @@ posthog/management/commands/clear_demo_data.py
 
 # Ignore Claude Code settings
 .claude/settings.local.json
+.claude/settings.local.json.tmp
+.claude/.migrate-permissions.lock
 .claude/worktrees/
 
 # Ignore local mprocs configs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,10 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - Use American English spelling
 - When mentioning PostHog products, the product names should use Sentence casing, not Title Casing. For example, 'Product analytics', not 'Product Analytics'. Any other buttons, tab text, tooltips, etc should also all use Sentence casing. For example, 'Save as view' instead of 'Save As View'.
 
+## Settings
+
+- When adding or modifying permission rules, always write to `.claude/settings.local.json`, not `.claude/settings.json`
+
 ## Skills
 
 Skills are created inside [.agents/skills](.agents/skills/) by default and then symlinked to [.claude/skills](.claude/skills). Make sure you always treat `.agents/skills` as the source of truth.


### PR DESCRIPTION
## Problem

Claude code constantly updates settings.json, which isn't gitignored as it has useful things that devex/others may change over time

## Changes

- Update Agents.md to point to settings.local.json instead (this is for tool calls that update the permissions)
- Add a hook that moves settings.json permission changes to settings.local.json (this is for when the "Always allow" button is pressed, which is hardcoded in the claude code harness to write to settings.json)
  - This hook uses a lockfile to ensure that we don't get into a race condition by changing settings.local.json which triggers ConfigChange again.
  - This hook only moves allowed requests, so the devex/security/whatever teams can still add denied commands that will stick in version control if needed.

## How did you test this code?

Tested the script itself in isolation locally, and then checked that only settings.local.json is updated after pressing "Always allow":


The ConfigChange Hook automatically moved the change to settings.local.json:

<img width="668" height="541" alt="Screenshot 2026-03-25 at 12 58 18 PM" src="https://github.com/user-attachments/assets/19c585c9-c8cd-4540-a50b-4c4cd7e4d1b0" />
<img width="527" height="494" alt="Screenshot 2026-03-25 at 12 58 25 PM" src="https://github.com/user-attachments/assets/833c3688-71a4-478d-8a6b-a9c2050d8f5a" />



## Publish to changelog?

No