### PR TITLE
chore: remove --invalidate-first from hypercache warm commands

### DIFF
--- a/docs/internal/feature-flags/hypercache-system.md
+++ b/docs/internal/feature-flags/hypercache-system.md
@@ -401,10 +401,10 @@ FLAGS_CACHE_VERIFICATION_GRACE_PERIOD_MINUTES=5  # Skip recently updated flags
 
 ### For initial cache build
 
-Scheduled tasks only maintain existing caches. For initial population or schema migrations, use the management command:
+Scheduled tasks only maintain existing caches. For initial population, use the management command:
 
 ```bash
-python manage.py warm_flags_cache [--invalidate-first] [--team-ids ID1 ID2 ...]
+python manage.py warm_flags_cache [--team-ids ID1 ID2 ...]
 ```
 
 By default, the command warms caches only for teams that have ever had a feature flag (using `config.get_teams_queryset()`). This includes teams whose flags have all been soft-deleted (so the cache correctly contains an empty flags list). Teams that have never had any feature flags are skipped to avoid unnecessary database queries and Redis writes.

--- a/posthog/management/commands/_base_hypercache_command.py
+++ b/posthog/management/commands/_base_hypercache_command.py
@@ -54,18 +54,13 @@ class BaseHyperCacheCommand(BaseCommand):
         """
         Add arguments specific to warming commands.
 
-        Includes: --batch-size, --invalidate-first, --no-stagger, --min-ttl-days, --max-ttl-days
+        Includes: --batch-size, --no-stagger, --min-ttl-days, --max-ttl-days
         """
         parser.add_argument(
             "--batch-size",
             type=int,
             default=1000,
             help="Number of teams to process at a time (default: 1000)",
-        )
-        parser.add_argument(
-            "--invalidate-first",
-            action="store_true",
-            help="Invalidate all existing caches before warming (use when schema changes)",
         )
         parser.add_argument(
             "--no-stagger",
@@ -702,30 +697,10 @@ class BaseHyperCacheCommand(BaseCommand):
 
         return teams if teams else None
 
-    def _confirm_invalidate(self, cache_name: str) -> bool:
-        """
-        Get user confirmation for invalidating all caches.
-
-        Returns:
-            True if user confirmed, False otherwise
-        """
-        self.stdout.write(
-            self.style.WARNING(
-                f"WARNING: This will invalidate ALL existing {cache_name} caches before warming.\n"
-                "This should only be used when the cache schema has changed.\n"
-            )
-        )
-        confirm = input("Are you sure? Type 'yes' to continue: ")
-        if confirm.lower() != "yes":
-            self.stdout.write(self.style.ERROR("Aborted."))
-            return False
-        return True
-
     def run_warm(
         self,
         team_ids: list[int] | None,
         batch_size: int,
-        invalidate_first: bool,
         stagger_ttl: bool,
         min_ttl_days: int,
         max_ttl_days: int,
@@ -739,7 +714,6 @@ class BaseHyperCacheCommand(BaseCommand):
         Args:
             team_ids: Specific team IDs to warm, or None for all teams
             batch_size: Number of teams to process at a time
-            invalidate_first: Whether to invalidate all caches before warming
             stagger_ttl: Whether to randomize TTLs
             min_ttl_days: Minimum TTL in days (when staggering)
             max_ttl_days: Maximum TTL in days (when staggering)
@@ -758,7 +732,6 @@ class BaseHyperCacheCommand(BaseCommand):
 
             # Process all specific teams at once (small batch)
             actual_batch_size = len(teams)
-            actual_invalidate_first = False  # Never invalidate for specific teams
         else:
             # Get current cache stats for upfront reporting
             total_teams = Team.objects.count()
@@ -772,16 +745,11 @@ class BaseHyperCacheCommand(BaseCommand):
                 f"  Teams to warm: {scoped_teams:,}\n"
                 f"  Current cache coverage: {cache_stats.get('cache_coverage', 'unknown')}\n"
                 f"  Batch size: {batch_size}\n"
-                f"  Invalidate first: {invalidate_first}\n"
                 f"  Stagger TTL: {stagger_ttl}\n"
                 f"  TTL range: {min_ttl_days}-{max_ttl_days} days\n"
             )
 
-            if invalidate_first and not self._confirm_invalidate(cache_name):
-                return
-
             actual_batch_size = batch_size
-            actual_invalidate_first = invalidate_first
 
         # Callbacks to write progress to stdout
         last_percent_reported = [0]  # Use list to allow mutation in closure
@@ -805,7 +773,6 @@ class BaseHyperCacheCommand(BaseCommand):
         successful, failed = warm_caches(
             config,
             batch_size=actual_batch_size,
-            invalidate_first=actual_invalidate_first,
             stagger_ttl=stagger_ttl,
             min_ttl_days=min_ttl_days,
             max_ttl_days=max_ttl_days,

--- a/posthog/management/commands/warm_flag_definitions_cache.py
+++ b/posthog/management/commands/warm_flag_definitions_cache.py
@@ -10,9 +10,6 @@ Usage:
     # Warm specific teams
     python manage.py warm_flag_definitions_cache --team-ids 12345 67890
 
-    # Schema changes (invalidates all caches first)
-    python manage.py warm_flag_definitions_cache --invalidate-first
-
     # Warm only one variant
     python manage.py warm_flag_definitions_cache --variant with-cohorts
     python manage.py warm_flag_definitions_cache --variant without-cohorts
@@ -46,7 +43,6 @@ class Command(BaseHyperCacheCommand):
         # default cache (REDIS_URL), not the dedicated flags cache (FLAGS_REDIS_URL).
         team_ids = options.get("team_ids")
         batch_size = options["batch_size"]
-        invalidate_first = options["invalidate_first"]
         stagger_ttl = not options["no_stagger"]
         min_ttl_days = options["min_ttl_days"]
         max_ttl_days = options["max_ttl_days"]
@@ -84,7 +80,6 @@ class Command(BaseHyperCacheCommand):
             self.run_warm(
                 team_ids=team_ids,
                 batch_size=batch_size,
-                invalidate_first=invalidate_first,
                 stagger_ttl=stagger_ttl,
                 min_ttl_days=min_ttl_days,
                 max_ttl_days=max_ttl_days,

--- a/posthog/management/commands/warm_flags_cache.py
+++ b/posthog/management/commands/warm_flags_cache.py
@@ -11,9 +11,6 @@ Usage:
     # Warm specific teams
     python manage.py warm_flags_cache --team-ids 12345 67890
 
-    # Schema changes (invalidates all caches first)
-    python manage.py warm_flags_cache --invalidate-first
-
     # Custom batch size and TTL range
     python manage.py warm_flags_cache --batch-size 200 --min-ttl-days 6 --max-ttl-days 8
 """
@@ -36,7 +33,6 @@ class Command(BaseHyperCacheCommand):
 
         team_ids = options.get("team_ids")
         batch_size = options["batch_size"]
-        invalidate_first = options["invalidate_first"]
         stagger_ttl = not options["no_stagger"]
         min_ttl_days = options["min_ttl_days"]
         max_ttl_days = options["max_ttl_days"]
@@ -51,7 +47,6 @@ class Command(BaseHyperCacheCommand):
         self.run_warm(
             team_ids=team_ids,
             batch_size=batch_size,
-            invalidate_first=invalidate_first,
             stagger_ttl=stagger_ttl,
             min_ttl_days=min_ttl_days,
             max_ttl_days=max_ttl_days,

--- a/posthog/management/commands/warm_team_metadata_cache.py
+++ b/posthog/management/commands/warm_team_metadata_cache.py
@@ -11,9 +11,6 @@ Usage:
     # Warm specific teams
     python manage.py warm_team_metadata_cache --team-ids 12345 67890
 
-    # Schema changes (invalidates all caches first)
-    python manage.py warm_team_metadata_cache --invalidate-first
-
     # Custom batch size and TTL range
     python manage.py warm_team_metadata_cache --batch-size 200 --min-ttl-days 6 --max-ttl-days 8
 """
@@ -36,7 +33,6 @@ class Command(BaseHyperCacheCommand):
 
         team_ids = options.get("team_ids")
         batch_size = options["batch_size"]
-        invalidate_first = options["invalidate_first"]
         stagger_ttl = not options["no_stagger"]
         min_ttl_days = options["min_ttl_days"]
         max_ttl_days = options["max_ttl_days"]
@@ -51,7 +47,6 @@ class Command(BaseHyperCacheCommand):
         self.run_warm(
             team_ids=team_ids,
             batch_size=batch_size,
-            invalidate_first=invalidate_first,
             stagger_ttl=stagger_ttl,
             min_ttl_days=min_ttl_days,
             max_ttl_days=max_ttl_days,

--- a/posthog/models/feature_flag/test/test_flags_cache.py
+++ b/posthog/models/feature_flag/test/test_flags_cache.py
@@ -1150,30 +1150,6 @@ class TestManagementCommands(BaseTest):
         self.assertIn("Total teams: 1", output)
         self.assertIn("Successful: 1", output)
 
-    @patch("builtins.input", return_value="yes")
-    def test_warm_command_invalidate_first(self, mock_input):
-        """Test warm_flags_cache command with --invalidate-first."""
-        from io import StringIO
-
-        from django.core.management import call_command
-
-        # Create a real flag for the team
-        FeatureFlag.objects.create(
-            team=self.team,
-            key="test-flag",
-            created_by=self.user,
-            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
-        )
-
-        # Call command with --invalidate-first
-        out = StringIO()
-        call_command("warm_flags_cache", "--invalidate-first", stdout=out)
-
-        output = out.getvalue()
-        # Should show warning about invalidation
-        self.assertIn("Invalidate first: True", output)
-        self.assertIn("Flags cache warm completed", output)
-
     def test_analyze_command_validates_sample_size_too_small(self):
         """Test analyze command rejects sample_size < 1."""
         from io import StringIO
@@ -1483,22 +1459,6 @@ class TestManagementCommands(BaseTest):
             # Should show failed count
             self.assertIn("Failed:", output)
             self.assertIn("1", output)  # 1 team failed
-
-    @patch("posthog.storage.hypercache_manager.warm_caches")
-    @patch("builtins.input", return_value="no")
-    def test_warm_invalidate_first_user_cancels(self, mock_input, mock_warm):
-        """Test that user can cancel --invalidate-first operation."""
-        from io import StringIO
-
-        from django.core.management import call_command
-
-        out = StringIO()
-        call_command("warm_flags_cache", "--invalidate-first", stdout=out)
-
-        output = out.getvalue()
-        self.assertIn("Aborted", output)
-        # Should NOT call warm_caches
-        mock_warm.assert_not_called()
 
     def test_warm_staggered_ttl_range(self):
         """Test that TTL staggering parameters are passed correctly."""

--- a/posthog/storage/hypercache_manager.py
+++ b/posthog/storage/hypercache_manager.py
@@ -6,7 +6,6 @@ This module provides unified batch operations for managing team-indexed HyperCac
 that specifies how to perform batch operations.
 
 Operations include:
-- Invalidating all caches for a namespace
 - Warming all caches with configurable batching and TTL staggering
 - Gathering cache statistics and coverage metrics
 """
@@ -59,12 +58,6 @@ HYPERCACHE_SIGNAL_UPDATE_COUNTER = Counter(
     "posthog_hypercache_signal_updates",
     "Cache updates triggered by Django signals",
     labelnames=["namespace", "operation", "result"],
-)
-
-HYPERCACHE_INVALIDATION_COUNTER = Counter(
-    "posthog_hypercache_invalidations",
-    "Full cache invalidations (schema changes)",
-    labelnames=["namespace"],
 )
 
 
@@ -254,45 +247,9 @@ class HyperCacheManagementConfig:
         return Team.objects.all()
 
 
-def invalidate_all_caches(config: HyperCacheManagementConfig) -> int:
-    """
-    Invalidate all caches for a specific HyperCache namespace.
-
-    Scans Redis for all keys matching the cache pattern, deletes them,
-    and clears the expiry tracking sorted set.
-
-    Args:
-        config: Cache configuration specifying which cache to invalidate
-
-    Returns:
-        Number of cache keys deleted
-    """
-    try:
-        redis_client = get_client(config.hypercache.redis_url)
-
-        deleted = 0
-        for key in redis_client.scan_iter(match=config.redis_pattern, count=1000):
-            redis_client.delete(key)
-            deleted += 1
-
-        # Clear the expiry tracking sorted set
-        if config.hypercache.expiry_sorted_set_key:
-            redis_client.delete(config.hypercache.expiry_sorted_set_key)
-
-        HYPERCACHE_INVALIDATION_COUNTER.labels(namespace=config.namespace).inc()
-
-        logger.info(f"Invalidated all {config.log_prefix}", deleted_keys=deleted)
-        return deleted
-    except Exception as e:
-        logger.exception(f"Failed to invalidate {config.log_prefix}", error=str(e))
-        capture_exception(e)
-        return 0
-
-
 def warm_caches(
     config: HyperCacheManagementConfig,
     batch_size: int = 1000,
-    invalidate_first: bool = False,
     stagger_ttl: bool = True,
     min_ttl_days: int = 5,
     max_ttl_days: int = 7,
@@ -303,8 +260,8 @@ def warm_caches(
     """
     Warm cache for teams (all or specific subset).
 
-    Run as a management command for initial cache build or when schema changes require
-    cache invalidation. Processes teams in batches with staggered TTLs to avoid
+    Run as a management command for initial cache build. Processes teams in batches
+    with staggered TTLs to avoid
     synchronized expiration. Continues on errors.
 
     Uses persistent database connection to avoid connection overhead across batches.
@@ -314,7 +271,6 @@ def warm_caches(
     Args:
         config: Cache configuration specifying which cache to warm
         batch_size: Number of teams to process at a time
-        invalidate_first: If True, clear all caches before warming (ignored when team_ids provided)
         stagger_ttl: If True, randomize TTLs between min/max to avoid synchronized expiration
         min_ttl_days: Minimum TTL in days (when staggering)
         max_ttl_days: Maximum TTL in days (when staggering)
@@ -337,15 +293,6 @@ def warm_caches(
         connection.ensure_connection()
 
     try:
-        # Skip invalidation when warming specific teams (doesn't make sense for subset)
-        if invalidate_first:
-            if team_ids:
-                logger.warning("Skipping invalidation when warming specific teams")
-            else:
-                logger.info(f"Invalidating all existing {config.log_prefix} before warming")
-                invalidated = invalidate_all_caches(config)
-                logger.info("Invalidated caches", count=invalidated)
-
         if team_ids:
             teams_queryset = Team.objects.filter(id__in=team_ids).select_related("organization", "project")
         else:
@@ -358,7 +305,6 @@ def warm_caches(
             total_teams=total_teams,
             batch_size=batch_size,
             stagger_ttl=stagger_ttl,
-            invalidate_first=invalidate_first and not team_ids,
             specific_teams=team_ids is not None,
         )
 

--- a/posthog/storage/test/test_hypercache_manager.py
+++ b/posthog/storage/test/test_hypercache_manager.py
@@ -4,7 +4,7 @@ Tests for HyperCache management operations.
 Covers:
 - Django key prefix extraction for Redis patterns
 - Redis URL routing for dedicated caches
-- Cache invalidation and stats operations
+- Cache stats operations
 """
 
 from posthog.test.base import BaseTest
@@ -14,7 +14,6 @@ from posthog.storage.hypercache import HyperCache
 from posthog.storage.hypercache_manager import (
     HyperCacheManagementConfig,
     get_cache_stats,
-    invalidate_all_caches,
     push_hypercache_stats_metrics,
     warm_caches,
 )
@@ -226,106 +225,6 @@ class TestRedisUrlRouting(BaseTest):
         # The default hypercache uses settings.REDIS_URL
         call_args = mock_get_client.call_args[0]
         assert call_args[0] is not None  # Should have a URL from settings
-
-    @patch("posthog.storage.hypercache_manager.get_client")
-    def test_invalidate_all_caches_uses_config_redis_url(self, mock_get_client):
-        """Test that invalidate_all_caches uses the Redis URL from config.
-
-        Regression test: Previously this function used get_client() without
-        the redis_url, causing it to scan the wrong Redis instance.
-        """
-        config = create_test_config()
-
-        mock_redis = MagicMock()
-        mock_get_client.return_value = mock_redis
-        mock_redis.scan_iter.return_value = iter([])
-
-        # Mock the hypercache's redis_url to simulate a dedicated Redis
-        with patch.object(config.hypercache, "redis_url", "redis://dedicated:6379/1"):
-            invalidate_all_caches(config)
-
-        mock_get_client.assert_called_once_with("redis://dedicated:6379/1")
-
-    @patch("posthog.storage.hypercache_manager.get_client")
-    def test_invalidate_all_caches_uses_default_redis_url(self, mock_get_client):
-        """Test that invalidate_all_caches uses the default Redis URL from settings."""
-        config = create_test_config()
-
-        mock_redis = MagicMock()
-        mock_get_client.return_value = mock_redis
-        mock_redis.scan_iter.return_value = iter([])
-
-        invalidate_all_caches(config)
-
-        # Should be called with whatever redis_url the hypercache has
-        mock_get_client.assert_called_once()
-        call_args = mock_get_client.call_args[0]
-        assert call_args[0] is not None  # Should have a URL from settings
-
-
-class TestInvalidateAllCaches(BaseTest):
-    """Test invalidate_all_caches functionality."""
-
-    @patch("posthog.storage.hypercache_manager.get_client")
-    def test_deletes_matching_keys(self, mock_get_client):
-        """Test that invalidate_all_caches deletes all keys matching the pattern."""
-        config = create_test_config()
-
-        mock_redis = MagicMock()
-        mock_get_client.return_value = mock_redis
-        mock_redis.scan_iter.return_value = iter([b"key1", b"key2", b"key3"])
-
-        deleted_count = invalidate_all_caches(config)
-
-        assert deleted_count == 3
-        # 3 cache keys + 1 expiry sorted set = 4 total deletes
-        assert mock_redis.delete.call_count == 4
-
-    @patch("posthog.storage.hypercache_manager.get_client")
-    def test_clears_expiry_sorted_set(self, mock_get_client):
-        """Test that invalidate_all_caches also clears the expiry tracking set."""
-        config = create_test_config()
-
-        mock_redis = MagicMock()
-        mock_get_client.return_value = mock_redis
-        mock_redis.scan_iter.return_value = iter([])
-
-        invalidate_all_caches(config)
-
-        # Should delete the expiry sorted set
-        mock_redis.delete.assert_called_with(config.hypercache.expiry_sorted_set_key)
-
-    @patch("posthog.storage.hypercache_manager.get_client")
-    def test_returns_zero_on_error(self, mock_get_client):
-        """Test that invalidate_all_caches returns 0 on error."""
-        config = create_test_config()
-
-        mock_get_client.side_effect = Exception("Redis connection failed")
-
-        deleted_count = invalidate_all_caches(config)
-
-        assert deleted_count == 0
-
-    @patch("posthog.storage.hypercache_manager.get_client")
-    def test_uses_correct_pattern_with_django_prefix(self, mock_get_client):
-        """Test that scan uses the pattern with Django prefix."""
-        config = create_test_config(namespace="feature_flags", value="flags.json")
-
-        mock_cache_client = MagicMock()
-        mock_cache_client.key_prefix = "posthog"
-        mock_cache_client.version = 1
-
-        mock_redis = MagicMock()
-        mock_get_client.return_value = mock_redis
-        mock_redis.scan_iter.return_value = iter([])
-
-        with patch.object(config.hypercache, "cache_client", mock_cache_client):
-            invalidate_all_caches(config)
-
-        # Verify scan was called with the correct pattern
-        mock_redis.scan_iter.assert_called_once()
-        call_kwargs = mock_redis.scan_iter.call_args[1]
-        assert call_kwargs["match"] == "posthog:1:cache/teams/*/feature_flags/*"
 
 
 class TestGetCacheStats(BaseTest):

--- a/posthog/tasks/feature_flags.py
+++ b/posthog/tasks/feature_flags.py
@@ -70,7 +70,7 @@ def refresh_expiring_flags_cache_entries(self: PushGatewayTask) -> None:
     This job just prevents expiration-related cache misses.
 
     For initial cache build or schema migrations, use the management command:
-        python manage.py warm_flags_cache [--invalidate-first]
+        python manage.py warm_flags_cache
     """
 
     if not settings.FLAGS_REDIS_URL:

--- a/posthog/tasks/team_metadata.py
+++ b/posthog/tasks/team_metadata.py
@@ -63,7 +63,7 @@ def refresh_expiring_team_metadata_cache_entries() -> None:
     This job just prevents expiration-related cache misses.
 
     For initial cache build or schema migrations, use the management command:
-        python manage.py warm_team_metadata_cache [--invalidate-first]
+        python manage.py warm_team_metadata_cache
     """
 
     if not settings.FLAGS_REDIS_URL:


### PR DESCRIPTION
## Problem

We've made recent changes to focus on pre-calculating as much of the `/flags` request processing as possible such as dependency graphs, cohort definitions, etc. This makes the old Rust code that resolved dependencies as dead code if the cache entry exists. We want to remove this dead code and require that the cache entries exist.

With that in mind, the `--invalidate-first` flag on HyperCache warm commands becomes a big foot gun. Invalidating the cache, then warming the cache would break `/flags`. Also, its unnecessary. The warm operation overwrites existing cache entries, making pre-invalidation redundant. Removing it simplifies the command interface, the base command class, and the `hypercache_manager` module.

## Changes

- Remove `--invalidate-first` argument from `_base_hypercache_command.py` and all three warm commands
- Remove `invalidate_all_caches()` function and `HYPERCACHE_INVALIDATION_COUNTER` metric from `hypercache_manager.py`
- Remove `_confirm_invalidate()` method from the base command
- Remove `invalidate_first` parameter from `run_warm()` and `warm_caches()`
- Remove associated tests
- Update documentation in `hypercache-system.md`

## How did you test this code?

Existing tests continue to pass after removing the invalidation-related tests and parameters.

## Publish to changelog?

No