### PR TITLE
chore: show user in slack

### DIFF
--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -232,7 +232,6 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
-    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',

--- a/products/conversations/backend/api/tests/test_slack_team_member_detection.py
+++ b/products/conversations/backend/api/tests/test_slack_team_member_detection.py
@@ -83,7 +83,8 @@ class TestCreateOrUpdateSlackTicketTeamMemberDetection(BaseTest):
         mock_resolve,
         mock_client,
     ):
-        mock_resolve.return_value = _team_member_user_info(self.user.email) if is_team else _customer_user_info()
+        user_info = _team_member_user_info(self.user.email) if is_team else _customer_user_info()
+        mock_resolve.return_value = user_info
         mock_client.return_value = MagicMock()
 
         ticket = create_or_update_slack_ticket(
@@ -103,6 +104,7 @@ class TestCreateOrUpdateSlackTicketTeamMemberDetection(BaseTest):
         assert (comment.created_by_id == self.user.id) == expect_created_by
         ticket.refresh_from_db()
         assert ticket.unread_team_count == expected_unread
+        assert ticket.distinct_id == user_info["email"]
 
     @parameterized.expand(
         [

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -455,7 +455,7 @@ def create_or_update_slack_ticket(
         channel_source=Channel.SLACK,
         channel_detail=channel_detail,
         widget_session_id="",  # Not used for Slack tickets
-        distinct_id="",  # Will be linked later if email matches a person
+        distinct_id=user_info.get("email") or "",
         status=Status.NEW,
         anonymous_traits={
             "name": user_info["name"],


### PR DESCRIPTION
We do not show who raised a ticket in slack, but now we have that data.
