### PR TITLE
fix: Document CDP sources inside posthog/posthog repo

### DIFF
--- a/.github/workflows/ci-source-docs-check.yml
+++ b/.github/workflows/ci-source-docs-check.yml
@@ -1,0 +1,68 @@
+name: Data warehouse source docs check
+
+on:
+    pull_request:
+        paths:
+            - 'products/data_warehouse/backend/types.py'
+            - 'posthog/temporal/data_imports/sources/**/source.py'
+            - 'docs/published/docs/cdp/sources/**'
+            - 'bin/check_source_docs.py'
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    check-source-docs:
+        name: Check all sources have docs
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Check for missing source docs
+              id: check
+              run: |
+                  output=$(python bin/check_source_docs.py 2>&1) || true
+                  echo "$output"
+                  if echo "$output" | grep -q "sources are missing docs"; then
+                      missing_count=$(echo "$output" | grep "sources are missing docs" | grep -oP '\d+')
+                      if [ "$missing_count" -gt 0 ]; then
+                          echo "has_missing=true" >> $GITHUB_OUTPUT
+                          # Save the missing list for the comment
+                          {
+                              echo 'missing_list<<EOF'
+                              echo "$output" | sed -n '/^Missing docs:/,$ p'
+                              echo 'EOF'
+                          } >> $GITHUB_OUTPUT
+                      fi
+                  fi
+
+            - name: Comment on PR about missing docs
+              if: steps.check.outputs.has_missing == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  # Check if comment already exists
+                  if gh pr view ${{ github.event.pull_request.number }} --json comments \
+                      --jq '.comments[].body' | grep -q 'Source Docs Check'; then
+                      echo "Comment already exists, skipping"
+                      exit 0
+                  fi
+
+                  gh pr comment ${{ github.event.pull_request.number }} --body "### Source Docs Check
+
+                  This PR adds or modifies data warehouse sources but some sources are missing documentation.
+
+                  ${{ steps.check.outputs.missing_list }}
+
+                  **To fix:** Run \`python bin/check_source_docs.py --generate\` to create stub pages, then flesh out the docs for released sources.
+
+                  See \`docs/published/docs/cdp/sources/\` for the expected structure."
+
+            - name: Fail if sources missing docs
+              if: steps.check.outputs.has_missing == 'true'
+              run: |
+                  echo "::error::Some data warehouse sources are missing documentation. Run 'python bin/check_source_docs.py' to see which ones."
+                  exit 1

--- a/bin/check_source_docs.py
+++ b/bin/check_source_docs.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+"""Check that every registered ExternalDataSourceType has a corresponding doc page.
+
+Usage:
+    python bin/check_source_docs.py              # check and report
+    python bin/check_source_docs.py --generate   # generate stubs for missing sources
+
+Exit code 0 if all sources have docs, 1 if any are missing.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+TYPES_FILE = Path("products/data_warehouse/backend/types.py")
+DOCS_DIR = Path("docs/published/docs/cdp/sources")
+SNIPPETS_DIR = DOCS_DIR / "_snippets"
+
+# Explicit slug overrides for sources where the automatic derivation doesn't match
+# the established URL pattern. Keyed by the ExternalDataSourceType value (first string
+# in the TextChoices tuple).
+SLUG_OVERRIDES: dict[str, str] = {
+    # From existing docsUrl values
+    "BigQuery": "bigquery",
+    "MongoDB": "mongodb",
+    "MSSQL": "azure-db",
+    "MySQL": "mysql",
+    "TemporalIO": "temporal",
+    "DoIt": "doit",
+    "TikTokAds": "tiktok-ads",
+    # Brand names that are single compound words
+    "BuildBetter": "buildbetter",
+    "CustomerIO": "customerio",
+    "SFTP": "sftp",
+    "DynamoDB": "dynamodb",
+    "CockroachDB": "cockroachdb",
+    "CircleCI": "circleci",
+    "Auth0": "auth0",
+    "GitLab": "gitlab",
+    "PayPal": "paypal",
+    "NetSuite": "netsuite",
+    "QuickBooks": "quickbooks",
+    "FullStory": "fullstory",
+    "BigCommerce": "bigcommerce",
+    "WooCommerce": "woocommerce",
+    "OneDrive": "onedrive",
+    "SharePoint": "sharepoint",
+    "LaunchDarkly": "launchdarkly",
+    "HelpScout": "helpscout",
+    "SalesLoft": "salesloft",
+    "SendGrid": "sendgrid",
+    "SurveyMonkey": "surveymonkey",
+    "ChartMogul": "chartmogul",
+    "ConvertKit": "convertkit",
+    "MailerLite": "mailerlite",
+    "RingCentral": "ringcentral",
+    "ServiceNow": "servicenow",
+    "PagerDuty": "pagerduty",
+    "RevenueCat": "revenuecat",
+    "AppsFlyer": "appsflyer",
+    "ActiveCampaign": "activecampaign",
+    "CampaignMonitor": "campaignmonitor",
+    "YouTubeAnalytics": "youtube-analytics",
+    "FacebookPages": "facebook-pages",
+    "ZohoCRM": "zoho-crm",
+    "BambooHR": "bamboo-hr",
+    "ClickUp": "clickup",
+    "MicrosoftTeams": "microsoft-teams",
+    "GoogleDrive": "google-drive",
+    "GoogleAnalytics": "google-analytics",
+}
+
+
+def camel_to_kebab(name: str) -> str:
+    """Convert CamelCase to kebab-case.
+
+    Handles sequences of uppercase letters (e.g., "GoogleAds" -> "google-ads",
+    "BambooHR" -> "bamboo-hr").
+    """
+    # Insert hyphen between a lowercase/digit and an uppercase letter
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1-\2", name)
+    # Insert hyphen between consecutive uppercase letters followed by lowercase
+    s = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1-\2", s)
+    return s.lower()
+
+
+def source_to_slug(source_value: str) -> str:
+    """Convert an ExternalDataSourceType value to a doc slug."""
+    if source_value in SLUG_OVERRIDES:
+        return SLUG_OVERRIDES[source_value]
+    return camel_to_kebab(source_value)
+
+
+def parse_source_types() -> list[str]:
+    """Parse ExternalDataSourceType enum values from types.py."""
+    content = TYPES_FILE.read_text()
+
+    # Extract only the ExternalDataSourceType class body
+    match = re.search(
+        r"class ExternalDataSourceType\(.*?\):\s*\n(.*?)(?:\nclass |\Z)",
+        content,
+        re.DOTALL,
+    )
+    if not match:
+        print(f"ERROR: ExternalDataSourceType class not found in {TYPES_FILE}", file=sys.stderr)
+        sys.exit(2)
+
+    class_body = match.group(1)
+    # Match lines like: STRIPE = "Stripe", "Stripe"
+    pattern = re.compile(r'^\s+\w+\s*=\s*"([^"]+)",\s*"[^"]+"', re.MULTILINE)
+    values = pattern.findall(class_body)
+    if not values:
+        print(f"ERROR: No enum values found in ExternalDataSourceType", file=sys.stderr)
+        sys.exit(2)
+    return values
+
+
+def find_doc_file(slug: str) -> Path | None:
+    """Check if a doc file exists for the given slug."""
+    path = DOCS_DIR / f"{slug}.mdx"
+    if path.exists():
+        return path
+    return None
+
+
+def human_readable_label(source_value: str) -> str:
+    """Convert a source value to a human-readable label for doc titles."""
+    # Insert spaces in CamelCase
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", source_value)
+    s = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", s)
+    return s
+
+
+def generate_stub(source_value: str, slug: str) -> None:
+    """Generate a stub doc page and snippet for a source."""
+    label = human_readable_label(source_value)
+    # Sanitize component name for MDX import (remove spaces, hyphens)
+    component_name = re.sub(r"[^a-zA-Z0-9]", "", f"Source{source_value}")
+
+    page_content = f"""---
+title: Linking {label} as a source
+sidebar: Docs
+showTitle: true
+availability:
+    free: full
+    selfServe: full
+    enterprise: full
+---
+
+import {component_name} from './_snippets/source-{slug}.mdx'
+
+<{component_name} />
+"""
+
+    snippet_content = f"""> **{label}** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.
+"""
+
+    page_path = DOCS_DIR / f"{slug}.mdx"
+    snippet_path = SNIPPETS_DIR / f"source-{slug}.mdx"
+
+    page_path.write_text(page_content)
+    snippet_path.write_text(snippet_content)
+    print(f"  CREATED {page_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--generate",
+        action="store_true",
+        help="Generate stub docs for missing sources",
+    )
+    args = parser.parse_args()
+
+    source_values = parse_source_types()
+    print(f"Found {len(source_values)} source types in {TYPES_FILE}")
+
+    missing: list[tuple[str, str]] = []
+    found = 0
+
+    for value in source_values:
+        slug = source_to_slug(value)
+        doc = find_doc_file(slug)
+        if doc:
+            found += 1
+        else:
+            missing.append((value, slug))
+
+    print(f"  {found} sources have docs")
+    print(f"  {len(missing)} sources are missing docs")
+
+    if missing:
+        print("\nMissing docs:")
+        for value, slug in sorted(missing, key=lambda x: x[1]):
+            print(f"  - {value} (expected: {slug}.mdx)")
+
+        if args.generate:
+            print("\nGenerating stubs...")
+            DOCS_DIR.mkdir(parents=True, exist_ok=True)
+            SNIPPETS_DIR.mkdir(parents=True, exist_ok=True)
+            for value, slug in missing:
+                generate_stub(value, slug)
+            print(f"\nGenerated {len(missing)} stub pages")
+        else:
+            print(f"\nRun with --generate to create stub pages")
+
+    if missing and not args.generate:
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/published/docs/_snippets/data-sources.tsx
+++ b/docs/published/docs/_snippets/data-sources.tsx
@@ -1,0 +1,40 @@
+import List from 'components/List'
+import { getLogo } from 'constants/logos'
+import usePlatformList from 'hooks/docs/usePlatformList'
+import React from 'react'
+
+export const ManagedSources = (): React.ReactElement => {
+    const platforms = usePlatformList('docs/data-warehouse/sources', 'as a source', {
+        platformSourceType: 'managed',
+    })
+
+    // Add Supabase link to tutorial
+    const supabase = {
+        label: 'Supabase',
+        url: '/tutorials/supabase-query',
+        image: getLogo('supabase'),
+    }
+
+    return <List className="grid gap-4 grid-cols-2 @md:grid-cols-3 not-prose" items={[...platforms, supabase]} />
+}
+
+export const SelfHostedSources = (): React.ReactElement => {
+    const platforms = usePlatformList('docs/data-warehouse/sources', 'as a source', {
+        platformSourceType: 'self-hosted',
+    })
+
+    return <List className="grid gap-4 grid-cols-2 @md:grid-cols-3 not-prose" items={platforms} />
+}
+
+export const AllSources = (): React.ReactElement => {
+    const platforms = usePlatformList('docs/data-warehouse/sources', 'as a source')
+
+    // Add Supabase link to tutorial
+    const supabase = {
+        label: 'Supabase',
+        url: '/tutorials/supabase-query',
+        image: getLogo('supabase'),
+    }
+
+    return <List className="grid @2xl:grid-cols-2 @3xl:grid-cols-3 mb-4" items={[...platforms, supabase]} />
+}

--- a/docs/published/docs/cdp/_snippets/community-maintained.mdx
+++ b/docs/published/docs/cdp/_snippets/community-maintained.mdx
@@ -1,0 +1,3 @@
+### Who maintains this?
+
+This is maintained by the community. If you have issues with it not functioning as intended, please [let us know](http://app.posthog.com/home#supportModal)!

--- a/docs/published/docs/cdp/_snippets/export-disabled.mdx
+++ b/docs/published/docs/cdp/_snippets/export-disabled.mdx
@@ -1,0 +1,1 @@
+> 🚧 **Note:** New installs of this destination are currently disabled as we develop our new [batch export](https://github.com/PostHog/posthog/issues/15997) and [webhook](https://github.com/PostHog/posthog/issues/16976) functionalities. Support their development and follow along on the linked issues.

--- a/docs/published/docs/cdp/_snippets/feedback-questions.mdx
+++ b/docs/published/docs/cdp/_snippets/feedback-questions.mdx
@@ -1,0 +1,7 @@
+### What if I have feedback on this destination?
+
+We love feature requests and feedback. Please [tell us what you think](https://us.posthog.com/#panel=support%3Afeedback%3Aapps%3Alow%3Atrue).
+
+### What if my question isn't answered above?
+
+We love answering questions. Ask us anything via [our community forum](/questions).

--- a/docs/published/docs/cdp/_snippets/inbound-ip-addresses.mdx
+++ b/docs/published/docs/cdp/_snippets/inbound-ip-addresses.mdx
@@ -1,0 +1,9 @@
+#### Inbound IP addresses
+
+We use a set of IP addresses to access your instance. To ensure this connector works, add these IPs to your inbound security rules:
+
+| US             | EU            |
+| -------------- | ------------- |
+| 44.205.89.55   | 3.75.65.221   |
+| 44.208.188.173 | 18.197.246.42 |
+| 52.4.194.122   | 3.120.223.253 |

--- a/docs/published/docs/cdp/_snippets/persons-model-note.mdx
+++ b/docs/published/docs/cdp/_snippets/persons-model-note.mdx
@@ -1,0 +1,4 @@
+> **Note:** The persons model only includes persons that have a person profile in PostHog.
+> If your project has [person profile processing disabled](/docs/data/anonymous-vs-identified-events) (via `person_profiles: 'identified_only'`, `person_profiles: 'never'`, or by sending events with `$process_person_profile: false`), anonymous users who have never been identified will **not** appear in the persons export.
+> To count unique users including those without person profiles, you can fall back to `distinct_id` from the events model.
+> See the example queries in each destination's documentation for details.

--- a/docs/published/docs/cdp/_snippets/posthog-maintained.mdx
+++ b/docs/published/docs/cdp/_snippets/posthog-maintained.mdx
@@ -1,0 +1,3 @@
+### Who maintains this?
+
+This is maintained by PostHog. If you have issues with it not functioning as intended, please [let us know](https://us.posthog.com/#panel=support%3Asupport%3Aapps%3A%3Atrue)!

--- a/docs/published/docs/cdp/_snippets/transformation-disabled.mdx
+++ b/docs/published/docs/cdp/_snippets/transformation-disabled.mdx
@@ -1,0 +1,1 @@
+> 🚧 **Note:** New installs of this transformation are currently disabled as we develop our new transformation functionalities.

--- a/docs/published/docs/cdp/batch-exports/azureblob.md
+++ b/docs/published/docs/cdp/batch-exports/azureblob.md
@@ -1,0 +1,114 @@
+---
+title: Azure Blob Storage destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+import InboundIpAddresses from '../\_snippets/inbound-ip-addresses.mdx'
+
+With batch exports, data can be exported to Azure Blob Storage.
+
+<CalloutBox icon="IconInfo" title="Azure Blob Storage destination is in beta" type="fyi">
+
+The Azure Blob Storage destination is currently in `beta`. This means the configuration and features are subject to change.
+
+</CalloutBox>
+
+## Setting up Azure Blob Storage access
+
+To set up a batch export to Azure Blob Storage, you'll need:
+
+1. **An Azure Storage account** with a blob storage container where PostHog can export data.
+2. **A connection string** to authenticate PostHog with your Azure Storage account.
+
+### Getting your connection string
+
+To retrieve your connection string from the Azure Portal:
+
+1. Navigate to your Storage account.
+2. Go to **Security + networking** > **Access keys**.
+3. Copy the connection string from either the primary or secondary key.
+
+<InboundIpAddresses />
+
+If your Azure Storage account has firewall rules enabled, you'll need to add these IP addresses to your allowlist. For more information on configuring Azure Storage firewall rules, see the [Azure Storage network security documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security).
+
+## Models
+
+Azure Blob Storage supports all the models mentioned in the [batch export models reference](/docs/cdp/batch-exports#models).
+
+You can view the schema for each model inside the batch export configuration in the UI.
+
+> **Note:** New fields may be added to these models over time. Therefore, it is recommended that any downstream processes are able to handle additional fields being added to the exported files.
+
+## Creating the batch export
+
+1. Click [Data management > Destinations](https://app.posthog.com/data-management/destinations) in the left sidebar.
+2. Click **+ New destination** in the top-right corner.
+3. Search for **Azure Blob Storage**.
+4. Click the **+ Create** button.
+5. Fill in the necessary [configuration details](#azure-blob-storage-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
+
+## Azure Blob Storage configuration
+
+Configuring a batch export targeting Azure Blob Storage requires the following Azure-specific configuration values:
+
+- **Azure connection:** Select or configure your Azure Blob Storage connection using your connection string.
+- **Container name:** The name of the Azure Blob Storage container where the data is to be exported. The container must already exist and follow Azure's naming rules.
+- **Blob prefix (optional):** A prefix to use for each blob created. This prefix can include [template variables](#blob-prefix-template-variables) to organize your data.
+- **Format:** Select a file format to use in the export. See the [file formats section](#file-formats) for details on which file formats are supported.
+- **Max file size (MiB) (optional):** If the size of the exported data exceeds this value, the data is split into multiple files. (Note that this is approximate and the actual file size may be slightly larger). If this value is not set, or is set to 0, the data is exported as a single file.
+- **Compression:** Select a compression method (like gzip, brotli, or zstd) to use for exported files or no compression. See the [compression section](#compression) for details on which compression methods are supported.
+- **Events to exclude:** A list of events to omit from the exported data.
+
+### Blob prefix template variables
+
+The blob prefix provided for data exporting can include template variables which are formatted at runtime. All template variables are defined between curly brackets (for example `{day}`). This allows you to partition files in your Azure Blob Storage container, such as by date.
+
+Template variables include:
+
+- Date and time variables:
+  - `year`
+  - `month`
+  - `day`
+  - `hour`
+  - `minute`
+  - `second`
+- Name of the table exported (for example, 'events' or 'persons')
+  - `table`
+- Batch export data bounds:
+  - `data_interval_start`
+  - `data_interval_end`
+
+So, as an example, setting `{year}-{month}-{day}_{table}/` as a blob prefix, will produce files prefixed with keys like `2023-07-28_events/`.
+
+### File formats
+
+PostHog Azure Blob Storage batch exports support two file formats for exporting data:
+
+- [JSON lines](https://jsonlines.org/)
+- [Apache Parquet](https://parquet.apache.org/) (latest version of the format specification is the only one supported)
+
+The batch export format is selected via a drop down menu when creating or editing an export.
+
+### Compression
+
+Each file format supports a variety of compression methods. The compression method you choose can have a significant effect on the exported file size and the overall time taken to export the data. From our own internal testing, we would recommend using Parquet with zstd compression for the best combination of speed and file size.
+
+The following compression methods are supported:
+
+- **Parquet:** zstd, gzip, brotli, lz4, snappy
+- **JSONLines:** gzip, brotli
+
+> **Note on Parquet compression:** The compression type is included in the file extension, even for Parquet files. For example, files compressed with zstd will have the extension `.parquet.zst`, lz4 will be `.parquet.lz4`, and snappy will be `.parquet.sz`. Since compression is embedded in the format itself, the file should be read directly as a Parquet file and not uncompressed first.
+
+### Manifest file
+
+If you specify a max file size in your configuration, several files may be exported. In order to know when the export is complete, we send a `manifest.json` file (with the same prefix as the other files) once all the data files have been exported. This manifest file contains the key names of all the files exported.

--- a/docs/published/docs/cdp/batch-exports/bigquery.mdx
+++ b/docs/published/docs/cdp/batch-exports/bigquery.mdx
@@ -1,0 +1,190 @@
+---
+title: BigQuery destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import PersonsModelNote from '../_snippets/persons-model-note.mdx'
+
+Batch exports can be used to export data to a BigQuery table.
+
+## Setting up BigQuery access
+
+To set up the right permissions for a batch export targeting BigQuery, you need:
+
+1. A Service Account.
+2. A dataset which has permissions allowing the service account to access it.
+
+Here's how to set these up so that the destination has access only to the dataset it needs:
+
+1. Create a [Service Account](https://cloud.google.com/iam/docs/service-accounts-create#creating).
+
+![Create service account](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/batch-exports/bigquery/create-service-account.png)
+
+2. Create a [key](https://cloud.google.com/iam/docs/keys-create-delete#creating) for the Service Account you created in the previous step.
+3. Save the key file as JSON to upload it when configuring a batch export.
+
+![Create JSON private key](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/batch-exports/bigquery/create-private-key-json.png)
+
+4. Create a role which has only the specific permissions the batch export requires:
+   - `bigquery.datasets.get`
+   - `bigquery.jobs.create`
+   - `bigquery.tables.create`
+   - `bigquery.tables.get`
+   - `bigquery.tables.getData`
+   - `bigquery.tables.list`
+   - `bigquery.tables.updateData`
+   - (Optional, for mutable models) `bigquery.tables.delete`
+
+![Create custom role for batch exports](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/batch-exports/bigquery/create-role.png)
+
+This step can be skipped if using the built-in roles `BigQuery Data Editor` and `BigQuery Job User` in the steps that follow.
+
+5. Grant the Service Account access to run jobs in your Google Cloud project. This can be done by granting the `BigQuery Jobs User` role or the role we created in the previous step on your project.
+
+Navigate to IAM and click on Grant Access to arrive at this screen:
+
+![Project grant](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/batch-exports/bigquery/project-grant.png)
+
+> In the screenshot above, we have used a custom role named `Testing PostHog BatchExports` with the permissions listed in the previous step.
+
+6. Create a dataset within a BigQuery project (ours is called `BatchExports`, but any name will do).
+7. Use the Sharing and Add Principal buttons to grant access to your dataset with your Service Account created in step 1. Next, assign either the `BigQuery Data Editor` role or your custom role created in step 4 to provide permissions for the dataset access. Read the full instructions on [granting access to the dataset in BigQuery](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_dataset) if unclear.
+
+![Sharing dataset](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/batch-exports/bigquery/dataset-sharing.png)
+![Add principal](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/batch-exports/bigquery/dataset-add-principal.png)
+
+> In the screenshot below, we grant our Service Account access to the `BatchExports` data set and assign the `Testing PostHog BatchExports` role permissions for it.
+
+![Dataset grant access](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/batch-exports/bigquery/dataset-grant-access.png)
+
+8. All done! After completing these steps you can create a BigQuery [batch export in PostHog](https://app.posthog.com/pipeline/new/destination?search=bigquery) and your data will start flowing from PostHog to BigQuery.
+
+## Models
+
+This section describes the models that can be exported to BigQuery.
+
+> **Note:** New fields may be added to these models over time. To maintain consistency, these fields are not automatically added to the destination tables. If a particular field is missing in your BigQuery tables, you can manually add the field, and it will be populated in future exports.
+
+### Events model
+
+This is the default model for BigQuery batch exports. The schema of the model as created in BigQuery is:
+
+| Field                 | Type               | Description                                                               |
+| --------------------- | ------------------ | ------------------------------------------------------------------------- |
+| uuid                  | `STRING`           | The unique ID of the event within PostHog                                 |
+| event                 | `STRING`           | The name of the event that was sent                                       |
+| properties            | `STRING` or `JSON` | A JSON object with all the properties sent along with an event            |
+| elements              | `STRING`           | This field is present for backwards compatibility but has been deprecated |
+| set                   | `STRING` or `JSON` | A JSON object with any person properties sent with the `$set` field       |
+| set_once              | `STRING` or `JSON` | A JSON object with any person properties sent with the `$set_once` field  |
+| distinct_id           | `STRING`           | The `distinct_id` of the user who sent the event                          |
+| team_id               | `INT64`            | The `team_id` for the event                                               |
+| ip                    | `STRING`           | The IP address that was sent with the event                               |
+| site_url              | `STRING`           | This field is present for backwards compatibility but has been deprecated |
+| timestamp             | `TIMESTAMP`        | The timestamp associated with an event                                    |
+| bq_ingested_timestamp | `TIMESTAMP`        | The timestamp when the event was sent to BigQuery                         |
+
+Some fields can be either `STRING` or `JSON` type depending on whether the corresponding checkbox is marked or not when creating the batch export.
+
+### Persons model
+
+The schema of the model as created in BigQuery is:
+
+| Field                      | Type               | Description                                                                                                                                        |
+| -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| team_id                    | `INT64`            | The id of the project (team) the person belongs to                                                                                                 |
+| distinct_id                | `STRING`           | A `distinct_id` associated with the person                                                                                                         |
+| person_id                  | `STRING`           | The id of the person associated to this (`team_id`, `distinct_id`) pair                                                                            |
+| properties                 | `STRING` or `JSON` | A JSON object with all the latest properties of the person                                                                                         |
+| person_version             | `INT64`            | Internal version of the person properties associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation               |
+| person_distinct_id_version | `INT64`            | Internal version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation |
+| created_at                 | `TIMESTAMP`        | The timestamp when the person was created                                                                                                          |
+
+The BigQuery table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`. The `properties` field can be either `STRING` or `JSON`, depending on whether the corresponding checkbox is marked or not when creating the batch export.
+
+<PersonsModelNote />
+
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
+
+## Creating the batch export
+
+1. Click [Data management > Destinations](https://app.posthog.com/data-management/destinations) in the left sidebar.
+2. Click **+ New destination** in the top-right corner.
+3. Select **BigQuery** as the batch export destination.
+4. Fill in the necessary [configuration details](#bigquery-configuration).
+5. Finalize the creation by clicking on **Create**.
+6. Done! The batch export will schedule its first run on the start of the next period.
+
+## BigQuery configuration
+
+Configuring a batch export targeting BigQuery requires the following BigQuery-specific configuration values:
+
+- **Table ID:** The ID of the destination BigQuery table. This is not the fully-qualified name of a table, so omit the dataset and project IDs. For example for the fully-qualified table name `project-123:dataset:MyExportTable`, use only `MyExportTable` as the table ID.
+- **Dataset ID:** The ID of the BigQuery dataset which contains the destination table. Only the dataset ID is required, so omit the project ID if present. For example for the fully-qualified dataset `project-123:my-dataset`, use only `my-dataset` as the dataset ID.
+- **Google Cloud JSON key file:** The JSON key file for your BigQuery Service Account to access your instance. Generated on Service Account creation. See the [BigQuery access setup section](#setting-up-bigquery-access) for more information.
+
+## Examples
+
+These examples illustrate how to use the data from batch exports in BigQuery.
+
+### Requirements
+
+Two batch exports need to be created:
+
+- An events model batch export.
+- A persons model batch export.
+
+For the purposes of these examples, assume that these two batch exports have already been created and have exported some data to BigQuery in tables `example.events` and `example.persons`.
+
+### Example: Count unique persons that have triggered an event
+
+The following query counts unique persons that have triggered events.
+It uses `COALESCE` to fall back to `distinct_id` for events where the person has no profile in the persons export (for example, anonymous users when [person profile processing is disabled](/docs/data/anonymous-vs-identified-events)):
+
+```sql runInPostHog=false
+SELECT
+  event,
+  COUNT(DISTINCT COALESCE(persons.person_id, events.distinct_id)) AS unique_persons_count
+FROM
+  example.events AS events
+LEFT JOIN
+  example.persons AS persons ON events.distinct_id = persons.distinct_id AND events.team_id = persons.team_id
+GROUP BY
+  event
+ORDER BY
+  unique_persons_count DESC
+```
+
+## FAQ
+
+### How does PostHog keep the persons model (or any mutable model) up to date?
+
+Exporting a mutable model can be divided into new rows that have to be inserted, and existing rows that have to be updated. When a PostHog batch export exports mutable data (like the persons model) to BigQuery, it executes a merge operation to apply new updates to existing rows.
+
+The operation the PostHog batch export executes in BigQuery roughly involves the following steps:
+
+1. Creating a stage table.
+2. Inserting new data into stage table.
+3. Execute a merge operation between existing table and stage table.
+   a. Any rows that match in the final table and for which any of the stage table's version fields is higher are updated.
+   b. Any new rows not found in the final table are inserted.
+4. Drop the stage table.
+
+### Why are additional permissions required to export the persons model?
+
+The merge operation described above explains why a mutable export requires additional permissions beyond the permissions required for exporting the events model: Since we need to clean-up a stage table, `bigquery.tables.delete` is required.
+
+### Which jobs does the batch export run in BigQuery?
+
+If you check your BigQuery [JOBS view](https://cloud.google.com/bigquery/docs/information-schema-jobs) or the [Google Cloud console](https://cloud.google.com/bigquery/docs/managing-jobs#view-job) for job details, you may notice the PostHog batch export running jobs in your BigQuery warehouse.
+
+Regardless of model, PostHog batch exports run a [load job](https://cloud.google.com/bigquery/docs/batch-loading-data) to batch load the data for the current period into BigQuery. Moreover, you will see additional [query jobs](https://cloud.google.com/bigquery/docs/running-queries) in your logs when exporting a mutable model as the merge operation the batch export executes requires running additional queries in your BigQuery warehouse.
+
+If you are noticing an issue with your BigQuery batch export, it may be useful to check the aforementioned [JOBS view](https://cloud.google.com/bigquery/docs/information-schema-jobs) and the [Google Cloud console](https://cloud.google.com/bigquery/docs/managing-jobs#view-job). The error logs in them could be valuable to either diagnose the issue by yourself, or when creating a support request for us to look into.

--- a/docs/published/docs/cdp/batch-exports/databricks.mdx
+++ b/docs/published/docs/cdp/batch-exports/databricks.mdx
@@ -1,0 +1,236 @@
+---
+title: Databricks destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+Batch exports can be used to export data to a Databricks Delta table.
+
+import PersonsModelNote from '../_snippets/persons-model-note.mdx'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+<CalloutBox icon="IconInfo" title="Databricks destination is in beta" type="fyi">
+
+The Databricks destination is currently in `beta`. This means the configuration and features are subject to change.
+
+</CalloutBox>
+
+## Requirements
+
+To create a batch export to Databricks, you need the following:
+
+- A Databricks account with serverless SQL warehouses enabled
+- A Databricks workspace with Unity Catalog enabled
+- A SQL warehouse
+- A catalog and schema you wish to use
+- A service principal with [OAuth Machine-to-Machine (M2M)](https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m) authentication configured. This is the only authentication type we support currently. This service principal must have the appropriate permissions (see below)
+
+## Setup instructions
+
+### 1. SQL warehouse
+
+Batch exports uses SQL warehouses to export data into your Delta tables.
+
+You can use either an existing warehouse, or you can [create a new one](https://docs.databricks.com/aws/en/compute/sql-warehouse/create).
+
+You will need to make a note of the **Server hostname** and **HTTP path** for your warehouse:
+
+1. In Databricks, navigate to **SQL Warehouses**.
+2. Select your SQL warehouse.
+3. Go to the **Connection details** tab.
+4. Copy the **Server hostname** (e.g. `abc123.cloud.databricks.com`).
+5. Copy the **HTTP path** (e.g. `/sql/1.0/warehouses/abc123def456`).
+
+### 2. Set up catalog and schema
+
+1. In your Databricks workspace, create a catalog (or use an existing one) where PostHog will export data.
+2. Create a schema within that catalog (or use an existing one).
+3. Note the names of both the catalog and schema – you'll need these when configuring the batch export.
+
+> **Note:** You don't need to create tables manually. PostHog will create destination tables for you to ensure the data schemas are correct.
+
+### 3. Create a service principal
+
+Service principals give automated tools and scripts API-only access to Databricks resources, providing greater security than using user accounts.
+
+1. In your Databricks workspace, navigate to **Settings** > **Identity and access** > **Service principals**.
+2. Click **Add service principal**.
+3. Click **Add new**.
+4. Enter a name for your service principal (e.g. "PostHog Batch Exports").
+5. Click **Add**.
+
+### 4. Generate OAuth credentials
+
+1. Select the service principal you just created.
+2. Navigate to the **Secrets** tab.
+3. Click **Generate secret**.
+4. Choose a lifetime for the new secret.
+5. Copy and save both the **Client ID** (also the same as the service principal UUID) and **Secret** securely - you'll need these for PostHog configuration.
+
+> **Important:** The client secret is only shown once. Make sure to save it securely before closing the dialog.
+
+### 5. Grant permissions to the service principal
+
+The service principal needs the following permissions:
+
+**At the catalog level:**
+
+- `USE CATALOG` - Required to access the catalog
+
+**At the schema level:**
+
+- `USE SCHEMA` - Required to access the schema
+- `CREATE TABLE` - Required to create new tables (if the destination table doesn't exist)
+- `CREATE VOLUME` - Required to create temporary volumes for staging data
+
+**At the table level:**
+
+(Only needed if your table already exists. In general it is recommended to allow PostHog to create tables for you to ensure the data schemas are correct)
+
+- `SELECT` - Required to read the table schema
+- `MODIFY` - Required to insert and update data
+
+You can grant these permissions using SQL commands in Databricks:
+
+```sql runInPostHog=false
+-- Grant catalog permissions
+GRANT USE CATALOG ON CATALOG `<catalog_name>` TO `<service_principal_id_or_group>`;
+
+-- Grant schema permissions
+GRANT USE SCHEMA ON SCHEMA `<catalog_name>`.`<schema_name>` TO `<service_principal_id_or_group>`;
+GRANT CREATE TABLE ON SCHEMA `<catalog_name>`.`<schema_name>` TO `<service_principal_id_or_group>`;
+GRANT CREATE VOLUME ON SCHEMA `<catalog_name>`.`<schema_name>` TO `<service_principal_id_or_group>`;
+
+-- Grant table permissions (only needed if the table already exists)
+GRANT SELECT ON TABLE `<catalog_name>`.`<schema_name>`.`<table_name>` TO `<service_principal_id_or_group>`;
+GRANT MODIFY ON TABLE `<catalog_name>`.`<schema_name>`.`<table_name>` TO `<service_principal_id_or_group>`;
+```
+
+> **Note:** Replace `<catalog_name>`, `<schema_name>`, `<table_name>`, and `<service_principal_id_or_group>` with your actual values. You can either assign permissions to the service principal directly or via a [group](https://docs.databricks.com/aws/en/admin/users-groups/groups).
+
+## Creating the batch export
+
+1. In PostHog, click [Data management > Destinations](https://app.posthog.com/data-management/destinations) in the left sidebar.
+2. Click **+ New destination** in the top-right corner.
+3. Search for **Databricks**.
+4. Click the **+ Create** button.
+5. Fill in the necessary [configuration details](#databricks-configuration)
+6. Create a Databricks integration (if you haven't already):
+   - Enter a name for the integration
+   - Enter your **Server hostname** (from [step 1](#1-sql-warehouse))
+   - Enter your **Client ID** (from [step 4](#4-generate-oauth-credentials))
+   - Enter your **Client Secret** (from [step 4](#4-generate-oauth-credentials))
+7. Finalize the creation by clicking on **Create**.
+8. Done! The batch export will schedule its first run on the start of the next period.
+
+## Databricks configuration
+
+You'll need to specify the following configuration settings in PostHog:
+
+**Connection settings:**
+
+- **Integration:** Select the Databricks integration you created (or create a new one). The integration stores your server hostname and OAuth credentials securely.
+- **HTTP Path:** The HTTP path value for your SQL warehouse or all-purpose compute cluster (e.g. `/sql/1.0/warehouses/abc123def456`).
+
+**Destination settings:**
+
+- **Catalog:** The name of the Databricks catalog where the table will be created.
+- **Schema:** The name of the schema within the catalog where the table will be created.
+- **Table name:** The name of the table where data will be exported. If the table doesn't exist, it will be created automatically (this is the recommended approach).
+
+**Advanced settings (optional):**
+
+- **Use VARIANT type:** Whether to use Databricks' `VARIANT` type for JSON fields (like `properties` and `person_properties`). Enabled by default. The `VARIANT` type is optimized for semi-structured data and provides better querying performance. However, it requires **Databricks Runtime 15.3 or above**. If you're using an older runtime version, disable this setting to use `STRING` type instead.
+
+## Models
+
+This section describes the models that can be exported to Databricks.
+
+> **Note:** New fields may be added to these models over time. PostHog uses Databricks' [automatic schema evolution](https://docs.databricks.com/aws/en/delta/update-schema#automatic-schema-evolution-for-delta-lake-merge) feature, which means these new fields will be automatically added to your destination tables. Existing columns are never removed or modified.
+
+### Events model
+
+This is the default model for Databricks batch exports. The schema of the model as created in Databricks is:
+
+| Field                         | Type                  | Description                                                                           |
+| ----------------------------- | --------------------- | ------------------------------------------------------------------------------------- |
+| uuid                          | `STRING`              | The unique ID of the event within PostHog                                             |
+| event                         | `STRING`              | The name of the event that was sent                                                   |
+| properties                    | `VARIANT` or `STRING` | A JSON object with all the properties sent along with an event                        |
+| distinct_id                   | `STRING`              | The `distinct_id` of the user who sent the event                                      |
+| team_id                       | `BIGINT`              | The `team_id` for the event                                                           |
+| timestamp                     | `TIMESTAMP`           | The timestamp associated with an event                                                |
+| databricks_ingested_timestamp | `TIMESTAMP`           | An additional metadata column, indicating when the event was ingested into Databricks |
+
+### Persons model
+
+The schema of the model as created in Databricks is:
+
+| Field                      | Type                  | Description                                                                                      |
+| -------------------------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| team_id                    | `BIGINT`              | The id of the project (team) the person belongs to                                               |
+| distinct_id                | `STRING`              | A `distinct_id` associated with the person                                                       |
+| person_id                  | `STRING`              | The id of the person associated to this (`team_id`, `distinct_id`) pair                          |
+| properties                 | `VARIANT` or `STRING` | A JSON object with all the latest properties of the person                                       |
+| person_version             | `BIGINT`              | Internal version of the person properties, used by batch export in merge operation               |
+| person_distinct_id_version | `BIGINT`              | Internal version of the person to `distinct_id` mapping, used by batch export in merge operation |
+| created_at                 | `TIMESTAMP`           | The timestamp when the person was created                                                        |
+
+The Databricks table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
+
+<PersonsModelNote />
+
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
+
+## FAQ
+
+### How does the batch export process work?
+
+The batch export process follows a consistent pattern regardless of the model being exported, with variations depending on whether the model is mutable (like persons) or immutable (like events).
+
+**For immutable models (e.g. events):**
+
+1. Create a temporary volume to store Parquet files.
+2. Create the destination table if it doesn't exist.
+3. Query data from PostHog and transform it into Parquet format.
+4. Upload Parquet files to the temporary volume.
+5. Copy data directly from the volume into the destination table using Databricks' `COPY INTO` command.
+6. Delete the temporary volume.
+
+**For mutable models (e.g. persons, sessions):**
+
+1. Create a temporary volume to store Parquet files.
+2. Create the destination table if it doesn't exist.
+3. Create a temporary stage table with the same schema as the destination table.
+4. Query data from PostHog and transform it into Parquet format.
+5. Upload Parquet files to the temporary volume.
+6. Copy data from the volume into the **stage table** using `COPY INTO`.
+7. Execute a `MERGE` operation between the stage table and the destination table:
+   - Update existing rows where the stage table has newer versions.
+   - Insert new rows that don't exist in the destination table.
+8. Delete the stage table and temporary volume.
+
+The merge operation for mutable models ensures that:
+
+- Rows that match in the destination table and have newer version fields in the stage table are updated.
+- New rows not found in the destination table are inserted.
+- Your data always reflects the latest state while maintaining historical records that haven't been updated.
+
+### Should I use VARIANT or STRING type for JSON fields?
+
+We recommend using `VARIANT` (the default) for the following reasons:
+
+- Better query performance
+- Native support for JSON operators and functions
+
+However, you should use `STRING` if:
+
+- You're using Databricks Runtime older than 15.3
+- You need to export the data to another system that doesn't support VARIANT
+- You prefer to handle JSON parsing in your application code

--- a/docs/published/docs/cdp/batch-exports/index.mdx
+++ b/docs/published/docs/cdp/batch-exports/index.mdx
@@ -1,0 +1,248 @@
+---
+title: Batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+Batch exports give you a platform to schedule data exports to supported destinations. Batch exports are built on [Temporal](https://www.temporal.io/) to enable reliable data exports, ensuring your data reaches your destination.
+
+The key features offered by this platform are:
+
+- **Resiliency:** Retry capabilities (both automated and manual) when the destination is temporarily unavailable.
+- **Efficient data transfers:** Processing data in batches reduces the number of data transfers required (less `INSERT` queries or file uploads).
+
+Batch exports are designed to power any complimentary analytics use cases outside of PostHog.
+
+## Destinations
+
+Every batch export exports data to a destination using the configuration parameters provided when creating a batch export. The following destinations are currently supported:
+
+- [Azure Blob Storage](/docs/cdp/batch-exports/azureblob)
+- [BigQuery](/docs/cdp/batch-exports/bigquery)
+- [Databricks](/docs/cdp/batch-exports/databricks)
+- [S3](/docs/cdp/batch-exports/s3)
+- [Snowflake](/docs/cdp/batch-exports/snowflake)
+- [Postgres](/docs/cdp/batch-exports/postgres)
+- [Redshift](/docs/cdp/batch-exports/redshift)
+
+You can test the configurations of each destination by clicking the **Start test** button below the configuration form:
+
+![image of configuration test showing 3 completed steps](https://res.cloudinary.com/dmukukwp6/image/upload/Destination_tests_998d84299b.png)
+
+This test can detect and diagnose configuration issues, like invalid credentials or missing permissions, before running the batch export.
+
+Support for new destinations will be added based on demand. Message us via the [in-app support form](https://us.posthog.com/#panel=support%3Asupport%3Abatch_exports%3Alow%3Atrue) or create an [issue in GitHub](https://github.com/PostHog/posthog/issues/new?template=feature_request.yml) to voice your interest in new destinations.
+
+import InboundIpAddresses from '../_snippets/inbound-ip-addresses.mdx'
+import PersonsModelNote from '../_snippets/persons-model-note.mdx'
+
+<InboundIpAddresses />
+
+## Models
+
+Batch exports can export different data models, like the events and persons model. Each data model represents a different view into the PostHog database, complete with their own schemas and semantic meanings.
+
+> **Note:** New fields may be added to these models over time.
+>
+> To maintain consistency, these fields are not automatically added to database destination tables.
+> If a particular field is missing from your tables, you can manually add the field and it will be populated in future exports.
+> In the case of S3, these new fields will be added to the exported files as soon as they become available.
+
+### Events model
+
+The events model is the default model for all batch exports, and it represents a view into the events received by PostHog.
+
+For historical reasons, this model can vary depending on the destination, so we suggest checking each destinations documentation for the precise composition of the model's schema:
+
+- [Azure Blob Storage](/docs/cdp/batch-exports/azureblob)
+- [BigQuery](/docs/cdp/batch-exports/bigquery)
+- [Databricks](/docs/cdp/batch-exports/databricks)
+- [S3](/docs/cdp/batch-exports/s3)
+- [Snowflake](/docs/cdp/batch-exports/snowflake)
+- [Postgres](/docs/cdp/batch-exports/postgres)
+- [Redshift](/docs/cdp/batch-exports/redshift)
+
+However, there are some properties of the model that apply to all destinations:
+
+- This model is **immutable** with all fields set once the event is ingested.
+- Each event is **uniquely** identified by a UUID that can be used for de-duplication.
+
+### Persons model
+
+The persons model represents a view into how PostHog identifies unique [persons](/docs/data/persons) assigned to each event.
+
+Initially, PostHog events include an unidentified or anonymous `distinct_id` with each event, as we don't know who the user is until they go through your log-in steps. After a user logs in and you call `identify` with their corresponding `distinct_id`, PostHog has to group all previous events that had an anonymous `distinct_id` with the new events coming after the call to `identify`. This grouping is done under the an entity known as a person, and you can get access to these groupings by exporting the persons model. In a few words, the persons model is a mapping of all `distinct_id`s in events, both anonymous and identified, to a single ID per unique user as determined by your calls to `identify`.
+
+In contrast to the events model, the persons model is **mutable**: As users of PostHog may `identify` and merge new and old persons all the time, the persons model has to change with every operation. This rate of change depends on how frequently you call `identify` or merge persons together.
+
+Being a mutable model has implications for the export process: PostHog must merge incoming data with existing data to find any rows that need updating, as incoming data could be both completely new persons and updates to old persons. This merging process is different depending on each destination, but it is likely to require a higher level of access to your destination in comparison to exporting the immutable events model, which only executes append operations.
+
+The intended use-case for this model is to be exported alongside the events model, creating one batch export for each. The persons model can then be joined together with the events model to assign events to their unique persons.
+
+<PersonsModelNote />
+
+More information, including any additional necessary permissions, schema information, and examples, can be found in each of the destinations documentation:
+
+- [Azure Blob Storage](/docs/cdp/batch-exports/azureblob)
+- [BigQuery](/docs/cdp/batch-exports/bigquery)
+- [Snowflake](/docs/cdp/batch-exports/snowflake)
+- [Postgres](/docs/cdp/batch-exports/postgres)
+- [Redshift](/docs/cdp/batch-exports/redshift)
+- [Databricks](/docs/cdp/batch-exports/databricks)
+
+### Sessions model
+
+A [session](/docs/data/sessions) in PostHog represents a series of events that make up a single use of your product or visit to your website. Each session is uniquely identified by its `session_id`.
+
+If you want to link events with sessions, you'll need to ensure you're capturing the `$session_id` in your events. This is done automatically by our JavaScript Web library and mobile SDKs. For server-side SDKs, refer to our [docs](/docs/data/sessions#server-sdks-and-sessions).
+
+## Batch runs
+
+A batch export is executed in batch runs depending on the configured frequency. For example, an hourly batch export starts a run on every hour. The data processed by every run has an **upper bound** given by the time in which the run is scheduled to start, and a **lower bound** that results from subtracting the frequency to the batch run's scheduled start time.
+
+As an example, creating a batch export of events with daily frequency today will schedule the first batch run to start right as tomorrow begins. Thus, the data exported are events that PostHog received from 00:00:00 until 23:59:59 of today.
+
+> **Note:** When deciding which data falls within the bounds of a specific batch run, we look at the time when the data landed in PostHog's ClickHouse database. This means that network and processing delays can make an event that was sent within the bounds of a batch run fall in a future run.
+
+### Tracking progress
+
+On each batch export view, you are presented with a list of the latest executed runs:
+
+![batch export runs](https://res.cloudinary.com/dmukukwp6/image/upload/runs_tracking_progress_3268c67863.png)
+
+Each run has:
+
+1. A state indicator which can be either "Starting", "Running", "Failed", or "Completed."
+2. The exported data start and end intervals.
+3. When the run actually started.
+4. The option of retrying or cancelling a specific run.
+
+## Backfills (exporting historical data)
+
+When you create a batch export, it will start exporting data from the current time interval. If you want to export historical data, you can **backfill** the batch export.
+
+To view your existing backfills or to start a new one, you can navigate to the "Backfills" tab of the destination:
+
+![batch exports backfills ui](https://res.cloudinary.com/dmukukwp6/image/upload/backfill_ui_c8cc586478.png)
+
+From here, you can create a new backfill by clicking the "Start backfill" button, which will let you input the start and end date of the historical export:
+
+![create historic export](https://res.cloudinary.com/dmukukwp6/image/upload/2024_08_09_at_14_54_54_90338968ac.png)
+
+After you start a backfill, PostHog first estimates the total number of records to export and validates the date range.
+
+The start date of a backfill may be adjusted depending on when the earliest available data is. For example, if you choose a start date of 2026-01-01 but the earliest event captured in PostHog is 2026-01-02, the start date is adjusted to 2026-01-02. On the other hand, the end date of the backfill cannot be set past the current time, as our engineers have yet to figure out time traveling to allow us to export events in the future.
+
+If the estimation finds no matching data to export, the backfill completes immediately rather than creating empty batch runs.
+
+The backfills table includes a **Total rows** column that displays the estimated or final number of rows exported. For in-progress backfills, the count is shown as an approximate value (e.g. `~1,000`). For completed backfills, the final row count is displayed.
+
+### Cancelling backfills
+
+You can cancel a running backfill from within the backfills view. This will also cancel any runs associated with the backfill.
+
+## FAQ
+
+### How do batch exports work?
+
+As previously mentioned, batch exports are implemented on [Temporal](https://www.temporal.io/). More in detail, each supported destination is defined as a [Temporal workflow](https://docs.temporal.io/workflows). These workflows contain all the destination-specific operations required to connect to each specific destination. For example, the `s3-export` workflow contains the code to export data from PostHog to AWS S3.
+
+When a batch export run is triggered, all workflows first read the data to export from our database and store it in an internal S3 bucket. The workflows then read the data from this internal bucket, processes it into the desired output format, and sends it to the destination.
+
+To trigger these workflows on intervals chosen by our users, we leverage another feature of Temporal: [schedules](https://docs.temporal.io/workflows#schedule). Whenever a PostHog user creates a batch export, under the hood PostHog creates a Temporal schedule configured to execute the workflow associated with the export destination at the chosen interval.
+
+After creation, the schedule will wait until the end of the current batch period as defined by the batch export frequency, such as until the end of the current hour for hourly exports. At this point, the schedule will trigger a workflow to export the data for the batch period that has just concluded. However, before doing so, the schedule will wait for an additional small and randomly assigned amount of time. This additional waiting time allows us to avoid issues with having all workflows starting just as the next hour or day starts (commonly known as the thundering herd problem).
+
+Each workflow is divided into activities, and we operate workers running in [PostHog infrastructure](/docs/how-posthog-works) that pick up and run these activities as they are queued-up by each workflow.
+
+> **Note:** Workers run in PostHog infrastructure and are maintained by PostHog, not by Temporal. This means no event, person, or session data is ever sent to Temporal, as it is only handled by the aforementioned workers. Only configuration parameters are sent to external Temporal servers as they coordinate the execution of batch exports across multiple workers. This configuration data is always encrypted before leaving PostHog.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant PostHog
+    participant Temporal
+    participant Worker
+    participant Destination
+
+    User->>PostHog: Batch export configuration
+    PostHog->>Temporal: Create Schedule
+    Temporal->>Temporal: Wait until end of current batch period
+    Temporal->>Worker: Trigger Workflow Execution
+
+    Worker->>Destination: Export data
+    critical
+        Destination->>Worker: Data export result
+    option Destination responds with a retryable error
+        Destination->>Worker: Retryable error (e.g. network timeout)
+        Worker->>Destination: Retry export data
+    option Destination responds with a non-retryable error
+        Destination->>Worker: Non-retryable error (e.g. authentication failure)
+        Worker->>Worker: Log error
+    end
+
+    Worker->>PostHog: Workflow Execution result
+    PostHog->>User: Inform batch export status
+```
+
+### How does this differ from the old export destinations, formerly known as apps?
+
+- The data is exported on batches at a fixed frequency, like daily, hourly, or sub-hour frequencies.
+  - This allows us to optimize uploads and insertions which generally perform better with larger sizes.
+  - If you need real time delivery, then you will want check out [webhooks](/docs/webhooks).
+
+### How do batch exports handle periods with no data?
+
+If no data is found for a particular batch period, then the batch export run will immediately succeed. No data to export is not considered a failure, as it is expected that there may be times of low or no volume of events coming into PostHog, and it is particularly relevant when heavily filtering the batch export.
+
+When this happens, the batch export logs will display a message like "Batch export will finish early as there is no data matching specified filters".
+
+> **Note:** When there is no data to export, a batch export may skip attempting to connect to a destination. This could mean that underlying issues with the destination configuration are not surfaced. It is recommended to test the configuration after every change by running the tests in the configuration tab.
+
+### Why do I get duplicate data?
+
+There are a few situations that can cause batch exports to export duplicate data. For this reason, although we strive to keep the number of duplicates below a threshold, we recommend that you set up processes to de-duplicate the data in your destination if any amount of duplicates is undesirable. Different destinations will offer different tools to optimally handle duplicates, so we suggest you review your destination's documentation to find out what is the best strategy.
+
+#### 1. Batch exports run before deduplication
+
+Occasionally, PostHog ingests duplicate data, as we want to ensure all data is captured, even if that means sometimes capturing the same event multiple times. PostHog has several asynchronous processes that clean up these duplicate values so that they never surface to any visible dashboards.
+
+Batch exports can run before these asynchronous processes have done their work. In that situation, the batch export can be served duplicate data by our underlying data storage. Batch exports will attempt to de-duplicate data within a batch, but any de-duplication across multiple batches would be too expensive to execute within the time constraints of the batch export.
+
+In these rare situations, you will see duplicate data in your destination.
+
+#### 2. Backfills
+
+When requesting a backfill, PostHog does not check if the data to backfill already exists in the destination. Doing so would negatively impact performance of each batch export run, potentially require more permissions to operate on the destination, and introduce more complexity into the configuration of the batch export.
+
+Batch exports assume that users who start a backfill want all the data within the backfill window exported, which means that multiple backfills over the same time period will produce duplicates.
+
+When requesting a backfill, we recommend doing so for data that wasn't exported at all, like data from before the batch export was created, or when re-exporting the same data is required, like if it is accidentally deleted from the destination by an unrelated error.
+
+In addition, depending on any delays in sending or ingesting data, batch export runs triggered by a backfill close to real time may have data that overlaps with regularly scheduled batch export runs.
+
+For these reasons, although we strive to keep the number of duplicates below a threshold, we recommend that you set up processes to de-duplicate the data in your destination if any amount of duplicates is undesirable. Different destinations will offer different tools to optimally handle duplicates, so we suggest you review your destination's documentation to find out what is the best strategy.
+
+### Why are events exported in runs that do not match the event's timestamp?
+
+Due to delays in ingestion, caused by unreliable networks, buffering strategies, and other quirks, an event may arrive at PostHog with a significant delay compared to its timestamp. If batch exports relied on the event's timestamp to decide which data to include in a particular batch, we could be missing events that arrive late. As it is impossible to know whether events with a delay exist before they arrive, batch exports instead relies on the time when an event is ingested to decide whether an event belongs in a batch or not.
+
+Here is an example to illustrate this situation:
+
+1. An event is generated by your mobile application with a timestamp with a time component of 12:59:59 (assume all times are on the same timezone, for simplicity).
+
+2. Since the mobile device is currently not connected to a stable WiFi connection, the event fails to be sent to PostHog, and is instead cached in the device to be sent later.
+
+3. In the time it took for the event to fail, the clock already moved past 13:00:00, and your hourly batch export has started the 12:00:00-13:00:00 run.
+
+4. A few minutes later, say 13:05:00, the batch export run finishes.
+
+5. Finally a few minutes after that, at 13:07:00, the mobile device connects to a reliable WiFi, the event with timestamp 12:59:59 is finally sent, and processed in PostHog.
+
+This example illustrates the issue: The event with timestamp 12:59:59 can only be exported by batch export runs triggered after its arrival (13:00:00-14:00:00, and beyond), as the previous runs (12:00:00-13:00:00, and before) execute before PostHog even knows that the event exists. But if the 13:00:00-14:00:00 batch export run looked for events with timestamps in the 13:00:00-14:00:00 range, it would not export the event with timestamp 12:59:59, in fact, the event would never be automatically exported; we would say the event was **missed**.
+
+For this reason, PostHog tracks the time when an event is ingested and uses that to determine which events to include in a batch export run. Continuing with the example, the 13:00:00-14:00:00 batch export run instead looks for events that arrived within those bounds, and since the event in our example arrived at 13:07:00, it would be picked up and exported. This way, no events are missed.

--- a/docs/published/docs/cdp/batch-exports/postgres.mdx
+++ b/docs/published/docs/cdp/batch-exports/postgres.mdx
@@ -1,0 +1,98 @@
+---
+title: Postgres destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import PersonsModelNote from '../_snippets/persons-model-note.mdx'
+
+Batch exports can be used to export data to a Postgres table.
+
+## Setting up Postgres access
+
+1. Make sure PostHog can access your Postgres database.
+
+> **Notes:**
+>
+> - We only support connections using SSL/TLS. This [provides protection against various types of attacks](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).
+
+2. Create a Postgres user with table creation privileges.
+
+When executing a batch export, if the destination table doesn't exist, it will be created. `CREATE TABLE` and `USAGE` permissions are required for this reason. The other permissions that are required on the destination table are `INSERT`, `SELECT`, and `UPDATE`. You can and should block PostHog from doing anything else on any other tables. In particular, we recommend creating a new schema and only granting PostHog `CREATE TABLE` and `USAGE` access limited to that schema:
+
+```sql runInPostHog=false
+CREATE USER posthog WITH PASSWORD 'insert-a-strong-password-here';
+CREATE SCHEMA posthog_exports;
+GRANT CREATE ON SCHEMA posthog_exports TO posthog;
+GRANT USAGE ON SCHEMA posthog_exports TO posthog;
+```
+
+## Models
+
+> **Note:** New fields may be added to these models over time. To maintain consistency, these fields are not automatically added to the destination tables. If a particular field is missing in your Postgres tables, you can manually add the field, and it will be populated in future exports.
+
+### Events model
+
+This is the default model for Postgres batch exports. The schema of the model as created in Postgres is:
+
+| Field       | Type                       | Description                                                               |
+| ----------- | -------------------------- | ------------------------------------------------------------------------- |
+| uuid        | `VARCHAR(200)`             | The unique ID of the event within PostHog                                 |
+| event       | `VARCHAR(200)`             | The name of the event that was sent                                       |
+| properties  | `JSONB`                    | A JSON object with all the properties sent along with an event            |
+| elements    | `JSONB`                    | This field is present for backwards compatibility but has been deprecated |
+| set         | `JSONB`                    | A JSON object with any person properties sent with the `$set` field       |
+| set_once    | `JSONB`                    | A JSON object with any person properties sent with the `$set_once` field  |
+| distinct_id | `VARCHAR(200)`             | The `distinct_id` of the user who sent the event                          |
+| team_id     | `INTEGER`                  | The `team_id` for the event                                               |
+| ip          | `VARCHAR(200)`             | The IP address that was sent with the event                               |
+| site_url    | `VARCHAR(200)`             | This field is present for backwards compatibility but has been deprecated |
+| timestamp   | `TIMESTAMP WITH TIME ZONE` | The timestamp associated with an event                                    |
+
+### Persons model
+
+The schema of the model as created in Postgres is:
+
+| Field                      | Type                       | Description                                                                                                                                        |
+| -------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| team_id                    | `INTEGER`                  | The id of the project (team) the person belongs to                                                                                                 |
+| distinct_id                | `TEXT`                     | A `distinct_id` associated with the person                                                                                                         |
+| person_id                  | `TEXT`                     | The id of the person associated to this (`team_id`, `distinct_id`) pair                                                                            |
+| properties                 | `JSONB`                    | A JSON object with all the latest properties of the person                                                                                         |
+| person_distinct_id_version | `INTEGER`                  | Internal version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation |
+| person_version             | `INTEGER`                  | Internal version of the person properties associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation               |
+| created_at                 | `TIMESTAMP WITH TIME ZONE` | The timestamp when the person was created                                                                                                          |
+
+The Postgres table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
+
+<PersonsModelNote />
+
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
+
+## Creating the batch export
+
+1. Click [Data management > Destinations](https://app.posthog.com/data-management/destinations) in the left sidebar.
+2. Click **+ New destination** in the top-right corner.
+3. Select **Postgres** as the batch export destination.
+4. Fill in the necessary [configuration details](#postgres-configuration).
+5. Finalize the creation by clicking on **Create**.
+6. Done! The batch export will schedule its first run on the start of the next period.
+
+## Postgres configuration
+
+Configuring a batch export targeting Postgres requires the following Postgres-specific configuration values:
+
+- **User:** User for your Postgres database with CREATE TABLE access used by PostHog to login to your database.
+- **Password:** The password of the username provided.
+- **Host:** The host name of the server on which your Postgres database is running. Must resolve to a publicly accessible address (internal/private IPs are not allowed).
+- **Port:** The TCP port on which the Postgres database server is listening for connections.
+- **Table name:** The name of a Postgres table where to export the data.
+- **Database:** The name of the Postgres database where the table provided to insert data is located.
+- **Schema:** The name of the Postgres database schema where the table provided to insert data is located.
+- **Does your Postgres instance have a self-signed SSL certificate?**: In most cases, Heroku and RDS users should check this box.

--- a/docs/published/docs/cdp/batch-exports/redshift.mdx
+++ b/docs/published/docs/cdp/batch-exports/redshift.mdx
@@ -1,0 +1,92 @@
+---
+title: Redshift destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import PersonsModelNote from '../_snippets/persons-model-note.mdx'
+
+Batch exports can be used to export data to Redshift, Amazon's data warehouse product. There are two SQL commands that can be used to export data: `COPY` and `INSERT`. Essentially, `COPY` works by reading and writing entire files in parallel from an S3 bucket, where as `INSERT` works by writing batches of rows. In general, we recommend `COPY` as it offers significantly better performance, but `INSERT` is provided as an alternative that requires less setup.
+
+## Creating the batch export
+
+1. Click [Data management > Destinations](https://app.posthog.com/data-management/destinations) in the left sidebar.
+2. Click **+ New destination** in the top-right corner.
+3. Search for **Redshift**.
+4. Click the **+ Create** button.
+5. Fill in the necessary [configuration details](#redshift-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
+
+## Redshift configuration
+
+Regardless of the SQL command used, configuring a batch export targeting Redshift requires the following Redshift-specific configuration values:
+
+- **User:** A Redshift user name with permissions to insert data into the specified table and, if the table does not exist, permissions to create the table.
+- **Password:** The password for the Redshift user specified.
+- **Host:** The endpoint of your Redshift cluster, excluding the port number and database name. Must resolve to a publicly accessible address (internal/private IPs are not allowed).
+- **Port:** The port number on which the Redshift cluster is listening (default is 5439).
+- **Database:** The name of the Redshift database to which the data is to be exported.
+- **Schema:** The name of the schema within the database. This determines where the table for exporting data will be located.
+- **Table name:** The name of the table where the data will be inserted.
+- **Semi-structured data type:** The Redshift data type to use to export semi-structured data, like data in the `properties`, `set`, and `set_once` columns of the `events` model. This can be either `SUPER` or `VARCHAR(65535)`. We recommend `SUPER` as `VARCHAR` limits the document size to 65535 bytes, whereas with a `SUPER` type the limit applies per value in the document, instead of to the entire document.
+- **Events to exclude:** A list of events to omit from the exported data.
+- **Events to include:** A list of events to include in the exported data. If added, only these events will be exported.
+
+Additionally, when choosing to `COPY` data to Redshift, the batch export requires access to an S3 bucket, thus the additional configuration is required:
+
+- **Bucket name:** The name of the S3 bucket. The bucket must already exist.
+- **Region:** The AWS region where the bucket is located. This must be in the same region as your Redshift instance.
+- **Key prefix:** A key prefix to use for the batch export files. The files will be cleaned up after the batch export finishes.
+- **AWS Access Key ID:** An AWS access key ID with access to the S3 bucket.
+- **AWS Secret Access Key:** An AWS secret access key with access to the S3 bucket.
+
+Finally, Redshift needs access to your S3 bucket too, and we must provide it with either AWS credentials (which could be the same PostHog uses to access your bucket) or an IAM role that Redshift can assume with sufficient privileges to read from your S3 bucket. We recommend using an IAM role to avoid the need for another set of credentials.
+
+## Models
+
+> **Note:** New fields may be added to these models over time. To maintain consistency, these fields are not automatically added to the destination tables. If a particular field is missing in your Redshift tables, you can manually add the field, and it will be populated in future exports.
+
+### Events model
+
+This is the default model for Redshift batch exports. The schema of the model as created in Redshift is:
+
+| Field       | Type                        | Description                                                               |
+| ----------- | --------------------------- | ------------------------------------------------------------------------- |
+| uuid        | `VARCHAR(200)`              | The unique ID of the event within PostHog                                 |
+| event       | `VARCHAR(200)`              | The name of the event that was sent                                       |
+| properties  | `SUPER` or `VARCHAR(65535)` | A JSON object with all the properties sent along with an event            |
+| elements    | `VARCHAR(65535)`            | This field is present for backwards compatibility but has been deprecated |
+| set         | `SUPER` or `VARCHAR(65535)` | A JSON object with any person properties sent with the `$set` field       |
+| set_once    | `SUPER` or `VARCHAR(65535)` | A JSON object with any person properties sent with the `$set_once` field  |
+| distinct_id | `VARCHAR(200)`              | The `distinct_id` of the user who sent the event                          |
+| team_id     | `INTEGER`                   | The `team_id` for the event                                               |
+| ip          | `VARCHAR(200)`              | The IP address that was sent with the event                               |
+| site_url    | `VARCHAR(200)`              | This field is present for backwards compatibility but has been deprecated |
+| timestamp   | `TIMESTAMP WITH TIME ZONE`  | The timestamp associated with an event                                    |
+
+### Persons model
+
+The schema of the model as created in Redshift is:
+
+| Field                      | Type                        | Description                                                                                                                                        |
+| -------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| team_id                    | `INTEGER`                   | The id of the project (team) the person belongs to                                                                                                 |
+| distinct_id                | `VARCHAR(200)`              | A `distinct_id` associated with the person                                                                                                         |
+| person_id                  | `VARCHAR(200)`              | The id of the person associated to this (`team_id`, `distinct_id`) pair                                                                            |
+| properties                 | `SUPER` or `VARCHAR(65535)` | A JSON object with all the latest properties of the person                                                                                         |
+| person_distinct_id_version | `INTEGER`                   | Internal version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation |
+| person_version             | `INTEGER`                   | Internal version of the person properties associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation               |
+| created_at                 | `TIMESTAMP WITH TIME ZONE`  | The timestamp when the person was created                                                                                                          |
+
+The Redshift table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
+
+<PersonsModelNote />
+
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).

--- a/docs/published/docs/cdp/batch-exports/s3.md
+++ b/docs/published/docs/cdp/batch-exports/s3.md
@@ -1,0 +1,117 @@
+---
+title: S3 destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+With batch exports, data can be exported to an S3 bucket.
+
+## Models
+
+S3 supports all the models mentioned in the [batch export models reference](/docs/cdp/batch-exports#models).
+
+You can view the schema for each model inside the batch export configuration in the UI.
+
+> **Note:** New fields may be added to these models over time. Therefore, it is recommended that any downstream processes are able to handle additional fields being added to the exported files.
+
+## Creating the batch export
+
+1. Click [Data management > Destinations](https://app.posthog.com/data-management/destinations) in the left sidebar.
+2. Click **+ New destination** in the top-right corner.
+3. Search for **S3**.
+4. Click the **+ Create** button.
+5. Fill in the necessary [configuration details](#s3-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
+
+## S3 configuration
+
+Configuring a batch export targeting S3 requires the following S3-specific configuration values:
+
+- **Bucket name:** The name of the S3 bucket where the data is to be exported.
+- **Region:** The AWS region where the bucket is located.
+- **Key prefix:** A key prefix to use for each S3 object created. This key can include [template variables](#s3-key-prefix-template-variables)
+- **Format:** Select a file format to use in the export. See the [S3 file formats section](#s3-file-formats) for details on which file formats are supported.
+- **Max file size (MiB):** If the size of the exported data exceeds this value, the data is split into multiple files. (Note that this is approximate and the actual file size may be slightly larger). If this value is not set, or is set to 0, the data is exported as a single file.
+- **Compression:** Select a compression method (like gzip) to use for exported files or no compression.
+- **Encryption:** Select a server-side encryption method (`AES256` or `aws:kms`) for AWS to encrypt data at rest.
+- **AWS Access Key ID (required):** An AWS access key ID with access to the S3 bucket.
+- **AWS Secret Access Key (required):** An AWS secret access key with access to the S3 bucket.
+- **AWS KMS Key ID:** The AWS KMS Key ID to use for server-side encryption. Only required when selecting `aws:kms` encryption.
+- **Events to exclude:** A list of events to omit from the exported data.
+- **Endpoint URL:** Required if exporting to an [S3-compatible blob storage](#s3-compatible-blob-storage). Must resolve to a publicly accessible address (internal or private IPs are not allowed).
+
+### S3 key prefix template variables
+
+The key prefix provided for data exporting can include template variables which are formatted at runtime. All template variables are defined between curly brackets (for example `{day}`). This allows you partition files in your S3 bucket, such as by date.
+
+Template variables include:
+
+- Date and time variables:
+  - `year`.
+  - `month`.
+  - `day`.
+  - `hour`.
+  - `minute`.
+  - `second`.
+- Name of the table exported (for example, 'events' or 'persons')
+  - `table`.
+- Batch export data bounds:
+  - `data_interval_start`.
+  - `data_interval_end`.
+
+So, as an example, setting `{year}-{month}-{day}_{table}/` as a key prefix, will produce files prefixed with keys like `2023-07-28_events/`.
+
+### S3 file formats
+
+PostHog S3 batch exports support two file formats for exporting data:
+
+- [JSON lines](https://jsonlines.org/).
+- [Apache Parquet](https://parquet.apache.org/) (latest version of the format specification is the only one supported).
+
+The batch export format is selected via a drop down menu when creating or editing an export.
+
+We intend to add support for other common formats, and format-specific configuration options. You can follow the [roadmap](https://github.com/PostHog/posthog/issues/15997) to track progress.
+
+### Compression
+
+Each file format supports a variety of compression methods. The compression method you choose can have a significant effect on the exported file size and the overall time taken to export the data. From our own internal testing, we would recommend using Parquet with zstd compression for the best combination of speed and file size.
+
+> **Note on Parquet compression:** The compression type is included in the file extension, even for Parquet files. For example, files compressed with zstd will have the extension `parquet.zst`. Since compression is embedded in the format itself, the file should be read directly as a Parquet file and not uncompressed first.
+
+### Manifest file
+
+If you specify a max file size in your configuration, several files may be exported. In order to know when the export is complete, we send a `manifest.json` file (with the same prefix as the other files) once all the data files have been exported. This manifest file contains the key names of all the files exported.
+
+### S3-compatible blob storage
+
+PostHog S3 batch exports may also export data to an S3-compatible blob storage like [MinIO](https://github.com/minio/minio), [Cloudflare R2](https://www.cloudflare.com/developer-platform/products/r2/), or [Google Cloud Storage (GCS)](https://cloud.google.com/storage). Here we describe configuration tweaks that are required for S3-compatible blob storage destinations that we have tested.
+
+#### MinIO
+
+- Set the _Endpoint URL_ configuration to your MinIO instance's host and port, for example: `https://my-minio-storage:9000`.
+
+#### Cloudflare R2
+
+- Set the _Endpoint URL_ configuration to the following after replacing your account id: `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`.
+- From the _Region_ dropdown, select one of the Cloudflare R2 regions that correspond to your bucket, like "Automatic (AUTO)".
+
+#### Google Cloud Storage (GCS)
+
+Access to GCS for batch exports follows a similar process to accessing [BigQuery](/docs/cdp/batch-exports/bigquery) as a Service Account is required:
+
+1. Follow the steps in the [BigQuery batch export documentation](/docs/cdp/batch-exports/bigquery) to create a Service Account.
+2. Create a [HMAC key for your Service Account](https://cloud.google.com/storage/docs/authentication/managing-hmackeys#console).
+3. Grant the Service Account the `Storage Object User` role or a custom role with at least the following permissions:
+   - `storage.multipartUploads.abort`
+   - `storage.multipartUploads.create`
+   - `storage.multipartUploads.list`
+   - `storage.multipartUploads.listParts`
+   - `storage.objects.create`
+   - `storage.objects.delete`
+4. Use the HMAC key access key and secret key as _AWS Access Key ID_ and _AWS Secret Access Key_ respectively when configuring your batch export.
+5. Finally, set the _Endpoint URL_ configuration to: `https://storage.googleapis.com`.

--- a/docs/published/docs/cdp/batch-exports/snowflake.mdx
+++ b/docs/published/docs/cdp/batch-exports/snowflake.mdx
@@ -1,0 +1,223 @@
+---
+title: Snowflake destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import PersonsModelNote from '../_snippets/persons-model-note.mdx'
+
+With batch exports, data can be exported to a Snowflake database table.
+
+## Creating the batch export
+
+1. Click [Data management > Destinations](https://app.posthog.com/data-management/destinations) in the left sidebar.
+2. Click **+ New destination** in the top-right corner.
+3. Search for **Snowflake**.
+4. Click the **+ Create** button.
+5. Fill in the necessary [configuration details](#snowflake-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
+
+## Authentication
+
+PostHog supports two authentication methods for Snowflake:
+
+1. **Password:** This is the simplest method, and just requires a password for the user.
+2. **Key pair:** For enhanced security, you can use a key pair to authenticate with Snowflake. For information on how to set this up, see [Snowflake's documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-authentication). We support both encrypted and unencrypted key pairs.
+
+## Snowflake configuration
+
+Configuring a batch export targeting Snowflake requires the following Snowflake-specific configuration values:
+
+- **Account:** A [Snowflake account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier) without the `snowflakecomputing.com` suffix (if any).
+- **User:** A Snowflake user name with permissions to insert data into the provided table and, if the table is meant to be created, permissions to create the table.
+- **Authentication type:** The authentication method to use: password or key pair.
+- **Password:** The password of the Snowflake user provided, if using password authentication.
+- **Private key:** The private key of the Snowflake user provided, if using key pair authentication.
+- **Private key passphrase (optional):** The private key passphrase, if using an encrypted key pair.
+- **Role (optional):** A role to assume for the required permissions.
+- **Database:** The Snowflake database where the table provided to insert data is located (and created if not present).
+- **Schema:** The Snowflake database schema where the table provided to insert data is located (and created if not present).
+- **Table name:** The name of a Snowflake table where to export the data.
+- **Warehouse:** The Snowflake warehouse used for data loading.
+
+### File staging
+
+Batch exports use Snowflake's [internal table stages](https://docs.snowflake.com/en/user-guide/data-load-local-file-system-create-stage#table-stages) to stage the files copied into your Snowflake tables. We recommend using separate tables to export data from PostHog to avoid conflicting with other workflows that use internal table stages.
+
+> **Note:** This differs from the old PostHog Snowflake export destination which required extra configuration and used S3 or GCS as an external stage.
+
+## Models
+
+This section describes the models that can be exported to Snowflake.
+
+> **Note:** New fields may be added to these models over time. To maintain consistency, these fields are not automatically added to the destination tables. If a particular field is missing in your Snowflake tables, you can manually add the field, and it will be populated in future exports.
+
+### Events model
+
+This is the default model for Snowflake batch exports. The schema of the model as created in Snowflake is:
+
+| Field           | Type        | Description                                                               |
+| --------------- | ----------- | ------------------------------------------------------------------------- |
+| uuid            | `STRING`    | The unique ID of the event within PostHog                                 |
+| event           | `STRING`    | The name of the event that was sent                                       |
+| properties      | `VARIANT`   | A JSON object with all the properties sent along with an event            |
+| elements        | `VARIANT`   | This field is present for backwards compatibility but has been deprecated |
+| people_set      | `VARIANT`   | A JSON object with any person properties sent with the `$set` field       |
+| people_set_once | `VARIANT`   | A JSON object with any person properties sent with the `$set_once` field  |
+| distinct_id     | `STRING`    | The `distinct_id` of the user who sent the event                          |
+| team_id         | `INTEGER`   | The `team_id` for the event                                               |
+| ip              | `STRING`    | The IP address that was sent with the event                               |
+| site_url        | `STRING`    | This field is present for backwards compatibility but has been deprecated |
+| timestamp       | `TIMESTAMP` | The timestamp associated with an event                                    |
+
+If the provided table doesn't exist in the provided database and schema, the first batch export run will create it. This is generally the safest option, but you may also create it yourself by running the query:
+
+```sql runInPostHog=false
+CREATE TABLE IF NOT EXISTS "{database}"."{schema}"."{table_name}" (
+    "uuid" STRING,
+    "event" STRING,
+    "properties" VARIANT,
+    "elements" VARIANT,
+    "people_set" VARIANT,
+    "people_set_once" VARIANT,
+    "distinct_id" STRING,
+    "team_id" INTEGER,
+    "ip" STRING,
+    "site_url" STRING,
+    "timestamp" TIMESTAMP
+)
+COMMENT = 'PostHog events table'
+```
+
+> **Note:** This is the same query used by PostHog Batch Exports if the table is not present in your database. Notice that the database, schema, and table_name parameters are surrounded by double quotes to respect the casing provided during configuration.
+
+### Persons model
+
+The schema of the model as created in Snowflake is:
+
+| Field                      | Type        | Description                                                                                          |
+| -------------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| team_id                    | `INTEGER`   | The id of the project (team) the person belongs to                                                   |
+| distinct_id                | `STRING`    | A `distinct_id` associated with the person                                                           |
+| person_id                  | `STRING`    | The id of the person associated to this (`team_id`, `distinct_id`) pair                              |
+| properties                 | `VARIANT`   | A JSON object with all the latest properties of the person                                           |
+| person_version             | `INTEGER`   | The version of the person properties associated with a (`team_id`, `distinct_id`) pair               |
+| person_distinct_id_version | `INTEGER`   | The version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair |
+| created_at                 | `TIMESTAMP` | The timestamp when the person was created                                                            |
+
+The Snowflake table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
+
+<PersonsModelNote />
+
+If the provided table doesn't exist in the provided database and schema, the first batch export run will create it. This is generally the safest option, but you may also create it yourself by running the query:
+
+```sql runInPostHog=false
+CREATE TABLE IF NOT EXISTS "{database}"."{schema}"."{table_name}" (
+    "team_id" INTEGER,
+    "distinct_id" STRING,
+    "person_id" STRING,
+    "properties" VARIANT,
+    "person_version" INTEGER,
+    "person_distinct_id_version" INTEGER,
+    "created_at" TIMESTAMP
+)
+COMMENT = 'PostHog persons table'
+```
+
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
+
+#### How is the persons model kept up to date?
+
+Exporting mutable data (like the persons model) requires executing a merge operation to apply new updates to existing rows. Executing this merge operation in Snowflake involves the following steps:
+
+1. Creating a stage table.
+2. Inserting new data into the stage table.
+3. Execute a merge operation between existing table and stage table.
+   a. Any rows that match in the final table and for which the stage table's version is higher are updated.
+   b. Any new rows not found in the final table are inserted.
+4. Drop the stage table.
+
+## FAQ
+
+### Export is showing up as NULL records in Snowflake
+
+This is most likely because the table's schema is different from what we are sending. To verify, run this command replacing the variables:
+
+```bash
+snow sql -q "SELECT GET_DDL('TABLE', '\"<database_name>\".\"<schema_name>\".\"<table_name>\"');" --password='<password>' --account='<account>' --username='<user>' --warehouse='<warehouse>' -x --database='"<database_name>"'
+```
+
+and check that the output matches this
+
+```sql
++------------------------------------------------------------------------------------------------------------------+
+| GET_DDL('TABLE',                                                                                                 |
+| '"DATABASE_NAME"."SCHEMA_NAME"."TABLE_NAME"')                                                                    |
+|------------------------------------------------------------------------------------------------------------------|
+| create or replace TABLE "table_name" (                                                         |
+|         "uuid" VARCHAR(16777216),                                                                                |
+|         "event" VARCHAR(16777216),                                                                               |
+|         "properties" VARIANT,                                                                                    |
+|         "elements" VARIANT,                                                                                      |
+|         "people_set" VARIANT,                                                                                    |
+|         "people_set_once" VARIANT,                                                                               |
+|         "distinct_id" VARCHAR(16777216),                                                                         |
+|         "team_id" NUMBER(38,0),                                                                                  |
+|         "ip" VARCHAR(16777216),                                                                                  |
+|         "site_url" VARCHAR(16777216),                                                                            |
+|         "timestamp" TIMESTAMP_NTZ(9)                                                                             |
+| )COMMENT='PostHog generated events table'                                                                        |
+| ;                                                                                                                |
++------------------------------------------------------------------------------------------------------------------+
+```
+
+If your table doesn't match exactly (including casing), then the recommended approach is delete the table and let PostHog create it for you (alternatively you can copy the DDL exactly).
+
+### Export shows a "no active warehouse selected" error
+
+This error indicates the warehouse provided is not active (likely `SUSPENDED`). You will have to inspect your Snowflake configuration to discover why. One potential explanation is that Snowflake's auto-suspend feature suspended the warehouse after some time of inactivity, which could be the case if the warehouse is used only for batch exports on slow frequencies (like daily).
+
+Batch exports require a `RUNNING` Snowflake warehouse to be able to export events to. It does not activate, suspend, or manipulate warehouses in any capacity, which can be enforced by not giving permissions required to do so to the user provided to batch exports. The reason for this is that a running warehouse consumes Snowflake credits, and deciding on Snowflake credit spending is out of scope for batch exports.
+
+Once the cause has been identified and the configuration amended, a warehouse can be started with the query `ALTER WAREHOUSE <name> RESUME` or via the Snowflake console.
+
+See Snowflake's documentation on [managing warehouses](https://docs.snowflake.com/en/user-guide/warehouses-tasks) and [the cost management auto-suspend feature](https://docs.snowflake.com/en/user-guide/cost-controlling#label-cost-control-auto-suspend) for more details.
+
+## Examples
+
+These examples illustrate how to use the data from batch exports in Snowflake.
+
+### Requirements
+
+Two batch exports need to be created:
+
+- An events model batch export.
+- A persons model batch export.
+
+For the purposes of these examples, assume that these two batch exports have already been created and have exported some data to Snowflake in tables `example.events` and `example.persons`.
+
+### Example: Count unique persons that have triggered an event
+
+The following query counts unique persons that have triggered events.
+It uses `COALESCE` to fall back to `distinct_id` for events where the person has no profile in the persons export (for example, anonymous users when [person profile processing is disabled](/docs/data/anonymous-vs-identified-events)):
+
+```sql
+SELECT
+  event,
+  COUNT(DISTINCT COALESCE(persons.person_id, events.distinct_id)) AS unique_persons_count
+FROM
+  example.events AS events
+LEFT JOIN
+  example.persons AS persons ON events.distinct_id = persons.distinct_id AND events.team_id = persons.team_id
+GROUP BY
+  event
+ORDER BY
+  unique_persons_count DESC
+```

--- a/docs/published/docs/cdp/changelog.mdx
+++ b/docs/published/docs/cdp/changelog.mdx
@@ -1,0 +1,8 @@
+---
+title: Data Pipelines changelog
+hideRightSidebar: true
+---
+
+import { ProductChangelog } from 'components/Docs/ProductChangelog'
+
+<ProductChangelog product="Data Pipelines" />

--- a/docs/published/docs/cdp/destinations/activecampaign.md
+++ b/docs/published/docs/cdp/destinations/activecampaign.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog person data to ActiveCampaign
+templateId:
+  - template-activecampaign
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant ActiveCampaign account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=activecampaign) tab.
+3. Search for 'ActiveCampaign' and click **+ Create**.
+4. Add your ActiveCampaign API Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Events' list get populated in ActiveCampaign!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/activecampaign/template_activecampaign.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/airtable.md
+++ b/docs/published/docs/cdp/destinations/airtable.md
@@ -1,0 +1,75 @@
+---
+title: Send PostHog analytics to Airtable
+templateId:
+  - template-airtable
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+It’s easier than ever to export realtime PostHog data to satisfy the Airtable fanatics in your life.
+
+## Configuring Airtable
+
+With data pipelines enabled, let’s get Airtable connected.
+
+First, [create](https://airtable.com/create/tokens/new) a **personal access token** in your Airtable account. You’ll need to add the `data.records:write` scope so that PostHog can create new records.
+
+Then add the **base** you want to create new records in.
+
+![Airtable token configuration](https://res.cloudinary.com/dmukukwp6/image/upload/airtable_pat_7ce7c538e6.png)
+
+Next, you’ll want to visit Airtable’s [API reference](https://airtable.com/developers/web/api/introduction) to get your base ID, table name, and field names.
+
+## Configuring PostHog’s Airtable destination
+
+You should have these details now:
+
+- Access token
+- Base ID
+- Table name
+- Field names
+
+With them, we’re ready to set up the Airtable destination.
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=airtable) tab.
+3. Click **New destination** and choose Airtable's **Create** button.
+
+Now we can plug in the above values.
+
+![Airtable field mapping](https://res.cloudinary.com/dmukukwp6/image/upload/airtable_fields_597f303a7a.png)
+
+The **Fields** editor enables you to map whatever PostHog [values](/docs/cdp/destinations#input-formatting) you like to columns in your Airtable base. The keys on the left should match the names you’ve already set for columns in Airtable. Values on the right can be any property on a `person` or `event` instance.
+
+<HideOnCDPIndex>
+
+### Filtering
+
+In its experimental state, the Airtable destination will not batch its output to your base. If you trigger on events that happen more than five times per second, you’ll hit the Airtable API [rate limit](https://airtable.com/developers/web/api/rate-limits).
+
+So be selective about the events you forward to Airtable. Instead of every pageview, for example, just send the high-impact events like conversions. Use the **Filters** panel to set this up.
+
+### Testing
+
+Once you’ve configured your Airtable destination, click **Start testing** to verify everything works the way you want. Switch off **Mock out async functions** in order to send a test event to Airtable and see a new record.
+
+### A note on data types
+
+Where possible, Airtable will convert values into native datatypes set in your columns. So, if you pass `event.timestamp` to an Airtable `Date` column, that will work just fine.
+
+---
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/airtable/template_airtable.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/attio.md
+++ b/docs/published/docs/cdp/destinations/attio.md
@@ -1,0 +1,54 @@
+---
+title: Create and update Attio CRM contacts from analytics events
+templateId:
+  - template-attio
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can use your PostHog event data to create and update contacts in Attio. Here's everything you need to get started.
+
+## Configuring Attio
+
+First, [create](https://attio.com/help/reference/integrations-automations/generating-an-api-key) a new **access token** in your Attio workspace. You’ll need to set read-write on the `Records` and `Object Configuration` scopes so that PostHog can communicate with Attio.
+
+![Attio scopes](https://res.cloudinary.com/dmukukwp6/image/upload/attio_scopes_e335544ba3.png)
+
+Close the scopes section and copy your new access token for the next step.
+
+## Configuring PostHog’s Attio destination
+
+1. In PostHog, click the **[Data pipeline](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=attio) tab.
+3. Click **New destination** and choose Attio's **Create** button.
+
+Paste in your access token and then add any other values you want to pipe from PostHog person properties into Attio, using **additional person attributes**.
+
+<HideOnCDPIndex>
+
+### Filtering
+
+At a minimum, you should filter to only send events that have an email property set, as Attio will use this to identify contacts.
+
+![Filtering events](https://res.cloudinary.com/dmukukwp6/image/upload/filter_person_email_86c1d7a350.png)
+
+### Testing
+
+Once you’ve configured your Attio destination, click **Start testing** to verify everything works the way you want. Switch off **Mock out async functions** in order to send a test event to Attio and see a new record.
+
+---
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/attio/template_attio.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/avo.md
+++ b/docs/published/docs/cdp/destinations/avo.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog event data to Avo
+templateId:
+  - template-avo
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Avo account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=avo) tab.
+3. Search for 'Avo' and click **+ Create**.
+4. Add your Avo access token at the configuration step.
+5. Press **Create & Enable** and watch your 'Events' list get populated in Avo!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/avo/template_avo.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/aws-kinesis.md
+++ b/docs/published/docs/cdp/destinations/aws-kinesis.md
@@ -1,0 +1,38 @@
+---
+title: Send PostHog event data to AWS Kinesis
+templateId:
+  - template-aws-kinesis
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+Send event data from PostHog into an AWS Kinesis stream.
+
+You'll also need access to the relevant AWS account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations) tab.
+3. Search for 'AWS Kinesis' and click **+ Create**.
+4. Add your AWS Access Key ID and Secret Access Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Events' get sent to AWS Kinesis!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/braze.md
+++ b/docs/published/docs/cdp/destinations/braze.md
@@ -1,0 +1,32 @@
+---
+title: Send PostHog event data to Braze
+templateId:
+  - template-braze
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Braze account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=braze) tab.
+3. Search for 'Braze' and click **+ Create**.
+4. Add your Braze API Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Users' list get populated in Braze!
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/braze/template_braze.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />

--- a/docs/published/docs/cdp/destinations/brevo.md
+++ b/docs/published/docs/cdp/destinations/brevo.md
@@ -1,0 +1,50 @@
+---
+title: Create and update Brevo contacts from analytics events
+templateId:
+  - template-brevo
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can use your PostHog event data to create and update contacts in Brevo. Here's everything you need to get started.
+
+## Configuring Brevo
+
+First, [create](https://app.brevo.com/settings/keys/api) a new **API key** in Brevo and copy it for the next step.
+
+## Configuring PostHog’s Brevo destination
+
+1. In PostHog, click the **[Data pipeline](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=brevo) tab.
+3. Click **New destination** and choose Brevo's **Create** button.
+
+Paste your API key and then add any other values you want to pipe from PostHog person properties into Brevo, using the **attributes** fields.
+
+<HideOnCDPIndex>
+
+### Filtering
+
+At a minimum, you should filter to only send events that have an email property set, as Brevo will use this to identify contacts.
+
+![Filtering events](https://res.cloudinary.com/dmukukwp6/image/upload/filter_person_email_86c1d7a350.png)
+
+### Testing
+
+Once you’ve configured your Brevo destination, click **Start testing** to verify everything works the way you want. Clicking **Test function** will send a test event to Brevo, creating a new contact if it doesn't exist in your account.
+
+---
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_airtable.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/customerio.md
+++ b/docs/published/docs/cdp/destinations/customerio.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog event data to Customer.io
+templateId:
+  - template-customerio
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Customer.io account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=customerio) tab.
+3. Search for 'Customer.io' and click **+ Create**.
+4. Add your Customer.io site ID and API Key at the configuration step. Note that our integration requires Track API credentials.
+5. Press **Create & Enable** and watch your 'People' list get populated in Customer.io!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/customerio/template_customerio.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/customizing-destinations.md
+++ b/docs/published/docs/cdp/destinations/customizing-destinations.md
@@ -1,0 +1,162 @@
+---
+title: 'Customizing destinations'
+showTitle: true
+---
+
+Although we recommend using one of our pre-built destinations, you can also customize them and build your own.
+
+## Customizing payload
+
+You can template destination output using curly braces `{}`.
+
+For example, given this PostHog event:
+
+```ts
+{
+    event: {
+        event: "$pageview",
+        distinct_id: "1234",
+        timestamp: "2024-01-01T12:00:00",
+        properties: {
+            $current_url: "https://posthog.com"
+        }
+    },
+    person: {
+        name: "max@posthog.com",
+        properties: {
+            email: "max@posthog.com",
+            first_name: "Max",
+            last_name: "the Hedgehog"
+        }
+    }
+}
+```
+
+You can create a template like:
+
+```text
+{event.event} was triggered by {person.properties.first_name} {person.properties.last_name}
+
+// Outputs: $pageview was triggered by Max the Hedgehog
+```
+
+You could use this approach to set parameters in a [webhook](/docs/cdp/destinations/webhook) destination’s URL:
+
+```text
+https://api.yourgreatwebsite/v0/track-conversion?username={person.name}
+```
+
+Or to construct a custom JSON payload that conforms to an existing API specification:
+
+```ts
+{
+    "event_source": "posthog",
+    "event": {
+        "event_label": "conversion",
+        "username": "{person.name}",
+        "datetime": "{event.timestamp}"
+    }
+}
+```
+
+> You can see the full capabilities of templating with our Hog programming language in the [Hog documentation](/docs/hog)
+
+### Global object
+
+Below is the structure of the global variables available whenever templating a destination.
+
+```ts
+{
+    event: {
+        uuid: string // The unique ID of the event
+        event: string // The event name (e.g. $pageview)
+        distinct_id: string // The distinct_id of the identity that created the event
+        properties: Record<string, any>
+        timestamp: string
+        url: string // A URL to view it in PostHog
+    }
+    person?: {
+        id: string // The UUID of the Person associated with the distinct_id of the event
+        name: string // Configured based on your "Display name" property in PostHog
+        url: string  // A URL to view it in PostHog
+        properties: Record<string, any>
+    }
+    groups?: {
+        [id: string]: {
+            id: string
+            type: string
+            index: number
+            url: string  // A URL to view it in PostHog
+            properties: Record<string, any>
+        }
+    }
+    project: {
+        id: number  // The ID of the PostHog project
+        name: string  // The name of the PostHog project
+        url: string  // A URL to view it in PostHog
+    }
+    source?: {
+        name: string // The name of the source (typically the destination name)
+        url: string  // A URL to view it in PostHog
+    }
+}
+```
+
+### Adding session replay links to Slack messages
+
+You can enhance your Slack notifications by adding direct links to session recordings. This is particularly useful when you want to quickly investigate the context of an event by watching the session replay.
+
+For example, to add a "Replay" button to your Slack message, you can add this block to your Slack destination's payload:
+
+```json
+{
+  "url": "{project.url}/replay/{event.properties.$session_id}?t={event.timestamp}",
+  "text": {
+    "text": "Replay",
+    "type": "plain_text"
+  },
+  "type": "button"
+}
+```
+
+This creates a button in your Slack message that links directly to the session recording at the exact timestamp when the event occurred. The URL is constructed using:
+
+- `{project.url}` - The base URL of your PostHog instance
+- `{event.properties.$session_id}` - The session ID from the event
+- `{event.timestamp}` - The timestamp when the event occurred
+
+For this to work the event must have the `session_id` as property on the event as well as a session recording associated with the `session_id`.
+
+## Modifying destinations with Hog
+
+For most cases, we recommend using one of the templates. These take care of most logic under the hood, exposing simple inputs for you to configure.
+
+You can, however, modify any destination by clicking `show source code`. From here you can modify the inputs – for example marking an input as secret so that it is encrypted as rest – or changing the implementation of the destination itself.
+
+Destinations are written in our [Hog language](/docs/hog). Most destinations are wrappers around `fetch` - a function for safely performing async, retry-able HTTP calls.
+
+```hog
+let res := fetch(inputs.url, {
+  'headers': inputs.headers,
+  'body': inputs.body,
+  'method': inputs.method
+});
+
+if (res.status >= 400) {
+  print('Bad response', res.status, res.body)
+}
+```
+
+For more details and inspiration, you can always view the source code of any destination.
+
+### Guidelines for modifying a destination
+
+- **Start from an existing template:** Check out existing templates that are close to the problem you’re solving and work from there.
+
+- **Rely on filters:** Offload as much as possible to the built in `filters` and `inputs`. This will make modifying your destination later much simpler (as well as being more performant).
+
+- **Use `inputs` wherever possible:** These are great for things like API credentials. You can even mark them as secret: they will not be returned to the UI in the future and will be stored encrypted.
+
+- **Keep it short:** We have tight controls on execution time, memory usage.
+
+- **Do not perform more than 5 `fetch` calls:** The function will error if you do. If you need to do more than 5 calls, please [contact support](https://us.posthog.com/#panel=support%3Asupport%3Aapps%3A%3Atrue).

--- a/docs/published/docs/cdp/destinations/discord.md
+++ b/docs/published/docs/cdp/destinations/discord.md
@@ -1,0 +1,51 @@
+---
+title: Send PostHog analytics events to your Discord server
+templateId:
+  - template-discord
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+Send event data from PostHog into the Discord server and channel of your choice.
+
+## Setup
+
+### Discord: create a webhook
+
+1. In Discord, go to the server you want to send events to.
+2. Click the server name in the top left and select **Server Settings**.
+3. Select **Integrations**, in the Apps section.
+4. Select **Webhooks**, then **New Webhook**.
+5. Give the webhook a name and pick the channel you want to send events to.
+6. Copy the webhook URL.
+
+![Discord webhook configuration](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_12_12_at_10_24_06_AM_0219cdb837.png)
+
+### PostHog: create a destination
+
+1. Back in PostHog, click the **[Data pipelines](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=discord) tab.
+3. Search for **Discord** and click **+ Create**.
+4. Add your Webhook URL.
+5. Use the **Content** field to format your message. You can include any properties that exist on `event` or `person`.
+6. Use the **Filters** panel to set up a query to filter the events you want to send, otherwise you'll get a firehose of all events filling your channel.
+7. Press **Create & enable**. Events will now be sent to Discord. If you'd like to send a test event to your channel, hit the **Start testing** button.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/discord/template_discord.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/engage.md
+++ b/docs/published/docs/cdp/destinations/engage.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog person data to Engage
+templateId:
+  - template-engage-so
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Engage account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=engage) tab.
+3. Search for **Engage** and click **+ Create**.
+4. Add your Engage Public key and Private key at the configuration step.
+5. Press **Create & Enable** and watch your 'Customers' list get populated in Engage!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/engage/template_engage.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/gleap.md
+++ b/docs/published/docs/cdp/destinations/gleap.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog person data to Gleap
+templateId:
+  - template-gleap
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Gleap account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=gleap) tab.
+3. Search for **Gleap** and click **+ Create**.
+4. Add your Gleap access token at the configuration step.
+5. Press **Create & Enable** and watch your 'Contacts' list get populated in Gleap!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/gleap/template_gleap.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/google-ads.md
+++ b/docs/published/docs/cdp/destinations/google-ads.md
@@ -1,0 +1,71 @@
+---
+title: Send PostHog conversion events to Google Ads
+templateId:
+  - template-google-ads
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+> **IMPORTANT:** This is an experimental destination that we do not provide official support for. Check out [this page](https://github.com/PostHog/posthog/issues/27712#issuecomment-2615849798) for more details on installing the integration.
+
+You'll also need access to the relevant Google Ads account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=googleads) tab.
+
+3. Search for **Google Ads Conversions** and click **+ Create**.
+
+4. Connect your Google account at the configuration step.
+
+5. Select your Customer ID.
+
+![Location of the Google Ads Customer ID](https://res.cloudinary.com/dmukukwp6/image/upload/2024_10_31_at_15_15_51_a7a003008c.png)
+
+6. In Google Ads, go to [Goals settings](https://ads.google.com/aw/conversions/customersettings), enable enhanced conversions, set the method to `Google Ads API`, and click **Save**.
+
+![Goal settings](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_11_01_at_13_38_50_d9c811bebd.png)
+
+7. Create a conversion action inside Google Ads
+   1. Under [Goals > Conversions > Summary](https://ads.google.com/aw/conversions), you'll need to create a conversion action
+   2. Click **New conversion action**
+   3. Enable **Conversions offline** and click **Add data source**
+      1. Click **Skip this step and set up a data source later**
+      2. Click **Done**
+   4. Select the conversion type that you want to capture
+   5. Click **Add a conversion action** and select **Add data source later**
+   6. Click **Settings**, edit the **Conversion name** and click **Done**
+   7. Click **Save and continue** and **Finish**
+
+![Steps to create a conversion action inside Google Ads](https://res.cloudinary.com/dmukukwp6/image/upload/2025_03_04_at_10_35_07_932d14fe5f.gif)
+
+8. Back in PostHog, select the conversion action in the destination configuration.
+
+9. Set up your event and property filters to remove unnecessary events. You only want to send events that are conversions. Filter out unrelated events or ones missing data like `gclid`.
+
+10. Press **Create & enable**, test your destination, and then watch your conversions get sent to Google Ads.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+## Why aren't my conversions appearing inside of Google Ads?
+
+Note that it might take around 6-48 hours for Google to process conversions and make them visible inside of Google Ads. Additionally you'll need to wait around 6 hours before new conversion goals will accept incoming data.
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/google_ads/template_google_ads.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/google-cloud-storage.md
+++ b/docs/published/docs/cdp/destinations/google-cloud-storage.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog event data to Google Cloud Storage
+templateId:
+  - template-google-cloud-storage
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Google Cloud account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=googlecloudstorage) tab.
+3. Search for **Google Cloud Storage** and click **+ Create**.
+4. Connect your Google Cloud account at the configuration step.
+5. Press **Create & Enable** and watch your 'events' get populated in Google Cloud Storage!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/google_cloud_storage/template_google_cloud_storage.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/google-pubsub.md
+++ b/docs/published/docs/cdp/destinations/google-pubsub.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog event data to Google Pub/Sub
+templateId:
+  - template-google-pubsub
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Google Cloud account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=googlepubsub) tab.
+3. Search for **Google Pub/Sub** and click **+ Create**.
+4. Connect your Google Cloud account at the configuration step.
+5. Press **Create & Enable** and watch your 'topic' list get populated in Google Pub/Sub!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/google_pubsub/template_google_pubsub.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/hubspot.md
+++ b/docs/published/docs/cdp/destinations/hubspot.md
@@ -1,0 +1,37 @@
+---
+title: Send PostHog person data to Hubspot
+templateId:
+  - template-hubspot
+  - template-hubspot-event
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Hubspot account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=hubspot) tab.
+3. Search for **Hubspot** and click **+ Create**.
+4. Connect your Hubspot account at the configuration step.
+5. Press **Create & Enable** and watch your 'Contacts' list get populated in Hubspot!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/hubspot/template_hubspot.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/index.md
+++ b/docs/published/docs/cdp/destinations/index.md
@@ -1,0 +1,68 @@
+---
+title: Realtime analytics data exports
+showTitle: true
+---
+
+As PostHog data arrives, you can export it _immediately_ to other tools. You can use this for things like:
+
+- Conversion tracking
+- Monitoring key events with your chat platform
+- Enriching customer data in your CRM
+- Triggering automations
+
+PostHog enables you to send realtime data to dozens of pre-configured destinations. Check out the [data pipeline tab](https://app.posthog.com/data-management/destinations) and choose **destinations** to get started.
+
+![Destinations list in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/destinations_list_acc7e07ae7.png)
+
+Missing a destination you need? Our [webhook destination](/docs/cdp/destinations/webhook) enables you to send events to any HTTP endpoint, using whatever request method, URL parameter values, and JSON payload structure your application requires. You can mix hard-coded keys and values with any person or event data. This integrates PostHog with yet more tools, or even your own internal services.
+
+Wherever your data is going, we’ve built destinations for many popular tools to get you up and running with just a few minutes of effort.
+
+## Filtering
+
+Instead of the firehose of all your PostHog data, you can construct a query that filters by event types, properties, or any SQL statement you can come up with, so that only the information you care about is sent to your destination.
+
+![Filtering destinations](https://res.cloudinary.com/dmukukwp6/image/upload/filter_ui_8c7b1fb3be.png)
+
+## Testing
+
+The hardest part of integrating two services is making sure everything works as you expect. Every destination includes a built-in testing interface, enabling you to send real data from PostHog on-demand to your target service and debug any errors.
+
+![Destination testing UI](https://res.cloudinary.com/dmukukwp6/image/upload/destination_testing_ui_e95cff873b.png)
+
+## Keep an eye on things
+
+Once your destination is up and running, the **metrics** and **logs** tabs will let you monitor usage and inspect errors.
+
+![Destination logs](https://res.cloudinary.com/dmukukwp6/image/upload/destination_logs_4c9c2ca6b2.png)
+
+## Going deeper
+
+For complete control of your destination’s behavior, you can view and edit the underlying Hog code that drives it. Experiment with rewriting your destination’s implementation to better address your needs, if the pre-built templates don’t quite do the job.
+
+Learn more about this in [customizing destinations](/docs/cdp/destinations/customizing-destinations).
+
+## Caveats
+
+### How up-to-date is the person information?
+
+The `person` object contains the latest information for the [person profile](/docs/data/persons) associated with the `distinct_id` of the event **at the time the event is processed**. You should make sure to filter for events that occur on or after person properties would be merged (such as `$identify`) if you need this information for your event.
+
+### How many events can I send to a destination?
+
+There is no limit on the number of events to be processed but the system requires that the destination responds with healthy status codes (non 5xx) and in a timely fashion.
+
+### What can cause a destination to be automatically disabled?
+
+If the destination performs poorly (too many errors, too slow) for a prolonged period, your destination will be quarantined and eventually disabled. We will try to re-enable it automatically after a temporary disabled period before stopping it entirely. You then need to modify either the filters or the destination and re-enable it in the UI to try again.
+
+The key metrics that we observe to determine poor performance are:
+
+1. Errors thrown within the code (for example if you try to access a property that doesn't exist).
+2. Repeatedly slow responses from the destination. Some slow HTTP calls are fine but if you send thousands of events and the destination can't keep up, we will eventually disable it to protect ourselves and the destination.
+
+We **do not** consider 4xx HTTP codes to be poor performance. Some destinations utilize these responses to determine if a follow up HTTP call is required (for example a 409 conflict indicating a record already exists). Non "OK" statuses will however be logged in order to help debugging potential issues.
+
+### How do you handle retries?
+
+By default, all HTTP calls (`fetch` calls in Hog) are expected to return a 2xx response. If we get a non-OK response we will retry up to 3 times depending on the error codes. We may modify this logic as we make improvements to try and balance reliability and speed.

--- a/docs/published/docs/cdp/destinations/intercom.md
+++ b/docs/published/docs/cdp/destinations/intercom.md
@@ -1,0 +1,50 @@
+---
+title: Send contacts and PostHog events to Intercom
+templateId:
+  - template-intercom
+  - template-intercom-event
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Intercom account.
+
+## Setting up Intercom as a PostHog destination
+
+1. In PostHog, click the **[Data pipeline](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=intercom) tab.
+3. Search for **Intercom** and click the **Create** button for either **Contacts** or **Events**.
+4. In the destination editor, click **Select Intercom connection** to log into your Intercom account.
+5. You can test your destination by sending a test event with **Test function**.
+6. When all is as you like it, click **Create & enable**.
+
+<HideOnCDPIndex>
+
+## Configuration details
+
+The Intercom destination requires that contacts **already exist** in Intercom before you can send events associated with them.
+
+You can use the Intercom contact creation destination to ensure those records exist. It is pre-configured to fire on [identify](/docs/product-analytics/identify) events, enabling Intercom to capture the same information on each user that PostHog does.
+
+<TemplateParameters />
+
+## FAQ
+
+### Can I send session replays to Intercom?
+
+Yes, you can add a link to the session replay in Intercom by setting the `integrations` config option when initializing PostHog's Web SDK to `{ intercom: true }`. See [our tutorial on adding session replays to Intercom](/tutorials/intercom-session-replays) for more details.
+
+### Can I add PostHog person profile data to Intercom?
+
+Yes, you can add a link to the PostHog person profile in Intercom by setting the `integrations` config option when initializing PostHog's Web SDK to `{ intercom: true }`. See [our tutorial on adding session replays to Intercom](/tutorials/intercom-session-replays) for more details.
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/intercom/template_intercom.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/june.md
+++ b/docs/published/docs/cdp/destinations/june.md
@@ -1,0 +1,54 @@
+---
+title: Send analytics events to June
+templateId:
+  - template-june
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can send analytics events to June to enrich your customer data in real-time.
+
+## Configuring June
+
+With data pipelines enabled, let’s get June connected.
+
+Create a **write API key** in your June account:
+
+1. Log into June and go to the settings tab, marked by a gear.
+2. Click on the **Developer tools** tab.
+3. Click **Create new key** in the **Write API keys** table.
+
+We'll use the new key in the next step.
+
+## Configuring PostHog’s June destination
+
+1. In PostHog, click the "[Data pipelines](https://app.posthog.com/data-management/destinations)" tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=june) tab.
+3. Click **New destination** and choose June's **Create** button.
+
+Drop in the API key you created in the previous step.
+
+You can map specific properties using the **Trait mapping** table, or switch on **Include all properties as attributes** to send everything.
+
+<HideOnCDPIndex>
+
+### Testing
+
+Once you’ve configured your June destination, click **Start testing** to verify everything works the way you want.
+
+---
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/june/template_june.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/klaviyo.md
+++ b/docs/published/docs/cdp/destinations/klaviyo.md
@@ -1,0 +1,60 @@
+---
+title: Send contacts and analytics events to Klaviyo
+templateId:
+  - template-klaviyo-event
+  - template-klaviyo-user
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can use your PostHog event data to create and update contacts in Klaviyo. Here's everything you need to get started.
+
+## Configuring Klaviyo
+
+First, [create](https://www.klaviyo.com/settings/account/api-keys) a new **API key** in your Klaviyo account settings.
+
+Make sure to set `Read/Write Access` for:
+
+- **Events** to send event data
+- **Profiles** to send contact data
+
+## Configuring PostHog’s Klaviyo destination
+
+1. In PostHog, click the **[Data pipeline](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=klaviyo) tab.
+3. Click **New destination** and choose a Klaviyo option for either creating/updating contacts or sending events.
+
+Insert your API key. You can also choose a different property to use as the contact's email; PostHog will default to `person.properties.email`.
+
+You can additionally forward all person or event properties to Klaviyo, or include specific ones by updating the property map:
+
+![Property map](https://res.cloudinary.com/dmukukwp6/image/upload/property_map_b81b1aa605.png)
+
+<HideOnCDPIndex>
+
+### Filtering
+
+You should configure the destination filter to only accept events that have an email property set.
+
+![Filtering events](https://res.cloudinary.com/dmukukwp6/image/upload/filter_person_email_86c1d7a350.png)
+
+### Testing
+
+Once you’ve configured your Klaviyo destination, click **Create & enable** then **Start testing** to verify everything works the way you want.
+
+---
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_airtable.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/knock.md
+++ b/docs/published/docs/cdp/destinations/knock.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog event data to Knock
+templateId:
+  - template-knock
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Knock account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=knock) tab.
+3. Search for **Knock** and click **+ Create**.
+4. Add your Knock.app webhook destination URL at the configuration step.
+5. Press **Create & Enable** and watch your 'Audience' list get populated in Knock!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/knock/template_knock.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/loops.md
+++ b/docs/published/docs/cdp/destinations/loops.md
@@ -1,0 +1,37 @@
+---
+title: Send PostHog person data to Loops
+templateId:
+  - template-loops
+  - template-loops-event
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Loops account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=loops) tab.
+3. Search for **Loops** and click **+ Create**.
+4. Add your Loops API Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Audience' list get populated in Loops!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/loops/template_loops.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/mailchimp.md
+++ b/docs/published/docs/cdp/destinations/mailchimp.md
@@ -1,0 +1,56 @@
+---
+title: Create and update Mailchimp contacts from analytics events
+templateId:
+  - template-mailchimp
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can use your PostHog event data to create and update contacts in Mailchimp. Here's everything you need to get started.
+
+## Configuring Mailchimp
+
+First, [create](https://mailchimp.com/help/about-api-keys/) a new **API key** in your Mailchimp account.
+
+You'll also need your **[Mailchimp audience ID](https://mailchimp.com/help/find-audience-id/)**.
+
+Finally, while logged into Mailchimp, check the subdomain of your account. You'll need this to configure the destination, as your `Mailchimp datacenter id`.
+
+## Configuring PostHog’s Mailchimp destination
+
+1. In PostHog, click the **[Data pipeline](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=mailchimp) tab.
+3. Click **New destination** and choose Mailchimp's **Create** button.
+
+Insert your API key, audience ID, and datacenter ID. You can also choose a different property to use as the contact's email; PostHog will default to `person.properties.email`.
+
+You can additionally forward all event properties to Mailchimp, or select specific ones using the **merge field** section.
+
+<HideOnCDPIndex>
+
+### Filtering
+
+As you'll be collecting or updating contact emails, you should configure the destination filter to only accept events that have an email property set.
+
+![Filtering events](https://res.cloudinary.com/dmukukwp6/image/upload/filter_person_email_86c1d7a350.png)
+
+### Testing
+
+Once you’ve configured your Mailchimp destination, click **Start testing** to verify everything works the way you want.
+
+---
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/mailchimp/template_mailchimp.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/mailgun.md
+++ b/docs/published/docs/cdp/destinations/mailgun.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog person data to Mailgun
+templateId:
+  - template-mailgun-send-email
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Mailgun account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=mailgun) tab.
+3. Search for **Mailgun** and click **+ Create**.
+4. Add your Mailgun API Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Contacts' list get populated in Mailgun!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/mailgun/template_mailgun.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/mailjet.md
+++ b/docs/published/docs/cdp/destinations/mailjet.md
@@ -1,0 +1,37 @@
+---
+title: Send PostHog person data to Mailjet
+templateId:
+  - template-mailjet-create-contact
+  - template-mailjet-update-contact-list
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Mailjet account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=mailjet) tab.
+3. Search for **Mailjet** and click **+ Create**.
+4. Add your Mailjet API Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Contacts' list get populated in Mailjet!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/mailjet/template_mailjet.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/make.md
+++ b/docs/published/docs/cdp/destinations/make.md
@@ -1,0 +1,41 @@
+---
+title: Send PostHog event data to Make
+templateId:
+  - template-make
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+Trigger scenarios in Make based on PostHog events.
+
+## Requirements
+
+You'll also need access to the relevant Make account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=make) tab.
+3. Search for **Make** and click **+ Create**.
+4. Add your Make webhook URL at the configuration step.
+5. Set up your event and property filters to remove unnecessary events. You only want to send events that you want to trigger scenarios. Filter out unrelated events or ones missing required data.
+6. Press **Create & Enable** and watch your **scenarios** get triggered in Make!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/make/template_make.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/meta-ads.md
+++ b/docs/published/docs/cdp/destinations/meta-ads.md
@@ -1,0 +1,50 @@
+---
+title: Send PostHog conversion events to Meta Ads
+templateId:
+  - template-meta-ads
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Meta Ads account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=meta) tab.
+
+3. Search for **Meta Ads Conversions** and click **+ Create**.
+
+4. Visit the [Meta Events Manager](https://business.facebook.com/events_manager2/overview).
+   1. If you’ve already set up a Pixel for your website, we recommend that you use the same Pixel ID for your browser and server events.
+      1. To create a new Pixel, click **Connect data** and select **Web**.
+      2. For the connection method, select **Set up manually** and **Conversions API**.
+   2. Go to your Pixel via **Data sources**.
+   3. Switch to the **Settings** tab and your Pixel ID will be listed as **Dataset ID**.
+   4. You can create an access token by clicking **Generate access token**.
+
+5. Back in PostHog, add the access token and Pixel ID to the destination configuration.
+
+6. Set up your event and property filters to remove unnecessary events. You only want to send events that are conversions. Filter out unrelated events or ones missing required data.
+
+7. Press **Create & enable**, test your destination, and then watch your conversions get sent to Meta Ads.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/meta_ads/template_meta_ads.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/microsoft-teams.md
+++ b/docs/published/docs/cdp/destinations/microsoft-teams.md
@@ -1,0 +1,56 @@
+---
+title: Send PostHog analytics events to your Microsoft Teams server
+templateId:
+  - template-microsoft-teams
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+Send event data from PostHog into the Microsoft Teams server and channel of your choice.
+
+## Setup
+
+### Microsoft Teams: create a webhook
+
+1. In Microsoft Teams, go to the channel you want to send events to.
+2. Click the three dots next to the channel name and select **Workflows**.
+3. Select the **Post to a channel when a webhook request is received**, in the templates section.
+4. Click **Next**, then **Add workflow**.
+5. Copy the webhook URL.
+
+> **Note:** The Microsoft Teams destination supports webhook URLs from:
+>
+> - Azure Logic Apps (`logic.azure.com`)
+> - Power Platform (`webhook.office.com`)
+> - Power Automate (`powerautomate.com` or `flow.microsoft.com`)
+
+### PostHog: create a destination
+
+1. Back in PostHog, click the **[Data pipelines](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=microsoft) tab.
+3. Search for **Microsoft Teams** and click **+ Create**.
+4. Add your Webhook URL.
+5. Use the **Text** field to format your message. You can include any properties that exist on `event` or `person`.
+6. Use the **Filters** panel to set up a query to filter the events you want to send, otherwise you'll get a firehose of all events filling your channel.
+7. Press **Create & enable**. Events will now be sent to Microsoft Teams. If you'd like to send a test event to your channel, hit the **Start testing** button.
+
+> **Note:** For advanced customization, you can click the **Edit source** button to modify the destination's code directly. This allows you to tailor the destination to your specific needs beyond the standard configuration options. See our guide on [customizing destinations](/docs/cdp/destinations/customizing-destinations) for more details.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/microsoft_teams/template_microsoft_teams.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/posthog.md
+++ b/docs/published/docs/cdp/destinations/posthog.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog event data to another PostHog instance
+templateId:
+  - template-posthog-replicator
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the destination PostHog account.
+
+## Installation
+
+1. In PostHog, click the **[Data pipelines](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=posthog) tab.
+3. Search for **PostHog** and click **+ Create**.
+4. Add the Host and API Key of the destination at the configuration step.
+5. Press **Create & Enable** and watch your 'Events' list get populated in the destination PostHog instance!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/posthog/template_posthog.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/reddit-ads-conversion-api.md
+++ b/docs/published/docs/cdp/destinations/reddit-ads-conversion-api.md
@@ -1,0 +1,50 @@
+---
+title: Send PostHog conversion events to Reddit Ads (Conversions API)
+templateId:
+  - template-reddit-conversions-api
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Reddit Ads account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=reddit) tab.
+
+3. Search for **Reddit Conversions API** and click **+ Create**.
+
+4. Find your Reddit Ads Account id on the [Reddit Ads dashboard](https://ads.reddit.com/).
+   1. Click the business name in the top-left
+   2. Click the copy icon next to the Account ID
+
+5. Back in PostHog, add the Account ID to the destination configuration.
+
+6. Create a Reddit [Conversion Access Token](https://business.reddithelp.com/s/article/conversion-access-token)
+
+7. Back in PostHog, add the Conversion Access Token to the destination configuration.
+
+8. Set up your event and property filters to remove unnecessary events. You only want to send events that are conversions. Filter out unrelated events or ones missing required data.
+
+9. Press **Create & enable**, test your destination, and then watch your conversions get sent to Snapchat Ads.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/reddit/template_reddit_conversions_api.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/reddit-ads-pixel.md
+++ b/docs/published/docs/cdp/destinations/reddit-ads-pixel.md
@@ -1,0 +1,44 @@
+---
+title: Send PostHog conversion events to Reddit Ads (Pixel)
+templateId:
+  - template-reddit-pixel
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You should be aware that this destination relies on creating third-party cookies. You'll also need access to the relevant Reddit Ads account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=reddit) tab.
+
+3. Search for **Reddit Pixel** and click **+ Create**.
+
+4. Find your Pixel ID in the Reddit [Events manager](https://ads.reddit.com/events-manager). Make sure that the intended business is selected.
+
+5. Back in PostHog, add the Pixel ID to the destination configuration.
+
+6. Set up your event and property filters to remove unnecessary events. You only want to send events that are conversions. Filter out unrelated events or ones missing required data.
+
+7. Press **Create & enable**, test your destination, and then watch your conversions get sent to Snapchat Ads.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/reddit/template_reddit_pixel.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/rudderstack.md
+++ b/docs/published/docs/cdp/destinations/rudderstack.md
@@ -1,0 +1,36 @@
+---
+title: Send PostHog event data to RudderStack
+templateId:
+  - template-rudderstack
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant RudderStack account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=rudderstack) tab.
+3. Search for 'RudderStack' and click **+ Create**.
+4. Add your RudderStack Write API Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Events' get sent to RudderStack!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/rudderstack/template_rudderstack.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/salesforce.md
+++ b/docs/published/docs/cdp/destinations/salesforce.md
@@ -1,0 +1,39 @@
+---
+title: Send PostHog event data to Salesforce
+templateId:
+  - template-salesforce-create
+  - template-salesforce-update
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+This destination connects to your Salesforce instance, sending events from PostHog to Salesforce as they are ingested.
+
+You'll also need access to the relevant Salesforce account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=salesforce) tab.
+3. Search for 'Salesforce' and click **+ Create**.
+4. Connect your Salesforce account at the configuration step.
+5. Press **Create & Enable** and watch your 'Objects' get populated in Salesforce!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/salesforce/template_salesforce.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/sendgrid.md
+++ b/docs/published/docs/cdp/destinations/sendgrid.md
@@ -1,0 +1,38 @@
+---
+title: Send PostHog person data to Sendgrid
+templateId:
+  - template-sendgrid
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can also send person properties to custom fields in Sendgrid.
+
+You'll also need access to the relevant Sendgrid account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=sendgrid) tab.
+3. Search for 'Sendgrid' and click **+ Create**.
+4. Add your Sendgrid API Key at the configuration step.
+5. Press **Create & Enable** and watch your 'Contacts' list get populated in Sendgrid!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/sendgrid/template_sendgrid.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/slack.mdx
+++ b/docs/published/docs/cdp/destinations/slack.mdx
@@ -1,0 +1,120 @@
+---
+title: Send PostHog event data to Slack webhooks
+templateId:
+  - template-slack
+---
+
+import FeedbackQuestions from '../_snippets/feedback-questions.mdx'
+import PostHogMaintained from '../_snippets/posthog-maintained.mdx'
+import { IconSparkles } from '@posthog/icons'
+
+Use this destination to send custom messages into Slack based on PostHog events or actions.
+
+> If you want to receive regular insight or dashboard subscriptions to Slack, checkout our [subscriptions docs](/docs/product-analytics/subscriptions).
+
+## Requirements
+
+Using this requires a PostHog Cloud account, access to an active Slack account, and permissions to add the PostHog bot to the Slack workspace and channel.
+
+## Installation
+
+### 1. Create a new destination
+
+First, you need to create a new destination in PostHog that will send the event data to Slack. To do this:
+
+1. Start in PostHog, click the [Data pipeline tab](https://app.posthog.com/data-management/destinations) in the left sidebar.
+
+1. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=slack) tab.
+
+1. Click the **+ New destination** button and search for `Slack`, then click **+ Create**.
+
+### 2. Configure a source
+
+Select a source that will trigger messages to be sent to Slack. To do this:
+
+1. Under **Source**, select if events or person updates will trigger messages to be sent to Slack.
+2. Update the filters to specify which events or person updates will trigger messages to be sent to Slack.
+3. Update the **Trigger options** to specify if the messages should be sent immediately or on a schedule.
+
+> 💡 You can also try clicking the <span className="inline-block"><IconSparkles className="h-4 w-4" /> </span> icon to create filters with PostHog AI.
+
+### 3. Add the PostHog Slack app to your workspace
+
+Next, connect your Slack workspace to PostHog by clicking **Choose Slack connection**. If you already have a Slack connection, you can select it from the dropdown, and continue to the next step.
+
+If you don't have a Slack connection, you can click **Connect to Slack** to create a new one. You will be redirected to Slack to install the PostHog app.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/allow_slack_bb68272218.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/allow_slack_bb68272218.png"
+  classes="rounded"
+  alt="Allow PostHog Slack app permissions"
+/>
+
+<Caption>Allow PostHog Slack app permissions</Caption>
+
+The PostHog Slack app will require some basic permissions which you can grant by clicking the **Allow** button.
+
+### 4. Add the PostHog Slack app to your channel
+
+You also need to configure which Slack channel will receive the messages from PostHog. To do this, add the PostHog app to the channel you want to send messages to:
+
+1. In the Slack [channel header](https://slack.com/help/articles/360059928654-How-to-use-Slack--your-quick-start-guide#channels), click the top right menu and click **Open channel details**
+2. Navigate to the **Integrations** tab
+3. Click the **Add an app** button
+4. Under **In your workspace**, click **PostHog**
+
+Once you've added the PostHog app to your workspace, you can select it under **Channel to post to** in the destination editor.
+
+### 5. Template your message
+
+Finally, you can template your message using Slack's [block kit](https://docs.slack.dev/block-kit/) or as a plain text message. You can template the message with the event and person properties using the `\{\}` syntax. For example:
+
+<MultiLanguage>
+
+```json file=Blocks
+[
+  {
+    "text": "Hello, \{person.name\}! You have a new message from \{event.event\}.",
+    "type": "mrkdwn"
+  }
+]
+```
+
+```text file=Text
+Hello, \{person.name\}! You have a new message from \{event.event\}.
+```
+
+</MultiLanguage>
+
+Once done, press **Create & Enable** and watch your messages appear in Slack.
+
+You can see a full example of this in our tutorial on [how to send survey responses to Slack](/tutorials/slack-surveys)
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Why can't I see all my Slack channels in the dropdown?
+
+Slack integrations will only show channels that the authorizing user has access to.
+
+### I have a lot of slack channels and loading all in the dropdown fails, how can I set a slack channel?
+
+If you have thousands of slack channels, the slack API might rate limit you before the dropdown can load all channels.
+
+In this case, you can manually paste a slack channel id into the field to load just that one by id. If it is found, you can then select and use it.
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/slack/template_slack.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/snapchat-ads.md
+++ b/docs/published/docs/cdp/destinations/snapchat-ads.md
@@ -1,0 +1,51 @@
+---
+title: Send PostHog conversion events to Snapchat Ads
+templateId:
+  - template-snapchat-ads
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You'll also need access to the relevant Snapchat Business account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=snapchat) tab.
+
+3. Search for **Snapchat Ads Conversions** and click **+ Create**.
+
+4. Connect your Snapchat Business account at the configuration step.
+
+5. Visit the [Snapchat Business Manager](https://business.snapchat.com/).
+   1. If you’ve already set up a Pixel for your website, we recommend that you use the same Pixel ID for your browser and server events.
+      1. To create a new Pixel, click **Pixels** and then click **Create Pixel** button.
+      2. Choose a name for your Pixel, and then click **Create**.
+   2. Go to your Pixel by clicking **Pixels** and then click the Pixel you want to use.
+   3. Copy the Pixel ID.
+
+6. Back in PostHog, add the Pixel ID to the destination configuration.
+
+7. Set up your event and property filters to remove unnecessary events. You only want to send events that are conversions. Filter out unrelated events or ones missing required data.
+
+8. Press **Create & enable**, test your destination, and then watch your conversions get sent to Snapchat Ads.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/snapchat_ads/template_snapchat_ads.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/tiktok-ads.md
+++ b/docs/published/docs/cdp/destinations/tiktok-ads.md
@@ -1,0 +1,52 @@
+---
+title: Send PostHog conversion events to TikTok Ads
+templateId:
+  - template-tiktok-ads
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You should be aware that this destination relies on creating third-party cookies. You'll also need access to the relevant TikTok Ads account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=tiktok) tab.
+
+3. Search for **TikTok Ads Conversions** and click **+ Create**.
+
+4. Visit the [TikTok Events Manager](https://ads.tiktok.com/i18n/events_manager/home).
+   1. If you’ve already set up a Pixel for your website, we recommend that you use the same Pixel for your browser and server events.
+      1. To create a new Pixel, click **Connect data source** and select **Web**.
+      2. Skip the **Add your website** step.
+      3. For the connection method, select **Manual setup** and **Events API**.
+      4. Enter a name for your Pixel and click **Create**.
+   2. Go to your Pixel via **Data sources**.
+   3. Switch to the **Settings** tab and your Pixel ID will be listed as **ID**.
+   4. You can create an access token by clicking **Generate Access Token**.
+
+5. Back in PostHog, add the Pixel ID and Access token to the destination configuration.
+
+6. Set up your event and property filters to remove unnecessary events. You only want to send events that are conversions. Filter out unrelated events or ones missing required data.
+
+7. Press **Create & enable**, test your destination, and then watch your conversions get sent to TikTok Ads.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/tiktok_ads/template_tiktok_ads.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/twilio.md
+++ b/docs/published/docs/cdp/destinations/twilio.md
@@ -1,0 +1,62 @@
+---
+title: Send SMS messages using Twilio from analytics events
+templateId:
+  - template-twilio
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can use your PostHog event data to send SMS messages via Twilio. Here's everything you need to get started.
+
+## Configuring Twilio
+
+First, you'll need to create a Twilio account if you don't have one already. Then, gather the following credentials from your Twilio dashboard:
+
+1. **Account SID**: Found on your [Twilio Console Dashboard](https://console.twilio.com/)
+2. **Auth Token**: Found on your [Twilio Console Dashboard](https://console.twilio.com/)
+3. **From Phone Number**: This is the Twilio phone number you'll be sending messages from. You can find or purchase one in the [Phone Numbers section](https://console.twilio.com/us1/develop/phone-numbers/manage/incoming) of your Twilio account.
+
+## Configuring PostHog's Twilio destination
+
+1. In PostHog, click the **[Data pipeline](https://app.posthog.com/data-management/destinations)** tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=twilio) tab.
+3. Click **New destination** and choose Twilio's **Create** button.
+
+Enter your Account SID, Auth Token, and From Phone Number from Twilio. The recipient phone number can be extracted from your event properties.
+
+> **Important:** The SMS body template has a character limit of 1600 characters. Messages exceeding this limit will fail to send.
+
+<HideOnCDPIndex>
+
+### Filtering
+
+Make sure to filter events to only those that contain a valid phone number property, as this is required for sending SMS messages.
+
+### Testing
+
+Once you've configured your Twilio destination, click **Start testing** to verify everything works the way you want. Switch off **Mock out async functions** in order to send a test SMS message via Twilio.
+
+---
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destinations on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_twilio.py) is available on GitHub.
+
+### What happens if the SMS body exceeds 1600 characters?
+
+If your SMS body template generates a message longer than 1600 characters, the message will fail to send. Make sure to keep your templates concise or include logic to truncate long messages.
+
+### What phone number format is required?
+
+Phone numbers should be in E.164 format (e.g., +1234567890). This includes the country code preceded by a plus sign, followed by the phone number without spaces or special characters.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/webhook.mdx
+++ b/docs/published/docs/cdp/destinations/webhook.mdx
@@ -1,0 +1,100 @@
+---
+title: Send PostHog event data using webhooks
+templateId:
+  - template-webhook
+---
+
+import FeedbackQuestions from '../_snippets/feedback-questions.mdx'
+import PostHogMaintained from '../_snippets/posthog-maintained.mdx'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+With webhook destinations, you can send event data from PostHog to any HTTP endpoint, whether it's to your own backend, an internal system, or a third-party platform.
+
+<details>
+<summary>Want to send PostHog data to a particular platform like Slack?</summary>
+
+Browse all the **Destinations** listed in the sidenav to integrate with well-known platforms like [Slack](/docs/cdp/destinations/slack), [HubSpot](/docs/cdp/destinations/hubspot), or [Zapier](/docs/cdp/destinations/zapier).
+
+</details>
+
+<details>
+<summary>Want to bring your data into PostHog?</summary>
+
+Check out [Sources](/docs/cdp/sources) to learn how to connect your systems like CRM, payment processor, or database with PostHog data for all-in-one analytics.
+
+</details>
+
+## Setting up destination webhooks
+
+### 1. Create a new destination
+
+In PostHog, navigate to the [data pipelines](https://app.posthog.com/data-management/destinations) section in the sidebar. Click **+ New** > **Destination** in the top-right corner. Search for "Webhook" then click **+ Create**.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/webhook_destination_cd495788fc.png"
+  alt="Create new destination"
+  classes="rounded"
+/>
+
+### 2. Configure the webhook
+
+On the configuration page, enter a **Webhook URL**. This is the HTTP endpoint that will receive the event data from PostHog. By default, PostHog sends a `POST` request with a templated JSON body.
+
+Click **Create & Enable**.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/webhook_url_config_5900a5a9b7.png"
+  alt="Configure webhook"
+  classes="rounded"
+/>
+
+<CalloutBox type="fyi" title="Webhook services" icon="IconInfo">
+
+You can use services like [webhook.site](https://webhook.site/) or [ngrok](https://ngrok.com/) to create **Webhook URLs** for quick testing.
+
+</CalloutBox>
+
+### 3. Test the webhook
+
+Now that the webhook is enabled, let's see it in action. In the **Testing** section of the configuration page, click **Start testing** > **Test function** to send an example event.
+
+You should see the webhook endpoint receive a `POST` request with event data.
+
+<ProductVideo
+  videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/webhook_test_01101dbebd.mp4"
+  classes="rounded"
+  alt="Test webhook"
+/>
+
+<CalloutBox type="fyi" title="Debugging" icon="IconInfo">
+
+Try enabling **Log responses** to help debug HTTP calls.
+
+</CalloutBox>
+
+### 4. Customize the webhook (optional)
+
+You can further configure and customize webhook destinations by:
+
+- Adding filters, match rules, and trigger options in the **Filters** section
+- Customizing the [payload](/docs/cdp/destinations/customizing-destinations#customizing-payload)
+- Using [global variables](/docs/cdp/destinations/customizing-destinations#global-object)
+- Modifying the [source code](/docs/cdp/destinations/customizing-destinations#modifying-destinations-with-hog) in the **Edit source** section
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_webhook.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/zapier.md
+++ b/docs/published/docs/cdp/destinations/zapier.md
@@ -1,0 +1,52 @@
+---
+title: Send PostHog event data to Zapier
+templateId:
+  - template-zapier
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+Trigger Zaps in Zapier based on PostHog events.
+
+## Requirements
+
+Using this requires either PostHog Cloud, or a self-hosted PostHog instance running a recent version of the docker image.
+
+You'll also need access to the relevant Zapier account.
+
+## Installation
+
+### Option 1: Via the PostHog app in Zapier <span class="bg-accent text-gray font-semibold align-middle text-sm p-1 rounded">Recommended</span>
+
+1. In your Zapier dashboard, go to your [zaps](https://zapier.com/app/assets/zaps) and create a new zap.
+2. Add the [PostHog app](https://zapier.com/apps/posthog/integrations/webhook) as a trigger.
+3. Configure the PostHog trigger accordingly.
+
+Note that the PostHog app in Zapier only supports receiving events from [actions](/docs/data/actions), so you may need to create an action for the event that you want to trigger the zap.
+
+### Option 2: Via PostHog's Data pipelines
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=zapier) tab.
+3. Search for **Zapier** and click **+ Create**.
+4. In your Zapier dashboard, create a new Zap with a [webhook trigger](https://zapier.com/apps/webhook/integrations) and then add your webhook URL in PostHog under **Zapier hook path**.
+5. Press **Create & Enable** and watch your 'Zaps' get triggered in Zapier!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/zapier/template_zapier.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/destinations/zendesk.md
+++ b/docs/published/docs/cdp/destinations/zendesk.md
@@ -1,0 +1,38 @@
+---
+title: Send PostHog person data to Zendesk
+templateId:
+  - template-zendesk
+---
+
+import FeedbackQuestions from "../\_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../\_snippets/posthog-maintained.mdx"
+
+You can also send person properties to User fields in Zendesk.
+
+You'll also need access to the relevant Zendesk account.
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/destinations) tab in the left sidebar.
+2. Click the [Destinations](https://app.posthog.com/data-management/destinations?search=zendesk) tab.
+3. Search for 'Zendesk' and click **+ Create**.
+4. Add your Zendesk subdomain, user email, and API token at the configuration step.
+5. Press **Create & Enable** and watch your 'Customer' list get populated in Zendesk!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/zendesk/template_zendesk.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/fivetran-airbyte.md
+++ b/docs/published/docs/cdp/fivetran-airbyte.md
@@ -1,0 +1,50 @@
+---
+title: Using Fivetran, Airbyte or other ETL tools with PostHog
+sidebar: Docs
+showTitle: true
+---
+
+While ETL tools like Fivetran, Airbyte, and similar platforms often offer unofficial PostHog connectors, **we do not recommend using those** to move data from PostHog to other destinations (like a data warehouse). They're not well-suited for the high-volume, real-time nature of product analytics data. PostHog's [data pipelines](/docs/cdp) are purpose-built for this use case and offer significant advantages, including being **much cheaper**.
+
+## ETL tools
+
+ETL tools like Fivetran and Airbyte are designed for traditional business data with predictable volumes and update patterns, but product analytics data is fundamentally different. PostHog customers often generate billions of events per day with bursty traffic patterns that can overwhelm ETL tool rate limits and quotas. These tools typically sync on hourly or daily schedules, which doesn't meet the real-time requirements of most of our customers. In addition, the way that these tools grab data (uncompressed rest API requests in small increments) requires disproportionally large amounts of resources, which means we often need to rate limit those requests.
+
+When data doesn't appear in your warehouse, ETL tools make it extremely difficult to diagnose issues due to their black box processing and limited error visibility. The complex dependency chains mean ETL tools add another layer of infrastructure that can fail independently of PostHog. Additionally, ETL tools introduce unnecessary costs and complexity through additional licensing fees based on data volume and data duplication as your data gets copied multiple times (PostHog → ETL tool → warehouse).
+
+## Why use PostHog's data pipelines
+
+PostHog's batch exports are purpose-built for product analytics, offering direct data access by reading from PostHog's optimized ClickHouse database to ensure data consistency. They're designed with analytics-optimized schemas in formats like Parquet with compression, built to scale with PostHog's infrastructure to support billions of events per day, and offer real-time capabilities with 5 minute exports for near real-time data freshness.
+
+Batch exports provide superior reliability and debugging through enterprise-grade workflow orchestration built on Temporal, comprehensive logging that shows exactly what data was exported and when, automatic retries with exponential backoff for temporary failures, and built-in testing to validate destinations before creating exports. Since PostHog owns the entire pipeline, our team can provide direct support to help debug any issues that arise.
+
+Using PostHog's data pipelines is also often much cheaper than using an external ETL tool.
+
+## Supported destinations
+
+PostHog batch exports support all major data warehouses:
+
+- [BigQuery](/docs/cdp/batch-exports/bigquery)
+- [Snowflake](/docs/cdp/batch-exports/snowflake)
+- [Redshift](/docs/cdp/batch-exports/redshift)
+- [Databricks](/docs/cdp/batch-exports/databricks)
+- [Postgres](/docs/cdp/batch-exports/postgres)
+- [S3](/docs/cdp/batch-exports/s3) (for custom destinations)
+- [Azure Blob Storage](/docs/cdp/batch-exports/azureblob)
+
+## Real-time alternatives
+
+For use cases requiring real-time data, consider:
+
+- [Real-time destinations](/docs/cdp/destinations) for streaming data to external systems
+- [Webhooks](/docs/webhooks) for event-driven integrations
+
+## Migration from ETL tools
+
+If you're currently using an ETL tool with PostHog, migrating to batch exports is straightforward:
+
+1. **Create a new batch export** in PostHog's [Data pipelines](https://app.posthog.com/data-management/destinations) interface
+2. **Configure your destination** using the same credentials you used with the ETL tool
+3. **Test the configuration** using PostHog's built-in testing
+4. **Start the export** and verify data appears in your warehouse
+5. **Disable the ETL tool** once you're confident the batch export is working

--- a/docs/published/docs/cdp/hog-functions-ai.mdx
+++ b/docs/published/docs/cdp/hog-functions-ai.mdx
@@ -1,0 +1,41 @@
+---
+title: Write Hog functions with PostHog AI
+---
+
+[PostHog AI](/docs/posthog-ai) writes [Hog functions](/docs/cdp) for transformations, filters, and realtime destinations using natural language. Describe what you want the function to do, and PostHog AI generates the code with the correct inputs, event handling, and API calls.
+
+## How it works
+
+Describe what you need and PostHog AI generates the function code, configures the correct inputs and variables, handles the event structure and property access patterns, and adds the right API calls for destinations like Slack or webhooks.
+
+You can iterate on the generated code by asking follow-up questions like "add a filter for internal IPs" or "also send the user's email in the Slack message."
+
+## Function types PostHog AI can write
+
+| Type               | What it does                                                      |
+| ------------------ | ----------------------------------------------------------------- |
+| **Transformation** | Adds, modifies, or removes event properties before they're stored |
+| **Filter**         | Drops events that match specific conditions                       |
+| **Destination**    | Sends event data to an external service                           |
+
+## Try it
+
+Select a prompt to try it out in the PostHog app:
+
+- [`Create a Hog function that filters out internal traffic by IP`](https://app.posthog.com/#panel=max:Create%20a%20Hog%20function%20that%20filters%20out%20internal%20traffic%20by%20IP)
+- [`Parse event timestamps into day, week, and month properties`](https://app.posthog.com/#panel=max:Parse%20event%20timestamps%20into%20day%2C%20week%2C%20and%20month%20properties)
+- [`Drop events where test_mode is true or the environment is staging`](https://app.posthog.com/#panel=max:Drop%20events%20where%20test_mode%20is%20true%20or%20the%20environment%20is%20staging)
+- [`Write a transformation that adds a user_tier property based on plan type`](https://app.posthog.com/#panel=max:Write%20a%20transformation%20that%20adds%20a%20user_tier%20property%20based%20on%20plan%20type)
+- [`Create a destination function that sends high-value events to Slack`](https://app.posthog.com/#panel=max:Create%20a%20destination%20function%20that%20sends%20high-value%20events%20to%20Slack)
+
+## Tips for better results
+
+- **Describe the input and output** – "Take `$pageview` events and add a `page_category` property based on the URL path" gives PostHog AI enough context to write the transformation
+- **Name specific events and properties** – Reference your actual event names (like `purchase_completed`) and properties (like `plan_type`) so the generated code matches your data
+- **Specify the destination** – For destination functions, name the service (Slack, webhook, email) and describe what data to send
+- **Include edge cases** – "Handle cases where `user_email` is null" helps PostHog AI write more robust code
+- **Describe the logic, not the implementation** – "Categorize pages into marketing, product, and docs based on URL prefix" lets PostHog AI choose the right approach
+
+## Get started
+
+To start writing Hog functions with PostHog AI, [set up PostHog AI](/docs/posthog-ai/start-here).

--- a/docs/published/docs/cdp/index.md
+++ b/docs/published/docs/cdp/index.md
@@ -1,0 +1,32 @@
+---
+title: 'Data pipelines: CDP integrations'
+showTitle: true
+---
+
+Data pipeline provides a full-featured customer data platform (CDP) in PostHog, with full-service integrations for ingesting, transforming, and sending data to destinations:
+
+- **Transformations** extend PostHog's functionality by filtering and transforming analytics data.
+
+- **Sources** let you [ingest data](/docs/cdp/sources) from your existing systems, and join them to existing person and event data using [data warehouse](/docs/data-warehouse).
+
+- **Destinations** send PostHog data to other sources in [realtime](/docs/cdp/destinations) or as [batch exports](/docs/cdp/batch-exports) which reliably send data to a destination on a schedule.
+
+## Billing for data pipelines
+
+For information about data pipeline pricing and billing, please visit our [pricing page](https://posthog.com/pricing).
+
+## Use cases
+
+Pipelines can be used for a wide variety of use cases, such as:
+
+- **Send event data to a data warehouse.** If you have a data lake or data warehouse, you can use destinations to send PostHog event data there, while ensuring you still have that data in PostHog to perform your analytics processes.
+
+- **Send event data via webhooks.** You can use our realtime destinations to send event data to external services through [webhooks](/docs/cdp/destinations/webhook). This is useful when you want to push event data to tools like [Slack](/docs/cdp/destinations/slack), [Hubspot](/docs/cdp/destinations/hubspot), or [Intercom](/docs/cdp/destinations/intercom).
+
+- **Enforce event schemas.** By default, PostHog does not enforce schemas on events it receives. However, a transformation could do so, preventing ingestion of events that do not match the specified schema in order to keep your data clean and following specific guidelines you need it to follow.
+
+- **Label events.** To facilitate sorting through your events, you can use transformations to determine arbitrary logic to label an event (e.g. by setting a `label` property). This can help you tailor your metrics in PostHog, as well as facilitate data ordering if you ever use PostHog data elsewhere.
+
+- **Correlate costs with impact.** You can [use the data warehouse](/blog/data-warehouse-at-posthog) to import cost data from sources like ads and cloud infrastructure platforms, and then use it in queries alongside product data to understand the impact and ROI of your spend.
+
+For a full list of transformations and destinations currently available, see the [destinations](https://app.posthog.com/data-management/destinations) and [transformations](https://app.posthog.com/data-management/transformations) tabs under data pipeline in-app.

--- a/docs/published/docs/cdp/sources/_snippets/source-activecampaign.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-activecampaign.mdx
@@ -1,0 +1,3 @@
+> **Active Campaign** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-adjust.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-adjust.mdx
@@ -1,0 +1,3 @@
+> **Adjust** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-aircall.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-aircall.mdx
@@ -1,0 +1,3 @@
+> **Aircall** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-airtable.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-airtable.mdx
@@ -1,0 +1,3 @@
+> **Airtable** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-amazon-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-amazon-ads.mdx
@@ -1,0 +1,3 @@
+> **Amazon Ads** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-amplitude.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-amplitude.mdx
@@ -1,0 +1,3 @@
+> **Amplitude** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-apple-search-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-apple-search-ads.mdx
@@ -1,0 +1,3 @@
+> **Apple Search Ads** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-appsflyer.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-appsflyer.mdx
@@ -1,0 +1,3 @@
+> **Apps Flyer** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-asana.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-asana.mdx
@@ -1,0 +1,3 @@
+> **Asana** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-ashby.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-ashby.mdx
@@ -1,0 +1,3 @@
+> **Ashby** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-attio.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-attio.mdx
@@ -1,0 +1,15 @@
+The Attio connector can link companies, people, lists, users, and workspaces to PostHog.
+
+To link Attio:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Attio.
+
+3. Next, you need an access token from Attio. Go to your [developer settings](https://attio.com/help/reference/integrations-automations/generating-an-api-key) in Attio and create a new access token with read permissions for the data you want to sync.
+
+4. Back in PostHog, paste the access token in the `Access token` field and click **Next**.
+
+5. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Attio data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-auth0.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-auth0.mdx
@@ -1,0 +1,3 @@
+> **Auth0** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-azure-blob.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-azure-blob.mdx
@@ -1,0 +1,34 @@
+The data warehouse can link to data in your Azure storage accounts.
+
+1. Create an Azure storage account
+2. Create a blob container
+3. Upload data and link to PostHog
+
+## Step 1: Create an Azure storage account
+
+Firstly, log into Azure and go to Storage Accounts, then create a storage account by following [this Azure guide](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal#create-a-storage-account).
+
+## Step 2: Create a blob container
+
+Once the storage account has been created, follow [this guide to create a blob container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container).
+
+![container creation](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_18_at_11_08_05_cf44b9340b.png)
+
+## Step 3: Upload data and link to PostHog
+
+[Upload your data to the newly created container](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#upload-a-block-blob), Parquet files are the recommended format, but the connector also works with JSON and CSVs too.
+
+Find the newly created file via the storage browser menu item. Once found, open the details and copy URL property. We need it to link the file in PostHog.
+
+![copy blob file](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_15_at_17_59_09_2f888aaa2f.png)
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select Azure from the self managed section
+3. Enter a name for your dataset and paste the copied URL into the "Files URL pattern" box
+4. Select the correct format for your data
+5. Enter the storage account name (this is name of the storage account you created in step 1)
+6. Find and paste your storage account key - you can use [this Azure doc](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal#view-account-access-keys) to view your access keys
+
+![linking your data in posthog](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_15_at_18_10_06_f93fadf82b.png)
+
+That's it! You should be able to query the data from the PostHog SQL editor.

--- a/docs/published/docs/cdp/sources/_snippets/source-azure-db.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-azure-db.mdx
@@ -1,0 +1,26 @@
+The Azure SQL Server connector can link your database tables to PostHog.
+
+> This applies to any MS SQL Server, not just Azure hosted databases. We use Microsoft ODBC 18 to connect to your SQL server.
+
+For Azure databases, we only use SQL authentication (and not Entra ID). You can find your connection details by [following the steps listed here](https://learn.microsoft.com/en-us/azure/azure-sql/database/connect-query-content-reference-guide?view=azuresql#get-adonet-connection-information-optional---sql-database-only).
+
+The Azure database also needs to be publicly accessible (or use a SSH tunnel). You can follow [step 1 of this Microsoft guide](https://learn.microsoft.com/en-us/azure/azure-sql/database/azure-sql-python-quickstart?view=azuresql&tabs=windows%2Csql-auth#configure-the-database) to enable public access and allow our inbound IP addresses found at the bottom of this page.
+
+To link Azure SQL Server:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select Azure SQL Server
+3. Enter your database connection details:
+   - **Host:** The hostname or IP your database server like `db.example.com` or `123.132.1.100`.
+   - **Port:** The port your database server is listening to. The default is `1433`.
+   - **Database:** The name of the database you want like `analytics_db`.
+   - **User:** The username with the necessary permissions to access the database.
+   - **Password:** The password for the user.
+   - **Schema:** The schema for your database where your tables are located. The default is `dbo`.
+4. Click **Link**
+
+The data warehouse then starts syncing your Azure SQL Server data. You can see details and progress in the [sources tab](https://app.posthog.com/data-management/sources).
+
+import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />

--- a/docs/published/docs/cdp/sources/_snippets/source-bamboo-hr.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-bamboo-hr.mdx
@@ -1,0 +1,3 @@
+> **Bamboo HR** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-bigcommerce.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-bigcommerce.mdx
@@ -1,0 +1,3 @@
+> **Big Commerce** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-bigquery.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-bigquery.mdx
@@ -1,0 +1,72 @@
+You can connect your BigQuery tables to PostHog by configuring it as a source. You must grant a limited set of permissions so the connector can create, query, and delete temporary tables without exposing your entire BigQuery environment.
+
+## Requirements
+
+- [A Google Cloud Service Account](https://cloud.google.com/iam/docs/service-account-overview) with the permissions described below
+- Google Cloud JSON Key file for that account's Dataset ID
+- (Optional) A Dataset ID for temporary tables
+
+## Configuring BigQuery
+
+To securely connect your BigQuery account to PostHog, create a dedicated service account with the minimum required permissions:
+
+1. **Create a service account:**
+
+- Go to the [**Google Cloud Console.**](https://console.cloud.google.com/)
+- Navigate to **IAM & Admin > Service Accounts.**
+- Click **Create Service Account.**
+- Provide a descriptive name (e.g., `bigquery-posthog-service-account`) and a brief description.
+
+2. **Assign required permissions:**
+
+- For simplicity, you can assign the **BigQuery Data Editor**, **BigQuery Job User**, and **BigQuery Read Session User** roles if it meets your security requirements.
+- Alternatively, create a custom role that includes only these permissions:
+
+  ```text
+  bigquery.readsessions.create
+  bigquery.readsessions.getData
+  bigquery.datasets.get
+  bigquery.jobs.create
+  bigquery.tables.get
+  bigquery.tables.list
+  bigquery.tables.getData
+  bigquery.tables.create
+  bigquery.tables.updateData
+  bigquery.tables.delete
+  ```
+
+3. **Generate and download the service account key:**
+
+- Once the service account is created, click on it and select the **Keys** tab.
+- Click **Add Key > Create new key**, choose **JSON**, and download the key file.
+- **Important:** Store the JSON key securely, as it contains sensitive credentials.
+
+## Configuring PostHog
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab, then choose **sources**
+2. Click **New source** and select BigQuery
+3. Drag and drop the **Google Cloud JSON Key file** to upload
+4. Enter the **Dataset ID** you want to import
+5. (Optional) If you're limiting permissions to the service account provided, enter a Dataset ID for temporary tables
+6. (Optional) Add a prefix for the table name
+
+> In some rare instances BigQuery is unable to auto-locate your dataset unless you specify a region. If you see an error message that looks something like:
+>
+> `Dataset xxx:xxx was not found in region`
+>
+> then you may need to toggle the switch for manually specifying your region. Regions typically look like `us-east1` or similar.
+
+## How it works
+
+PostHog creates and deletes [temporary tables](https://cloud.google.com/bigquery/docs/writing-results#temporary_and_permanent_tables) when querying your data. This is necessary for handling large BigQuery tables. Temporary tables help break down large data processing tasks into manageable chunks. However, they incur storage and query costs in BigQuery while they exist. We delete them as soon as the job is done.
+
+PostHog requires a unique primary key when importing data and will look for it in this order:
+
+1. PostHog will use the `id` column as the primary key if it exists
+2. If the `id` column does not exist, PostHog will use any primary key constraints in the table
+
+After selecting the primary key, PostHog will query the table to see if the column is unique. If it is not, PostHog will fail the import with a `DuplicatePrimaryKeysException`. If you have no `id` column and no primary key constraints, future incremental imports will fail.
+
+### Costs
+
+We minimize BigQuery costs by keeping queries to a minimum and deleting temporary tables immediately after use. Although the connector automates temporary table management, check [BigQuery’s pricing](https://cloud.google.com/bigquery/pricing) for details on storage and query costs.

--- a/docs/published/docs/cdp/sources/_snippets/source-bing-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-bing-ads.mdx
@@ -1,0 +1,54 @@
+You can sync data from Bing Ads reports by configuring it as a source in PostHog. These are the supported entity and reports:
+
+| Report Type                                                                                                  | Description                               |
+| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| [Campaigns](https://learn.microsoft.com/en-us/advertising/guides/campaign-management-guides?view=bingads-13) |                                           |
+| [Campaign Performance Report](https://learn.microsoft.com/en-us/advertising/guides/reports)                  | Performance metrics at the campaign level |
+| [Ad Group Performance Report](https://learn.microsoft.com/en-us/advertising/guides/reports)                  | Performance metrics at the ad group level |
+| [Ad Performance Report](https://learn.microsoft.com/en-us/advertising/guides/reports)                        | Performance metrics at the ad level       |
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+
+- A Bing Ads account with permission to access data from accounts you want to sync.
+- Your **Account ID** (numeric only) from the [Bing Ads interface](https://ui.ads.microsoft.com/) > **Settings** > **Account Settings** > The account ID is visible below the **Account ID** header.
+
+<CalloutBox icon="IconWarning" title="Don't confuse Account Number with Account ID" type="caution">
+
+Microsoft Advertising shows both an **Account Number** and an **Account ID** in the UI:
+
+- **Account Number** - An eight-character alphanumeric value (e.g., `A1B2C3D4`). This is NOT what you need.
+- **Account ID** - A numeric-only value (e.g., `123456789`). This is what PostHog requires.
+
+Make sure you enter the numeric **Account ID**, not the alphanumeric **Account Number**.
+
+</CalloutBox>
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2025_11_20_at_2_31_35_PM_57e3bef9cc.png"
+  classes="rounded"
+  alt="Bing Ads account ID"
+/>
+
+<CalloutBox icon="IconWarning" title="Don't confuse Account Number with Account ID" type="caution">
+
+Microsoft Advertising has two different identifiers:
+
+- **Account Number** - An alphanumeric, 8-character value (e.g., `AB12CD34`). This is displayed prominently in the UI but is **not** what PostHog needs.
+- **Account ID** - A numeric-only value (e.g., `123456789`). This is required for the API and is what you should enter in PostHog.
+
+You can find your **Account ID** in Microsoft Advertising under **Settings** > **Account Settings**. Make sure you use the numeric **Account ID**, not the alphanumeric **Account Number**.
+
+</CalloutBox>
+
+## Configuring PostHog
+
+Connect PostHog to your Bing Ads account using a Microsoft account. The Microsoft account must have administrator or standard access to your Bing Ads account to view campaign data and reports.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find Bing Ads in the sources list and click **Link**.
+4. Enter the **Account ID** of the Bing Ads account you want to sync.
+5. Select an existing Bing Ads account, or create a new integration.
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-box.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-box.mdx
@@ -1,0 +1,3 @@
+> **Box** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-braintree.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-braintree.mdx
@@ -1,0 +1,3 @@
+> **Braintree** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-braze.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-braze.mdx
@@ -1,0 +1,3 @@
+> **Braze** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-brevo.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-brevo.mdx
@@ -1,0 +1,3 @@
+> **Brevo** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-buildbetter.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-buildbetter.mdx
@@ -1,0 +1,15 @@
+The BuildBetter connector can link interviews, extractions, persons, and companies to PostHog.
+
+To link BuildBetter:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to BuildBetter.
+
+3. You need an API key from BuildBetter. Go to your [API & MCP settings](https://app.buildbetter.app/settings/org/api-mcp) in BuildBetter and copy your API key.
+
+4. Back in PostHog, paste the API key in the `API key` field and click **Next**.
+
+5. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using BuildBetter data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-calendly.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-calendly.mdx
@@ -1,0 +1,3 @@
+> **Calendly** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-campaignmonitor.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-campaignmonitor.mdx
@@ -1,0 +1,3 @@
+> **Campaign Monitor** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-chargebee.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-chargebee.mdx
@@ -1,0 +1,19 @@
+The Chargebee connector can link customers, subscriptions, invoices, events, and more to PostHog.
+
+To link Chargebee:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Chargebee.
+
+3. Next, you need an API key from Chargebee. To start, in your Chargebee dashboard click on **Settings** in the sidebar. In the dropdown, select **Configure Chargebee**. Next, scroll down and select **API keys**. Here you should see a list of existing API keys. It is recommended to use a dedicated read-only key for this integration, so go to **+ Add API Key** and select **Read-Only Key**. Copy the value of the newly created key.
+
+4. Back in PostHog, paste the API key in the `API key` field.
+
+5. You will also need to provide your Chargebee's site name. You can find this in the top-left of your dashboard. It is also the same as the subdomain of your dashboard (i.e. the part before `.chargebee.com`)
+
+6. Once you've entered these 2 pieces of information, hit **Next**.
+
+7. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Chargebee data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-chartmogul.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-chartmogul.mdx
@@ -1,0 +1,3 @@
+> **Chart Mogul** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-circleci.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-circleci.mdx
@@ -1,0 +1,3 @@
+> **Circle CI** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-clerk.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-clerk.mdx
@@ -1,0 +1,15 @@
+The Clerk connector can link users, organizations, organization memberships, and invitations to PostHog.
+
+To link Clerk:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Clerk.
+
+3. Next, you need a secret key from Clerk. Go to your [API keys settings](https://dashboard.clerk.com/last-active?path=api-keys) in Clerk. Copy the **Secret key** value.
+
+4. Back in PostHog, paste the secret key in the `Secret key` field and click **Next**.
+
+5. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Clerk data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-clickup.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-clickup.mdx
@@ -1,0 +1,3 @@
+> **Click Up** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-close.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-close.mdx
@@ -1,0 +1,3 @@
+> **Close** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-cockroachdb.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-cockroachdb.mdx
@@ -1,0 +1,3 @@
+> **Cockroach DB** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-confluence.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-confluence.mdx
@@ -1,0 +1,3 @@
+> **Confluence** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-convertkit.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-convertkit.mdx
@@ -1,0 +1,3 @@
+> **Convert Kit** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-copper.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-copper.mdx
@@ -1,0 +1,3 @@
+> **Copper** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-customerio.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-customerio.mdx
@@ -1,0 +1,3 @@
+> **Customer IO** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-datadog.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-datadog.mdx
@@ -1,0 +1,3 @@
+> **Datadog** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-doit.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-doit.mdx
@@ -1,0 +1,15 @@
+The DoIt connector can link infrastructure reports to PostHog.
+
+To link DoIt:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to DoIt.
+
+3. Next, you need an API key from DoIt. To start, in your DoIt dashboard open up the [API key page](https://app.doit.com/profile/api), generate a key and note it down - you won't be able to view this key once you leave the page.
+
+4. Back in PostHog, paste the API key in the `API key` field and hit **Next**.
+
+5. On the next page, set up the reports you want to sync and modify the method and frequency as needed. Once done, click **Import**. New reports will show up in your schemas list periodically as they're created on DoIt.
+
+Once the syncs are complete, you can start using DoIt data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-drip.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-drip.mdx
@@ -1,0 +1,3 @@
+> **Drip** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-dynamodb.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-dynamodb.mdx
@@ -1,0 +1,3 @@
+> **Dynamo DB** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-elasticsearch.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-elasticsearch.mdx
@@ -1,0 +1,3 @@
+> **Elasticsearch** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-eventbrite.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-eventbrite.mdx
@@ -1,0 +1,3 @@
+> **Eventbrite** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-facebook-pages.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-facebook-pages.mdx
@@ -1,0 +1,3 @@
+> **Facebook Pages** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-firebase.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-firebase.mdx
@@ -1,0 +1,3 @@
+> **Firebase** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-freshdesk.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-freshdesk.mdx
@@ -1,0 +1,3 @@
+> **Freshdesk** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-freshsales.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-freshsales.mdx
@@ -1,0 +1,3 @@
+> **Freshsales** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-front.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-front.mdx
@@ -1,0 +1,3 @@
+> **Front** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-fullstory.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-fullstory.mdx
@@ -1,0 +1,3 @@
+> **Full Story** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-gcs.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-gcs.mdx
@@ -1,0 +1,57 @@
+You can sync and query files and folders from Google Cloud Storage (GCS) in PostHog by setting up a link.
+
+## Step 1: Creating a bucket in GCS
+
+1. Go to your Google Cloud console.
+2. Create a bucket in GCS.
+   - For location, we recommend choosing `us-east1` for US Cloud or `europe-west3` for EU Cloud to keep them close to our servers.
+   - For storage class, choose `Standard`.
+   - For access control, choose `Uniform`.
+3. Upload your data to the bucket. This can be as simple as a `.csv` file like this:
+
+```csv
+name,age
+John,30
+Jane,25
+```
+
+## Step 2: Set up a service account
+
+GCS uses service accounts to control access to resources. We need one to connect to GCS. To create one:
+
+1. Go to the [service accounts page](https://console.cloud.google.com/iam-admin/serviceaccounts) in the GCS console and click **Create service account**.
+2. Fill in the account name and ID and click **Create and continue**.
+3. Grant the account the **Storage Object User** role.
+4. Click **Done**.
+
+## Step 3: Set up access keys.
+
+1. Go to the [cloud storage settings page](https://console.cloud.google.com/storage/settings) and click the **Interoperability** tab.
+2. Click **Create a key for another service account**.
+3. Select the service account you created in step 2 and click **create key**.
+4. Copy both the access key and secret. Save them some place safe because you'll need to regenerate them if you lose them.
+
+![Access keys](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_17_at_12_57_42_2x_ace42b1d0e.png)
+
+## Step 4: Create the table in PostHog
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source**. Under self managed, look for **Google Cloud Storage** and click **Link**
+3. Fill the table name, then use the data from GCS:
+   - For files URL pattern, use `https://storage.googleapis.com/` followed by your bucket and file or folder name like `https://storage.googleapis.com/posthog-warehouse/july12_google_ads_fixed.csv`. You can also use `*` to query multiple files.
+   - Choose the correct file format
+   - When using CSV format, choose the **CSV quote handling** option: **RFC 4180 double quotes** for CSVs that use standard double-quote escaping, or **Literal quotes** (default) for CSVs where quotes are treated as literal characters.
+   - For access key, use your Access Key ID
+   - For secret key, use your Secret Access Key
+4. Click **Next**
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_17_at_13_03_25_2x_0ec0ddecaf.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_17_at_13_03_43_2x_465b2300b3.png"
+  alt="GCS source configuration form"
+  classes="rounded"
+/>
+
+## Step 5: Query the table
+
+Once it is done syncing, you can now [query](/docs/data-warehouse/query) your new table using the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-github.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-github.mdx
@@ -1,0 +1,23 @@
+The GitHub connector can link issues, pull requests, commits, stargazers, and releases to PostHog.
+
+To link GitHub:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to GitHub.
+
+3. Select your **Authentication type**. OAuth is the default and recommended method:
+   - **OAuth (GitHub App)** – Click the GitHub account field and follow the prompts to connect your GitHub account. This handles authentication automatically.
+
+   - **Personal access token (PAT)** – If you prefer using a PAT, select this option. Go to your [personal access tokens settings](https://github.com/settings/tokens) in GitHub, click **Generate new token**, give it a name, select the required scopes (`repo` for private repositories or `public_repo` for public repositories), and paste the token into PostHog.
+
+4. Select the repository you want to sync:
+   - **OAuth** – Use the searchable dropdown to find and select a repository your GitHub integration has access to.
+
+   - **PAT** – Manually enter the repository in the format `owner/repo` (e.g., `posthog/posthog`).
+
+   Click **Next**.
+
+5. Set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using GitHub data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-gitlab.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-gitlab.mdx
@@ -1,0 +1,3 @@
+> **Git Lab** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-gong.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-gong.mdx
@@ -1,0 +1,3 @@
+> **Gong** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-google-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-google-ads.mdx
@@ -1,0 +1,32 @@
+You can sync data from Google Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Ad, AdStats, AdGroup, AdGroupStats, Campaign, CampaignStats, GeographicStats, Keyword, KeywordStats, Video, and VideoStats, as they are described in the [Google Ads BigQuery transformation documentation](https://cloud.google.com/bigquery/docs/google-ads-transformation). Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+> **Note:** The GeographicStats table is disabled by default because it can load hundreds of millions of rows for active campaigns. You can enable it manually during source configuration if you need geographic performance data.
+
+## Requirements
+
+- The [Google Ads customer ID](https://support.google.com/google-ads/answer/1704344) of the account you are trying to sync to PostHog.
+- Administrator access to the Google Ads account you want to sync. If you use manager accounts then this is often enough to connect. An manager account is an Ads account type that enables you to manage several Ads accounts under a single login – [see here for more on Google Ads manager accounts](https://support.google.com/google-ads/answer/6139186).
+- During the authentication, make sure you check the necessary scopes.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Screenshot_2025_10_02_at_1_46_13_PM_fda20371c8.png"
+  classes="rounded"
+  alt="Accept scope checkbox"
+/>
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/2024_10_31_at_15_15_51_a7a003008c.png"
+  classes="rounded"
+  alt="Location of the Google Ads Customer ID"
+/>
+
+## Configuring PostHog
+
+Connect PostHog to your Google Ads account using a Google account. The Google account must have administrator access to your Google Ads account.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find Google Ads in the sources list and click **Link**.
+4. Enter the **Google Ads customer ID** of the Google Ads account you want to sync.
+5. Select an existing Google Ads account, or create a new integration
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-google-analytics.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-google-analytics.mdx
@@ -1,0 +1,3 @@
+> **Google Analytics** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-google-drive.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-google-drive.mdx
@@ -1,0 +1,3 @@
+> **Google Drive** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-google-sheets.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-google-sheets.mdx
@@ -1,0 +1,33 @@
+The Google Sheets connector can link your spreadsheets in to PostHog to be queryable.
+
+## Syncing a worksheet
+
+Each Google Sheets source in PostHog is a single spreadsheet where each worksheet is represented as a schema.
+
+> Changing the name of a worksheet will require you to setup the schema in PostHog again to continue syncing it. We recommend not renaming worksheets.
+
+The first row of the spreadsheet is treated as the column names for the table.
+
+### Configure Google Sheets
+
+To connect to your Google Sheet, PostHog uses a Google Cloud service account. Thus, you must grant this service account access to your Google Sheet by following these steps:
+
+1. Open your Google Sheet.
+2. Navigate to **Share**.
+3. Share the sheet with our service account by entering `google-sheets@posthog-external.iam.gserviceaccount.com` into the **Add people** field. We only require "Viewer" permissions to sync the sheet.
+
+### Configuring PostHog
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Google Sheets.
+
+3. Enter the **Google Sheets URL** of the sheet you want to sync and hit **Next**.
+
+4. On the next page, set up the worksheets you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Google Sheets data in PostHog.
+
+## Incremental and append only syncs
+
+To enable incremental or append only syncs of your spreadsheet, we require a numerical `id` column with auto-incrementing values. This can be achieved by using the formula `=ROW()` in a column with the column header (row 1) being set to `id`. This will then sync only newly added rows to PostHog

--- a/docs/published/docs/cdp/sources/_snippets/source-gorgias.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-gorgias.mdx
@@ -1,0 +1,3 @@
+> **Gorgias** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-granola.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-granola.mdx
@@ -1,0 +1,3 @@
+> **Granola** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-greenhouse.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-greenhouse.mdx
@@ -1,0 +1,3 @@
+> **Greenhouse** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-helpscout.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-helpscout.mdx
@@ -1,0 +1,3 @@
+> **Help Scout** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-hubspot.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-hubspot.mdx
@@ -1,0 +1,34 @@
+The HubSpot connector can link contacts, companies, deals, emails, meetings, quotes, and tickets to PostHog.
+
+To link Hubspot:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select Hubspot
+3. Select the Hubspot account you want to link and click **Connect app**
+4. _Optional:_ Add a prefix to your table names
+5. Select the tables you want to import (incremental/append syncs are not supported for HubSpot tables.)
+6. Click **Import**
+
+### Customize synced properties
+
+By default, PostHog syncs a standard set of properties for each HubSpot schema. To control which properties are synced, enable the **Customize synced properties** toggle during setup.
+
+When enabled, a text field appears for each schema (contacts, companies, deals, tickets, quotes, emails, meetings). Enter a comma-separated list of HubSpot property names to sync. Leave a field empty to use the defaults.
+
+The default properties for each schema are:
+
+- **contacts** - `createdate`, `email`, `firstname`, `hs_object_id`, `hs_lead_status`, `lastmodifieddate`, `lastname`, `hs_buying_role`
+- **companies** - `createdate`, `domain`, `hs_lastmodifieddate`, `hs_object_id`, `hs_csm_sentiment`, `hs_lead_status`, `name`
+- **deals** - `amount`, `closedate`, `createdate`, `dealname`, `dealstage`, `hs_lastmodifieddate`, `hs_object_id`, `pipeline`, `hs_mrr`
+- **tickets** - `createdate`, `content`, `hs_lastmodifieddate`, `hs_object_id`, `hs_pipeline`, `hs_pipeline_stage`, `hs_ticket_category`, `hs_ticket_priority`, `subject`
+- **quotes** - `hs_createdate`, `hs_expiration_date`, `hs_lastmodifieddate`, `hs_object_id`, `hs_public_url_key`, `hs_status`, `hs_title`
+- **emails** - `hs_timestamp`, `hs_email_direction`, `hs_email_html`, `hs_email_status`, `hs_email_subject`, `hs_email_text`, `hs_attachment_ids`, `hs_email_headers`
+- **meetings** - `hs_timestamp`, `hs_meeting_title`, `hs_meeting_body`, `hs_internal_meeting_notes`, `hs_meeting_external_URL`, `hs_meeting_location`, `hs_meeting_start_time`, `hs_meeting_end_time`, `hs_meeting_outcome`, `hs_activity_type`, `hs_attachment_ids`
+
+<CalloutBox icon="IconWarning" title="Changing properties requires a full resync" type="caution">
+
+Changing the synced properties after the initial import requires a full resync of your HubSpot data. Invalid properties are automatically filtered out. If all specified properties are invalid, the defaults are used instead.
+
+</CalloutBox>
+
+The data warehouse then starts syncing your Hubspot data. You can see details, progress, and rows synced in the [data pipeline sources tab](https://app.posthog.com/data-management/sources).

--- a/docs/published/docs/cdp/sources/_snippets/source-instagram.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-instagram.mdx
@@ -1,0 +1,3 @@
+> **Instagram** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-intercom.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-intercom.mdx
@@ -1,0 +1,3 @@
+> **Intercom** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-iterable.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-iterable.mdx
@@ -1,0 +1,3 @@
+> **Iterable** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-jira.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-jira.mdx
@@ -1,0 +1,3 @@
+> **Jira** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-kafka.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-kafka.mdx
@@ -1,0 +1,3 @@
+> **Kafka** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-klaviyo.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-klaviyo.mdx
@@ -1,0 +1,15 @@
+The Klaviyo connector can link campaigns, profiles, events, flows, and more to PostHog.
+
+To link Klaviyo:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Klaviyo.
+
+3. Next, you need an API key from Klaviyo. Go to your [API keys settings](https://www.klaviyo.com/settings/account/api-keys) in Klaviyo. Click **Create Private API Key**, give it a name, and select **Read-Only Key** for the access level. Copy the value of the newly created key.
+
+4. Back in PostHog, paste the API key in the `API key` field and click **Next**.
+
+5. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Klaviyo data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-launchdarkly.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-launchdarkly.mdx
@@ -1,0 +1,3 @@
+> **Launch Darkly** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-lever.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-lever.mdx
@@ -1,0 +1,3 @@
+> **Lever** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-linear.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-linear.mdx
@@ -1,0 +1,13 @@
+The Linear connector can link issues, projects, teams, users, comments, labels, cycles, and resources to PostHog.
+
+To link Linear:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Linear.
+
+3. Log in to your Linear account and authorize PostHog to access your data.
+
+4. Select the tables you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Linear data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -1,0 +1,31 @@
+You can sync data from LinkedIn Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Account, Campaigns, Campaign Stats, Campaign Groups and Campaign Groups Stats, as described here:
+
+- [Accounts](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?view=li-lms-2025-08&tabs=http)
+- [Campaigns](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaigns)
+- [Campaign Groups](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaign-groups)
+- [Campaign Stats](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=curl#ad-analytics): Ad analytics by CAMPAIGN
+- [Campaign Group Stats](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=curl#ad-analytics): Ad analytics by CAMPAIGN_GROUP
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+
+- A LinkedIn Ads account with permission to access data from accounts you want to sync.
+- Your account ID from the campaign manager (see how in the image below, it can also be taken from the URL like `https://www.linkedin.com/campaignmanager/accounts/(ID here)/overview?businessId=personal`)
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_04_at_5_12_47_PM_073654a608.png"
+  classes="rounded"
+  alt="LinkedIn account ID"
+/>
+
+## Configuring PostHog
+
+Connect PostHog to your LinkedIn Ads account using a LinkedIn account. The LinkedIn account must have permission to access data.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find LinkedIn Ads in the sources list and click **Link**.
+4. Enter the **Account ID** of the LinkedIn Ads account you want to sync.
+5. Select an existing LinkedIn Ads account, or create a new integration
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-mailchimp.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-mailchimp.mdx
@@ -1,0 +1,15 @@
+The Mailchimp connector can link lists, campaigns, reports, and contacts to PostHog.
+
+To link Mailchimp:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Mailchimp.
+
+3. Next, you need an API key from Mailchimp. Go to your [API keys settings](https://us1.admin.mailchimp.com/account/api/) in Mailchimp. Click **Create A Key**, give it a name, and copy the value of the newly created key. The key should be in the format `key-dc` (e.g., `abc123def456-us6`), where the suffix after the last hyphen is your Mailchimp data center.
+
+4. Back in PostHog, paste the API key in the `API key` field and click **Next**.
+
+5. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Mailchimp data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-mailerlite.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-mailerlite.mdx
@@ -1,0 +1,3 @@
+> **Mailer Lite** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-mailjet.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-mailjet.mdx
@@ -1,0 +1,3 @@
+> **Mailjet** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-marketo.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-marketo.mdx
@@ -1,0 +1,3 @@
+> **Marketo** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-meta-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-meta-ads.mdx
@@ -1,0 +1,32 @@
+You can sync data from Meta Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Adsets, Campaigns, Ads, Adset Report, Campaign Report, and Ad Report, as described here:
+
+- [Adsets](https://developers.facebook.com/docs/marketing-api/reference/ad-account/adsets/)
+- [Campaigns](https://developers.facebook.com/docs/marketing-api/reference/ad-account/campaigns/)
+- [Ads](https://developers.facebook.com/docs/marketing-api/reference/ad-account/ads/)
+- [Adset Insight](https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights/): filtered by level = `adset`
+- [Campaign Insight](https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights/): filtered by level = `campaign`
+- [Ad Insight](https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights/): filtered by level = `ad`
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+
+- A Meta Ads account with permission to access data from accounts you want to sync.
+- Your account ID from the [ads manager](https://adsmanager.facebook.com/) > Menu > Campaigns > Right next to the title you will see a dropdown > get the ID from the account or check the url `https://adsmanager.facebook.com/adsmanager/manage/campaigns?act=ID_HERE`
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Screenshot_2025_09_30_at_2_14_45_PM_ecce1881cf.png"
+  classes="rounded"
+  alt="Meta account ID"
+/>
+
+## Configuring PostHog
+
+Connect PostHog to your Meta Ads account using a Meta account. The Meta account must have permission to access data.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find Meta Ads in the sources list and click **Link**.
+4. Enter the **Account ID** of the Meta Ads account you want to sync.
+5. Select an existing Meta Ads account, or create a new integration.
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-microsoft-teams.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-microsoft-teams.mdx
@@ -1,0 +1,3 @@
+> **Microsoft Teams** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-mixpanel.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-mixpanel.mdx
@@ -1,0 +1,3 @@
+> **Mixpanel** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-monday.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-monday.mdx
@@ -1,0 +1,3 @@
+> **Monday** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-mongodb.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-mongodb.mdx
@@ -1,0 +1,29 @@
+The MongoDB connector can link your MongoDB collections to PostHog.
+
+To link MongoDB:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select MongoDB
+3. Enter your MongoDB connection string
+4. Click **Next**, select the collections you want to sync, as well as the [sync method](/docs/cdp/sources#incremental-vs-full-table), and then press **Import**
+
+Once the syncs are complete, you can start using MongoDB data in PostHog.
+
+> **Note:** MongoDB data is unstructured so the returned columns are an `_id` field and a `data` column that contain the entire document contents. Data fields can be selected with dot notation (e.g. `data.field1`)
+
+### Incremental and append-only syncing
+
+MongoDB supports incremental and append-only sync methods. For a field to be available for these sync methods, it must:
+
+1. **Have an index** — only indexed fields are eligible.
+2. **Be a supported type** — the following BSON types work:
+   - `date` or `timestamp`
+   - `int` or `long`
+   - `double` or `decimal`
+   - `objectId` (only for the `_id` field)
+
+PostHog infers field types from the first 10,000 documents in the collection, so fields with mixed types may resolve to an unsupported type.
+
+import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />

--- a/docs/published/docs/cdp/sources/_snippets/source-mysql.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-mysql.mdx
@@ -1,0 +1,27 @@
+The MySQL connector can link your database tables to PostHog.
+
+To link MySQL:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select MySQL
+3. Enter your database connection details:
+   - **Host:** The hostname or IP your database server like `db.example.com` or `123.132.1.100`.
+   - **Port:** The port your database server is listening to. The default is `3306`.
+   - **Database:** The name of the database you want like `analytics_db`.
+   - **User:** The username with the necessary permissions to access the database.
+   - **Password:** The password for the user.
+   - **Schema:** The schema for your database where your tables are located. The default is `public`.
+   - **Use SSL:** Whether to use SSL for the connection. Default is enabled.
+4. If you need to connect through an SSH tunnel, enable and configure it (optional):
+   - **Tunnel host:** The hostname of your SSH server.
+   - **Tunnel port:** The port your SSH server is listening on.
+   - **Authentication type:**
+     - For password authentication, enter your SSH username and password.
+     - For key-based authentication, enter your SSH username, private key, and optional passphrase.
+5. Click **Next**
+
+The data warehouse then starts syncing your MySQL data. You can see details and progress in the [sources tab](https://app.posthog.com/data-management/sources).
+
+import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />

--- a/docs/published/docs/cdp/sources/_snippets/source-netsuite.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-netsuite.mdx
@@ -1,0 +1,3 @@
+> **Net Suite** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-notion.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-notion.mdx
@@ -1,0 +1,3 @@
+> **Notion** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-okta.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-okta.mdx
@@ -1,0 +1,3 @@
+> **Okta** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-omnisend.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-omnisend.mdx
@@ -1,0 +1,3 @@
+> **Omnisend** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-onedrive.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-onedrive.mdx
@@ -1,0 +1,3 @@
+> **One Drive** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-oracle.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-oracle.mdx
@@ -1,0 +1,3 @@
+> **Oracle** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-outreach.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-outreach.mdx
@@ -1,0 +1,3 @@
+> **Outreach** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-paddle.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-paddle.mdx
@@ -1,0 +1,3 @@
+> **Paddle** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-pagerduty.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-pagerduty.mdx
@@ -1,0 +1,3 @@
+> **Pager Duty** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-pardot.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-pardot.mdx
@@ -1,0 +1,3 @@
+> **Pardot** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-paypal.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-paypal.mdx
@@ -1,0 +1,3 @@
+> **Pay Pal** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-pendo.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-pendo.mdx
@@ -1,0 +1,3 @@
+> **Pendo** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-pinterest-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-pinterest-ads.mdx
@@ -1,0 +1,26 @@
+You can sync data from Pinterest Ads by configuring it as a source in PostHog. The supported entities and reports include campaigns, ad groups, ads, campaign analytics, ad group analytics, and ad analytics:
+
+- [Campaigns](https://developers.pinterest.com/docs/api/v5/campaigns-list/): Campaign entities from your Pinterest Ads account
+- [Ad Groups](https://developers.pinterest.com/docs/api/v5/ad_groups-list/): Ad group entities within campaigns
+- [Ads](https://developers.pinterest.com/docs/api/v5/ads-list/): Individual ad entities within ad groups
+- [Campaign Analytics](https://developers.pinterest.com/docs/api/v5/campaigns-analytics/): Performance metrics at the campaign level
+- [Ad Group Analytics](https://developers.pinterest.com/docs/api/v5/ad_groups-analytics/): Performance metrics at the ad group level
+- [Ad Analytics](https://developers.pinterest.com/docs/api/v5/ads-analytics/): Performance metrics at the ad level
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+
+- A Pinterest Ads account with permission to access data from the accounts you want to sync.
+- Your Ad Account ID from [Pinterest Business](https://business.pinterest.com/) > Ads > select your account > the ID is in the URL or account settings.
+
+## Configuring PostHog
+
+Connect PostHog to your Pinterest Ads account. The Pinterest account must have permission to access the ad account data.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find Pinterest Ads in the sources list and click **Link**.
+4. Enter the **Ad Account ID** of the Pinterest Ads account you want to sync.
+5. Select an existing Pinterest Ads account, or create a new integration.
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-pipedrive.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-pipedrive.mdx
@@ -1,0 +1,3 @@
+> **Pipedrive** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-plaid.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-plaid.mdx
@@ -1,0 +1,3 @@
+> **Plaid** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-polar.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-polar.mdx
@@ -1,0 +1,3 @@
+> **Polar** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-postgres.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-postgres.mdx
@@ -1,0 +1,32 @@
+The Postgres connector can link your database tables to PostHog.
+
+To link Postgres:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select Postgres
+3. Enter your database connection details:
+   - **Host:** The hostname or IP your database server like `db.example.com` or `123.132.1.100`.
+   - **Port:** The port your database server is listening to. The default is `5432`.
+   - **Database:** The name of the database you want like `analytics_db`.
+   - **User:** The username with the necessary permissions to access the database.
+   - **Password:** The password for the user.
+   - **Schema:** The schema for your database where your tables are located. The default is `public`.
+4. Click **Link**
+
+The data warehouse then starts syncing your Postgres data. You can see details and progress in the [sources tab](https://app.posthog.com/data-management/sources).
+
+<CalloutBox icon="IconWarning" title="SSL/TLS required for new sources" type="caution">
+
+PostgreSQL sources created after February 18, 2026 require SSL/TLS encryption for database connections. Ensure your PostgreSQL database supports SSL/TLS connections before linking. Existing sources created before this date are not affected.
+
+</CalloutBox>
+
+> **Permissions** The Postgres source only requires read permissions on the schemas and tables you intend to sync.
+
+> **Looking for an example of the Postgres source?** Check out our tutorial where we [connect and query Supabase data](/tutorials/supabase-query).
+
+import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />
+
+> **Note:** We currently don't support connections using IPv6, therefore, you may need to enable IPv4 connections to your database. This is required for Supabase, for example.

--- a/docs/published/docs/cdp/sources/_snippets/source-postmark.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-postmark.mdx
@@ -1,0 +1,3 @@
+> **Postmark** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-productboard.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-productboard.mdx
@@ -1,0 +1,3 @@
+> **Productboard** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-quickbooks.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-quickbooks.mdx
@@ -1,0 +1,3 @@
+> **Quick Books** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-r2.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-r2.mdx
@@ -1,0 +1,52 @@
+The data warehouse can link to data in Cloudflare R2. To start, you'll need to:
+
+1. Create a bucket in R2
+2. Set up an access key and secret
+3. Add data to the bucket
+4. Create the table in PostHog
+
+## Step 1: Creating a bucket in R2
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. Go to the R2 overview and create a new bucket. We suggest using **Eastern North America** as a location hint if you're using PostHog Cloud US or **European Union** as a specific jurisdiction if you're using PostHog Cloud EU.
+
+![created bucket](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_16_at_10_06_02_2x_152e3c2309.png)
+
+3. In your bucket, upload the data you want to query such as [CSV](/tutorials/csv-query) or Parquet data. It can be as simple as a `.csv` file like this:
+
+```csv
+id,name,email
+1,John Doe,john@example.com
+2,Jane Doe,jane@example.com
+```
+
+> **Adding data to R2 automatically:** See our [S3 docs](/docs/data-warehouse/setup/s3#step-3-add-data-to-the-bucket) for how to set up Airbyte to automatically add data to the bucket. You can also use other ETL tools like Fivetran or Stitch.
+
+## Step 2: Create API tokens
+
+1. Head back to the R2 overview and under account details, click **Manage R2 API Tokens**
+2. Click **Create API token**, give your token a name, choose **Object Read only** as the permission type, apply it to your bucket, and click **Create API Token**
+
+![Create token](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_16_at_10_20_43_2x_97c29591fb.png)
+
+3. Copy the credentials for S3 clients, including the **Access Key ID**, **Secret Access Key**, and jurisdiction-specific endpoint URL. These will not be shown again, so make sure to copy them to a safe place.
+
+## Step 3: Create the table in PostHog
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and under self managed, look for **Cloudflare R2** and click **Link**
+3. Fill the table name, then use the data from Cloudflare:
+   - For files URL pattern, use the jurisdiction-specific endpoint URL with your bucket name and file name like `https://b27247d543c.r2.cloudflarestorage.com/posthog-warehouse/cool_data.csv`. You can also use `*` to query multiple files.
+   - Choose the correct file format
+   - When using CSV format, you can configure **CSV quote handling** to control how quotes are processed:
+     - **RFC 4180 double quotes** – for CSVs that use standard double-quote escaping (e.g., `"Hello ""World"""` becomes `Hello "World"`)
+     - **Literal quotes** – for CSVs where quote characters are treated as literal values (default)
+   - For access key, use your Access Key ID
+   - For secret key, use your Secret Access Key
+4. Click **Next**
+
+![Linking source](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_16_at_10_53_02_2x_0dc05b1af5.png)
+
+## Step 4: Query the table
+
+Once it is done syncing, you can now [query](/docs/data-warehouse/query) your new table using the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-recharge.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-recharge.mdx
@@ -1,0 +1,3 @@
+> **Recharge** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-recurly.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-recurly.mdx
@@ -1,0 +1,3 @@
+> **Recurly** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-reddit-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-reddit-ads.mdx
@@ -1,0 +1,32 @@
+You can sync data from Reddit Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Ad Groups, Campaigns, Ads, Ad Group Report, Campaign Report, and Ad Report, as described here:
+
+- [Ad Groups](https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Groups)
+- [Campaigns](https://ads-api.reddit.com/docs/v3/operations/List%20Campaigns)
+- [Ads](https://ads-api.reddit.com/docs/v3/operations/List%20Ads)
+- [Ad Groups Report](https://ads-api.reddit.com/docs/v3/operations/Get%20A%20Report): Report broken down by `AD_GROUP_ID`
+- [Campaign Report](https://ads-api.reddit.com/docs/v3/operations/Get%20A%20Report): Report broken down by `CAMPAIGN_ID`
+- [Ad Report](https://ads-api.reddit.com/docs/v3/operations/Get%20A%20Report): Report broken down by `AD_ID`
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+
+- A Reddit Ads account with permission to access data from accounts you want to sync.
+- Your account ID from the [business manager app](https://ads.reddit.com/business/) > Menu > Assets > Ad Accounts > get the ID
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_11_at_7_01_43_PM_c31b74db4c.png"
+  classes="rounded"
+  alt="Reddit account ID"
+/>
+
+## Configuring PostHog
+
+Connect PostHog to your Reddit Ads account using a Reddit account. The Reddit account must have permission to access data.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find Reddit Ads in the sources list and click **Link**.
+4. Enter the **Account ID** of the Reddit Ads account you want to sync.
+5. Select an existing Reddit Ads account, or create a new integration
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-redshift.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-redshift.mdx
@@ -1,0 +1,22 @@
+The Redshift connector can link your database tables to PostHog.
+
+To link Redshift:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select Redshift
+3. Enter your database connection details:
+   - **Host:** The hostname or IP of your Redshift cluster like `my-cluster.abc123.us-east-1.redshift.amazonaws.com`.
+   - **Port:** The port your Redshift cluster is listening on. The default is `5439`.
+   - **Database:** The name of the database you want like `analytics_db`.
+   - **User:** The username with the necessary permissions to access the database.
+   - **Password:** The password for the user.
+   - **Schema:** The schema for your database where your tables are located. The default is `public`.
+4. Click **Next**
+
+The data warehouse then starts syncing your Redshift data. You can see details and progress in the [sources tab](https://app.posthog.com/data-management/sources).
+
+> **Permissions:** The Redshift source only requires read permissions on the schemas and tables you intend to sync.
+
+import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />

--- a/docs/published/docs/cdp/sources/_snippets/source-revenuecat.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-revenuecat.mdx
@@ -1,0 +1,3 @@
+> **Revenue Cat** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-ringcentral.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-ringcentral.mdx
@@ -1,0 +1,3 @@
+> **Ring Central** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-s3.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-s3.mdx
@@ -1,0 +1,126 @@
+The data warehouse can link to data in your object storage system like S3. To start, you'll need to:
+
+1. Create a bucket in S3
+2. Set up an access key and secret
+3. Add data to the bucket (we'll use Airbyte)
+4. Create the table in PostHog
+
+## Step 1: Creating a bucket in S3
+
+1. Log in to [AWS](https://console.aws.amazon.com/).
+2. Open [S3](https://s3.console.aws.amazon.com/) in the AWS console and create a new bucket. We suggest `us-east-1` if you're using PostHog Cloud US, or `eu-central-1` if you're using PostHog Cloud EU.
+
+![created bucket](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/apps/s3-export/bucket.png)
+
+> Make sure to note both the name and region of your bucket, we'll need these later.
+
+## Step 2: Set up access policy and key
+
+Next, we need to create a new user in our AWS console with programmatic access to our newly created bucket.
+
+1. Open [IAM](https://console.aws.amazon.com/iam/home) and create a new policy to enable access to this bucket
+2. On the left under **Access management**, select **Policies** and click **Create policy**
+3. Under the service, choose **S3**
+4. Under **Actions**, select:
+5. **List** -> **ListBucket** and **ListBucketMultipartUploads**
+6. **Read** -> **GetBucketLocation** and **GetObject**
+7. **Write** -> **AbortMultipartUpload** and **PutObject**
+8. **Permission Management** -> **PutObjectAcl**
+9. Under **Resources**, select **Specific**. Under object, click **Add ARNs**
+10. Specify your bucket name and choose **Any object name**. In the example below, replace `posthog-s3-export` with the bucket name you chose in the previous section
+
+![bucket arn config](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_15_at_15_19_29_2x_15416e8e84.png)
+
+7. Your policy in JSON should look like this:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:PutObjectAcl",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::posthog-s3-export/*"
+    }
+  ]
+}
+```
+
+8. Click "Next" until you end up on the "Review Policy" page
+9. Give your policy a name and click "Create policy"
+
+The final step is to create a new user and give them access to our bucket by attaching our newly created policy.
+
+1. Open [IAM](https://console.aws.amazon.com/iam/home) and navigate to **Users** on the left
+2. Click **Create user**, add a user name, and click **Next**
+3. Select **Attach policies directly**
+4. Search for the policy you just created and click the checkbox on the far left to attach it to this user
+5. Click **Next** and then click **Create user**
+
+![User](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_15_at_16_16_34_2x_9f0f99d7a4.png)
+
+8. Once created, search and click on the user name and then click **Create access key**
+9. Select **Application running outside AWS** and then click **Next**
+10. Add a description tag value and click **Create access key**
+11. Copy the access key and secret access key values to somewhere safe. You will need to recreate these values if you lose them.
+
+![AWS access keys](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_15_at_16_17_45_2x_e7dcb9dd39.png)
+
+## Step 3: Add data to the bucket
+
+> For this section, we'll be using **Airbyte**. However, we accept any data in [CSV](/tutorials/csv-query) or Parquet format, so if you already have data in S3 you can skip this section.
+
+1. Go to [Airbyte](https://airbyte.com) and sign up for an account if you haven't already.
+2. Go to connections and click "New connection"
+3. Select a source. For this example, we'll grab data from **Stripe**, but you can use any of Airbyte's sources.
+4. Click "Set up a new destination"
+5. Select "S3" as the destination
+6. Fill in the "S3 Bucket Name", "S3 Bucket Region" with the name and region you created earlier.
+7. For "S3 Bucket Path", use `airbyte`.
+8. For the "Output Format", pick Parquet. You can use the default settings
+9. Under "Optional fields", you'll want to add the access key and secret from step 2.
+10. In the next step, pick the streams you want to fill. Given you'll manually need to create a table for each stream, we suggest being selective.
+11. Wait for the sync to finish
+
+![creating the s3 destination](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/features/data-warehouse/airbyte-destination.png)
+
+## Step 4: Create the table in PostHog
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and under self managed, look for **S3** and click **Link**
+3. Fill in the table name.
+4. For the URL pattern, copy the URL from S3, up to the bucket name. Replace the file name with `*`, as Airbyte will split large streams out into multiple files.
+   - For example: `https://your-bucket.s3.amazonaws.com/airbyte/invoices/*`
+5. For file format, select Parquet. Fill in the access key and secret key.
+6. When using CSV format, a **CSV quote handling** dropdown appears with two options:
+   - **RFC 4180 double quotes** - Use this if your CSV uses standard double-quote escaping (e.g., `"Hello ""World"""` becomes `Hello "World"`)
+   - **Literal quotes** - Use this if quotes in your CSV should be treated as literal characters. This is the default.
+
+> You'll want to repeat this step for each "stream" or folder that Airbyte created in your S3 bucket.
+
+![creating table in posthog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/features/data-warehouse/create-table.png)
+
+## Step 5: Query the table.
+
+Amazing! You can now [query](/docs/data-warehouse/query) your new table.
+
+## Troubleshooting
+
+- **Create table failed: Could not get columns**: Check that your **Files URL pattern** is correct and that your file format is correct. For example, make sure your columns don't have spaces and there aren't commas in cells in your `.csv` file.
+
+- **Create table failed: Access was denied when reading the provided file**: Make sure your access policies are correct.
+
+- **Create table failed: The provided file is not in Parquet format**: Make sure you've selected the correct file format.
+
+- **Create table failed: Some files in the bucket are archived**: Files stored in S3 Glacier or S3 Intelligent-Tiering archive storage classes cannot be accessed directly. Restore the files to Standard storage class or narrow your URL pattern to exclude archived files.
+
+- **CSV parsing failed with the selected quote setting**: Try switching the **CSV quote handling** option. Select **RFC 4180 double quotes** if your CSV uses standard quoting, or **Literal quotes** if quotes should be treated as-is.

--- a/docs/published/docs/cdp/sources/_snippets/source-salesforce.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-salesforce.mdx
@@ -1,0 +1,29 @@
+The Salesforce connector syncs your Salesforce data to PostHog. The following objects are supported:
+
+| Object             | Description                         |
+| ------------------ | ----------------------------------- |
+| Account            | Companies and organizations         |
+| Campaign           | Marketing campaigns                 |
+| Contact            | Individual contacts                 |
+| Event              | Calendar events                     |
+| Lead               | Sales leads                         |
+| Opportunity        | Sales opportunities                 |
+| OpportunityHistory | Historical changes to opportunities |
+| Order              | Orders                              |
+| Pricebook2         | Price books                         |
+| PricebookEntry     | Price book entries                  |
+| Product2           | Products                            |
+| Task               | Tasks and to-dos                    |
+| User               | Salesforce users                    |
+| UserRole           | User roles                          |
+
+To link Salesforce:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **Link Source** and select Salesforce
+3. Log in to your Salesforce account and authorize PostHog to access your data
+4. Select the objects you want to sync from the table above
+5. _Optional:_ Add a prefix to your table names
+6. Click **Next**
+
+The data warehouse then starts syncing your Salesforce data. You can see details and progress in the [data pipeline sources tab](https://app.posthog.com/data-management/sources).

--- a/docs/published/docs/cdp/sources/_snippets/source-salesloft.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-salesloft.mdx
@@ -1,0 +1,3 @@
+> **Sales Loft** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-sendgrid.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-sendgrid.mdx
@@ -1,0 +1,3 @@
+> **Send Grid** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-sentry.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-sentry.mdx
@@ -1,0 +1,42 @@
+The Sentry connector can link data from your Sentry organization into PostHog.
+
+## Creating a Sentry Auth Token
+
+Sentry supports several authentication methods, but for PostHog you should use an **Auth Token**.
+
+1. In Sentry, create a token from your account settings (for internal integrations or personal tokens).
+2. Give the token read access for the resources you want to sync.
+3. Copy the token and paste it into PostHog when linking your source.
+
+For token setup details, see Sentry's [Authentication docs](https://docs.sentry.io/api/auth/).
+
+Once the syncs are complete, you can start using Sentry data in PostHog.
+
+To link Sentry:
+
+1. Go to the [Data pipeline sources page](https://app.posthog.com/data-management/sources) in PostHog.
+2. Click **+ New source** and then click **Link** next to Sentry.
+3. In Sentry, create an **Auth Token** and copy it. PostHog currently supports Auth Tokens only.
+4. In PostHog, enter your Sentry **Organization slug** and **Auth Token**.
+5. Click **Next**, choose the tables you want to sync, and then click **Import**.
+
+## Available datasets and endpoints
+
+The Sentry source currently supports syncing the following datasets and API endpoints:
+
+| Dataset                 | Endpoint path                                          |
+| ----------------------- | ------------------------------------------------------ |
+| `projects`              | `/organizations/{organization_slug}/projects/`         |
+| `teams`                 | `/organizations/{organization_slug}/teams/`            |
+| `members`               | `/organizations/{organization_slug}/members/`          |
+| `releases`              | `/organizations/{organization_slug}/releases/`         |
+| `environments`          | `/organizations/{organization_slug}/environments/`     |
+| `monitors`              | `/organizations/{organization_slug}/monitors/`         |
+| `issues`                | `/organizations/{organization_slug}/issues/`           |
+| `project_events`        | `/projects/{organization_slug}/{project_slug}/events/` |
+| `project_users`         | `/projects/{organization_slug}/{project_slug}/users/`  |
+| `project_client_keys`   | `/projects/{organization_slug}/{project_slug}/keys/`   |
+| `project_service_hooks` | `/projects/{organization_slug}/{project_slug}/hooks/`  |
+| `issue_events`          | `/issues/{issue_id}/events/`                           |
+| `issue_hashes`          | `/issues/{issue_id}/hashes/`                           |
+| `issue_tag_values`      | `/issues/{issue_id}/tags/{key}/values/`                |

--- a/docs/published/docs/cdp/sources/_snippets/source-servicenow.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-servicenow.mdx
@@ -1,0 +1,3 @@
+> **Service Now** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-sftp.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-sftp.mdx
@@ -1,0 +1,3 @@
+> **SFTP** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-sharepoint.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-sharepoint.mdx
@@ -1,0 +1,3 @@
+> **Share Point** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-shopify.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-shopify.mdx
@@ -1,0 +1,35 @@
+The Shopify connector can sync your Shopify store data into PostHog.
+
+To sync Shopify data:
+
+## In Shopify
+
+1. Go to your Shopify store's admin panel at `https://admin.shopify.com/store/your-store-id`
+2. Click **Settings**.
+3. Click **Apps and sales channels**.
+4. Click **Develop apps**.
+5. **IMPORTANT:** Click **Build apps in Dev Dashboard** (legacy apps will be deprecated January 1 2026).
+6. Click **Create app**.
+7. Give your app a name and click **Create**.
+8. You will be redirected to a screen for releasing a new version of your app. Here, you need to:
+9. Set the app URL. Use the default value `https://shopify.dev/apps/default-app-home`.
+10. Choose the app scopes. We recommend that you select all read options for the simplest setup.
+11. Click **Release** and fill in the optional release details.
+12. Go to **Home** in the Dev Dashboard and click **Install app** to install the app in your store.
+13. Go to **Settings** in the Dev Dashboard and note your `Client ID` and `Secret` for later.
+
+For more information about creating apps in Dev Dashboard see
+[the Shopify docs](https://shopify.dev/docs/apps/build/dev-dashboard/create-apps-using-dev-dashboard).
+
+## In PostHog
+
+1. Go to the [data pipelines page](https://app.posthog.com/data-management/sources), and select the **Sources** tab.
+2. Click the **+ New source** button and select Shopify by clicking the **+ Create** button.
+3. Fill in your Shopify `Store ID` as well as the `Client ID` and `Secret` from above.
+4. _Optional:_ Add a prefix to your table names.
+5. Click **Next**.
+6. Select the Shopify objects you want to sync, and make any sync configuration changes you need.
+7. Click **Import**.
+
+After these setup steps, your Shopify data will be automatically synced to the PostHog data warehouse.
+You can see details and progress in the data pipelines [sources tab](https://app.posthog.com/data-management/sources).

--- a/docs/published/docs/cdp/sources/_snippets/source-shortcut.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-shortcut.mdx
@@ -1,0 +1,3 @@
+> **Shortcut** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-slack.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-slack.mdx
@@ -1,0 +1,3 @@
+> **Slack** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-smartsheet.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-smartsheet.mdx
@@ -1,0 +1,3 @@
+> **Smartsheet** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-snapchat-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-snapchat-ads.mdx
@@ -1,0 +1,39 @@
+You can sync data from Snapchat Ads by configuring it as a source in PostHog. These are the supported entities and reports:
+
+- [Campaigns](https://developers.snap.com/api/marketing-api/Ads-API/campaigns)
+- [Ad Squads](https://developers.snap.com/api/marketing-api/Ads-API/ad-squads)
+- [Ads](https://developers.snap.com/api/marketing-api/Ads-API/ads)
+- [Campaign Stats](https://developers.snap.com/api/marketing-api/Ads-API/measurement): Performance metrics at the campaign level
+- [Ad Squad Stats](https://developers.snap.com/api/marketing-api/Ads-API/measurement): Performance metrics at the ad squad level
+- [Ad Stats](https://developers.snap.com/api/marketing-api/Ads-API/measurement): Performance metrics at the ad level
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+
+- A Snapchat Ads account with permission to access data from accounts you want to sync.
+- Your ad account ID from the [Snapchat Ads Manager](https://ads.snapchat.com/) > **Ad Accounts** > The ad account ID will be visible next to the account name.
+- **Note:** You can also find it in the dashboard URL, e.g. `https://ads.snapchat.com/{ID_IS_HERE}/manage`.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2026_02_10_at_6_44_43_PM_c83b961fc0.png"
+  classes="rounded"
+  alt="Snapchat Ads account menu"
+/>
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2026_02_10_at_6_45_03_PM_4eced5e6a8.png"
+  classes="rounded"
+  alt="Snapchat Ads account ID"
+/>
+
+## Configuring PostHog
+
+Connect PostHog to your Snapchat Ads account using a Snapchat account. The Snapchat account must have permission to access the ad account data you want to sync.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/pipeline/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find Snapchat Ads in the sources list and click **Link**.
+4. Enter the **Ad Account ID** of the Snapchat Ads account you want to sync.
+5. Select an existing Snapchat Ads account, or create a new integration.
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-snowflake.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-snowflake.mdx
@@ -1,0 +1,34 @@
+The data warehouse can link to data in Snowflake.
+
+Start by going to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab and clicking **New source**. Choose Snowflake and enter the following data:
+
+- **Account identifier**: Likely a combination of your organization and the name of the account (e.g. `myorg-account123`). You can find this in the sidebar account selector or by executing the `CURRENT_ACCOUNT_NAME` and `CURRENT_ORGANIZATION_NAME` functions in SQL.
+- **Database**: Like `tasty_bytes_sample_data`
+- **Warehouse**: Like `compute_wh`
+- **User**: Your username like `IANVPH`
+- **Password**: The password for your user
+- **Role (optional)**: The role with necessary privileges to access your context like `accountadmin`.
+- **Schema**: The schema for your database like `RAW_POS`. If it isn't working, trying using all caps.
+- **Table Prefix:** The optional prefix for your tables in PostHog. For example, if your table name ended up being `menu`, a prefix of `snow_prod_` would create a table in PostHog called `snow_prod_menu`.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_23_at_13_50_56_2x_c31bfa6237.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_23_at_13_50_42_2x_aa20de1109.png"
+  alt="Snowflake details"
+  classes="rounded"
+/>
+
+Once added, click **Next**, select the tables you want to sync, as well as the [sync method](/docs/cdp/sources#incremental-vs-full-table), and then press **Import**.
+
+Once done, you can now [query](/docs/data-warehouse/query) your new table using the table name.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_23_at_13_56_32_2x_9c0bc2d35f.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_07_23_at_13_56_53_2x_76a2b7f711.png"
+  alt="Snowflake details"
+  classes="rounded"
+/>
+
+import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />

--- a/docs/published/docs/cdp/sources/_snippets/source-square.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-square.mdx
@@ -1,0 +1,3 @@
+> **Square** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-stripe.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-stripe.mdx
@@ -1,0 +1,30 @@
+The Stripe connector can link charges, customers, invoices, prices, products, subscriptions, and balance transactions to PostHog.
+
+## Creating a Stripe API key
+
+You need a [Stripe API key](https://dashboard.stripe.com/apikeys) to create a connector. Head to your Stripe dashboard > **Developers** > **API keys**, under **Restricted keys**, click [+ Create a restricted key](https://dashboard.stripe.com/apikeys/create).
+
+You need to give your API key the following **Read** permissions in the **Permissions** column:
+
+| Resource Type | Required Read Permissions                                                    |
+| ------------- | ---------------------------------------------------------------------------- |
+| Core          | Balance transaction sources, Charges, Customers, Disputes, Payouts, Products |
+| Billing       | Credit notes, Invoices, Prices, Subscriptions                                |
+| Connect       | Click **Read** in the **Connect** header                                     |
+
+If you aren't concerned with giving us more permissions than necessary, you can also simply click **Read** on the **Core**, **Billing**, and **Connect** headers to give us the necessary permissions.
+
+If your Stripe account is in a language other than English, we suggest you update it to English before following the steps above to guarantee the correct permissions are set.
+
+## Adding a data source
+
+1. In PostHog, go to the [Data pipeline page](https://app.posthog.com/data-management/sources) select the **Sources** tab.
+2. Click **+ New source** button and select Stripe by clicking the **Link** button.
+3. In Stripe, get your Account ID by going to **Settings** > **Business**, selecting the [Account details](https://dashboard.stripe.com/settings/account) tab, and clicking your **Account ID** or pressing `⌘` + `I` to copy your ID.
+4. Get your API key from the [previous section](#creating-a-stripe-api-key)
+5. _Optional:_ Add a prefix to your table names
+6. Click **Next**
+
+> For Stripe tables, incremental syncs will only sync new records and not update existing records. This is a limitation of the Stripe API in which it's not possible to query for updated data.
+
+The data warehouse then starts syncing your Stripe data. You can see details and progress in the [data pipeline sources tab](https://app.posthog.com/data-management/sources).

--- a/docs/published/docs/cdp/sources/_snippets/source-supabase.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-supabase.mdx
@@ -1,0 +1,3 @@
+> **Supabase** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-surveymonkey.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-surveymonkey.mdx
@@ -1,0 +1,3 @@
+> **Survey Monkey** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-temporal.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-temporal.mdx
@@ -1,0 +1,13 @@
+The Temporal.io connector can link workflows and workflow history to PostHog.
+
+To link Temporal.io:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Temporal.io.
+
+3. We only allow TLS certificate connections to your temporal namespace, so you need to ensure your namespace has a [certificate](https://docs.temporal.io/cloud/certificates) set up. Once done, copy all the same TLS certificate values into PostHog.
+
+4. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Temporal.io data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-tiktok-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-tiktok-ads.mdx
@@ -1,0 +1,32 @@
+You can sync data from TikTok Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Ad Groups, Campaigns, Ads, Ad Group Report, Campaign Report, and Ad Report, as described here:
+
+- [Ad Groups](https://business-api.tiktok.com/portal/docs?id=1739314558673922)
+- [Campaigns](https://business-api.tiktok.com/portal/docs?id=1739315828649986)
+- [Ads](https://business-api.tiktok.com/portal/docs?id=1735735588640770)
+- [Ad Groups Report](https://business-api.tiktok.com/portal/docs?id=1740302848100353): Filter by `adgroup_ids`
+- [Campaign Report](https://business-api.tiktok.com/portal/docs?id=1740302848100353): Filter by `campaign_ids`
+- [Ad Report](https://business-api.tiktok.com/portal/docs?id=1740302848100353): Filter by `ad_ids`
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+
+- A TikTok Ads account with permission to access data from accounts you want to sync.
+- Your account ID from the [ads manager](https://ads.tiktok.com/i18n/dashboard) > in the top right it's your account > open the dropdown > check your ad account ID or check the dashboard url, e.g `https://ads.tiktok.com/i18n/dashboard?aadvid=ID_HERE`
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Screenshot_2025_09_30_at_11_25_16_AM_ab70c4f7c4.png"
+  classes="rounded"
+  alt="Tiktok account ID"
+/>
+
+## Configuring PostHog
+
+Connect PostHog to your TikTok Ads account. The TikTok account must have permission to access data.
+
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/data-management/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find Tiktok Ads in the sources list and click **Link**.
+4. Enter the **Account ID** of the Tiktok Ads account you want to sync.
+5. Select an existing TikTok Ads account, or create a new integration.
+6. (Optional) Add a prefix for the table name.

--- a/docs/published/docs/cdp/sources/_snippets/source-trello.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-trello.mdx
@@ -1,0 +1,3 @@
+> **Trello** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-twilio.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-twilio.mdx
@@ -1,0 +1,3 @@
+> **Twilio** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-twitter-ads.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-twitter-ads.mdx
@@ -1,0 +1,3 @@
+> **Twitter Ads** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-typeform.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-typeform.mdx
@@ -1,0 +1,28 @@
+The Typeform connector can link data from your Typeform account into PostHog.
+
+## Linking Typeform
+
+1. In Typeform, go to your **Account** settings, navigate to **Personal tokens**, and click **Generate a new token**.
+2. Give the token a name and select the required scopes: **Forms: Read** and **Responses: Read**. Copy the token. For more details, see Typeform's [Personal Access Tokens docs](https://www.typeform.com/developers/get-started/personal-access-token/).
+3. In PostHog, go to the [Data pipeline sources page](https://app.posthog.com/data-management/sources), click **+ New source**, and then click **Link** next to Typeform.
+4. Paste your **Personal Access Token**. If your account is on the EU region, set the **API base URL** to `https://api.eu.typeform.com` or `https://api.typeform.eu`.
+5. Click **Next**, choose the tables you want to sync, and then click **Import**.
+
+## Available datasets and endpoints
+
+The Typeform source currently supports syncing the following datasets and API endpoints:
+
+| Dataset     | Endpoint path                |
+| ----------- | ---------------------------- |
+| `forms`     | `/forms`                     |
+| `responses` | `/forms/{form_id}/responses` |
+
+The `responses` dataset is a dependent (fan-out) endpoint — PostHog fetches all your forms first, then retrieves responses for each form individually.
+
+## Supported API base URLs
+
+| Region           | API base URL                  |
+| ---------------- | ----------------------------- |
+| Global (default) | `https://api.typeform.com`    |
+| EU               | `https://api.eu.typeform.com` |
+| EU (alternative) | `https://api.typeform.eu`     |

--- a/docs/published/docs/cdp/sources/_snippets/source-vitally.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-vitally.mdx
@@ -1,0 +1,15 @@
+The Vitally connector can link accounts, conversations, notes, tasks, and more to PostHog.
+
+To link Vitally:
+
+1. Go to the [sources tab](https://app.posthog.com/data-management/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Vitally.
+
+3. Next, you need a secret token from Vitally. To start, click on your account logo in the top left, then **Settings**. Next, under **Operations**, select **Integrations**. Choose **Vitally REST API**, enable the integration with the toggle, and copy the secret token.
+
+4. Back in PostHog, paste the token in the `Secret token` field, choose your Vitally region, and add a prefix for your tables if you want. Once all this is entered, click **Save**.
+
+5. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Vitally data in PostHog.

--- a/docs/published/docs/cdp/sources/_snippets/source-webflow.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-webflow.mdx
@@ -1,0 +1,3 @@
+> **Webflow** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-woocommerce.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-woocommerce.mdx
@@ -1,0 +1,3 @@
+> **Woo Commerce** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-workday.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-workday.mdx
@@ -1,0 +1,3 @@
+> **Workday** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-wrike.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-wrike.mdx
@@ -1,0 +1,3 @@
+> **Wrike** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-xero.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-xero.mdx
@@ -1,0 +1,3 @@
+> **Xero** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-youtube-analytics.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-youtube-analytics.mdx
@@ -1,0 +1,3 @@
+> **You Tube Analytics** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-zendesk.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-zendesk.mdx
@@ -1,0 +1,12 @@
+The Zendesk connector can link brands, groups, organizations, tickets, users, and sla policies.
+
+To link Zendesk:
+
+1. Go to the [Data pipeline page](https://app.posthog.com/data-management/sources) and the sources tab in PostHog
+2. Click **New source** and select Zendesk
+3. Provide the subdomain of your zendesk account (`https://posthoghelp.zendesk.com/` -> "posthoghelp" is the subdomain)
+4. Provide the [API token](https://support.zendesk.com/hc/en-us/articles/4408889192858-Managing-access-to-the-Zendesk-API#topic_bsw_lfg_mmb) and email associated with it
+5. _Optional:_ Add a prefix to your table names
+6. Click **Next**
+
+The data warehouse then starts syncing your Zendesk data. You can see details and progress in the [data pipeline sources tab](https://app.posthog.com/data-management/sources).

--- a/docs/published/docs/cdp/sources/_snippets/source-zoho-crm.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-zoho-crm.mdx
@@ -1,0 +1,3 @@
+> **Zoho CRM** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-zoom.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-zoom.mdx
@@ -1,0 +1,3 @@
+> **Zoom** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/_snippets/source-zuora.mdx
+++ b/docs/published/docs/cdp/sources/_snippets/source-zuora.mdx
@@ -1,0 +1,3 @@
+> **Zuora** as a data warehouse source is coming soon.
+>
+> Check the [sources overview](/docs/cdp/sources) for currently available sources.

--- a/docs/published/docs/cdp/sources/activecampaign.mdx
+++ b/docs/published/docs/cdp/sources/activecampaign.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Active Campaign as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceActiveCampaign from './_snippets/source-activecampaign.mdx'
+
+<SourceActiveCampaign />

--- a/docs/published/docs/cdp/sources/adjust.mdx
+++ b/docs/published/docs/cdp/sources/adjust.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Adjust as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAdjust from './_snippets/source-adjust.mdx'
+
+<SourceAdjust />

--- a/docs/published/docs/cdp/sources/aircall.mdx
+++ b/docs/published/docs/cdp/sources/aircall.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Aircall as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAircall from './_snippets/source-aircall.mdx'
+
+<SourceAircall />

--- a/docs/published/docs/cdp/sources/airtable.mdx
+++ b/docs/published/docs/cdp/sources/airtable.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Airtable as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAirtable from './_snippets/source-airtable.mdx'
+
+<SourceAirtable />

--- a/docs/published/docs/cdp/sources/amazon-ads.mdx
+++ b/docs/published/docs/cdp/sources/amazon-ads.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Amazon Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAmazonAds from './_snippets/source-amazon-ads.mdx'
+
+<SourceAmazonAds />

--- a/docs/published/docs/cdp/sources/amplitude.mdx
+++ b/docs/published/docs/cdp/sources/amplitude.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Amplitude as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAmplitude from './_snippets/source-amplitude.mdx'
+
+<SourceAmplitude />

--- a/docs/published/docs/cdp/sources/apple-search-ads.mdx
+++ b/docs/published/docs/cdp/sources/apple-search-ads.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Apple Search Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAppleSearchAds from './_snippets/source-apple-search-ads.mdx'
+
+<SourceAppleSearchAds />

--- a/docs/published/docs/cdp/sources/appsflyer.mdx
+++ b/docs/published/docs/cdp/sources/appsflyer.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Apps Flyer as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAppsFlyer from './_snippets/source-appsflyer.mdx'
+
+<SourceAppsFlyer />

--- a/docs/published/docs/cdp/sources/asana.mdx
+++ b/docs/published/docs/cdp/sources/asana.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Asana as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAsana from './_snippets/source-asana.mdx'
+
+<SourceAsana />

--- a/docs/published/docs/cdp/sources/ashby.mdx
+++ b/docs/published/docs/cdp/sources/ashby.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Ashby as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAshby from './_snippets/source-ashby.mdx'
+
+<SourceAshby />

--- a/docs/published/docs/cdp/sources/attio.mdx
+++ b/docs/published/docs/cdp/sources/attio.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Attio as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Attio from './_snippets/source-attio.mdx'
+
+<Attio />

--- a/docs/published/docs/cdp/sources/auth0.mdx
+++ b/docs/published/docs/cdp/sources/auth0.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Auth0 as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceAuth0 from './_snippets/source-auth0.mdx'
+
+<SourceAuth0 />

--- a/docs/published/docs/cdp/sources/azure-blob.mdx
+++ b/docs/published/docs/cdp/sources/azure-blob.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Azure as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import AzureBlob from './_snippets/source-azure-blob.mdx'
+
+<AzureBlob />

--- a/docs/published/docs/cdp/sources/azure-db.mdx
+++ b/docs/published/docs/cdp/sources/azure-db.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Azure SQL Server as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import AzureDB from './_snippets/source-azure-db.mdx'
+
+<AzureDB />

--- a/docs/published/docs/cdp/sources/bamboo-hr.mdx
+++ b/docs/published/docs/cdp/sources/bamboo-hr.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Bamboo HR as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceBambooHR from './_snippets/source-bamboo-hr.mdx'
+
+<SourceBambooHR />

--- a/docs/published/docs/cdp/sources/bigcommerce.mdx
+++ b/docs/published/docs/cdp/sources/bigcommerce.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Big Commerce as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceBigCommerce from './_snippets/source-bigcommerce.mdx'
+
+<SourceBigCommerce />

--- a/docs/published/docs/cdp/sources/bigquery.mdx
+++ b/docs/published/docs/cdp/sources/bigquery.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking BigQuery as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import BigQuery from './_snippets/source-bigquery.mdx'
+
+<BigQuery />

--- a/docs/published/docs/cdp/sources/bing-ads.mdx
+++ b/docs/published/docs/cdp/sources/bing-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking Bing Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import BingAds from './_snippets/source-bing-ads.mdx'
+
+<BingAds />

--- a/docs/published/docs/cdp/sources/box.mdx
+++ b/docs/published/docs/cdp/sources/box.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Box as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceBox from './_snippets/source-box.mdx'
+
+<SourceBox />

--- a/docs/published/docs/cdp/sources/braintree.mdx
+++ b/docs/published/docs/cdp/sources/braintree.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Braintree as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceBraintree from './_snippets/source-braintree.mdx'
+
+<SourceBraintree />

--- a/docs/published/docs/cdp/sources/braze.mdx
+++ b/docs/published/docs/cdp/sources/braze.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Braze as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceBraze from './_snippets/source-braze.mdx'
+
+<SourceBraze />

--- a/docs/published/docs/cdp/sources/brevo.mdx
+++ b/docs/published/docs/cdp/sources/brevo.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Brevo as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceBrevo from './_snippets/source-brevo.mdx'
+
+<SourceBrevo />

--- a/docs/published/docs/cdp/sources/buildbetter.mdx
+++ b/docs/published/docs/cdp/sources/buildbetter.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking BuildBetter as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import BuildBetter from './_snippets/source-buildbetter.mdx'
+
+<BuildBetter />

--- a/docs/published/docs/cdp/sources/calendly.mdx
+++ b/docs/published/docs/cdp/sources/calendly.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Calendly as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceCalendly from './_snippets/source-calendly.mdx'
+
+<SourceCalendly />

--- a/docs/published/docs/cdp/sources/campaignmonitor.mdx
+++ b/docs/published/docs/cdp/sources/campaignmonitor.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Campaign Monitor as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceCampaignMonitor from './_snippets/source-campaignmonitor.mdx'
+
+<SourceCampaignMonitor />

--- a/docs/published/docs/cdp/sources/chargebee.mdx
+++ b/docs/published/docs/cdp/sources/chargebee.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Chargebee as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Chargebee from './_snippets/source-chargebee.mdx'
+
+<Chargebee />

--- a/docs/published/docs/cdp/sources/chartmogul.mdx
+++ b/docs/published/docs/cdp/sources/chartmogul.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Chart Mogul as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceChartMogul from './_snippets/source-chartmogul.mdx'
+
+<SourceChartMogul />

--- a/docs/published/docs/cdp/sources/circleci.mdx
+++ b/docs/published/docs/cdp/sources/circleci.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Circle CI as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceCircleCI from './_snippets/source-circleci.mdx'
+
+<SourceCircleCI />

--- a/docs/published/docs/cdp/sources/clerk.mdx
+++ b/docs/published/docs/cdp/sources/clerk.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Clerk as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Clerk from './_snippets/source-clerk.mdx'
+
+<Clerk />

--- a/docs/published/docs/cdp/sources/clickup.mdx
+++ b/docs/published/docs/cdp/sources/clickup.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Click Up as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceClickUp from './_snippets/source-clickup.mdx'
+
+<SourceClickUp />

--- a/docs/published/docs/cdp/sources/close.mdx
+++ b/docs/published/docs/cdp/sources/close.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Close as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceClose from './_snippets/source-close.mdx'
+
+<SourceClose />

--- a/docs/published/docs/cdp/sources/cockroachdb.mdx
+++ b/docs/published/docs/cdp/sources/cockroachdb.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Cockroach DB as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceCockroachDB from './_snippets/source-cockroachdb.mdx'
+
+<SourceCockroachDB />

--- a/docs/published/docs/cdp/sources/confluence.mdx
+++ b/docs/published/docs/cdp/sources/confluence.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Confluence as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceConfluence from './_snippets/source-confluence.mdx'
+
+<SourceConfluence />

--- a/docs/published/docs/cdp/sources/convertkit.mdx
+++ b/docs/published/docs/cdp/sources/convertkit.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Convert Kit as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceConvertKit from './_snippets/source-convertkit.mdx'
+
+<SourceConvertKit />

--- a/docs/published/docs/cdp/sources/copper.mdx
+++ b/docs/published/docs/cdp/sources/copper.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Copper as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceCopper from './_snippets/source-copper.mdx'
+
+<SourceCopper />

--- a/docs/published/docs/cdp/sources/customerio.mdx
+++ b/docs/published/docs/cdp/sources/customerio.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Customer IO as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceCustomerIO from './_snippets/source-customerio.mdx'
+
+<SourceCustomerIO />

--- a/docs/published/docs/cdp/sources/datadog.mdx
+++ b/docs/published/docs/cdp/sources/datadog.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Datadog as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceDatadog from './_snippets/source-datadog.mdx'
+
+<SourceDatadog />

--- a/docs/published/docs/cdp/sources/doit.mdx
+++ b/docs/published/docs/cdp/sources/doit.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking DoIt as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import DoIt from './_snippets/source-doit.mdx'
+
+<DoIt />

--- a/docs/published/docs/cdp/sources/drip.mdx
+++ b/docs/published/docs/cdp/sources/drip.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Drip as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceDrip from './_snippets/source-drip.mdx'
+
+<SourceDrip />

--- a/docs/published/docs/cdp/sources/dynamodb.mdx
+++ b/docs/published/docs/cdp/sources/dynamodb.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Dynamo DB as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceDynamoDB from './_snippets/source-dynamodb.mdx'
+
+<SourceDynamoDB />

--- a/docs/published/docs/cdp/sources/elasticsearch.mdx
+++ b/docs/published/docs/cdp/sources/elasticsearch.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Elasticsearch as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceElasticsearch from './_snippets/source-elasticsearch.mdx'
+
+<SourceElasticsearch />

--- a/docs/published/docs/cdp/sources/eventbrite.mdx
+++ b/docs/published/docs/cdp/sources/eventbrite.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Eventbrite as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceEventbrite from './_snippets/source-eventbrite.mdx'
+
+<SourceEventbrite />

--- a/docs/published/docs/cdp/sources/facebook-pages.mdx
+++ b/docs/published/docs/cdp/sources/facebook-pages.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Facebook Pages as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceFacebookPages from './_snippets/source-facebook-pages.mdx'
+
+<SourceFacebookPages />

--- a/docs/published/docs/cdp/sources/firebase.mdx
+++ b/docs/published/docs/cdp/sources/firebase.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Firebase as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceFirebase from './_snippets/source-firebase.mdx'
+
+<SourceFirebase />

--- a/docs/published/docs/cdp/sources/freshdesk.mdx
+++ b/docs/published/docs/cdp/sources/freshdesk.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Freshdesk as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceFreshdesk from './_snippets/source-freshdesk.mdx'
+
+<SourceFreshdesk />

--- a/docs/published/docs/cdp/sources/freshsales.mdx
+++ b/docs/published/docs/cdp/sources/freshsales.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Freshsales as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceFreshsales from './_snippets/source-freshsales.mdx'
+
+<SourceFreshsales />

--- a/docs/published/docs/cdp/sources/front.mdx
+++ b/docs/published/docs/cdp/sources/front.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Front as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceFront from './_snippets/source-front.mdx'
+
+<SourceFront />

--- a/docs/published/docs/cdp/sources/fullstory.mdx
+++ b/docs/published/docs/cdp/sources/fullstory.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Full Story as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceFullStory from './_snippets/source-fullstory.mdx'
+
+<SourceFullStory />

--- a/docs/published/docs/cdp/sources/gcs.mdx
+++ b/docs/published/docs/cdp/sources/gcs.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Google Cloud Storage as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import GCS from './_snippets/source-gcs.mdx'
+
+<GCS />

--- a/docs/published/docs/cdp/sources/github.mdx
+++ b/docs/published/docs/cdp/sources/github.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking GitHub as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import GitHub from './_snippets/source-github.mdx'
+
+<GitHub />

--- a/docs/published/docs/cdp/sources/gitlab.mdx
+++ b/docs/published/docs/cdp/sources/gitlab.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Git Lab as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceGitLab from './_snippets/source-gitlab.mdx'
+
+<SourceGitLab />

--- a/docs/published/docs/cdp/sources/gong.mdx
+++ b/docs/published/docs/cdp/sources/gong.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Gong as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceGong from './_snippets/source-gong.mdx'
+
+<SourceGong />

--- a/docs/published/docs/cdp/sources/google-ads.mdx
+++ b/docs/published/docs/cdp/sources/google-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking Google Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import GoogleAds from './_snippets/source-google-ads.mdx'
+
+<GoogleAds />

--- a/docs/published/docs/cdp/sources/google-analytics.mdx
+++ b/docs/published/docs/cdp/sources/google-analytics.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Google Analytics as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceGoogleAnalytics from './_snippets/source-google-analytics.mdx'
+
+<SourceGoogleAnalytics />

--- a/docs/published/docs/cdp/sources/google-drive.mdx
+++ b/docs/published/docs/cdp/sources/google-drive.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Google Drive as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceGoogleDrive from './_snippets/source-google-drive.mdx'
+
+<SourceGoogleDrive />

--- a/docs/published/docs/cdp/sources/google-sheets.mdx
+++ b/docs/published/docs/cdp/sources/google-sheets.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking Google Sheets as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import GoogleSheets from './_snippets/source-google-sheets.mdx'
+
+<GoogleSheets />

--- a/docs/published/docs/cdp/sources/gorgias.mdx
+++ b/docs/published/docs/cdp/sources/gorgias.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Gorgias as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceGorgias from './_snippets/source-gorgias.mdx'
+
+<SourceGorgias />

--- a/docs/published/docs/cdp/sources/granola.mdx
+++ b/docs/published/docs/cdp/sources/granola.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Granola as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceGranola from './_snippets/source-granola.mdx'
+
+<SourceGranola />

--- a/docs/published/docs/cdp/sources/greenhouse.mdx
+++ b/docs/published/docs/cdp/sources/greenhouse.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Greenhouse as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceGreenhouse from './_snippets/source-greenhouse.mdx'
+
+<SourceGreenhouse />

--- a/docs/published/docs/cdp/sources/helpscout.mdx
+++ b/docs/published/docs/cdp/sources/helpscout.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Help Scout as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceHelpScout from './_snippets/source-helpscout.mdx'
+
+<SourceHelpScout />

--- a/docs/published/docs/cdp/sources/hubspot.mdx
+++ b/docs/published/docs/cdp/sources/hubspot.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Hubspot as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Hubspot from './_snippets/source-hubspot.mdx'
+
+<Hubspot />

--- a/docs/published/docs/cdp/sources/incoming-webhooks.mdx
+++ b/docs/published/docs/cdp/sources/incoming-webhooks.mdx
@@ -1,0 +1,104 @@
+---
+title: Incoming webhooks
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import { ProductScreenshot } from 'components/ProductScreenshot'
+
+Incoming webhooks enable you to send data from external systems directly into PostHog. This is useful for integrating with custom applications, third-party services, or any system that can make HTTP requests.
+
+In general, we recommend using our [SDKs](/docs/libraries) or [capture API](/docs/api/capture) but this is useful when you don't have control over the sender format and need to perform some transformation to match PostHog's event format.
+
+## How it works
+
+When you create an incoming webhook source, PostHog generates a unique URL that you can use to send data from your external systems. The webhook accepts POST requests with any JSON payload or GET requests with query parameters, and you can configure how to parse and map the incoming data to PostHog events.
+
+### Webhook URL format
+
+Your webhook URL will look like this:
+
+```text
+https://webhooks.us.posthog.com/public/webhooks/<UUID>
+```
+
+### Payload size limits
+
+Incoming webhook requests have a maximum payload size of 500KB. Requests exceeding this limit receive a `413` status code with the message "Request entity too large".
+
+## Transforming the webhook payload
+
+We recommend starting from the default [HTTP incoming webhook template](/docs/hog#hog-by-example-webhook). For most use cases, you can transform the incoming webhook to the required properties simply using our [Hog templating language](/docs/hog).
+
+### The request object
+
+The request object is available for templating the inputs as well as the underlying Hog code. It contains the following properties:
+
+- `request.method`: The HTTP method of the request
+- `request.query`: The query parameters of the request parsed as a dictionary of strings
+- `request.body`: The body of the request parsed as JSON
+- `request.headers`: The headers of the request as a dictionary
+- `request.ip`: The IP address of the requester
+
+For example if you send a request with curl like so:
+
+```bash
+curl -X POST https://webhooks.<region>.posthog.com/public/webhooks/<UUID>?test=123 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "event": "my example event",
+    "distinct_id": "webhook-test-123"
+  }'
+```
+
+Then the variables available to use will look like:
+
+```hog
+print(request.method)
+// Outputs: 'POST'
+print(request.query)
+// Outputs: { 'test': '123' }
+print(request.headers)
+// Outputs: { 'Content-Type': 'application/json' }
+print(request.body)
+// Outputs: { 'event': 'my example event', 'distinct_id': 'webhook-test-123' }
+print(request.ip)
+// Outputs: '127.0.0.1'
+```
+
+### Capturing a PostHog event
+
+If using the default template, you simply need to customize the inputs so that the required values `event` and `distinct_id` are set as well as the optional `properties` object.
+
+Under the hood, the code to capture an event is:
+
+```hog
+postHogCapture({
+    'event': input.event,
+    'distinct_id': input.distinct_id,
+    'properties': input.properties
+})
+```
+
+## (Advanced) HTTP requests and background processing
+
+Webhook sources can call `postHogCapture` to ingest events to PostHog. You can also do HTTP calls with `fetch`, but, in this case, the request is queued to a background task, a 201 Created response is returned, and the event is ingested asynchronously.
+
+## Troubleshooting
+
+### Testing your webhook
+
+You can test your webhook by sending a request to the webhook URL. You can use a tool like [curl](https://curl.se/) to send a request or use our built in testing tools when setting up the webhook. If you use `curl` or another tool, you can turn on the `Log payloads` switch in the `configuration` tab, and then check the `logs` tab to see the webhooks come in.
+
+Currently you have to save the webhook to test it as it directly hits the endpoint ensuring that the complete flow works.
+
+### Common issues
+
+- 401 Unauthorized - Check that your authorization header matches the configured value
+- 400 Bad Request - Verify that required fields (`event` and `distinct_id`) are provided
+- Timeout errors - Ensure your webhook processing completes within the time limit
+- 413 Request Entity Too Large - Your request payload exceeds the 500KB size limit. Reduce the payload size or split into multiple requests.

--- a/docs/published/docs/cdp/sources/index.mdx
+++ b/docs/published/docs/cdp/sources/index.mdx
@@ -1,0 +1,103 @@
+---
+title: Link a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import { ProductScreenshot } from 'components/ProductScreenshot'
+import { ManagedSources, SelfHostedSources } from '../../_snippets/data-sources'
+export const SettingsLight =
+  'https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_08_30_at_10_45_12_ef06f67105.png'
+export const SettingsDark =
+  'https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_08_30_at_10_47_20_f6c1d42503.png'
+
+PostHog enables you to link your most important data from sources like your CRM, payment processor, or database. Once linked, you can combine this data with the product analytics data already in PostHog and query across all of it.
+
+To link a source, go to the Integrations tab, and click the **Sources** tab.
+
+## Managed sources
+
+Provide your credentials and PostHog handles the entire extract and load process. Data syncs automatically from your source to PostHog's storage.
+
+<ManagedSources />
+
+## Self-hosted sources
+
+Upload CSV or Parquet files to your own object storage and link them as a source. PostHog reads directly from your storage on every query. You control data freshness and can store as much data as you want.
+
+<SelfHostedSources />
+
+import InboundIpAddresses from '../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />
+
+## Linking a custom source
+
+The data warehouse can link to data in your object storage system. To do this, you'll need to:
+
+1. Create a bucket in your object storage system like S3, GCS, or Cloudflare R2
+2. Set up an access key and secret
+3. Add data to the bucket (potentially using a tool like Airbyte, Fivetran, Stitch, or others)
+4. Link the table in PostHog
+
+See an example in our [S3 setup docs](/docs/cdp/sources/s3).
+
+## Incremental vs append only vs full table
+
+On some sources and tables, you can choose the sync method. The options are incremental replication or full table replication.
+
+### Incremental
+
+With incremental replication, you only sync new or updated data. This reduces the total number of rows synced and how long it takes to sync.
+
+When choosing incremental replication, you must select a field to identify new and updated data. This is often something like an `updated_at` timestamp, or an autoincrementing ID. Not all fields are suitable to be used to identify new and updated data, and so we only support the following types as replication keys:
+
+- `integer` (including `bigint` and `smallint`)
+- `datetime`
+- `date`
+- `timestamp`
+- `numeric` (for Snowflake)
+
+The one downside to incremental syncing is that deletions of data won't be synced to your PostHog data warehouse. You need to use full table refreshes for this.
+
+If you select a nullable field as the replication key, any rows where that field is null are skipped during sync. PostHog displays a warning when you select a nullable field. To avoid missing data, use a non-nullable field as the replication key.
+
+### Append only
+
+Append only does what it says on the tin: append rows to your table.
+
+We use a cursor in the form of an incremental field (similar to incremental syncing above) to query the source for new data. This replication method won't merge any rows, but this can cause duplicate data if you're using an incremental field that can change. To avoid this, we recommend using a timestamp field like `created_at`.
+
+Append only is ideal for tables where rows are never updated, only added. A common example is an event log table, where each new event is recorded as a new row and existing records remain unchanged.
+
+As with incremental syncing, selecting a nullable field as the cursor skips any rows where that field is null.
+
+### Full table
+
+This reloads the whole table on every sync. This is great for tables with common data deletions or ones without an incrementing field (such as a `updated_at` timestamp).
+
+## Syncing
+
+Once you add a source, you can see its status, sync frequency, and last successful run in the [sources page](https://app.posthog.com/data-management/sources). You can also reload or delete sources here.
+
+When you expand each source, you can see:
+
+- Schema name
+- Enable or disable syncing for that table
+- Synced table name in PostHog
+- Time the table was last synced
+
+If you add new tables to your source database, click **Pull new schemas** to discover them without waiting for the next sync. This only updates the list of available schemas – it doesn't trigger a data sync.
+
+To sync all enabled schemas at once, click **Sync now**. A confirmation dialog appears before the sync starts. This triggers a new sync for every enabled schema that isn't already syncing, so you don't need to sync schemas one by one.
+
+<ProductScreenshot
+  imageLight={SettingsLight}
+  imageDark={SettingsDark}
+  alt="Source settings in PostHog"
+  classes="rounded"
+/>

--- a/docs/published/docs/cdp/sources/instagram.mdx
+++ b/docs/published/docs/cdp/sources/instagram.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Instagram as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceInstagram from './_snippets/source-instagram.mdx'
+
+<SourceInstagram />

--- a/docs/published/docs/cdp/sources/intercom.mdx
+++ b/docs/published/docs/cdp/sources/intercom.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Intercom as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceIntercom from './_snippets/source-intercom.mdx'
+
+<SourceIntercom />

--- a/docs/published/docs/cdp/sources/iterable.mdx
+++ b/docs/published/docs/cdp/sources/iterable.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Iterable as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceIterable from './_snippets/source-iterable.mdx'
+
+<SourceIterable />

--- a/docs/published/docs/cdp/sources/jira.mdx
+++ b/docs/published/docs/cdp/sources/jira.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Jira as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceJira from './_snippets/source-jira.mdx'
+
+<SourceJira />

--- a/docs/published/docs/cdp/sources/kafka.mdx
+++ b/docs/published/docs/cdp/sources/kafka.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Kafka as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceKafka from './_snippets/source-kafka.mdx'
+
+<SourceKafka />

--- a/docs/published/docs/cdp/sources/klaviyo.mdx
+++ b/docs/published/docs/cdp/sources/klaviyo.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Klaviyo as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Klaviyo from './_snippets/source-klaviyo.mdx'
+
+<Klaviyo />

--- a/docs/published/docs/cdp/sources/launchdarkly.mdx
+++ b/docs/published/docs/cdp/sources/launchdarkly.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Launch Darkly as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceLaunchDarkly from './_snippets/source-launchdarkly.mdx'
+
+<SourceLaunchDarkly />

--- a/docs/published/docs/cdp/sources/lever.mdx
+++ b/docs/published/docs/cdp/sources/lever.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Lever as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceLever from './_snippets/source-lever.mdx'
+
+<SourceLever />

--- a/docs/published/docs/cdp/sources/linear.mdx
+++ b/docs/published/docs/cdp/sources/linear.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Linear as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Linear from './_snippets/source-linear.mdx'
+
+<Linear />

--- a/docs/published/docs/cdp/sources/linkedin-ads.mdx
+++ b/docs/published/docs/cdp/sources/linkedin-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking LinkedIn Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import LinkedinAds from './_snippets/source-linkedin-ads.mdx'
+
+<LinkedinAds />

--- a/docs/published/docs/cdp/sources/mailchimp.mdx
+++ b/docs/published/docs/cdp/sources/mailchimp.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Mailchimp as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Mailchimp from './_snippets/source-mailchimp.mdx'
+
+<Mailchimp />

--- a/docs/published/docs/cdp/sources/mailerlite.mdx
+++ b/docs/published/docs/cdp/sources/mailerlite.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Mailer Lite as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceMailerLite from './_snippets/source-mailerlite.mdx'
+
+<SourceMailerLite />

--- a/docs/published/docs/cdp/sources/mailjet.mdx
+++ b/docs/published/docs/cdp/sources/mailjet.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Mailjet as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceMailjet from './_snippets/source-mailjet.mdx'
+
+<SourceMailjet />

--- a/docs/published/docs/cdp/sources/marketo.mdx
+++ b/docs/published/docs/cdp/sources/marketo.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Marketo as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceMarketo from './_snippets/source-marketo.mdx'
+
+<SourceMarketo />

--- a/docs/published/docs/cdp/sources/meta-ads.mdx
+++ b/docs/published/docs/cdp/sources/meta-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking Meta Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import MetaAds from './_snippets/source-meta-ads.mdx'
+
+<MetaAds />

--- a/docs/published/docs/cdp/sources/microsoft-teams.mdx
+++ b/docs/published/docs/cdp/sources/microsoft-teams.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Microsoft Teams as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceMicrosoftTeams from './_snippets/source-microsoft-teams.mdx'
+
+<SourceMicrosoftTeams />

--- a/docs/published/docs/cdp/sources/mixpanel.mdx
+++ b/docs/published/docs/cdp/sources/mixpanel.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Mixpanel as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceMixpanel from './_snippets/source-mixpanel.mdx'
+
+<SourceMixpanel />

--- a/docs/published/docs/cdp/sources/monday.mdx
+++ b/docs/published/docs/cdp/sources/monday.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Monday as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceMonday from './_snippets/source-monday.mdx'
+
+<SourceMonday />

--- a/docs/published/docs/cdp/sources/mongodb.mdx
+++ b/docs/published/docs/cdp/sources/mongodb.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking MongoDB as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import MongoDB from './_snippets/source-mongodb.mdx'
+
+<MongoDB />

--- a/docs/published/docs/cdp/sources/mysql.mdx
+++ b/docs/published/docs/cdp/sources/mysql.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking MySQL as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import MySQL from './_snippets/source-mysql.mdx'
+
+<MySQL />

--- a/docs/published/docs/cdp/sources/netsuite.mdx
+++ b/docs/published/docs/cdp/sources/netsuite.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Net Suite as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceNetSuite from './_snippets/source-netsuite.mdx'
+
+<SourceNetSuite />

--- a/docs/published/docs/cdp/sources/notion.mdx
+++ b/docs/published/docs/cdp/sources/notion.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Notion as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceNotion from './_snippets/source-notion.mdx'
+
+<SourceNotion />

--- a/docs/published/docs/cdp/sources/okta.mdx
+++ b/docs/published/docs/cdp/sources/okta.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Okta as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceOkta from './_snippets/source-okta.mdx'
+
+<SourceOkta />

--- a/docs/published/docs/cdp/sources/omnisend.mdx
+++ b/docs/published/docs/cdp/sources/omnisend.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Omnisend as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceOmnisend from './_snippets/source-omnisend.mdx'
+
+<SourceOmnisend />

--- a/docs/published/docs/cdp/sources/onedrive.mdx
+++ b/docs/published/docs/cdp/sources/onedrive.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking One Drive as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceOneDrive from './_snippets/source-onedrive.mdx'
+
+<SourceOneDrive />

--- a/docs/published/docs/cdp/sources/oracle.mdx
+++ b/docs/published/docs/cdp/sources/oracle.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Oracle as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceOracle from './_snippets/source-oracle.mdx'
+
+<SourceOracle />

--- a/docs/published/docs/cdp/sources/outreach.mdx
+++ b/docs/published/docs/cdp/sources/outreach.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Outreach as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceOutreach from './_snippets/source-outreach.mdx'
+
+<SourceOutreach />

--- a/docs/published/docs/cdp/sources/paddle.mdx
+++ b/docs/published/docs/cdp/sources/paddle.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Paddle as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePaddle from './_snippets/source-paddle.mdx'
+
+<SourcePaddle />

--- a/docs/published/docs/cdp/sources/pagerduty.mdx
+++ b/docs/published/docs/cdp/sources/pagerduty.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Pager Duty as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePagerDuty from './_snippets/source-pagerduty.mdx'
+
+<SourcePagerDuty />

--- a/docs/published/docs/cdp/sources/pardot.mdx
+++ b/docs/published/docs/cdp/sources/pardot.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Pardot as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePardot from './_snippets/source-pardot.mdx'
+
+<SourcePardot />

--- a/docs/published/docs/cdp/sources/paypal.mdx
+++ b/docs/published/docs/cdp/sources/paypal.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Pay Pal as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePayPal from './_snippets/source-paypal.mdx'
+
+<SourcePayPal />

--- a/docs/published/docs/cdp/sources/pendo.mdx
+++ b/docs/published/docs/cdp/sources/pendo.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Pendo as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePendo from './_snippets/source-pendo.mdx'
+
+<SourcePendo />

--- a/docs/published/docs/cdp/sources/pinterest-ads.mdx
+++ b/docs/published/docs/cdp/sources/pinterest-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking Pinterest Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import PinterestAds from './_snippets/source-pinterest-ads.mdx'
+
+<PinterestAds />

--- a/docs/published/docs/cdp/sources/pipedrive.mdx
+++ b/docs/published/docs/cdp/sources/pipedrive.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Pipedrive as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePipedrive from './_snippets/source-pipedrive.mdx'
+
+<SourcePipedrive />

--- a/docs/published/docs/cdp/sources/plaid.mdx
+++ b/docs/published/docs/cdp/sources/plaid.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Plaid as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePlaid from './_snippets/source-plaid.mdx'
+
+<SourcePlaid />

--- a/docs/published/docs/cdp/sources/polar.mdx
+++ b/docs/published/docs/cdp/sources/polar.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Polar as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePolar from './_snippets/source-polar.mdx'
+
+<SourcePolar />

--- a/docs/published/docs/cdp/sources/postgres.mdx
+++ b/docs/published/docs/cdp/sources/postgres.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Postgres as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Postgres from './_snippets/source-postgres.mdx'
+
+<Postgres />

--- a/docs/published/docs/cdp/sources/postmark.mdx
+++ b/docs/published/docs/cdp/sources/postmark.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Postmark as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourcePostmark from './_snippets/source-postmark.mdx'
+
+<SourcePostmark />

--- a/docs/published/docs/cdp/sources/productboard.mdx
+++ b/docs/published/docs/cdp/sources/productboard.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Productboard as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceProductboard from './_snippets/source-productboard.mdx'
+
+<SourceProductboard />

--- a/docs/published/docs/cdp/sources/quickbooks.mdx
+++ b/docs/published/docs/cdp/sources/quickbooks.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Quick Books as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceQuickBooks from './_snippets/source-quickbooks.mdx'
+
+<SourceQuickBooks />

--- a/docs/published/docs/cdp/sources/r2.mdx
+++ b/docs/published/docs/cdp/sources/r2.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Cloudflare R2 as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import R2 from './_snippets/source-r2.mdx'
+
+<R2 />

--- a/docs/published/docs/cdp/sources/recharge.mdx
+++ b/docs/published/docs/cdp/sources/recharge.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Recharge as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceRecharge from './_snippets/source-recharge.mdx'
+
+<SourceRecharge />

--- a/docs/published/docs/cdp/sources/recurly.mdx
+++ b/docs/published/docs/cdp/sources/recurly.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Recurly as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceRecurly from './_snippets/source-recurly.mdx'
+
+<SourceRecurly />

--- a/docs/published/docs/cdp/sources/reddit-ads.mdx
+++ b/docs/published/docs/cdp/sources/reddit-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking Reddit Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import RedditAds from './_snippets/source-reddit-ads.mdx'
+
+<RedditAds />

--- a/docs/published/docs/cdp/sources/redshift.mdx
+++ b/docs/published/docs/cdp/sources/redshift.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Redshift as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Redshift from './_snippets/source-redshift.mdx'
+
+<Redshift />

--- a/docs/published/docs/cdp/sources/revenuecat.mdx
+++ b/docs/published/docs/cdp/sources/revenuecat.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Revenue Cat as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceRevenueCat from './_snippets/source-revenuecat.mdx'
+
+<SourceRevenueCat />

--- a/docs/published/docs/cdp/sources/ringcentral.mdx
+++ b/docs/published/docs/cdp/sources/ringcentral.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Ring Central as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceRingCentral from './_snippets/source-ringcentral.mdx'
+
+<SourceRingCentral />

--- a/docs/published/docs/cdp/sources/s3.mdx
+++ b/docs/published/docs/cdp/sources/s3.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking S3 as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import S3 from './_snippets/source-s3.mdx'
+
+<S3 />

--- a/docs/published/docs/cdp/sources/salesforce.mdx
+++ b/docs/published/docs/cdp/sources/salesforce.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Salesforce as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Salesforce from './_snippets/source-salesforce.mdx'
+
+<Salesforce />

--- a/docs/published/docs/cdp/sources/salesloft.mdx
+++ b/docs/published/docs/cdp/sources/salesloft.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Sales Loft as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSalesLoft from './_snippets/source-salesloft.mdx'
+
+<SourceSalesLoft />

--- a/docs/published/docs/cdp/sources/sendgrid.mdx
+++ b/docs/published/docs/cdp/sources/sendgrid.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Send Grid as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSendGrid from './_snippets/source-sendgrid.mdx'
+
+<SourceSendGrid />

--- a/docs/published/docs/cdp/sources/sentry.mdx
+++ b/docs/published/docs/cdp/sources/sentry.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Sentry as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Sentry from './_snippets/source-sentry.mdx'
+
+<Sentry />

--- a/docs/published/docs/cdp/sources/servicenow.mdx
+++ b/docs/published/docs/cdp/sources/servicenow.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Service Now as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceServiceNow from './_snippets/source-servicenow.mdx'
+
+<SourceServiceNow />

--- a/docs/published/docs/cdp/sources/sftp.mdx
+++ b/docs/published/docs/cdp/sources/sftp.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking SFTP as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSFTP from './_snippets/source-sftp.mdx'
+
+<SourceSFTP />

--- a/docs/published/docs/cdp/sources/sharepoint.mdx
+++ b/docs/published/docs/cdp/sources/sharepoint.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Share Point as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSharePoint from './_snippets/source-sharepoint.mdx'
+
+<SourceSharePoint />

--- a/docs/published/docs/cdp/sources/shopify.mdx
+++ b/docs/published/docs/cdp/sources/shopify.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Shopify as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Shopify from './_snippets/source-shopify.mdx'
+
+<Shopify />

--- a/docs/published/docs/cdp/sources/shortcut.mdx
+++ b/docs/published/docs/cdp/sources/shortcut.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Shortcut as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceShortcut from './_snippets/source-shortcut.mdx'
+
+<SourceShortcut />

--- a/docs/published/docs/cdp/sources/slack.mdx
+++ b/docs/published/docs/cdp/sources/slack.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Slack as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSlack from './_snippets/source-slack.mdx'
+
+<SourceSlack />

--- a/docs/published/docs/cdp/sources/smartsheet.mdx
+++ b/docs/published/docs/cdp/sources/smartsheet.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Smartsheet as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSmartsheet from './_snippets/source-smartsheet.mdx'
+
+<SourceSmartsheet />

--- a/docs/published/docs/cdp/sources/snapchat-ads.mdx
+++ b/docs/published/docs/cdp/sources/snapchat-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking Snapchat Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import SnapchatAds from './_snippets/source-snapchat-ads.mdx'
+
+<SnapchatAds />

--- a/docs/published/docs/cdp/sources/snowflake.mdx
+++ b/docs/published/docs/cdp/sources/snowflake.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Snowflake as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Snowflake from './_snippets/source-snowflake.mdx'
+
+<Snowflake />

--- a/docs/published/docs/cdp/sources/square.mdx
+++ b/docs/published/docs/cdp/sources/square.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Square as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSquare from './_snippets/source-square.mdx'
+
+<SourceSquare />

--- a/docs/published/docs/cdp/sources/stripe.mdx
+++ b/docs/published/docs/cdp/sources/stripe.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Stripe as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Stripe from './_snippets/source-stripe.mdx'
+
+<Stripe />

--- a/docs/published/docs/cdp/sources/supabase.mdx
+++ b/docs/published/docs/cdp/sources/supabase.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Supabase as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSupabase from './_snippets/source-supabase.mdx'
+
+<SourceSupabase />

--- a/docs/published/docs/cdp/sources/surveymonkey.mdx
+++ b/docs/published/docs/cdp/sources/surveymonkey.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Survey Monkey as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceSurveyMonkey from './_snippets/source-surveymonkey.mdx'
+
+<SourceSurveyMonkey />

--- a/docs/published/docs/cdp/sources/temporal.mdx
+++ b/docs/published/docs/cdp/sources/temporal.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Temporal.io as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Temporal from './_snippets/source-temporal.mdx'
+
+<Temporal />

--- a/docs/published/docs/cdp/sources/tiktok-ads.mdx
+++ b/docs/published/docs/cdp/sources/tiktok-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking TikTok Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import TiktokAds from './_snippets/source-tiktok-ads.mdx'
+
+<TiktokAds />

--- a/docs/published/docs/cdp/sources/trello.mdx
+++ b/docs/published/docs/cdp/sources/trello.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Trello as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceTrello from './_snippets/source-trello.mdx'
+
+<SourceTrello />

--- a/docs/published/docs/cdp/sources/twilio.mdx
+++ b/docs/published/docs/cdp/sources/twilio.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Twilio as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceTwilio from './_snippets/source-twilio.mdx'
+
+<SourceTwilio />

--- a/docs/published/docs/cdp/sources/twitter-ads.mdx
+++ b/docs/published/docs/cdp/sources/twitter-ads.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Twitter Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceTwitterAds from './_snippets/source-twitter-ads.mdx'
+
+<SourceTwitterAds />

--- a/docs/published/docs/cdp/sources/typeform.mdx
+++ b/docs/published/docs/cdp/sources/typeform.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Typeform as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Typeform from './_snippets/source-typeform.mdx'
+
+<Typeform />

--- a/docs/published/docs/cdp/sources/vitally.mdx
+++ b/docs/published/docs/cdp/sources/vitally.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Vitally as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Vitally from './_snippets/source-vitally.mdx'
+
+<Vitally />

--- a/docs/published/docs/cdp/sources/webflow.mdx
+++ b/docs/published/docs/cdp/sources/webflow.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Webflow as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceWebflow from './_snippets/source-webflow.mdx'
+
+<SourceWebflow />

--- a/docs/published/docs/cdp/sources/woocommerce.mdx
+++ b/docs/published/docs/cdp/sources/woocommerce.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Woo Commerce as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceWooCommerce from './_snippets/source-woocommerce.mdx'
+
+<SourceWooCommerce />

--- a/docs/published/docs/cdp/sources/workday.mdx
+++ b/docs/published/docs/cdp/sources/workday.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Workday as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceWorkday from './_snippets/source-workday.mdx'
+
+<SourceWorkday />

--- a/docs/published/docs/cdp/sources/wrike.mdx
+++ b/docs/published/docs/cdp/sources/wrike.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Wrike as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceWrike from './_snippets/source-wrike.mdx'
+
+<SourceWrike />

--- a/docs/published/docs/cdp/sources/xero.mdx
+++ b/docs/published/docs/cdp/sources/xero.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Xero as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceXero from './_snippets/source-xero.mdx'
+
+<SourceXero />

--- a/docs/published/docs/cdp/sources/youtube-analytics.mdx
+++ b/docs/published/docs/cdp/sources/youtube-analytics.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking You Tube Analytics as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceYouTubeAnalytics from './_snippets/source-youtube-analytics.mdx'
+
+<SourceYouTubeAnalytics />

--- a/docs/published/docs/cdp/sources/zendesk.mdx
+++ b/docs/published/docs/cdp/sources/zendesk.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Zendesk as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Zendesk from './_snippets/source-zendesk.mdx'
+
+<Zendesk />

--- a/docs/published/docs/cdp/sources/zoho-crm.mdx
+++ b/docs/published/docs/cdp/sources/zoho-crm.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Zoho CRM as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceZohoCRM from './_snippets/source-zoho-crm.mdx'
+
+<SourceZohoCRM />

--- a/docs/published/docs/cdp/sources/zoom.mdx
+++ b/docs/published/docs/cdp/sources/zoom.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Zoom as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceZoom from './_snippets/source-zoom.mdx'
+
+<SourceZoom />

--- a/docs/published/docs/cdp/sources/zuora.mdx
+++ b/docs/published/docs/cdp/sources/zuora.mdx
@@ -1,0 +1,13 @@
+---
+title: Linking Zuora as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import SourceZuora from './_snippets/source-zuora.mdx'
+
+<SourceZuora />

--- a/docs/published/docs/cdp/transformations/customizing-transformations.md
+++ b/docs/published/docs/cdp/transformations/customizing-transformations.md
@@ -1,0 +1,165 @@
+---
+title: 'Customizing transformations'
+showTitle: true
+---
+
+We've got a great library to get you started with the most common transformation needs. If you want to go further, you can write your own using our [Hog](/docs/hog) programming language.
+
+## Event object
+
+During ingestion, transformations only have access to the event object. Here's the structure of the event object available in transformations:
+
+```ts
+{
+  uuid: string // The unique ID of the event
+  event: string // The event name (e.g. $pageview)
+  distinct_id: string // The distinct_id of the identity that created the event
+  properties: Record<string, any> // All event properties
+  timestamp: string
+}
+```
+
+## Modifying transformations with Hog
+
+For most cases, we recommend using one of the pre-built transformations. These take care of most logic under the hood, exposing simple inputs for you to configure.
+
+You can also use any of these transformations as a starting point for your own code by clicking `edit source code`. From here you can modify the inputs – for example marking an input as `secret` so that it is encrypted at rest – or changing the implementation of the transformation itself.
+
+![Modifying transformation inputs](https://res.cloudinary.com/dmukukwp6/image/upload/inputs_4cedae5a39.png)
+
+Since transformations happen during ingestion, they cannot make external HTTP calls. Instead, they focus on modifying the event object directly.
+
+## Writing custom Hog transformations
+
+A transformation in PostHog receives an `event` object as input and should return a modified version of that event (or `null` to drop the event).
+
+Here's a basic transformation template:
+
+```Hog
+// Basic transformation template
+// Return the event to keep it, or null to drop it entirely
+return event
+```
+
+> **Important:** Returning `null` will completely drop the event from further processing. Be extremely careful with this as the event will be permanently lost.
+
+### Working with the event object
+
+The `event` object is a global that cannot be modified directly. Instead, you need to:
+
+1. Create a copy of the event
+2. Modify the copy
+3. Return the modified copy
+
+Here's the pattern:
+
+```Hog
+// Create a copy of the event
+let returnEvent := event
+
+// Ensure properties exist
+returnEvent.properties := returnEvent.properties ?? {}
+
+// Modify properties on the copy
+returnEvent.properties.my_custom_property := "new value"
+
+// Return the modified copy
+return returnEvent
+```
+
+Returning `event` without modification will simply pass the original event through unchanged.
+
+### Debugging with print statements
+
+Use `print()` statements to debug your transformations. These logs will appear in the Logs tab of your Hog function:
+
+```Hog
+print("Processing event", event.event)
+print("Current properties", event.properties)
+
+// After making changes
+print("Modified event", returnEvent)
+```
+
+This is extremely helpful for understanding what data you're working with and verifying your transformation logic.
+
+### Accessing inputs
+
+You can add inputs to your transformation. You can access them through the `inputs` object. In the default transformation, inputs are named sequentially:
+
+```Hog
+// Example of accessing inputs in the default transformation
+let firstInput := inputs.input_1
+let secondInput := inputs.input_2
+let thirdInput := inputs.input_3
+
+print("Using first input", firstInput)
+print("Using second input", secondInput)
+```
+
+### Testing your transformation
+
+You can test your transformation in the testing section with:
+
+1. Our example event (pre-populated)
+2. A real event from your instance (randomly selected)
+3. Your own custom event JSON
+
+This allows you to verify your transformation works correctly before enabling it.
+
+Here's a simple example of a custom transformation that anonymizes IP addresses by replacing the last octet with '0' to protect user privacy while still maintaining geographic information:
+
+```Hog
+// Check if the event has an IP address
+if (empty(event.properties?.$ip)) {
+    print('No IP address found in event')
+    return event
+}
+
+let ip := event.properties.$ip
+let parts := splitByString('.', ip)
+
+// Check if we have exactly 4 parts for IPv4
+if (length(parts) != 4) {
+    print('Invalid IP address format: wrong number of octets')
+    return event
+}
+
+// Validate each octet is a number between 0 and 255
+for (let i := 1; i <= 4; i := i + 1) {
+    let octet := toInt(parts[i])
+    if (octet = null or octet < 0 or octet > 255) {
+        print('Invalid IP address: octets must be numbers between 0 and 255')
+        return event
+    }
+}
+
+// Replace the last octet with '0'
+let anonymizedIp := concat(parts[1], '.', parts[2], '.', parts[3], '.0')
+
+//Note: The global event object is immutable and cannot be modified directly.
+//That's why we create a new returnEvent object to make our changes.
+let returnEvent := event
+returnEvent.properties.$ip := anonymizedIp
+return returnEvent
+```
+
+![Edit source code](https://res.cloudinary.com/dmukukwp6/image/upload/dropping_events_93de04fa29.png)
+
+Important: Returning `undefined` or `null` will drop the event entirely. This means the event will not be ingested into PostHog and the data will be lost forever. Use this feature carefully and only when you are certain you want to permanently discard certain events.
+
+For more details and inspiration, you can always view the source code of any transformation.
+
+### Guidelines for modifying a transformation
+
+- **Start from an existing template:** You can either choose the "Custom transformation" transformation from our transformations list, or check out existing transformations that are close to the problem you're solving and work from there.
+
+- **Rely on filters:** Offload as much as possible to the built in `filters` and `inputs`. This will make modifying your transformation later much simpler (as well as being more performant). Remember that your transformation will only be applied to events that match the filter criteria.
+
+- **Use `inputs` wherever possible:** These are great for configuration values. You can even mark them as secret: they will not be returned to the UI in the future and will be stored encrypted.
+
+- **Keep it short:** We have tight controls on execution time and memory usage. Transformations should be lightweight since they run on every event during ingestion.
+
+- **No external calls:** Transformations cannot make HTTP calls or access external services. They can only modify the event object directly.
+
+- **Focus on the event:** Remember that you only have access to the event object during ingestion. You cannot access person profiles, groups, or any other PostHog data.

--- a/docs/published/docs/cdp/transformations/drop-events.mdx
+++ b/docs/published/docs/cdp/transformations/drop-events.mdx
@@ -1,0 +1,120 @@
+---
+title: Drop events
+templateId:
+  - template-drop-events
+---
+
+import FeedbackQuestions from '../_snippets/feedback-questions.mdx'
+import PostHogMaintained from '../_snippets/posthog-maintained.mdx'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+Selectively discard events from being ingested based on specific criteria. Dropped events are permanently removed from your data pipeline, preventing them from being stored or processed by PostHog.
+
+<CalloutBox icon="IconPiggyBank" title="Impact on usage & billing" type="info">
+
+Events that are dropped using a transformation **do not count towards your usage/billing**.
+
+While we encourage you to [instrument custom events](/docs/getting-started/send-events#2-capture-custom-events) and [configure autocapture](/docs/product-analytics/autocapture) to only capture the events you need long term, a **Drop Events** transformation can serve as a temporary solution to reduce usage immediately (vs. waiting for your next deployment cycle to modify custom events or configuration).
+
+It can also be useful when you want more granular control over _bundled_ autocapture events such as excluding a [specific app lifecycle events](/docs/product-analytics/autocapture#react-native-navigation-and-lifecycle-autocapture) and only capturing the ones you need.
+
+</CalloutBox>
+
+## Installation
+
+1. In PostHog, click the [Data pipeline](https://app.posthog.com/data-management/transformations) tab in the left sidebar.
+2. Click the [Transformations](https://app.posthog.com/data-management/transformations) tab.
+3. Search for **Drop events** and click **+ Create**.
+4. Configure your filters to target the events you want to drop.
+5. Press **Create & Enable** to start dropping matching events.
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+The drop events transformation uses filters to target specific events for removal.
+
+### Filtering options
+
+1. **Event matching**: Target specific event types by name (e.g., `$pageview`, `user_signed_up`)
+2. **Property filters**: Further refine your filters with property conditions:
+   - Match on any event property
+   - Supports operators like equals, contains, greater than, etc.
+   - Apply property filters globally across all events or specifically to individual event types
+
+### How to use the filters
+
+The drop events transformation uses two types of filters that work together:
+
+1. **Match events filters**: These filters operate with OR logic. If an event matches ANY of these filters, it will be considered for dropping. For example, if you select both `$pageview` and `$pageleave` events, the transformation will match events of either type.
+
+![Drop events based on event filters](https://res.cloudinary.com/dmukukwp6/image/upload/Event_Filter_OR_066f58e3bc.png)
+
+2. **Property filters**: These filters use AND logic and are applied after the event matching. ALL property conditions must be met for an event to be dropped. For example, if you set:
+   - `browser is set`
+   - `Country Name is set`
+
+   Only events that have BOTH properties matching these conditions will be dropped.
+
+![Drop events based on property filters](https://res.cloudinary.com/dmukukwp6/image/upload/Property_Filter_And_2dc645185c.png)
+
+3. **Property filters on event match filter**: You can add property filters directly to event match filters. For example:
+   - If you select "All events" and add a property filter "browser is set", it will drop ALL events that have the browser property set
+   - If you also add specific event matches like `$pageview` and `$pageleave`, it will drop:
+     - All `$pageview` events
+     - All `$pageleave` events
+     - Any other events that have the browser property set
+
+![Drop events based on combined filters](https://res.cloudinary.com/dmukukwp6/image/upload/Both_Event_Filter_And_Property_Filter_9b5360cdd4.png)
+
+### Example of combined filters
+
+Let's say you configure the following:
+
+**Match events**:
+
+- `$pageview`
+- `user_signed_up`
+
+**Property filters**:
+
+- `browser is set`
+- `Country Name is set`
+
+This configuration will drop:
+
+- Any `$pageview` events that have both browser and country name properties set
+- Any `$pageleave` events that have both browser and country name properties set
+
+Events that don't meet ALL these criteria (like a `$pageview` missing the browser property, or a `$pageleave` event missing the country name) will not be dropped.
+
+## Testing
+
+Before enabling your drop events transformation in production, use the built-in testing interface to verify it works as expected:
+
+1. Go to the **Testing** section of your transformation
+2. Select an event to test with
+3. Run the test to see if the event would be dropped
+4. Iterate on your filters until you're satisfied with the results
+
+## FAQ
+
+### Is the source code for this transformation available?
+
+PostHog is open-source and so are all the transformations on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/drop_events/template_drop_events.py) is available on GitHub.
+
+### What happens to dropped events?
+
+Dropped events are permanently deleted and cannot be recovered. They are removed before ingestion, so they won't appear in any analytics, cohorts, or exports.
+
+### How do I monitor what's being dropped?
+
+Check the metrics and logs tabs regularly to ensure the transformation is working as expected. The metrics tab shows how many events have been processed and dropped.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/docs/published/docs/cdp/transformations/index.md
+++ b/docs/published/docs/cdp/transformations/index.md
@@ -1,0 +1,106 @@
+---
+title: Realtime transformations
+showTitle: true
+---
+
+As PostHog data arrives, you can transform it _immediately_ before ingestion. You can use this for things like:
+
+- Anonymizing sensitive data
+- Enriching events with geo information
+- Dropping unnecessary properties
+<!-- - Writing custom transformations using our Hog programming language -->
+- Filtering out bot traffic
+- Much more..
+
+PostHog enables you to transform your events in realtime using a variety of pre-built transformations. Check out the [data pipelines transformations](https://app.posthog.com/data-management/transformations) tab to get started.
+
+![Transformations list in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/transformation_list_a15ad4e309.png)
+
+Need more flexibility? Our [custom transformations](/docs/cdp/transformations/customizing-transformations) enable you to write your own Hog code to transform events exactly how you want. You can modify, enrich, or filter your events using our powerful Hog programming language.
+
+**Note**: Transformations don't apply to exceptions we capture as part of error tracking. If you need to run transformation against your exception data, please [let us know in-app](https://us.posthog.com#panel=support%3Afeedback%3Aerror_tracking%3Alow%3Atrue).
+
+## Filtering
+
+Filters enable you to target your transformations, affecting only the kinds of events you chose. Filter by event type, properties, or any SQL statement you can come up with.
+
+![Filtering transformations](https://res.cloudinary.com/dmukukwp6/image/upload/filters_b86669f2f9.png)
+
+## Testing
+
+As you build your transformations, PostHog makes it easy to confirm they do what you expect. Every transformation includes a built-in testing interface, enabling you to instantly send real data through it and verify the results. You can iterate until everything works to your satisfaction.
+
+![Transformation testing UI](https://res.cloudinary.com/dmukukwp6/image/upload/testing_eb82d9f16b.png)
+
+## Keep an eye on things
+
+Once your transformation is up and running, the **metrics** and **logs** tabs will let you monitor usage and inspect any errors.
+
+![Transformation logs](https://res.cloudinary.com/dmukukwp6/image/upload/logs_09fa698dd4.png)
+
+![Transformation metrics](https://res.cloudinary.com/dmukukwp6/image/upload/metrics_7cf05cc3b8.png)
+
+## History
+
+For projects with the **[teams add-on](https://posthog.com/addons#teams)**, each transformation has a history tab that shows you a complete audit trail of changes. You can see who modified the transformation, what changes were made, and when they occurred.
+
+![Transformation history](https://res.cloudinary.com/dmukukwp6/image/upload/history_e0873f6741.png)
+
+This history helps you:
+
+- Track changes over time
+- Understand when and why modifications were made
+- See who made specific changes
+
+The history tab is particularly useful when multiple team members are working with transformations, as it provides transparency and accountability for all changes.
+
+## Going deeper
+
+If your needs are more specific than our defaults, try customizing your transformation's implementation. You can write, test, and deploy your own transformation in minutes.
+
+Learn more about this in [customizing transformations](/docs/cdp/transformations/customizing-transformations).
+
+## Creating transformations via API
+
+You can also create and manage transformations programmatically using our API. This is particularly useful for automating your workflows, such as setting up new projects with predefined transformations.
+
+To use the API, you'll need to:
+
+1. Enable the `Hog functions` scope in your personal API key
+2. Use the [Hog functions API endpoints](/docs/api/hog-functions#get-api-projects-project_id-hog_functions-id) to create your transformations.
+
+Here's an example of creating a new transformation:
+
+```bash
+# Create a new transformation
+curl --location 'https://us.i.posthog.com/api/environments/:project_id/hog_functions' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer <POSTHOG_PERSONAL_API_KEY>' \
+--data '{
+    "type": "transformation",
+    "name": "Filter Out Plugin",
+    "inputs": {},
+    "enabled": true,
+    "template_id": "plugin-posthog-filter-out-plugin"
+}'
+```
+
+> **Important:** When creating a transformation from a template, make sure to use the correct `template_id`. You can find the available template IDs by making a GET request to `/api/projects/:project_id/hog_function_templates?types=transformation` or by checking the [Hog functions API documentation](https://us.posthog.com/api/schema/swagger-ui/#/environments/environments_hog_functions_list).
+
+### How many events can I transform?
+
+There is no limit on the number of events to be transformed - transformations are completely free! However, the system requires that transformations perform efficiently and don't consume excessive resources (don't worry we have built some rail guards into that and let you know if something is funky).
+
+### What can cause a transformation to be automatically disabled?
+
+If the transformation performs poorly (too many errors, too slow, or consumes too much memory) for a prolonged period, your transformation will be quarantined and eventually disabled. We will try to re-enable it automatically after a temporary disabled period before stopping it entirely. You then need to modify either the filters or the transformation and re-enable it in the UI to try again.
+
+The key metrics that we observe to determine poor performance are:
+
+1. Errors thrown within the code (for example if you try to access a property that doesn't exist).
+2. Excessive memory usage or processing time. While some complex transformations are fine, if your transformation consistently takes too long or uses too much memory, we will eventually disable it to protect our systems.
+3. Repeatedly slow transformations. Some slow transformations are fine, but if your transformation consistently can't keep up, we will eventually disable it to protect our systems.
+
+### How do you handle errors?
+
+By default, if a transformation encounters an error, we will log the error and continue processing other events. This ensures that a single problematic event doesn't block the processing of all other events. We may modify this logic as we make improvements to try and balance reliability and speed.

--- a/docs/published/docs/cdp/troubleshooting.md
+++ b/docs/published/docs/cdp/troubleshooting.md
@@ -1,0 +1,85 @@
+---
+title: Customer Data Platform troubleshooting
+---
+
+This page covers troubleshooting for CDP. For setup, see the [installation guides](/docs/cdp/sources).
+
+## Have a question? Ask PostHog AI
+
+<AskAIInput placeholder="Type your question and hit enter..." />
+
+## My transformation or destination isn't working, what do I do?
+
+1. Wait 60 seconds, then check that the transformation or destination is enabled with the correct configuration options in the [data pipeline tab](https://app.posthog.com/data-management/destinations). You can find the correct configuration options in the [transformation or destination's documentation](/docs/cdp) by searching for it in the destinations, transformations, or filtering sections of the docs.
+
+2. Click "Logs & metrics" and go to the `Metrics` tab to check that the transformation or destination is processing events without errors.
+
+3. Check the `Logs` tab to see if there are any errors.
+
+4. Go to the data management tab to check if there any [ingestion warnings](https://us.posthog.com/data-management/ingestion-warnings).
+
+5. If the transformation or destination relates to an external service, check that the external service is working correctly. Make a request to the relevant API endpoint. You can also use a tool like [webhook.site](https://webhook.site/) to check that PostHog sends events as expected.
+
+## How do I capture data from another application?
+
+We deprecated the functionality of data pipelines that enable you to capture data from other tools on a schedule. Functionally, these were a cron which ran every minute (or more) and pulled data from another tool.
+
+There are two options for recreating this functionality:
+
+1. **Set up a cron of your own**. You can use a tool like [val.town](https://val.town/) to easily set up scheduled tasks that capture data from other tools and send them to PostHog. Our tutorials on [capturing new RSS items](/tutorials/rss-item-capture), [events from Calendly webhooks](/tutorials/calendly-webhooks), and [GitHub stars](/tutorials/github-star-tracker) are examples of this.
+
+2. **Use our data warehouse**. PostHog's data warehouse enables you to import and use data from platforms like Stripe, Hubspot, and Postgres natively in PostHog. See our [docs](/docs/data-warehouse) for more information.
+
+## How do I track when users do an event for the first time?
+
+There are a few ways to capture a user doing an event for the first time. We cover a few of these in our tutorials on [tracking new and returning users](/tutorials/track-new-returning-users) and [first touch attribution](/tutorials/first-last-touch-attribution).
+
+- Create a [cohort](/docs/data/cohorts) matching users who have done an event for the first time recently.
+- Use a custom event to set a [person](/docs/getting-started/person-properties) or [event property](/docs/data/events). For example, you can set a `first_seen` property with the `$set_once` option.
+- Use [SQL](/docs/product-analytics/sql) to query for the `min(timestamp)` of an event.
+
+## How do I migrate events or rows into PostHog?
+
+See our [migration docs](/docs/migrate) for the full details.
+
+## How do I do real time exports?
+
+If you need real time exports, check out our list of [realtime destinations](/docs/cdp/destinations).
+
+## Where are my missing events?
+
+See our troubleshooting guide for [events not appearing in a project](/docs/product-analytics/troubleshooting#why-are-events-not-appearing-in-my-project).
+
+## Why can't I use the UI or events API to export data?
+
+You can, but they are rate-limited. [Batch exports](/docs/cdp/batch-exports) should be your default. The table below compares the options:
+
+| Method                                          | When?                                                                           | Limitations                       |
+| ----------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------- |
+| PostHog UI - click "Export" on the events table | You need to export a small number of events                                     | 3,500 events                      |
+| Events API                                      | Great for one-off smaller exports                                               | 1 day date range and 3,500 events |
+| Batch exports                                   | You need to export a large number of events, can be used for continuous exports | No limits                         |
+
+If that isn't clear enough, here's a decision tree you might find useful:
+
+```mermaid
+graph TD
+    A[Do you need to export more than 3,500 events?] --> |Yes| B[Use batch exports]
+    A --> |No| C[Do you need to run regular exports e.g. once a day or once a week?]
+    C --> |Yes| B
+    C --> |No| E[Use the PostHog UI or the Events API]
+```
+
+## Why am I seeing duplicate events?
+
+We recommend sending a `uuid` value with every captured event. Events with the same UUID, event name, timestamp, and `distinct_id` are considered duplicates and are eventually de-duplicated.
+
+This is important because failures and retries happen, so your application or our library might send the same event multiple times. If you don't send UUIDs for every event, we aren't able to know if it's the same event, and hence we are not able to de-duplicate it for you.
+
+Some of our SDKs, such as JavaScript Web, do this automatically, other SDKs allow you to pass UUIDs. If you're using an SDK which doesn't currently support UUIDs for every event, please consider creating a PR or filing an issue in GitHub.
+
+## Solved community questions
+
+<SolvedQuestions
+    topicLabel="CDP"
+/>

--- a/posthog/temporal/data_imports/sources/active_campaign/source.py
+++ b/posthog/temporal/data_imports/sources/active_campaign/source.py
@@ -22,6 +22,7 @@ class ActiveCampaignSource(SimpleSource[ActiveCampaignSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ACTIVE_CAMPAIGN,
+            docsUrl="https://posthog.com/docs/cdp/sources/activecampaign",
             label="ActiveCampaign",
             iconPath="/static/services/activecampaign.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/adjust/source.py
+++ b/posthog/temporal/data_imports/sources/adjust/source.py
@@ -22,6 +22,7 @@ class AdjustSource(SimpleSource[AdjustSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ADJUST,
+            docsUrl="https://posthog.com/docs/cdp/sources/adjust",
             label="Adjust",
             iconPath="/static/services/adjust.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/aircall/source.py
+++ b/posthog/temporal/data_imports/sources/aircall/source.py
@@ -22,6 +22,7 @@ class AircallSource(SimpleSource[AircallSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.AIRCALL,
+            docsUrl="https://posthog.com/docs/cdp/sources/aircall",
             label="Aircall",
             iconPath="/static/services/aircall.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/airtable/source.py
+++ b/posthog/temporal/data_imports/sources/airtable/source.py
@@ -22,6 +22,7 @@ class AirtableSource(SimpleSource[AirtableSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.AIRTABLE,
+            docsUrl="https://posthog.com/docs/cdp/sources/airtable",
             label="Airtable",
             iconPath="/static/services/airtable.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/amazon_ads/source.py
+++ b/posthog/temporal/data_imports/sources/amazon_ads/source.py
@@ -22,6 +22,7 @@ class AmazonAdsSource(SimpleSource[AmazonAdsSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.AMAZON_ADS,
+            docsUrl="https://posthog.com/docs/cdp/sources/amazon-ads",
             label="Amazon Ads",
             iconPath="/static/services/amazon_ads.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/amplitude/source.py
+++ b/posthog/temporal/data_imports/sources/amplitude/source.py
@@ -22,6 +22,7 @@ class AmplitudeSource(SimpleSource[AmplitudeSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.AMPLITUDE,
+            docsUrl="https://posthog.com/docs/cdp/sources/amplitude",
             label="Amplitude",
             iconPath="/static/services/amplitude.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/apple_search_ads/source.py
+++ b/posthog/temporal/data_imports/sources/apple_search_ads/source.py
@@ -22,6 +22,7 @@ class AppleSearchAdsSource(SimpleSource[AppleSearchAdsSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.APPLE_SEARCH_ADS,
+            docsUrl="https://posthog.com/docs/cdp/sources/apple-search-ads",
             label="Apple Search Ads",
             iconPath="/static/services/apple_search_ads.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/appsflyer/source.py
+++ b/posthog/temporal/data_imports/sources/appsflyer/source.py
@@ -22,6 +22,7 @@ class AppsFlyerSource(SimpleSource[AppsFlyerSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.APPS_FLYER,
+            docsUrl="https://posthog.com/docs/cdp/sources/appsflyer",
             label="AppsFlyer",
             iconPath="/static/services/appsflyer.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/asana/source.py
+++ b/posthog/temporal/data_imports/sources/asana/source.py
@@ -22,6 +22,7 @@ class AsanaSource(SimpleSource[AsanaSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ASANA,
+            docsUrl="https://posthog.com/docs/cdp/sources/asana",
             label="Asana",
             iconPath="/static/services/asana.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/ashby/source.py
+++ b/posthog/temporal/data_imports/sources/ashby/source.py
@@ -29,7 +29,7 @@ class AshbySource(SimpleSource[AshbySourceConfig]):
             iconPath="/static/services/ashby.png",
             label="Ashby",  # only needed if the readable name is complex. delete otherwise
             caption=None,  # only needed if you want to inline docs
-            docsUrl=None,  # TODO(Andrew J. McGehee): link to the docs in the website, full path including https://
+            docsUrl="https://posthog.com/docs/cdp/sources/ashby",
             fields=cast(list[FieldType], []),  # TODO(Andrew J. McGehee): add source config fields here
             unreleasedSource=True,
         )

--- a/posthog/temporal/data_imports/sources/auth0/source.py
+++ b/posthog/temporal/data_imports/sources/auth0/source.py
@@ -22,6 +22,7 @@ class Auth0Source(SimpleSource[Auth0SourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.AUTH0,
+            docsUrl="https://posthog.com/docs/cdp/sources/auth0",
             label="Auth0",
             iconPath="/static/services/auth0.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/azure_blob/source.py
+++ b/posthog/temporal/data_imports/sources/azure_blob/source.py
@@ -22,6 +22,7 @@ class AzureBlobSource(SimpleSource[AzureBlobSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.AZURE_BLOB,
+            docsUrl="https://posthog.com/docs/cdp/sources/azure-blob",
             label="Azure Blob",
             iconPath="/static/services/azure_blob.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/bamboohr/source.py
+++ b/posthog/temporal/data_imports/sources/bamboohr/source.py
@@ -22,6 +22,7 @@ class BambooHRSource(SimpleSource[BambooHRSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BAMBOO_HR,
+            docsUrl="https://posthog.com/docs/cdp/sources/bamboo-hr",
             label="BambooHR",
             iconPath="/static/services/bamboohr.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/bigcommerce/source.py
+++ b/posthog/temporal/data_imports/sources/bigcommerce/source.py
@@ -22,6 +22,7 @@ class BigCommerceSource(SimpleSource[BigCommerceSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BIG_COMMERCE,
+            docsUrl="https://posthog.com/docs/cdp/sources/bigcommerce",
             label="BigCommerce",
             iconPath="/static/services/bigcommerce.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/box/source.py
+++ b/posthog/temporal/data_imports/sources/box/source.py
@@ -22,6 +22,7 @@ class BoxSource(SimpleSource[BoxSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BOX,
+            docsUrl="https://posthog.com/docs/cdp/sources/box",
             label="Box",
             iconPath="/static/services/box.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/braintree/source.py
+++ b/posthog/temporal/data_imports/sources/braintree/source.py
@@ -22,6 +22,7 @@ class BraintreeSource(SimpleSource[BraintreeSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BRAINTREE,
+            docsUrl="https://posthog.com/docs/cdp/sources/braintree",
             label="Braintree",
             iconPath="/static/services/braintree.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/braze/source.py
+++ b/posthog/temporal/data_imports/sources/braze/source.py
@@ -22,6 +22,7 @@ class BrazeSource(SimpleSource[BrazeSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BRAZE,
+            docsUrl="https://posthog.com/docs/cdp/sources/braze",
             iconPath="/static/services/braze.png",
             fields=cast(list[FieldType], []),
             unreleasedSource=True,

--- a/posthog/temporal/data_imports/sources/brevo/source.py
+++ b/posthog/temporal/data_imports/sources/brevo/source.py
@@ -22,6 +22,7 @@ class BrevoSource(SimpleSource[BrevoSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BREVO,
+            docsUrl="https://posthog.com/docs/cdp/sources/brevo",
             label="Brevo",
             iconPath="/static/services/brevo.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/buildbetter/source.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/source.py
@@ -73,6 +73,7 @@ class BuildBetterSource(SimpleSource[BuildBetterSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.BUILD_BETTER,
+            docsUrl="https://posthog.com/docs/cdp/sources/buildbetter",
             label="BuildBetter",
             betaSource=True,
             caption="Connect your BuildBetter workspace to sync interviews, extractions, persons, and companies.",

--- a/posthog/temporal/data_imports/sources/calendly/source.py
+++ b/posthog/temporal/data_imports/sources/calendly/source.py
@@ -22,6 +22,7 @@ class CalendlySource(SimpleSource[CalendlySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CALENDLY,
+            docsUrl="https://posthog.com/docs/cdp/sources/calendly",
             label="Calendly",
             iconPath="/static/services/calendly.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/campaign_monitor/source.py
+++ b/posthog/temporal/data_imports/sources/campaign_monitor/source.py
@@ -22,6 +22,7 @@ class CampaignMonitorSource(SimpleSource[CampaignMonitorSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CAMPAIGN_MONITOR,
+            docsUrl="https://posthog.com/docs/cdp/sources/campaignmonitor",
             label="Campaign Monitor",
             iconPath="/static/services/campaign_monitor.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/chartmogul/source.py
+++ b/posthog/temporal/data_imports/sources/chartmogul/source.py
@@ -22,6 +22,7 @@ class ChartMogulSource(SimpleSource[ChartMogulSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CHART_MOGUL,
+            docsUrl="https://posthog.com/docs/cdp/sources/chartmogul",
             label="ChartMogul",
             iconPath="/static/services/chartmogul.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/circleci/source.py
+++ b/posthog/temporal/data_imports/sources/circleci/source.py
@@ -22,6 +22,7 @@ class CircleCISource(SimpleSource[CircleCISourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CIRCLE_CI,
+            docsUrl="https://posthog.com/docs/cdp/sources/circleci",
             label="CircleCI",
             iconPath="/static/services/circleci.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -31,6 +31,7 @@ class ClerkSource(SimpleSource[ClerkSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLERK,
+            docsUrl="https://posthog.com/docs/cdp/sources/clerk",
             label="Clerk",
             betaSource=True,
             caption="""Enter your Clerk secret key to automatically pull your Clerk data into the PostHog Data warehouse.

--- a/posthog/temporal/data_imports/sources/clickup/source.py
+++ b/posthog/temporal/data_imports/sources/clickup/source.py
@@ -22,6 +22,7 @@ class ClickUpSource(SimpleSource[ClickUpSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLICK_UP,
+            docsUrl="https://posthog.com/docs/cdp/sources/clickup",
             label="ClickUp",
             iconPath="/static/services/clickup.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/close/source.py
+++ b/posthog/temporal/data_imports/sources/close/source.py
@@ -22,6 +22,7 @@ class CloseSource(SimpleSource[CloseSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLOSE,
+            docsUrl="https://posthog.com/docs/cdp/sources/close",
             label="Close",
             iconPath="/static/services/close.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/cockroachdb/source.py
+++ b/posthog/temporal/data_imports/sources/cockroachdb/source.py
@@ -22,6 +22,7 @@ class CockroachDBSource(SimpleSource[CockroachDBSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.COCKROACH_DB,
+            docsUrl="https://posthog.com/docs/cdp/sources/cockroachdb",
             label="CockroachDB",
             iconPath="/static/services/cockroachdb.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/confluence/source.py
+++ b/posthog/temporal/data_imports/sources/confluence/source.py
@@ -22,6 +22,7 @@ class ConfluenceSource(SimpleSource[ConfluenceSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CONFLUENCE,
+            docsUrl="https://posthog.com/docs/cdp/sources/confluence",
             label="Confluence",
             iconPath="/static/services/confluence.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/convertkit/source.py
+++ b/posthog/temporal/data_imports/sources/convertkit/source.py
@@ -22,6 +22,7 @@ class ConvertKitSource(SimpleSource[ConvertKitSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CONVERT_KIT,
+            docsUrl="https://posthog.com/docs/cdp/sources/convertkit",
             label="ConvertKit",
             iconPath="/static/services/convertkit.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/copper/source.py
+++ b/posthog/temporal/data_imports/sources/copper/source.py
@@ -22,6 +22,7 @@ class CopperSource(SimpleSource[CopperSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.COPPER,
+            docsUrl="https://posthog.com/docs/cdp/sources/copper",
             label="Copper",
             iconPath="/static/services/copper.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/customer_io/source.py
+++ b/posthog/temporal/data_imports/sources/customer_io/source.py
@@ -29,7 +29,7 @@ class CustomerIOSource(SimpleSource[CustomerIOSourceConfig]):
             iconPath="/static/services/customer-io.png",
             label="Customer.io",
             caption=None,  # only needed if you want to inline docs
-            docsUrl=None,  # TODO(Andrew J. McGehee): link to the docs in the website, full path including https://
+            docsUrl="https://posthog.com/docs/cdp/sources/customerio",
             fields=cast(list[FieldType], []),  # TODO(Andrew J. McGehee): add source config fields here
             unreleasedSource=True,
         )

--- a/posthog/temporal/data_imports/sources/datadog/source.py
+++ b/posthog/temporal/data_imports/sources/datadog/source.py
@@ -22,6 +22,7 @@ class DatadogSource(SimpleSource[DatadogSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.DATADOG,
+            docsUrl="https://posthog.com/docs/cdp/sources/datadog",
             label="Datadog",
             iconPath="/static/services/datadog.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/drip/source.py
+++ b/posthog/temporal/data_imports/sources/drip/source.py
@@ -22,6 +22,7 @@ class DripSource(SimpleSource[DripSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.DRIP,
+            docsUrl="https://posthog.com/docs/cdp/sources/drip",
             label="Drip",
             iconPath="/static/services/drip.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/dynamodb/source.py
+++ b/posthog/temporal/data_imports/sources/dynamodb/source.py
@@ -22,6 +22,7 @@ class DynamoDBSource(SimpleSource[DynamoDBSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.DYNAMO_DB,
+            docsUrl="https://posthog.com/docs/cdp/sources/dynamodb",
             label="DynamoDB",
             iconPath="/static/services/dynamodb.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/elasticsearch/source.py
+++ b/posthog/temporal/data_imports/sources/elasticsearch/source.py
@@ -22,6 +22,7 @@ class ElasticsearchSource(SimpleSource[ElasticsearchSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ELASTICSEARCH,
+            docsUrl="https://posthog.com/docs/cdp/sources/elasticsearch",
             label="Elasticsearch",
             iconPath="/static/services/elasticsearch.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/eventbrite/source.py
+++ b/posthog/temporal/data_imports/sources/eventbrite/source.py
@@ -22,6 +22,7 @@ class EventbriteSource(SimpleSource[EventbriteSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.EVENTBRITE,
+            docsUrl="https://posthog.com/docs/cdp/sources/eventbrite",
             label="Eventbrite",
             iconPath="/static/services/eventbrite.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/facebook_pages/source.py
+++ b/posthog/temporal/data_imports/sources/facebook_pages/source.py
@@ -22,6 +22,7 @@ class FacebookPagesSource(SimpleSource[FacebookPagesSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.FACEBOOK_PAGES,
+            docsUrl="https://posthog.com/docs/cdp/sources/facebook-pages",
             label="Facebook Pages",
             iconPath="/static/services/facebook_pages.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/firebase/source.py
+++ b/posthog/temporal/data_imports/sources/firebase/source.py
@@ -22,6 +22,7 @@ class FirebaseSource(SimpleSource[FirebaseSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.FIREBASE,
+            docsUrl="https://posthog.com/docs/cdp/sources/firebase",
             label="Firebase",
             iconPath="/static/services/firebase.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/freshdesk/source.py
+++ b/posthog/temporal/data_imports/sources/freshdesk/source.py
@@ -22,6 +22,7 @@ class FreshdeskSource(SimpleSource[FreshdeskSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.FRESHDESK,
+            docsUrl="https://posthog.com/docs/cdp/sources/freshdesk",
             label="Freshdesk",
             iconPath="/static/services/freshdesk.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/freshsales/source.py
+++ b/posthog/temporal/data_imports/sources/freshsales/source.py
@@ -22,6 +22,7 @@ class FreshsalesSource(SimpleSource[FreshsalesSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.FRESHSALES,
+            docsUrl="https://posthog.com/docs/cdp/sources/freshsales",
             label="Freshsales",
             iconPath="/static/services/freshsales.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/front/source.py
+++ b/posthog/temporal/data_imports/sources/front/source.py
@@ -22,6 +22,7 @@ class FrontSource(SimpleSource[FrontSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.FRONT,
+            docsUrl="https://posthog.com/docs/cdp/sources/front",
             label="Front",
             iconPath="/static/services/front.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/fullstory/source.py
+++ b/posthog/temporal/data_imports/sources/fullstory/source.py
@@ -22,6 +22,7 @@ class FullStorySource(SimpleSource[FullStorySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.FULL_STORY,
+            docsUrl="https://posthog.com/docs/cdp/sources/fullstory",
             label="FullStory",
             iconPath="/static/services/fullstory.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/github/source.py
+++ b/posthog/temporal/data_imports/sources/github/source.py
@@ -36,6 +36,7 @@ class GithubSource(SimpleSource[GithubSourceConfig], OAuthMixin):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GITHUB,
+            docsUrl="https://posthog.com/docs/cdp/sources/github",
             label="GitHub",
             betaSource=True,
             caption="Connect your GitHub repository to sync issues, pull requests, commits, and more.",

--- a/posthog/temporal/data_imports/sources/gitlab/source.py
+++ b/posthog/temporal/data_imports/sources/gitlab/source.py
@@ -22,6 +22,7 @@ class GitLabSource(SimpleSource[GitLabSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GIT_LAB,
+            docsUrl="https://posthog.com/docs/cdp/sources/gitlab",
             label="GitLab",
             iconPath="/static/services/gitlab.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/gong/source.py
+++ b/posthog/temporal/data_imports/sources/gong/source.py
@@ -22,6 +22,7 @@ class GongSource(SimpleSource[GongSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GONG,
+            docsUrl="https://posthog.com/docs/cdp/sources/gong",
             label="Gong",
             iconPath="/static/services/gong.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/google_analytics/source.py
+++ b/posthog/temporal/data_imports/sources/google_analytics/source.py
@@ -22,6 +22,7 @@ class GoogleAnalyticsSource(SimpleSource[GoogleAnalyticsSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GOOGLE_ANALYTICS,
+            docsUrl="https://posthog.com/docs/cdp/sources/google-analytics",
             label="Google Analytics",
             iconPath="/static/services/google_analytics.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/google_drive/source.py
+++ b/posthog/temporal/data_imports/sources/google_drive/source.py
@@ -22,6 +22,7 @@ class GoogleDriveSource(SimpleSource[GoogleDriveSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GOOGLE_DRIVE,
+            docsUrl="https://posthog.com/docs/cdp/sources/google-drive",
             label="Google Drive",
             iconPath="/static/services/google_drive.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/gorgias/source.py
+++ b/posthog/temporal/data_imports/sources/gorgias/source.py
@@ -22,6 +22,7 @@ class GorgiasSource(SimpleSource[GorgiasSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GORGIAS,
+            docsUrl="https://posthog.com/docs/cdp/sources/gorgias",
             label="Gorgias",
             iconPath="/static/services/gorgias.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/granola/source.py
+++ b/posthog/temporal/data_imports/sources/granola/source.py
@@ -22,6 +22,7 @@ class GranolaSource(SimpleSource[GranolaSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GRANOLA,
+            docsUrl="https://posthog.com/docs/cdp/sources/granola",
             label="Granola",
             iconPath="/static/services/granola.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/greenhouse/source.py
+++ b/posthog/temporal/data_imports/sources/greenhouse/source.py
@@ -22,6 +22,7 @@ class GreenhouseSource(SimpleSource[GreenhouseSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GREENHOUSE,
+            docsUrl="https://posthog.com/docs/cdp/sources/greenhouse",
             label="Greenhouse",
             iconPath="/static/services/greenhouse.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/helpscout/source.py
+++ b/posthog/temporal/data_imports/sources/helpscout/source.py
@@ -22,6 +22,7 @@ class HelpScoutSource(SimpleSource[HelpScoutSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.HELP_SCOUT,
+            docsUrl="https://posthog.com/docs/cdp/sources/helpscout",
             label="Help Scout",
             iconPath="/static/services/helpscout.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/instagram/source.py
+++ b/posthog/temporal/data_imports/sources/instagram/source.py
@@ -22,6 +22,7 @@ class InstagramSource(SimpleSource[InstagramSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.INSTAGRAM,
+            docsUrl="https://posthog.com/docs/cdp/sources/instagram",
             label="Instagram",
             iconPath="/static/services/instagram.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/intercom/source.py
+++ b/posthog/temporal/data_imports/sources/intercom/source.py
@@ -22,6 +22,7 @@ class IntercomSource(SimpleSource[IntercomSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.INTERCOM,
+            docsUrl="https://posthog.com/docs/cdp/sources/intercom",
             label="Intercom",
             iconPath="/static/services/intercom.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/iterable/source.py
+++ b/posthog/temporal/data_imports/sources/iterable/source.py
@@ -22,6 +22,7 @@ class IterableSource(SimpleSource[IterableSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ITERABLE,
+            docsUrl="https://posthog.com/docs/cdp/sources/iterable",
             label="Iterable",
             iconPath="/static/services/iterable.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/jira/source.py
+++ b/posthog/temporal/data_imports/sources/jira/source.py
@@ -22,6 +22,7 @@ class JiraSource(SimpleSource[JiraSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.JIRA,
+            docsUrl="https://posthog.com/docs/cdp/sources/jira",
             label="Jira",
             iconPath="/static/services/jira.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/kafka/source.py
+++ b/posthog/temporal/data_imports/sources/kafka/source.py
@@ -22,6 +22,7 @@ class KafkaSource(SimpleSource[KafkaSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.KAFKA,
+            docsUrl="https://posthog.com/docs/cdp/sources/kafka",
             label="Kafka",
             iconPath="/static/services/kafka.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/launchdarkly/source.py
+++ b/posthog/temporal/data_imports/sources/launchdarkly/source.py
@@ -22,6 +22,7 @@ class LaunchDarklySource(SimpleSource[LaunchDarklySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.LAUNCH_DARKLY,
+            docsUrl="https://posthog.com/docs/cdp/sources/launchdarkly",
             label="LaunchDarkly",
             iconPath="/static/services/launchdarkly.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/lever/source.py
+++ b/posthog/temporal/data_imports/sources/lever/source.py
@@ -22,6 +22,7 @@ class LeverSource(SimpleSource[LeverSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.LEVER,
+            docsUrl="https://posthog.com/docs/cdp/sources/lever",
             label="Lever",
             iconPath="/static/services/lever.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/linear/source.py
+++ b/posthog/temporal/data_imports/sources/linear/source.py
@@ -32,6 +32,7 @@ class LinearSource(SimpleSource[LinearSourceConfig], OAuthMixin):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.LINEAR,
+            docsUrl="https://posthog.com/docs/cdp/sources/linear",
             label="Linear",
             betaSource=True,
             caption="Connect your Linear workspace to sync issues, projects, teams, and more.",

--- a/posthog/temporal/data_imports/sources/mailerlite/source.py
+++ b/posthog/temporal/data_imports/sources/mailerlite/source.py
@@ -22,6 +22,7 @@ class MailerLiteSource(SimpleSource[MailerLiteSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.MAILER_LITE,
+            docsUrl="https://posthog.com/docs/cdp/sources/mailerlite",
             label="MailerLite",
             iconPath="/static/services/mailerlite.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/marketo/source.py
+++ b/posthog/temporal/data_imports/sources/marketo/source.py
@@ -22,6 +22,7 @@ class MarketoSource(SimpleSource[MarketoSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.MARKETO,
+            docsUrl="https://posthog.com/docs/cdp/sources/marketo",
             label="Marketo",
             iconPath="/static/services/marketo.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -73,6 +73,7 @@ class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.META_ADS,
+            docsUrl="https://posthog.com/docs/cdp/sources/meta-ads",
             label="Meta Ads",
             caption="Ensure you have granted PostHog access to your Meta Ads account, learn how to do this in the [documentation](https://posthog.com/docs/cdp/sources/meta-ads).",
             iconPath="/static/services/meta-ads.png",

--- a/posthog/temporal/data_imports/sources/microsoft_teams/source.py
+++ b/posthog/temporal/data_imports/sources/microsoft_teams/source.py
@@ -22,6 +22,7 @@ class MicrosoftTeamsSource(SimpleSource[MicrosoftTeamsSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.MICROSOFT_TEAMS,
+            docsUrl="https://posthog.com/docs/cdp/sources/microsoft-teams",
             label="Microsoft Teams",
             iconPath="/static/services/microsoft_teams.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/mixpanel/source.py
+++ b/posthog/temporal/data_imports/sources/mixpanel/source.py
@@ -22,6 +22,7 @@ class MixpanelSource(SimpleSource[MixpanelSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.MIXPANEL,
+            docsUrl="https://posthog.com/docs/cdp/sources/mixpanel",
             label="Mixpanel",
             iconPath="/static/services/mixpanel.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/monday/source.py
+++ b/posthog/temporal/data_imports/sources/monday/source.py
@@ -22,6 +22,7 @@ class MondaySource(SimpleSource[MondaySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.MONDAY,
+            docsUrl="https://posthog.com/docs/cdp/sources/monday",
             label="Monday",
             iconPath="/static/services/monday.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/netsuite/source.py
+++ b/posthog/temporal/data_imports/sources/netsuite/source.py
@@ -22,6 +22,7 @@ class NetSuiteSource(SimpleSource[NetSuiteSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.NET_SUITE,
+            docsUrl="https://posthog.com/docs/cdp/sources/netsuite",
             label="NetSuite",
             iconPath="/static/services/netsuite.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/notion/source.py
+++ b/posthog/temporal/data_imports/sources/notion/source.py
@@ -22,6 +22,7 @@ class NotionSource(SimpleSource[NotionSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.NOTION,
+            docsUrl="https://posthog.com/docs/cdp/sources/notion",
             label="Notion",
             iconPath="/static/services/notion.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/okta/source.py
+++ b/posthog/temporal/data_imports/sources/okta/source.py
@@ -22,6 +22,7 @@ class OktaSource(SimpleSource[OktaSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.OKTA,
+            docsUrl="https://posthog.com/docs/cdp/sources/okta",
             label="Okta",
             iconPath="/static/services/okta.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/omnisend/source.py
+++ b/posthog/temporal/data_imports/sources/omnisend/source.py
@@ -22,6 +22,7 @@ class OmnisendSource(SimpleSource[OmnisendSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.OMNISEND,
+            docsUrl="https://posthog.com/docs/cdp/sources/omnisend",
             label="Omnisend",
             iconPath="/static/services/omnisend.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/onedrive/source.py
+++ b/posthog/temporal/data_imports/sources/onedrive/source.py
@@ -22,6 +22,7 @@ class OneDriveSource(SimpleSource[OneDriveSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ONE_DRIVE,
+            docsUrl="https://posthog.com/docs/cdp/sources/onedrive",
             label="OneDrive",
             iconPath="/static/services/onedrive.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/oracle/source.py
+++ b/posthog/temporal/data_imports/sources/oracle/source.py
@@ -22,6 +22,7 @@ class OracleSource(SimpleSource[OracleSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ORACLE,
+            docsUrl="https://posthog.com/docs/cdp/sources/oracle",
             label="Oracle",
             iconPath="/static/services/oracle.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/outreach/source.py
+++ b/posthog/temporal/data_imports/sources/outreach/source.py
@@ -22,6 +22,7 @@ class OutreachSource(SimpleSource[OutreachSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.OUTREACH,
+            docsUrl="https://posthog.com/docs/cdp/sources/outreach",
             label="Outreach",
             iconPath="/static/services/outreach.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/paddle/source.py
+++ b/posthog/temporal/data_imports/sources/paddle/source.py
@@ -22,6 +22,7 @@ class PaddleSource(SimpleSource[PaddleSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PADDLE,
+            docsUrl="https://posthog.com/docs/cdp/sources/paddle",
             label="Paddle",
             iconPath="/static/services/paddle.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/pagerduty/source.py
+++ b/posthog/temporal/data_imports/sources/pagerduty/source.py
@@ -22,6 +22,7 @@ class PagerDutySource(SimpleSource[PagerDutySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PAGER_DUTY,
+            docsUrl="https://posthog.com/docs/cdp/sources/pagerduty",
             label="PagerDuty",
             iconPath="/static/services/pagerduty.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/pardot/source.py
+++ b/posthog/temporal/data_imports/sources/pardot/source.py
@@ -22,6 +22,7 @@ class PardotSource(SimpleSource[PardotSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PARDOT,
+            docsUrl="https://posthog.com/docs/cdp/sources/pardot",
             label="Pardot",
             iconPath="/static/services/pardot.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/paypal/source.py
+++ b/posthog/temporal/data_imports/sources/paypal/source.py
@@ -22,6 +22,7 @@ class PayPalSource(SimpleSource[PayPalSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PAY_PAL,
+            docsUrl="https://posthog.com/docs/cdp/sources/paypal",
             label="PayPal",
             iconPath="/static/services/paypal.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/pendo/source.py
+++ b/posthog/temporal/data_imports/sources/pendo/source.py
@@ -22,6 +22,7 @@ class PendoSource(SimpleSource[PendoSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PENDO,
+            docsUrl="https://posthog.com/docs/cdp/sources/pendo",
             label="Pendo",
             iconPath="/static/services/pendo.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/pipedrive/source.py
+++ b/posthog/temporal/data_imports/sources/pipedrive/source.py
@@ -22,6 +22,7 @@ class PipedriveSource(SimpleSource[PipedriveSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PIPEDRIVE,
+            docsUrl="https://posthog.com/docs/cdp/sources/pipedrive",
             label="Pipedrive",
             iconPath="/static/services/pipedrive.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/plaid/source.py
+++ b/posthog/temporal/data_imports/sources/plaid/source.py
@@ -22,6 +22,7 @@ class PlaidSource(SimpleSource[PlaidSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PLAID,
+            docsUrl="https://posthog.com/docs/cdp/sources/plaid",
             label="Plaid",
             iconPath="/static/services/plaid.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/polar/source.py
+++ b/posthog/temporal/data_imports/sources/polar/source.py
@@ -22,6 +22,7 @@ class PolarSource(SimpleSource[PolarSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.POLAR,
+            docsUrl="https://posthog.com/docs/cdp/sources/polar",
             label="Polar",
             iconPath="/static/services/polar.png",
             iconClassName="rounded dark:bg-white p-[2px]",

--- a/posthog/temporal/data_imports/sources/postmark/source.py
+++ b/posthog/temporal/data_imports/sources/postmark/source.py
@@ -22,6 +22,7 @@ class PostmarkSource(SimpleSource[PostmarkSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.POSTMARK,
+            docsUrl="https://posthog.com/docs/cdp/sources/postmark",
             label="Postmark",
             iconPath="/static/services/postmark.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/productboard/source.py
+++ b/posthog/temporal/data_imports/sources/productboard/source.py
@@ -22,6 +22,7 @@ class ProductboardSource(SimpleSource[ProductboardSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.PRODUCTBOARD,
+            docsUrl="https://posthog.com/docs/cdp/sources/productboard",
             label="Productboard",
             iconPath="/static/services/productboard.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/quickbooks/source.py
+++ b/posthog/temporal/data_imports/sources/quickbooks/source.py
@@ -22,6 +22,7 @@ class QuickBooksSource(SimpleSource[QuickBooksSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.QUICK_BOOKS,
+            docsUrl="https://posthog.com/docs/cdp/sources/quickbooks",
             label="QuickBooks",
             iconPath="/static/services/quickbooks.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/recharge/source.py
+++ b/posthog/temporal/data_imports/sources/recharge/source.py
@@ -22,6 +22,7 @@ class RechargeSource(SimpleSource[RechargeSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.RECHARGE,
+            docsUrl="https://posthog.com/docs/cdp/sources/recharge",
             label="Recharge",
             iconPath="/static/services/recharge.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/recurly/source.py
+++ b/posthog/temporal/data_imports/sources/recurly/source.py
@@ -22,6 +22,7 @@ class RecurlySource(SimpleSource[RecurlySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.RECURLY,
+            docsUrl="https://posthog.com/docs/cdp/sources/recurly",
             label="Recurly",
             iconPath="/static/services/recurly.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/revenuecat/source.py
+++ b/posthog/temporal/data_imports/sources/revenuecat/source.py
@@ -22,6 +22,7 @@ class RevenueCatSource(SimpleSource[RevenueCatSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.REVENUE_CAT,
+            docsUrl="https://posthog.com/docs/cdp/sources/revenuecat",
             label="RevenueCat",
             iconPath="/static/services/revenuecat.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/ringcentral/source.py
+++ b/posthog/temporal/data_imports/sources/ringcentral/source.py
@@ -22,6 +22,7 @@ class RingCentralSource(SimpleSource[RingCentralSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.RING_CENTRAL,
+            docsUrl="https://posthog.com/docs/cdp/sources/ringcentral",
             label="RingCentral",
             iconPath="/static/services/ringcentral.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/salesloft/source.py
+++ b/posthog/temporal/data_imports/sources/salesloft/source.py
@@ -22,6 +22,7 @@ class SalesLoftSource(SimpleSource[SalesLoftSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SALES_LOFT,
+            docsUrl="https://posthog.com/docs/cdp/sources/salesloft",
             label="SalesLoft",
             iconPath="/static/services/salesloft.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/sendgrid/source.py
+++ b/posthog/temporal/data_imports/sources/sendgrid/source.py
@@ -22,6 +22,7 @@ class SendGridSource(SimpleSource[SendGridSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SEND_GRID,
+            docsUrl="https://posthog.com/docs/cdp/sources/sendgrid",
             label="SendGrid",
             iconPath="/static/services/sendgrid.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/servicenow/source.py
+++ b/posthog/temporal/data_imports/sources/servicenow/source.py
@@ -22,6 +22,7 @@ class ServiceNowSource(SimpleSource[ServiceNowSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SERVICE_NOW,
+            docsUrl="https://posthog.com/docs/cdp/sources/servicenow",
             label="ServiceNow",
             iconPath="/static/services/servicenow.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/sftp/source.py
+++ b/posthog/temporal/data_imports/sources/sftp/source.py
@@ -22,6 +22,7 @@ class SFTPSource(SimpleSource[SFTPSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SFTP,
+            docsUrl="https://posthog.com/docs/cdp/sources/sftp",
             label="SFTP",
             iconPath="/static/services/sftp.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/sharepoint/source.py
+++ b/posthog/temporal/data_imports/sources/sharepoint/source.py
@@ -22,6 +22,7 @@ class SharePointSource(SimpleSource[SharePointSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SHARE_POINT,
+            docsUrl="https://posthog.com/docs/cdp/sources/sharepoint",
             label="SharePoint",
             iconPath="/static/services/sharepoint.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/shortcut/source.py
+++ b/posthog/temporal/data_imports/sources/shortcut/source.py
@@ -22,6 +22,7 @@ class ShortcutSource(SimpleSource[ShortcutSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SHORTCUT,
+            docsUrl="https://posthog.com/docs/cdp/sources/shortcut",
             label="Shortcut",
             iconPath="/static/services/shortcut.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -22,6 +22,7 @@ class SlackSource(SimpleSource[SlackSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SLACK,
+            docsUrl="https://posthog.com/docs/cdp/sources/slack",
             label="Slack",
             iconPath="/static/services/slack.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/smartsheet/source.py
+++ b/posthog/temporal/data_imports/sources/smartsheet/source.py
@@ -22,6 +22,7 @@ class SmartsheetSource(SimpleSource[SmartsheetSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SMARTSHEET,
+            docsUrl="https://posthog.com/docs/cdp/sources/smartsheet",
             label="Smartsheet",
             iconPath="/static/services/smartsheet.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/square/source.py
+++ b/posthog/temporal/data_imports/sources/square/source.py
@@ -22,6 +22,7 @@ class SquareSource(SimpleSource[SquareSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SQUARE,
+            docsUrl="https://posthog.com/docs/cdp/sources/square",
             label="Square",
             iconPath="/static/services/square.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/surveymonkey/source.py
+++ b/posthog/temporal/data_imports/sources/surveymonkey/source.py
@@ -22,6 +22,7 @@ class SurveyMonkeySource(SimpleSource[SurveyMonkeySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.SURVEY_MONKEY,
+            docsUrl="https://posthog.com/docs/cdp/sources/surveymonkey",
             label="SurveyMonkey",
             iconPath="/static/services/surveymonkey.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/trello/source.py
+++ b/posthog/temporal/data_imports/sources/trello/source.py
@@ -22,6 +22,7 @@ class TrelloSource(SimpleSource[TrelloSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.TRELLO,
+            docsUrl="https://posthog.com/docs/cdp/sources/trello",
             label="Trello",
             iconPath="/static/services/trello.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/twilio/source.py
+++ b/posthog/temporal/data_imports/sources/twilio/source.py
@@ -22,6 +22,7 @@ class TwilioSource(SimpleSource[TwilioSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.TWILIO,
+            docsUrl="https://posthog.com/docs/cdp/sources/twilio",
             label="Twilio",
             iconPath="/static/services/twilio.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/twitter_ads/source.py
+++ b/posthog/temporal/data_imports/sources/twitter_ads/source.py
@@ -22,6 +22,7 @@ class TwitterAdsSource(SimpleSource[TwitterAdsSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.TWITTER_ADS,
+            docsUrl="https://posthog.com/docs/cdp/sources/twitter-ads",
             label="Twitter Ads",
             iconPath="/static/services/twitter_ads.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/typeform/source.py
+++ b/posthog/temporal/data_imports/sources/typeform/source.py
@@ -38,6 +38,7 @@ class TypeformSource(SimpleSource[TypeformSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.TYPEFORM,
+            docsUrl="https://posthog.com/docs/cdp/sources/typeform",
             label="Typeform",
             iconPath="/static/services/typeform.png",
             caption="""Enter a Typeform personal access token to sync forms and responses.

--- a/posthog/temporal/data_imports/sources/webflow/source.py
+++ b/posthog/temporal/data_imports/sources/webflow/source.py
@@ -22,6 +22,7 @@ class WebflowSource(SimpleSource[WebflowSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.WEBFLOW,
+            docsUrl="https://posthog.com/docs/cdp/sources/webflow",
             label="Webflow",
             iconPath="/static/services/webflow.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/woocommerce/source.py
+++ b/posthog/temporal/data_imports/sources/woocommerce/source.py
@@ -22,6 +22,7 @@ class WooCommerceSource(SimpleSource[WooCommerceSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.WOO_COMMERCE,
+            docsUrl="https://posthog.com/docs/cdp/sources/woocommerce",
             label="WooCommerce",
             iconPath="/static/services/woocommerce.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/workday/source.py
+++ b/posthog/temporal/data_imports/sources/workday/source.py
@@ -22,6 +22,7 @@ class WorkdaySource(SimpleSource[WorkdaySourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.WORKDAY,
+            docsUrl="https://posthog.com/docs/cdp/sources/workday",
             label="Workday",
             iconPath="/static/services/workday.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/wrike/source.py
+++ b/posthog/temporal/data_imports/sources/wrike/source.py
@@ -22,6 +22,7 @@ class WrikeSource(SimpleSource[WrikeSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.WRIKE,
+            docsUrl="https://posthog.com/docs/cdp/sources/wrike",
             label="Wrike",
             iconPath="/static/services/wrike.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/xero/source.py
+++ b/posthog/temporal/data_imports/sources/xero/source.py
@@ -22,6 +22,7 @@ class XeroSource(SimpleSource[XeroSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.XERO,
+            docsUrl="https://posthog.com/docs/cdp/sources/xero",
             label="Xero",
             iconPath="/static/services/xero.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/youtube_analytics/source.py
+++ b/posthog/temporal/data_imports/sources/youtube_analytics/source.py
@@ -22,6 +22,7 @@ class YouTubeAnalyticsSource(SimpleSource[YouTubeAnalyticsSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.YOU_TUBE_ANALYTICS,
+            docsUrl="https://posthog.com/docs/cdp/sources/youtube-analytics",
             label="YouTube Analytics",
             iconPath="/static/services/youtube_analytics.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/zoho_crm/source.py
+++ b/posthog/temporal/data_imports/sources/zoho_crm/source.py
@@ -22,6 +22,7 @@ class ZohoCRMSource(SimpleSource[ZohoCRMSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ZOHO_CRM,
+            docsUrl="https://posthog.com/docs/cdp/sources/zoho-crm",
             label="Zoho CRM",
             iconPath="/static/services/zoho_crm.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/zoom/source.py
+++ b/posthog/temporal/data_imports/sources/zoom/source.py
@@ -22,6 +22,7 @@ class ZoomSource(SimpleSource[ZoomSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ZOOM,
+            docsUrl="https://posthog.com/docs/cdp/sources/zoom",
             label="Zoom",
             iconPath="/static/services/zoom.png",
             fields=cast(list[FieldType], []),

--- a/posthog/temporal/data_imports/sources/zuora/source.py
+++ b/posthog/temporal/data_imports/sources/zuora/source.py
@@ -22,6 +22,7 @@ class ZuoraSource(SimpleSource[ZuoraSourceConfig]):
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.ZUORA,
+            docsUrl="https://posthog.com/docs/cdp/sources/zuora",
             label="Zuora",
             iconPath="/static/services/zuora.png",
             fields=cast(list[FieldType], []),


### PR DESCRIPTION
We're currently having a big problem in the posthog/posthog repo where we dont have a very consistent view of the sources we have because we haven't documented them all in all the different places they might exist. This brings all that documentation into this repo and adds some checks to guarantee we'll always keep these in sync