### PR TITLE
feat(workflows): emit email_delivered metric from SES Delivery events

### DIFF
--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -57,18 +57,32 @@ describe('SesWebhookHandler', () => {
         expect(result.metrics?.[0].metricName).toBe('email_link_clicked')
     })
 
-    it.each([
-        ['Send', {}],
-        ['Delivery', { delivery: { timestamp: '2025-10-03T12:03:00Z' } }],
-    ] as const)(
-        'skips %s events (email_sent is recorded synchronously, not from webhooks)',
-        async (eventType, extra) => {
-            const body = [{ eventType, mail: baseMail, ...extra }]
-            const result = await handler.handleWebhook({ body, headers: {} })
-            expect(result.status).toBe(200)
-            expect(result.metrics).toHaveLength(0)
-        }
-    )
+    it('skips Send events (email_sent is recorded synchronously, not from webhooks)', async () => {
+        const body = [{ eventType: 'Send', mail: baseMail }]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.metrics).toHaveLength(0)
+    })
+
+    it('parses a raw Delivery event', async () => {
+        const body = [
+            {
+                eventType: 'Delivery',
+                mail: baseMail,
+                delivery: { timestamp: '2025-10-03T12:03:00Z' },
+            },
+        ]
+        const result = await handler.handleWebhook({ body, headers: {} })
+        expect(result.status).toBe(200)
+        expect(result.metrics).toEqual([
+            {
+                functionId: 'abc123',
+                invocationId: 'inv456',
+                actionId: undefined,
+                metricName: 'email_delivered',
+            },
+        ])
+    })
 
     it('parses a raw Bounce event and returns opt-out recipients for permanent bounces', async () => {
         const body = [

--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -12,7 +12,18 @@ describe('SesWebhookHandler', () => {
         source: 'sender@example.com',
         messageId: 'msg-123',
         destination: ['to@example.com'],
-        tags: { ph_id: [generateEmailTrackingCode({ functionId: 'abc123', id: 'inv456', teamId: 1 })] },
+        tags: {
+            ph_id: [
+                generateEmailTrackingCode({
+                    functionId: 'abc123',
+                    id: 'inv456',
+                    teamId: 1,
+                    state: {
+                        actionId: 'act789',
+                    },
+                }),
+            ],
+        },
     }
 
     it('parses a raw Open event', async () => {
@@ -34,6 +45,7 @@ describe('SesWebhookHandler', () => {
             {
                 functionId: 'abc123',
                 invocationId: 'inv456',
+                actionId: 'act789',
                 metricName: 'email_opened',
             },
         ])
@@ -78,7 +90,7 @@ describe('SesWebhookHandler', () => {
             {
                 functionId: 'abc123',
                 invocationId: 'inv456',
-                actionId: undefined,
+                actionId: 'act789',
                 metricName: 'email_delivered',
             },
         ])

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -144,10 +144,11 @@ const SesEventBatchSchema = z.array(SesEventRecordSchema)
 export type SesEventRecord = z.infer<typeof SesEventRecordSchema>
 
 // email_sent is recorded synchronously in email.service.ts when the email is sent,
-// so we don't record it again from SES Send/Delivery webhooks to avoid double counting.
+// so we don't record it again from SES Send webhooks to avoid double counting.
 const EVENT_TYPE_TO_METRIC_NAME: Partial<Record<SesEventRecord['eventType'], MinimalAppMetric['metric_name']>> = {
     Open: 'email_opened',
     Click: 'email_link_clicked',
+    Delivery: 'email_delivered',
     Bounce: 'email_bounced',
     Complaint: 'email_blocked',
     RenderingFailure: 'email_failed',

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -226,6 +226,7 @@ export type MinimalAppMetric = {
         | 'billable_invocation'
         | 'dropped'
         | 'email_sent'
+        | 'email_delivered'
         | 'email_failed'
         | 'email_opened'
         | 'email_link_clicked'

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -322,10 +322,14 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
             (emailActions, emailTotalsByActionId): EmailMetricRow[] =>
                 emailActions.map((action: { id: string; name: string }) => {
                     const totals = emailTotalsByActionId[action.id] || {}
+                    const sent = totals.email_sent ?? 0
+                    const bounced = totals.email_bounced ?? 0
+                    const blocked = totals.email_blocked ?? 0
                     return {
                         id: action.id,
                         email: action.name,
-                        delivered: totals.email_delivered ?? 0,
+                        // Fallback to calculating delivered as sent - bounced - blocked if email_delivered metric is not available, since we were not always collecting this metric
+                        delivered: totals.email_delivered ?? Math.max(0, sent - bounced - blocked),
                         sent: totals.email_sent ?? 0,
                         opened: totals.email_opened ?? 0,
                         linkClicked: totals.email_link_clicked ?? 0,

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -15,9 +15,10 @@ import { isEmailAction } from './hogflows/steps/types'
 import { EXIT_NODE_ID, workflowLogic } from './workflowLogic'
 import type { workflowMetricsSummaryLogicType } from './workflowMetricsSummaryLogicType'
 
-export type WorkflowSummaryMetric = 'started' | 'in_progress' | 'persons_messaged' | 'completed'
+export type WorkflowSummaryMetric = 'started' | 'in_progress' | 'persons_messaged' | 'delivered' | 'completed'
 export type EmailMetric =
     | 'email_sent'
+    | 'email_delivered'
     | 'email_failed'
     | 'email_opened'
     | 'email_link_clicked'
@@ -61,6 +62,13 @@ export const WORKFLOW_SUMMARY_METRICS: Record<
         color: '#00F',
         metricNames: ['email_sent'],
     },
+    delivered: {
+        name: 'Delivered',
+        description:
+            "Total number of emails that were successfully delivered to the recipient's inbox. This is confirmed by the recipient's mail server accepting the email.",
+        color: getColorVar('success'),
+        metricNames: ['email_delivered'],
+    },
     completed: {
         name: 'Completed',
         description:
@@ -79,6 +87,13 @@ export const WORKFLOW_EMAIL_METRICS: Record<
         description: 'Total number of emails sent to recipients',
         color: getColorVar('primary'),
         metricNames: ['email_sent'],
+    },
+    email_delivered: {
+        name: 'Delivered',
+        description:
+            "Total number of emails that were successfully delivered to the recipient's inbox. This is confirmed by the recipient's mail server accepting the email.",
+        color: getColorVar('success'),
+        metricNames: ['email_delivered'],
     },
     email_failed: {
         name: 'Failed',
@@ -125,6 +140,7 @@ const SUMMARY_METRIC_KEYS = (Object.keys(WORKFLOW_SUMMARY_METRICS) as WorkflowSu
 
 const EMAIL_METRICS: EmailMetric[] = [
     'email_sent',
+    'email_delivered',
     'email_opened',
     'email_failed',
     'email_link_clicked',
@@ -313,14 +329,11 @@ export const workflowMetricsSummaryLogic = kea<workflowMetricsSummaryLogicType>(
             (emailActions, emailTotalsByActionId): EmailMetricRow[] =>
                 emailActions.map((action: { id: string; name: string }) => {
                     const totals = emailTotalsByActionId[action.id] || {}
-                    const sent = totals.email_sent ?? 0
-                    const bounced = totals.email_bounced ?? 0
-                    const blocked = totals.email_blocked ?? 0
                     return {
                         id: action.id,
                         email: action.name,
-                        delivered: Math.max(0, sent - bounced - blocked),
-                        sent,
+                        delivered: totals.email_delivered ?? 0,
+                        sent: totals.email_sent ?? 0,
                         opened: totals.email_opened ?? 0,
                         linkClicked: totals.email_link_clicked ?? 0,
                     }

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -15,7 +15,7 @@ import { isEmailAction } from './hogflows/steps/types'
 import { EXIT_NODE_ID, workflowLogic } from './workflowLogic'
 import type { workflowMetricsSummaryLogicType } from './workflowMetricsSummaryLogicType'
 
-export type WorkflowSummaryMetric = 'started' | 'in_progress' | 'persons_messaged' | 'delivered' | 'completed'
+export type WorkflowSummaryMetric = 'started' | 'in_progress' | 'persons_messaged' | 'completed'
 export type EmailMetric =
     | 'email_sent'
     | 'email_delivered'

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -62,13 +62,6 @@ export const WORKFLOW_SUMMARY_METRICS: Record<
         color: '#00F',
         metricNames: ['email_sent'],
     },
-    delivered: {
-        name: 'Delivered',
-        description:
-            "Total number of emails that were successfully delivered to the recipient's inbox. This is confirmed by the recipient's mail server accepting the email.",
-        color: getColorVar('success'),
-        metricNames: ['email_delivered'],
-    },
     completed: {
         name: 'Completed',
         description:


### PR DESCRIPTION
## Summary

- Handle SES `Delivery` webhook events by emitting a new `email_delivered` metric, giving accurate delivery confirmation from the recipient's mail server
- Add `email_delivered` to the `MinimalAppMetric` type, `WORKFLOW_EMAIL_METRICS`, and `WORKFLOW_SUMMARY_METRICS` so it appears as a metrics card and in the email metrics summary table
- Replace the previous heuristic (`sent - bounced - blocked`) in the email metrics table with actual `email_delivered` data
- The "Delivered" tooltip explains that the metric represents an email making it to the recipient's inbox, confirmed by the recipient's mail server

## Test plan

- [x] Updated SES webhook test to verify `Delivery` events now emit `email_delivered` metric
- [x] Verified `Send` events are still skipped (no double-counting with synchronous `email_sent`)
- [x] All 12 SES webhook handler tests pass
- [x] Verify the "Delivered" metrics card renders in WorkflowMetricsSummary with correct tooltip
- [x] Verify the email metrics table shows actual delivery counts from the new metric

<img width="685" height="276" alt="image" src="https://github.com/user-attachments/assets/53caeff7-360e-4667-ae28-c4369535bf4f" />

<img width="778" height="120" alt="image" src="https://github.com/user-attachments/assets/84e44318-52d4-426e-9513-d2a3b659798c" />

https://claude.ai/code/session_01VL6CiB36tESp7rZ2LKvdfv