### PR TITLE
fix: perform correct access check for org invites

### DIFF
--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -25,7 +25,7 @@ from posthog.permissions import (
     TimeSensitiveActionPermission,
     UserCanInvitePermission,
 )
-from posthog.rbac.user_access_control import UserAccessControl
+from posthog.rbac.user_access_control import UserAccessControl, ordered_access_levels
 from posthog.tasks.email import send_invite
 
 
@@ -220,24 +220,21 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
             if not team_access_controls.exists():
                 continue
 
-            # Check if there's an access control with level 'none' (private team)
-            private_team_access = team_access_controls.filter(access_level="none").exists()
+            # Team is restricted, check if user has sufficient access
+            user_access_control = UserAccessControl(user=self.context["request"].user, team=team)
+            access_level = user_access_control.access_level_for_object(team)
+            if access_level == "none":
+                raise exceptions.ValidationError(team_error)
 
-            if private_team_access:
-                # Team is private, check if user has admin access
-                uac = UserAccessControl(user=self.context["request"].user, team=team)
-                access_level = uac.access_level_for_object(team)
-                if access_level == "none":
-                    raise exceptions.ValidationError(team_error)
+            # Check if user is trying to invite with a higher level than their own
+            levels = ordered_access_levels("project")
+            user_level_rank = levels.index(access_level) if access_level in levels else 0
+            requested_level_rank = levels.index(level) if level in levels else 0
 
-                # Check if user is trying to invite with a higher level than their own
-                user_level_rank = {"member": 1, "admin": 2}.get(access_level or "", 0)
-                requested_level_rank = {"member": 1, "admin": 2}.get(level, 0)
-
-                if requested_level_rank > user_level_rank:
-                    raise exceptions.ValidationError(
-                        "You cannot invite to a private project with a higher level than your own."
-                    )
+            if requested_level_rank > user_level_rank:
+                raise exceptions.ValidationError(
+                    "You cannot invite to a restricted project with a higher level than your own."
+                )
 
         return private_project_access
 

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -384,7 +384,47 @@ class TestOrganizationInvitesAPI(APIBaseTest):
             {
                 "type": "validation_error",
                 "code": "invalid_input",
-                "detail": "You cannot invite to a private project with a higher level than your own.",
+                "detail": "You cannot invite to a restricted project with a higher level than your own.",
+                "attr": "private_project_access",
+            },
+            response_data,
+        )
+        self.assertEqual(OrganizationInvite.objects.count(), count)
+
+    def test_invite_fails_if_inviter_level_is_lower_than_requested_level_on_member_restricted_project(self):
+        """
+        Regression test: when a project's default access_level is "member" (not "none"),
+        a standard member must still be prevented from requesting admin access.
+        """
+        email = "escalation@posthog.com"
+        count = OrganizationInvite.objects.count()
+        restricted_team = Team.objects.create(organization=self.organization, name="Member-Restricted Team")
+        organization_membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        organization_membership.level = OrganizationMembership.Level.MEMBER
+        organization_membership.save()
+
+        # Restrict the project with default access level "member" (not "none")
+        AccessControl.objects.create(
+            team=restricted_team,
+            access_level="member",
+            resource="project",
+            resource_id=str(restricted_team.id),
+        )
+        response = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.MEMBER,
+                "private_project_access": [{"id": restricted_team.id, "level": "admin"}],
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+        self.assertDictEqual(
+            {
+                "type": "validation_error",
+                "code": "invalid_input",
+                "detail": "You cannot invite to a restricted project with a higher level than your own.",
                 "attr": "private_project_access",
             },
             response_data,


### PR DESCRIPTION
## Problem

Access control checks are not correctly performed when the team has default access = `None`. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Verify that the user can only invite users up to their current access level to the project.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
