### PR TITLE
fix(rich markdown): fixes a bug on rich markdown editor that might show extra space

### DIFF
--- a/frontend/src/lib/components/MarkdownEditor/shared/RichMarkdownEditor.scss
+++ b/frontend/src/lib/components/MarkdownEditor/shared/RichMarkdownEditor.scss
@@ -27,6 +27,18 @@
             margin-bottom: 0.5rem;
         }
 
+        // Used to prevent extra spaces at the end from appearing when its just one element
+        // Readonly (e.g. TextCard body): no caret — hide the placeholder paragraph entirely.
+        &[contenteditable='false'] > p:last-child:has(> br.ProseMirror-trailingBreak:only-child) {
+            display: none;
+        }
+
+        // Drop bottom margin when a heading is the last block, or only followed by the trailing caret paragraph.
+        > :is(h1, h2, h3, h4, h5, h6):last-child,
+        > :is(h1, h2, h3, h4, h5, h6):has(+ p:last-child > br.ProseMirror-trailingBreak:only-child) {
+            margin-bottom: 0;
+        }
+
         ul,
         ol {
             padding-left: 1.5rem;


### PR DESCRIPTION
## Problem

People use text cards as a way to act as section breaks in dashboards.

Often they just use a single heading element.

However, each heading element has a tiny bit of margin at the bottom, which causes it to have a scroll.

<img width="500" height="248" alt="CleanShot 2026-03-25 at 16 19 23@2x" src="https://github.com/user-attachments/assets/b4e83f17-776d-4d86-a286-a00b5c639a14" />


## Changes

<img width="1216" height="286" alt="CleanShot 2026-03-25 at 16 19 41@2x" src="https://github.com/user-attachments/assets/5af577f0-b78d-4d8c-82eb-96232bddf465" />
## How did you test this code?

Locally.

## Publish to changelog?

No.