### PR TITLE
chore(devex): block accidental commits of .claude/settings.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "fsevents": "^2.3.3"
     },
     "lint-staged": {
-        ".claude/settings.json": "sh -c 'echo \"\\n\\033[31mDon'\\''t commit .claude/settings.json — personal permissions belong in .claude/settings.local.json (gitignored).\\nUnstage with: git restore --staged .claude/settings.json\\033[0m\\n\" >&2 && exit 1'",
+        ".claude/settings.json": "sh -c 'printf \"\\n\\033[31mDo not commit .claude/settings.json — personal permissions belong in .claude/settings.local.json (gitignored).\\nUnstage with: git restore --staged .claude/settings.json\\033[0m\\n\\n\" >&2 && exit 1'",
         "products/**/manifest.tsx": [
             "bin/hogli format:js",
             "sh -c 'pnpm build:products && git add frontend/src/products.tsx frontend/src/products.json'"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "fsevents": "^2.3.3"
     },
     "lint-staged": {
+        ".claude/settings.json": "sh -c 'echo \"\\n\\033[31mDon'\\''t commit .claude/settings.json — personal permissions belong in .claude/settings.local.json (gitignored).\\nUnstage with: git restore --staged .claude/settings.json\\033[0m\\n\" >&2 && exit 1'",
         "products/**/manifest.tsx": [
             "bin/hogli format:js",
             "sh -c 'pnpm build:products && git add frontend/src/products.tsx frontend/src/products.json'"


### PR DESCRIPTION
**Problem**

Claude Code's "Always allow" button hardcodes writes to `settings.json` (committed), not `settings.local.json` (gitignored). This dirties the working tree and risks committing personal permissions.

**Changes**

Adds a lint-staged rule that blocks commits touching `.claude/settings.json` with a message pointing to `settings.local.json`. One line in `package.json`, no hooks or scripts.

**Alternative to #52303** which solves the same problem with a ConfigChange hook + lockfile + embedded Python script. This is simpler — just fail the commit early.