### PR TITLE
fix: improve secret API key validation

### DIFF
--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -1,3 +1,4 @@
+import json
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -1907,6 +1908,25 @@ class TestProjectSecretAPIKeyAuthentication(APIBaseTest):
         user, _ = result
         self.assertIsInstance(user, ProjectSecretAPIKeyUser)
         self.assertEqual(user.team, self.team)
+
+    @parameterized.expand(
+        [
+            ("public_token", "phc_test_public_token"),
+            ("non_prefixed_token", "some_random_token_without_prefix"),
+            ("empty_string", ""),
+            ("integer_value", 12345),
+        ]
+    )
+    def test_authenticate_with_invalid_token_in_body_rejected(self, _name, token_value):
+        data = json.dumps({"secret_api_key": token_value})
+        wsgi_request = self.factory.post("/", data=data, content_type="application/json")
+        request = Request(wsgi_request)
+        request.parsers = [JSONParser()]
+
+        authenticator = ProjectSecretAPIKeyAuthentication()
+        result = authenticator.authenticate(request)
+
+        self.assertIsNone(result)
 
 
 @override_settings(

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -56,6 +56,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 structlog_logger = structlog.get_logger(__name__)
 
+_SECRET_API_KEY_RE = re.compile(r"^phs_[a-zA-Z0-9]+$")
+
+SECRET_API_KEY_BODY_COUNTER = Counter(
+    "api_auth_secret_api_key_body",
+    "Requests where the secret API key is provided in the request body instead of the Authorization header",
+)
+
 PERSONAL_API_KEY_QUERY_PARAM_COUNTER = Counter(
     "api_auth_personal_api_key_query_param",
     "Requests where the personal api key is specified in a query parameter",
@@ -319,9 +326,11 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
     ) -> Optional[str]:
         """Try to find project secret API key in request and return it"""
         if "authorization" in request.headers:
-            authorization_match = re.match(rf"^{cls.keyword}\s+(phs_[a-zA-Z0-9]+)$", request.headers["authorization"])
+            authorization_match = re.match(rf"^{cls.keyword}\s+(.+)$", request.headers["authorization"])
             if authorization_match:
-                return authorization_match.group(1).strip()
+                token = authorization_match.group(1).strip()
+                if _SECRET_API_KEY_RE.match(token):
+                    return token
 
         # Wrap HttpRequest in DRF Request if needed
         if not isinstance(request, Request):
@@ -330,7 +339,10 @@ class ProjectSecretAPIKeyAuthentication(authentication.BaseAuthentication):
         data = request.data
 
         if data and "secret_api_key" in data:
-            return data["secret_api_key"]
+            secret_api_key = data["secret_api_key"]
+            if isinstance(secret_api_key, str) and _SECRET_API_KEY_RE.match(secret_api_key):
+                SECRET_API_KEY_BODY_COUNTER.inc()
+                return secret_api_key
 
         return None
 


### PR DESCRIPTION
## Problem

`ProjectSecretAPIKeyAuthentication.find_secret_api_token` enforces the `phs_` prefix for tokens in the `Authorization` header but accepts any value from `data["secret_api_key"]` in the request body. This means an attacker can use a public project token (`phc_*`) — exposed in frontend JS snippets — to authenticate against secret-key-gated endpoints (`local_evaluation`, `remote_config`, `active_breakpoints`).

All three affected endpoints are read-only (GET), so the impact is data exposure (feature flag definitions, remote config values, debugger breakpoints), not integrity or availability.

## Changes

- **Enforce `phs_` prefix on body-extracted tokens** (`posthog/auth.py`): Apply the same `phs_` prefix + alphanumeric regex validation to body tokens that already exists for header tokens. Non-`phs_` tokens in the body are now silently rejected.
- **Normalize header token extraction** (`posthog/auth.py`): Refactor the header regex to capture the full token first, then validate format separately — consistent with the body path.
- **Add deprecation metric** (`posthog/auth.py`): `SECRET_API_KEY_BODY_COUNTER` Prometheus counter tracks body-based secret key usage for future deprecation planning.
- **Parameterized tests** (`posthog/api/test/test_authentication.py`): Covers public tokens, non-prefixed tokens, empty strings, and integer values in the body — all correctly rejected.

## How did you test this code?

- Added parameterized auth tests for invalid body tokens (public token, non-prefixed, empty, integer) — all rejected
- Ran existing `TestProjectSecretAPIKeyAuthentication` suite — all pass
- Manually tested with curl.

Do not publish to changelog

## Docs update

No docs changes needed.