### PR TITLE
fix(visual-review): post green commit status during migration

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -533,7 +533,9 @@ def mark_run_completed(run_id: UUID, error_message: str = "") -> Run:
             parts.append(f"{new_count} new")
         if removed_count:
             parts.append(f"{removed_count} removed")
-        _post_commit_status(run, repo, "failure", f"Visual changes detected: {', '.join(parts)}")
+        # During migration VR is observational — always green so drift doesn't block PRs.
+        # Flip to "failure" when VR becomes the gate.
+        _post_commit_status(run, repo, "success", f"Visual changes detected: {', '.join(parts)}")
     else:
         _post_commit_status(run, repo, "success", "No visual changes")
 

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -431,7 +431,8 @@ class TestCommitStatusChecks:
         logic.mark_run_completed(run.id)
 
         statuses = mock_github_api.status_checks
-        assert statuses[-1]["state"] == "failure"
+        # During migration VR is observational — always green
+        assert statuses[-1]["state"] == "success"
         assert "1 changed" in statuses[-1]["description"]
         assert "1 new" in statuses[-1]["description"]
 


### PR DESCRIPTION
VR is observational during migration — visual changes should show as green, not red. The status description still reports what changed, just as `success` instead of `failure`.

Flip to `failure` when VR becomes the gate.