### PR TITLE
chore: increase per-team query cache limit from 500 to 800

### DIFF
--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -38,8 +38,8 @@ COUNT_TILES_WITH_NO_FILTERS_HASH_INTERVAL_SECONDS = get_from_env(
 CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
-# Per-team cache size limit (default 500MB, can be overridden per-team via Team.extra_settings)
-TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 500 * 1024 * 1024, type_cast=int)
+# Per-team cache size limit (default 800MB, can be overridden per-team via Team.extra_settings)
+TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 800 * 1024 * 1024, type_cast=int)
 
 # Schedule to run asynchronous data deletion on. Follows crontab syntax.
 # Use empty string to prevent this

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -38,7 +38,7 @@ COUNT_TILES_WITH_NO_FILTERS_HASH_INTERVAL_SECONDS = get_from_env(
 CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
-# Per-team cache size limit (default 800MB, can be overridden per-team via Team.extra_settings)
+# Per-team cache size limit (default 800MiB, can be overridden per-team via Team.extra_settings)
 TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 800 * 1024 * 1024, type_cast=int)
 
 # Schedule to run asynchronous data deletion on. Follows crontab syntax.


### PR DESCRIPTION
## Problem

Teams are hitting the 500MB per-team query cache limit. P90 is around 600MB. 

## Changes

Bumps the default `TEAM_CACHE_SIZE_LIMIT_BYTES` from 500MiB to 800MiB in `posthog/settings/schedules.py`. The setting remains overridable per-team via `Team.extra_settings["cache_size_limit_bytes"]` and via the `TEAM_CACHE_SIZE_LIMIT_BYTES` environment variable.

## How did you test this code?

Can't really test but there is plenty of room in the cluster for this and we can always add nodes. 

<img width="869" height="315" alt="Screenshot 2026-03-25 at 6 01 38 PM" src="https://github.com/user-attachments/assets/2827dbcb-a8fa-4617-82df-397264413df9" />

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 LLM context

Co-authored by Claude Opus 4.6 via Claude Code.