### PR TITLE
fix(replay): add feature tags to ClickHouse queries

### DIFF
--- a/posthog/hogql_queries/utils/recordings_helper.py
+++ b/posthog/hogql_queries/utils/recordings_helper.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import Team
 
 
@@ -55,7 +55,7 @@ class RecordingsHelper:
                     {having_predicates}
                 """
 
-        tag_queries(team_id=self.team.id, product=Product.REPLAY)
+        tag_queries(team_id=self.team.id, product=Product.REPLAY, feature=Feature.QUERY)
         response = execute_hogql_query(
             query,
             placeholders={

--- a/posthog/session_recordings/models/system_status_queries.py
+++ b/posthog/session_recordings/models/system_status_queries.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 
 
 @dataclasses.dataclass(frozen=True)
@@ -12,7 +12,7 @@ class RecordingsSystemStatus:
 
 
 def get_recording_status_month_to_date() -> RecordingsSystemStatus:
-    tag_queries(product=Product.REPLAY)
+    tag_queries(product=Product.REPLAY, feature=Feature.HEALTH_CHECK)
     result = sync_execute(
         """
         SELECT count(distinct session_id), sum(event_count), sum(message_count), formatReadableSize(sum(size))

--- a/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/posthog/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -20,7 +20,7 @@ from posthog.schema import (
     RecordingsQuery,
 )
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.helpers.session_recording_playlist_templates import DEFAULT_PLAYLIST_NAMES
 from posthog.redis import get_client
 from posthog.session_recordings.models.session_recording_playlist import SessionRecordingPlaylist
@@ -405,7 +405,9 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
             playlist = SessionRecordingPlaylist.objects.get(id=playlist_id)
             redis_client = get_client()
 
-            tag_queries(product=Product.REPLAY, team_id=playlist.team.pk, replay_playlist_id=playlist_id)
+            tag_queries(
+                product=Product.REPLAY, feature=Feature.QUERY, team_id=playlist.team.pk, replay_playlist_id=playlist_id
+            )
 
             existing_value = redis_client.getex(
                 name=f"{PLAYLIST_COUNT_REDIS_PREFIX}{playlist.short_id}", ex=THIRTY_SIX_HOURS_IN_SECONDS

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -8,7 +8,7 @@ import pytz
 from posthog.schema import HogQLQuery
 
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models.team import Team
 from posthog.session_recordings.models.metadata import RecordingMetadata
 
@@ -94,7 +94,7 @@ class SessionReplayEvents:
 
     @staticmethod
     def _check_exists(session_id: str, team: Team) -> bool:
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         result = sync_execute(
             """
             SELECT
@@ -188,7 +188,7 @@ class SessionReplayEvents:
                 "now": now,
             },
         )
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         result = HogQLQueryRunner(team=team, query=query).calculate()
         if not result.results:
             return []
@@ -221,7 +221,7 @@ class SessionReplayEvents:
                 "max_timestamp": max_timestamp,
             },
         )
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         result = HogQLQueryRunner(team=team, query=query).calculate()
         if not result.results:
             return set()
@@ -318,7 +318,7 @@ class SessionReplayEvents:
         recording_start_time: Optional[datetime] = None,
     ) -> Optional[RecordingMetadata]:
         query = self.get_metadata_query(recording_start_time)
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         replay_response: list[tuple] = sync_execute(
             query,
             {
@@ -389,7 +389,7 @@ class SessionReplayEvents:
                 expiry_time >= %(python_now)s
                 AND max(is_deleted) = 0
         """
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         replay_response: list[tuple] = sync_execute(
             query,
             {
@@ -473,7 +473,7 @@ class SessionReplayEvents:
         from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 
         hq = self.get_events_query(session_id, metadata, events_to_ignore, extra_fields, limit, page)
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         result: HogQLQueryResponse = HogQLQueryRunner(
             team=team,
             query=hq,
@@ -630,7 +630,7 @@ def get_person_emails_for_session_ids(
             "max_timestamp": max_timestamp,
         },
     )
-    tag_queries(product=Product.REPLAY, team_id=team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team_id)
     result = HogQLQueryRunner(team=team, query=query).calculate()
     email_mapping: dict[str, str | None] = dict.fromkeys(session_ids)
     if result.results:

--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -18,7 +18,7 @@ from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query, tracer
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import MathAvailability, legacy_entity_to_node
 from posthog.models import Entity, EventProperty, Team
 from posthog.session_recordings.queries.sub_queries.base_query import SessionRecordingsListingBaseQuery
@@ -508,7 +508,7 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
     def get_event_ids_for_session(self) -> SessionRecordingQueryResult:
         query = self.get_query_for_event_id_matching()
 
-        tag_queries(product=Product.REPLAY, team_id=self._team.id)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=self._team.id)
         hogql_query_response = execute_hogql_query(
             query=query,
             team=self._team,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -64,7 +64,7 @@ from posthog.auth import (
     PersonalAPIKeyAuthentication,
     SharingAccessTokenAuthentication,
 )
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.constants import AvailableFeature
 from posthog.errors import CHQueryErrorCannotScheduleTask, CHQueryErrorTooManySimultaneousQueries
@@ -728,7 +728,7 @@ class SessionRecordingViewSet(
         return super().get_throttles()
 
     def list(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        tag_queries(product=Product.REPLAY)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
         user_distinct_id = cast(User, request.user).distinct_id
         auth_type = _request_auth_type(request)
 
@@ -804,7 +804,7 @@ class SessionRecordingViewSet(
     )
     @action(methods=["GET"], detail=False)
     def matching_events(self, request: request.Request, *args: Any, **kwargs: Any) -> JsonResponse:
-        tag_queries(product=Product.REPLAY)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
         data_dict = query_as_params_to_dict(request.GET.dict())
         query = RecordingsQuery.model_validate(data_dict)
 
@@ -841,7 +841,7 @@ class SessionRecordingViewSet(
     )
     @action(methods=["GET"], detail=True)
     def viewed(self, request: request.Request, *args: Any, **kwargs: Any) -> JsonResponse:
-        tag_queries(product=Product.REPLAY)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
         recording: SessionRecording = self.get_object()
 
         if not request.user.is_anonymous:
@@ -855,7 +855,7 @@ class SessionRecordingViewSet(
 
     # Returns metadata about the recording
     def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        tag_queries(product=Product.REPLAY)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
 
         with tracer.start_as_current_span("retrieve_recording", kind=trace.SpanKind.SERVER):
             with tracer.start_as_current_span("get_recording_object"):
@@ -882,7 +882,7 @@ class SessionRecordingViewSet(
                 return Response(serializer.data)
 
     def update(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        tag_queries(product=Product.REPLAY)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
         recording = self.get_object()
         loaded = recording.load_metadata()
 
@@ -1156,7 +1156,7 @@ class SessionRecordingViewSet(
         And then once for each source in the returned list to get the actual snapshots.
         """
 
-        tag_queries(product=Product.REPLAY)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
         timer = ServerTimingsGathered()
 
         with timer("get_recording"):
@@ -1421,7 +1421,7 @@ class SessionRecordingViewSet(
     def summarize(self, request: request.Request, **kwargs):
         if not request.user.is_authenticated:
             raise exceptions.NotAuthenticated()
-        tag_queries(product=Product.REPLAY)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY)
 
         user = cast(User, request.user)
 

--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -23,7 +23,7 @@ from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import SessionRecording, SessionRecordingPlaylist, SessionRecordingPlaylistItem, User
 from posthog.models.activity_logging.activity_log import Change, Detail, changes_between, log_activity
 from posthog.models.team.team import Team
@@ -543,7 +543,7 @@ class SessionRecordingPlaylistViewSet(
     # As of now, you can only "update" a session recording by adding or removing a recording from a static playlist
     @action(methods=["GET"], detail=True, url_path="recordings")
     def recordings(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
-        tag_queries(team_id=self.team.id, product=Product.REPLAY)
+        tag_queries(team_id=self.team.id, product=Product.REPLAY, feature=Feature.QUERY)
         playlist = self.get_object()
 
         limit = int(request.GET.get("limit", 50))

--- a/posthog/session_recordings/synthetic_playlists.py
+++ b/posthog/session_recordings/synthetic_playlists.py
@@ -18,7 +18,7 @@ import posthoganalytics
 from posthog.schema import RecordingOrder, RecordingsQuery
 
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import Comment, Team, User
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.sharing_configuration import SharingConfiguration
@@ -338,7 +338,7 @@ class FrustrationSignalsPlaylistSource(SyntheticPlaylistSource):
             LIMIT 1000
         """
 
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         result = sync_execute(
             query,
             {
@@ -503,7 +503,7 @@ class NewUrlsSyntheticPlaylistSource(SyntheticPlaylistSource):
             LIMIT 50000
         """
 
-        tag_queries(product=Product.REPLAY, team_id=team.pk)
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=team.pk)
         result = sync_execute(
             query,
             {

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -19,7 +19,7 @@ from structlog import get_logger
 from posthog.hogql.constants import LimitContext
 
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_concurrency
-from posthog.clickhouse.query_tagging import Product, get_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, get_query_tags, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.exceptions_capture import capture_exception
@@ -322,7 +322,7 @@ def replay_count_metrics() -> None:
         --group by team_id
         """
 
-        tag_queries(product=Product.REPLAY, name="replay_count_metrics")
+        tag_queries(product=Product.REPLAY, feature=Feature.QUERY, name="replay_count_metrics")
 
         results = sync_execute(
             query,

--- a/posthog/temporal/delete_recordings/activities.py
+++ b/posthog/temporal/delete_recordings/activities.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models import Team
 from posthog.security.outbound_proxy import internal_httpx_async_client
 from posthog.session_recordings.queries.session_recording_list_from_query import SessionRecordingListFromQuery
@@ -52,7 +52,7 @@ def _parse_session_recording_list_response(raw_response: bytes) -> list[str]:
 @activity.defn(name="load-recordings-with-person")
 async def load_recordings_with_person(input: RecordingsWithPersonInput) -> LoadRecordingsPage:
     bind_contextvars(distinct_ids=input.distinct_ids, team_id=input.team_id)
-    tag_queries(product=Product.REPLAY, team_id=input.team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=input.team_id)
     logger = LOGGER.bind()
     logger.info("Loading sessions for distinct IDs", distinct_id_count=len(input.distinct_ids), cursor=input.cursor)
 
@@ -81,7 +81,7 @@ async def load_recordings_with_person(input: RecordingsWithPersonInput) -> LoadR
 @activity.defn(name="load-recordings-with-team-id")
 async def load_recordings_with_team_id(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
     bind_contextvars(team_id=input.team_id)
-    tag_queries(product=Product.REPLAY, team_id=input.team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=input.team_id)
     logger = LOGGER.bind()
     logger.info("Loading sessions for team", cursor=input.cursor)
 
@@ -109,7 +109,7 @@ async def load_recordings_with_team_id(input: RecordingsWithTeamInput) -> LoadRe
 @activity.defn(name="load-recordings-with-query")
 async def load_recordings_with_query(input: RecordingsWithQueryInput) -> LoadRecordingsPage:
     bind_contextvars(team_id=input.team_id)
-    tag_queries(product=Product.REPLAY, team_id=input.team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=input.team_id)
     logger = LOGGER.bind()
     logger.info("Loading sessions matching query", cursor=input.cursor)
 

--- a/posthog/temporal/export_recording/activities.py
+++ b/posthog/temporal/export_recording/activities.py
@@ -11,7 +11,7 @@ from django.conf import settings
 import pytz
 from temporalio import activity
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models.exported_recording import ExportedRecording
 from posthog.redis import get_async_client
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
@@ -63,7 +63,7 @@ async def build_recording_export_context(input: ExportRecordingInput) -> ExportC
 
 @activity.defn
 async def export_replay_clickhouse_rows(input: ExportContext) -> None:
-    tag_queries(product=Product.REPLAY, team_id=input.team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=input.team_id)
     logger = LOGGER.bind()
     logger.info(f"Exporting Replay ClickHouse rows for session {input.session_id}")
 
@@ -93,7 +93,7 @@ async def export_replay_clickhouse_rows(input: ExportContext) -> None:
 
 @activity.defn
 async def export_event_clickhouse_rows(input: ExportContext) -> None:
-    tag_queries(product=Product.REPLAY, team_id=input.team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=input.team_id)
     logger = LOGGER.bind()
     logger.info(f"Exporting event ClickHouse rows for session {input.session_id}")
 

--- a/posthog/temporal/import_recording/activities.py
+++ b/posthog/temporal/import_recording/activities.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from temporalio import activity
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.session_recordings.recordings import recording_s3_client
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.logger import get_write_only_logger
@@ -150,7 +150,7 @@ FORMAT JSONEachRow
 
 @activity.defn
 async def import_replay_clickhouse_rows(input: ImportContext) -> None:
-    tag_queries(product=Product.REPLAY, team_id=input.team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=input.team_id)
     logger = LOGGER.bind()
     logger.info(f"Importing replay ClickHouse rows for session {input.session_id}")
 
@@ -203,7 +203,7 @@ async def import_replay_clickhouse_rows(input: ImportContext) -> None:
 
 @activity.defn
 async def import_event_clickhouse_rows(input: ImportContext) -> None:
-    tag_queries(product=Product.REPLAY, team_id=input.team_id)
+    tag_queries(product=Product.REPLAY, feature=Feature.QUERY, team_id=input.team_id)
     logger = LOGGER.bind()
     logger.info(f"Importing event ClickHouse rows for session {input.session_id}")
 


### PR DESCRIPTION
## Problem

ClickHouse queries originating from Replay code are tagged with `product=replay` but are missing the `feature` tag. This makes it harder to attribute query performance to specific features within the Replay product when monitoring ClickHouse query performance.

## Changes

- `posthog/session_recordings/queries/session_replay_events.py`: Added `feature=Feature.QUERY` to 7 `tag_queries()` calls across `_check_exists`, `_find_with_timestamps`, `_find_sessions_in_events`, `get_metadata`, `get_group_metadata`, `get_events`, and `get_person_emails_for_session_ids`
- `posthog/session_recordings/queries/sub_queries/events_subquery.py`: Added `feature=Feature.QUERY` to the `tag_queries()` call in `get_event_ids_for_session`
- `posthog/session_recordings/synthetic_playlists.py`: Added `feature=Feature.QUERY` to 2 `tag_queries()` calls in `_get_frustrated_session_ids` and `_get_new_urls_with_sessions`

Feature/team assignment came from the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

### Sibling PRs (one per team)

- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR adding query tags to existing ClickHouse queries. No manual testing was done beyond linting. The change is mechanical -- adding a `feature=Feature.QUERY` parameter to existing `tag_queries()` calls.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. The change is mechanical: every `tag_queries(product=Product.REPLAY, ...)` call in the session recordings directory was updated to also include `feature=Feature.QUERY`.