### PR TITLE
fix(analytics-platform): add product and feature tags to ClickHouse queries

### DIFF
--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -14,8 +14,11 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.schema import ProductKey
+
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload, get_client_from_pool
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.settings.base_variables import DEBUG
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
@@ -76,6 +79,7 @@ class DebugCHQueries(viewsets.ViewSet):
             ORDER BY hour
         """
 
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         response = sync_execute(sql_query, params)
         return [
             {
@@ -115,6 +119,7 @@ class DebugCHQueries(viewsets.ViewSet):
             )
         """
 
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         response = sync_execute(sql_query, params)
         return {
             "total_queries": response[0][0],
@@ -141,6 +146,7 @@ class DebugCHQueries(viewsets.ViewSet):
             params["start_time"] = (now() - relativedelta(minutes=10)).timestamp()
 
         # nosemgrep: clickhouse-fstring-param-audit - where_clause/limit_clause from internal builder
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         response = sync_execute(
             f"""
             SELECT
@@ -246,6 +252,7 @@ class DebugCHQueries(viewsets.ViewSet):
             raise exceptions.ValidationError("No profile_query_id provided.")
 
         try:
+            tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
             trace_results = sync_execute(
                 """
                 SELECT

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -12,7 +12,6 @@ from posthog.schema import ProductKey
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import ServerTimingsGathered, action
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models import Element, Filter
 from posthog.models.element.element import chain_to_elements
 from posthog.models.element.sql import GET_ELEMENTS, GET_VALUES
@@ -112,7 +111,6 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 )
 
             with timer("execute_query"):
-                tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
                 result = sync_execute(
                     GET_ELEMENTS.format(
                         date_from=date_from,
@@ -202,7 +200,6 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             else:
                 filter_regex = select_regex
 
-        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         result = sync_execute(
             GET_VALUES.format(),
             {

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -12,6 +12,7 @@ from posthog.schema import ProductKey
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import ServerTimingsGathered, action
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models import Element, Filter
 from posthog.models.element.element import chain_to_elements
 from posthog.models.element.sql import GET_ELEMENTS, GET_VALUES
@@ -111,6 +112,7 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 )
 
             with timer("execute_query"):
+                tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
                 result = sync_execute(
                     GET_ELEMENTS.format(
                         date_from=date_from,
@@ -200,6 +202,7 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             else:
                 filter_regex = select_regex
 
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         result = sync_execute(
             GET_VALUES.format(),
             {

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -13,6 +13,8 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from loginas.utils import is_impersonated_session
 from rest_framework import mixins, request, response, serializers, status, viewsets
 
+from posthog.schema import ProductKey
+
 from posthog.api.event_definition_generators.base import EventDefinitionGenerator
 from posthog.api.event_definition_generators.golang import GolangGenerator
 from posthog.api.event_definition_generators.python import PythonGenerator
@@ -22,6 +24,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.api.utils import action
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.constants import EventDefinitionType
 from posthog.event_usage import report_user_action
 from posthog.filters import TermSearchFilterBackend, term_search_filter_sql
@@ -562,6 +565,7 @@ def fetch_30day_event_queries(
         AND metric_name = %(metric_name)s
     """
 
+    tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
     results = sync_execute(clickhouse_query, clickhouse_kwargs)
 
     if not isinstance(results, list):

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -5,7 +5,10 @@ from typing import Any, Optional, Union
 import posthoganalytics
 from dateutil.parser import isoparse, parser
 
+from posthog.schema import ProductKey
+
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.path_filter import PathFilter
@@ -28,6 +31,7 @@ def ensure_is_date(candidate: Optional[Union[str, datetime]]) -> Optional[dateti
 
 
 def largest_teams(limit: int) -> set[int]:
+    tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.CACHE_WARMUP)
     teams_by_event_count = sync_execute(
         """
             SELECT team_id, COUNT(*) AS event_count
@@ -57,6 +61,7 @@ def active_teams() -> set[int]:
     if not all_teams:
         # NOTE: `active_teams()` doesn't cooperate with freezegun (aka `freeze_time()`), because of
         # the ClickHouse `now()` function being used below
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.CACHE_WARMUP)
         teams_by_recency = sync_execute(
             """
             SELECT team_id, date_diff('second', max(timestamp), now()) AS age

--- a/posthog/tasks/poll_query_performance.py
+++ b/posthog/tasks/poll_query_performance.py
@@ -5,9 +5,12 @@ from typing import Any, Optional
 
 from structlog import get_logger
 
+from posthog.schema import ProductKey
+
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.client.execute_async import QueryStatusManager
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.settings import CLICKHOUSE_CLUSTER
 from posthog.utils import UUID_REGEX
 
@@ -51,6 +54,7 @@ def get_query_results() -> list[Any]:
         SETTINGS skip_unavailable_shards=1
         """
 
+    tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.HEALTH_CHECK)
     raw_results = sync_execute(
         SYSTEM_PROCESSES_SQL, {"cluster": CLICKHOUSE_CLUSTER}, workload=Workload.ONLINE, ch_user=ClickHouseUser.OPS
     )


### PR DESCRIPTION
## Problem

ClickHouse queries originating from Analytics Platform team-owned code are missing `product` and `feature` query tags. This makes it difficult to attribute query performance and resource consumption to specific products and features when monitoring ClickHouse query health.

## Changes

- `posthog/tasks/poll_query_performance.py`: Added `product=product_analytics, feature=health_check` tags to the system process monitoring query
- `posthog/api/event_definition.py`: Added `product=product_analytics, feature=query` tags to the 30-day event metrics query
- `posthog/api/element.py`: Added `product=product_analytics, feature=query` tags to the element stats and values queries
- `posthog/api/debug_ch_queries.py`: Added `product=product_analytics, feature=query` tags to all four debug ClickHouse query endpoints (hourly stats, totals, recent queries, trace profiling)
- `posthog/caching/utils.py`: Added `product=product_analytics, feature=cache_warmup` tags to `largest_teams` and `active_teams` queries

Feature/team assignment was based on the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

### Sibling PRs (one per team)

- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR that adds query tags to existing ClickHouse queries. No manual testing was done beyond linting. The changes are mechanical additions of `tag_queries()` calls before `sync_execute()` calls, following the established pattern used elsewhere in the codebase.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. The changes follow the established query tagging pattern (calling `tag_queries()` before `sync_execute()`) to ensure all Analytics Platform ClickHouse queries are properly attributed for performance monitoring.