### PR TITLE
fix(surveys): add product and feature tags to ClickHouse queries

### DIFF
--- a/posthog/tasks/stop_surveys_reached_target.py
+++ b/posthog/tasks/stop_surveys_reached_target.py
@@ -4,8 +4,11 @@ from itertools import groupby
 from django.db.models import Q
 from django.utils import timezone
 
+from posthog.schema import ProductKey
+
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models.utils import UUIDT
 
 from products.surveys.backend.models import Survey
@@ -14,6 +17,7 @@ from products.surveys.backend.models import Survey
 def _get_surveys_response_counts(
     surveys_ids: list[UUIDT], team_id: int, earliest_survey_creation_date: datetime
 ) -> dict[str, int]:
+    tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)
     data = sync_execute(
         """
         SELECT

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -48,6 +48,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action, get_token
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.constants import SURVEY_TARGETING_FLAG_PREFIX, AvailableFeature
 from posthog.event_usage import report_user_action
@@ -1621,6 +1622,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             GROUP BY survey_id
         """
 
+        tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)
         data = sync_execute(query, params)
 
         counts = {}
@@ -1854,6 +1856,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             "dismissed": SurveyEventName.DISMISSED.value,
             "sent": SurveyEventName.SENT.value,
         }
+        tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)
         results_base = sync_execute(base_stats_query, query_params)
 
         # Query 2: Count of unique persons who both dismissed AND sent
@@ -1877,6 +1880,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                    AND sum(if(event = %(sent)s, 1, 0)) > 0
             ) AS PersonsWithBothEvents
         """
+        tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)
         dismissed_and_sent_count_result = sync_execute(dismissed_and_sent_query, query_params)
         dismissed_and_sent_count = dismissed_and_sent_count_result[0][0] if dismissed_and_sent_count_result else 0
 

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -1880,7 +1880,6 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                    AND sum(if(event = %(sent)s, 1, 0)) > 0
             ) AS PersonsWithBothEvents
         """
-        tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)
         dismissed_and_sent_count_result = sync_execute(dismissed_and_sent_query, query_params)
         dismissed_and_sent_count = dismissed_and_sent_count_result[0][0] if dismissed_and_sent_count_result else 0
 


### PR DESCRIPTION
## Problem

ClickHouse queries originating from Surveys-owned code (both the survey API endpoints and the background task that stops surveys when they reach response targets) are missing `product` and `feature` query tags. This makes it difficult to attribute query performance and costs to the Surveys product in monitoring dashboards.

## Changes

- `products/surveys/backend/api/survey.py`: Added `tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)` before ClickHouse queries in `responses_count` and `_get_survey_stats` methods
- `posthog/tasks/stop_surveys_reached_target.py`: Added `tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)` before the ClickHouse query in `_get_surveys_response_counts`

Feature/team assignment was based on the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

### Sibling PRs (one per team)

- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR that adds query tags to existing ClickHouse queries. No manual testing was done beyond linting. The changes are mechanical additions of `tag_queries` calls before `sync_execute` invocations.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. The Greptile bot flagged a redundant `tag_queries` call in `_get_survey_stats` (where `tag_queries` was called twice with identical values for two sequential queries in the same method). This was addressed in a follow-up commit that removed the redundant call, since `tag_queries` uses `contextvars.ContextVar` and persists for the duration of the function scope.