### PR TITLE
fix(llma): add product and feature tags to ClickHouse queries

### DIFF
--- a/posthog/tasks/llm_analytics_usage_report.py
+++ b/posthog/tasks/llm_analytics_usage_report.py
@@ -13,7 +13,7 @@ from posthog.schema import AIEventType
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.exceptions_capture import capture_exception
 from posthog.logging.timing import timed_log
 from posthog.models.property.util import get_property_string_expr
@@ -154,6 +154,7 @@ def _execute_split_query(
         # Execute the query for this time split
         with tags_context(
             product=Product.LLM_ANALYTICS,
+            feature=Feature.QUERY,
             kind="celery",
             id=CELERY_TASK_ID,
             name=query_name,
@@ -224,6 +225,7 @@ def get_teams_with_ai_events(begin: datetime, end: datetime) -> list[int]:
 
     with tags_context(
         product=Product.LLM_ANALYTICS,
+        feature=Feature.QUERY,
         kind="celery",
         id=CELERY_TASK_ID,
         name="Get teams with LLM analytics trigger events",

--- a/posthog/temporal/llm_analytics/sentiment/data.py
+++ b/posthog/temporal/llm_analytics/sentiment/data.py
@@ -7,7 +7,7 @@ results by trace_id for downstream processing.
 import json
 from dataclasses import dataclass, field
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.temporal.llm_analytics.sentiment.constants import (
     GENERATIONS_BY_UUID_QUERY,
     GENERATIONS_QUERY,
@@ -44,7 +44,7 @@ def fetch_generations(
 
     team = Team.objects.get(id=team_id)
     query = parse_select(GENERATIONS_QUERY)
-    with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team_id):
         result = execute_hogql_query(
             query_type="SentimentOnDemand",
             query=query,
@@ -96,7 +96,7 @@ def fetch_generations_by_uuid(
 
     team = Team.objects.get(id=team_id)
     query = parse_select(GENERATIONS_BY_UUID_QUERY)
-    with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team_id):
         result = execute_hogql_query(
             query_type="SentimentOnDemandGeneration",
             query=query,

--- a/posthog/temporal/llm_analytics/trace_clustering/data.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/data.py
@@ -14,7 +14,7 @@ from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.temporal.llm_analytics.trace_clustering import constants
 from posthog.temporal.llm_analytics.trace_clustering.models import (
@@ -100,7 +100,7 @@ def fetch_item_embeddings_for_clustering(
         placeholders["document_type_legacy"] = ast.Constant(value=constants.LLMA_TRACE_DOCUMENT_TYPE_LEGACY)
         placeholders["rendering_legacy"] = ast.Constant(value=constants.LLMA_TRACE_RENDERING_LEGACY)
 
-    with tags_context(product=Product.LLM_ANALYTICS):
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY):
         result = execute_hogql_query(
             query_type="ItemEmbeddingsForClustering",
             query=query,
@@ -203,7 +203,7 @@ def fetch_item_summaries(
     # Build item_ids tuple for IN clause
     item_ids_tuple = ast.Tuple(exprs=[ast.Constant(value=iid) for iid in item_ids])
 
-    with tags_context(product=Product.LLM_ANALYTICS):
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY):
         result = execute_hogql_query(
             query_type="ItemSummariesForClustering",
             query=query,

--- a/posthog/temporal/llm_analytics/trace_summarization/fetch_and_format.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/fetch_and_format.py
@@ -9,7 +9,7 @@ from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.redis import get_async_client
 from posthog.sync import database_sync_to_async
@@ -109,7 +109,7 @@ def _fetch_and_format_generation(
         """
     )
 
-    with tags_context(product=Product.LLM_ANALYTICS, team_id=team.id):
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team.id):
         result = execute_hogql_query(
             query_type="GenerationForSummarization",
             query=query,

--- a/posthog/temporal/llm_analytics/trace_summarization/queries.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/queries.py
@@ -16,7 +16,7 @@ from posthog.hogql.constants import LimitContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.temporal.llm_analytics.trace_summarization.constants import AI_EVENT_TYPES, TRACE_CAPTURE_RANGE
 
@@ -42,7 +42,7 @@ def fetch_trace(team: Team, trace_id: str, window_start: str, window_end: str) -
     end_dt = datetime.fromisoformat(window_end).astimezone(UTC) + TRACE_CAPTURE_RANGE
 
     query = parse_select(_TRACE_EVENTS_QUERY)
-    with tags_context(product=Product.LLM_ANALYTICS, team_id=team.id):
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team.id):
         result = execute_hogql_query(
             query_type="SummarizationTraceFetch",
             query=query,

--- a/posthog/temporal/llm_analytics/trace_summarization/sampling.py
+++ b/posthog/temporal/llm_analytics/trace_summarization/sampling.py
@@ -16,7 +16,7 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
@@ -101,7 +101,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 """
             )
 
-            with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+            with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team_id):
                 result = execute_hogql_query(
                     query_type="GenerationsForSampling",
                     query=generations_query,
@@ -168,7 +168,7 @@ async def sample_items_in_window_activity(inputs: BatchSummarizationInputs) -> l
                 """
             )
 
-            with tags_context(product=Product.LLM_ANALYTICS, team_id=team_id):
+            with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY, team_id=team_id):
                 result = execute_hogql_query(
                     query_type="TracesForSampling",
                     query=traces_query,

--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -11,9 +11,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
+from posthog.schema import ProductKey
+
 from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.client import query_with_columns
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.event_usage import report_user_action
 from posthog.permissions import AccessControlPermission
 from posthog.temporal.common.client import sync_connect
@@ -82,6 +85,7 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             where_clauses.append("distinct_id = %(distinct_id)s")
             params["distinct_id"] = distinct_id
 
+        tag_queries(product=ProductKey.LLM_EVALUATIONS, feature=Feature.QUERY)
         query_result = query_with_columns(
             f"""
             SELECT

--- a/products/llm_analytics/backend/api/evaluation_runs.py
+++ b/products/llm_analytics/backend/api/evaluation_runs.py
@@ -11,12 +11,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
-from posthog.schema import ProductKey
-
 from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.client import query_with_columns
-from posthog.clickhouse.query_tagging import Feature, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.event_usage import report_user_action
 from posthog.permissions import AccessControlPermission
 from posthog.temporal.common.client import sync_connect
@@ -85,7 +83,7 @@ class EvaluationRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             where_clauses.append("distinct_id = %(distinct_id)s")
             params["distinct_id"] = distinct_id
 
-        tag_queries(product=ProductKey.LLM_EVALUATIONS, feature=Feature.QUERY)
+        tag_queries(product=Product.LLM_ANALYTICS, feature=Feature.QUERY)
         query_result = query_with_columns(
             f"""
             SELECT

--- a/products/llm_analytics/backend/api/evaluation_summary.py
+++ b/products/llm_analytics/backend/api/evaluation_summary.py
@@ -28,7 +28,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.api.monitoring import monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.event_usage import report_user_action
 from posthog.models import Team, User
 from posthog.permissions import AccessControlPermission
@@ -196,7 +196,7 @@ def _fetch_evaluation_runs(
         """
     )
 
-    with tags_context(product=Product.LLM_ANALYTICS):
+    with tags_context(product=Product.LLM_ANALYTICS, feature=Feature.QUERY):
         query_result = execute_hogql_query(
             query_type="EvaluationSummaryFetchRuns",
             query=query,

--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -360,11 +360,14 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
         allows_na = serializer.validated_data["allows_na"]
         conditions = serializer.validated_data.get("conditions", [])
 
+        from posthog.schema import ProductKey
+
         from posthog.hogql import ast
         from posthog.hogql.property import property_to_expr
         from posthog.hogql.query import execute_hogql_query
 
         from posthog.cdp.validation import compile_hog
+        from posthog.clickhouse.query_tagging import Feature, tag_queries
         from posthog.models.team import Team
 
         try:
@@ -422,6 +425,7 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
             limit=ast.Constant(value=sample_count),
         )
 
+        tag_queries(product=ProductKey.LLM_EVALUATIONS, feature=Feature.QUERY)
         response = execute_hogql_query(query=query, team=team, limit_context=None)
 
         if not response.results:

--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -360,14 +360,12 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
         allows_na = serializer.validated_data["allows_na"]
         conditions = serializer.validated_data.get("conditions", [])
 
-        from posthog.schema import ProductKey
-
         from posthog.hogql import ast
         from posthog.hogql.property import property_to_expr
         from posthog.hogql.query import execute_hogql_query
 
         from posthog.cdp.validation import compile_hog
-        from posthog.clickhouse.query_tagging import Feature, tag_queries
+        from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
         from posthog.models.team import Team
 
         try:
@@ -425,7 +423,7 @@ class EvaluationViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, Forbi
             limit=ast.Constant(value=sample_count),
         )
 
-        tag_queries(product=ProductKey.LLM_EVALUATIONS, feature=Feature.QUERY)
+        tag_queries(product=Product.LLM_ANALYTICS, feature=Feature.QUERY)
         response = execute_hogql_query(query=query, team=team, limit_context=None)
 
         if not response.results:


### PR DESCRIPTION
## Problem

ClickHouse queries from LLM analytics code are missing `product` and/or `feature` query tags, making it hard to attribute query performance and costs to specific product areas in the `system.query_log`.

## Changes

- Adds missing `feature=Feature.QUERY` tags to LLM analytics temporal queries that already had `product` set (sentiment, trace clustering, trace summarization, usage report)
- Adds both `product=Product.LLM_ANALYTICS` and `feature=Feature.QUERY` tags to evaluation API queries (`evaluation_runs.py`, `evaluations.py`, `evaluation_summary.py`)
- Uses consistent `Product.LLM_ANALYTICS` across all evaluation API files for predictable query attribution

Files modified:
- `posthog/tasks/llm_analytics_usage_report.py`
- `posthog/temporal/llm_analytics/sentiment/data.py`
- `posthog/temporal/llm_analytics/trace_clustering/data.py`
- `posthog/temporal/llm_analytics/trace_summarization/fetch_and_format.py`
- `posthog/temporal/llm_analytics/trace_summarization/queries.py`
- `posthog/temporal/llm_analytics/trace_summarization/sampling.py`
- `products/llm_analytics/backend/api/evaluation_runs.py`
- `products/llm_analytics/backend/api/evaluation_summary.py`
- `products/llm_analytics/backend/api/evaluations.py`

Feature/team assignment was based on the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

### Sibling PRs (one per team)

- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR adding query tags to ClickHouse queries. No manual testing was done beyond linting. The changes are purely additive metadata annotations that do not affect query behavior.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. The initial commit added query tags, and a follow-up commit addressed Greptile review feedback to use consistent `Product.LLM_ANALYTICS` (instead of `ProductKey.LLM_EVALUATIONS`) across all evaluation API files.