### PR TITLE
fix(experiments): add feature tag to ClickHouse queries

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -21,7 +21,7 @@ from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.hogql_queries.experiments import MULTIPLE_VARIANT_KEY
 from posthog.hogql_queries.experiments.error_handling import experiment_error_handler
 from posthog.hogql_queries.experiments.experiment_query_builder import (
@@ -235,10 +235,11 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # Adding experiment specific tags to the tag collection
         # This will be available as labels in Prometheus
         tag_queries(
+            product=Product.EXPERIMENTS,
+            feature=Feature.QUERY,
             experiment_id=self.query.experiment_id,
             experiment_name=self.query.experiment_name,
             experiment_feature_flag_key=self.feature_flag_key,
-            product=Product.EXPERIMENTS,
         )
 
         # Set limit to avoid being cut-off by the default 100 rows limit

--- a/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
@@ -21,7 +21,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.constants import ExperimentNoResultsErrorKeys
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
 from posthog.hogql_queries.experiments.funnels_statistics_v2 import (
@@ -61,6 +61,8 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
         # Adding experiment specific tags to the tag collection
         # This will be available as labels in Prometheus
         tag_queries(
+            product=Product.EXPERIMENTS,
+            feature=Feature.QUERY,
             query_type="ExperimentFunnelsQuery",
             experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -24,7 +24,7 @@ from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY, MULTIPLE_VARIANT_KEY
 from posthog.hogql_queries.experiments.base_query_utils import get_experiment_date_range
 from posthog.hogql_queries.experiments.error_handling import experiment_error_handler
@@ -238,6 +238,7 @@ class ExperimentQueryRunner(QueryRunner):
         # This will be available as labels in Prometheus
         tag_queries(
             product=Product.EXPERIMENTS,
+            feature=Feature.QUERY,
             experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,
             experiment_feature_flag_key=self.feature_flag.key,

--- a/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
@@ -31,7 +31,7 @@ from posthog.schema import (
 
 from posthog.hogql import ast
 
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.constants import ExperimentNoResultsErrorKeys
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
 from posthog.hogql_queries.experiments.trends_statistics_v2_continuous import (
@@ -242,6 +242,8 @@ class ExperimentTrendsQueryRunner(QueryRunner):
         # Adding experiment specific tags to the tag collection
         # This will be available as labels in Prometheus
         tag_queries(
+            product=Product.EXPERIMENTS,
+            feature=Feature.QUERY,
             query_type="ExperimentTrendsQuery",
             experiment_id=str(self.experiment.id),
             experiment_name=self.experiment.name,


### PR DESCRIPTION
## Problem

ClickHouse queries originating from the Experiments product code (`experiment_query_runner.py`) are tagged with a `product` label but are missing a `feature` tag. Without the `feature=Feature.QUERY` tag, it is harder to attribute query performance and costs specifically to the experiment query execution path in Prometheus metrics.

## Changes

- **`posthog/hogql_queries/experiments/experiment_query_runner.py`**: Added `feature=Feature.QUERY` to the `tag_queries()` call in `_evaluate_experiment_query()`, and imported the `Feature` enum alongside the existing `Product` import.

Feature/team assignment was determined from the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

### Sibling PRs (one per team)

- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR that adds a query tag to an existing `tag_queries()` call. No manual testing was done beyond linting. The change is additive and follows the same pattern used in other query runners across the codebase.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. The change mirrors the `feature=Feature.QUERY` tagging pattern already established in other query runners and ensures Experiments queries are properly attributed in ClickHouse query performance monitoring.