### PR TITLE
fix(growth): add feature tag to ClickHouse queries

### DIFF
--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -51,7 +51,7 @@ def run_query(team: Team) -> HogQLQueryResponse:
     query_type = "sdk_versions_for_team"
     with tags_context(
         product=Product.SDK_DOCTOR,
-        feature=Feature.CACHE_WARMUP,
+        feature=Feature.HEALTH_CHECK,
         team_id=team.pk,
         org_id=team.organization_id,
         query_type=query_type,

--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -12,7 +12,7 @@ from posthog.schema import HogQLQueryResponse
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.dags.common import JobOwners, skip_if_already_running
 from posthog.dags.common.ops import get_all_team_ids_op
 from posthog.dags.common.resources import redis
@@ -49,7 +49,13 @@ QUERY = parse_select("""
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=10))
 def run_query(team: Team) -> HogQLQueryResponse:
     query_type = "sdk_versions_for_team"
-    with tags_context(product=Product.SDK_DOCTOR, team_id=team.pk, org_id=team.organization_id, query_type=query_type):
+    with tags_context(
+        product=Product.SDK_DOCTOR,
+        feature=Feature.QUERY,
+        team_id=team.pk,
+        org_id=team.organization_id,
+        query_type=query_type,
+    ):
         response = execute_hogql_query(QUERY, team, query_type=query_type)
     return response
 

--- a/products/growth/dags/team_sdk_versions.py
+++ b/products/growth/dags/team_sdk_versions.py
@@ -51,7 +51,7 @@ def run_query(team: Team) -> HogQLQueryResponse:
     query_type = "sdk_versions_for_team"
     with tags_context(
         product=Product.SDK_DOCTOR,
-        feature=Feature.QUERY,
+        feature=Feature.CACHE_WARMUP,
         team_id=team.pk,
         org_id=team.organization_id,
         query_type=query_type,


### PR DESCRIPTION
## Problem

ClickHouse queries from Growth-owned code (specifically the SDK Doctor DAG that caches team SDK versions) are missing `feature` tags in their query tagging context. This makes it hard to attribute query performance and route queries to the appropriate ClickHouse user.

## Changes

- `products/growth/dags/team_sdk_versions.py`: Added `Feature.CACHE_WARMUP` tag to the `tags_context` in `run_query()`, and imported `Feature` from `posthog.clickhouse.query_tagging`. Uses `CACHE_WARMUP` (not `QUERY`) because this is a scheduled background DAG that warms a Redis cache across all teams, matching the pattern used by `products/web_analytics/dags/cache_warming.py` and `posthog/caching/warming.py`.

Feature/team assignment came from the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

Sibling PRs (one per team):
- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR adding query tags. No manual testing done beyond linting. The change is a straightforward addition of a feature tag to an existing `tags_context` call.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. The initial commit added `Feature.QUERY` as the feature tag, but after review feedback from Greptile (correctly noting this is a cache-warming DAG, not a user-facing query), the tag was updated to `Feature.CACHE_WARMUP` to route these background queries through the dedicated cache-warmup ClickHouse user.