### PR TITLE
chore: tag cache_key in query log_comment

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1237,6 +1237,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     tag_queries(scene=tags.scene)
 
             tag_queries(execution_mode=execution_mode.value)
+            tag_queries(cache_key=cache_key)
 
             # Abort early if the user doesn't have access to the query runner
             # We'll proceed as usual if there's no user connected to this request


### PR DESCRIPTION
## Problem

I noticed identical SQL queries re-execute on ClickHouse 1-3 seconds apart despite the cache staleness threshold being 5+ minutes and the execution mode being `blocking` (which means it goes to the cache first). 

https://metabase.prod-us.posthog.dev/question/2001-duplicate-blocking-queries

To diagnose whether this is caused by different cache keys vs cache write failures, we need the `cache_key visible in the query log.

## Changes

Adds `tag_queries(cache_key=cache_key)` to `QueryRunner.run()` 

## How did you test this code?

N/A

## Publish to changelog?

no