### PR TITLE
fix(product-analytics): add product and feature tags to ClickHouse queries

### DIFF
--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -4,8 +4,10 @@ from typing import Optional, Union
 
 from django.utils.timezone import now
 
+from posthog.schema import ProductKey
+
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models import Team
 from posthog.models.filters.utils import validate_group_type_index
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -44,6 +46,7 @@ class RelatedActorsQuery:
         return self.group_type_index is not None
 
     def run(self, variant: str = "control") -> list[SerializedActor]:
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         results: list[SerializedActor] = []
         results.extend(self._query_related_people())
 

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -22,6 +22,8 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 
+from posthog.schema import ProductKey
+
 from posthog.hogql import ast
 from posthog.hogql.constants import DEFAULT_RETURNED_ROWS, MAX_SELECT_RETURNED_ROWS
 from posthog.hogql.property_utils import create_property_conditions
@@ -33,6 +35,7 @@ from posthog.api.utils import action
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.clickhouse.client import query_with_columns
 from posthog.clickhouse.client.limit import get_events_list_rate_limiter
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.event_usage import get_request_analytics_properties
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Element, Filter, Person, PropertyDefinition
@@ -419,6 +422,8 @@ class EventViewSet(
                 },
                 status=400,
             )
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
+        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         query_result = query_with_columns(
             SELECT_ONE_EVENT_SQL,
             {"team_id": self.team.pk, "event_id": pk.replace("-", "")},

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -423,7 +423,6 @@ class EventViewSet(
                 status=400,
             )
         tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
-        tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)
         query_result = query_with_columns(
             SELECT_ONE_EVENT_SQL,
             {"team_id": self.team.pk, "event_id": pk.replace("-", "")},


### PR DESCRIPTION
## Problem

ClickHouse queries originating from Product Analytics code (related actors queries and event API) are missing `product` and `feature` query tags. This makes it difficult to attribute query performance and costs back to the Product Analytics team and specific features.

## Changes

- `ee/clickhouse/queries/related_actors_query.py`: Added `tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)` call in the `run()` method so related actors queries are tagged
- `posthog/api/event.py`: Added `tag_queries(product=ProductKey.PRODUCT_ANALYTICS, feature=Feature.QUERY)` call in the `retrieve()` method so single-event lookups are tagged; also added the necessary imports (`ProductKey`, `Feature`, `tag_queries`)

Feature/team assignment was determined from the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

### Sibling PRs (one per team)

- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR adding query tags to ClickHouse queries. No manual testing was done beyond linting and pre-commit checks passing.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. The duplicate `tag_queries` call flagged by Greptile in the initial review has been fixed in a follow-up commit.