### PR TITLE
fix(ingestion): add product and feature tags to ClickHouse queries

### DIFF
--- a/posthog/api/ingestion_warnings.py
+++ b/posthog/api/ingestion_warnings.py
@@ -7,8 +7,11 @@ from rest_framework import viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.schema import ProductKey
+
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 
 
 class IngestionWarningsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
@@ -45,6 +48,7 @@ class IngestionWarningsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             GROUP BY
                 type
         """
+        tag_queries(product=ProductKey.INGESTION_WARNINGS, feature=Feature.QUERY)
         warning_events = sync_execute(
             query,
             {

--- a/posthog/models/person/deletion.py
+++ b/posthog/models/person/deletion.py
@@ -5,7 +5,10 @@ from django.db import router, transaction
 import structlog
 from rest_framework.exceptions import NotFound
 
+from posthog.schema import ProductKey
+
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.person.util import create_person, create_person_distinct_id
 
@@ -29,6 +32,7 @@ def reset_deleted_person_distinct_ids(team_id: int, distinct_id: str):
 
 def _get_distinct_ids_tied_to_deleted_persons(team_id: int) -> list[str]:
     # find distinct_ids where the person is set to be deleted
+    tag_queries(product=ProductKey.PERSONS, feature=Feature.QUERY)
     rows = sync_execute(
         """
             SELECT distinct_id FROM (
@@ -46,6 +50,7 @@ def _get_distinct_ids_tied_to_deleted_persons(team_id: int) -> list[str]:
 
 
 def _get_version_for_distinct_id(team_id: int, distinct_id: str) -> int:
+    tag_queries(product=ProductKey.PERSONS, feature=Feature.QUERY)
     rows = sync_execute(
         """
             SELECT max(version) as version FROM person_distinct_id2 WHERE team_id = %(team)s AND distinct_id = %(distinct_id)s
@@ -109,6 +114,7 @@ def _update_distinct_id_in_postgres(distinct_id: str, version: int, team_id: int
 
 def _get_person_version_if_deleted(team_id: int, person_uuid: str) -> Optional[int]:
     """Returns the max version if the person is soft-deleted in ClickHouse, None otherwise."""
+    tag_queries(product=ProductKey.PERSONS, feature=Feature.QUERY)
     rows = sync_execute(
         """
             SELECT max(version), argMax(is_deleted, version)

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -9,7 +9,10 @@ from django.utils.timezone import now
 import structlog
 from celery import shared_task
 
+from posthog.schema import ProductKey
+
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models.person import Person, PersonDistinctId
 
 logger = structlog.get_logger(__name__)
@@ -82,6 +85,7 @@ def verify_persons_data_in_sync(
 
 
 def _team_integrity_statistics(person_data: list[Any]) -> Counter:
+    tag_queries(product=ProductKey.PERSONS, feature=Feature.QUERY)
     person_ids = [id for id, _, _ in person_data]
     person_uuids = [uuid for _, uuid, _ in person_data]
     team_ids = list({team_id for _, _, team_id in person_data})


### PR DESCRIPTION
## Problem

ClickHouse queries executed from Ingestion team-owned code (ingestion warnings API, person deletion, and person sync verification) are missing `product` and `feature` query tags. Without these tags, it is difficult to attribute query performance and resource usage back to the specific product areas generating them.

## Changes

- `posthog/api/ingestion_warnings.py` -- adds `tag_queries(product=ProductKey.INGESTION_WARNINGS, feature=Feature.QUERY)` before the ingestion warnings list query
- `posthog/models/person/deletion.py` -- adds `tag_queries(product=ProductKey.PERSONS, feature=Feature.QUERY)` before three ClickHouse queries: fetching distinct IDs tied to deleted persons, getting version for a distinct ID, and checking if a person is deleted
- `posthog/tasks/verify_persons_data_in_sync.py` -- adds `tag_queries(product=ProductKey.PERSONS, feature=Feature.QUERY)` before the person/distinct-ID sync verification queries

Feature/team assignment was based on the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

This is one of 18 sibling PRs (one per team) adding query tags across the codebase:
- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR that adds query tags to existing ClickHouse queries. No manual testing was performed beyond linting. The changes are additive metadata annotations and do not alter query logic or results.

## Publish to changelog?

No.

## Docs update

Not needed.

## 🤖 LLM context

This PR was authored by Claude Code. It adds `product` and `feature` query tags to ClickHouse queries in Ingestion team-owned code paths, following the same pattern used elsewhere in the codebase via `posthog.clickhouse.query_tagging.tag_queries`.