### PR TITLE
fix(data-warehouse): add product and feature tags to ClickHouse queries

### DIFF
--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -18,6 +18,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.batch_exports.models import BatchExportRun
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.helpers.dashboard_templates import create_data_ops_dashboard
 from posthog.models.hog_functions.hog_function import HogFunction, HogFunctionState, HogFunctionType
@@ -97,6 +98,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             limit=ast.Constant(value=10),
         )
 
+        tag_queries(product=Product.WAREHOUSE, feature=Feature.QUERY)
         result = execute_hogql_query(query, team=self.team)
 
         values = [row[0] for row in result.results]

--- a/products/data_warehouse/backend/api/view_link.py
+++ b/products/data_warehouse/backend/api/view_link.py
@@ -15,6 +15,7 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.errors import look_up_clickhouse_error_code_meta
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
@@ -231,6 +232,7 @@ class ViewLinkViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         try:
             user = cast(User, self.request.user)
+            tag_queries(product=Product.WAREHOUSE, feature=Feature.QUERY)
             query_response = execute_hogql_query(
                 query=validation_query,
                 team=self.team,

--- a/products/data_warehouse/backend/models/table.py
+++ b/products/data_warehouse/backend/models/table.py
@@ -26,7 +26,7 @@ from posthog.hogql.database.s3_table import (
 from posthog.hogql.escape_sql import escape_clickhouse_identifier
 
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries, wrap_clickhouse_query_error
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
@@ -183,6 +183,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 select_from=ast.JoinExpr(table=ast.Field(chain=[self.name])),
             )
 
+            tag_queries(product=Product.WAREHOUSE, feature=Feature.QUERY)
             execute_hogql_query(
                 query,
                 self.team,
@@ -243,6 +244,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 warehouse_query=True,
                 name="get_columns",
                 product=Product.WAREHOUSE,
+                feature=Feature.QUERY,
             )
 
             # The cluster is a little broken right now, and so this can intermittently fail.
@@ -304,6 +306,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 warehouse_query=True,
                 name="get_max_value_for_column",
                 product=Product.WAREHOUSE,
+                feature=Feature.QUERY,
             )
             result = sync_execute(
                 f"SELECT max({escape_clickhouse_identifier(column)}) FROM {s3_table_func}",
@@ -348,6 +351,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                     warehouse_query=True,
                     name="get_count",
                     product=Product.WAREHOUSE,
+                    feature=Feature.QUERY,
                 )
 
                 result = sync_execute(
@@ -546,6 +550,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             warehouse_query=True,
             name="validate_csv_double_quotes",
             product=Product.WAREHOUSE,
+            feature=Feature.QUERY,
         )
         try:
             ctx = HogQLContext(team_id=self.team.pk)


### PR DESCRIPTION
## Problem

ClickHouse queries originating from Data Warehouse code (API views, table model methods) are missing `feature` query tags. While many already have `product=warehouse`, the `feature` tag is absent, making it harder to attribute query performance and costs to specific features within the Data Warehouse product.

## Changes

- `products/data_warehouse/backend/api/data_warehouse.py`: Added `tag_queries(product=Product.WAREHOUSE, feature=Feature.QUERY)` before `execute_hogql_query` in the `DataWarehouseViewSet`
- `products/data_warehouse/backend/api/view_link.py`: Added `tag_queries(product=Product.WAREHOUSE, feature=Feature.QUERY)` before `execute_hogql_query` in the `ViewLinkViewSet`
- `products/data_warehouse/backend/models/table.py`: Added `feature=Feature.QUERY` to all existing `tag_queries` and `sync_execute` calls that already had `product=Product.WAREHOUSE` but were missing the feature tag

Feature/team assignment came from the [feature ownership page](https://posthog.com/handbook/engineering/feature-ownership).

### Sibling PRs (one per team)

- Surveys: https://github.com/PostHog/posthog/pull/52341
- Replay: https://github.com/PostHog/posthog/pull/52338
- Product Analytics: https://github.com/PostHog/posthog/pull/52350
- Web Analytics: https://github.com/PostHog/posthog/pull/52351
- Platform Features: https://github.com/PostHog/posthog/pull/52352
- Ingestion: https://github.com/PostHog/posthog/pull/52353
- Data Warehouse: https://github.com/PostHog/posthog/pull/52354
- Signals: https://github.com/PostHog/posthog/pull/52355
- Billing: https://github.com/PostHog/posthog/pull/52356
- Customer Analytics: https://github.com/PostHog/posthog/pull/52340
- Analytics Platform: https://github.com/PostHog/posthog/pull/52339
- PostHog AI: https://github.com/PostHog/posthog/pull/52342
- Infrastructure: https://github.com/PostHog/posthog/pull/52344
- Feature Flags: https://github.com/PostHog/posthog/pull/52347
- Data Modeling: https://github.com/PostHog/posthog/pull/52348
- Workflows: https://github.com/PostHog/posthog/pull/52346
- Growth: https://github.com/PostHog/posthog/pull/52345
- Experiments: https://github.com/PostHog/posthog/pull/52343

## How did you test this code?

This is an agent-authored PR that adds query tags to existing ClickHouse queries. No manual testing was done beyond linting. The changes are mechanical additions of `feature=Feature.QUERY` to call sites that already use the query tagging infrastructure.

## Publish to changelog?

No

## Docs update

Not needed

## 🤖 LLM context

This PR was authored by Claude Code. It adds missing `feature` query tags to Data Warehouse ClickHouse queries to improve query performance attribution and monitoring.