### PR TITLE
feat(data-management): add verified and tags filters to definitions pages

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2004,6 +2004,15 @@ export type PropertyDefinitionsListParams = {
      */
     properties?: string
     /**
+ * Filter by property name type: posthog ($ prefixed) or custom
+
+* `all` - all
+* `posthog` - posthog
+* `custom` - custom
+ * @minLength 1
+ */
+    property_name_type?: PropertyDefinitionsListPropertyNameType
+    /**
      * Searches properties by name
      */
     search?: string
@@ -2028,6 +2037,15 @@ export type PropertyDefinitionsListParams = {
      */
     verified?: boolean | null
 }
+
+export type PropertyDefinitionsListPropertyNameType =
+    (typeof PropertyDefinitionsListPropertyNameType)[keyof typeof PropertyDefinitionsListPropertyNameType]
+
+export const PropertyDefinitionsListPropertyNameType = {
+    All: 'all',
+    Posthog: 'posthog',
+    Custom: 'custom',
+} as const
 
 export type PropertyDefinitionsListType = (typeof PropertyDefinitionsListType)[keyof typeof PropertyDefinitionsListType]
 

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2008,6 +2008,11 @@ export type PropertyDefinitionsListParams = {
      */
     search?: string
     /**
+     * JSON-encoded list of tag names to filter by
+     * @minLength 1
+     */
+    tags?: string
+    /**
  * What property definitions to return
 
 * `event` - event
@@ -2017,6 +2022,11 @@ export type PropertyDefinitionsListParams = {
  * @minLength 1
  */
     type?: PropertyDefinitionsListType
+    /**
+     * Whether to return only verified (true) or unverified (false) property definitions
+     * @nullable
+     */
+    verified?: boolean | null
 }
 
 export type PropertyDefinitionsListType = (typeof PropertyDefinitionsListType)[keyof typeof PropertyDefinitionsListType]

--- a/frontend/src/scenes/data-management/constants.ts
+++ b/frontend/src/scenes/data-management/constants.ts
@@ -1,0 +1,7 @@
+import { LemonSelectOptions } from '@posthog/lemon-ui'
+
+export const verifiedOptions: LemonSelectOptions<string> = [
+    { value: '', label: 'Any status' },
+    { value: 'true', label: 'Verified only' },
+    { value: 'false', label: 'Unverified only' },
+]

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -39,6 +39,12 @@ const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
     },
 ]
 
+const verifiedOptions: LemonSelectOptions<string> = [
+    { value: '', label: 'Any status' },
+    { value: 'true', label: 'Verified only' },
+    { value: 'false', label: 'Unverified only' },
+]
+
 export function EventDefinitionsTable(): JSX.Element {
     const { eventDefinitions, eventDefinitionsLoading, filters } = useValues(eventDefinitionsTableLogic)
     const { loadEventDefinitions, setFilters } = useActions(eventDefinitionsTableLogic)
@@ -180,6 +186,17 @@ export function EventDefinitionsTable(): JSX.Element {
                         dropdownMatchSelectWidth={false}
                         onChange={(value) => {
                             setFilters({ event_type: value as EventDefinitionType })
+                        }}
+                        size="small"
+                    />
+                    <span>Verified:</span>
+                    <LemonSelect
+                        value={filters.verified ?? ''}
+                        options={verifiedOptions}
+                        data-attr="event-verified-filter"
+                        dropdownMatchSelectWidth={false}
+                        onChange={(value) => {
+                            setFilters({ verified: value || undefined })
                         }}
                         size="small"
                     />

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -13,6 +13,7 @@ import { EVENT_DEFINITIONS_PER_PAGE } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { cn } from 'lib/utils/css-classes'
+import { verifiedOptions } from 'scenes/data-management/constants'
 import { DefinitionHeader, getEventDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
 import { EventDefinitionModal } from 'scenes/data-management/events/EventDefinitionModal'
 import { EventDefinitionProperties } from 'scenes/data-management/events/EventDefinitionProperties'
@@ -37,12 +38,6 @@ const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
         label: 'PostHog events',
         'data-attr': 'event-type-option-event-posthog',
     },
-]
-
-const verifiedOptions: LemonSelectOptions<string> = [
-    { value: '', label: 'Any status' },
-    { value: 'true', label: 'Verified only' },
-    { value: 'false', label: 'Unverified only' },
 ]
 
 export function EventDefinitionsTable(): JSX.Element {

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -30,6 +30,7 @@ export interface Filters {
     event_type: EventDefinitionType
     ordering?: string
     tags?: string[]
+    verified?: string
 }
 
 const DEFAULT_FILTERS: Filters = {
@@ -38,6 +39,7 @@ const DEFAULT_FILTERS: Filters = {
     event_type: EventDefinitionType.Event,
     ordering: 'event',
     tags: undefined,
+    verified: undefined,
 }
 
 export function createDefinitionKey(event?: EventDefinition, property?: PropertyDefinition): string {
@@ -295,6 +297,9 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                 if (filters.tags && filters.tags.length > 0) {
                     params.tags = JSON.stringify(filters.tags)
                 }
+                if (filters.verified !== undefined) {
+                    params.verified = filters.verified
+                }
                 return params
             },
         ],
@@ -349,7 +354,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
     })),
     urlToAction(({ actions, values }) => ({
         '/data-management/events': (_, searchParams) => {
-            const { event, event_type, ordering, tags } = searchParams
+            const { event, event_type, ordering, tags, verified } = searchParams
 
             const filtersFromUrl: Filters = {
                 ...DEFAULT_FILTERS,
@@ -357,6 +362,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                 ...(event_type !== undefined && { event_type }),
                 ...(ordering !== undefined && { ordering }),
                 ...(parseTagsFilter(tags) !== undefined && { tags: parseTagsFilter(tags) }),
+                ...(verified !== undefined && { verified }),
             }
 
             if (!objectsEqual(values.filters, filtersFromUrl)) {

--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
@@ -2,9 +2,10 @@ import './PropertyDefinitionsTable.scss'
 
 import { useActions, useValues } from 'kea'
 
-import { LemonInput, LemonSelect, LemonTag, Link } from '@posthog/lemon-ui'
+import { LemonInput, LemonSelect, LemonSelectOptions, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { TagSelect } from 'lib/components/TagSelect'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { EVENT_PROPERTY_DEFINITIONS_PER_PAGE } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -19,6 +20,12 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { PropertyDefinition } from '~/types'
+
+const verifiedOptions: LemonSelectOptions<string> = [
+    { value: '', label: 'Any status' },
+    { value: 'true', label: 'Verified only' },
+    { value: 'false', label: 'Unverified only' },
+]
 
 export function PropertyDefinitionsTable(): JSX.Element {
     const { propertyDefinitions, propertyDefinitionsLoading, filters, propertyTypeOptions } =
@@ -94,18 +101,44 @@ export function PropertyDefinitionsTable(): JSX.Element {
                     Query with SQL
                 </Link>
             </LemonBanner>
-            <div className={cn('flex gap-2 flex-wrap')}>
+            <div className={cn('flex flex-wrap justify-between items-center gap-2')}>
                 <LemonInput
                     type="search"
                     placeholder="Search for properties"
                     onChange={(e) => setFilters({ property: e || '' })}
                     value={filters.property}
+                    className="flex-1 min-w-60"
                 />
-                <LemonSelect
-                    options={propertyTypeOptions}
-                    value={`${filters.type}::${filters.group_type_index ?? ''}`}
-                    onSelect={setPropertyType}
-                />
+                <div className="flex items-center gap-2 flex-shrink-0">
+                    <span>Tags:</span>
+                    <TagSelect
+                        defaultLabel="Any tags"
+                        value={filters.tags || []}
+                        onChange={(tags) => {
+                            setFilters({ tags })
+                        }}
+                        data-attr="property-tags-filter"
+                        size="small"
+                    />
+                    <span>Type:</span>
+                    <LemonSelect
+                        options={propertyTypeOptions}
+                        value={`${filters.type}::${filters.group_type_index ?? ''}`}
+                        onSelect={setPropertyType}
+                        size="small"
+                    />
+                    <span>Verified:</span>
+                    <LemonSelect
+                        value={filters.verified ?? ''}
+                        options={verifiedOptions}
+                        data-attr="property-verified-filter"
+                        dropdownMatchSelectWidth={false}
+                        onChange={(value) => {
+                            setFilters({ verified: value || undefined })
+                        }}
+                        size="small"
+                    />
+                </div>
             </div>
             <LemonTable
                 columns={columns}

--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
@@ -27,6 +27,12 @@ const verifiedOptions: LemonSelectOptions<string> = [
     { value: 'false', label: 'Unverified only' },
 ]
 
+const propertyNameTypeOptions: LemonSelectOptions<string> = [
+    { value: '', label: 'All properties' },
+    { value: 'posthog', label: 'PostHog properties' },
+    { value: 'custom', label: 'Custom properties' },
+]
+
 export function PropertyDefinitionsTable(): JSX.Element {
     const { propertyDefinitions, propertyDefinitionsLoading, filters, propertyTypeOptions } =
         useValues(propertyDefinitionsTableLogic)
@@ -118,6 +124,17 @@ export function PropertyDefinitionsTable(): JSX.Element {
                             setFilters({ tags })
                         }}
                         data-attr="property-tags-filter"
+                        size="small"
+                    />
+                    <span>Source:</span>
+                    <LemonSelect
+                        value={filters.property_name_type ?? ''}
+                        options={propertyNameTypeOptions}
+                        data-attr="property-name-type-filter"
+                        dropdownMatchSelectWidth={false}
+                        onChange={(value) => {
+                            setFilters({ property_name_type: value || undefined })
+                        }}
                         size="small"
                     />
                     <span>Type:</span>

--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.tsx
@@ -11,6 +11,7 @@ import { EVENT_PROPERTY_DEFINITIONS_PER_PAGE } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { cn } from 'lib/utils/css-classes'
+import { verifiedOptions } from 'scenes/data-management/constants'
 import { DefinitionHeader, getPropertyDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
 import { propertyDefinitionsTableLogic } from 'scenes/data-management/properties/propertyDefinitionsTableLogic'
 import { sceneConfigurations } from 'scenes/scenes'
@@ -20,12 +21,6 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { PropertyDefinition } from '~/types'
-
-const verifiedOptions: LemonSelectOptions<string> = [
-    { value: '', label: 'Any status' },
-    { value: 'true', label: 'Verified only' },
-    { value: 'false', label: 'Unverified only' },
-]
 
 const propertyNameTypeOptions: LemonSelectOptions<string> = [
     { value: '', label: 'All properties' },

--- a/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
@@ -24,6 +24,7 @@ export interface Filters {
     group_type_index: number | null
     verified?: string
     tags?: string[]
+    property_name_type?: string
 }
 
 function cleanFilters(filter: Partial<Filters>): Filters {
@@ -33,6 +34,7 @@ function cleanFilters(filter: Partial<Filters>): Filters {
         group_type_index: null,
         verified: undefined,
         tags: undefined,
+        property_name_type: undefined,
         ...filter,
     }
 }
@@ -44,6 +46,7 @@ function removeDefaults(filter: Filters): Partial<Filters> {
         group_type_index: filter.group_type_index !== null ? filter.group_type_index : undefined,
         verified: filter.verified !== undefined ? filter.verified : undefined,
         tags: filter.tags && filter.tags.length > 0 ? filter.tags : undefined,
+        property_name_type: filter.property_name_type !== undefined ? filter.property_name_type : undefined,
     }
 }
 
@@ -175,6 +178,9 @@ export const propertyDefinitionsTableLogic = kea<propertyDefinitionsTableLogicTy
             }
             if (values.filters.tags && values.filters.tags.length > 0) {
                 params.tags = JSON.stringify(values.filters.tags)
+            }
+            if (values.filters.property_name_type !== undefined) {
+                params.property_name_type = values.filters.property_name_type
             }
             actions.loadPropertyDefinitions(
                 normalizePropertyDefinitionEndpointUrl(values.propertyDefinitions.current, params, true)

--- a/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
@@ -5,7 +5,7 @@ import { actionToUrl, combineUrl, router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { EVENT_PROPERTY_DEFINITIONS_PER_PAGE } from 'lib/constants'
 import { LemonSelectOption } from 'lib/lemon-ui/LemonSelect'
-import { capitalizeFirstLetter, objectsEqual } from 'lib/utils'
+import { capitalizeFirstLetter, objectsEqual, parseTagsFilter } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import {
     PropertyDefinitionsPaginatedResponse,
@@ -22,6 +22,8 @@ export interface Filters {
     property: string
     type: string
     group_type_index: number | null
+    verified?: string
+    tags?: string[]
 }
 
 function cleanFilters(filter: Partial<Filters>): Filters {
@@ -29,6 +31,8 @@ function cleanFilters(filter: Partial<Filters>): Filters {
         property: '',
         type: 'event',
         group_type_index: null,
+        verified: undefined,
+        tags: undefined,
         ...filter,
     }
 }
@@ -38,6 +42,8 @@ function removeDefaults(filter: Filters): Partial<Filters> {
         property: filter.property !== '' ? filter.property : undefined,
         type: filter.type !== 'event' ? filter.type : undefined,
         group_type_index: filter.group_type_index !== null ? filter.group_type_index : undefined,
+        verified: filter.verified !== undefined ? filter.verified : undefined,
+        tags: filter.tags && filter.tags.length > 0 ? filter.tags : undefined,
     }
 }
 
@@ -158,17 +164,20 @@ export const propertyDefinitionsTableLogic = kea<propertyDefinitionsTableLogicTy
     listeners(({ actions, values, cache }) => ({
         setFilters: async (_, breakpoint) => {
             await breakpoint(500)
+            const params: Record<string, any> = {
+                offset: 0,
+                search: values.filters.property,
+                type: values.filters.type,
+                group_type_index: values.filters.group_type_index,
+            }
+            if (values.filters.verified !== undefined) {
+                params.verified = values.filters.verified
+            }
+            if (values.filters.tags && values.filters.tags.length > 0) {
+                params.tags = JSON.stringify(values.filters.tags)
+            }
             actions.loadPropertyDefinitions(
-                normalizePropertyDefinitionEndpointUrl(
-                    values.propertyDefinitions.current,
-                    {
-                        offset: 0,
-                        search: values.filters.property,
-                        type: values.filters.type,
-                        group_type_index: values.filters.group_type_index,
-                    },
-                    true
-                )
+                normalizePropertyDefinitionEndpointUrl(values.propertyDefinitions.current, params, true)
             )
         },
         loadPropertyDefinitionsSuccess: () => {
@@ -206,8 +215,14 @@ export const propertyDefinitionsTableLogic = kea<propertyDefinitionsTableLogicTy
             if (values.propertyDefinitionsLoading) {
                 return
             }
-            if (!objectsEqual(cleanFilters(values.filters), cleanFilters(router.values.searchParams))) {
-                actions.setFilters(searchParams as Filters)
+            const filtersFromUrl: Partial<Filters> = {
+                ...searchParams,
+                ...(parseTagsFilter(searchParams.tags) !== undefined && {
+                    tags: parseTagsFilter(searchParams.tags),
+                }),
+            }
+            if (!objectsEqual(cleanFilters(values.filters), cleanFilters(filtersFromUrl))) {
+                actions.setFilters(filtersFromUrl as Filters)
             } else if (!values.propertyDefinitions.results.length) {
                 actions.loadPropertyDefinitions()
             }

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -191,7 +191,18 @@ class EventDefinitionSerializer(TaggedItemSerializerMixin, serializers.ModelSeri
         return hasattr(obj, "action_id") and obj.action_id is not None
 
 
-@extend_schema(tags=["core"])
+@extend_schema(
+    tags=["core"],
+    parameters=[
+        OpenApiParameter(
+            "verified",
+            OpenApiTypes.BOOL,
+            description="Filter by verified status. True returns only verified, false returns only unverified.",
+            required=False,
+            location=OpenApiParameter.QUERY,
+        ),
+    ],
+)
 class EventDefinitionViewSet(
     TeamAndOrgViewSetMixin,
     TaggedItemViewSetMixin,

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -239,6 +239,13 @@ class EventDefinitionViewSet(
         if exclude_hidden and EE_AVAILABLE:
             search_query = search_query + " AND (hidden IS NULL OR hidden = false)"
 
+        verified_filter = self.request.GET.get("verified", None)
+        if verified_filter is not None and EE_AVAILABLE:
+            if verified_filter.lower() == "true":
+                search_query = search_query + " AND verified = true"
+            elif verified_filter.lower() == "false":
+                search_query = search_query + " AND (verified IS NULL OR verified = false)"
+
         excluded_properties = self.request.GET.get("excluded_properties")
 
         if excluded_properties:

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -7,7 +7,8 @@ from unittest.mock import ANY, patch
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.models import ActivityLog, EventDefinition, EventProperty, Organization, PropertyDefinition, Team
+from posthog.models import ActivityLog, EventDefinition, EventProperty, Organization, PropertyDefinition, Tag, Team
+from posthog.models.tagged_item import TaggedItem
 from posthog.taxonomy.property_definition_api import PropertyDefinitionQuerySerializer, PropertyDefinitionViewSet
 
 
@@ -819,3 +820,106 @@ class TestPropertyDefinitionQuerySerializer(BaseTest):
         assert not PropertyDefinitionQuerySerializer(data={"type": "group", "group_type_index": 77}).is_valid()
         assert not PropertyDefinitionQuerySerializer(data={"type": "group", "group_type_index": -1}).is_valid()
         assert not PropertyDefinitionQuerySerializer(data={"type": "event", "group_type_index": 3}).is_valid()
+
+    def test_tags_validation_valid(self):
+        serializer = PropertyDefinitionQuerySerializer(data={"tags": '["alpha", "beta"]'})
+        assert serializer.is_valid(), serializer.errors
+
+    def test_tags_validation_invalid_json(self):
+        serializer = PropertyDefinitionQuerySerializer(data={"tags": "not-json"})
+        assert not serializer.is_valid()
+        assert "tags" in serializer.errors
+
+    def test_tags_validation_non_list(self):
+        serializer = PropertyDefinitionQuerySerializer(data={"tags": '{"key": "value"}'})
+        assert not serializer.is_valid()
+        assert "tags" in serializer.errors
+
+    def test_tags_validation_non_string_items(self):
+        serializer = PropertyDefinitionQuerySerializer(data={"tags": "[1, 2]"})
+        assert not serializer.is_valid()
+        assert "tags" in serializer.errors
+
+    @parameterized.expand(
+        [
+            ("all", True),
+            ("posthog", True),
+            ("custom", True),
+            ("invalid_choice", False),
+        ]
+    )
+    def test_property_name_type_validation(self, value: str, expected_valid: bool):
+        serializer = PropertyDefinitionQuerySerializer(data={"property_name_type": value})
+        assert serializer.is_valid() == expected_valid
+
+    @parameterized.expand(
+        [
+            ("true", True),
+            ("false", True),
+        ]
+    )
+    def test_verified_validation(self, value: str, expected_valid: bool):
+        serializer = PropertyDefinitionQuerySerializer(data={"verified": value})
+        assert serializer.is_valid() == expected_valid
+
+
+class TestPropertyDefinitionFilters(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        PropertyDefinition.objects.get_or_create(team=self.team, name="$browser")
+        PropertyDefinition.objects.get_or_create(team=self.team, name="$current_url")
+        PropertyDefinition.objects.get_or_create(team=self.team, name="custom_prop")
+        PropertyDefinition.objects.get_or_create(team=self.team, name="another_custom")
+
+    def test_filter_by_property_name_type_posthog(self):
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?property_name_type=posthog")
+        assert response.status_code == status.HTTP_200_OK
+        names = [r["name"] for r in response.json()["results"]]
+        assert all(name.startswith("$") for name in names)
+        assert "$browser" in names
+        assert "$current_url" in names
+        assert "custom_prop" not in names
+        assert "another_custom" not in names
+
+    def test_filter_by_property_name_type_custom(self):
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?property_name_type=custom")
+        assert response.status_code == status.HTTP_200_OK
+        names = [r["name"] for r in response.json()["results"]]
+        assert all(not name.startswith("$") for name in names)
+        assert "custom_prop" in names
+        assert "another_custom" in names
+        assert "$browser" not in names
+        assert "$current_url" not in names
+
+    def test_filter_by_tags(self):
+        prop = PropertyDefinition.objects.get(team=self.team, name="custom_prop")
+        tag = Tag.objects.create(name="tag1", team=self.team)
+        TaggedItem.objects.create(tag=tag, property_definition=prop)
+
+        response = self.client.get(f'/api/projects/{self.team.pk}/property_definitions/?tags=["tag1"]')
+        assert response.status_code == status.HTTP_200_OK
+        names = [r["name"] for r in response.json()["results"]]
+        assert "custom_prop" in names
+        assert "another_custom" not in names
+        assert "$browser" not in names
+
+    def test_filter_by_tags_pagination_correct(self):
+        prop_a = PropertyDefinition.objects.get(team=self.team, name="custom_prop")
+        prop_b = PropertyDefinition.objects.get(team=self.team, name="another_custom")
+        tag = Tag.objects.create(name="shared_tag", team=self.team)
+        TaggedItem.objects.create(tag=tag, property_definition=prop_a)
+        TaggedItem.objects.create(tag=tag, property_definition=prop_b)
+
+        response = self.client.get(f'/api/projects/{self.team.pk}/property_definitions/?tags=["shared_tag"]')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["count"] == 2
+        assert len(data["results"]) == 2
+
+    def test_filter_by_tags_invalid_json(self):
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?tags=not-valid-json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_tags_validation_rejects_non_string_items(self):
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/?tags=[1,2]")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -115,6 +115,13 @@ class PropertyDefinitionQuerySerializer(serializers.Serializer):
         required=False,
     )
 
+    property_name_type = serializers.ChoiceField(
+        choices=["all", "posthog", "custom"],
+        help_text="Filter by property name type: posthog ($ prefixed) or custom",
+        default="all",
+        required=False,
+    )
+
     def validate(self, attrs):
         type_ = attrs.get("type", "event")
 
@@ -352,6 +359,22 @@ class QueryContext:
                 ),
             )
         return self
+
+    def with_property_name_type_filter(self, property_name_type: str) -> Self:
+        if property_name_type == "posthog":
+            name_type_filter = f" AND {self.property_definition_table}.name LIKE '$%%'"
+        elif property_name_type == "custom":
+            name_type_filter = f" AND {self.property_definition_table}.name NOT LIKE '$%%'"
+        else:
+            return self
+        return dataclasses.replace(
+            self,
+            excluded_properties_filter=(
+                self.excluded_properties_filter + name_type_filter
+                if self.excluded_properties_filter
+                else name_type_filter
+            ),
+        )
 
     def as_sql(self, order_by_verified: bool):
         verified_ordering = "verified DESC NULLS LAST," if order_by_verified else ""
@@ -695,6 +718,7 @@ class PropertyDefinitionViewSet(
                     query.validated_data.get("exclude_hidden", False), use_enterprise_taxonomy=EE_AVAILABLE
                 )
                 .with_verified_filter(query.validated_data.get("verified", None), use_enterprise_taxonomy=EE_AVAILABLE)
+                .with_property_name_type_filter(query.validated_data.get("property_name_type", "all"))
             )
 
             span.set_attribute("joins_event_property", query_context.should_join_event_property)

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Self, Union, cast
 from django.db import connection, models
 from django.db.models import Manager, QuerySet
 from django.db.models.functions import Coalesce
+from django.db.models.query import RawQuerySet
 from django.shortcuts import get_object_or_404
 
 from loginas.utils import is_impersonated_session
@@ -142,9 +143,9 @@ class PropertyDefinitionQuerySerializer(serializers.Serializer):
             try:
                 parsed = json.loads(tags)
                 if not isinstance(parsed, list) or not all(isinstance(t, str) for t in parsed):
-                    raise ValidationError("`tags` must be a JSON-encoded list of strings")
+                    raise ValidationError({"tags": "`tags` must be a JSON-encoded list of strings"})
             except (json.JSONDecodeError, TypeError):
-                raise ValidationError("`tags` must be valid JSON")
+                raise ValidationError({"tags": "`tags` must be valid JSON"})
 
         return super().validate(attrs)
 
@@ -630,6 +631,13 @@ class PropertyDefinitionViewSet(
         for (key, val) in CORE_FILTER_DEFINITIONS_BY_GROUP["groups"].items()
         if val.get("virtual", False)
     ]
+
+    def prefetch_tagged_items_if_available(self, queryset: QuerySet) -> QuerySet:
+        # RawQuerySet doesn't support prefetch_related properly — the serializer
+        # falls back to fetching tags via tagged_items when prefetched_tags is absent
+        if isinstance(queryset, RawQuerySet):
+            return queryset
+        return super().prefetch_tagged_items_if_available(queryset)
 
     def dangerously_get_queryset(self):
         with tracer.start_as_current_span("property_definitions_get_queryset") as span:

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -161,7 +161,7 @@ class QueryContext:
     event_property_filter: str = ""
     event_name_filter: str = ""
     is_feature_flag_filter: str = ""
-    excluded_properties_filter: str = ""
+    extra_where_conditions: str = ""
 
     order_by_search_relevance: bool = False
 
@@ -170,6 +170,8 @@ class QueryContext:
 
     # the event name filter is used with and without a posthog_eventproperty_table_join_alias qualifier
     event_name_join_filter: str = ""
+
+    tags_join: str = ""
 
     posthog_eventproperty_table_join_alias = "check_for_matching_event_property"
 
@@ -294,7 +296,7 @@ class QueryContext:
 
         return dataclasses.replace(
             self,
-            excluded_properties_filter=(
+            extra_where_conditions=(
                 f"AND NOT {self.property_definition_table}.name = ANY(%(excluded_properties)s)"
                 if len(excluded_list) > 0
                 else ""
@@ -310,8 +312,8 @@ class QueryContext:
             # exclude always excluded event properties
             return dataclasses.replace(
                 self,
-                excluded_properties_filter=(
-                    self.excluded_properties_filter
+                extra_where_conditions=(
+                    self.extra_where_conditions
                     + f"AND NOT {self.property_definition_table}.name = ANY(%(excluded_core_properties)s)"
                 ),
                 params={**self.params, "excluded_core_properties": list(ALWAYS_EXCLUDED_EVENT_PROPERTIES)},
@@ -320,8 +322,8 @@ class QueryContext:
             # exclude all properties starting with $ and other event properties defined in the taxonomy
             return dataclasses.replace(
                 self,
-                excluded_properties_filter=(
-                    self.excluded_properties_filter
+                extra_where_conditions=(
+                    self.extra_where_conditions
                     + f"AND NOT {self.property_definition_table}.name LIKE '$%%' AND NOT {self.property_definition_table}.name = ANY(%(excluded_core_properties)s)"
                 ),
                 params={
@@ -336,10 +338,8 @@ class QueryContext:
             hidden_filter = " AND (hidden IS NULL OR hidden = false)"
             return dataclasses.replace(
                 self,
-                excluded_properties_filter=(
-                    self.excluded_properties_filter + hidden_filter
-                    if self.excluded_properties_filter
-                    else hidden_filter
+                extra_where_conditions=(
+                    self.extra_where_conditions + hidden_filter if self.extra_where_conditions else hidden_filter
                 ),
             )
         return self
@@ -352,10 +352,8 @@ class QueryContext:
                 verified_filter = " AND (verified IS NULL OR verified = false)"
             return dataclasses.replace(
                 self,
-                excluded_properties_filter=(
-                    self.excluded_properties_filter + verified_filter
-                    if self.excluded_properties_filter
-                    else verified_filter
+                extra_where_conditions=(
+                    self.extra_where_conditions + verified_filter if self.extra_where_conditions else verified_filter
                 ),
             )
         return self
@@ -369,11 +367,26 @@ class QueryContext:
             return self
         return dataclasses.replace(
             self,
-            excluded_properties_filter=(
-                self.excluded_properties_filter + name_type_filter
-                if self.excluded_properties_filter
-                else name_type_filter
+            extra_where_conditions=(
+                self.extra_where_conditions + name_type_filter if self.extra_where_conditions else name_type_filter
             ),
+        )
+
+    def with_tags_filter(self, tags_list: list[str]) -> Self:
+        if not tags_list:
+            return self
+        return dataclasses.replace(
+            self,
+            tags_join=(
+                f"INNER JOIN posthog_taggeditem ON posthog_taggeditem.property_definition_id = {self.property_definition_table}.id"
+                " INNER JOIN posthog_tag ON posthog_tag.id = posthog_taggeditem.tag_id"
+            ),
+            extra_where_conditions=(
+                self.extra_where_conditions + " AND posthog_tag.name = ANY(%(tags_list)s)"
+                if self.extra_where_conditions
+                else " AND posthog_tag.name = ANY(%(tags_list)s)"
+            ),
+            params={**self.params, "tags_list": tags_list},
         )
 
     def as_sql(self, order_by_verified: bool):
@@ -381,14 +394,16 @@ class QueryContext:
         length_ordering = (
             f"length({self.property_definition_table}.name) ASC," if self.order_by_search_relevance else ""
         )
+        distinct = "DISTINCT" if self.tags_join else ""
         query = f"""
-            SELECT {self.property_definition_fields}, {self.event_property_field} AS is_seen_on_filtered_events
+            SELECT {distinct} {self.property_definition_fields}, {self.event_property_field} AS is_seen_on_filtered_events
             FROM {self.table}
             {self._join_on_event_property()}
+            {self.tags_join}
             WHERE coalesce({self.property_definition_table}.project_id, {self.property_definition_table}.team_id) = %(project_id)s
               AND type = %(type)s
               AND coalesce(group_type_index, -1) = %(group_type_index)s
-              {self.excluded_properties_filter}
+              {self.extra_where_conditions}
              {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
              {self.event_name_filter}
             ORDER BY is_seen_on_filtered_events DESC, {length_ordering} {verified_ordering} {self.property_definition_table}.name ASC
@@ -399,13 +414,14 @@ class QueryContext:
 
     def as_count_sql(self):
         query = f"""
-            SELECT count(*) as full_count
+            SELECT count(DISTINCT {self.property_definition_table}.id) as full_count
             FROM {self.table}
             {self._join_on_event_property()}
+            {self.tags_join}
             WHERE coalesce({self.property_definition_table}.project_id, {self.property_definition_table}.team_id) = %(project_id)s
               AND type = %(type)s
               AND coalesce(group_type_index, -1) = %(group_type_index)s
-             {self.excluded_properties_filter} {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
+             {self.extra_where_conditions} {self.name_filter} {self.numerical_filter} {self.search_query} {self.event_property_filter} {self.is_feature_flag_filter}
              {self.event_name_filter}
             """
 
@@ -719,6 +735,7 @@ class PropertyDefinitionViewSet(
                 )
                 .with_verified_filter(query.validated_data.get("verified", None), use_enterprise_taxonomy=EE_AVAILABLE)
                 .with_property_name_type_filter(query.validated_data.get("property_name_type", "all"))
+                .with_tags_filter(self._parse_tags(query.validated_data.get("tags")))
             )
 
             span.set_attribute("joins_event_property", query_context.should_join_event_property)
@@ -733,20 +750,17 @@ class PropertyDefinitionViewSet(
             span.set_attribute("full_count", full_count)
 
             # nosemgrep: python.django.security.audit.custom-expression-as-sql.custom-expression-as-sql (all user input goes through query_context.params)
-            raw_queryset = queryset.raw(query_context.as_sql(order_by_verified), params=query_context.params)
+            return queryset.raw(query_context.as_sql(order_by_verified), params=query_context.params)
 
-            # Apply tags filter if provided
-            tags = query.validated_data.get("tags")
-            if tags:
-                try:
-                    tags_list = json.loads(tags)
-                    if tags_list:
-                        ids = [obj.id for obj in raw_queryset]
-                        return queryset.filter(id__in=ids, tagged_items__tag__name__in=tags_list).distinct()
-                except (json.JSONDecodeError, TypeError):
-                    pass
-
-            return raw_queryset
+    @staticmethod
+    def _parse_tags(tags: Optional[str]) -> list[str]:
+        if not tags:
+            return []
+        try:
+            parsed = json.loads(tags)
+            return parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, TypeError):
+            return []
 
     def get_serializer_class(self) -> type[serializers.ModelSerializer]:
         serializer_class: type[serializers.ModelSerializer] = self.serializer_class

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -103,6 +103,18 @@ class PropertyDefinitionQuerySerializer(serializers.Serializer):
         default=False,
     )
 
+    verified = serializers.BooleanField(
+        help_text="Whether to return only verified (true) or unverified (false) property definitions",
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+
+    tags = serializers.CharField(
+        help_text="JSON-encoded list of tag names to filter by",
+        required=False,
+    )
+
     def validate(self, attrs):
         type_ = attrs.get("type", "event")
 
@@ -321,6 +333,22 @@ class QueryContext:
                     self.excluded_properties_filter + hidden_filter
                     if self.excluded_properties_filter
                     else hidden_filter
+                ),
+            )
+        return self
+
+    def with_verified_filter(self, verified: Optional[bool], use_enterprise_taxonomy: bool) -> Self:
+        if verified is not None and use_enterprise_taxonomy:
+            if verified:
+                verified_filter = " AND verified = true"
+            else:
+                verified_filter = " AND (verified IS NULL OR verified = false)"
+            return dataclasses.replace(
+                self,
+                excluded_properties_filter=(
+                    self.excluded_properties_filter + verified_filter
+                    if self.excluded_properties_filter
+                    else verified_filter
                 ),
             )
         return self
@@ -666,6 +694,7 @@ class PropertyDefinitionViewSet(
                 .with_hidden_filter(
                     query.validated_data.get("exclude_hidden", False), use_enterprise_taxonomy=EE_AVAILABLE
                 )
+                .with_verified_filter(query.validated_data.get("verified", None), use_enterprise_taxonomy=EE_AVAILABLE)
             )
 
             span.set_attribute("joins_event_property", query_context.should_join_event_property)
@@ -680,7 +709,20 @@ class PropertyDefinitionViewSet(
             span.set_attribute("full_count", full_count)
 
             # nosemgrep: python.django.security.audit.custom-expression-as-sql.custom-expression-as-sql (all user input goes through query_context.params)
-            return queryset.raw(query_context.as_sql(order_by_verified), params=query_context.params)
+            raw_queryset = queryset.raw(query_context.as_sql(order_by_verified), params=query_context.params)
+
+            # Apply tags filter if provided
+            tags = query.validated_data.get("tags")
+            if tags:
+                try:
+                    tags_list = json.loads(tags)
+                    if tags_list:
+                        ids = [obj.id for obj in raw_queryset]
+                        return queryset.filter(id__in=ids, tagged_items__tag__name__in=tags_list).distinct()
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            return raw_queryset
 
     def get_serializer_class(self) -> type[serializers.ModelSerializer]:
         serializer_class: type[serializers.ModelSerializer] = self.serializer_class

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -137,6 +137,15 @@ class PropertyDefinitionQuerySerializer(serializers.Serializer):
         if type_ != "event" and attrs.get("event_names"):
             raise ValidationError("`event_names` can only be set for `event` type")
 
+        tags = attrs.get("tags")
+        if tags is not None:
+            try:
+                parsed = json.loads(tags)
+                if not isinstance(parsed, list) or not all(isinstance(t, str) for t in parsed):
+                    raise ValidationError("`tags` must be a JSON-encoded list of strings")
+            except (json.JSONDecodeError, TypeError):
+                raise ValidationError("`tags` must be valid JSON")
+
         return super().validate(attrs)
 
 
@@ -335,41 +344,34 @@ class QueryContext:
 
     def with_hidden_filter(self, exclude_hidden: bool, use_enterprise_taxonomy: bool) -> Self:
         if exclude_hidden and use_enterprise_taxonomy:
-            hidden_filter = " AND (hidden IS NULL OR hidden = false)"
             return dataclasses.replace(
                 self,
-                extra_where_conditions=(
-                    self.extra_where_conditions + hidden_filter if self.extra_where_conditions else hidden_filter
-                ),
+                extra_where_conditions=self.extra_where_conditions + " AND (hidden IS NULL OR hidden = false)",
             )
         return self
 
     def with_verified_filter(self, verified: Optional[bool], use_enterprise_taxonomy: bool) -> Self:
         if verified is not None and use_enterprise_taxonomy:
             if verified:
-                verified_filter = " AND verified = true"
+                condition = " AND verified = true"
             else:
-                verified_filter = " AND (verified IS NULL OR verified = false)"
+                condition = " AND (verified IS NULL OR verified = false)"
             return dataclasses.replace(
                 self,
-                extra_where_conditions=(
-                    self.extra_where_conditions + verified_filter if self.extra_where_conditions else verified_filter
-                ),
+                extra_where_conditions=self.extra_where_conditions + condition,
             )
         return self
 
     def with_property_name_type_filter(self, property_name_type: str) -> Self:
         if property_name_type == "posthog":
-            name_type_filter = f" AND {self.property_definition_table}.name LIKE '$%%'"
+            condition = f" AND {self.property_definition_table}.name LIKE '$%%'"
         elif property_name_type == "custom":
-            name_type_filter = f" AND {self.property_definition_table}.name NOT LIKE '$%%'"
+            condition = f" AND {self.property_definition_table}.name NOT LIKE '$%%'"
         else:
             return self
         return dataclasses.replace(
             self,
-            extra_where_conditions=(
-                self.extra_where_conditions + name_type_filter if self.extra_where_conditions else name_type_filter
-            ),
+            extra_where_conditions=self.extra_where_conditions + condition,
         )
 
     def with_tags_filter(self, tags_list: list[str]) -> Self:
@@ -381,11 +383,7 @@ class QueryContext:
                 f"INNER JOIN posthog_taggeditem ON posthog_taggeditem.property_definition_id = {self.property_definition_table}.id"
                 " INNER JOIN posthog_tag ON posthog_tag.id = posthog_taggeditem.tag_id"
             ),
-            extra_where_conditions=(
-                self.extra_where_conditions + " AND posthog_tag.name = ANY(%(tags_list)s)"
-                if self.extra_where_conditions
-                else " AND posthog_tag.name = ANY(%(tags_list)s)"
-            ),
+            extra_where_conditions=self.extra_where_conditions + " AND posthog_tag.name = ANY(%(tags_list)s)",
             params={**self.params, "tags_list": tags_list},
         )
 
@@ -756,11 +754,7 @@ class PropertyDefinitionViewSet(
     def _parse_tags(tags: Optional[str]) -> list[str]:
         if not tags:
             return []
-        try:
-            parsed = json.loads(tags)
-            return parsed if isinstance(parsed, list) else []
-        except (json.JSONDecodeError, TypeError):
-            return []
+        return json.loads(tags)
 
     def get_serializer_class(self) -> type[serializers.ModelSerializer]:
         serializer_class: type[serializers.ModelSerializer] = self.serializer_class

--- a/posthog/taxonomy/test/test_query_context.py
+++ b/posthog/taxonomy/test/test_query_context.py
@@ -1,0 +1,148 @@
+import re
+
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from posthog.taxonomy.property_definition_api import QueryContext
+
+
+def normalize_sql(sql: str) -> str:
+    return re.sub(r"\s+", " ", sql).strip()
+
+
+def base_query_context() -> QueryContext:
+    return QueryContext(
+        project_id=1,
+        table="posthog_propertydefinition",
+        property_definition_fields="posthog_propertydefinition.*",
+        property_definition_table="posthog_propertydefinition",
+        limit=100,
+        offset=0,
+        should_join_event_property=False,
+    )
+
+
+class TestQueryContextVerifiedFilter(BaseTest):
+    def test_with_verified_true_and_ee_enabled_adds_verified_true_condition(self):
+        ctx = base_query_context().with_verified_filter(True, True)
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "AND verified = true" in sql
+
+    def test_with_verified_false_and_ee_enabled_adds_verified_null_or_false_condition(self):
+        ctx = base_query_context().with_verified_filter(False, True)
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "AND (verified IS NULL OR verified = false)" in sql
+
+    def test_with_verified_true_and_ee_disabled_leaves_sql_unchanged(self):
+        base_ctx = base_query_context()
+        ctx = base_ctx.with_verified_filter(True, False)
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "verified" not in sql
+
+    def test_with_verified_none_leaves_sql_unchanged(self):
+        base_ctx = base_query_context()
+        ctx = base_ctx.with_verified_filter(None, True)
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "verified = true" not in sql
+        assert "verified IS NULL" not in sql
+
+    def test_verified_filter_appears_in_count_sql(self):
+        ctx = base_query_context().with_verified_filter(True, True)
+        count_sql = normalize_sql(ctx.as_count_sql())
+
+        assert "AND verified = true" in count_sql
+
+    def test_verified_false_filter_appears_in_count_sql(self):
+        ctx = base_query_context().with_verified_filter(False, True)
+        count_sql = normalize_sql(ctx.as_count_sql())
+
+        assert "AND (verified IS NULL OR verified = false)" in count_sql
+
+
+class TestQueryContextPropertyNameTypeFilter(BaseTest):
+    @parameterized.expand(
+        [
+            ("posthog", "AND posthog_propertydefinition.name LIKE '$%'"),
+            ("custom", "AND posthog_propertydefinition.name NOT LIKE '$%'"),
+        ]
+    )
+    def test_property_name_type_filter_adds_correct_condition(self, property_name_type: str, expected_fragment: str):
+        ctx = base_query_context().with_property_name_type_filter(property_name_type)
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert expected_fragment in sql
+
+    def test_with_property_name_type_all_leaves_sql_unchanged(self):
+        base_ctx = base_query_context()
+        ctx = base_ctx.with_property_name_type_filter("all")
+
+        assert ctx.extra_where_conditions == base_ctx.extra_where_conditions
+
+    def test_property_name_type_posthog_appears_in_count_sql(self):
+        ctx = base_query_context().with_property_name_type_filter("posthog")
+        count_sql = normalize_sql(ctx.as_count_sql())
+
+        assert "AND posthog_propertydefinition.name LIKE '$%'" in count_sql
+
+    def test_property_name_type_custom_appears_in_count_sql(self):
+        ctx = base_query_context().with_property_name_type_filter("custom")
+        count_sql = normalize_sql(ctx.as_count_sql())
+
+        assert "AND posthog_propertydefinition.name NOT LIKE '$%'" in count_sql
+
+
+class TestQueryContextTagsFilter(BaseTest):
+    def test_with_tags_filter_adds_inner_join_on_taggeditem(self):
+        ctx = base_query_context().with_tags_filter(["tag1", "tag2"])
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "INNER JOIN posthog_taggeditem" in sql
+
+    def test_with_tags_filter_adds_inner_join_on_tag(self):
+        ctx = base_query_context().with_tags_filter(["tag1", "tag2"])
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "INNER JOIN posthog_tag" in sql
+
+    def test_with_tags_filter_adds_tag_name_where_condition(self):
+        ctx = base_query_context().with_tags_filter(["tag1", "tag2"])
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "posthog_tag.name = ANY(%(tags_list)s)" in sql
+
+    def test_with_tags_filter_stores_tags_in_params(self):
+        ctx = base_query_context().with_tags_filter(["tag1", "tag2"])
+
+        assert ctx.params["tags_list"] == ["tag1", "tag2"]
+
+    def test_with_empty_tags_filter_leaves_sql_unchanged(self):
+        base_ctx = base_query_context()
+        ctx = base_ctx.with_tags_filter([])
+
+        assert ctx.tags_join == base_ctx.tags_join
+        assert ctx.extra_where_conditions == base_ctx.extra_where_conditions
+
+    def test_tags_filter_adds_inner_join_in_count_sql(self):
+        ctx = base_query_context().with_tags_filter(["tag1"])
+        count_sql = normalize_sql(ctx.as_count_sql())
+
+        assert "INNER JOIN posthog_taggeditem" in count_sql
+        assert "INNER JOIN posthog_tag" in count_sql
+        assert "posthog_tag.name = ANY(%(tags_list)s)" in count_sql
+
+    def test_tags_join_causes_distinct_in_select(self):
+        ctx = base_query_context().with_tags_filter(["tag1"])
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert sql.startswith("SELECT DISTINCT")
+
+    def test_no_tags_join_means_no_distinct_in_select(self):
+        ctx = base_query_context()
+        sql = normalize_sql(ctx.as_sql(order_by_verified=False))
+
+        assert "SELECT DISTINCT" not in sql

--- a/products/event_definitions/frontend/generated/api.schemas.ts
+++ b/products/event_definitions/frontend/generated/api.schemas.ts
@@ -175,6 +175,52 @@ export type EventDefinitionsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsCreateParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsUpdateParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsPartialUpdateParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsDestroyParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsMetricsRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
 }
 
 export type EventDefinitionsByNameRetrieveParams = {
@@ -182,4 +228,29 @@ export type EventDefinitionsByNameRetrieveParams = {
      * The exact event name to look up
      */
     name: string
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsGolangRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsPythonRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
+}
+
+export type EventDefinitionsTypescriptRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean
 }

--- a/products/event_definitions/frontend/generated/api.ts
+++ b/products/event_definitions/frontend/generated/api.ts
@@ -12,7 +12,16 @@ import type {
     EnterpriseEventDefinitionApi,
     EventDefinitionApi,
     EventDefinitionsByNameRetrieveParams,
+    EventDefinitionsCreateParams,
+    EventDefinitionsDestroyParams,
+    EventDefinitionsGolangRetrieveParams,
     EventDefinitionsListParams,
+    EventDefinitionsMetricsRetrieveParams,
+    EventDefinitionsPartialUpdateParams,
+    EventDefinitionsPythonRetrieveParams,
+    EventDefinitionsRetrieveParams,
+    EventDefinitionsTypescriptRetrieveParams,
+    EventDefinitionsUpdateParams,
     PaginatedEnterpriseEventDefinitionListApi,
     PatchedEnterpriseEventDefinitionApi,
 } from './api.schemas'
@@ -61,16 +70,29 @@ export const eventDefinitionsList = async (
     })
 }
 
-export const getEventDefinitionsCreateUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/`
+export const getEventDefinitionsCreateUrl = (projectId: string, params?: EventDefinitionsCreateParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/`
 }
 
 export const eventDefinitionsCreate = async (
     projectId: string,
     enterpriseEventDefinitionApi: NonReadonly<EnterpriseEventDefinitionApi>,
+    params?: EventDefinitionsCreateParams,
     options?: RequestInit
 ): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsCreateUrl(projectId), {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsCreateUrl(projectId, params), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -78,32 +100,62 @@ export const eventDefinitionsCreate = async (
     })
 }
 
-export const getEventDefinitionsRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
+export const getEventDefinitionsRetrieveUrl = (
+    projectId: string,
+    id: string,
+    params?: EventDefinitionsRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/${id}/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/${id}/`
 }
 
 export const eventDefinitionsRetrieve = async (
     projectId: string,
     id: string,
+    params?: EventDefinitionsRetrieveParams,
     options?: RequestInit
 ): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsRetrieveUrl(projectId, id), {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
     })
 }
 
-export const getEventDefinitionsUpdateUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
+export const getEventDefinitionsUpdateUrl = (projectId: string, id: string, params?: EventDefinitionsUpdateParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/${id}/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/${id}/`
 }
 
 export const eventDefinitionsUpdate = async (
     projectId: string,
     id: string,
     enterpriseEventDefinitionApi: NonReadonly<EnterpriseEventDefinitionApi>,
+    params?: EventDefinitionsUpdateParams,
     options?: RequestInit
 ): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsUpdateUrl(projectId, id), {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsUpdateUrl(projectId, id, params), {
         ...options,
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -111,17 +163,34 @@ export const eventDefinitionsUpdate = async (
     })
 }
 
-export const getEventDefinitionsPartialUpdateUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
+export const getEventDefinitionsPartialUpdateUrl = (
+    projectId: string,
+    id: string,
+    params?: EventDefinitionsPartialUpdateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/${id}/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/${id}/`
 }
 
 export const eventDefinitionsPartialUpdate = async (
     projectId: string,
     id: string,
     patchedEnterpriseEventDefinitionApi: NonReadonly<PatchedEnterpriseEventDefinitionApi>,
+    params?: EventDefinitionsPartialUpdateParams,
     options?: RequestInit
 ): Promise<EnterpriseEventDefinitionApi> => {
-    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsPartialUpdateUrl(projectId, id), {
+    return apiMutator<EnterpriseEventDefinitionApi>(getEventDefinitionsPartialUpdateUrl(projectId, id, params), {
         ...options,
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
@@ -129,27 +198,65 @@ export const eventDefinitionsPartialUpdate = async (
     })
 }
 
-export const getEventDefinitionsDestroyUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/`
+export const getEventDefinitionsDestroyUrl = (
+    projectId: string,
+    id: string,
+    params?: EventDefinitionsDestroyParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/${id}/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/${id}/`
 }
 
-export const eventDefinitionsDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsDestroyUrl(projectId, id), {
+export const eventDefinitionsDestroy = async (
+    projectId: string,
+    id: string,
+    params?: EventDefinitionsDestroyParams,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsDestroyUrl(projectId, id, params), {
         ...options,
         method: 'DELETE',
     })
 }
 
-export const getEventDefinitionsMetricsRetrieveUrl = (projectId: string, id: string) => {
-    return `/api/projects/${projectId}/event_definitions/${id}/metrics/`
+export const getEventDefinitionsMetricsRetrieveUrl = (
+    projectId: string,
+    id: string,
+    params?: EventDefinitionsMetricsRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/${id}/metrics/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/${id}/metrics/`
 }
 
 export const eventDefinitionsMetricsRetrieve = async (
     projectId: string,
     id: string,
+    params?: EventDefinitionsMetricsRetrieveParams,
     options?: RequestInit
 ): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsMetricsRetrieveUrl(projectId, id), {
+    return apiMutator<void>(getEventDefinitionsMetricsRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
     })
@@ -188,34 +295,91 @@ export const eventDefinitionsByNameRetrieve = async (
     })
 }
 
-export const getEventDefinitionsGolangRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/golang/`
+export const getEventDefinitionsGolangRetrieveUrl = (
+    projectId: string,
+    params?: EventDefinitionsGolangRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/golang/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/golang/`
 }
 
-export const eventDefinitionsGolangRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsGolangRetrieveUrl(projectId), {
+export const eventDefinitionsGolangRetrieve = async (
+    projectId: string,
+    params?: EventDefinitionsGolangRetrieveParams,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsGolangRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })
 }
 
-export const getEventDefinitionsPythonRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/python/`
+export const getEventDefinitionsPythonRetrieveUrl = (
+    projectId: string,
+    params?: EventDefinitionsPythonRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/python/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/python/`
 }
 
-export const eventDefinitionsPythonRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsPythonRetrieveUrl(projectId), {
+export const eventDefinitionsPythonRetrieve = async (
+    projectId: string,
+    params?: EventDefinitionsPythonRetrieveParams,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsPythonRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })
 }
 
-export const getEventDefinitionsTypescriptRetrieveUrl = (projectId: string) => {
-    return `/api/projects/${projectId}/event_definitions/typescript/`
+export const getEventDefinitionsTypescriptRetrieveUrl = (
+    projectId: string,
+    params?: EventDefinitionsTypescriptRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/event_definitions/typescript/?${stringifiedParams}`
+        : `/api/projects/${projectId}/event_definitions/typescript/`
 }
 
-export const eventDefinitionsTypescriptRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getEventDefinitionsTypescriptRetrieveUrl(projectId), {
+export const eventDefinitionsTypescriptRetrieve = async (
+    projectId: string,
+    params?: EventDefinitionsTypescriptRetrieveParams,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getEventDefinitionsTypescriptRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -34157,6 +34157,11 @@ export namespace Schemas {
      */
     search?: string;
     /**
+     * JSON-encoded list of tag names to filter by
+     * @minLength 1
+     */
+    tags?: string;
+    /**
      * What property definitions to return
 
     * `event` - event
@@ -34166,6 +34171,11 @@ export namespace Schemas {
      * @minLength 1
      */
     type?: PropertyDefinitionsListType;
+    /**
+     * Whether to return only verified (true) or unverified (false) property definitions
+     * @nullable
+     */
+    verified?: boolean | null;
     };
 
     export type PropertyDefinitionsListType = typeof PropertyDefinitionsListType[keyof typeof PropertyDefinitionsListType];

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -32718,6 +32718,52 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsCreateParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsUpdateParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsPartialUpdateParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsDestroyParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsMetricsRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
     };
 
     export type EventDefinitionsByNameRetrieveParams = {
@@ -32725,6 +32771,31 @@ export namespace Schemas {
      * The exact event name to look up
      */
     name: string;
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsGolangRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsPythonRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
+    };
+
+    export type EventDefinitionsTypescriptRetrieveParams = {
+    /**
+     * Filter by verified status. True returns only verified, false returns only unverified.
+     */
+    verified?: boolean;
     };
 
     export type EventSchemasListParams = {
@@ -34153,6 +34224,15 @@ export namespace Schemas {
      */
     properties?: string;
     /**
+     * Filter by property name type: posthog ($ prefixed) or custom
+
+    * `all` - all
+    * `posthog` - posthog
+    * `custom` - custom
+     * @minLength 1
+     */
+    property_name_type?: PropertyDefinitionsListPropertyNameType;
+    /**
      * Searches properties by name
      */
     search?: string;
@@ -34177,6 +34257,15 @@ export namespace Schemas {
      */
     verified?: boolean | null;
     };
+
+    export type PropertyDefinitionsListPropertyNameType = typeof PropertyDefinitionsListPropertyNameType[keyof typeof PropertyDefinitionsListPropertyNameType];
+
+
+    export const PropertyDefinitionsListPropertyNameType = {
+      All: 'all',
+      Posthog: 'posthog',
+      Custom: 'custom',
+    } as const;
 
     export type PropertyDefinitionsListType = typeof PropertyDefinitionsListType[keyof typeof PropertyDefinitionsListType];
 


### PR DESCRIPTION
## Problem

Users need better filtering options on the data management pages for event and property definitions. From the support thread:
- The property definitions page is missing a **PostHog vs custom properties** filter (events page has this)
- Neither page has a **verified status** filter
- The property definitions page is missing **tag filtering** (events page has this)

## Changes

- **Event Definitions page**: Add a "Verified" filter dropdown (Any status / Verified only / Unverified only)
- **Property Definitions page**: Add three new filters:
  - "Verified" filter dropdown (Any status / Verified only / Unverified only)
  - "Tags" filter using the existing `TagSelect` component (matching the events page pattern)
  - "Source" filter dropdown (All properties / PostHog properties / Custom properties) — filters by `$` prefix, matching the PostHog/Custom filter on the events page
- **Event Definitions API** (`posthog/api/event_definition.py`): Add `verified` query parameter
- **Property Definitions API** (`posthog/taxonomy/property_definition_api.py`):
  - Add `verified` query parameter via `with_verified_filter` on `QueryContext`
  - Add `tags` query parameter (JSON-encoded list, same approach as event definitions)
  - Add `property_name_type` query parameter (`all`/`posthog`/`custom`) via `with_property_name_type_filter` on `QueryContext`, using `name LIKE '$%'` SQL condition
- All new filters persist in URL params via the existing `urlToAction`/`actionToUrl` kea pattern

## How did you test this code?

I am an agent and have not tested this manually. I verified:
- Python linting passes (`ruff check` and `ruff format`)
- Frontend linting passes (`oxlint`)
- Pre-commit hooks pass successfully
- TypeScript has no new errors (all errors are pre-existing in unrelated files)

Manual testing recommended:
- Navigate to `/data-management/events` and verify the new "Verified" filter appears and works
- Navigate to `/data-management/properties` and verify "Tags", "Source", and "Verified" filters appear and work
- Select "PostHog properties" — should show only `$`-prefixed properties; select "Custom properties" — only non-`$` properties
- Apply filters, reload the page, and confirm URL persistence works
- Verify the verified filter only shows results when EE features are available

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

This PR was authored by Claude Code. Session: https://claude.ai/code/session_01JV72Z8wQ8TPYF37M1EJHBU
