### PR TITLE
fix: node pre context when read from disk

### DIFF
--- a/rust/cymbal/src/langs/node.rs
+++ b/rust/cymbal/src/langs/node.rs
@@ -129,6 +129,7 @@ impl RawNodeFrame {
         let before = self
             .pre_context
             .iter()
+            .rev()
             .enumerate()
             .map(|(i, line)| ContextLine::new_rel(lineno, -(i as i32) - 1, line.clone()))
             .collect();

--- a/rust/cymbal/tests/types.rs
+++ b/rust/cymbal/tests/types.rs
@@ -80,6 +80,21 @@ fn node_exceptions() {
         .collect::<Vec<_>>();
 
     assert_eq!(frames.len(), 4);
+    let context = frames[3].context.as_ref().unwrap();
+    assert_eq!(context.line.number, 27);
+    assert_eq!(
+        context.line.line,
+        "  throw new Error(\"My first PostHog error!\");"
+    );
+    assert_eq!(context.before.len(), 7);
+    // Adjacent to context line (lineno - 1); pre_context order is reversed into display order
+    assert_eq!(context.before[0].number, 26);
+    assert_eq!(
+        context.before[0].line,
+        "  posthog.capture({ event: \"Test event\", distinctId: \"test\" });"
+    );
+    assert_eq!(context.before[6].number, 20);
+    assert_eq!(context.before[6].line, "});");
 }
 
 #[test]


### PR DESCRIPTION
We have two ways of displaying stack traces in node:
- uploading source maps - this works fine,
- we also attempt to read code from the disk in an unminified form. If that succeeds, we attach special metadata to the event so then when cymbal resolves it, it uses that.

We had a bug in that second approach where order of lines was reversed :)

Code I changed only applies to reading context from the event (which reads it from the disk)