### PR TITLE
chore(personhog): allow configurable msg sizes

### DIFF
--- a/rust/personhog-replica/src/config.rs
+++ b/rust/personhog-replica/src/config.rs
@@ -49,7 +49,7 @@ pub struct Config {
     #[envconfig(default = "10")]
     pub grpc_keepalive_timeout_secs: u64,
 
-    /// Maximum gRPC message size to encode (send), in bytes. Defaults to 128 MB.
+    /// Maximum gRPC message size to encode (send), in bytes. Defaults to 128 MiB.
     #[envconfig(default = "134217728")]
     pub grpc_max_send_message_size: usize,
 

--- a/rust/personhog-replica/src/config.rs
+++ b/rust/personhog-replica/src/config.rs
@@ -49,12 +49,11 @@ pub struct Config {
     #[envconfig(default = "10")]
     pub grpc_keepalive_timeout_secs: u64,
 
-    /// Maximum gRPC message size the server will encode (send), in bytes.
-    /// Defaults to 128 MB.
+    /// Maximum gRPC message size to encode (send), in bytes. Defaults to 128 MB.
     #[envconfig(default = "134217728")]
     pub grpc_max_send_message_size: usize,
 
-    /// Maximum gRPC message size the server will decode (receive), in bytes.
+    /// Maximum gRPC message size to decode (receive), in bytes.
     #[envconfig(default = "134217728")]
     pub grpc_max_recv_message_size: usize,
 }

--- a/rust/personhog-replica/src/config.rs
+++ b/rust/personhog-replica/src/config.rs
@@ -48,6 +48,15 @@ pub struct Config {
     /// Timeout for a keepalive ping ack before considering the connection dead
     #[envconfig(default = "10")]
     pub grpc_keepalive_timeout_secs: u64,
+
+    /// Maximum gRPC message size the server will encode (send), in bytes.
+    /// Defaults to 128 MB.
+    #[envconfig(default = "134217728")]
+    pub grpc_max_send_message_size: usize,
+
+    /// Maximum gRPC message size the server will decode (receive), in bytes.
+    #[envconfig(default = "134217728")]
+    pub grpc_max_recv_message_size: usize,
 }
 
 impl Config {

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -174,6 +174,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let grpc_addr = config.grpc_address;
     let keepalive_interval = config.grpc_keepalive_interval();
     let keepalive_timeout = config.grpc_keepalive_timeout();
+    let max_send = config.grpc_max_send_message_size;
+    let max_recv = config.grpc_max_recv_message_size;
 
     tracing::info!("Starting gRPC server on {}", grpc_addr);
 
@@ -191,7 +193,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .http2_keepalive_interval(keepalive_interval)
             .http2_keepalive_timeout(keepalive_timeout)
             .layer(GrpcMetricsLayer)
-            .add_service(PersonHogReplicaServer::new(service))
+            .add_service(
+                PersonHogReplicaServer::new(service)
+                    .max_encoding_message_size(max_send)
+                    .max_decoding_message_size(max_recv),
+            )
             .serve_with_incoming_shutdown(incoming, grpc_handle.shutdown_signal())
             .await
         {

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -32,6 +32,8 @@ pub struct LeaderBackend {
     num_partitions: u32,
     retry_config: RetryConfig,
     timeout: Duration,
+    max_send_message_size: usize,
+    max_recv_message_size: usize,
 }
 
 impl LeaderBackend {
@@ -41,6 +43,8 @@ impl LeaderBackend {
         num_partitions: u32,
         timeout: Duration,
         retry_config: RetryConfig,
+        max_send_message_size: usize,
+        max_recv_message_size: usize,
     ) -> Self {
         assert!(
             num_partitions > 0,
@@ -53,6 +57,8 @@ impl LeaderBackend {
             num_partitions,
             retry_config,
             timeout,
+            max_send_message_size,
+            max_recv_message_size,
         }
     }
 
@@ -108,7 +114,9 @@ impl LeaderBackend {
             .map_err(|e| Status::internal(format!("invalid leader address: {e}")))?
             .timeout(self.timeout)
             .connect_lazy();
-        let client = PersonHogLeaderClient::new(channel);
+        let client = PersonHogLeaderClient::new(channel)
+            .max_encoding_message_size(self.max_send_message_size)
+            .max_decoding_message_size(self.max_recv_message_size);
         self.clients.insert(address, client.clone());
         Ok(client)
     }
@@ -269,6 +277,8 @@ mod tests {
                 initial_backoff_ms: 1,
                 max_backoff_ms: 1,
             },
+            4 * 1024 * 1024,
+            4 * 1024 * 1024,
         );
 
         let p1 = backend.partition_for_person(1, 42);
@@ -295,6 +305,8 @@ mod tests {
                 initial_backoff_ms: 1,
                 max_backoff_ms: 1,
             },
+            4 * 1024 * 1024,
+            4 * 1024 * 1024,
         );
 
         let mut counts = [0u32; 8];
@@ -326,6 +338,8 @@ mod tests {
                 initial_backoff_ms: 1,
                 max_backoff_ms: 1,
             },
+            4 * 1024 * 1024,
+            4 * 1024 * 1024,
         );
 
         let partition = backend.partition_for_person(1, 42);
@@ -347,6 +361,8 @@ mod tests {
                 initial_backoff_ms: 1,
                 max_backoff_ms: 1,
             },
+            4 * 1024 * 1024,
+            4 * 1024 * 1024,
         );
 
         let partition = backend.partition_for_person(1, 42);
@@ -375,6 +391,8 @@ mod tests {
                 initial_backoff_ms: 1,
                 max_backoff_ms: 1,
             },
+            4 * 1024 * 1024,
+            4 * 1024 * 1024,
         );
 
         let partition = backend.partition_for_person(1, 42);
@@ -402,6 +420,8 @@ mod tests {
                 initial_backoff_ms: 1,
                 max_backoff_ms: 1,
             },
+            4 * 1024 * 1024,
+            4 * 1024 * 1024,
         );
 
         let partition = backend.partition_for_person(1, 42);

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -37,6 +37,8 @@ impl ReplicaBackend {
         retry_config: RetryConfig,
         keepalive_interval: Option<Duration>,
         keepalive_timeout: Option<Duration>,
+        max_send_message_size: usize,
+        max_recv_message_size: usize,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let mut endpoint = Channel::from_shared(url.to_string())?.timeout(timeout);
         if let Some(interval) = keepalive_interval {
@@ -50,7 +52,9 @@ impl ReplicaBackend {
         let channel = endpoint.connect_lazy();
 
         Ok(Self {
-            client: PersonHogReplicaClient::new(channel),
+            client: PersonHogReplicaClient::new(channel)
+                .max_encoding_message_size(max_send_message_size)
+                .max_decoding_message_size(max_recv_message_size),
             retry_config,
         })
     }

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -87,7 +87,7 @@ pub struct Config {
 
     /// Maximum gRPC message size to encode (send), in bytes.
     /// Applied to the router's gRPC server and its backend clients (replica, leader).
-    /// Defaults to 128 MB.
+    /// Defaults to 128 MiB.
     #[envconfig(default = "134217728")]
     pub grpc_max_send_message_size: usize,
 

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -85,12 +85,14 @@ pub struct Config {
     #[envconfig(default = "10")]
     pub backend_keepalive_timeout_secs: u64,
 
-    /// Maximum gRPC message size the server will encode (send), in bytes.
+    /// Maximum gRPC message size to encode (send), in bytes.
+    /// Applied to the router's gRPC server and its backend clients (replica, leader).
     /// Defaults to 128 MB.
     #[envconfig(default = "134217728")]
     pub grpc_max_send_message_size: usize,
 
-    /// Maximum gRPC message size the server will decode (receive), in bytes.
+    /// Maximum gRPC message size to decode (receive), in bytes.
+    /// Applied to the router's gRPC server and its backend clients (replica, leader).
     #[envconfig(default = "134217728")]
     pub grpc_max_recv_message_size: usize,
 

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -85,6 +85,15 @@ pub struct Config {
     #[envconfig(default = "10")]
     pub backend_keepalive_timeout_secs: u64,
 
+    /// Maximum gRPC message size the server will encode (send), in bytes.
+    /// Defaults to 128 MB.
+    #[envconfig(default = "134217728")]
+    pub grpc_max_send_message_size: usize,
+
+    /// Maximum gRPC message size the server will decode (receive), in bytes.
+    #[envconfig(default = "134217728")]
+    pub grpc_max_recv_message_size: usize,
+
     // ── etcd coordination (leader mode only) ─────────────────────
     #[envconfig(default = "http://localhost:2379")]
     pub etcd_endpoints: String,

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -168,6 +168,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.retry_config(),
         config.backend_keepalive_interval(),
         config.backend_keepalive_timeout(),
+        config.grpc_max_send_message_size,
+        config.grpc_max_recv_message_size,
     )
     .expect("Failed to create replica backend");
 
@@ -214,6 +216,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             num_partitions,
             config.backend_timeout(),
             config.retry_config(),
+            config.grpc_max_send_message_size,
+            config.grpc_max_recv_message_size,
         ));
 
         let cutover_handler: Arc<dyn CutoverHandler> = Arc::new(RouterCutoverHandler {
@@ -268,6 +272,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let grpc_addr = config.grpc_address;
     let keepalive_interval = config.grpc_keepalive_interval();
     let keepalive_timeout = config.grpc_keepalive_timeout();
+    let max_send = config.grpc_max_send_message_size;
+    let max_recv = config.grpc_max_recv_message_size;
     tracing::info!("Starting gRPC server on {}", grpc_addr);
 
     tokio::spawn(async move {
@@ -284,7 +290,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .http2_keepalive_interval(keepalive_interval)
             .http2_keepalive_timeout(keepalive_timeout)
             .layer(GrpcMetricsLayer)
-            .add_service(PersonHogServiceServer::new(service))
+            .add_service(
+                PersonHogServiceServer::new(service)
+                    .max_encoding_message_size(max_send)
+                    .max_decoding_message_size(max_recv),
+            )
             .serve_with_incoming_shutdown(incoming, grpc_handle.shutdown_signal())
             .await
         {

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -329,6 +329,8 @@ pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
         retry_config,
         None,
         None,
+        4 * 1024 * 1024,
+        4 * 1024 * 1024,
     )
     .unwrap();
     let router = PersonHogRouter::new(Arc::new(backend));
@@ -499,6 +501,8 @@ pub async fn start_test_router_with_leader(
         retry_config,
         None,
         None,
+        4 * 1024 * 1024,
+        4 * 1024 * 1024,
     )
     .unwrap();
 
@@ -517,6 +521,8 @@ pub async fn start_test_router_with_leader(
         num_partitions,
         Duration::from_secs(5),
         retry_config,
+        4 * 1024 * 1024,
+        4 * 1024 * 1024,
     );
 
     let router = PersonHogRouter::new(Arc::new(replica)).with_leader(Arc::new(leader));


### PR DESCRIPTION
## Problem

The maximum size of messages received and sent from the gRPC services/clients within the personhog ecosystem should be configurable.

## Changes

- Added `GRPC_MAX_SEND_MESSAGE_SIZE` and `GRPC_MAX_RECV_MESSAGE_SIZE` env vars to both `personhog-replica` and `personhog-router` configs (default 128 MB)
- Applied the limits to:
  - `PersonHogReplicaServer` (encoding/decoding)
  - `PersonHogRouterServer` (encoding/decoding)
  - `PersonHogReplicaClient` in the router (encoding/decoding)
  - `PersonHogLeaderClient` in the router (encoding/decoding)


## How did you test this code?

- `cargo check -p personhog-router -p personhog-replica` passes
- Existing tests updated to compile with the new constructor signatures
