### PR TITLE
fix(cdp): Fix grouped logs pagination for non-UTC project timezones

### DIFF
--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.test.ts
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.test.ts
@@ -1,32 +1,46 @@
 import { dayjs } from 'lib/dayjs'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { toAbsoluteClickhouseTimestamp } from './logsViewerLogic'
 
 describe('logsViewerLogic', () => {
     describe('toAbsoluteClickhouseTimestamp', () => {
+        afterEach(() => jest.restoreAllMocks())
+
+        it('falls back to UTC when teamLogic is not mounted', () => {
+            const input = dayjs.tz('2024-01-15 10:30:45.123', 'UTC')
+            expect(toAbsoluteClickhouseTimestamp(input)).toBe('2024-01-15 10:30:45.123')
+        })
+
         it.each([
             {
-                description: 'converts UTC timestamp correctly',
-                input: dayjs.tz('2024-01-15 10:30:45.123', 'UTC'),
-                expected: '2024-01-15 10:30:45.123',
-            },
-            {
-                description: 'converts US/Pacific timestamp to UTC',
+                description: 'normalizes US/Pacific to UTC (fallback: teamLogic not mounted)',
                 input: dayjs.tz('2024-01-15 02:30:45.123', 'US/Pacific'),
                 expected: '2024-01-15 10:30:45.123',
             },
             {
-                description: 'converts Europe/Berlin timestamp to UTC',
+                description: 'normalizes Europe/Berlin to UTC (fallback: teamLogic not mounted)',
                 input: dayjs.tz('2024-01-15 11:30:45.123', 'Europe/Berlin'),
                 expected: '2024-01-15 10:30:45.123',
             },
             {
-                description: 'converts Asia/Tokyo timestamp to UTC',
+                description: 'normalizes Asia/Tokyo to UTC (fallback: teamLogic not mounted)',
                 input: dayjs.tz('2024-01-15 19:30:45.123', 'Asia/Tokyo'),
                 expected: '2024-01-15 10:30:45.123',
             },
         ])('$description', ({ input, expected }) => {
             expect(toAbsoluteClickhouseTimestamp(input)).toBe(expected)
+        })
+
+        it('formats in team timezone when teamLogic is mounted', () => {
+            // The same moment in time: 10:30 UTC = 05:30 America/Bogota (UTC-5)
+            const input = dayjs.tz('2024-01-15 10:30:45.123', 'UTC')
+
+            jest.spyOn(teamLogic, 'findMounted').mockReturnValue({
+                values: { currentTeam: { timezone: 'America/Bogota' } },
+            } as any)
+
+            expect(toAbsoluteClickhouseTimestamp(input)).toBe('2024-01-15 05:30:45.123')
         })
 
         it('formats timestamp without ISO format', () => {

--- a/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/hog-functions/logs/logsViewerLogic.tsx
@@ -79,9 +79,11 @@ const toKey = (log: LogEntry): string => {
 }
 
 export const toAbsoluteClickhouseTimestamp = (timestamp: Dayjs): string => {
-    // TRICKY: CH query is timezone aware so we dont send iso, and we need to convert to UTC
+    // TRICKY: HogQL interprets bare timestamps as being in the team's timezone,
+    // so we must format in the team timezone (not UTC).
     // See https://github.com/PostHog/posthog/pull/45651
-    return timestamp.tz('UTC').format('YYYY-MM-DD HH:mm:ss.SSS')
+    const teamTimezone = teamLogic.findMounted()?.values.currentTeam?.timezone ?? 'UTC'
+    return timestamp.tz(teamTimezone).format('YYYY-MM-DD HH:mm:ss.SSS')
 }
 
 const buildBoundaryFilters = (request: LogEntryParams): string => {


### PR DESCRIPTION
## Problem

Came from a [report](https://posthoghelp.zendesk.com/agent/tickets/53800). Customers with non-UTC project timezones cannot load more grouped logs in CDP destination logs. Clicking "Load up to 10 older groups" does nothing because `toAbsoluteClickhouseTimestamp` formats the pagination cursor in UTC, but the HogQL backend interprets bare timestamps as being in the team's timezone. For a project in `America/Bogota` (UTC-5), this shifts the `date_to` cutoff 5 hours forward, making the subquery return the same 10 instances every time.

Confirmed by inspecting the generated ClickHouse SQL: `toDateTime64('2026-03-25 20:34:45.084000', 6, 'America/Bogota')` shows the backend applying team timezone to what was intended as a UTC value.

## Changes

Fix `toAbsoluteClickhouseTimestamp` to format in the team timezone instead of UTC, matching what the HogQL backend expects for bare timestamp strings

## How did you test this code?

- Set local project timezone to `America/Bogota` to reproduce the bug
- Verified the fix resolves the issue (10 new groups load on each click)
- Updated unit tests to cover team timezone formatting via mocked `teamLogic`

## Publish to changelog?

No