### PR TITLE
chore: don't send org id in billing request

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -544,7 +544,6 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         try:
             params_to_pass = {k: v for k, v in serializer.validated_data.items() if v is not None}
-            params_to_pass["organization_id"] = organization.id
             params_to_pass["teams_map"] = teams_map
             res = billing_manager.get_usage_data(organization, params_to_pass)
             return Response(res, status=status.HTTP_200_OK)
@@ -582,7 +581,6 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         try:
             params_to_pass = {k: v for k, v in serializer.validated_data.items() if v is not None}
-            params_to_pass["organization_id"] = organization.id
             params_to_pass["teams_map"] = teams_map
             res = billing_manager.get_spend_data(organization, params_to_pass)
             return Response(res, status=status.HTTP_200_OK)


### PR DESCRIPTION
The org id is already encoded into the JWT and signed, so don't send it again in a param that can be forged.

Corresponds to https://github.com/PostHog/billing/pull/1817
