### PR TITLE
chore(flags): migrate super_groups flags key (phase 3)

### DIFF
--- a/posthog/migrations/1068_backfill_feature_enrollment.py
+++ b/posthog/migrations/1068_backfill_feature_enrollment.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1067_add_dashboardtemplate_is_featured"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            UPDATE posthog_featureflag
+            SET filters = jsonb_set(filters, '{feature_enrollment}', 'true')
+            WHERE
+                deleted = false
+                AND filters ? 'super_groups'
+                AND filters->>'super_groups' IS NOT NULL
+                AND filters->>'super_groups' != 'null'
+                AND jsonb_typeof(filters->'super_groups') = 'array'
+                AND jsonb_array_length(filters->'super_groups') > 0
+                AND (
+                    NOT filters ? 'feature_enrollment'
+                    OR filters->>'feature_enrollment' != 'true'
+                );
+            """,
+            reverse_sql=migrations.RunSQL.noop,
+            elidable=True,
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1067_add_dashboardtemplate_is_featured
+1068_backfill_feature_enrollment


### PR DESCRIPTION
Part of #47929 

## Summary

Phase 3 of the `super_groups` → `feature_enrollment` migration. Backfills all existing flags that have non-empty `super_groups` to also have `feature_enrollment: true`.

### Why a single UPDATE instead of batched Python

We use a single `RunSQL` with `jsonb_set` instead of a `RunPython` iterator with `bulk_update` in batches because:

- **~900 rows is small** — row locks are held for milliseconds, not seconds
- **Less overhead** — one transaction vs hundreds of individual commits
- **Simpler** — no Python object loading or loop
- **Precedent** — migration 0748 uses the same pattern (`RunSQL` + `jsonb_set` on `posthog_featureflag.filters`)

The batching pattern from the safe migrations guide is for tens/hundreds of thousands of rows or tables under heavy write contention. Neither applies here.

### Pre-migration verification

Ran the following query in both regions to confirm scope:

```sql
SELECT COUNT(*) FROM posthog_featureflag
WHERE deleted = false
  AND filters ? 'super_groups'
  AND filters->>'super_groups' IS NOT NULL
  AND filters->>'super_groups' != 'null'
  AND jsonb_typeof(filters->'super_groups') = 'array'
  AND jsonb_array_length(filters->'super_groups') > 0
  AND (
    NOT filters ? 'feature_enrollment'
    OR filters->>'feature_enrollment' != 'true'
  );
```

| Region | Rows to update |
| ------ | -------------- |
| US     | 966            |
| EU     | 550            |