### PR TITLE
fix(error-tracking): scope frame expansion per exception

### DIFF
--- a/frontend/src/lib/components/Errors/ExceptionList/CollapsibleExceptionList.tsx
+++ b/frontend/src/lib/components/Errors/ExceptionList/CollapsibleExceptionList.tsx
@@ -73,15 +73,19 @@ export function CollapsibleExceptionList({
                                     frames={frames}
                                     className="border-1 rounded overflow-hidden divide-y divide-solid"
                                     stackFrameRecords={stackFrameRecords}
-                                    renderFrame={(frame, record) => (
-                                        <CollapsibleFrame
-                                            frame={frame}
-                                            record={record}
-                                            recordLoading={stackFrameRecordsLoading}
-                                            expanded={expandedFrameRawIds.has(frame.raw_id)}
-                                            onExpandedChange={(open) => onFrameExpandedChange(frame.raw_id, open)}
-                                        />
-                                    )}
+                                    renderFrame={(frame, record) => {
+                                        const expansionKey = `${exception.id}:${frame.raw_id}`
+
+                                        return (
+                                            <CollapsibleFrame
+                                                frame={frame}
+                                                record={record}
+                                                recordLoading={stackFrameRecordsLoading}
+                                                expanded={expandedFrameRawIds.has(expansionKey)}
+                                                onExpandedChange={(open) => onFrameExpandedChange(expansionKey, open)}
+                                            />
+                                        )
+                                    }}
                                 />
                             )}
                             renderUndefinedTrace={(exception, known) => (


### PR DESCRIPTION
## Problem

Nested exceptions can reuse the same stack frame raw ID. In the error tracking issue view, expanding one frame would also expand the matching frame in another exception because expansion state was keyed only by raw frame ID.

## Changes

- Scope frame expansion state by exception ID and frame raw ID instead of raw frame ID alone.
- Keep the change local to the stacktrace rendering path.

## How did you test this code?

- Investigated the stacktrace rendering and state flow for nested exceptions.
- Ran `pnpm --filter=@posthog/frontend exec oxlint src/lib/components/Errors/ExceptionList/CollapsibleExceptionList.tsx`.

## Publish to changelog?

no

## Docs update

No docs update needed. Internal UI bug fix.
