### PR TITLE
fix(insights): route legacy trend/funnel endpoints through unified QueryRunner cache

### DIFF
--- a/ee/clickhouse/views/insights.py
+++ b/ee/clickhouse/views/insights.py
@@ -13,7 +13,6 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.filters import Filter
 
 from ee.clickhouse.queries.funnels.funnel_correlation import FunnelCorrelation
-from ee.clickhouse.queries.stickiness import ClickhouseStickiness
 
 
 class CanEditInsight(BasePermission):
@@ -28,7 +27,6 @@ class CanEditInsight(BasePermission):
 
 class EnterpriseInsightsViewSet(InsightViewSet):
     permission_classes = [CanEditInsight]
-    stickiness_query_class = ClickhouseStickiness
 
     # ******************************************
     # /projects/:id/insights/funnel/correlation

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1539,7 +1539,6 @@ When set, the specified dashboard's filters and date range override will be appl
             filter = filter.shallow_clone(overrides=filter_overrides)
 
         query_dict = filter_to_query(filter.to_dict()).model_dump()
-        query_dict = upgrade(query_dict)
 
         refresh = refresh_requested_by_client(request)
         if refresh:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1555,14 +1555,14 @@ When set, the specified dashboard's filters and date range override will be appl
             team,
             query_dict,
             execution_mode=execution_mode,
-            user=request.user,
+            user=request.user if isinstance(request.user, User) else None,
             analytics_props=get_request_analytics_properties(request),
         )
 
         if isinstance(query_response, BaseModel):
             return {
-                "result": query_response.results,
-                "timezone": query_response.timezone,
+                "result": getattr(query_response, "results", []),
+                "timezone": getattr(query_response, "timezone", team.timezone),
                 "is_cached": getattr(query_response, "is_cached", False),
                 "last_refresh": getattr(query_response, "last_refresh", None),
             }

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -45,7 +45,7 @@ from posthog.api.insight_variable import map_stale_to_latest
 from posthog.api.monitoring import Feature, monitor
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
-from posthog.api.services.query import process_query_model
+from posthog.api.services.query import process_query_dict, process_query_model
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.api.utils import action, format_paginated_url
@@ -53,8 +53,7 @@ from posthog.auth import SharingAccessTokenAuthentication, SharingPasswordProtec
 from posthog.caching.fetch_from_cache import InsightResult, fetch_cached_response_by_key
 from posthog.clickhouse.cancel import cancel_query_on_cluster
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
-from posthog.constants import INSIGHT, INSIGHT_FUNNELS, INSIGHT_STICKINESS, TRENDS_STICKINESS, FunnelVizType
-from posthog.decorators import cached_by_filters
+from posthog.constants import INSIGHT
 from posthog.errors import ExposedCHQueryError
 from posthog.event_usage import get_request_analytics_properties, report_user_action
 from posthog.helpers.multi_property_breakdown import protect_old_clients_from_multi_property_default
@@ -66,9 +65,9 @@ from posthog.hogql_queries.apply_dashboard_filters import (
 from posthog.hogql_queries.legacy_compatibility.feature_flag import get_query_method, hogql_insights_replace_filters
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.hogql_queries.query_runner import (
+    BLOCKING_EXECUTION_MODES,
     ExecutionMode,
     execution_mode_from_refresh,
-    get_query_runner,
     shared_insights_execution_mode,
 )
 from posthog.kafka_client.topics import KAFKA_METRICS_TIME_TO_SEE_DATA
@@ -84,18 +83,12 @@ from posthog.models.activity_logging.activity_log import (
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.alert import AlertConfiguration
 from posthog.models.dashboard import Dashboard
-from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.utils import get_filter
 from posthog.models.insight import InsightViewed
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDT
-from posthog.queries.funnels import ClickhouseFunnelTimeToConvert, ClickhouseFunnelTrends
-from posthog.queries.funnels.utils import get_funnel_order_class
-from posthog.queries.stickiness import Stickiness
-from posthog.queries.trends.trends import Trends
-from posthog.queries.util import get_earliest_timestamp
 from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
@@ -1042,7 +1035,6 @@ class InsightViewSet(
     sharing_enabled_actions = ["retrieve", "list"]
     queryset = Insight.objects_including_soft_deleted.all()
 
-    stickiness_query_class = Stickiness
     parser_classes = (QuerySchemaParser,)
 
     def get_throttles(self):
@@ -1532,6 +1524,55 @@ When set, the specified dashboard's filters and date range override will be appl
             )
         return Response({"name": metadata.name, "description": metadata.description})
 
+    def _run_legacy_query(
+        self,
+        request: request.Request,
+        filter_overrides: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Convert Filter-style params to a query and run via process_query_dict.
+
+        Uses the unified QueryRunner cache instead of the legacy @cached_by_filters system.
+        """
+        team = self.team
+        filter = Filter(request=request, team=team)
+        if filter_overrides:
+            filter = filter.shallow_clone(overrides=filter_overrides)
+
+        query_dict = filter_to_query(filter.to_dict()).model_dump()
+        query_dict = upgrade(query_dict)
+
+        refresh = refresh_requested_by_client(request)
+        if refresh:
+            execution_mode = execution_mode_from_refresh(refresh)
+        else:
+            execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+
+        # Legacy endpoints never supported async — restrict to blocking modes
+        if execution_mode not in BLOCKING_EXECUTION_MODES:
+            execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+
+        query_response = process_query_dict(
+            team,
+            query_dict,
+            execution_mode=execution_mode,
+            user=request.user,
+            analytics_props=get_request_analytics_properties(request),
+        )
+
+        if isinstance(query_response, BaseModel):
+            return {
+                "result": query_response.results,
+                "timezone": query_response.timezone,
+                "is_cached": getattr(query_response, "is_cached", False),
+                "last_refresh": getattr(query_response, "last_refresh", None),
+            }
+        return {
+            "result": query_response.get("results", query_response.get("result", [])),
+            "timezone": query_response.get("timezone", team.timezone),
+            "is_cached": query_response.get("is_cached", False),
+            "last_refresh": query_response.get("last_refresh", None),
+        }
+
     @extend_schema(exclude=True)
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def trend(self, request: request.Request, *args: Any, **kwargs: Any):
@@ -1540,17 +1581,14 @@ When set, the specified dashboard's filters and date range override will be appl
         timings = HogQLTimings()
         try:
             with timings.measure("calculate"):
-                query_method = get_query_method(request=request, team=self.team)
-                if query_method == "hogql":
-                    result = self.calculate_trends_hogql(request)
-                else:
-                    result = self.calculate_trends(request)
+                result = self._run_legacy_query(request)
         except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
         except UserAccessControlError as e:
             raise ValidationError(str(e))
         except Cohort.DoesNotExist as e:
             raise ValidationError(str(e))
+
         filter = Filter(request=request, team=self.team)
 
         params_breakdown_limit = request.GET.get("breakdown_limit")
@@ -1591,45 +1629,6 @@ When set, the specified dashboard's filters and date range override will be appl
 
         return Response({**result, "next": next})
 
-    @cached_by_filters
-    def calculate_trends(self, request: request.Request) -> dict[str, Any]:
-        team = self.team
-        filter = Filter(request=request, team=self.team)
-
-        if filter.insight == INSIGHT_STICKINESS or filter.shown_as == TRENDS_STICKINESS:
-            stickiness_filter = StickinessFilter(
-                request=request,
-                team=team,
-                get_earliest_timestamp=get_earliest_timestamp,
-            )
-            result = self.stickiness_query_class().run(stickiness_filter, team)
-        else:
-            trends_query = Trends()
-            result = trends_query.run(filter, team, is_csv_export=bool(request.GET.get("is_csv_export", False)))
-
-        return {"result": result, "timezone": team.timezone}
-
-    @cached_by_filters
-    def calculate_trends_hogql(self, request: request.Request) -> dict[str, Any]:
-        team = self.team
-        filter = Filter(request=request, team=team)
-        query = filter_to_query(filter.to_dict()).model_dump()
-        query = upgrade(query)  # should not be necessary, but just in case
-        query_runner = get_query_runner(query, team, limit_context=None)
-
-        # we use the legacy caching mechanism (@cached_by_filters decorator), no need to cache in the query runner
-        result = query_runner.run(
-            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-            analytics_props=get_request_analytics_properties(request),
-        )
-        assert (
-            isinstance(result, schema.CachedTrendsQueryResponse)
-            or isinstance(result, schema.CachedStickinessQueryResponse)
-            or isinstance(result, schema.CachedLifecycleQueryResponse)
-        )
-
-        return {"result": result.results, "timezone": team.timezone}
-
     @extend_schema(exclude=True)
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
@@ -1638,12 +1637,7 @@ When set, the specified dashboard's filters and date range override will be appl
         timings = HogQLTimings()
         try:
             with timings.measure("calculate"):
-                query_method = get_query_method(request=request, team=self.team)
-                if query_method == "hogql":
-                    funnel = self.calculate_funnel_hogql(request)
-                else:
-                    funnel = self.calculate_funnel(request)
-
+                funnel = self._run_legacy_query(request, filter_overrides={"insight": "FUNNELS"})
         except (ExposedHogQLError, ExposedCHQueryError, HogVMException) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
 
@@ -1653,46 +1647,6 @@ When set, the specified dashboard's filters and date range override will be appl
         funnel["timings"] = [val.model_dump() for val in timings.to_list()]
 
         return Response(funnel)
-
-    @cached_by_filters
-    def calculate_funnel(self, request: request.Request) -> dict[str, Any]:
-        team = self.team
-        filter = Filter(request=request, data={"insight": INSIGHT_FUNNELS}, team=self.team)
-
-        if filter.funnel_viz_type == FunnelVizType.TRENDS:
-            return {
-                "result": ClickhouseFunnelTrends(team=team, filter=filter).run(),
-                "timezone": team.timezone,
-            }
-        elif filter.funnel_viz_type == FunnelVizType.TIME_TO_CONVERT:
-            return {
-                "result": ClickhouseFunnelTimeToConvert(team=team, filter=filter).run(),
-                "timezone": team.timezone,
-            }
-        else:
-            funnel_order_class = get_funnel_order_class(filter)
-            return {
-                "result": funnel_order_class(team=team, filter=filter).run(),
-                "timezone": team.timezone,
-            }
-
-    @cached_by_filters
-    def calculate_funnel_hogql(self, request: request.Request) -> dict[str, Any]:
-        team = self.team
-        filter = Filter(request=request, team=team)
-        filter = filter.shallow_clone(overrides={"insight": "FUNNELS"})
-        query = filter_to_query(filter.to_dict()).model_dump()
-        query = upgrade(query)  # should not be necessary, but just in case
-        query_runner = get_query_runner(query, team, limit_context=None)
-
-        # we use the legacy caching mechanism (@cached_by_filters decorator), no need to cache in the query runner
-        result = query_runner.run(
-            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-            analytics_props=get_request_analytics_properties(request),
-        )
-        assert isinstance(result, schema.CachedFunnelsQueryResponse)
-
-        return {"result": result.results, "timezone": team.timezone}
 
     # ******************************************
     # /projects/:id/insights/viewed

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -2821,21 +2821,20 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         )
         self.assertEqual(response.status_code, 201, response.content)
 
-    @patch("posthog.decorators.get_safe_cache")
-    def test_including_query_id_does_not_affect_cache_key(self, patched_get_safe_cache) -> None:
+    def test_including_query_id_does_not_affect_cache_key(self) -> None:
         """
         regression test, by introducing a query_id we were changing the cache key
         so, if you made the same query twice, the second one would not be cached, only because the query id had changed
         """
         self._get_insight_with_client_query_id("b3ef3987-b8e7-4339-b9b8-fa2b65606692")
-        self._get_insight_with_client_query_id("00000000-b8e7-4339-b9b8-fa2b65606692")
+        response = self._get_insight_with_client_query_id("00000000-b8e7-4339-b9b8-fa2b65606692")
 
-        assert patched_get_safe_cache.call_count == 2
-        assert patched_get_safe_cache.call_args_list[0] == patched_get_safe_cache.call_args_list[1]
+        # Second call should hit cache since client_query_id is not part of the cache key
+        assert response.get("is_cached") is True
 
-    def _get_insight_with_client_query_id(self, client_query_id: str) -> None:
+    def _get_insight_with_client_query_id(self, client_query_id: str) -> dict:
         query_params = f"?events={json.dumps([{'id': '$pageview'}])}&client_query_id={client_query_id}"
-        self.client.get(f"/api/projects/{self.team.id}/insights/trend/{query_params}").json()
+        return self.client.get(f"/api/projects/{self.team.id}/insights/trend/{query_params}").json()
 
     def assert_insight_activity(self, insight_id: Optional[int], expected: list[dict]):
         activity_response = self.dashboard_api.get_insight_activity(insight_id)
@@ -4064,10 +4063,9 @@ class TestInsightErrorHandling(ClickhouseTestMixin, APIBaseTest):
             ("HogVMException", "Global variable not found: variables"),
         ]
     )
-    @patch("posthog.api.insight.InsightViewSet.calculate_trends_hogql")
-    @patch("posthog.api.insight.get_query_method", return_value="hogql")
+    @patch("posthog.api.insight.process_query_dict")
     def test_trend_returns_400_for_exposed_errors(
-        self, error_type: str, error_message: str, _mock_query_method: mock.MagicMock, mock_calculate: mock.MagicMock
+        self, error_type: str, error_message: str, mock_process: mock.MagicMock
     ) -> None:
         from posthog.hogql.errors import ExposedHogQLError
 
@@ -4080,7 +4078,7 @@ class TestInsightErrorHandling(ClickhouseTestMixin, APIBaseTest):
             "ExposedHogQLError": ExposedHogQLError,
             "HogVMException": HogVMException,
         }
-        mock_calculate.side_effect = error_classes[error_type](error_message)
+        mock_process.side_effect = error_classes[error_type](error_message)
 
         response = self.client.get(
             f"/api/environments/{self.team.id}/insights/trend/",
@@ -4097,10 +4095,9 @@ class TestInsightErrorHandling(ClickhouseTestMixin, APIBaseTest):
             ("HogVMException", "Global variable not found: variables"),
         ]
     )
-    @patch("posthog.api.insight.InsightViewSet.calculate_funnel_hogql")
-    @patch("posthog.api.insight.get_query_method", return_value="hogql")
+    @patch("posthog.api.insight.process_query_dict")
     def test_funnel_returns_400_for_exposed_errors(
-        self, error_type: str, error_message: str, _mock_query_method: mock.MagicMock, mock_calculate: mock.MagicMock
+        self, error_type: str, error_message: str, mock_process: mock.MagicMock
     ) -> None:
         from posthog.hogql.errors import ExposedHogQLError
 
@@ -4113,7 +4110,7 @@ class TestInsightErrorHandling(ClickhouseTestMixin, APIBaseTest):
             "ExposedHogQLError": ExposedHogQLError,
             "HogVMException": HogVMException,
         }
-        mock_calculate.side_effect = error_classes[error_type](error_message)
+        mock_process.side_effect = error_classes[error_type](error_message)
 
         response = self.client.get(
             f"/api/environments/{self.team.id}/insights/funnel/",


### PR DESCRIPTION
## Problem

The legacy `/insights/trend/` and `/insights/funnel/` API endpoints use a separate caching system (`@cached_by_filters`) isolated from the QueryRunner cache used by `/query` and dashboard tiles. 

These endpoints are called about 100k times a day

<img width="1507" height="745" alt="Screenshot 2026-03-25 at 7 51 10 PM" src="https://github.com/user-attachments/assets/99e91da4-e5ca-4fa3-ab3e-cff538d96130" />

https://us.posthog.com/project/2/insights/37h5QFxs

## Changes

- Add `_run_legacy_query()` helper that converts Filter-style params → `filter_to_query()` → `process_query_dict()` with `RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE` execution mode
- Rewrite `trend()` and `funnel()` to use the helper, preserving CSV export, pagination, and funnel backward-compat transforms

## How did you test this code?

- Updated 3 tests that mocked deleted methods to target `process_query_dict` instead

## Publish to changelog?

No

## Docs update

No 