### PR TITLE
fix(flags): show evaluation contexts section in readonly view

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagOverviewV2.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagOverviewV2.tsx
@@ -41,9 +41,7 @@ interface TagsDisplayProps {
 }
 
 function TagsDisplay({ tags, evaluationContexts, flagId, hasEvaluationContexts }: TagsDisplayProps): JSX.Element {
-    const hasTags = tags.length > 0 || evaluationContexts.length > 0
-
-    if (hasEvaluationContexts && hasTags) {
+    if (hasEvaluationContexts) {
         return (
             <FeatureFlagEvaluationContexts
                 tags={tags}


### PR DESCRIPTION
## Problem

When viewing a feature flag in readonly mode with the evaluation contexts feature enabled, the "Evaluation contexts" section is hidden if there are no tags or contexts set. This is inconsistent with edit mode, which always shows both sections.

Users expect the readonly view to mirror what they see in edit mode, showing "No tags" and "No contexts" placeholders when empty.

## Changes

Simplified the `TagsDisplay` component to always render `FeatureFlagEvaluationContexts` when the feature is enabled, regardless of whether values are present.

**Before:** Only showed evaluation contexts section when `tags.length > 0 || evaluationContexts.length > 0`

<img width="422" height="293" alt="image" src="https://github.com/user-attachments/assets/837799b9-ee14-4831-8a2d-175b37059d1e" />

**After:** Always shows both sections when feature is enabled, displaying "No tags" / "No contexts" when empty

<img width="427" height="349" alt="image" src="https://github.com/user-attachments/assets/12e08157-9a3b-478f-aef1-7d1606f99ccc" />


## How did you test this code?

The change is minimal (removing a condition) and the `FeatureFlagEvaluationContexts` component already handles empty states correctly.

To verify manually:
1. Enable the `flag-evaluation-tags` feature flag
2. View a feature flag with no tags and no evaluation contexts
3. Confirm both "No tags" and "No contexts" appear in Advanced options

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code. Single-line fix to remove an unnecessary condition that was hiding the evaluation contexts section in readonly mode.