### PR TITLE
fix(flags): handle both evaluation_tags and evaluation_contexts in cache

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1118,4 +1118,160 @@ mod tests {
             "Exact filter should NOT have compiled regex"
         );
     }
+
+    // =========================================================================
+    // Tests for evaluation_tags / evaluation_contexts migration handling
+    // =========================================================================
+
+    #[test]
+    fn test_deserialize_flag_with_legacy_evaluation_tags() {
+        // Old cache entries may have `evaluation_tags` key
+        let data = json!({
+            "id": 1,
+            "key": "legacy_flag",
+            "team_id": 123,
+            "active": true,
+            "deleted": false,
+            "filters": { "groups": [] },
+            "evaluation_tags": ["docs-page", "marketing-site"]
+        });
+
+        let flag: FeatureFlag =
+            serde_json::from_value(data).expect("Should deserialize with evaluation_tags");
+        assert_eq!(flag.key, "legacy_flag");
+        let tags = flag.evaluation_tags.expect("Should have evaluation_tags");
+        assert_eq!(tags.len(), 2);
+        assert!(tags.contains(&"docs-page".to_string()));
+        assert!(tags.contains(&"marketing-site".to_string()));
+    }
+
+    #[test]
+    fn test_deserialize_flag_with_new_evaluation_contexts() {
+        // New cache entries have `evaluation_contexts` key
+        let data = json!({
+            "id": 2,
+            "key": "new_flag",
+            "team_id": 123,
+            "active": true,
+            "deleted": false,
+            "filters": { "groups": [] },
+            "evaluation_contexts": ["app", "dashboard"]
+        });
+
+        let flag: FeatureFlag =
+            serde_json::from_value(data).expect("Should deserialize with evaluation_contexts");
+        assert_eq!(flag.key, "new_flag");
+        let tags = flag.evaluation_tags.expect("Should have evaluation_tags");
+        assert_eq!(tags.len(), 2);
+        assert!(tags.contains(&"app".to_string()));
+        assert!(tags.contains(&"dashboard".to_string()));
+    }
+
+    #[test]
+    fn test_deserialize_flag_with_both_keys_prefers_evaluation_contexts() {
+        // Race condition: some cache entries may have BOTH keys.
+        // We should prefer evaluation_contexts (the canonical name) over evaluation_tags.
+        let data = json!({
+            "id": 3,
+            "key": "race_condition_flag",
+            "team_id": 123,
+            "active": true,
+            "deleted": false,
+            "filters": { "groups": [] },
+            "evaluation_tags": ["old-value-1", "old-value-2"],
+            "evaluation_contexts": ["new-value-1", "new-value-2", "new-value-3"]
+        });
+
+        let flag: FeatureFlag = serde_json::from_value(data)
+            .expect("Should deserialize when both evaluation_tags and evaluation_contexts present");
+        assert_eq!(flag.key, "race_condition_flag");
+        let tags = flag
+            .evaluation_tags
+            .expect("Should have evaluation_tags from evaluation_contexts");
+        // Should have the evaluation_contexts values, NOT evaluation_tags
+        assert_eq!(tags.len(), 3);
+        assert!(tags.contains(&"new-value-1".to_string()));
+        assert!(tags.contains(&"new-value-2".to_string()));
+        assert!(tags.contains(&"new-value-3".to_string()));
+        // Should NOT have the old values
+        assert!(!tags.contains(&"old-value-1".to_string()));
+        assert!(!tags.contains(&"old-value-2".to_string()));
+    }
+
+    #[test]
+    fn test_deserialize_flag_with_neither_key() {
+        // Flags without evaluation contexts should deserialize with None
+        let data = json!({
+            "id": 4,
+            "key": "no_contexts_flag",
+            "team_id": 123,
+            "active": true,
+            "deleted": false,
+            "filters": { "groups": [] }
+        });
+
+        let flag: FeatureFlag =
+            serde_json::from_value(data).expect("Should deserialize without evaluation context");
+        assert_eq!(flag.key, "no_contexts_flag");
+        assert!(
+            flag.evaluation_tags.is_none(),
+            "Should have None when neither key present"
+        );
+    }
+
+    #[test]
+    fn test_serialize_flag_uses_evaluation_contexts() {
+        // When we serialize a FeatureFlag, it should use the `evaluation_contexts` key
+        let flag = FeatureFlag {
+            id: 5,
+            team_id: 123,
+            name: Some("Serialization Test".to_string()),
+            key: "serialize_test".to_string(),
+            filters: FlagFilters::default(),
+            deleted: false,
+            active: true,
+            ensure_experience_continuity: None,
+            version: None,
+            evaluation_runtime: None,
+            evaluation_tags: Some(vec!["context-1".to_string(), "context-2".to_string()]),
+            bucketing_identifier: None,
+        };
+
+        let json_str = serde_json::to_string(&flag).expect("Should serialize");
+        // Should serialize to evaluation_contexts, not evaluation_tags
+        assert!(
+            json_str.contains("evaluation_contexts"),
+            "Should use evaluation_contexts key when serializing"
+        );
+        assert!(
+            !json_str.contains("evaluation_tags"),
+            "Should NOT use evaluation_tags key when serializing"
+        );
+    }
+
+    #[test]
+    fn test_parse_hypercache_with_both_evaluation_keys() {
+        // Full integration test: parse a hypercache response with both keys
+        let data = json!({
+            "flags": [
+                {
+                    "id": 1,
+                    "key": "both_keys_flag",
+                    "team_id": 123,
+                    "active": true,
+                    "deleted": false,
+                    "filters": { "groups": [] },
+                    "evaluation_tags": ["stale"],
+                    "evaluation_contexts": ["fresh-context"]
+                }
+            ]
+        });
+
+        let result = FeatureFlagList::parse_hypercache_value(data, 123);
+        assert!(result.is_ok(), "Should parse successfully");
+        let (flags, _, _) = result.unwrap();
+        assert_eq!(flags.len(), 1);
+        let tags = flags[0].evaluation_tags.as_ref().expect("Should have tags");
+        assert_eq!(tags, &vec!["fresh-context".to_string()]);
+    }
 }

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1120,37 +1120,15 @@ mod tests {
     }
 
     // =========================================================================
-    // Tests for evaluation_tags / evaluation_contexts migration handling
+    // Tests for evaluation_contexts JSON key (renamed from evaluation_tags)
     // =========================================================================
 
     #[test]
-    fn test_deserialize_flag_with_legacy_evaluation_tags() {
-        // Old cache entries may have `evaluation_tags` key
+    fn test_deserialize_flag_with_evaluation_contexts() {
+        // Cache entries use `evaluation_contexts` key (renamed from `evaluation_tags` in PR #52186)
         let data = json!({
             "id": 1,
-            "key": "legacy_flag",
-            "team_id": 123,
-            "active": true,
-            "deleted": false,
-            "filters": { "groups": [] },
-            "evaluation_tags": ["docs-page", "marketing-site"]
-        });
-
-        let flag: FeatureFlag =
-            serde_json::from_value(data).expect("Should deserialize with evaluation_tags");
-        assert_eq!(flag.key, "legacy_flag");
-        let tags = flag.evaluation_tags.expect("Should have evaluation_tags");
-        assert_eq!(tags.len(), 2);
-        assert!(tags.contains(&"docs-page".to_string()));
-        assert!(tags.contains(&"marketing-site".to_string()));
-    }
-
-    #[test]
-    fn test_deserialize_flag_with_new_evaluation_contexts() {
-        // New cache entries have `evaluation_contexts` key
-        let data = json!({
-            "id": 2,
-            "key": "new_flag",
+            "key": "test_flag",
             "team_id": 123,
             "active": true,
             "deleted": false,
@@ -1160,7 +1138,8 @@ mod tests {
 
         let flag: FeatureFlag =
             serde_json::from_value(data).expect("Should deserialize with evaluation_contexts");
-        assert_eq!(flag.key, "new_flag");
+        assert_eq!(flag.key, "test_flag");
+        // Rust field is still named `evaluation_tags` for internal compatibility
         let tags = flag.evaluation_tags.expect("Should have evaluation_tags");
         assert_eq!(tags.len(), 2);
         assert!(tags.contains(&"app".to_string()));
@@ -1168,41 +1147,9 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_flag_with_both_keys_prefers_evaluation_contexts() {
-        // Race condition: some cache entries may have BOTH keys.
-        // We should prefer evaluation_contexts (the canonical name) over evaluation_tags.
+    fn test_deserialize_flag_without_evaluation_contexts() {
         let data = json!({
-            "id": 3,
-            "key": "race_condition_flag",
-            "team_id": 123,
-            "active": true,
-            "deleted": false,
-            "filters": { "groups": [] },
-            "evaluation_tags": ["old-value-1", "old-value-2"],
-            "evaluation_contexts": ["new-value-1", "new-value-2", "new-value-3"]
-        });
-
-        let flag: FeatureFlag = serde_json::from_value(data)
-            .expect("Should deserialize when both evaluation_tags and evaluation_contexts present");
-        assert_eq!(flag.key, "race_condition_flag");
-        let tags = flag
-            .evaluation_tags
-            .expect("Should have evaluation_tags from evaluation_contexts");
-        // Should have the evaluation_contexts values, NOT evaluation_tags
-        assert_eq!(tags.len(), 3);
-        assert!(tags.contains(&"new-value-1".to_string()));
-        assert!(tags.contains(&"new-value-2".to_string()));
-        assert!(tags.contains(&"new-value-3".to_string()));
-        // Should NOT have the old values
-        assert!(!tags.contains(&"old-value-1".to_string()));
-        assert!(!tags.contains(&"old-value-2".to_string()));
-    }
-
-    #[test]
-    fn test_deserialize_flag_with_neither_key() {
-        // Flags without evaluation contexts should deserialize with None
-        let data = json!({
-            "id": 4,
+            "id": 2,
             "key": "no_contexts_flag",
             "team_id": 123,
             "active": true,
@@ -1211,19 +1158,15 @@ mod tests {
         });
 
         let flag: FeatureFlag =
-            serde_json::from_value(data).expect("Should deserialize without evaluation context");
+            serde_json::from_value(data).expect("Should deserialize without evaluation_contexts");
         assert_eq!(flag.key, "no_contexts_flag");
-        assert!(
-            flag.evaluation_tags.is_none(),
-            "Should have None when neither key present"
-        );
+        assert!(flag.evaluation_tags.is_none());
     }
 
     #[test]
-    fn test_serialize_flag_uses_evaluation_contexts() {
-        // When we serialize a FeatureFlag, it should use the `evaluation_contexts` key
+    fn test_serialize_flag_uses_evaluation_contexts_key() {
         let flag = FeatureFlag {
-            id: 5,
+            id: 3,
             team_id: 123,
             name: Some("Serialization Test".to_string()),
             key: "serialize_test".to_string(),
@@ -1238,7 +1181,7 @@ mod tests {
         };
 
         let json_str = serde_json::to_string(&flag).expect("Should serialize");
-        // Should serialize to evaluation_contexts, not evaluation_tags
+        // Rust field `evaluation_tags` serializes to JSON key `evaluation_contexts`
         assert!(
             json_str.contains("evaluation_contexts"),
             "Should use evaluation_contexts key when serializing"
@@ -1247,31 +1190,5 @@ mod tests {
             !json_str.contains("evaluation_tags"),
             "Should NOT use evaluation_tags key when serializing"
         );
-    }
-
-    #[test]
-    fn test_parse_hypercache_with_both_evaluation_keys() {
-        // Full integration test: parse a hypercache response with both keys
-        let data = json!({
-            "flags": [
-                {
-                    "id": 1,
-                    "key": "both_keys_flag",
-                    "team_id": 123,
-                    "active": true,
-                    "deleted": false,
-                    "filters": { "groups": [] },
-                    "evaluation_tags": ["stale"],
-                    "evaluation_contexts": ["fresh-context"]
-                }
-            ]
-        });
-
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok(), "Should parse successfully");
-        let (flags, _, _) = result.unwrap();
-        assert_eq!(flags.len(), 1);
-        let tags = flags[0].evaluation_tags.as_ref().expect("Should have tags");
-        assert_eq!(tags, &vec!["fresh-context".to_string()]);
     }
 }

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -168,8 +168,34 @@ pub enum BucketingIdentifier {
 // TODO: see if you can combine these two structs, like we do with cohort models
 // this will require not deserializing on read and instead doing it lazily, on-demand
 // (which, tbh, is probably a better idea)
-#[derive(Debug, Clone, Deserialize, Serialize)]
+//
+// Deserialization uses FeatureFlagRaw to handle both `evaluation_tags` and
+// `evaluation_contexts` keys (or both present due to cache race conditions).
+#[derive(Debug, Clone, Serialize)]
+#[serde(into = "FeatureFlagRaw")]
 pub struct FeatureFlag {
+    pub id: FeatureFlagId,
+    pub team_id: i32,
+    pub name: Option<String>,
+    pub key: String,
+    pub filters: FlagFilters,
+    pub deleted: bool,
+    pub active: bool,
+    pub ensure_experience_continuity: Option<bool>,
+    pub version: Option<i32>,
+    pub evaluation_runtime: Option<String>,
+    /// Evaluation context tags for this flag. Accepts JSON with either `evaluation_tags`
+    /// or `evaluation_contexts` keys (or both). When both are present, `evaluation_contexts`
+    /// takes precedence as the canonical key name.
+    pub evaluation_tags: Option<Vec<String>>,
+    pub bucketing_identifier: Option<String>,
+}
+
+/// Raw deserialization struct for FeatureFlag that handles both `evaluation_tags` and
+/// `evaluation_contexts` keys. Some cache entries may have the old key, new key, or both
+/// due to race conditions during the rename migration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct FeatureFlagRaw {
     pub id: FeatureFlagId,
     pub team_id: i32,
     pub name: Option<String>,
@@ -185,10 +211,64 @@ pub struct FeatureFlag {
     pub version: Option<i32>,
     #[serde(default)]
     pub evaluation_runtime: Option<String>,
-    #[serde(default, alias = "evaluation_contexts")]
+    /// Legacy key name, kept for backwards compatibility with old cache entries.
+    #[serde(default, skip_serializing)]
     pub evaluation_tags: Option<Vec<String>>,
+    /// New canonical key name for evaluation contexts.
+    #[serde(default)]
+    pub evaluation_contexts: Option<Vec<String>>,
     #[serde(default)]
     pub bucketing_identifier: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for FeatureFlag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = FeatureFlagRaw::deserialize(deserializer)?;
+        Ok(FeatureFlag::from(raw))
+    }
+}
+
+impl From<FeatureFlagRaw> for FeatureFlag {
+    fn from(raw: FeatureFlagRaw) -> Self {
+        FeatureFlag {
+            id: raw.id,
+            team_id: raw.team_id,
+            name: raw.name,
+            key: raw.key,
+            filters: raw.filters,
+            deleted: raw.deleted,
+            active: raw.active,
+            ensure_experience_continuity: raw.ensure_experience_continuity,
+            version: raw.version,
+            evaluation_runtime: raw.evaluation_runtime,
+            // Prefer evaluation_contexts (new canonical name) over evaluation_tags (legacy)
+            evaluation_tags: raw.evaluation_contexts.or(raw.evaluation_tags),
+            bucketing_identifier: raw.bucketing_identifier,
+        }
+    }
+}
+
+impl From<FeatureFlag> for FeatureFlagRaw {
+    fn from(flag: FeatureFlag) -> Self {
+        FeatureFlagRaw {
+            id: flag.id,
+            team_id: flag.team_id,
+            name: flag.name,
+            key: flag.key,
+            filters: flag.filters,
+            deleted: flag.deleted,
+            active: flag.active,
+            ensure_experience_continuity: flag.ensure_experience_continuity,
+            version: flag.version,
+            evaluation_runtime: flag.evaluation_runtime,
+            evaluation_tags: None, // Don't serialize the legacy key
+            evaluation_contexts: flag.evaluation_tags, // Serialize using the new canonical name
+            bucketing_identifier: flag.bucketing_identifier,
+        }
+    }
 }
 
 impl FeatureFlag {
@@ -202,6 +282,8 @@ impl FeatureFlag {
     }
 }
 
+/// Row struct for PostgreSQL queries via sqlx. The `evaluation_tags` column is
+/// always named `evaluation_tags` in the SQL query, so no alias is needed.
 #[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct FeatureFlagRow {
     pub id: i32,
@@ -215,7 +297,7 @@ pub struct FeatureFlagRow {
     pub version: Option<i32>,
     #[serde(default)]
     pub evaluation_runtime: Option<String>,
-    #[serde(default, alias = "evaluation_contexts")]
+    #[serde(default)]
     pub evaluation_tags: Option<Vec<String>>,
     #[serde(default)]
     pub bucketing_identifier: Option<String>,

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -6,6 +6,10 @@ use std::collections::{HashMap, HashSet};
 use crate::cohorts::cohort_models::Cohort;
 use crate::properties::property_models::PropertyFilter;
 
+// NOTE: The `evaluation_tags` field was renamed to `evaluation_contexts` in the Python
+// serializer (PR #52186). The Rust field keeps the old name for internal compatibility,
+// but uses `#[serde(rename = "evaluation_contexts")]` to match the JSON key.
+
 /// Deserializes a JSON object with string keys into `HashMap<i32, HashSet<i32>>`.
 /// JSON only supports string keys, so Python serializes `{1: [2, 3]}` as `{"1": [2, 3]}`.
 fn deserialize_string_keyed_i32_map<'de, D>(
@@ -168,39 +172,13 @@ pub enum BucketingIdentifier {
 // TODO: see if you can combine these two structs, like we do with cohort models
 // this will require not deserializing on read and instead doing it lazily, on-demand
 // (which, tbh, is probably a better idea)
-//
-// Deserialization uses FeatureFlagRaw to handle both `evaluation_tags` and
-// `evaluation_contexts` keys (or both present due to cache race conditions).
-#[derive(Debug, Clone, Serialize)]
-#[serde(into = "FeatureFlagRaw")]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FeatureFlag {
     pub id: FeatureFlagId,
     pub team_id: i32,
     pub name: Option<String>,
     pub key: String,
     pub filters: FlagFilters,
-    pub deleted: bool,
-    pub active: bool,
-    pub ensure_experience_continuity: Option<bool>,
-    pub version: Option<i32>,
-    pub evaluation_runtime: Option<String>,
-    /// Evaluation context tags for this flag. Accepts JSON with either `evaluation_tags`
-    /// or `evaluation_contexts` keys (or both). When both are present, `evaluation_contexts`
-    /// takes precedence as the canonical key name.
-    pub evaluation_tags: Option<Vec<String>>,
-    pub bucketing_identifier: Option<String>,
-}
-
-/// Raw deserialization struct for FeatureFlag that handles both `evaluation_tags` and
-/// `evaluation_contexts` keys. Some cache entries may have the old key, new key, or both
-/// due to race conditions during the rename migration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct FeatureFlagRaw {
-    pub id: FeatureFlagId,
-    pub team_id: i32,
-    pub name: Option<String>,
-    pub key: String,
-    pub filters: FlagFilters,
     #[serde(default)]
     pub deleted: bool,
     #[serde(default)]
@@ -211,64 +189,12 @@ struct FeatureFlagRaw {
     pub version: Option<i32>,
     #[serde(default)]
     pub evaluation_runtime: Option<String>,
-    /// Legacy key name, kept for backwards compatibility with old cache entries.
-    #[serde(default, skip_serializing)]
+    /// Evaluation context tags for this flag. JSON key is `evaluation_contexts`,
+    /// but Rust field remains `evaluation_tags` for internal compatibility.
+    #[serde(default, rename = "evaluation_contexts")]
     pub evaluation_tags: Option<Vec<String>>,
-    /// New canonical key name for evaluation contexts.
-    #[serde(default)]
-    pub evaluation_contexts: Option<Vec<String>>,
     #[serde(default)]
     pub bucketing_identifier: Option<String>,
-}
-
-impl<'de> Deserialize<'de> for FeatureFlag {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let raw = FeatureFlagRaw::deserialize(deserializer)?;
-        Ok(FeatureFlag::from(raw))
-    }
-}
-
-impl From<FeatureFlagRaw> for FeatureFlag {
-    fn from(raw: FeatureFlagRaw) -> Self {
-        FeatureFlag {
-            id: raw.id,
-            team_id: raw.team_id,
-            name: raw.name,
-            key: raw.key,
-            filters: raw.filters,
-            deleted: raw.deleted,
-            active: raw.active,
-            ensure_experience_continuity: raw.ensure_experience_continuity,
-            version: raw.version,
-            evaluation_runtime: raw.evaluation_runtime,
-            // Prefer evaluation_contexts (new canonical name) over evaluation_tags (legacy)
-            evaluation_tags: raw.evaluation_contexts.or(raw.evaluation_tags),
-            bucketing_identifier: raw.bucketing_identifier,
-        }
-    }
-}
-
-impl From<FeatureFlag> for FeatureFlagRaw {
-    fn from(flag: FeatureFlag) -> Self {
-        FeatureFlagRaw {
-            id: flag.id,
-            team_id: flag.team_id,
-            name: flag.name,
-            key: flag.key,
-            filters: flag.filters,
-            deleted: flag.deleted,
-            active: flag.active,
-            ensure_experience_continuity: flag.ensure_experience_continuity,
-            version: flag.version,
-            evaluation_runtime: flag.evaluation_runtime,
-            evaluation_tags: None, // Don't serialize the legacy key
-            evaluation_contexts: flag.evaluation_tags, // Serialize using the new canonical name
-            bucketing_identifier: flag.bucketing_identifier,
-        }
-    }
 }
 
 impl FeatureFlag {


### PR DESCRIPTION
## Problem

PR #52186 renamed the JSON key from `evaluation_tags` to `evaluation_contexts` in the Python serializer. The Rust code used `#[serde(alias = "evaluation_contexts")]` but since the cache was flushed, we only need to match the new key name.

## Changes

- Changed `#[serde(alias = "evaluation_contexts")]` to `#[serde(rename = "evaluation_contexts")]` on the `evaluation_tags` field
- The Rust field name remains `evaluation_tags` for internal compatibility
- Removed unnecessary alias from `FeatureFlagRow` (only used for PostgreSQL queries)
- Added 3 unit tests for the rename behavior

## How did you test this code?

Added unit tests:
- `test_deserialize_flag_with_evaluation_contexts` - JSON key deserializes correctly
- `test_deserialize_flag_without_evaluation_contexts` - None case works
- `test_serialize_flag_uses_evaluation_contexts_key` - serialization uses correct key

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)