### PR TITLE
docs: note that product databases need infra provisioning

### DIFF
--- a/common/hogli/product/scaffold.py
+++ b/common/hogli/product/scaffold.py
@@ -199,6 +199,11 @@ def bootstrap_product(name: str, dry_run: bool, force: bool) -> None:
             "connections, and migrations so one product can't bring down the app. "
             "This is new but fully working. Reach out in #team-devex with questions."
         )
+        click.secho(
+            "  ⚠ Adding a route here is only the Django side. The database must also "
+            "be provisioned by #team-infrastructure (Terraform + charts).",
+            fg="yellow",
+        )
         existing_dbs = _get_existing_databases()
         if existing_dbs:
             click.echo(f"  Existing databases: {', '.join(existing_dbs)}")

--- a/products/README.md
+++ b/products/README.md
@@ -200,7 +200,12 @@ This automatically:
 - Runs migrations via `bin/migrate` (calls `migrate_product_databases` management command)
 - Creates the database in local Docker via the Postgres init script
 
-Locally (`DEBUG=1`), it auto-connects to `posthog_visual_review` on localhost. In prod, set `PRODUCT_DB_VISUAL_REVIEW_WRITER_URL` (and optionally `…_READER_URL`). If the env var is absent, the route is silently skipped.
+Locally (`DEBUG=1`), it auto-connects to `posthog_visual_review` on localhost. In prod, the infrastructure handles env vars and connections automatically. If the env var is absent, the route is silently skipped.
+
+### Adding a new product database
+
+1. Add a route in `products/db_routing.yaml` (this repo)
+2. Ask `#team-infrastructure` to provision the database — they'll handle the cluster, credentials, and connection plumbing
 
 ### Cross-database constraints
 


### PR DESCRIPTION
Update README and bootstrap prompt to clarify that adding a route in db_routing.yaml is only the Django side — infra needs to provision the database too.