### PR TITLE
fix(notifications): add NotificationsMenu to NavBarFooter and gate on feature flag

### DIFF
--- a/frontend/src/layout/panel-layout/NavBarFooter.tsx
+++ b/frontend/src/layout/panel-layout/NavBarFooter.tsx
@@ -5,11 +5,15 @@ import { DebugNotice } from 'lib/components/DebugNotice'
 import { HealthMenu } from 'lib/components/HealthMenu/HealthMenu'
 import { HelpMenu } from 'lib/components/HelpMenu/HelpMenu'
 import { NavPanelAdvertisement } from 'lib/components/NavPanelAdvertisement/NavPanelAdvertisement'
+import { NotificationsMenu } from 'lib/components/NotificationsMenu/NotificationsMenu'
 import { PosthogStatusShownOnlyIfNotOperational } from 'lib/components/PosthogStatus/PosthogStatusShownOnlyIfNotOperational'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
 export function NavBarFooter({ isLayoutNavCollapsed }: { isLayoutNavCollapsed: boolean }): JSX.Element {
+    const isNotificationsEnabled = useFeatureFlag('REAL_TIME_NOTIFICATIONS')
+
     return (
         <div className="p-1 flex flex-col gap-px items-start pb-2">
             <div
@@ -27,6 +31,7 @@ export function NavBarFooter({ isLayoutNavCollapsed }: { isLayoutNavCollapsed: b
                     'items-center': isLayoutNavCollapsed,
                 })}
             >
+                {isNotificationsEnabled && <NotificationsMenu iconOnly={isLayoutNavCollapsed} />}
                 <Link
                     to={urls.settings('project')}
                     buttonProps={{ menuItem: isLayoutNavCollapsed ? false : true }}

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -98,6 +98,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const { featureFlags } = useValues(featureFlagLogic)
     const { toggleCommand } = useActions(commandLogic)
     const isProductAutonomyEnabled = useFeatureFlag('PRODUCT_AUTONOMY')
+    const isNotificationsEnabled = useFeatureFlag('REAL_TIME_NOTIFICATIONS')
 
     function handlePanelTriggerClick(item: PanelLayoutNavIdentifier): void {
         if (activePanelIdentifier !== item) {
@@ -504,7 +505,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                     'items-center': isLayoutNavCollapsed,
                                 })}
                             >
-                                <NotificationsMenu iconOnly={isLayoutNavCollapsed} />
+                                {isNotificationsEnabled && <NotificationsMenu iconOnly={isLayoutNavCollapsed} />}
                                 <Link
                                     to={urls.settings('project')}
                                     buttonProps={{ menuItem: isLayoutNavCollapsed ? false : true }}


### PR DESCRIPTION
## Problem

Hide Notification menu item under a FF.

## Changes

- Add `NotificationsMenu` to `NavBarFooter` (used by AI-first nav), positioned above Settings
- Gate `NotificationsMenu` on `real-time-notifications` feature flag in both `NavBarFooter` and `PanelLayoutNavBar`

## How did you test this code?

- Verified both nav layouts render the menu when flag is enabled
- Verified the menu is hidden when flag is disabled

## Publish to changelog?

no