### PR TITLE
fix(logs): don't try to fetch values for message filters

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -413,13 +413,12 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             { endpoint, type, newInput, propertyKey, eventNames, properties, forceRefresh },
             breakpoint
         ) => {
-            if (['cohort'].includes(type)) {
+            if (['cohort', 'log'].includes(type)) {
                 return
             }
             if (!propertyKey || values.currentTeamId === null) {
                 return
             }
-
             if (!forceRefresh && localOptions[getPropertyKey(type, propertyKey)]) {
                 actions.setOptions(propertyKey, localOptions[getPropertyKey(type, propertyKey)], false)
                 return


### PR DESCRIPTION

## Problem

the values endpoint is only for attributes+resource attributes, it breaks on e.g message, showing an annoying toast error

## Changes

exclude "log" type properties (not "log_attributes") from loading values

## How did you test this code?
locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
