### PR TITLE
chore(tracking): add separate event for triggering dwh insight survey"

### DIFF
--- a/frontend/src/lib/posthog-typed.ts
+++ b/frontend/src/lib/posthog-typed.ts
@@ -1776,6 +1776,7 @@ interface EventSchemas {
     'insight person modal viewed': Record<string, any>
     'insight refresh time': Record<string, any>
     'insight saved': Record<string, any>
+    'insight with data warehouse source saved': Record<string, any>
     'insight short url visited': Record<string, any>
     'insights table calc toggled': Record<string, any>
     'insights tab reset': Record<string, any>

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1083,11 +1083,17 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportInsightSaved: async ({ insight, query, isNewInsight }) => {
             // "insight saved" is a proxy for the new insight's results being valuable to the user
+            const sanitizedQuery = sanitizeQuery(query)
+
             posthog.capture('insight saved', {
-                ...sanitizeQuery(query),
+                ...sanitizedQuery,
                 insight: sanitizeInsight(insight),
                 is_new_insight: isNewInsight,
             })
+
+            if ((sanitizedQuery.data_warehouse_entity_count ?? 0) > 0) {
+                posthog.capture('insight with data warehouse source saved')
+            }
         },
         reportInsightViewed: ({ insightModel, query, isFirstLoad, delay }) => {
             const payload: Record<string, any> = {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1091,7 +1091,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 is_new_insight: isNewInsight,
             })
 
-            if ((sanitizedQuery.data_warehouse_entity_count ?? 0) > 0) {
+            if (isNewInsight && (sanitizedQuery.data_warehouse_entity_count ?? 0) > 0) {
                 posthog.capture('insight with data warehouse source saved')
             }
         },


### PR DESCRIPTION
## Problem

Survey triggers don't support event properties and I want to show a survey for users who created a data warehouse insight.

## Changes

Adds a separate event.

## How did you test this code?

n/a