### PR TITLE
fix(logs-alerts): bind form logic context so edit modal populates persisted filter values

### DIFF
--- a/playwright/e2e/logs/logs-alerts.spec.ts
+++ b/playwright/e2e/logs/logs-alerts.spec.ts
@@ -1,0 +1,184 @@
+import { randomString } from '../../utils'
+import { expect, test } from '../../utils/playwright-test-base'
+
+test.describe('Logs Alerts CRUD', () => {
+    const ALERTS_API = '**/api/projects/*/logs/alerts/'
+    const ALERTS_API_DETAIL = '**/api/projects/*/logs/alerts/*/'
+
+    const makeAlert = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+        id: '019d-test-alert-id',
+        name: 'Test Alert',
+        enabled: true,
+        state: 'not_firing',
+        filters: { severityLevels: ['error'], serviceNames: ['api-gateway'] },
+        threshold_count: 50,
+        threshold_operator: 'above',
+        window_minutes: 10,
+        evaluation_periods: 1,
+        datapoints_to_alarm: 1,
+        cooldown_minutes: 0,
+        ...overrides,
+    })
+
+    // The kea-forms <Form> renders as <form class="LemonModal__layout">
+    const formModal = 'form.LemonModal__layout'
+
+    test('creates an alert, verifies edit populates persisted values, edits, and deletes', async ({ page }) => {
+        const alertName = randomString('alert')
+        let createdAlert: Record<string, unknown> | null = null
+
+        await test.step('mock APIs and navigate to alerts', async () => {
+            // Mock the alerts list and create endpoints
+            await page.route(ALERTS_API, async (route) => {
+                const method = route.request().method()
+                if (method === 'GET') {
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify({ results: createdAlert ? [createdAlert] : [] }),
+                    })
+                } else if (method === 'POST') {
+                    const body = route.request().postDataJSON()
+                    createdAlert = makeAlert({
+                        ...body,
+                        id: '019d-created-alert-id',
+                        name: body.name,
+                    })
+                    await route.fulfill({
+                        status: 201,
+                        contentType: 'application/json',
+                        body: JSON.stringify(createdAlert),
+                    })
+                } else {
+                    await route.continue()
+                }
+            })
+
+            await page.route(ALERTS_API_DETAIL, async (route) => {
+                const method = route.request().method()
+                if (method === 'PATCH') {
+                    const body = route.request().postDataJSON()
+                    createdAlert = { ...createdAlert, ...body }
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify(createdAlert),
+                    })
+                } else if (method === 'DELETE') {
+                    createdAlert = null
+                    await route.fulfill({ status: 204 })
+                } else if (method === 'GET') {
+                    if (!createdAlert) {
+                        await route.fulfill({ status: 404 })
+                        return
+                    }
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify(createdAlert),
+                    })
+                } else {
+                    await route.continue()
+                }
+            })
+
+            // Inject the logs-alerting feature flag before the app hydrates.
+            // The settings map gates the Alerting section behind this flag.
+            await page.addInitScript(() => {
+                let _context: any
+                Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {
+                    get() {
+                        return _context
+                    },
+                    set(value: any) {
+                        if (value) {
+                            value.persisted_feature_flags = [
+                                ...(value.persisted_feature_flags || []),
+                                'logs-settings',
+                                'logs-alerting',
+                            ]
+                        }
+                        _context = value
+                    },
+                    configurable: true,
+                })
+            })
+
+            await page.goto('/project/1/settings/environment-logs')
+            await expect(page.getByRole('heading', { name: 'Alerting' })).toBeVisible({ timeout: 15000 })
+            // Wait for the mocked empty alerts list to render
+            await expect(page.getByText('No alerts configured yet.')).toBeVisible()
+        })
+
+        await test.step('create an alert with severity filter', async () => {
+            await page.getByRole('button', { name: 'New alert' }).click()
+            await expect(page.locator(formModal)).toBeVisible()
+
+            // Fill in name
+            await page.locator(formModal).getByPlaceholder('e.g. API 5xx errors').fill(alertName)
+
+            // Select severity — panels are already expanded via defaultActiveKeys
+            await page.locator(formModal).getByTestId('logs-severity-filter').click()
+            await page.locator('[data-attr="logs-severity-option-error"]').click()
+            // Close dropdown by clicking elsewhere in the modal, not Escape (which closes the modal)
+            await page.locator(formModal).getByPlaceholder('e.g. API 5xx errors').click()
+
+            // Submit the form
+            await page.locator(formModal).getByRole('button', { name: 'Create alert' }).click()
+
+            // Assert modal closes and success toast
+            await expect(page.locator(formModal)).not.toBeVisible()
+            await expect(page.getByText('Alert created')).toBeVisible()
+        })
+
+        await test.step('verify alert appears in list', async () => {
+            await expect(page.getByRole('button', { name: alertName })).toBeVisible()
+        })
+
+        await test.step('edit modal populates persisted values', async () => {
+            await page.getByRole('button', { name: alertName }).click()
+            await expect(page.locator(formModal)).toBeVisible()
+            await expect(page.getByRole('heading', { name: 'Edit alert' })).toBeVisible()
+
+            // Verify name is populated
+            await expect(page.locator(formModal).getByPlaceholder('e.g. API 5xx errors')).toHaveValue(alertName)
+
+            // Verify severity filter shows "Error" (not "All levels")
+            await expect(page.locator(formModal).getByTestId('logs-severity-filter')).toContainText('error', {
+                ignoreCase: true,
+            })
+
+            // Verify save button is disabled (no changes)
+            await expect(page.locator(formModal).getByRole('button', { name: 'Save' })).toBeDisabled()
+        })
+
+        await test.step('edit the alert name and save', async () => {
+            const updatedName = alertName + '-updated'
+            await page.locator(formModal).getByPlaceholder('e.g. API 5xx errors').fill(updatedName)
+
+            // Save button should now be enabled
+            const saveButton = page.locator(formModal).getByRole('button', { name: 'Save' })
+            await expect(saveButton).toBeEnabled()
+            await saveButton.click()
+
+            // Assert modal closes and success toast
+            await expect(page.locator(formModal)).not.toBeVisible()
+            await expect(page.getByText('Alert updated')).toBeVisible()
+
+            // Verify updated name in list
+            await expect(page.getByRole('button', { name: updatedName })).toBeVisible()
+        })
+
+        await test.step('delete the alert', async () => {
+            await page.locator('[aria-label="more"]').click()
+            await page.getByRole('menuitem', { name: 'Delete' }).click()
+
+            // Confirm in the deletion dialog
+            await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
+
+            // Assert success
+            await expect(page.getByText('Alert deleted')).toBeVisible()
+            await expect(page.getByText('No alerts configured yet.')).toBeVisible()
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -54,37 +54,39 @@ function LogsAlertModalContent({ editingAlert }: { editingAlert: LogsAlertConfig
     const hasPendingNotifications = pendingNotifications.length > 0
 
     return (
-        <BindLogic logic={logsAlertNotificationLogic} props={notifLogicProps}>
-            <Form
-                logic={logsAlertFormLogic}
-                props={formLogicProps}
-                formKey="alertForm"
-                enableFormOnSubmit
-                className="LemonModal__layout"
-            >
-                <LemonModal.Header>
-                    <h3>{editingAlert ? 'Edit alert' : 'New alert'}</h3>
-                    <p className="text-muted text-sm m-0">Alerts are checked every minute.</p>
-                </LemonModal.Header>
-                <LemonModal.Content>
-                    <LogsAlertForm />
-                </LemonModal.Content>
-                <LemonModal.Footer>
-                    <div className="flex-1" />
-                    <LemonButton
-                        type="primary"
-                        htmlType="submit"
-                        loading={isAlertFormSubmitting}
-                        disabledReason={
-                            editingAlert && !alertFormChanged && !hasPendingNotifications
-                                ? 'No changes to save'
-                                : undefined
-                        }
-                    >
-                        {editingAlert ? 'Save' : 'Create alert'}
-                    </LemonButton>
-                </LemonModal.Footer>
-            </Form>
+        <BindLogic logic={logsAlertFormLogic} props={formLogicProps}>
+            <BindLogic logic={logsAlertNotificationLogic} props={notifLogicProps}>
+                <Form
+                    logic={logsAlertFormLogic}
+                    props={formLogicProps}
+                    formKey="alertForm"
+                    enableFormOnSubmit
+                    className="LemonModal__layout"
+                >
+                    <LemonModal.Header>
+                        <h3>{editingAlert ? 'Edit alert' : 'New alert'}</h3>
+                        <p className="text-muted text-sm m-0">Alerts are checked every minute.</p>
+                    </LemonModal.Header>
+                    <LemonModal.Content>
+                        <LogsAlertForm />
+                    </LemonModal.Content>
+                    <LemonModal.Footer>
+                        <div className="flex-1" />
+                        <LemonButton
+                            type="primary"
+                            htmlType="submit"
+                            loading={isAlertFormSubmitting}
+                            disabledReason={
+                                editingAlert && !alertFormChanged && !hasPendingNotifications
+                                    ? 'No changes to save'
+                                    : undefined
+                            }
+                        >
+                            {editingAlert ? 'Save' : 'Create alert'}
+                        </LemonButton>
+                    </LemonModal.Footer>
+                </Form>
+            </BindLogic>
         </BindLogic>
     )
 }

--- a/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, key, path, props, selectors } from 'kea'
+import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
 import { forms } from 'kea-forms'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -78,6 +78,22 @@ function hasAnyFilter(severityLevels: string[], serviceNames: string[], filterGr
     return severityLevels.length > 0 || serviceNames.length > 0 || filterGroup.values.length > 0
 }
 
+function buildFormDefaults(alert: LogsAlertConfigurationApi | null): LogsAlertFormType {
+    return {
+        name: alert?.name ?? '',
+        severityLevels:
+            ((alert?.filters as Record<string, unknown>)?.severityLevels as LogMessage['severity_text'][]) ?? [],
+        serviceNames: ((alert?.filters as Record<string, unknown>)?.serviceNames as string[]) ?? [],
+        filterGroup: extractFilterGroup(alert),
+        thresholdOperator: alert?.threshold_operator ?? ThresholdOperatorEnumApi.Above,
+        thresholdCount: alert?.threshold_count ?? 100,
+        windowMinutes: alert?.window_minutes ?? 10,
+        evaluationPeriods: alert?.evaluation_periods ?? 1,
+        datapointsToAlarm: alert?.datapoints_to_alarm ?? 1,
+        cooldownMinutes: alert?.cooldown_minutes ?? 0,
+    }
+}
+
 export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
     path(['products', 'logs', 'frontend', 'components', 'LogsAlerting', 'logsAlertFormLogic']),
     props({} as LogsAlertFormLogicProps),
@@ -102,20 +118,16 @@ export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
         isEditing: [() => [(_, props) => props.alert], (alert: LogsAlertConfigurationApi | null) => alert !== null],
     }),
 
+    afterMount(({ actions, props }) => {
+        // Pass values explicitly to reset — kea caches logic instances by key,
+        // so defaults from a previous mount may be stale
+        actions.resetAlertForm(buildFormDefaults(props.alert))
+    }),
+
     forms(({ props, actions, values }) => ({
         alertForm: {
-            defaults: {
-                name: props.alert?.name ?? '',
-                severityLevels: ((props.alert?.filters as Record<string, unknown>)?.severityLevels as string[]) ?? [],
-                serviceNames: ((props.alert?.filters as Record<string, unknown>)?.serviceNames as string[]) ?? [],
-                filterGroup: extractFilterGroup(props.alert),
-                thresholdOperator: props.alert?.threshold_operator ?? ThresholdOperatorEnumApi.Above,
-                thresholdCount: props.alert?.threshold_count ?? 100,
-                windowMinutes: props.alert?.window_minutes ?? 10,
-                evaluationPeriods: props.alert?.evaluation_periods ?? 1,
-                datapointsToAlarm: props.alert?.datapoints_to_alarm ?? 1,
-                cooldownMinutes: props.alert?.cooldown_minutes ?? 0,
-            } as LogsAlertFormType,
+            // Provides typed shape for kea-forms; afterMount resets with fresh values on every remount
+            defaults: buildFormDefaults(props.alert),
             errors: ({ name }) => ({
                 name: !name?.trim() ? 'Name is required' : undefined,
             }),


### PR DESCRIPTION
## Problem

Alert filter fields weren't being populated correctly on edit

## Changes

Ensure that when editing an existing alert, the form fields (like severity levels and service names) are properly populated with the current alert's values instead of showing empty defaults.

- Added end-to-end test for logs alerts CRUD operations that verifies create, edit, and delete functionality
- Fixed form initialization by moving from static defaults to `afterMount` hook that explicitly resets form values
- Corrected logic binding structure to ensure proper form state management
- Extracted form defaults into a reusable `buildFormDefaults` function for consistency

## How did you test this code?

Added an e2e test suite

## Publish to changelog?

No