### PR TITLE
fix(conversations): use Slack app_redirect for deep linking

### DIFF
--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -264,7 +264,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                                     <div className="flex justify-between items-center">
                                         <span className="text-muted-alt">Slack thread</span>
                                         <Link
-                                            to={`https://app.slack.com/client/${ticket.slack_team_id}/${ticket.slack_channel_id}/thread/${ticket.slack_channel_id}-${ticket.slack_thread_ts.replace('.', '')}`}
+                                            to={`https://slack.com/app_redirect?team=${ticket.slack_team_id}&channel=${ticket.slack_channel_id}&thread_ts=${ticket.slack_thread_ts}`}
                                             target="_blank"
                                             className="text-xs"
                                         >


### PR DESCRIPTION
## Problem

Open in slack option opens the web client, not the app

## Changes

Uses slacks deep-linking instead to try the app first and if not present then the web client https://docs.slack.dev/interactivity/deep-linking/ 

