### PR TITLE
feat(logs): switch logs to use distributed tables

### DIFF
--- a/bin/clickhouse-logs.sql
+++ b/bin/clickhouse-logs.sql
@@ -4,77 +4,15 @@ CREATE OR REPLACE FUNCTION extractIPv4Substrings AS
 (
   body -> extractAll(body, '(\d\.((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){2,2}([0-9]))')
 );
-CREATE OR REPLACE TABLE logs31
-(
-    -- time bucket is set to day which means it's effectively not in the order by key (same as partition)
-    -- but gives us flexibility to add the bucket to the order key if needed
-    `time_bucket` DateTime MATERIALIZED toStartOfDay(timestamp) CODEC(DoubleDelta, ZSTD(1)),
-    `uuid` String CODEC(ZSTD(1)),
-    `team_id` Int32 CODEC(ZSTD(1)),
-    `trace_id` String CODEC(ZSTD(1)),
-    `span_id` String CODEC(ZSTD(1)),
-    `trace_flags` Int32 CODEC(ZSTD(1)),
-    `timestamp` DateTime64(6) CODEC(DoubleDelta, ZSTD(1)),
-    `observed_timestamp` DateTime64(6) CODEC(DoubleDelta, ZSTD(1)),
-    `created_at` DateTime64(6) MATERIALIZED now() CODEC(DoubleDelta, ZSTD(1)),
-    `body` String CODEC(ZSTD(1)),
-    `severity_text` String CODEC(ZSTD(1)),
-    `severity_number` Int32 CODEC(ZSTD(1)),
-    `service_name` String CODEC(ZSTD(1)),
-    `resource_attributes` Map(String, String) CODEC(ZSTD(1)),
-    `resource_fingerprint` UInt64 MATERIALIZED cityHash64(resource_attributes) CODEC(DoubleDelta, ZSTD(1)),
-    `resource_id` String CODEC(ZSTD(1)),
-    `instrumentation_scope` String CODEC(ZSTD(1)),
-    `event_name` String CODEC(ZSTD(1)),
-    `attributes_map_str` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-    `attributes_map_float` Map(LowCardinality(String), Float64) CODEC(ZSTD(1)),
-    `attributes_map_datetime` Map(LowCardinality(String), DateTime64(6)) CODEC(ZSTD(1)),
-    `level` String ALIAS severity_text,
-    `mat_body_ipv4_matches` Array(String) ALIAS extractAll(body, '(\\d\\.((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){2,2}([0-9]))'),
-    `time_minute` DateTime ALIAS toStartOfMinute(timestamp),
-    `attributes` Map(String, String) ALIAS mapApply((k, v) -> (left(k, -5), v), attributes_map_str),
-    INDEX idx_severity_text_set severity_text TYPE set(10) GRANULARITY 1,
-    INDEX idx_attributes_str_keys mapKeys(attributes_map_str) TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_attributes_str_values mapValues(attributes_map_str) TYPE bloom_filter(0.001) GRANULARITY 1,
-    INDEX idx_mat_body_ipv4_matches mat_body_ipv4_matches TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_body_ngram3 body TYPE ngrambf_v1(3, 25000, 2, 0) GRANULARITY 1,
-    INDEX idx_observed_minmax observed_timestamp TYPE minmax GRANULARITY 1,
-    PROJECTION projection_aggregate_counts
-    (
-        SELECT
-            team_id,
-            time_bucket,
-            toStartOfMinute(timestamp),
-            service_name,
-            severity_text,
-            resource_fingerprint,
-            count() AS event_count
-        GROUP BY
-            team_id,
-            time_bucket,
-            toStartOfMinute(timestamp),
-            service_name,
-            severity_text,
-            resource_fingerprint
-    )
-)
-ENGINE = MergeTree
-PARTITION BY toDate(timestamp)
-PRIMARY KEY (team_id, time_bucket, service_name, resource_fingerprint, severity_text, timestamp)
-ORDER BY (team_id, time_bucket, service_name, resource_fingerprint, severity_text, timestamp)
-SETTINGS
-    index_granularity_bytes = 104857600,
-    index_granularity = 8192,
-    ttl_only_drop_parts = 1,
-    allow_part_offset_column_in_projections = 1;
 
-create or replace TABLE logs AS logs31 ENGINE = Distributed('posthog', 'default', 'logs31');
+create or replace TABLE logs AS logs32 ENGINE = Distributed('posthog', 'default', 'logs32');
 
 create or replace table default.log_attributes
 
 (
     `team_id` Int32,
     `time_bucket` DateTime64(0),
+    `original_expiry_time_bucket` DateTime64(0) DEFAULT time_bucket + interval 7 days,
     `service_name` LowCardinality(String),
     `resource_id` String DEFAULT '',
     `resource_fingerprint` UInt64 DEFAULT 0,
@@ -123,7 +61,7 @@ FROM
         attribute.1 AS attribute_key,
         attribute.2 AS attribute_value,
         sumSimpleState(1) AS attribute_count
-    FROM logs31
+    FROM logs32
     GROUP BY
         team_id,
         time_bucket,
@@ -164,7 +102,7 @@ FROM
         attribute.1 AS attribute_key,
         attribute.2 AS attribute_value,
         sumSimpleState(1) AS attribute_count
-    FROM logs31
+    FROM logs32
     GROUP BY
         team_id,
         time_bucket,
@@ -202,7 +140,7 @@ SETTINGS
 
 drop table if exists kafka_logs_avro_mv;
 
-CREATE MATERIALIZED VIEW kafka_logs_avro_mv TO logs31
+CREATE MATERIALIZED VIEW kafka_logs_avro_mv TO logs32
 (
     `uuid` String,
     `trace_id` String,
@@ -222,8 +160,8 @@ CREATE MATERIALIZED VIEW kafka_logs_avro_mv TO logs31
 AS SELECT
 * except (attributes, resource_attributes),
 mapSort(mapApply((k,v) -> (concat(k, '__str'), JSONExtractString(v)), attributes)) as attributes_map_str,
-mapSort(mapFilter((k, v) -> isNotNull(v), mapApply((k,v) -> (concat(k, '__float'), toFloat64OrNull(JSONExtract(v, 'String'))), attributes))) as attributes_map_float,
-mapSort(mapFilter((k, v) -> isNotNull(v), mapApply((k,v) -> (concat(k, '__datetime'), parseDateTimeBestEffortOrNull(JSONExtract(v, 'String'), 6)), attributes))) as attributes_map_datetime,
+-- mapSort(mapFilter((k, v) -> isNotNull(v), mapApply((k,v) -> (concat(k, '__float'), toFloat64OrNull(JSONExtract(v, 'String'))), attributes))) as attributes_map_float,
+-- mapSort(mapFilter((k, v) -> isNotNull(v), mapApply((k,v) -> (concat(k, '__datetime'), parseDateTimeBestEffortOrNull(JSONExtract(v, 'String'), 6)), attributes))) as attributes_map_datetime,
 mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
 toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id
 FROM kafka_logs_avro settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0;

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -226,7 +226,7 @@ property_groups = PropertyGroupManager(
             }
             for column_name, column_group_definitions in event_property_group_definitions.items()
         },
-        "logs": {
+        "logs_distributed": {
             "attributes": {
                 "str": PropertyGroupDefinition(
                     "key like '%__str'",

--- a/posthog/hogql/database/schema/logs.py
+++ b/posthog/hogql/database/schema/logs.py
@@ -43,7 +43,7 @@ class LogsTable(Table):
     }
 
     def to_printed_clickhouse(self, context):
-        return "logs"
+        return "logs_distributed"
 
     def to_printed_hogql(self):
         return "logs"
@@ -63,7 +63,7 @@ class LogAttributesTable(Table):
     }
 
     def to_printed_clickhouse(self, context):
-        return "log_attributes"
+        return "log_attributes_distributed"
 
     def to_printed_hogql(self):
         return "log_attributes"
@@ -84,7 +84,7 @@ class LogsKafkaMetricsTable(DANGEROUS_NoTeamIdCheckTable):
     }
 
     def to_printed_clickhouse(self, context):
-        return "logs_kafka_metrics"
+        return "logs_kafka_metrics_distributed"
 
     def to_printed_hogql(self):
         return "logs_kafka_metrics"


### PR DESCRIPTION

## Problem

this is part of the work cleaning up/normalising the logs schema, this will make it easier to migrate tables in the future as we can swap out the distributed tables

also slowly working to make bin/clickhouse-logs-init redundant

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
