### PR TITLE
fix: github repository selector

### DIFF
--- a/frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/GitHubIntegrationHelpers.tsx
@@ -58,7 +58,7 @@ export function useRepositories(integrationId: number): { options: LemonInputSel
         loadRepositories()
     }, [loadRepositories])
 
-    const options = useMemo(() => repositories.map((r) => ({ key: r.full_name, label: r.full_name })), [repositories])
+    const options = useMemo(() => repositories.map((r) => ({ key: r.name, label: r.full_name })), [repositories])
 
     return { options, loading: repositoriesLoading }
 }


### PR DESCRIPTION
Ooops. We had a bug where we were trying to call github api with full repo name like `owner/owner/repo` instead of `owner/repo`

Picker was returning owner + repo name instead of just the repo name

I tested entire flow and it works
![CleanShot 2026-03-26 at 12 56 22](https://github.com/user-attachments/assets/371e84de-4a56-4f88-ac1a-9131a15d78d9)

