### PR TITLE
fix: guard husky.sh source in git hooks to prevent worktree failures

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,5 +1,5 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+[ -f "$(dirname "$0")/_/husky.sh" ] && . "$(dirname "$0")/_/husky.sh"
 
 # Args: $1=prev_ref, $2=new_ref, $3=1 if branch checkout, 0 if file checkout
 [ "$3" = "1" ] || exit 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+[ -f "$(dirname "$0")/_/husky.sh" ] && . "$(dirname "$0")/_/husky.sh"
 
 # Skip lint-staged during merges — staged files include the entire merge diff,
 # not just your changes, making it slow and pointless

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+[ -f "$(dirname "$0")/_/husky.sh" ] && . "$(dirname "$0")/_/husky.sh"
 
 protected_branch='master'
 current_branch=$(git branch --show-current)

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -53,6 +53,7 @@ class Feature(StrEnum):
     HEALTH_CHECK = "health_check"
     IMPORT_PIPELINE = "import_pipeline"
     DATA_DELETION = "data_deletion"
+    USAGE_REPORT = "usage_report"
 
 
 class TemporalTags(BaseModel):

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -53,7 +53,6 @@ class Feature(StrEnum):
     HEALTH_CHECK = "health_check"
     IMPORT_PIPELINE = "import_pipeline"
     DATA_DELETION = "data_deletion"
-    USAGE_REPORT = "usage_report"
 
 
 class TemporalTags(BaseModel):


### PR DESCRIPTION
## Problem

Creating git worktrees fails with:

```
.husky/post-checkout: line 2: .husky/_/husky.sh: No such file or directory
```

The `post-checkout` hook unconditionally sources `.husky/_/husky.sh` on line 2, which doesn't exist in a fresh worktree before `pnpm install` runs. The hook fails before reaching the worktree-detection and bootstrap logic on lines 5–27.

This was introduced in #51104 (March 17) and breaks Claude Code worktree creation.

## Changes

Guard the `. husky.sh` source in all three hooks (`post-checkout`, `pre-commit`, `pre-push`) so they silently skip the source if the file doesn't exist, allowing the rest of the hook logic to execute.

`husky.sh` is a thin wrapper providing `HUSKY=0` skip support, `HUSKY_DEBUG` logging, and `~/.huskyrc` sourcing — none of which are needed when husky hasn't been installed yet, so skipping it when absent has no downstream consequences.

## How did you test this code?

I'm an agent — I haven't tested this manually. The fix is a straightforward shell guard (`[ -f ... ] && .`) that is a standard pattern for optional sourcing. Verification steps:

- Create a git worktree (`git worktree add ...`) — should no longer error
- Confirm `pre-commit` and `pre-push` hooks still work normally in the main repo

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 LLM context

Co-authored by Claude Code (Opus 4.6). The fix was identified by tracing the error to the unconditional `husky.sh` source running before the worktree guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)