### PR TITLE
chore: discourage claude hooks, prefer alternatives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,14 +107,9 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 Prefer these approaches in order:
 
 1. **AGENTS.md / CLAUDE.md instructions** — try this first
-2. **Skills** (`.agents/skills/`) — scaffold with `hogli init:skill`. Source of truth is `.agents/skills`, symlinked to `.claude/skills`
+2. **Skills** (`.agents/skills/`) — scaffold with `hogli init:skill`
 3. **lint-staged / husky** — file-level validation at commit time
 4. **CI checks** — PR-level enforcement
 5. **Linters** (ruff, oxlint, semgrep) — code pattern enforcement
 
-### Claude Code hooks
-
-Hooks are reserved for environment bootstrapping (`SessionStart` only).
-Do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks —
-they add latency on every tool call and are fragile.
-Changes to `.claude/hooks/` (external hook scripts) trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.
+Claude Code hooks are reserved for environment bootstrapping (`SessionStart` only) — do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks as they add latency and are fragile. Changes to `.claude/hooks/` trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,27 +104,17 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 
 ## Agent automation
 
-When you want to shape agent behavior, prefer these approaches in order:
+Prefer these approaches in order:
 
-1. **AGENTS.md / CLAUDE.md instructions** — conventions, rules, templates.
-   Cheapest, most portable, works across all agents. Try this first.
-2. **Skills** (`.agents/skills/`) — multi-step domain workflows, product-specific procedures.
-   Scaffold with `hogli init:skill`. Source of truth is `.agents/skills`, symlinked to `.claude/skills`.
-3. **lint-staged / husky** — file-level validation at commit time.
-   Add rules in root `package.json` under `lint-staged`.
-4. **CI checks** — PR-level enforcement (tests, build validation).
-5. **Linters** (ruff, oxlint, semgrep) — code pattern enforcement.
+1. **AGENTS.md / CLAUDE.md instructions** — try this first
+2. **Skills** (`.agents/skills/`) — scaffold with `hogli init:skill`. Source of truth is `.agents/skills`, symlinked to `.claude/skills`
+3. **lint-staged / husky** — file-level validation at commit time
+4. **CI checks** — PR-level enforcement
+5. **Linters** (ruff, oxlint, semgrep) — code pattern enforcement
 
 ### Claude Code hooks
 
-Hooks in `.claude/settings.json` are reserved for environment bootstrapping (`SessionStart` only).
-Do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks for behavioral enforcement —
-they add latency on every tool call, are fragile to input variations, and only work in Claude Code.
-
-If AGENTS.md instructions alone are insufficient, consider:
-
-- A **skill** with built-in verification steps
-- A **lint-staged rule** that catches issues at commit time
-- A **CI check** for PR-level enforcement
-
-Changes to `.claude/hooks/` trigger a lint-staged warning at commit time.
+Hooks are reserved for environment bootstrapping (`SessionStart` only).
+Do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks —
+they add latency on every tool call and are fragile.
+Changes to `.claude/hooks/` (external hook scripts) trigger a lint-staged warning; changes to `.claude/settings.json` are blocked outright.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,29 @@ See [.agents/security.md](.agents/security.md) for SQL, HogQL, and semgrep secur
 - Use American English spelling
 - When mentioning PostHog products, the product names should use Sentence casing, not Title Casing. For example, 'Product analytics', not 'Product Analytics'. Any other buttons, tab text, tooltips, etc should also all use Sentence casing. For example, 'Save as view' instead of 'Save As View'.
 
-## Skills
+## Agent automation
 
-Skills are created inside [.agents/skills](.agents/skills/) by default and then symlinked to [.claude/skills](.claude/skills). Make sure you always treat `.agents/skills` as the source of truth.
+When you want to shape agent behavior, prefer these approaches in order:
+
+1. **AGENTS.md / CLAUDE.md instructions** — conventions, rules, templates.
+   Cheapest, most portable, works across all agents. Try this first.
+2. **Skills** (`.agents/skills/`) — multi-step domain workflows, product-specific procedures.
+   Scaffold with `hogli init:skill`. Source of truth is `.agents/skills`, symlinked to `.claude/skills`.
+3. **lint-staged / husky** — file-level validation at commit time.
+   Add rules in root `package.json` under `lint-staged`.
+4. **CI checks** — PR-level enforcement (tests, build validation).
+5. **Linters** (ruff, oxlint, semgrep) — code pattern enforcement.
+
+### Claude Code hooks
+
+Hooks in `.claude/settings.json` are reserved for environment bootstrapping (`SessionStart` only).
+Do not add `PreToolUse`, `PostToolUse`, or `Notification` hooks for behavioral enforcement —
+they add latency on every tool call, are fragile to input variations, and only work in Claude Code.
+
+If AGENTS.md instructions alone are insufficient, consider:
+
+- A **skill** with built-in verification steps
+- A **lint-staged rule** that catches issues at commit time
+- A **CI check** for PR-level enforcement
+
+Changes to `.claude/hooks/` trigger a lint-staged warning at commit time.

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     "lint-staged": {
         ".claude/settings.json": "sh -c 'printf \"\\n\\033[31mDo not commit .claude/settings.json — personal permissions belong in .claude/settings.local.json (gitignored).\\nUnstage with: git restore --staged .claude/settings.json\\033[0m\\n\\n\" >&2 && exit 1'",
-        ".claude/hooks/**": "sh -c 'printf \"\\n\\033[33mWarning: hooks in .claude/ are reserved for env bootstrapping (SessionStart only).\\nPrefer skills, AGENTS.md instructions, or lint-staged rules. See Agent automation in AGENTS.md.\\033[0m\\n\\n\" >&2'",
+        ".claude/hooks/**": "sh -c 'printf \"\\n\\033[33mWarning: hooks in .claude/ are reserved for env bootstrapping (SessionStart only).\\nPrefer skills, AGENTS.md instructions, or lint-staged rules. See Agent automation in AGENTS.md.\\033[0m\\n\\n\"'",
         "products/**/manifest.tsx": [
             "bin/hogli format:js",
             "sh -c 'pnpm build:products && git add frontend/src/products.tsx frontend/src/products.json'"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     },
     "lint-staged": {
         ".claude/settings.json": "sh -c 'printf \"\\n\\033[31mDo not commit .claude/settings.json — personal permissions belong in .claude/settings.local.json (gitignored).\\nUnstage with: git restore --staged .claude/settings.json\\033[0m\\n\\n\" >&2 && exit 1'",
+        ".claude/hooks/**": "sh -c 'printf \"\\n\\033[33mWarning: hooks in .claude/ are reserved for env bootstrapping (SessionStart only).\\nPrefer skills, AGENTS.md instructions, or lint-staged rules. See Agent automation in AGENTS.md.\\033[0m\\n\\n\" >&2'",
         "products/**/manifest.tsx": [
             "bin/hogli format:js",
             "sh -c 'pnpm build:products && git add frontend/src/products.tsx frontend/src/products.json'"


### PR DESCRIPTION
## Problem

Engineers reach for Claude Code hooks (`PreToolUse`, `PostToolUse`) for behavioral enforcement when lighter, more portable alternatives exist.

## Changes

- Replaced `## Skills` in AGENTS.md with `## Agent automation` — a preference hierarchy
  (instructions > skills > lint-staged > CI > linters) with explicit hooks policy
- Added lint-staged warning (non-blocking) for `.claude/hooks/` changes

## How did you test this code?

Verified lint-staged rule fires on staged hook changes. Existing lint-staged rules unaffected.