### PR TITLE
feat: add k8s-awareness crate for pod departure classification

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4965,6 +4965,7 @@ dependencies = [
  "http 1.4.0",
  "k8s-openapi",
  "kube",
+ "rstest",
  "serde",
  "serde_json",
  "tempfile",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -261,6 +261,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.1",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +284,18 @@ checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -830,7 +858,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.37",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1150,6 +1178,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.17",
+ "instant",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,11 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.18.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
+ "async-stream",
  "base64 0.22.1",
+ "bitflags 2.11.0",
+ "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -1430,33 +1472,54 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "log",
+ "num",
  "pin-project-lite",
+ "rand 0.9.2",
  "rustls 0.23.37",
- "rustls-native-certs",
- "rustls-pemfile 2.2.0",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
+ "time",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tonic 0.14.5",
  "tower-service",
  "url",
  "winapi",
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.47.1-rc.27.3.1"
+name = "bollard-buildkit-proto"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.3",
  "serde",
+ "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -1968,7 +2031,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2919,6 +2982,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,6 +3100,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,7 +3191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3126,6 +3221,16 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3296,6 +3401,17 @@ dependencies = [
  "getrandom 0.2.17",
  "openssl",
  "zeroize",
+]
+
+[[package]]
+name = "ferroid"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
+dependencies = [
+ "portable-atomic",
+ "rand 0.9.2",
+ "web-time",
 ]
 
 [[package]]
@@ -3909,6 +4025,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.4.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.4.0",
+]
+
+[[package]]
 name = "health"
 version = "0.1.0"
 dependencies = [
@@ -3972,6 +4112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -4137,6 +4288,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-named-pipe"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4175,8 +4346,9 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
+ "log",
  "rustls 0.23.37",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -4242,7 +4414,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4518,6 +4690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,7 +4745,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4718,6 +4899,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "json5"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4728,17 +4921,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.7",
- "pem",
+ "pem 1.1.1",
  "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "k8s-awareness"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "http 1.4.0",
+ "k8s-openapi",
+ "kube",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "testcontainers",
+ "testcontainers-modules",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-test",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
 ]
 
 [[package]]
@@ -4822,6 +5072,102 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "kube"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32053dc495efad4d188c7b33cc7c02ef4a6e43038115348348876efd39a53cba"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-runtime",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d34ad38cdfbd1fa87195d42569f57bb1dda6ba5f260ee32fef9570b7937a0c9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-http-proxy",
+ "hyper-rustls 0.27.7",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem 3.0.6",
+ "rustls 0.23.37",
+ "rustls-pemfile 2.2.0",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97aa830b288a178a90e784d1b0f1539f2d200d2188c7b4a3146d9dc983d596f3"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http 1.4.0",
+ "json-patch",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "0.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a41af186a0fe80c71a13a13994abdc3ebff80859ca6a4b8a6079948328c135b"
+dependencies = [
+ "ahash 0.8.12",
+ "async-broadcast",
+ "async-stream",
+ "async-trait",
+ "backoff",
+ "educe",
+ "futures",
+ "hashbrown 0.15.5",
+ "hostname",
+ "json-patch",
+ "jsonptr",
+ "k8s-openapi",
+ "kube-client",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -5306,7 +5652,7 @@ dependencies = [
  "indexmap 2.13.0",
  "metrics",
  "num_cpus",
- "ordered-float",
+ "ordered-float 4.6.0",
  "quanta 0.12.6",
  "radix_trie",
  "sketches-ddsketch",
@@ -5487,10 +5833,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5613,7 +5959,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5846,6 +6192,12 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -5968,7 +6320,7 @@ dependencies = [
  "glob",
  "once_cell",
  "opentelemetry 0.22.0",
- "ordered-float",
+ "ordered-float 4.6.0",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror 1.0.69",
@@ -5991,6 +6343,15 @@ dependencies = [
  "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6121,6 +6482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -7146,7 +7517,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7183,9 +7554,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7378,7 +7749,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.9.2",
  "rustls 0.23.37",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "ryu",
  "sha1_smol",
  "socket2 0.6.2",
@@ -7387,15 +7758,6 @@ dependencies = [
  "tokio-util",
  "url",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -7577,7 +7939,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.37",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7807,7 +8169,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7829,6 +8191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
@@ -7839,14 +8202,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -8033,6 +8409,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8093,6 +8491,16 @@ dependencies = [
  "iter-read",
  "num-bigint",
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -8223,6 +8631,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -8617,7 +9038,7 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -9190,10 +9611,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9248,18 +9669,21 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.23.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
 dependencies = [
+ "astral-tokio-tar",
  "async-trait",
  "bollard",
- "bollard-stubs",
  "bytes",
  "docker_credential",
  "either",
- "etcetera",
+ "etcetera 0.11.0",
+ "ferroid",
  "futures",
+ "http 1.4.0",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -9270,9 +9694,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -9536,18 +9968,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tar"
-version = "0.3.1"
+name = "tokio-test"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
 dependencies = [
- "filetime",
  "futures-core",
- "libc",
- "redox_syscall 0.3.5",
  "tokio",
  "tokio-stream",
- "xattr",
 ]
 
 [[package]]
@@ -9800,16 +10228,19 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -9823,6 +10254,20 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
+dependencies = [
+ "futures-util",
+ "pin-project",
+ "tokio",
+ "tokio-test",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -10012,6 +10457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10028,6 +10479,33 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -10047,6 +10525,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -10373,7 +10857,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "capture-logs",
     "common/alloc",
     "common/assignment-coordination",
+    "common/k8s-awareness",
     "common/cache",
     "common/cookieless",
     "common/database",
@@ -157,4 +158,4 @@ clickhouse = { version = "0.13.2", features = [
 fernet = "0.2"
 tiktoken-rs = "0.7.0"
 sha2 = "0.10"
-testcontainers = "0.23"
+testcontainers = "0.27"

--- a/rust/common/k8s-awareness/Cargo.toml
+++ b/rust/common/k8s-awareness/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "k8s-awareness"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+k8s-openapi = { version = "0.24", features = ["latest"] }
+kube = { version = "0.98", features = ["runtime", "client"] }
+futures = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+http = "1"
+serde_json = { workspace = true }
+tempfile = "3"
+testcontainers = { workspace = true }
+testcontainers-modules = { version = "0.15", features = ["k3s"] }
+tokio = { workspace = true, features = ["test-util"] }
+tower-test = "0.4"
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/common/k8s-awareness/Cargo.toml
+++ b/rust/common/k8s-awareness/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 http = "1"
+rstest = "0.26"
 serde_json = { workspace = true }
 tempfile = "3"
 testcontainers = { workspace = true }

--- a/rust/common/k8s-awareness/README.md
+++ b/rust/common/k8s-awareness/README.md
@@ -1,0 +1,84 @@
+# k8s-awareness
+
+Classifies why a Kubernetes pod is departing by watching its owning controller (Deployment or StatefulSet). Consumers of this library can use the departure reason to choose the right response: drain gracefully on rollout, redistribute permanently on downscale, or reassign quickly on crash.
+
+## How it works
+
+```text
+Pod departs
+    │
+    ▼
+┌─────────────────────┐
+│  discover_controller │  Walk ownerReferences:
+│                      │  pod → ReplicaSet → Deployment
+│                      │  pod → StatefulSet (direct)
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│   K8sAwareness       │  Watch the controller for changes.
+│   (watcher)          │  Track ClusterIntent per controller:
+│                      │  replicas, generation hashes, rollout state
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  classify_departure  │  Compare pod's generation + replica counts
+│                      │  → Rollout | Downscale | Crash | Unknown
+└─────────────────────┘
+```
+
+### Departure classification
+
+| Signal | Result |
+|---|---|
+| Pod's generation hash differs from controller's current/target generation | **Rollout** |
+| Desired replicas < previous replicas | **Downscale** |
+| Generation matches, replicas stable | **Crash** |
+| Controller not watched | **Unknown** |
+
+### Generation tracking
+
+Deployments and StatefulSets use different mechanisms:
+
+- **Deployment**: each ReplicaSet gets a `pod-template-hash` label. During a rollout, a new RS is created with a new hash. The watcher lists RSes to find `current_generation` (active hash) and `target_generation` (new hash during rollout).
+- **StatefulSet**: uses `controller-revision-hash` on pods and `status.currentRevision` / `status.updateRevision` on the StatefulSet itself.
+
+## Usage
+
+```rust
+use k8s_awareness::{K8sAwareness, DepartureReason};
+use tokio_util::sync::CancellationToken;
+
+let cancel = CancellationToken::new();
+let awareness = K8sAwareness::new(client, "default".into(), cancel);
+
+// On member join: discover its controller and start watching
+let pod_info = awareness.discover_controller("my-pod-abc123-xyz").await?;
+
+// On member departure: classify why
+let reason = awareness
+    .classify_departure(&pod_info.controller, &pod_info.generation)
+    .await;
+
+match reason {
+    DepartureReason::Rollout => { /* drain gracefully, replacement coming */ }
+    DepartureReason::Downscale => { /* redistribute permanently */ }
+    DepartureReason::Crash => { /* fast reassignment, pod will restart */ }
+    DepartureReason::Unknown => { /* fall back to default behavior */ }
+}
+```
+
+## Testing
+
+Mock tests (no Docker required):
+
+```bash
+cargo test -p k8s-awareness --test mock_discovery
+```
+
+Integration tests against a real k3s cluster via testcontainers (requires Docker):
+
+```bash
+cargo test -p k8s-awareness --test k3s_integration
+```

--- a/rust/common/k8s-awareness/src/detection.rs
+++ b/rust/common/k8s-awareness/src/detection.rs
@@ -42,6 +42,7 @@ pub fn classify_departure(intent: &ClusterIntent, member_generation: &str) -> De
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     fn intent(
         desired: u32,
@@ -59,71 +60,103 @@ mod tests {
         }
     }
 
-    #[test]
-    fn rollout_old_gen_member() {
-        let i = intent(3, None, true, "abc123", Some("def456"));
-        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Rollout);
-    }
-
-    #[test]
-    fn rollout_new_gen_member_is_crash() {
-        let i = intent(3, None, true, "abc123", Some("def456"));
-        assert_eq!(classify_departure(&i, "def456"), DepartureReason::Crash);
-    }
-
-    #[test]
-    fn downscale() {
-        let i = intent(2, Some(3), false, "abc123", None);
-        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Downscale);
-    }
-
-    #[test]
-    fn downscale_during_rollout_prefers_rollout_for_old_gen() {
-        let i = intent(2, Some(3), true, "abc123", Some("def456"));
-        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Rollout);
-    }
-
-    #[test]
-    fn downscale_during_rollout_new_gen_member() {
-        let i = intent(2, Some(3), true, "abc123", Some("def456"));
-        assert_eq!(classify_departure(&i, "def456"), DepartureReason::Downscale);
-    }
-
-    #[test]
-    fn crash_steady_state() {
-        let i = intent(3, Some(3), false, "abc123", None);
-        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
-    }
-
-    #[test]
-    fn crash_no_previous_replicas() {
-        let i = intent(3, None, false, "abc123", None);
-        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
-    }
-
-    #[test]
-    fn scale_up_is_crash() {
-        let i = intent(5, Some(3), false, "abc123", None);
-        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
-    }
-
-    #[test]
-    fn rollout_without_target_gen_is_crash() {
-        let i = intent(3, None, true, "abc123", None);
-        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
-    }
-
-    #[test]
-    fn completed_rollout_old_gen_member() {
-        // Rollout finished (rollout_in_progress=false), but old-gen pod still exists
-        let i = intent(3, Some(3), false, "new_hash", None);
-        assert_eq!(classify_departure(&i, "old_hash"), DepartureReason::Rollout);
-    }
-
-    #[test]
-    fn completed_rollout_current_gen_member_is_crash() {
-        // Rollout finished, pod is on the current generation
-        let i = intent(3, Some(3), false, "new_hash", None);
-        assert_eq!(classify_departure(&i, "new_hash"), DepartureReason::Crash);
+    #[rstest]
+    // Rollout scenarios
+    #[case::rollout_old_gen_member(
+        3,
+        None,
+        true,
+        "abc123",
+        Some("def456"),
+        "abc123",
+        DepartureReason::Rollout
+    )]
+    #[case::rollout_new_gen_member_is_crash(
+        3,
+        None,
+        true,
+        "abc123",
+        Some("def456"),
+        "def456",
+        DepartureReason::Crash
+    )]
+    #[case::rollout_without_target_gen_is_crash(
+        3,
+        None,
+        true,
+        "abc123",
+        None,
+        "abc123",
+        DepartureReason::Crash
+    )]
+    #[case::completed_rollout_old_gen_member(
+        3,
+        Some(3),
+        false,
+        "new_hash",
+        None,
+        "old_hash",
+        DepartureReason::Rollout
+    )]
+    #[case::completed_rollout_current_gen_is_crash(
+        3,
+        Some(3),
+        false,
+        "new_hash",
+        None,
+        "new_hash",
+        DepartureReason::Crash
+    )]
+    // Downscale scenarios
+    #[case::downscale(
+        2,
+        Some(3),
+        false,
+        "abc123",
+        None,
+        "abc123",
+        DepartureReason::Downscale
+    )]
+    #[case::downscale_during_rollout_prefers_rollout_for_old_gen(
+        2,
+        Some(3),
+        true,
+        "abc123",
+        Some("def456"),
+        "abc123",
+        DepartureReason::Rollout
+    )]
+    #[case::downscale_during_rollout_new_gen_member(
+        2,
+        Some(3),
+        true,
+        "abc123",
+        Some("def456"),
+        "def456",
+        DepartureReason::Downscale
+    )]
+    // Crash scenarios
+    #[case::crash_steady_state(3, Some(3), false, "abc123", None, "abc123", DepartureReason::Crash)]
+    #[case::crash_no_previous_replicas(
+        3,
+        None,
+        false,
+        "abc123",
+        None,
+        "abc123",
+        DepartureReason::Crash
+    )]
+    #[case::scale_up_is_crash(5, Some(3), false, "abc123", None, "abc123", DepartureReason::Crash)]
+    fn classify(
+        #[case] desired: u32,
+        #[case] previous: Option<u32>,
+        #[case] rollout: bool,
+        #[case] current_gen: &str,
+        #[case] target_gen: Option<&str>,
+        #[case] member_gen: &str,
+        #[case] expected: DepartureReason,
+    ) {
+        let i = intent(desired, previous, rollout, current_gen, target_gen);
+        assert_eq!(classify_departure(&i, member_gen), expected);
     }
 }

--- a/rust/common/k8s-awareness/src/detection.rs
+++ b/rust/common/k8s-awareness/src/detection.rs
@@ -1,0 +1,129 @@
+use crate::types::{ClusterIntent, DepartureReason};
+
+/// Classify why a member is departing based on its controller's current intent
+/// and the member's generation hash.
+///
+/// Logic:
+/// 1. If a rollout is in progress and the member's generation doesn't match
+///    the target generation, the member is being replaced.
+/// 2. If desired_replicas < previous_replicas, the fleet is shrinking.
+/// 3. Otherwise, assume crash (etcd lease TTL handles recovery).
+pub fn classify_departure(intent: &ClusterIntent, member_generation: &str) -> DepartureReason {
+    // Rollout in progress: member is old-gen if it doesn't match the target
+    if intent.rollout_in_progress {
+        if let Some(target) = &intent.target_generation {
+            if member_generation != target {
+                return DepartureReason::Rollout;
+            }
+        }
+    }
+
+    // Rollout completed: member is old-gen if it doesn't match the current generation.
+    // This catches the case where a rollout finishes faster than our polling interval
+    // but old-gen pods are still departing.
+    if !intent.rollout_in_progress
+        && !intent.current_generation.is_empty()
+        && member_generation != intent.current_generation
+    {
+        return DepartureReason::Rollout;
+    }
+
+    // Downscale: desired replicas decreased
+    if let Some(previous) = intent.previous_replicas {
+        if intent.desired_replicas < previous {
+            return DepartureReason::Downscale;
+        }
+    }
+
+    // Default: crash or unknown disruption
+    DepartureReason::Crash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn intent(
+        desired: u32,
+        previous: Option<u32>,
+        rollout: bool,
+        current_gen: &str,
+        target_gen: Option<&str>,
+    ) -> ClusterIntent {
+        ClusterIntent {
+            desired_replicas: desired,
+            previous_replicas: previous,
+            rollout_in_progress: rollout,
+            current_generation: current_gen.to_string(),
+            target_generation: target_gen.map(String::from),
+        }
+    }
+
+    #[test]
+    fn rollout_old_gen_member() {
+        let i = intent(3, None, true, "abc123", Some("def456"));
+        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Rollout);
+    }
+
+    #[test]
+    fn rollout_new_gen_member_is_crash() {
+        let i = intent(3, None, true, "abc123", Some("def456"));
+        assert_eq!(classify_departure(&i, "def456"), DepartureReason::Crash);
+    }
+
+    #[test]
+    fn downscale() {
+        let i = intent(2, Some(3), false, "abc123", None);
+        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Downscale);
+    }
+
+    #[test]
+    fn downscale_during_rollout_prefers_rollout_for_old_gen() {
+        let i = intent(2, Some(3), true, "abc123", Some("def456"));
+        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Rollout);
+    }
+
+    #[test]
+    fn downscale_during_rollout_new_gen_member() {
+        let i = intent(2, Some(3), true, "abc123", Some("def456"));
+        assert_eq!(classify_departure(&i, "def456"), DepartureReason::Downscale);
+    }
+
+    #[test]
+    fn crash_steady_state() {
+        let i = intent(3, Some(3), false, "abc123", None);
+        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
+    }
+
+    #[test]
+    fn crash_no_previous_replicas() {
+        let i = intent(3, None, false, "abc123", None);
+        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
+    }
+
+    #[test]
+    fn scale_up_is_crash() {
+        let i = intent(5, Some(3), false, "abc123", None);
+        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
+    }
+
+    #[test]
+    fn rollout_without_target_gen_is_crash() {
+        let i = intent(3, None, true, "abc123", None);
+        assert_eq!(classify_departure(&i, "abc123"), DepartureReason::Crash);
+    }
+
+    #[test]
+    fn completed_rollout_old_gen_member() {
+        // Rollout finished (rollout_in_progress=false), but old-gen pod still exists
+        let i = intent(3, Some(3), false, "new_hash", None);
+        assert_eq!(classify_departure(&i, "old_hash"), DepartureReason::Rollout);
+    }
+
+    #[test]
+    fn completed_rollout_current_gen_member_is_crash() {
+        // Rollout finished, pod is on the current generation
+        let i = intent(3, Some(3), false, "new_hash", None);
+        assert_eq!(classify_departure(&i, "new_hash"), DepartureReason::Crash);
+    }
+}

--- a/rust/common/k8s-awareness/src/discovery.rs
+++ b/rust/common/k8s-awareness/src/discovery.rs
@@ -1,0 +1,106 @@
+use k8s_openapi::api::apps::v1::ReplicaSet;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::Api;
+use kube::Client;
+
+use crate::types::{ControllerKind, ControllerRef, PodInfo};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DiscoveryError {
+    #[error("pod {0} not found")]
+    PodNotFound(String),
+    #[error("pod {0} has no owner references")]
+    NoOwnerReferences(String),
+    #[error("unsupported owner kind for pod {pod}: {kind}")]
+    UnsupportedOwner { pod: String, kind: String },
+    #[error("replicaset {0} has no Deployment owner")]
+    ReplicaSetNoDeploymentOwner(String),
+    #[error("pod {0} missing generation label")]
+    MissingGenerationLabel(String),
+    #[error("kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+}
+
+/// Discover which controller owns a pod by walking ownerReferences.
+///
+/// For Deployments: pod → ReplicaSet → Deployment
+/// For StatefulSets: pod → StatefulSet (direct)
+///
+/// Returns the controller reference and the pod's generation hash.
+pub async fn discover_controller(
+    client: &Client,
+    namespace: &str,
+    pod_name: &str,
+) -> Result<PodInfo, DiscoveryError> {
+    let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let pod = pods.get(pod_name).await.map_err(|e| {
+        if is_not_found(&e) {
+            DiscoveryError::PodNotFound(pod_name.to_string())
+        } else {
+            DiscoveryError::Kube(e)
+        }
+    })?;
+
+    let owner_refs = pod.metadata.owner_references.as_deref().unwrap_or_default();
+
+    if owner_refs.is_empty() {
+        return Err(DiscoveryError::NoOwnerReferences(pod_name.to_string()));
+    }
+
+    let labels = pod.metadata.labels.as_ref();
+
+    // StatefulSet: direct ownership
+    if let Some(ss_owner) = owner_refs.iter().find(|r| r.kind == "StatefulSet") {
+        let generation = labels
+            .and_then(|l| l.get("controller-revision-hash"))
+            .cloned()
+            .ok_or_else(|| DiscoveryError::MissingGenerationLabel(pod_name.to_string()))?;
+
+        return Ok(PodInfo {
+            controller: ControllerRef {
+                kind: ControllerKind::StatefulSet,
+                name: ss_owner.name.clone(),
+            },
+            generation,
+        });
+    }
+
+    // ReplicaSet → Deployment
+    if let Some(rs_owner) = owner_refs.iter().find(|r| r.kind == "ReplicaSet") {
+        let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
+        let rs = rs_api.get(&rs_owner.name).await?;
+
+        let rs_owners = rs.metadata.owner_references.as_deref().unwrap_or_default();
+
+        let deploy_owner = rs_owners
+            .iter()
+            .find(|r| r.kind == "Deployment")
+            .ok_or_else(|| DiscoveryError::ReplicaSetNoDeploymentOwner(rs_owner.name.clone()))?;
+
+        let generation = labels
+            .and_then(|l| l.get("pod-template-hash"))
+            .cloned()
+            .ok_or_else(|| DiscoveryError::MissingGenerationLabel(pod_name.to_string()))?;
+
+        return Ok(PodInfo {
+            controller: ControllerRef {
+                kind: ControllerKind::Deployment,
+                name: deploy_owner.name.clone(),
+            },
+            generation,
+        });
+    }
+
+    let kind = owner_refs
+        .first()
+        .map(|r| r.kind.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+    Err(DiscoveryError::UnsupportedOwner {
+        pod: pod_name.to_string(),
+        kind,
+    })
+}
+
+fn is_not_found(e: &kube::Error) -> bool {
+    matches!(e, kube::Error::Api(resp) if resp.code == 404)
+}

--- a/rust/common/k8s-awareness/src/lib.rs
+++ b/rust/common/k8s-awareness/src/lib.rs
@@ -1,0 +1,9 @@
+mod detection;
+mod discovery;
+pub mod types;
+mod watcher;
+
+pub use detection::classify_departure;
+pub use discovery::{discover_controller, DiscoveryError};
+pub use types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
+pub use watcher::{K8sAwareness, K8sAwarenessError};

--- a/rust/common/k8s-awareness/src/types.rs
+++ b/rust/common/k8s-awareness/src/types.rs
@@ -1,0 +1,78 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// What kind of K8s controller manages the consumer/pod fleet.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ControllerKind {
+    Deployment,
+    StatefulSet,
+}
+
+impl fmt::Display for ControllerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Deployment => write!(f, "Deployment"),
+            Self::StatefulSet => write!(f, "StatefulSet"),
+        }
+    }
+}
+
+/// Identifies a specific controller instance (e.g., "Deployment/kafka-dedup").
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ControllerRef {
+    pub kind: ControllerKind,
+    pub name: String,
+}
+
+impl fmt::Display for ControllerRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.kind, self.name)
+    }
+}
+
+/// The coordinator's understanding of what K8s is doing with a controller's fleet.
+#[derive(Debug, Clone)]
+pub struct ClusterIntent {
+    /// Current desired replica count.
+    pub desired_replicas: u32,
+    /// Previous desired replica count (to detect downscale).
+    pub previous_replicas: Option<u32>,
+    /// Whether a rollout is in progress.
+    pub rollout_in_progress: bool,
+    /// The current generation hash (pod-template-hash or controller-revision-hash).
+    pub current_generation: String,
+    /// The target generation hash (differs from current during rollout).
+    pub target_generation: Option<String>,
+}
+
+/// Why a member is departing, as determined by correlating K8s state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepartureReason {
+    /// Pod is being replaced by a new version.
+    Rollout,
+    /// Replica count was reduced; this pod will not come back.
+    Downscale,
+    /// Pod crashed or unknown disruption; K8s will restart it.
+    Crash,
+    /// K8s awareness unavailable; fall back to current behavior.
+    Unknown,
+}
+
+impl fmt::Display for DepartureReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Rollout => write!(f, "rollout"),
+            Self::Downscale => write!(f, "downscale"),
+            Self::Crash => write!(f, "crash"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Information about a pod's relationship to its K8s controller.
+#[derive(Debug, Clone)]
+pub struct PodInfo {
+    pub controller: ControllerRef,
+    /// pod-template-hash (Deployment) or controller-revision-hash (StatefulSet).
+    pub generation: String,
+}

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -1,0 +1,480 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use futures::StreamExt;
+use k8s_openapi::api::apps::v1::{Deployment, ReplicaSet, StatefulSet};
+use kube::api::{Api, ListParams};
+use kube::runtime::watcher::{self, Config as WatcherConfig, Event};
+use kube::Client;
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::detection;
+use crate::discovery::{self, DiscoveryError};
+use crate::types::{ClusterIntent, ControllerKind, ControllerRef, DepartureReason, PodInfo};
+
+#[derive(Debug, thiserror::Error)]
+pub enum K8sAwarenessError {
+    #[error("discovery failed: {0}")]
+    Discovery(#[from] DiscoveryError),
+    #[error("kubernetes API error: {0}")]
+    Kube(#[from] kube::Error),
+}
+
+/// Manages K8s watchers for multiple controllers.
+///
+/// One assigner can serve consumers from N different Deployments/StatefulSets.
+/// `K8sAwareness` auto-discovers each consumer's controller via ownerReferences
+/// and starts a watcher for new controllers as they're discovered.
+pub struct K8sAwareness {
+    client: Client,
+    namespace: String,
+    controllers: Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    watching: Arc<RwLock<HashMap<ControllerRef, CancellationToken>>>,
+    cancel: CancellationToken,
+}
+
+impl K8sAwareness {
+    pub fn new(client: Client, namespace: String, cancel: CancellationToken) -> Self {
+        Self {
+            client,
+            namespace,
+            controllers: Arc::new(RwLock::new(HashMap::new())),
+            watching: Arc::new(RwLock::new(HashMap::new())),
+            cancel,
+        }
+    }
+
+    /// Discover which controller owns a pod and start watching it.
+    ///
+    /// Walks ownerReferences: pod → ReplicaSet → Deployment, or pod → StatefulSet.
+    /// Starts a watcher for the controller if not already watching.
+    pub async fn discover_controller(&self, pod_name: &str) -> Result<PodInfo, K8sAwarenessError> {
+        let pod_info =
+            discovery::discover_controller(&self.client, &self.namespace, pod_name).await?;
+
+        self.ensure_watching(&pod_info.controller).await?;
+
+        Ok(pod_info)
+    }
+
+    /// Classify why a member is departing based on its controller's current intent.
+    ///
+    /// Returns `DepartureReason::Unknown` if the controller isn't being watched.
+    pub async fn classify_departure(
+        &self,
+        controller: &ControllerRef,
+        generation: &str,
+    ) -> DepartureReason {
+        let controllers = self.controllers.read().await;
+        match controllers.get(controller) {
+            Some(intent) => detection::classify_departure(intent, generation),
+            None => {
+                warn!(
+                    controller = %controller,
+                    "no cluster intent available, returning Unknown"
+                );
+                DepartureReason::Unknown
+            }
+        }
+    }
+
+    /// Start watching a controller if not already watching.
+    async fn ensure_watching(&self, controller: &ControllerRef) -> Result<(), K8sAwarenessError> {
+        let mut watching = self.watching.write().await;
+        if watching.contains_key(controller) {
+            return Ok(());
+        }
+
+        let child_cancel = self.cancel.child_token();
+        watching.insert(controller.clone(), child_cancel.clone());
+        drop(watching);
+
+        let controllers = Arc::clone(&self.controllers);
+        let client = self.client.clone();
+        let namespace = self.namespace.clone();
+        let controller_ref = controller.clone();
+
+        info!(controller = %controller_ref, "starting K8s watcher");
+
+        tokio::spawn(async move {
+            match controller_ref.kind {
+                ControllerKind::Deployment => {
+                    run_deployment_watcher(
+                        &client,
+                        &namespace,
+                        &controller_ref,
+                        &controllers,
+                        child_cancel,
+                    )
+                    .await;
+                }
+                ControllerKind::StatefulSet => {
+                    run_statefulset_watcher(
+                        &client,
+                        &namespace,
+                        &controller_ref,
+                        &controllers,
+                        child_cancel,
+                    )
+                    .await;
+                }
+            }
+        });
+
+        Ok(())
+    }
+}
+
+/// Watch a Deployment and update its ClusterIntent on changes.
+async fn run_deployment_watcher(
+    client: &Client,
+    namespace: &str,
+    controller: &ControllerRef,
+    controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    cancel: CancellationToken,
+) {
+    let api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
+    let config = WatcherConfig::default().fields(&format!("metadata.name={}", controller.name));
+
+    let stream = watcher::watcher(api, config);
+    tokio::pin!(stream);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            item = stream.next() => {
+                match item {
+                    Some(Ok(event)) => {
+                        handle_deployment_event(
+                            client,
+                            namespace,
+                            controller,
+                            controllers,
+                            event,
+                        ).await;
+                    }
+                    Some(Err(e)) => {
+                        warn!(
+                            controller = %controller,
+                            error = %e,
+                            "deployment watcher error, stream will retry"
+                        );
+                    }
+                    None => {
+                        info!(controller = %controller, "deployment watcher stream ended");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_deployment_event(
+    client: &Client,
+    namespace: &str,
+    controller: &ControllerRef,
+    controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    event: Event<Deployment>,
+) {
+    let deploy = match event {
+        Event::Apply(d) | Event::InitApply(d) => d,
+        Event::Delete(_) => {
+            info!(controller = %controller, "deployment deleted");
+            let mut map = controllers.write().await;
+            map.remove(controller);
+            return;
+        }
+        Event::Init | Event::InitDone => return,
+    };
+
+    let spec = match &deploy.spec {
+        Some(s) => s,
+        None => return,
+    };
+    let status = deploy.status.as_ref();
+
+    let desired_replicas = spec.replicas.unwrap_or(1) as u32;
+    let generation = deploy.metadata.generation.unwrap_or(0);
+    let observed_generation = status.and_then(|s| s.observed_generation).unwrap_or(0);
+    let rollout_in_progress = generation != observed_generation;
+
+    // Determine generations by inspecting owned ReplicaSets
+    let (current_gen, target_gen) = if rollout_in_progress {
+        match find_deployment_generations(client, namespace, &controller.name).await {
+            Ok((current, target)) => (current, Some(target)),
+            Err(e) => {
+                warn!(
+                    controller = %controller,
+                    error = %e,
+                    "failed to discover deployment generations during rollout"
+                );
+                (String::new(), None)
+            }
+        }
+    } else {
+        match find_active_generation(client, namespace, &controller.name).await {
+            Ok(gen) => (gen, None),
+            Err(e) => {
+                debug!(
+                    controller = %controller,
+                    error = %e,
+                    "failed to discover active generation"
+                );
+                (String::new(), None)
+            }
+        }
+    };
+
+    let mut map = controllers.write().await;
+    // Only update previous_replicas when desired_replicas actually changes,
+    // otherwise status-only events would overwrite it with the current value.
+    let previous_replicas = map.get(controller).and_then(|prev| {
+        if prev.desired_replicas != desired_replicas {
+            Some(prev.desired_replicas)
+        } else {
+            prev.previous_replicas
+        }
+    });
+
+    let intent = ClusterIntent {
+        desired_replicas,
+        previous_replicas,
+        rollout_in_progress,
+        current_generation: current_gen,
+        target_generation: target_gen,
+    };
+
+    debug!(
+        controller = %controller,
+        desired_replicas = intent.desired_replicas,
+        previous_replicas = ?intent.previous_replicas,
+        rollout_in_progress = intent.rollout_in_progress,
+        current_generation = %intent.current_generation,
+        target_generation = ?intent.target_generation,
+        "updated deployment cluster intent"
+    );
+
+    map.insert(controller.clone(), intent);
+}
+
+/// Find the current and target pod-template-hash during a Deployment rollout.
+///
+/// Lists ReplicaSets owned by the Deployment and identifies:
+/// - target: the RS with the highest revision (the new one being scaled up)
+/// - current: the RS with the second-highest revision that has replicas
+async fn find_deployment_generations(
+    client: &Client,
+    namespace: &str,
+    deployment_name: &str,
+) -> Result<(String, String), kube::Error> {
+    let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
+    let rs_list = rs_api.list(&ListParams::default()).await?;
+
+    // Collect (revision, pod-template-hash, replica_count) for owned RSes
+    let mut owned: Vec<(u64, String, i32)> = Vec::new();
+
+    for rs in &rs_list.items {
+        let owners = rs.metadata.owner_references.as_deref().unwrap_or_default();
+        if !owners
+            .iter()
+            .any(|o| o.kind == "Deployment" && o.name == deployment_name)
+        {
+            continue;
+        }
+
+        let revision = rs
+            .metadata
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get("deployment.kubernetes.io/revision"))
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        let hash = rs
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get("pod-template-hash"))
+            .cloned()
+            .unwrap_or_default();
+
+        let replicas = rs.spec.as_ref().and_then(|s| s.replicas).unwrap_or(0);
+
+        owned.push((revision, hash, replicas));
+    }
+
+    // Sort by revision descending: newest first
+    owned.sort_by(|a, b| b.0.cmp(&a.0));
+
+    let target = owned
+        .first()
+        .map(|(_, hash, _)| hash.clone())
+        .unwrap_or_default();
+
+    let current = owned
+        .iter()
+        .skip(1)
+        .find(|(_, _, replicas)| *replicas > 0)
+        .map(|(_, hash, _)| hash.clone())
+        .unwrap_or_default();
+
+    Ok((current, target))
+}
+
+/// Find the active pod-template-hash for a Deployment not in rollout.
+async fn find_active_generation(
+    client: &Client,
+    namespace: &str,
+    deployment_name: &str,
+) -> Result<String, kube::Error> {
+    let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
+    let rs_list = rs_api.list(&ListParams::default()).await?;
+
+    let mut best_revision = 0u64;
+    let mut best_hash = String::new();
+
+    for rs in &rs_list.items {
+        let owners = rs.metadata.owner_references.as_deref().unwrap_or_default();
+        if !owners
+            .iter()
+            .any(|o| o.kind == "Deployment" && o.name == deployment_name)
+        {
+            continue;
+        }
+
+        let revision = rs
+            .metadata
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get("deployment.kubernetes.io/revision"))
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        if revision > best_revision {
+            best_revision = revision;
+            best_hash = rs
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get("pod-template-hash"))
+                .cloned()
+                .unwrap_or_default();
+        }
+    }
+
+    Ok(best_hash)
+}
+
+/// Watch a StatefulSet and update its ClusterIntent on changes.
+async fn run_statefulset_watcher(
+    client: &Client,
+    namespace: &str,
+    controller: &ControllerRef,
+    controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    cancel: CancellationToken,
+) {
+    let api: Api<StatefulSet> = Api::namespaced(client.clone(), namespace);
+    let config = WatcherConfig::default().fields(&format!("metadata.name={}", controller.name));
+
+    let stream = watcher::watcher(api, config);
+    tokio::pin!(stream);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            item = stream.next() => {
+                match item {
+                    Some(Ok(event)) => {
+                        handle_statefulset_event(controller, controllers, event).await;
+                    }
+                    Some(Err(e)) => {
+                        warn!(
+                            controller = %controller,
+                            error = %e,
+                            "statefulset watcher error, stream will retry"
+                        );
+                    }
+                    None => {
+                        info!(controller = %controller, "statefulset watcher stream ended");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_statefulset_event(
+    controller: &ControllerRef,
+    controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    event: Event<StatefulSet>,
+) {
+    let ss = match event {
+        Event::Apply(s) | Event::InitApply(s) => s,
+        Event::Delete(_) => {
+            info!(controller = %controller, "statefulset deleted");
+            let mut map = controllers.write().await;
+            map.remove(controller);
+            return;
+        }
+        Event::Init | Event::InitDone => return,
+    };
+
+    let spec = match &ss.spec {
+        Some(s) => s,
+        None => return,
+    };
+    let status = ss.status.as_ref();
+
+    let desired_replicas = spec.replicas.unwrap_or(1) as u32;
+
+    // StatefulSet rollout: currentRevision != updateRevision
+    let current_revision = status
+        .and_then(|s| s.current_revision.clone())
+        .unwrap_or_default();
+    let update_revision = status
+        .and_then(|s| s.update_revision.clone())
+        .unwrap_or_default();
+
+    let rollout_in_progress = !current_revision.is_empty()
+        && !update_revision.is_empty()
+        && current_revision != update_revision;
+
+    let target_generation = if rollout_in_progress {
+        Some(update_revision.clone())
+    } else {
+        None
+    };
+
+    let mut map = controllers.write().await;
+    let previous_replicas = map.get(controller).and_then(|prev| {
+        if prev.desired_replicas != desired_replicas {
+            Some(prev.desired_replicas)
+        } else {
+            prev.previous_replicas
+        }
+    });
+
+    let intent = ClusterIntent {
+        desired_replicas,
+        previous_replicas,
+        rollout_in_progress,
+        current_generation: current_revision,
+        target_generation,
+    };
+
+    debug!(
+        controller = %controller,
+        desired_replicas = intent.desired_replicas,
+        previous_replicas = ?intent.previous_replicas,
+        rollout_in_progress = intent.rollout_in_progress,
+        current_generation = %intent.current_generation,
+        target_generation = ?intent.target_generation,
+        "updated statefulset cluster intent"
+    );
+
+    map.insert(controller.clone(), intent);
+}

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -92,6 +92,7 @@ impl K8sAwareness {
         drop(watching);
 
         let controllers = Arc::clone(&self.controllers);
+        let watching = Arc::clone(&self.watching);
         let client = self.client.clone();
         let namespace = self.namespace.clone();
         let controller_ref = controller.clone();
@@ -106,6 +107,7 @@ impl K8sAwareness {
                         &namespace,
                         &controller_ref,
                         &controllers,
+                        &watching,
                         child_cancel,
                     )
                     .await;
@@ -116,6 +118,7 @@ impl K8sAwareness {
                         &namespace,
                         &controller_ref,
                         &controllers,
+                        &watching,
                         child_cancel,
                     )
                     .await;
@@ -127,12 +130,23 @@ impl K8sAwareness {
     }
 }
 
+/// Remove a controller from the `watching` map so `ensure_watching` can restart it.
+async fn unregister_watcher(
+    controller: &ControllerRef,
+    watching: &Arc<RwLock<HashMap<ControllerRef, CancellationToken>>>,
+) {
+    let mut map = watching.write().await;
+    map.remove(controller);
+    info!(controller = %controller, "unregistered watcher");
+}
+
 /// Watch a Deployment and update its ClusterIntent on changes.
 async fn run_deployment_watcher(
     client: &Client,
     namespace: &str,
     controller: &ControllerRef,
     controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    watching: &Arc<RwLock<HashMap<ControllerRef, CancellationToken>>>,
     cancel: CancellationToken,
 ) {
     let api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
@@ -152,6 +166,7 @@ async fn run_deployment_watcher(
                             namespace,
                             controller,
                             controllers,
+                            watching,
                             event,
                         ).await;
                     }
@@ -170,6 +185,8 @@ async fn run_deployment_watcher(
             }
         }
     }
+
+    unregister_watcher(controller, watching).await;
 }
 
 async fn handle_deployment_event(
@@ -177,6 +194,7 @@ async fn handle_deployment_event(
     namespace: &str,
     controller: &ControllerRef,
     controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    watching: &Arc<RwLock<HashMap<ControllerRef, CancellationToken>>>,
     event: Event<Deployment>,
 ) {
     let deploy = match event {
@@ -185,6 +203,7 @@ async fn handle_deployment_event(
             info!(controller = %controller, "deployment deleted");
             let mut map = controllers.write().await;
             map.remove(controller);
+            unregister_watcher(controller, watching).await;
             return;
         }
         Event::Init | Event::InitDone => return,
@@ -201,30 +220,60 @@ async fn handle_deployment_event(
     let observed_generation = status.and_then(|s| s.observed_generation).unwrap_or(0);
     let rollout_in_progress = generation != observed_generation;
 
+    // Build a label selector from the Deployment's matchLabels to scope RS queries
+    let label_selector = spec
+        .selector
+        .match_labels
+        .as_ref()
+        .map(|labels| {
+            labels
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .unwrap_or_default();
+
     // Determine generations by inspecting owned ReplicaSets
-    let (current_gen, target_gen) = if rollout_in_progress {
-        match find_deployment_generations(client, namespace, &controller.name).await {
-            Ok((current, target)) => (current, Some(target)),
-            Err(e) => {
+    let owned_rses =
+        list_owned_replicasets(client, namespace, &controller.name, &label_selector).await;
+    let (current_gen, target_gen) = match owned_rses {
+        Ok(rses) => {
+            if rollout_in_progress {
+                let target = rses
+                    .first()
+                    .map(|(_, hash, _)| hash.clone())
+                    .unwrap_or_default();
+                let current = rses
+                    .iter()
+                    .skip(1)
+                    .find(|(_, _, replicas)| *replicas > 0)
+                    .map(|(_, hash, _)| hash.clone())
+                    .unwrap_or_default();
+                (current, Some(target))
+            } else {
+                let gen = rses
+                    .first()
+                    .map(|(_, hash, _)| hash.clone())
+                    .unwrap_or_default();
+                (gen, None)
+            }
+        }
+        Err(e) => {
+            if rollout_in_progress {
                 warn!(
                     controller = %controller,
                     error = %e,
                     "failed to discover deployment generations during rollout"
                 );
-                (String::new(), None)
-            }
-        }
-    } else {
-        match find_active_generation(client, namespace, &controller.name).await {
-            Ok(gen) => (gen, None),
-            Err(e) => {
+            } else {
                 debug!(
                     controller = %controller,
                     error = %e,
                     "failed to discover active generation"
                 );
-                (String::new(), None)
             }
+            (String::new(), None)
         }
     };
 
@@ -260,20 +309,25 @@ async fn handle_deployment_event(
     map.insert(controller.clone(), intent);
 }
 
-/// Find the current and target pod-template-hash during a Deployment rollout.
+/// List ReplicaSets owned by a Deployment, sorted by revision descending.
 ///
-/// Lists ReplicaSets owned by the Deployment and identifies:
-/// - target: the RS with the highest revision (the new one being scaled up)
-/// - current: the RS with the second-highest revision that has replicas
-async fn find_deployment_generations(
+/// Returns `(revision, pod-template-hash, replica_count)` tuples.
+/// Uses the Deployment's pod-selector labels to scope the query instead of
+/// listing all RSes in the namespace.
+async fn list_owned_replicasets(
     client: &Client,
     namespace: &str,
     deployment_name: &str,
-) -> Result<(String, String), kube::Error> {
+    label_selector: &str,
+) -> Result<Vec<(u64, String, i32)>, kube::Error> {
     let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
-    let rs_list = rs_api.list(&ListParams::default()).await?;
+    let params = if label_selector.is_empty() {
+        ListParams::default()
+    } else {
+        ListParams::default().labels(label_selector)
+    };
+    let rs_list = rs_api.list(&params).await?;
 
-    // Collect (revision, pod-template-hash, replica_count) for owned RSes
     let mut owned: Vec<(u64, String, i32)> = Vec::new();
 
     for rs in &rs_list.items {
@@ -309,63 +363,7 @@ async fn find_deployment_generations(
     // Sort by revision descending: newest first
     owned.sort_by(|a, b| b.0.cmp(&a.0));
 
-    let target = owned
-        .first()
-        .map(|(_, hash, _)| hash.clone())
-        .unwrap_or_default();
-
-    let current = owned
-        .iter()
-        .skip(1)
-        .find(|(_, _, replicas)| *replicas > 0)
-        .map(|(_, hash, _)| hash.clone())
-        .unwrap_or_default();
-
-    Ok((current, target))
-}
-
-/// Find the active pod-template-hash for a Deployment not in rollout.
-async fn find_active_generation(
-    client: &Client,
-    namespace: &str,
-    deployment_name: &str,
-) -> Result<String, kube::Error> {
-    let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
-    let rs_list = rs_api.list(&ListParams::default()).await?;
-
-    let mut best_revision = 0u64;
-    let mut best_hash = String::new();
-
-    for rs in &rs_list.items {
-        let owners = rs.metadata.owner_references.as_deref().unwrap_or_default();
-        if !owners
-            .iter()
-            .any(|o| o.kind == "Deployment" && o.name == deployment_name)
-        {
-            continue;
-        }
-
-        let revision = rs
-            .metadata
-            .annotations
-            .as_ref()
-            .and_then(|a| a.get("deployment.kubernetes.io/revision"))
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(0);
-
-        if revision > best_revision {
-            best_revision = revision;
-            best_hash = rs
-                .metadata
-                .labels
-                .as_ref()
-                .and_then(|l| l.get("pod-template-hash"))
-                .cloned()
-                .unwrap_or_default();
-        }
-    }
-
-    Ok(best_hash)
+    Ok(owned)
 }
 
 /// Watch a StatefulSet and update its ClusterIntent on changes.
@@ -374,6 +372,7 @@ async fn run_statefulset_watcher(
     namespace: &str,
     controller: &ControllerRef,
     controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    watching: &Arc<RwLock<HashMap<ControllerRef, CancellationToken>>>,
     cancel: CancellationToken,
 ) {
     let api: Api<StatefulSet> = Api::namespaced(client.clone(), namespace);
@@ -388,7 +387,7 @@ async fn run_statefulset_watcher(
             item = stream.next() => {
                 match item {
                     Some(Ok(event)) => {
-                        handle_statefulset_event(controller, controllers, event).await;
+                        handle_statefulset_event(controller, controllers, watching, event).await;
                     }
                     Some(Err(e)) => {
                         warn!(
@@ -405,11 +404,14 @@ async fn run_statefulset_watcher(
             }
         }
     }
+
+    unregister_watcher(controller, watching).await;
 }
 
 async fn handle_statefulset_event(
     controller: &ControllerRef,
     controllers: &Arc<RwLock<HashMap<ControllerRef, ClusterIntent>>>,
+    watching: &Arc<RwLock<HashMap<ControllerRef, CancellationToken>>>,
     event: Event<StatefulSet>,
 ) {
     let ss = match event {
@@ -418,6 +420,7 @@ async fn handle_statefulset_event(
             info!(controller = %controller, "statefulset deleted");
             let mut map = controllers.write().await;
             map.remove(controller);
+            unregister_watcher(controller, watching).await;
             return;
         }
         Event::Init | Event::InitDone => return,

--- a/rust/common/k8s-awareness/tests/k3s_integration.rs
+++ b/rust/common/k8s-awareness/tests/k3s_integration.rs
@@ -1,0 +1,509 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, StatefulSet, StatefulSetSpec};
+use k8s_openapi::api::core::v1::{
+    Container, ContainerPort, PodSpec, PodTemplateSpec, Service, ServicePort, ServiceSpec,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use kube::api::{Api, ListParams, Patch, PatchParams, PostParams};
+use kube::config::{KubeConfigOptions, Kubeconfig};
+use kube::Client;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ImageExt;
+use testcontainers_modules::k3s::{K3s, KUBE_SECURE_PORT};
+use tokio_util::sync::CancellationToken;
+
+use k8s_awareness::{discover_controller, ControllerKind, DepartureReason, K8sAwareness};
+
+const NAMESPACE: &str = "default";
+
+// ── Helpers ──────────────────────────────────────────────
+
+/// Start a k3s container and return a kube::Client connected to it.
+async fn setup_k3s() -> (
+    testcontainers::ContainerAsync<K3s>,
+    Client,
+    tempfile::TempDir,
+) {
+    drop(tracing_subscriber::fmt::try_init());
+
+    let tmp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let container = K3s::default()
+        .with_conf_mount(tmp_dir.path())
+        .with_privileged(true)
+        .start()
+        .await
+        .expect("failed to start k3s container");
+
+    // k3s writes the kubeconfig after the readiness log message;
+    // give it a moment to flush the file.
+    let config_path = tmp_dir.path().join("k3s.yaml");
+    for _ in 0..30 {
+        if config_path.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    let config_yaml = std::fs::read_to_string(&config_path).expect("failed to read k3s kubeconfig");
+
+    // Replace the server address with the mapped host port
+    let host_port = container
+        .get_host_port_ipv4(KUBE_SECURE_PORT)
+        .await
+        .expect("failed to get host port");
+    let config_yaml = config_yaml.replace("127.0.0.1:6443", &format!("127.0.0.1:{host_port}"));
+
+    let kubeconfig = Kubeconfig::from_yaml(&config_yaml).expect("failed to parse kubeconfig YAML");
+    let client_config =
+        kube::Config::from_custom_kubeconfig(kubeconfig, &KubeConfigOptions::default())
+            .await
+            .expect("failed to build kube config");
+    let client = Client::try_from(client_config).expect("failed to create kube client");
+
+    // Verify connectivity
+    let version = client
+        .apiserver_version()
+        .await
+        .expect("failed to reach K8s API server");
+    tracing::info!(version = %version.git_version, "connected to k3s");
+
+    (container, client, tmp_dir)
+}
+
+fn labels(app: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([("app".to_string(), app.to_string())])
+}
+
+async fn create_deployment(client: &Client, name: &str, replicas: i32) {
+    let deployments: Api<Deployment> = Api::namespaced(client.clone(), NAMESPACE);
+    let deploy = Deployment {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        },
+        spec: Some(DeploymentSpec {
+            replicas: Some(replicas),
+            selector: LabelSelector {
+                match_labels: Some(labels(name)),
+                ..Default::default()
+            },
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels(name)),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    containers: vec![Container {
+                        name: "pause".to_string(),
+                        image: Some("registry.k8s.io/pause:3.9".to_string()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    deployments
+        .create(&PostParams::default(), &deploy)
+        .await
+        .expect("failed to create deployment");
+}
+
+async fn create_statefulset(client: &Client, name: &str, replicas: i32) {
+    // StatefulSet needs a headless service
+    let services: Api<Service> = Api::namespaced(client.clone(), NAMESPACE);
+    let svc = Service {
+        metadata: ObjectMeta {
+            name: Some(format!("{name}-headless")),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        },
+        spec: Some(ServiceSpec {
+            selector: Some(labels(name)),
+            cluster_ip: Some("None".to_string()),
+            ports: Some(vec![ServicePort {
+                port: 80,
+                target_port: Some(IntOrString::Int(80)),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    services
+        .create(&PostParams::default(), &svc)
+        .await
+        .expect("failed to create headless service");
+
+    let statefulsets: Api<StatefulSet> = Api::namespaced(client.clone(), NAMESPACE);
+    let ss = StatefulSet {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(NAMESPACE.to_string()),
+            ..Default::default()
+        },
+        spec: Some(StatefulSetSpec {
+            replicas: Some(replicas),
+            service_name: format!("{name}-headless"),
+            selector: LabelSelector {
+                match_labels: Some(labels(name)),
+                ..Default::default()
+            },
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels(name)),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    containers: vec![Container {
+                        name: "pause".to_string(),
+                        image: Some("registry.k8s.io/pause:3.9".to_string()),
+                        ports: Some(vec![ContainerPort {
+                            container_port: 80,
+                            ..Default::default()
+                        }]),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    statefulsets
+        .create(&PostParams::default(), &ss)
+        .await
+        .expect("failed to create statefulset");
+}
+
+/// Wait until at least `count` pods matching `label_selector` are Running.
+async fn wait_for_ready_pods(client: &Client, label_selector: &str, count: usize) {
+    let pods: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), NAMESPACE);
+    let timeout = Duration::from_secs(120);
+    let start = std::time::Instant::now();
+
+    loop {
+        let list = pods
+            .list(&ListParams::default().labels(label_selector))
+            .await
+            .expect("failed to list pods");
+
+        let ready_count = list
+            .items
+            .iter()
+            .filter(|p| p.status.as_ref().and_then(|s| s.phase.as_deref()) == Some("Running"))
+            .count();
+
+        if ready_count >= count {
+            return;
+        }
+
+        if start.elapsed() > timeout {
+            panic!(
+                "timed out waiting for {count} ready pods (selector={label_selector}), got {ready_count}"
+            );
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+/// Get the name of the first pod matching a label selector.
+async fn get_first_pod_name(client: &Client, label_selector: &str) -> String {
+    let pods: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), NAMESPACE);
+    let list = pods
+        .list(&ListParams::default().labels(label_selector))
+        .await
+        .expect("failed to list pods");
+
+    list.items
+        .first()
+        .and_then(|p| p.metadata.name.clone())
+        .expect("no pods found")
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn discover_deployment_controller() {
+    let (_container, client, _tmp) = setup_k3s().await;
+
+    let deploy_name = "test-deploy";
+    create_deployment(&client, deploy_name, 1).await;
+    wait_for_ready_pods(&client, &format!("app={deploy_name}"), 1).await;
+
+    let pod_name = get_first_pod_name(&client, &format!("app={deploy_name}")).await;
+    let pod_info = discover_controller(&client, NAMESPACE, &pod_name)
+        .await
+        .expect("discover_controller failed");
+
+    assert_eq!(pod_info.controller.kind, ControllerKind::Deployment);
+    assert_eq!(pod_info.controller.name, deploy_name);
+    assert!(
+        !pod_info.generation.is_empty(),
+        "generation should not be empty"
+    );
+}
+
+#[tokio::test]
+async fn discover_statefulset_controller() {
+    let (_container, client, _tmp) = setup_k3s().await;
+
+    let ss_name = "test-ss";
+    create_statefulset(&client, ss_name, 1).await;
+    wait_for_ready_pods(&client, &format!("app={ss_name}"), 1).await;
+
+    let pod_name = get_first_pod_name(&client, &format!("app={ss_name}")).await;
+    let pod_info = discover_controller(&client, NAMESPACE, &pod_name)
+        .await
+        .expect("discover_controller failed");
+
+    assert_eq!(pod_info.controller.kind, ControllerKind::StatefulSet);
+    assert_eq!(pod_info.controller.name, ss_name);
+    assert!(
+        !pod_info.generation.is_empty(),
+        "generation should not be empty"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn watcher_detects_deployment_rollout() {
+    let (_container, client, _tmp) = setup_k3s().await;
+
+    let deploy_name = "test-rollout";
+    create_deployment(&client, deploy_name, 2).await;
+    wait_for_ready_pods(&client, &format!("app={deploy_name}"), 2).await;
+
+    let cancel = CancellationToken::new();
+    let awareness = K8sAwareness::new(client.clone(), NAMESPACE.to_string(), cancel.clone());
+
+    // Discover the controller (starts a watcher)
+    let pod_name = get_first_pod_name(&client, &format!("app={deploy_name}")).await;
+    let pod_info = awareness
+        .discover_controller(&pod_name)
+        .await
+        .expect("discover failed");
+    let old_generation = pod_info.generation.clone();
+
+    // Give the watcher time to receive the initial state
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Before rollout: departure should be Crash (steady state)
+    let reason = awareness
+        .classify_departure(&pod_info.controller, &old_generation)
+        .await;
+    assert_eq!(
+        reason,
+        DepartureReason::Crash,
+        "steady state departure should be Crash"
+    );
+
+    // Trigger a rollout by changing the container image
+    let deployments: Api<Deployment> = Api::namespaced(client.clone(), NAMESPACE);
+    let patch = serde_json::json!({
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [{
+                        "name": "pause",
+                        "image": "registry.k8s.io/pause:3.10"
+                    }]
+                }
+            }
+        }
+    });
+    deployments
+        .patch(deploy_name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .expect("failed to patch deployment");
+
+    // Wait for the watcher to detect the rollout
+    let mut detected = false;
+    for i in 0..30 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let reason = awareness
+            .classify_departure(&pod_info.controller, &old_generation)
+            .await;
+        tracing::debug!(iteration = i, ?reason, gen = %old_generation, "polling rollout detection");
+        if reason == DepartureReason::Rollout {
+            detected = true;
+            break;
+        }
+    }
+
+    cancel.cancel();
+    assert!(detected, "watcher should detect rollout for old-gen pods");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn watcher_detects_deployment_downscale() {
+    let (_container, client, _tmp) = setup_k3s().await;
+
+    let deploy_name = "test-downscale";
+    create_deployment(&client, deploy_name, 3).await;
+    wait_for_ready_pods(&client, &format!("app={deploy_name}"), 3).await;
+
+    let cancel = CancellationToken::new();
+    let awareness = K8sAwareness::new(client.clone(), NAMESPACE.to_string(), cancel.clone());
+
+    // Discover and let watcher initialize
+    let pod_name = get_first_pod_name(&client, &format!("app={deploy_name}")).await;
+    let pod_info = awareness
+        .discover_controller(&pod_name)
+        .await
+        .expect("discover failed");
+
+    // Wait for initial state
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Scale down from 3 to 1
+    let deployments: Api<Deployment> = Api::namespaced(client.clone(), NAMESPACE);
+    let patch = serde_json::json!({ "spec": { "replicas": 1 } });
+    deployments
+        .patch(deploy_name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .expect("failed to scale down deployment");
+
+    // Wait for the watcher to detect the downscale
+    let mut detected = false;
+    for i in 0..30 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let reason = awareness
+            .classify_departure(&pod_info.controller, &pod_info.generation)
+            .await;
+        tracing::debug!(iteration = i, ?reason, "polling downscale detection");
+        if reason == DepartureReason::Downscale {
+            detected = true;
+            break;
+        }
+    }
+
+    cancel.cancel();
+    assert!(detected, "watcher should detect downscale");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn watcher_detects_statefulset_rollout() {
+    let (_container, client, _tmp) = setup_k3s().await;
+
+    let ss_name = "test-ss-rollout";
+    create_statefulset(&client, ss_name, 2).await;
+    wait_for_ready_pods(&client, &format!("app={ss_name}"), 2).await;
+
+    let cancel = CancellationToken::new();
+    let awareness = K8sAwareness::new(client.clone(), NAMESPACE.to_string(), cancel.clone());
+
+    // Discover the controller (starts a watcher)
+    let pod_name = get_first_pod_name(&client, &format!("app={ss_name}")).await;
+    let pod_info = awareness
+        .discover_controller(&pod_name)
+        .await
+        .expect("discover failed");
+    let old_generation = pod_info.generation.clone();
+
+    // Give the watcher time to receive the initial state
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Before rollout: departure should be Crash (steady state)
+    let reason = awareness
+        .classify_departure(&pod_info.controller, &old_generation)
+        .await;
+    assert_eq!(
+        reason,
+        DepartureReason::Crash,
+        "steady state departure should be Crash"
+    );
+
+    // Trigger a rollout by changing the container image
+    let statefulsets: Api<StatefulSet> = Api::namespaced(client.clone(), NAMESPACE);
+    let patch = serde_json::json!({
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [{
+                        "name": "pause",
+                        "image": "registry.k8s.io/pause:3.10"
+                    }]
+                }
+            }
+        }
+    });
+    statefulsets
+        .patch(ss_name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .expect("failed to patch statefulset");
+
+    // Wait for the watcher to detect the rollout
+    let mut detected = false;
+    for i in 0..30 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let reason = awareness
+            .classify_departure(&pod_info.controller, &old_generation)
+            .await;
+        tracing::debug!(iteration = i, ?reason, gen = %old_generation, "polling ss rollout detection");
+        if reason == DepartureReason::Rollout {
+            detected = true;
+            break;
+        }
+    }
+
+    cancel.cancel();
+    assert!(
+        detected,
+        "watcher should detect statefulset rollout for old-gen pods"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn watcher_detects_statefulset_downscale() {
+    let (_container, client, _tmp) = setup_k3s().await;
+
+    let ss_name = "test-ss-downscale";
+    create_statefulset(&client, ss_name, 3).await;
+    wait_for_ready_pods(&client, &format!("app={ss_name}"), 3).await;
+
+    let cancel = CancellationToken::new();
+    let awareness = K8sAwareness::new(client.clone(), NAMESPACE.to_string(), cancel.clone());
+
+    // Discover and let watcher initialize
+    let pod_name = get_first_pod_name(&client, &format!("app={ss_name}")).await;
+    let pod_info = awareness
+        .discover_controller(&pod_name)
+        .await
+        .expect("discover failed");
+
+    // Wait for initial state
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Scale down from 3 to 1
+    let statefulsets: Api<StatefulSet> = Api::namespaced(client.clone(), NAMESPACE);
+    let patch = serde_json::json!({ "spec": { "replicas": 1 } });
+    statefulsets
+        .patch(ss_name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .expect("failed to scale down statefulset");
+
+    // Wait for the watcher to detect the downscale
+    let mut detected = false;
+    for i in 0..30 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let reason = awareness
+            .classify_departure(&pod_info.controller, &pod_info.generation)
+            .await;
+        tracing::debug!(iteration = i, ?reason, "polling ss downscale detection");
+        if reason == DepartureReason::Downscale {
+            detected = true;
+            break;
+        }
+    }
+
+    cancel.cancel();
+    assert!(detected, "watcher should detect statefulset downscale");
+}

--- a/rust/common/k8s-awareness/tests/mock_discovery.rs
+++ b/rust/common/k8s-awareness/tests/mock_discovery.rs
@@ -1,0 +1,360 @@
+use std::pin::pin;
+
+use http::{Request, Response};
+use kube::client::Body;
+use kube::Client;
+use tower_test::mock;
+
+use k8s_awareness::{discover_controller, ControllerKind, DiscoveryError};
+
+const NAMESPACE: &str = "default";
+
+// ── Helpers ──────────────────────────────────────────────
+
+fn mock_client() -> (Client, mock::Handle<Request<Body>, Response<Body>>) {
+    let (service, handle) = mock::pair::<Request<Body>, Response<Body>>();
+    let client = Client::new(service, NAMESPACE);
+    (client, handle)
+}
+
+fn json_response(body: serde_json::Value) -> Response<Body> {
+    Response::builder()
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+fn not_found_response() -> Response<Body> {
+    let body = serde_json::json!({
+        "kind": "Status",
+        "apiVersion": "v1",
+        "status": "Failure",
+        "message": "pods \"missing\" not found",
+        "reason": "NotFound",
+        "code": 404
+    });
+    Response::builder()
+        .status(404)
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+fn pod_json(
+    name: &str,
+    owner_kind: &str,
+    owner_name: &str,
+    label_key: &str,
+    label_value: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": name,
+            "namespace": NAMESPACE,
+            "labels": { label_key: label_value },
+            "ownerReferences": [{
+                "apiVersion": "apps/v1",
+                "kind": owner_kind,
+                "name": owner_name,
+                "uid": "fake-uid",
+                "controller": true
+            }]
+        },
+        "spec": {
+            "containers": [{ "name": "test", "image": "test:latest" }]
+        }
+    })
+}
+
+fn replicaset_json(name: &str, deploy_name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "apiVersion": "apps/v1",
+        "kind": "ReplicaSet",
+        "metadata": {
+            "name": name,
+            "namespace": NAMESPACE,
+            "ownerReferences": [{
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "name": deploy_name,
+                "uid": "fake-deploy-uid",
+                "controller": true
+            }]
+        },
+        "spec": {
+            "replicas": 1,
+            "selector": { "matchLabels": { "app": "test" } },
+            "template": {
+                "metadata": { "labels": { "app": "test" } },
+                "spec": {
+                    "containers": [{ "name": "test", "image": "test:latest" }]
+                }
+            }
+        }
+    })
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn deployment_discovery_walks_replicaset() {
+    let (client, handle) = mock_client();
+
+    let mock_handler = tokio::spawn(async move {
+        let mut handle = pin!(handle);
+
+        // 1. GET pod
+        let (request, send) = handle.next_request().await.expect("expected pod request");
+        assert_eq!(request.method(), http::Method::GET);
+        assert!(request.uri().path().ends_with("/pods/my-pod"));
+        send.send_response(json_response(pod_json(
+            "my-pod",
+            "ReplicaSet",
+            "my-deploy-abc123",
+            "pod-template-hash",
+            "abc123",
+        )));
+
+        // 2. GET replicaset
+        let (request, send) = handle.next_request().await.expect("expected RS request");
+        assert_eq!(request.method(), http::Method::GET);
+        assert!(request
+            .uri()
+            .path()
+            .ends_with("/replicasets/my-deploy-abc123"));
+        send.send_response(json_response(replicaset_json(
+            "my-deploy-abc123",
+            "my-deploy",
+        )));
+    });
+
+    let info = discover_controller(&client, NAMESPACE, "my-pod")
+        .await
+        .expect("discovery should succeed");
+
+    assert_eq!(info.controller.kind, ControllerKind::Deployment);
+    assert_eq!(info.controller.name, "my-deploy");
+    assert_eq!(info.generation, "abc123");
+
+    mock_handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn statefulset_discovery_is_direct() {
+    let (client, handle) = mock_client();
+
+    let mock_handler = tokio::spawn(async move {
+        let mut handle = pin!(handle);
+
+        // Only 1 request: GET pod (no RS lookup needed)
+        let (request, send) = handle.next_request().await.expect("expected pod request");
+        assert_eq!(request.method(), http::Method::GET);
+        assert!(request.uri().path().ends_with("/pods/my-ss-pod"));
+        send.send_response(json_response(pod_json(
+            "my-ss-pod",
+            "StatefulSet",
+            "my-statefulset",
+            "controller-revision-hash",
+            "my-statefulset-rev1",
+        )));
+    });
+
+    let info = discover_controller(&client, NAMESPACE, "my-ss-pod")
+        .await
+        .expect("discovery should succeed");
+
+    assert_eq!(info.controller.kind, ControllerKind::StatefulSet);
+    assert_eq!(info.controller.name, "my-statefulset");
+    assert_eq!(info.generation, "my-statefulset-rev1");
+
+    mock_handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn pod_not_found_returns_error() {
+    let (client, handle) = mock_client();
+
+    let mock_handler = tokio::spawn(async move {
+        let mut handle = pin!(handle);
+        let (_request, send) = handle.next_request().await.expect("expected pod request");
+        send.send_response(not_found_response());
+    });
+
+    let err = discover_controller(&client, NAMESPACE, "missing")
+        .await
+        .expect_err("should fail for missing pod");
+
+    assert!(
+        matches!(err, DiscoveryError::PodNotFound(ref name) if name == "missing"),
+        "expected PodNotFound, got: {err}"
+    );
+
+    mock_handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn pod_without_owner_refs_returns_error() {
+    let (client, handle) = mock_client();
+
+    let mock_handler = tokio::spawn(async move {
+        let mut handle = pin!(handle);
+        let (_request, send) = handle.next_request().await.expect("expected pod request");
+        send.send_response(json_response(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "orphan-pod",
+                "namespace": NAMESPACE,
+            },
+            "spec": {
+                "containers": [{ "name": "test", "image": "test:latest" }]
+            }
+        })));
+    });
+
+    let err = discover_controller(&client, NAMESPACE, "orphan-pod")
+        .await
+        .expect_err("should fail for pod without owners");
+
+    assert!(
+        matches!(err, DiscoveryError::NoOwnerReferences(ref name) if name == "orphan-pod"),
+        "expected NoOwnerReferences, got: {err}"
+    );
+
+    mock_handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn unsupported_owner_kind_returns_error() {
+    let (client, handle) = mock_client();
+
+    let mock_handler = tokio::spawn(async move {
+        let mut handle = pin!(handle);
+        let (_request, send) = handle.next_request().await.expect("expected pod request");
+        send.send_response(json_response(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "job-pod",
+                "namespace": NAMESPACE,
+                "ownerReferences": [{
+                    "apiVersion": "batch/v1",
+                    "kind": "Job",
+                    "name": "my-job",
+                    "uid": "fake-uid",
+                    "controller": true
+                }]
+            },
+            "spec": {
+                "containers": [{ "name": "test", "image": "test:latest" }]
+            }
+        })));
+    });
+
+    let err = discover_controller(&client, NAMESPACE, "job-pod")
+        .await
+        .expect_err("should fail for unsupported owner");
+
+    assert!(
+        matches!(err, DiscoveryError::UnsupportedOwner { ref kind, .. } if kind == "Job"),
+        "expected UnsupportedOwner(Job), got: {err}"
+    );
+
+    mock_handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn deployment_pod_missing_hash_label_returns_error() {
+    let (client, handle) = mock_client();
+
+    let mock_handler = tokio::spawn(async move {
+        let mut handle = pin!(handle);
+
+        // 1. GET pod (owned by RS but missing pod-template-hash label)
+        let (_request, send) = handle.next_request().await.expect("expected pod request");
+        send.send_response(json_response(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "no-hash-pod",
+                "namespace": NAMESPACE,
+                "ownerReferences": [{
+                    "apiVersion": "apps/v1",
+                    "kind": "ReplicaSet",
+                    "name": "my-rs",
+                    "uid": "fake-uid",
+                    "controller": true
+                }]
+            },
+            "spec": {
+                "containers": [{ "name": "test", "image": "test:latest" }]
+            }
+        })));
+
+        // 2. GET replicaset (discovery fetches the RS before checking labels)
+        let (_request, send) = handle.next_request().await.expect("expected RS request");
+        send.send_response(json_response(replicaset_json("my-rs", "my-deploy")));
+    });
+
+    let err = discover_controller(&client, NAMESPACE, "no-hash-pod")
+        .await
+        .expect_err("should fail for missing hash label");
+
+    assert!(
+        matches!(err, DiscoveryError::MissingGenerationLabel(ref name) if name == "no-hash-pod"),
+        "expected MissingGenerationLabel, got: {err}"
+    );
+
+    mock_handler.await.unwrap();
+}
+
+#[tokio::test]
+async fn replicaset_without_deployment_owner_returns_error() {
+    let (client, handle) = mock_client();
+
+    let mock_handler = tokio::spawn(async move {
+        let mut handle = pin!(handle);
+
+        // 1. GET pod (owned by RS, has hash label)
+        let (_request, send) = handle.next_request().await.expect("expected pod request");
+        send.send_response(json_response(pod_json(
+            "orphan-rs-pod",
+            "ReplicaSet",
+            "standalone-rs",
+            "pod-template-hash",
+            "abc123",
+        )));
+
+        // 2. GET replicaset (no Deployment owner)
+        let (_request, send) = handle.next_request().await.expect("expected RS request");
+        send.send_response(json_response(serde_json::json!({
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "metadata": {
+                "name": "standalone-rs",
+                "namespace": NAMESPACE,
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": { "matchLabels": { "app": "test" } },
+                "template": {
+                    "metadata": { "labels": { "app": "test" } },
+                    "spec": {
+                        "containers": [{ "name": "test", "image": "test:latest" }]
+                    }
+                }
+            }
+        })));
+    });
+
+    let err = discover_controller(&client, NAMESPACE, "orphan-rs-pod")
+        .await
+        .expect_err("should fail for RS without deploy owner");
+
+    assert!(
+        matches!(err, DiscoveryError::ReplicaSetNoDeploymentOwner(ref name) if name == "standalone-rs"),
+        "expected ReplicaSetNoDeploymentOwner, got: {err}"
+    );
+
+    mock_handler.await.unwrap();
+}


### PR DESCRIPTION
## Problem

PostHog's Kafka consumer rebalancing treats all pod departures the same, triggering full stop-the-world rebalances regardless of whether a pod left due to a rolling deploy, a downscale, or a crash. This causes unnecessary latency spikes and partition reassignment churn. To make smarter rebalancing decisions, the coordinator needs to understand _why_ a pod departed.

## Changes

- Add a new `k8s-awareness` crate under `rust/common/` that watches Kubernetes controllers (Deployments and StatefulSets) and classifies pod departures into four categories: **Rollout**, **Downscale**, **Crash**, or **Unknown**
- Implement controller discovery by walking `ownerReferences` from pod to ReplicaSet to Deployment (or directly to StatefulSet)
- Track cluster intent per controller including desired/previous replica counts, generation hashes, and rollout state
- Classify departures by comparing a pod's generation hash against the controller's current/target generation and checking replica count changes
- Include integration tests against a real k3s cluster via testcontainers and mock-based unit tests for controller discovery logic


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
