### PR TITLE
fix: add cross-region webhook proxy and lazy cleanup for orphaned Vercel integrations

### DIFF
--- a/ee/api/vercel/test/test_vercel_connect.py
+++ b/ee/api/vercel/test/test_vercel_connect.py
@@ -330,7 +330,7 @@ class TestVercelConnectComplete(VercelConnectTestBase):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "already has a Vercel integration" in response.json()["detail"]
-
+        assert OrganizationIntegration.objects.filter(integration_id="icfg_existing").exists()
     @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=True)
     def test_stale_integration_deleted_and_new_one_created(self, _mock_orphaned):
         OrganizationIntegration.objects.create(
@@ -357,26 +357,6 @@ class TestVercelConnectComplete(VercelConnectTestBase):
         )
         assert new_integration.integration_id == "icfg_connect_test"
 
-    @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=False)
-    def test_valid_existing_integration_still_rejects(self, _mock_orphaned):
-        OrganizationIntegration.objects.create(
-            organization=self.organization,
-            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
-            integration_id="icfg_valid",
-            config={"credentials": {"access_token": "tok_valid"}},
-            created_by=self.user,
-        )
-        session_token = _seed_session()
-
-        response = self.client.post(
-            self.url,
-            {"session": session_token, "organization_id": str(self.organization.id)},
-            content_type="application/json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "already has a Vercel integration" in response.json()["detail"]
-        assert OrganizationIntegration.objects.filter(integration_id="icfg_valid").exists()
 
     def test_unauthenticated_returns_403(self):
         self.client.logout()

--- a/ee/api/vercel/test/test_vercel_connect.py
+++ b/ee/api/vercel/test/test_vercel_connect.py
@@ -170,12 +170,13 @@ class TestVercelConnectSessionInfo(VercelConnectTestBase):
         assert data["organizations"][0]["name"] == self.organization.name
         assert data["organizations"][0]["already_linked"] is False
 
-    def test_marks_already_linked_orgs(self):
+    @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=False)
+    def test_marks_already_linked_orgs(self, _mock_orphaned):
         OrganizationIntegration.objects.create(
             organization=self.organization,
             kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
             integration_id="icfg_existing",
-            config={},
+            config={"credentials": {"access_token": "tok"}},
             created_by=self.user,
         )
         session_token = _seed_session()
@@ -184,6 +185,23 @@ class TestVercelConnectSessionInfo(VercelConnectTestBase):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["organizations"][0]["already_linked"] is True
+
+    @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=True)
+    def test_orphaned_integration_cleaned_up_in_session(self, _mock_orphaned):
+        OrganizationIntegration.objects.create(
+            organization=self.organization,
+            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
+            integration_id="icfg_orphaned",
+            config={"credentials": {"access_token": "tok_dead"}},
+            created_by=self.user,
+        )
+        session_token = _seed_session()
+
+        response = self.client.get(self.url, {"session": session_token})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["organizations"][0]["already_linked"] is False
+        assert not OrganizationIntegration.objects.filter(integration_id="icfg_orphaned").exists()
 
     def test_excludes_orgs_where_user_is_member_not_admin(self):
         other_org = Organization.objects.create(name="Other Org")
@@ -293,12 +311,13 @@ class TestVercelConnectComplete(VercelConnectTestBase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "already used" in response.json()["detail"]
 
-    def test_already_linked_org_returns_400(self):
+    @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=False)
+    def test_already_linked_org_returns_400(self, _mock_orphaned):
         OrganizationIntegration.objects.create(
             organization=self.organization,
             kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
             integration_id="icfg_existing",
-            config={},
+            config={"credentials": {"access_token": "tok_old"}},
             created_by=self.user,
         )
         session_token = _seed_session()
@@ -311,6 +330,53 @@ class TestVercelConnectComplete(VercelConnectTestBase):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "already has a Vercel integration" in response.json()["detail"]
+
+    @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=True)
+    def test_stale_integration_deleted_and_new_one_created(self, _mock_orphaned):
+        OrganizationIntegration.objects.create(
+            organization=self.organization,
+            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
+            integration_id="icfg_stale",
+            config={"credentials": {"access_token": "tok_stale"}},
+            created_by=self.user,
+        )
+        session_token = _seed_session()
+
+        response = self.client.post(
+            self.url,
+            {"session": session_token, "organization_id": str(self.organization.id)},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["status"] == "linked"
+        assert not OrganizationIntegration.objects.filter(integration_id="icfg_stale").exists()
+        new_integration = OrganizationIntegration.objects.get(
+            organization=self.organization,
+            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
+        )
+        assert new_integration.integration_id == "icfg_connect_test"
+
+    @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=False)
+    def test_valid_existing_integration_still_rejects(self, _mock_orphaned):
+        OrganizationIntegration.objects.create(
+            organization=self.organization,
+            kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
+            integration_id="icfg_valid",
+            config={"credentials": {"access_token": "tok_valid"}},
+            created_by=self.user,
+        )
+        session_token = _seed_session()
+
+        response = self.client.post(
+            self.url,
+            {"session": session_token, "organization_id": str(self.organization.id)},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "already has a Vercel integration" in response.json()["detail"]
+        assert OrganizationIntegration.objects.filter(integration_id="icfg_valid").exists()
 
     def test_unauthenticated_returns_403(self):
         self.client.logout()

--- a/ee/api/vercel/test/test_vercel_connect.py
+++ b/ee/api/vercel/test/test_vercel_connect.py
@@ -331,6 +331,7 @@ class TestVercelConnectComplete(VercelConnectTestBase):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "already has a Vercel integration" in response.json()["detail"]
         assert OrganizationIntegration.objects.filter(integration_id="icfg_existing").exists()
+
     @patch("ee.api.vercel.vercel_connect._is_installation_orphaned", return_value=True)
     def test_stale_integration_deleted_and_new_one_created(self, _mock_orphaned):
         OrganizationIntegration.objects.create(
@@ -356,7 +357,6 @@ class TestVercelConnectComplete(VercelConnectTestBase):
             kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
         )
         assert new_integration.integration_id == "icfg_connect_test"
-
 
     def test_unauthenticated_returns_403(self):
         self.client.logout()

--- a/ee/api/vercel/test/test_vercel_webhooks.py
+++ b/ee/api/vercel/test/test_vercel_webhooks.py
@@ -155,6 +155,91 @@ class TestVercelWebhooks(VercelTestBase):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["status"] == "ok"
 
+    @override_settings(
+        VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret",
+        SITE_URL="https://us.posthog.com",
+        REGION_US_DOMAIN="us.posthog.com",
+        REGION_EU_DOMAIN="eu.posthog.com",
+    )
+    @patch("ee.api.vercel.vercel_webhooks.outbound_requests.post")
+    def test_deauthorization_unknown_config_on_us_proxies_to_eu(self, mock_post):
+        mock_eu_response = MagicMock()
+        mock_eu_response.status_code = 200
+        mock_post.return_value = mock_eu_response
+
+        payload = {
+            "type": "integration-configuration.removed",
+            "payload": {"installationId": "icfg_unknown"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "ok"
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs.kwargs["url"] == "https://eu.posthog.com/webhooks/vercel"
+        assert call_kwargs.kwargs["headers"]["x-vercel-signature"] == signature
+
+    @override_settings(
+        VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret",
+        SITE_URL="https://eu.posthog.com",
+        REGION_US_DOMAIN="us.posthog.com",
+        REGION_EU_DOMAIN="eu.posthog.com",
+    )
+    @patch("ee.api.vercel.vercel_webhooks.outbound_requests.post")
+    def test_deauthorization_unknown_config_on_eu_does_not_proxy(self, mock_post):
+        payload = {
+            "type": "integration-configuration.removed",
+            "payload": {"installationId": "icfg_unknown"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_post.assert_not_called()
+
+    @override_settings(
+        VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret",
+        SITE_URL="http://localhost:8000",
+        REGION_US_DOMAIN="us.posthog.com",
+        REGION_EU_DOMAIN="eu.posthog.com",
+    )
+    @patch("ee.api.vercel.vercel_webhooks.outbound_requests.post")
+    def test_deauthorization_unknown_config_on_dev_does_not_proxy(self, mock_post):
+        payload = {
+            "type": "integration-configuration.removed",
+            "payload": {"installationId": "icfg_unknown"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_post.assert_not_called()
+
+    @override_settings(
+        VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret",
+        SITE_URL="https://us.posthog.com",
+        REGION_US_DOMAIN="us.posthog.com",
+        REGION_EU_DOMAIN="eu.posthog.com",
+    )
+    @patch("ee.api.vercel.vercel_webhooks.outbound_requests.post")
+    def test_billing_event_unknown_config_does_not_proxy(self, mock_post):
+        payload = {
+            "type": "marketplace.invoice.paid",
+            "payload": {"installationId": "icfg_unknown", "invoiceId": "mi_123"},
+        }
+        signature = self._sign_payload(payload)
+
+        response = self._post_webhook(payload, signature=signature)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        mock_post.assert_not_called()
+
     @override_settings(VERCEL_CLIENT_INTEGRATION_SECRET="test_webhook_secret")
     @patch("ee.api.vercel.vercel_webhooks.BillingManager")
     @patch("ee.api.vercel.vercel_webhooks.License")

--- a/ee/api/vercel/vercel_connect.py
+++ b/ee/api/vercel/vercel_connect.py
@@ -17,7 +17,7 @@ from posthog.models.organization_integration import OrganizationIntegration
 from posthog.models.user import User
 
 from ee.api.vercel.crypto import decrypt_payload, encrypt_payload, mark_token_used
-from ee.vercel.client import VercelAPIClient
+from ee.vercel.client import APIError, VercelAPIClient
 
 logger = structlog.get_logger(__name__)
 
@@ -58,6 +58,24 @@ def _validate_next_url(url: str) -> str:
     if not parsed.hostname or parsed.hostname not in ALLOWED_REDIRECT_DOMAINS:
         return ""
     return url
+
+
+def _is_installation_orphaned(integration: OrganizationIntegration) -> bool:
+    """Return True if Vercel no longer recognises this installation (401/403/404).
+
+    Returns False when Vercel confirms the installation is active, or when
+    we cannot reach Vercel (network/5xx) -- in that ambiguous case we keep
+    the existing integration to avoid accidental deletion.
+    """
+    access_token = integration.config.get("credentials", {}).get("access_token")
+    if not access_token:
+        return False
+
+    client = VercelAPIClient(bearer_token=access_token)
+    try:
+        return not client.check_installation_active(integration.integration_id)
+    except APIError:
+        return False
 
 
 class VercelConnectCallbackViewSet(viewsets.GenericViewSet):
@@ -170,17 +188,25 @@ class VercelConnectLinkViewSet(viewsets.GenericViewSet):
         organization = membership.organization
         installation_id = cached_data["installation_id"]
 
-        # Check if this org already has a Vercel integration
         existing = OrganizationIntegration.objects.filter(
             organization=organization,
             kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
         ).first()
 
         if existing:
-            raise exceptions.ValidationError(
-                "This organization already has a Vercel integration. "
-                "Please unlink the existing one first or choose a different organization."
-            )
+            if _is_installation_orphaned(existing):
+                logger.info(
+                    "vercel_connect_deleting_orphaned_integration",
+                    old_installation_id=existing.integration_id,
+                    organization_id=str(organization_id),
+                    integration="vercel",
+                )
+                existing.delete()
+            else:
+                raise exceptions.ValidationError(
+                    "This organization already has a Vercel integration. "
+                    "Please unlink the existing one first or choose a different organization."
+                )
 
         OrganizationIntegration.objects.create(
             organization=organization,
@@ -238,18 +264,32 @@ class VercelConnectLinkViewSet(viewsets.GenericViewSet):
         ).select_related("organization")
 
         org_ids = [m.organization_id for m in memberships]
-        orgs_with_vercel = set(
-            OrganizationIntegration.objects.filter(
+        vercel_integrations = {
+            i.organization_id: i
+            for i in OrganizationIntegration.objects.filter(
                 organization_id__in=org_ids,
                 kind=OrganizationIntegration.OrganizationIntegrationKind.VERCEL,
-            ).values_list("organization_id", flat=True)
-        )
+            )
+        }
+
+        orphaned_org_ids: set = set()
+        for org_id, integration in vercel_integrations.items():
+            if _is_installation_orphaned(integration):
+                logger.info(
+                    "vercel_session_deleting_orphaned_integration",
+                    installation_id=integration.integration_id,
+                    organization_id=str(org_id),
+                    integration="vercel",
+                )
+                integration.delete()
+                orphaned_org_ids.add(org_id)
 
         organizations = [
             {
                 "id": str(m.organization.id),
                 "name": m.organization.name,
-                "already_linked": m.organization_id in orgs_with_vercel,
+                "already_linked": m.organization_id in vercel_integrations
+                and m.organization_id not in orphaned_org_ids,
             }
             for m in memberships
         ]

--- a/ee/api/vercel/vercel_connect.py
+++ b/ee/api/vercel/vercel_connect.py
@@ -71,9 +71,13 @@ def _is_installation_orphaned(integration: OrganizationIntegration) -> bool:
     if not access_token:
         return False
 
+    installation_id = integration.integration_id
+    if not installation_id:
+        return False
+
     client = VercelAPIClient(bearer_token=access_token)
     try:
-        return not client.check_installation_active(integration.integration_id)
+        return not client.check_installation_active(installation_id)
     except APIError:
         return False
 

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -152,18 +152,17 @@ def vercel_webhook(request: Request) -> Response:
                     logger.exception("vercel_webhook_deauthorize_delete_failed", config_id=config_id)
                     capture_exception(e, {"config_id": config_id})
                     return Response({"error": "Processing failed"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        elif _is_us_region():
+            logger.info("vercel_webhook_deauthorize_proxying_to_eu", config_id=config_id)
+            eu_status = _proxy_deauthorization_to_eu(request.body, signature)
+            if eu_status is None or eu_status >= 300:
+                logger.warning(
+                    "vercel_webhook_deauthorize_eu_proxy_non_ok",
+                    config_id=config_id,
+                    eu_status=eu_status,
+                )
         else:
-            if _is_us_region():
-                logger.info("vercel_webhook_deauthorize_proxying_to_eu", config_id=config_id)
-                eu_status = _proxy_deauthorization_to_eu(request.body, signature)
-                if eu_status is None or eu_status >= 300:
-                    logger.warning(
-                        "vercel_webhook_deauthorize_eu_proxy_non_ok",
-                        config_id=config_id,
-                        eu_status=eu_status,
-                    )
-            else:
-                logger.warning("vercel_webhook_deauthorize_unknown_config", config_id=config_id)
+            logger.warning("vercel_webhook_deauthorize_unknown_config", config_id=config_id)
 
         return Response({"status": "ok"}, status=status.HTTP_200_OK)
 

--- a/ee/api/vercel/vercel_webhooks.py
+++ b/ee/api/vercel/vercel_webhooks.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from django.conf import settings
 
+import requests as outbound_requests
 import structlog
 from rest_framework import status
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
@@ -21,6 +22,41 @@ logger = structlog.get_logger(__name__)
 
 BILLING_EVENT_PREFIX = "marketplace.invoice."
 DEAUTHORIZATION_EVENT = "integration-configuration.removed"
+
+CROSS_REGION_PROXY_TIMEOUT = 10
+DEFAULT_US_DOMAIN = "us.posthog.com"
+DEFAULT_EU_DOMAIN = "eu.posthog.com"
+
+
+def _is_us_region() -> bool:
+    us_domain = getattr(settings, "REGION_US_DOMAIN", DEFAULT_US_DOMAIN)
+    return settings.SITE_URL == f"https://{us_domain}"
+
+
+def _proxy_deauthorization_to_eu(raw_body: bytes, signature: str | None) -> int | None:
+    """Forward a deauthorization webhook to EU. Returns the EU status code, or None on failure."""
+    eu_domain = getattr(settings, "REGION_EU_DOMAIN", DEFAULT_EU_DOMAIN)
+    target_url = f"https://{eu_domain}/webhooks/vercel"
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if signature:
+        headers["x-vercel-signature"] = signature
+
+    try:
+        response = outbound_requests.post(
+            url=target_url,
+            data=raw_body,
+            headers=headers,
+            timeout=CROSS_REGION_PROXY_TIMEOUT,
+        )
+        logger.info(
+            "vercel_webhook_proxied_to_eu",
+            status_code=response.status_code,
+        )
+        return response.status_code
+    except outbound_requests.RequestException as e:
+        logger.warning("vercel_webhook_proxy_to_eu_failed", error=str(e))
+        return None
 
 
 def _is_valid_signature(payload: bytes, signature: str | None) -> bool:
@@ -117,7 +153,17 @@ def vercel_webhook(request: Request) -> Response:
                     capture_exception(e, {"config_id": config_id})
                     return Response({"error": "Processing failed"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         else:
-            logger.warning("vercel_webhook_deauthorize_unknown_config", config_id=config_id)
+            if _is_us_region():
+                logger.info("vercel_webhook_deauthorize_proxying_to_eu", config_id=config_id)
+                eu_status = _proxy_deauthorization_to_eu(request.body, signature)
+                if eu_status is None or eu_status >= 300:
+                    logger.warning(
+                        "vercel_webhook_deauthorize_eu_proxy_non_ok",
+                        config_id=config_id,
+                        eu_status=eu_status,
+                    )
+            else:
+                logger.warning("vercel_webhook_deauthorize_unknown_config", config_id=config_id)
 
         return Response({"status": "ok"}, status=status.HTTP_200_OK)
 

--- a/ee/vercel/client.py
+++ b/ee/vercel/client.py
@@ -290,6 +290,22 @@ class VercelAPIClient:
                 error_description=str(e),
             )
 
+    def check_installation_active(self, installation_id: str) -> bool:
+        """Check if a Vercel installation is still active.
+
+        Returns True if the installation exists and is accessible, False if
+        Vercel returns 401/403/404 (meaning it's been removed). Raises on
+        transient errors (5xx / network) so callers can distinguish
+        "definitely gone" from "can't tell".
+        """
+        try:
+            self._request("GET", f"{self.base_url}/installations/{installation_id}")
+            return True
+        except APIError as e:
+            if e.status_code in (401, 403, 404):
+                return False
+            raise
+
     def sso_token_exchange(
         self,
         code: str,


### PR DESCRIPTION
## Problem

Two issues with the Vercel integration:

1. **Cross-region deauthorization webhooks silently dropped**: All Vercel webhooks go to the US region. When a Vercel integration exists only on EU, the deauthorization webhook arrives at US, can't find the integration locally, and is silently logged as `vercel_webhook_deauthorize_unknown_config` without actually cleaning up the EU integration.

2. **Stale integrations block new connections**: If a Vercel integration is removed from Vercel's side (e.g., user uninstalls from Vercel dashboard) but our `OrganizationIntegration` record remains, users get "This organization already has a Vercel integration" when trying to reconnect. The only fix is manual DB cleanup.

## Changes

### Feature 1: Cross-region webhook proxy for deauthorization events
- When a deauthorization webhook arrives on US and the integration isn't found locally, proxy the raw request body + `x-vercel-signature` header to EU
- EU can re-validate the signature (same `VERCEL_CLIENT_INTEGRATION_SECRET` on both regions) and process the deauthorization
- Only proxies deauthorization events, not billing events (billing is handled by the billing service separately)
- Uses runtime `settings.SITE_URL` / `REGION_*_DOMAIN` for region detection (not module-level, per PR #52130 review feedback)
- If EU returns non-200 or proxy fails, logs a warning and returns 200 to Vercel (don't block retries)

### Feature 2: Lazy cleanup of orphaned integrations in the connect flow
- Added `check_installation_active(installation_id)` to `VercelAPIClient` - calls `GET /v1/installations/{id}` and returns `True`/`False` based on whether Vercel returns success or 401/403/404
- Added `_is_installation_orphaned(integration)` helper in `vercel_connect.py` that uses the stored access token to check with Vercel
- `complete` method: when an existing integration is found, checks if it's orphaned before rejecting. If orphaned, deletes the stale record and proceeds with the new connection
- `session_info` method: eagerly cleans up orphaned integrations so orgs aren't shown as `already_linked` when the integration is actually gone

## How did you test this code?

### Automated tests (all 55 pass)

**Webhook cross-region proxy tests** (`test_vercel_webhooks.py`):
- Deauthorization on US with unknown config proxies to EU (verifies URL, signature header forwarded)
- Deauthorization on EU with unknown config does NOT proxy
- Deauthorization on localhost/dev does NOT proxy
- Billing events with unknown config do NOT proxy (still return 404)

**Connect lazy cleanup tests** (`test_vercel_connect.py`):
- Stale integration (orphaned) is deleted and new connection proceeds (201)
- Valid existing integration still rejects (400)
- `session_info` cleans up orphaned integrations and shows org as not linked
- `session_info` marks orgs with valid integrations as already linked

## Changelog

No - this is a backend infrastructure fix, not a user-facing feature.