### PR TITLE
fix: set COOP unsafe-none on /login when redirecting to OAuth flows

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -747,6 +747,10 @@ class OAuthCoopMiddleware:
         response = self.get_response(request)
         if any(request.path.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
             response["Cross-Origin-Opener-Policy"] = "unsafe-none"
+        elif request.path == "/login" or request.path == "/login/":
+            next_url = request.GET.get("next", "")
+            if any(next_url.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
+                response["Cross-Origin-Opener-Policy"] = "unsafe-none"
         return response
 
 


### PR DESCRIPTION
## Problem

When a user initiates Vercel's "Link Existing Account" (connectable) flow, the popup opens on `us.posthog.com` (the configured Redirect URL). If the user isn't logged in on US - which is always the case for EU users since their account only exists on EU - the popup redirects through `/login?next=/connect/vercel/link?session=...`.

Django's default `Cross-Origin-Opener-Policy: same-origin` on the `/login` page severs `window.opener`, so Vercel's parent window can no longer detect when the popup navigates to the `next` URL. Vercel shows "The installation was canceled" even though PostHog successfully creates the integration.

For EU users the full chain is:
1. Vercel opens popup to `us.posthog.com/connect/vercel/callback` (COOP: `unsafe-none` via existing middleware)
2. US redirects to `/login?next=/connect/vercel/link` (COOP: `same-origin` - **severs opener**)
3. US login page detects EU cookie, client-side redirects to `eu.posthog.com/login?next=...`
4. EU sees user is logged in, loads the connect page, user completes - 201
5. Frontend redirects popup to Vercel's `next` URL
6. Vercel can't detect the redirect because `window.opener` was severed in step 2

We already have `OAuthCoopMiddleware` that sets `COOP: unsafe-none` on `/connect/vercel/` paths, but the `/login` redirect was a gap. There is no workaround for EU users - telling them to "log in first" doesn't help because the popup always starts on US.

## Changes

When `/login` has a `next` query param pointing to an OAuth path (any of `OAUTH_PATH_PREFIXES`), set `Cross-Origin-Opener-Policy: unsafe-none` so the opener reference is preserved through the login redirect. Plain `/login` requests are unaffected.

## How did you test this code

- Reproduced the bug locally: ngrok -> Vercel dev integration -> "Link Existing Account" while logged out -> confirmed popup stays open, Vercel shows "canceled"
- Verified the fix: same flow on the fix branch -> popup redirects back to Vercel and closes correctly
- Verified COOP header values via curl:
  - `/login?next=/connect/vercel/link` -> `unsafe-none`
  - `/login` (plain) -> `same-origin`
- Confirmed from EU production logs that 5 attempts by the affected user all succeeded on PostHog's side (HTTP 201) but Vercel showed "canceled" every time

## Changelog

No