### PR TITLE
feat(cohorts): add unique constraint on cohort kind per team

### DIFF
--- a/posthog/migrations/1070_add_unique_cohort_kind_per_team.py
+++ b/posthog/migrations/1070_add_unique_cohort_kind_per_team.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for CREATE INDEX CONCURRENTLY
+
+    dependencies = [
+        ("posthog", "1069_datadeletionrequest"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="cohort",
+                    constraint=models.UniqueConstraint(
+                        condition=models.Q(("deleted", False), kind__isnull=False),
+                        fields=("team", "kind"),
+                        name="unique_cohort_kind_per_team",
+                    ),
+                ),
+            ],
+            database_operations=[
+                # CREATE UNIQUE INDEX CONCURRENTLY does not hold an exclusive lock
+                # on the table — it only takes a ShareUpdateExclusiveLock, which
+                # allows concurrent reads AND writes to continue while the index is
+                # built in the background. The migration must be non-atomic
+                # (atomic = False) because CONCURRENTLY cannot run inside a
+                # transaction.
+                migrations.RunSQL(
+                    sql="""
+                        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_cohort_kind_per_team"
+                        ON "posthog_cohort" ("team_id", "kind")
+                        WHERE "kind" IS NOT NULL AND "deleted" = false
+                    """,
+                    reverse_sql='DROP INDEX CONCURRENTLY IF EXISTS "unique_cohort_kind_per_team"',
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1069_datadeletionrequest
+1070_add_unique_cohort_kind_per_team

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -223,6 +223,15 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
 
     objects = CohortManager()  # type: ignore
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["team", "kind"],
+                condition=models.Q(kind__isnull=False, deleted=False),
+                name="unique_cohort_kind_per_team",
+            ),
+        ]
+
     def __str__(self):
         return self.name or "Untitled cohort"
 


### PR DESCRIPTION
## Problem

There's no database-level enforcement preventing a team from having multiple cohorts with the same system-defined `kind` (e.g. `internal_test_users`). While this doesn't happen in practice today, adding a constraint ensures data integrity as we rely on `kind` for system-managed cohort lookups.

## Changes

- Added a partial unique constraint `(team_id, kind)` on the `posthog_cohort` table, scoped to rows where `kind IS NOT NULL AND deleted = false`
- Uses `CREATE UNIQUE INDEX CONCURRENTLY` to avoid locking the table during index creation on large datasets
- Added matching `UniqueConstraint` to the `Cohort` model's `Meta` class for ORM-level validation

## How did you test this code?

This is a migration-only change. The `CREATE UNIQUE INDEX CONCURRENTLY` approach is a well-established Postgres pattern used elsewhere in the codebase (e.g. `0947`, `0987`). I'm an agent and have not run this manually.

## Publish to changelog?

No

## 🤖 LLM context

Co-authored by Claude Code. The non-locking migration pattern (`SeparateDatabaseAndState` + `CONCURRENTLY`) follows existing precedent in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)