### PR TITLE
feat: add preaggregation and backfill Feature tags for query tagging

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -43,15 +43,17 @@ class Product(StrEnum):
 
 
 class Feature(StrEnum):
+    BACKFILL = "backfill"
     BEHAVIORAL_COHORTS = "behavioral_cohorts"
     COHORT = "cohort"
-    QUERY = "query"
+    QUERY = "query"  # user-facing queries only
     INSIGHT = "insight"
     DASHBOARD = "dashboard"
     CACHE_WARMUP = "cache_warmup"
     DATA_MODELING = "data_modeling"
     HEALTH_CHECK = "health_check"
     IMPORT_PIPELINE = "import_pipeline"
+    PREAGGREGATION = "preaggregation"
     DATA_DELETION = "data_deletion"
     SCHEMA_INTROSPECTION = "schema_introspection"
     USAGE_REPORT = "usage_report"


### PR DESCRIPTION
## Problem

Preaggregation and backfill workloads run ClickHouse queries but lack dedicated `Feature` tags, making it harder to attribute query load to these workloads in `system.query_log`. The `QUERY` feature tag also had no documentation clarifying its intended scope.

## Changes

- Add `PREAGGREGATION` and `BACKFILL` members to the `Feature` enum in `posthog/clickhouse/query_tagging.py`
- Add a comment on `QUERY` clarifying it is intended for user-facing queries only

## How did you test this code?

This is an additive-only enum change with no behavioral impact until callers adopt the new values. No tests needed for the enum definition itself.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

Co-authored by Claude Code (Claude Opus 4.6).