### PR TITLE
chore: mark hogql parser outputs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -43,3 +43,9 @@ common/hogql_parser/HogQLLexer.interp linguist-generated
 common/hogql_parser/HogQLParser.interp linguist-generated
 common/hogql_parser/HogQLLexer.tokens linguist-generated
 common/hogql_parser/HogQLParser.tokens linguist-generated
+common/hogql_parser/HogQLLexer.h linguist-generated
+common/hogql_parser/HogQLParser.h linguist-generated
+common/hogql_parser/HogQLParserVisitor.cpp linguist-generated
+common/hogql_parser/HogQLParserVisitor.h linguist-generated
+common/hogql_parser/HogQLParserBaseVisitor.cpp linguist-generated
+common/hogql_parser/HogQLParserBaseVisitor.h linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,18 @@ posthog/temporal/data_imports/sources/generated_configs.py linguist-generated
 posthog/temporal/proxy_service/proto/*_pb2*.py linguist-generated
 
 nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts linguist-generated
+
+posthog/hogql/grammar/HogQLLexer.py linguist-generated
+posthog/hogql/grammar/HogQLParser.py linguist-generated
+posthog/hogql/grammar/HogQLParserVisitor.py linguist-generated
+posthog/hogql/grammar/HogQLLexer.interp linguist-generated
+posthog/hogql/grammar/HogQLParser.interp linguist-generated
+posthog/hogql/grammar/HogQLLexer.tokens linguist-generated
+posthog/hogql/grammar/HogQLParser.tokens linguist-generated
+
+common/hogql_parser/HogQLLexer.cpp linguist-generated
+common/hogql_parser/HogQLParser.cpp linguist-generated
+common/hogql_parser/HogQLLexer.interp linguist-generated
+common/hogql_parser/HogQLParser.interp linguist-generated
+common/hogql_parser/HogQLLexer.tokens linguist-generated
+common/hogql_parser/HogQLParser.tokens linguist-generated


### PR DESCRIPTION
## Problem

Mark HogQL ANTLR-generated files as such to reduce noise.

## Changes

Add .gitattributes entries for generated HogQL parser outputs in posthog/hogql/grammar and common/hogql_parser.

## How did you test this code?

👀 

## Publish to changelog?

No