### PR TITLE
chore: normalize next URL in COOP middleware and add tests

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -2,6 +2,7 @@ import re
 import json
 import time
 import uuid
+import posixpath
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timedelta
@@ -750,7 +751,8 @@ class OAuthCoopMiddleware:
             response["Cross-Origin-Opener-Policy"] = "unsafe-none"
         elif request.path == "/login" or request.path == "/login/":
             next_url = request.GET.get("next", "")
-            if any(next_url.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
+            normalized = posixpath.normpath(next_url) if next_url.startswith("/") else next_url
+            if any(normalized.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
                 response["Cross-Origin-Opener-Policy"] = "unsafe-none"
         return response
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -734,9 +734,9 @@ class OAuthCoopMiddleware:
     """
 
     OAUTH_PATH_PREFIXES = (
-        "/toolbar_oauth/",
-        "/oauth/",
-        "/connect/vercel/",
+        "/toolbar_oauth",
+        "/oauth",
+        "/connect/vercel",
         "/login/vercel/",
         "/api/agentic/authorize",
         "/api/agentic/oauth/",
@@ -747,9 +747,10 @@ class OAuthCoopMiddleware:
 
     def __call__(self, request):
         response = self.get_response(request)
-        if any(request.path.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
+        path = request.path.rstrip("/")
+        if any(path.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
             response["Cross-Origin-Opener-Policy"] = "unsafe-none"
-        elif request.path == "/login" or request.path == "/login/":
+        elif path == "/login":
             next_url = request.GET.get("next", "")
             normalized = posixpath.normpath(next_url) if next_url.startswith("/") else next_url
             if any(normalized.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -734,9 +734,9 @@ class OAuthCoopMiddleware:
     """
 
     OAUTH_PATH_PREFIXES = (
-        "/toolbar_oauth",
-        "/oauth",
-        "/connect/vercel",
+        "/toolbar_oauth/",
+        "/oauth/",
+        "/connect/vercel/",
         "/login/vercel/",
         "/api/agentic/authorize",
         "/api/agentic/oauth/",
@@ -745,15 +745,21 @@ class OAuthCoopMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
+    @staticmethod
+    def _matches_oauth_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
+        for prefix in prefixes:
+            if path.startswith(prefix) or path.rstrip("/") + "/" == prefix:
+                return True
+        return False
+
     def __call__(self, request):
         response = self.get_response(request)
-        path = request.path.rstrip("/")
-        if any(path.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
+        if self._matches_oauth_prefix(request.path, self.OAUTH_PATH_PREFIXES):
             response["Cross-Origin-Opener-Policy"] = "unsafe-none"
-        elif path == "/login":
+        elif request.path == "/login" or request.path == "/login/":
             next_url = request.GET.get("next", "")
             normalized = posixpath.normpath(next_url) if next_url.startswith("/") else next_url
-            if any(normalized.startswith(prefix) for prefix in self.OAUTH_PATH_PREFIXES):
+            if self._matches_oauth_prefix(normalized, self.OAUTH_PATH_PREFIXES):
                 response["Cross-Origin-Opener-Policy"] = "unsafe-none"
         return response
 

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timedelta
 
+import pytest
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, FuzzyInt, override_settings
 from unittest.mock import patch
@@ -1390,3 +1391,45 @@ class TestSocialAuthExceptionMiddleware(APIBaseTest):
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response.url, "/login?error_code=oauth_cancelled")
+
+
+@pytest.mark.parametrize(
+    "path,query_string,expected_coop",
+    [
+        ("/connect/vercel/link", "", "unsafe-none"),
+        ("/oauth/callback", "", "unsafe-none"),
+        ("/login", "next=/connect/vercel/link", "unsafe-none"),
+        ("/login", "next=/connect/vercel/link?session=abc", "unsafe-none"),
+        ("/login", "", "same-origin"),
+        ("/login", "next=/dashboard", "same-origin"),
+        ("/login", "next=/connect/vercel/../../admin", "same-origin"),
+        ("/some/other/path", "", "same-origin"),
+    ],
+    ids=[
+        "direct-oauth-vercel",
+        "direct-oauth-callback",
+        "login-next-oauth",
+        "login-next-oauth-with-params",
+        "login-no-next",
+        "login-next-non-oauth",
+        "login-next-path-traversal",
+        "unrelated-path",
+    ],
+)
+def test_oauth_coop_middleware(path, query_string, expected_coop):
+    from django.http import HttpResponse
+    from django.test import RequestFactory
+
+    from posthog.middleware import OAuthCoopMiddleware
+
+    factory = RequestFactory()
+    request = factory.get(path + ("?" + query_string if query_string else ""))
+
+    def get_response(req):
+        resp = HttpResponse("ok")
+        resp["Cross-Origin-Opener-Policy"] = "same-origin"
+        return resp
+
+    middleware = OAuthCoopMiddleware(get_response)
+    response = middleware(request)
+    assert response["Cross-Origin-Opener-Policy"] == expected_coop


### PR DESCRIPTION
## Problem

Follow-up to #52419. The bot review flagged two issues:

1. **Path traversal**: `/login?next=/connect/vercel/../../admin` matched the prefix check and set `COOP: unsafe-none` on a non-OAuth path
2. **No tests**: `OAuthCoopMiddleware` had no unit tests

## Changes

- Normalize the `next` URL with `posixpath.normpath()` before the prefix check
- Add parameterized tests covering: direct OAuth paths, login with OAuth next, login without next, login with non-OAuth next, path traversal, and unrelated paths

## How did you test this code

All 8 parameterized tests pass.

## Changelog

No