### PR TITLE
feat(notifications): send in-app notification on discussion mention

### DIFF
--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -14,7 +14,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import ClassicBehaviorBooleanFieldSerializer, action
 from posthog.models import User
 from posthog.models.comment import Comment
-from posthog.models.comment.utils import produce_discussion_mention_events
+from posthog.models.comment.utils import produce_discussion_mention_events, send_mention_notifications
 from posthog.tasks.email import send_discussions_mentioned
 
 
@@ -108,6 +108,7 @@ class CommentSerializer(serializers.ModelSerializer):
         if mentions:
             send_discussions_mentioned.delay(comment.id, mentions, slug)
             produce_discussion_mention_events(comment, mentions, slug)
+            send_mention_notifications(comment, mentions, slug)
 
         return comment
 
@@ -137,6 +138,7 @@ class CommentSerializer(serializers.ModelSerializer):
         if mentions:
             send_discussions_mentioned.delay(updated_instance.id, mentions, slug)
             produce_discussion_mention_events(updated_instance, mentions, slug)
+            send_mention_notifications(updated_instance, mentions, slug)
 
         return updated_instance
 

--- a/posthog/models/comment/utils.py
+++ b/posthog/models/comment/utils.py
@@ -130,37 +130,41 @@ def send_mention_notifications(
     mentioned_user_ids: list[int],
     slug: str,
 ) -> None:
-    from products.notifications.backend.facade.api import (
-        NotificationData,
-        NotificationType,
-        TargetType,
-        create_notification,
-    )
-    from products.notifications.backend.facade.enums import NotificationOnlyResourceType
-
-    commenter = comment.created_by
-    if not commenter:
-        return
-
-    item_url = build_comment_item_url(comment.scope, comment.item_id, slug)
-    comment_content = extract_plain_text_from_rich_content(comment.rich_content) or comment.content
-    body = comment_content[:200] if comment_content else ""
-
-    for user_id in mentioned_user_ids:
-        if user_id == commenter.id:
-            continue
-        create_notification(
-            NotificationData(
-                team_id=comment.team_id,
-                notification_type=NotificationType.COMMENT_MENTION,
-                title=f"@{commenter.first_name or commenter.email} mentioned you",
-                body=body,
-                target_type=TargetType.USER,
-                target_id=str(user_id),
-                resource_type=NotificationOnlyResourceType.COMMENT,
-                resource_id=str(comment.id),
-                source_url=item_url.replace(settings.SITE_URL, "")
-                if item_url.startswith(settings.SITE_URL)
-                else item_url,
-            )
+    try:
+        from products.notifications.backend.facade.api import (
+            NotificationData,
+            NotificationType,
+            TargetType,
+            create_notification,
         )
+        from products.notifications.backend.facade.enums import NotificationOnlyResourceType
+
+        commenter = comment.created_by
+        if not commenter:
+            return
+
+        item_url = build_comment_item_url(comment.scope, comment.item_id, slug)
+        comment_content = extract_plain_text_from_rich_content(comment.rich_content) or comment.content
+        body = comment_content[:200] if comment_content else ""
+
+        for user_id in mentioned_user_ids:
+            if user_id == commenter.id:
+                continue
+            create_notification(
+                NotificationData(
+                    team_id=comment.team_id,
+                    notification_type=NotificationType.COMMENT_MENTION,
+                    title=f"@{commenter.first_name or commenter.email} mentioned you",
+                    body=body,
+                    target_type=TargetType.USER,
+                    target_id=str(user_id),
+                    resource_type=NotificationOnlyResourceType.COMMENT,
+                    resource_id=str(comment.id),
+                    source_url=item_url.replace(settings.SITE_URL, "")
+                    if item_url.startswith(settings.SITE_URL)
+                    else item_url,
+                )
+            )
+    except Exception as e:
+        logger.exception("Failed to send mention notifications", error=e)
+        capture_exception(e)

--- a/posthog/models/comment/utils.py
+++ b/posthog/models/comment/utils.py
@@ -123,3 +123,44 @@ def produce_discussion_mention_events(
     except Exception as e:
         logger.exception("Failed to produce discussion mention events", error=e)
         capture_exception(e)
+
+
+def send_mention_notifications(
+    comment: "Comment",
+    mentioned_user_ids: list[int],
+    slug: str,
+) -> None:
+    from products.notifications.backend.facade.api import (
+        NotificationData,
+        NotificationType,
+        TargetType,
+        create_notification,
+    )
+    from products.notifications.backend.facade.enums import NotificationOnlyResourceType
+
+    commenter = comment.created_by
+    if not commenter:
+        return
+
+    item_url = build_comment_item_url(comment.scope, comment.item_id, slug)
+    comment_content = extract_plain_text_from_rich_content(comment.rich_content) or comment.content
+    body = comment_content[:200] if comment_content else ""
+
+    for user_id in mentioned_user_ids:
+        if user_id == commenter.id:
+            continue
+        create_notification(
+            NotificationData(
+                team_id=comment.team_id,
+                notification_type=NotificationType.COMMENT_MENTION,
+                title=f"@{commenter.first_name or commenter.email} mentioned you",
+                body=body,
+                target_type=TargetType.USER,
+                target_id=str(user_id),
+                resource_type=NotificationOnlyResourceType.COMMENT,
+                resource_id=str(comment.id),
+                source_url=item_url.replace(settings.SITE_URL, "")
+                if item_url.startswith(settings.SITE_URL)
+                else item_url,
+            )
+        )


### PR DESCRIPTION
## Problem

When a user is @mentioned in a discussion comment, they receive an email and a CDP event but no in-app notification. Users who have the notifications popover open won't see mentions in real-time.

## Changes

- Add `send_mention_notifications()` to `posthog/models/comment/utils.py` — creates a `comment_mention` notification for each mentioned user (excluding self-mentions) via the notifications facade API
- Call it from `CommentSerializer.create()` and `CommentSerializer.update()` alongside the existing email and CDP event triggers
- Uses lazy imports to avoid circular dependency with the notifications product module

## How did you test this code?

- Manually tested end-to-end: created a comment with @mention as a second user, verified the notification appeared in the bell popover for the mentioned user with correct title, body, and source URL linking to the dashboard discussion panel

## Publish to changelog?

no