### PR TITLE
refactor: rely on outputs for groups processing

### DIFF
--- a/nodejs/src/ingestion/analytics/config/outputs.ts
+++ b/nodejs/src/ingestion/analytics/config/outputs.ts
@@ -5,9 +5,10 @@ import {
     KAFKA_EVENTS_PLUGIN_INGESTION_ASYNC,
     KAFKA_EVENTS_PLUGIN_INGESTION_DLQ,
     KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
+    KAFKA_GROUPS,
     KAFKA_INGESTION_WARNINGS,
 } from '../../../config/kafka-topics'
-import { DLQ_OUTPUT, INGESTION_WARNINGS_OUTPUT, OVERFLOW_OUTPUT } from '../../common/outputs'
+import { DLQ_OUTPUT, GROUPS_OUTPUT, INGESTION_WARNINGS_OUTPUT, OVERFLOW_OUTPUT } from '../../common/outputs'
 import { IngestionOutputDefinition } from '../../outputs/resolver'
 import { AI_EVENTS_OUTPUT, ASYNC_OUTPUT, EVENTS_OUTPUT, HEATMAPS_OUTPUT } from '../outputs'
 import { DEFAULT_PRODUCER, ProducerName } from './producers'
@@ -55,5 +56,11 @@ export const INGESTION_OUTPUT_DEFINITIONS: Record<string, IngestionOutputDefinit
         defaultProducerName: DEFAULT_PRODUCER,
         producerOverrideEnvVar: 'INGESTION_OUTPUT_ASYNC_PRODUCER',
         topicOverrideEnvVar: 'INGESTION_OUTPUT_ASYNC_TOPIC',
+    },
+    [GROUPS_OUTPUT]: {
+        defaultTopic: KAFKA_GROUPS,
+        defaultProducerName: DEFAULT_PRODUCER,
+        producerOverrideEnvVar: 'INGESTION_OUTPUT_GROUPS_PRODUCER',
+        topicOverrideEnvVar: 'INGESTION_OUTPUT_GROUPS_TOPIC',
     },
 }

--- a/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/analytics/joined-ingestion-pipeline.ts
@@ -10,7 +10,7 @@ import { TeamManager } from '../../utils/team-manager'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
 import { BatchWritingGroupStore } from '../../worker/ingestion/groups/batch-writing-group-store'
 import { PersonsStore } from '../../worker/ingestion/persons/persons-store'
-import { DlqOutput, IngestionWarningsOutput, OverflowOutput } from '../common/outputs'
+import { DlqOutput, GroupsOutput, IngestionWarningsOutput, OverflowOutput } from '../common/outputs'
 import { CookielessManager } from '../cookieless/cookieless-manager'
 import { EventPipelineRunnerOptions } from '../event-processing/event-pipeline-options'
 import { createFlushBatchStoresStep } from '../event-processing/flush-batch-stores-step'
@@ -50,6 +50,7 @@ export interface JoinedIngestionPipelineConfig {
         | DlqOutput
         | OverflowOutput
         | AsyncOutput
+        | GroupsOutput
     >
     splitAiEventsConfig: SplitAiEventsStepConfig
     perDistinctIdOptions: EventPipelineRunnerOptions

--- a/nodejs/src/ingestion/common/outputs.ts
+++ b/nodejs/src/ingestion/common/outputs.ts
@@ -9,3 +9,6 @@ export type DlqOutput = typeof DLQ_OUTPUT
 
 export const OVERFLOW_OUTPUT = 'overflow' as const
 export type OverflowOutput = typeof OVERFLOW_OUTPUT
+
+export const GROUPS_OUTPUT = 'groups' as const
+export type GroupsOutput = typeof GROUPS_OUTPUT

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -21,6 +21,7 @@ import { PostgresUse } from '../utils/db/postgres'
 import { parseJSON } from '../utils/json-parse'
 import { logger } from '../utils/logger'
 import { UUIDT } from '../utils/utils'
+import { ClickhouseGroupRepository } from '../worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { createPrepareEventStep } from './event-processing/prepare-event-step'
 import { IngestionConsumer } from './ingestion-consumer'
 
@@ -109,6 +110,7 @@ describe('IngestionConsumer', () => {
                 ...hub,
                 kafkaMetricsProducer: hub.kafkaProducer,
                 outputs,
+                clickhouseGroupRepository: new ClickhouseGroupRepository(outputs),
                 hogTransformer: createHogTransformerService(hub, hub),
             },
             overrides

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -36,7 +36,7 @@ import {
     createJoinedIngestionPipeline,
 } from './analytics'
 import { AiEventOutput, AsyncOutput, EventOutput, HeatmapsOutput } from './analytics/outputs'
-import { DlqOutput, IngestionWarningsOutput, OverflowOutput } from './common/outputs'
+import { DlqOutput, GroupsOutput, IngestionWarningsOutput, OverflowOutput } from './common/outputs'
 import { IngestionConsumerConfig } from './config'
 import { CookielessManager } from './cookieless/cookieless-manager'
 import { parseSplitAiEventsConfig } from './event-processing/split-ai-events-step'
@@ -66,6 +66,7 @@ export interface IngestionConsumerDeps {
         | DlqOutput
         | OverflowOutput
         | AsyncOutput
+        | GroupsOutput
     >
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
@@ -181,7 +182,7 @@ export class IngestionConsumer {
         })
 
         this.groupStore = new BatchWritingGroupStore(
-            this.deps.kafkaProducer,
+            this.deps.outputs,
             this.deps.groupRepository,
             this.deps.clickhouseGroupRepository,
             {

--- a/nodejs/src/ingestion/ingestion-e2e.test.ts
+++ b/nodejs/src/ingestion/ingestion-e2e.test.ts
@@ -16,6 +16,7 @@ import { closeHub, createHub } from '../utils/db/hub'
 import { parseRawClickHouseEvent } from '../utils/event'
 import { parseJSON } from '../utils/json-parse'
 import { UUIDT } from '../utils/utils'
+import { ClickhouseGroupRepository } from '../worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { fetchDistinctIds } from '../worker/ingestion/persons/repositories/test-helpers'
 import { IngestionConsumer } from './ingestion-consumer'
 
@@ -248,11 +249,13 @@ const createTestWithTeamIngester = (baseConfig: Partial<PluginsServerConfig> = {
                 throw new Error(`Failed to fetch team ${newTeam.id} from database`)
             }
 
+            const outputs = createTestIngestionOutputs(hub.kafkaProducer)
             const ingester = new IngestionConsumer(hub, {
                 ...hub,
                 kafkaMetricsProducer: hub.kafkaProducer,
                 hogTransformer: createHogTransformerService(hub, hub),
-                outputs: createTestIngestionOutputs(hub.kafkaProducer),
+                outputs,
+                clickhouseGroupRepository: new ClickhouseGroupRepository(outputs),
             })
             // NOTE: We don't actually use kafka so we skip instantiation for faster tests
             ingester['kafkaConsumer'] = {

--- a/nodejs/src/ingestion/person-properties-metadata.e2e.test.ts
+++ b/nodejs/src/ingestion/person-properties-metadata.e2e.test.ts
@@ -19,6 +19,7 @@ import { createHogTransformerService } from '../cdp/hog-transformations/hog-tran
 import { Hub, PipelineEvent, PluginsServerConfig, ProjectId, Team } from '../types'
 import { closeHub, createHub } from '../utils/db/hub'
 import { UUIDT } from '../utils/utils'
+import { ClickhouseGroupRepository } from '../worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { IngestionConsumer } from './ingestion-consumer'
 
 jest.mock('~/utils/token-bucket', () => {
@@ -175,11 +176,13 @@ const createTestWithTeamIngester = (baseConfig: Partial<PluginsServerConfig> = {
                 throw new Error(`Failed to fetch team ${newTeam.id} from database`)
             }
 
+            const outputs = createTestIngestionOutputs(hub.kafkaProducer)
             const ingester = new IngestionConsumer(hub, {
                 ...hub,
                 kafkaMetricsProducer: hub.kafkaProducer,
                 hogTransformer: createHogTransformerService(hub, hub),
-                outputs: createTestIngestionOutputs(hub.kafkaProducer),
+                outputs,
+                clickhouseGroupRepository: new ClickhouseGroupRepository(outputs),
             })
             ingester['kafkaConsumer'] = {
                 connect: jest.fn(),

--- a/nodejs/src/ingestion/person-updates-e2e.test.ts
+++ b/nodejs/src/ingestion/person-updates-e2e.test.ts
@@ -25,6 +25,7 @@ import { createHogTransformerService } from '../cdp/hog-transformations/hog-tran
 import { Hub, PersonBatchWritingDbWriteMode, PipelineEvent, ProjectId, Team } from '../types'
 import { closeHub, createHub } from '../utils/db/hub'
 import { UUIDT } from '../utils/utils'
+import { ClickhouseGroupRepository } from '../worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { IngestionConsumer } from './ingestion-consumer'
 
 jest.mock('~/utils/token-bucket', () => {
@@ -224,11 +225,13 @@ describe.each(FLAG_COMBINATIONS)('Person Updates E2E ($#)', (config) => {
         team = fetchedTeam
         currentToken = team.api_token
 
+        const outputs = createTestIngestionOutputs(hub.kafkaProducer)
         ingester = new IngestionConsumer(hub, {
             ...hub,
             kafkaMetricsProducer: hub.kafkaProducer,
             hogTransformer: createHogTransformerService(hub, hub),
-            outputs: createTestIngestionOutputs(hub.kafkaProducer),
+            outputs,
+            clickhouseGroupRepository: new ClickhouseGroupRepository(outputs),
         })
         ingester['kafkaConsumer'] = {
             connect: jest.fn(),

--- a/nodejs/src/servers/ingestion-general-server.ts
+++ b/nodejs/src/servers/ingestion-general-server.ts
@@ -194,7 +194,6 @@ export class IngestionGeneralServer implements NodeServer {
 
         this.cookielessManager = new CookielessManager(this.config, this.cookielessRedisPool)
         const groupTypeManager = new GroupTypeManager(groupRepository, teamManager)
-        const clickhouseGroupRepository = new ClickhouseGroupRepository(this.kafkaProducer)
 
         const serviceLoaders: (() => Promise<PluginServerService>)[] = []
 
@@ -238,6 +237,7 @@ export class IngestionGeneralServer implements NodeServer {
                 this.ingestionProducerRegistry,
                 INGESTION_OUTPUT_DEFINITIONS
             )
+            const clickhouseGroupRepository = new ClickhouseGroupRepository(ingestionOutputs)
 
             const ingestionDeps: IngestionConsumerDeps = {
                 postgres: this.postgres,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -23,7 +23,6 @@ import { GeoIPService } from './utils/geoip'
 import { PubSub } from './utils/pubsub'
 import { TeamManager } from './utils/team-manager'
 import { GroupTypeManager } from './worker/ingestion/group-type-manager'
-import { ClickhouseGroupRepository } from './worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { GroupRepository } from './worker/ingestion/groups/repositories/group-repository.interface'
 import { PersonRepository } from './worker/ingestion/persons/repositories/person-repository'
 
@@ -131,7 +130,6 @@ export interface HubServices {
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository
-    clickhouseGroupRepository: ClickhouseGroupRepository
     personRepository: PersonRepository
     geoipService: GeoIPService
     encryptedFields: EncryptedFields

--- a/nodejs/src/utils/db/hub.ts
+++ b/nodejs/src/utils/db/hub.ts
@@ -14,7 +14,6 @@ import { CookielessManager } from '../../ingestion/cookieless/cookieless-manager
 import { KafkaProducerWrapper } from '../../kafka/producer'
 import { Hub, PluginsServerConfig } from '../../types'
 import { GroupTypeManager } from '../../worker/ingestion/group-type-manager'
-import { ClickhouseGroupRepository } from '../../worker/ingestion/groups/repositories/clickhouse-group-repository'
 import { PostgresGroupRepository } from '../../worker/ingestion/groups/repositories/postgres-group-repository'
 import { PostgresPersonRepository } from '../../worker/ingestion/persons/repositories/postgres-person-repository'
 import { isTestEnv } from '../env-utils'
@@ -94,7 +93,6 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
     }
     const personRepository = new PostgresPersonRepository(postgres, personRepositoryOptions)
 
-    const clickhouseGroupRepository = new ClickhouseGroupRepository(kafkaProducer)
     const cookielessManager = new CookielessManager(serverConfig, cookielessRedisPool)
     const geoipService = new GeoIPService(serverConfig.MMDB_FILE_LOCATION)
     await geoipService.get()
@@ -117,7 +115,6 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
         groupTypeManager,
         teamManager,
         groupRepository,
-        clickhouseGroupRepository,
         personRepository,
         geoipService,
         encryptedFields,

--- a/nodejs/src/worker/ingestion/groups/batch-writing-group-store.test.ts
+++ b/nodejs/src/worker/ingestion/groups/batch-writing-group-store.test.ts
@@ -297,7 +297,10 @@ describe('BatchWritingGroupStore', () => {
         expect(groupRepository.updateGroup).toHaveBeenCalledTimes(0)
         expect(groupRepository.inTransaction).toHaveBeenCalledTimes(0)
         // No transaction calls expected since optimistic update failed
-        expect(emitIngestionWarning).toHaveBeenCalledTimes(1)
+        expect(emitIngestionWarning).toHaveBeenCalledWith(mockOutputs, teamId, 'group_upsert_message_size_too_large', {
+            groupTypeIndex: 1,
+            groupKey: 'test',
+        })
     })
 
     it('should retry on race condition error and clear cache', async () => {

--- a/nodejs/src/worker/ingestion/groups/batch-writing-group-store.test.ts
+++ b/nodejs/src/worker/ingestion/groups/batch-writing-group-store.test.ts
@@ -11,12 +11,13 @@ import { ClickhouseGroupRepository } from './repositories/clickhouse-group-repos
 import { GroupRepository } from './repositories/group-repository.interface'
 
 // Mock the module before importing
-jest.mock('../utils', () => ({
-    captureIngestionWarning: jest.fn().mockResolvedValue(undefined),
+jest.mock('../../../ingestion/common/ingestion-warnings', () => ({
+    emitIngestionWarning: jest.fn().mockResolvedValue(undefined),
 }))
 
-import { KafkaProducerWrapper } from '~/kafka/producer'
-import { captureIngestionWarning } from '../utils'
+import { GroupsOutput, IngestionWarningsOutput } from '../../../ingestion/common/outputs'
+import { emitIngestionWarning } from '../../../ingestion/common/ingestion-warnings'
+import { IngestionOutputs } from '../../../ingestion/outputs/ingestion-outputs'
 
 // Mock the DB class
 
@@ -27,6 +28,7 @@ describe('BatchWritingGroupStore', () => {
     let teamId: TeamId
     let projectId: ProjectId
     let group: Group
+    let mockOutputs: IngestionOutputs<GroupsOutput | IngestionWarningsOutput>
 
     beforeEach(() => {
         teamId = 1
@@ -105,11 +107,8 @@ describe('BatchWritingGroupStore', () => {
         clickhouseGroupRepository = {
             upsertGroup: jest.fn().mockResolvedValue(undefined),
         } as unknown as ClickhouseGroupRepository
-        groupStore = new BatchWritingGroupStore(
-            {} as unknown as KafkaProducerWrapper,
-            groupRepository,
-            clickhouseGroupRepository
-        )
+        mockOutputs = {} as unknown as IngestionOutputs<GroupsOutput | IngestionWarningsOutput>
+        groupStore = new BatchWritingGroupStore(mockOutputs, groupRepository, clickhouseGroupRepository)
     })
 
     afterEach(() => {
@@ -298,7 +297,7 @@ describe('BatchWritingGroupStore', () => {
         expect(groupRepository.updateGroup).toHaveBeenCalledTimes(0)
         expect(groupRepository.inTransaction).toHaveBeenCalledTimes(0)
         // No transaction calls expected since optimistic update failed
-        expect(captureIngestionWarning).toHaveBeenCalledTimes(1)
+        expect(emitIngestionWarning).toHaveBeenCalledTimes(1)
     })
 
     it('should retry on race condition error and clear cache', async () => {

--- a/nodejs/src/worker/ingestion/groups/batch-writing-group-store.ts
+++ b/nodejs/src/worker/ingestion/groups/batch-writing-group-store.ts
@@ -1,16 +1,17 @@
 import { DateTime } from 'luxon'
 import pLimit from 'p-limit'
 
-import { KafkaProducerWrapper } from '~/kafka/producer'
 import { Properties } from '~/plugin-scaffold'
 
+import { emitIngestionWarning } from '../../../ingestion/common/ingestion-warnings'
+import { GroupsOutput, IngestionWarningsOutput } from '../../../ingestion/common/outputs'
+import { IngestionOutputs } from '../../../ingestion/outputs/ingestion-outputs'
 import { GroupTypeIndex, TeamId } from '../../../types'
 import { MessageSizeTooLarge } from '../../../utils/db/error'
 import { logger } from '../../../utils/logger'
 import { promiseRetry } from '../../../utils/retries'
 import { RaceConditionError } from '../../../utils/utils'
 import { FlushResult } from '../persons/persons-store'
-import { captureIngestionWarning } from '../utils'
 import { logMissingRow, logVersionMismatch } from './group-logging'
 import { CacheMetrics, GroupStore } from './group-store.interface'
 import { GroupUpdate, calculateUpdate, fromGroup } from './group-update'
@@ -135,12 +136,12 @@ export class BatchWritingGroupStore implements GroupStore {
     private groupCache: GroupCache
     private databaseOperationCounts: Map<string, number>
     private options: BatchWritingGroupStoreOptions
-    private kafkaProducer: KafkaProducerWrapper
+    private outputs: IngestionOutputs<GroupsOutput | IngestionWarningsOutput>
     private groupRepository: GroupRepository
     private clickhouseGroupRepository: ClickhouseGroupRepository
 
     constructor(
-        kafkaProducer: KafkaProducerWrapper,
+        outputs: IngestionOutputs<GroupsOutput | IngestionWarningsOutput>,
         groupRepository: GroupRepository,
         clickhouseGroupRepository: ClickhouseGroupRepository,
         options?: Partial<BatchWritingGroupStoreOptions>
@@ -148,7 +149,7 @@ export class BatchWritingGroupStore implements GroupStore {
         this.options = { ...DEFAULT_OPTIONS, ...options }
         this.groupCache = new GroupCache()
         this.databaseOperationCounts = new Map()
-        this.kafkaProducer = kafkaProducer
+        this.outputs = outputs
         this.groupRepository = groupRepository
         this.clickhouseGroupRepository = clickhouseGroupRepository
     }
@@ -204,7 +205,7 @@ export class BatchWritingGroupStore implements GroupStore {
         distinctId: string
     ): Promise<void> {
         if (error instanceof MessageSizeTooLarge) {
-            await captureIngestionWarning(this.kafkaProducer, update.team_id, 'group_upsert_message_size_too_large', {
+            await emitIngestionWarning(this.outputs, update.team_id, 'group_upsert_message_size_too_large', {
                 groupTypeIndex: update.group_type_index,
                 groupKey: update.group_key,
             })
@@ -556,7 +557,7 @@ export class BatchWritingGroupStore implements GroupStore {
         timestamp: DateTime
     ): Promise<void> {
         if (error instanceof MessageSizeTooLarge) {
-            await captureIngestionWarning(this.kafkaProducer, teamId, 'group_upsert_message_size_too_large', {
+            await emitIngestionWarning(this.outputs, teamId, 'group_upsert_message_size_too_large', {
                 groupTypeIndex,
                 groupKey,
             })

--- a/nodejs/src/worker/ingestion/groups/repositories/clickhouse-group-repository.test.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/clickhouse-group-repository.test.ts
@@ -1,22 +1,25 @@
 import { DateTime } from 'luxon'
 
-import { KAFKA_GROUPS } from '~/config/kafka-topics'
+import { GROUPS_OUTPUT, GroupsOutput } from '~/ingestion/common/outputs'
+import { IngestionOutputs } from '~/ingestion/outputs/ingestion-outputs'
 
 import { GroupTypeIndex, TeamId } from '../../../../types'
 import { ClickhouseGroupRepository } from './clickhouse-group-repository'
 
 describe('ClickhouseGroupRepository', () => {
-    let kafkaProducer: any
+    let mockQueueMessages: jest.Mock
+    let outputs: IngestionOutputs<GroupsOutput>
     let repository: ClickhouseGroupRepository
 
     beforeEach(() => {
-        kafkaProducer = {
-            queueMessages: jest.fn().mockResolvedValue(undefined),
-        }
-        repository = new ClickhouseGroupRepository(kafkaProducer)
+        mockQueueMessages = jest.fn().mockResolvedValue(undefined)
+        outputs = {
+            queueMessages: mockQueueMessages,
+        } as unknown as IngestionOutputs<GroupsOutput>
+        repository = new ClickhouseGroupRepository(outputs)
     })
 
-    it('should upsert group to ClickHouse via Kafka', async () => {
+    it('should upsert group to ClickHouse via outputs', async () => {
         const teamId = 1 as TeamId
         const groupTypeIndex = 0 as GroupTypeIndex
         const groupKey = 'test-group'
@@ -26,20 +29,19 @@ describe('ClickhouseGroupRepository', () => {
 
         await repository.upsertGroup(teamId, groupTypeIndex, groupKey, properties, createdAt, version)
 
-        expect(kafkaProducer.queueMessages).toHaveBeenCalledWith({
-            topic: KAFKA_GROUPS,
-            messages: [
-                {
-                    value: JSON.stringify({
+        expect(mockQueueMessages).toHaveBeenCalledWith(GROUPS_OUTPUT, [
+            {
+                value: Buffer.from(
+                    JSON.stringify({
                         group_type_index: groupTypeIndex,
                         group_key: groupKey,
                         team_id: teamId,
                         group_properties: JSON.stringify(properties),
                         created_at: createdAt.toFormat('yyyy-MM-dd HH:mm:ss'),
                         version,
-                    }),
-                },
-            ],
-        })
+                    })
+                ),
+            },
+        ])
     })
 })

--- a/nodejs/src/worker/ingestion/groups/repositories/clickhouse-group-repository.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/clickhouse-group-repository.ts
@@ -2,13 +2,13 @@ import { DateTime } from 'luxon'
 
 import { Properties } from '~/plugin-scaffold'
 
-import { KAFKA_GROUPS } from '../../../../config/kafka-topics'
-import { KafkaProducerWrapper } from '../../../../kafka/producer'
+import { GROUPS_OUTPUT, GroupsOutput } from '../../../../ingestion/common/outputs'
+import { IngestionOutputs } from '../../../../ingestion/outputs/ingestion-outputs'
 import { GroupTypeIndex, TeamId, TimestampFormat } from '../../../../types'
 import { castTimestampOrNow } from '../../../../utils/utils'
 
 export class ClickhouseGroupRepository {
-    constructor(private kafkaProducer: KafkaProducerWrapper) {}
+    constructor(private outputs: IngestionOutputs<GroupsOutput>) {}
 
     public async upsertGroup(
         teamId: TeamId,
@@ -18,20 +18,19 @@ export class ClickhouseGroupRepository {
         createdAt: DateTime,
         version: number
     ): Promise<void> {
-        await this.kafkaProducer.queueMessages({
-            topic: KAFKA_GROUPS,
-            messages: [
-                {
-                    value: JSON.stringify({
+        await this.outputs.queueMessages(GROUPS_OUTPUT, [
+            {
+                value: Buffer.from(
+                    JSON.stringify({
                         group_type_index: groupTypeIndex,
                         group_key: groupKey,
                         team_id: teamId,
                         group_properties: JSON.stringify(properties),
                         created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouseSecondPrecision),
                         version,
-                    }),
-                },
-            ],
-        })
+                    })
+                ),
+            },
+        ])
     }
 }

--- a/nodejs/tests/helpers/ingestion-outputs.ts
+++ b/nodejs/tests/helpers/ingestion-outputs.ts
@@ -5,10 +5,16 @@ import {
     KAFKA_EVENTS_PLUGIN_INGESTION_ASYNC,
     KAFKA_EVENTS_PLUGIN_INGESTION_DLQ,
     KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW,
+    KAFKA_GROUPS,
     KAFKA_INGESTION_WARNINGS,
 } from '../../src/config/kafka-topics'
 import { AI_EVENTS_OUTPUT, ASYNC_OUTPUT, EVENTS_OUTPUT, HEATMAPS_OUTPUT } from '../../src/ingestion/analytics/outputs'
-import { DLQ_OUTPUT, INGESTION_WARNINGS_OUTPUT, OVERFLOW_OUTPUT } from '../../src/ingestion/common/outputs'
+import {
+    DLQ_OUTPUT,
+    GROUPS_OUTPUT,
+    INGESTION_WARNINGS_OUTPUT,
+    OVERFLOW_OUTPUT,
+} from '../../src/ingestion/common/outputs'
 import { IngestionOutputs } from '../../src/ingestion/outputs/ingestion-outputs'
 import { KafkaProducerWrapper } from '../../src/kafka/producer'
 
@@ -21,5 +27,6 @@ export function createTestIngestionOutputs(kafkaProducer: KafkaProducerWrapper) 
         [DLQ_OUTPUT]: { topic: KAFKA_EVENTS_PLUGIN_INGESTION_DLQ, producer: kafkaProducer },
         [OVERFLOW_OUTPUT]: { topic: KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW, producer: kafkaProducer },
         [ASYNC_OUTPUT]: { topic: KAFKA_EVENTS_PLUGIN_INGESTION_ASYNC, producer: kafkaProducer },
+        [GROUPS_OUTPUT]: { topic: KAFKA_GROUPS, producer: kafkaProducer },
     })
 }


### PR DESCRIPTION
## Problem

We want to rely on outputs abstraction for handling kafka messages produced for Group processing

## Changes

- Add an output for groups
- Reshuffle some code on server.ts so we can initialize the ClickhouseGroupRepository with the already initialized IngestionOutputs

## How did you test this code?

All unit/integration tests pass

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
