### PR TITLE
feat(add-to-dashboard): show pinned,my dashboards first when adding insights to dashboard

### DIFF
--- a/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
+++ b/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { CSSProperties, useEffect } from 'react'
 import { List, useListRef } from 'react-window'
 
-import { IconHome } from '@posthog/icons'
+import { IconHome, IconPinFilled, IconUser } from '@posthog/icons'
 
 import { addToDashboardModalLogic } from 'lib/components/AddToDashboard/addToDashboardModalLogic'
 import { AutoSizer } from 'lib/components/AutoSizer'
@@ -24,6 +24,7 @@ interface DashboardRelationRowProps {
     canEditInsight: boolean
     isHighlighted: boolean
     isAlreadyOnDashboard: boolean
+    currentUserUuid: string | null
     style: CSSProperties
 }
 
@@ -34,12 +35,14 @@ const DashboardRelationRow = ({
     dashboard,
     insightProps,
     canEditInsight,
+    currentUserUuid,
 }: DashboardRelationRowProps): JSX.Element => {
     const { addToDashboard, removeFromDashboard } = useActions(addToDashboardModalLogic(insightProps))
     const { dashboardWithActiveAPICall } = useValues(addToDashboardModalLogic(insightProps))
 
     const { currentTeam } = useValues(teamLogic)
     const isPrimary = dashboard.id === currentTeam?.primary_dashboard
+    const isMine = Boolean(currentUserUuid && dashboard.created_by?.uuid === currentUserUuid)
     return (
         <div
             data-attr="dashboard-list-item"
@@ -54,6 +57,20 @@ const DashboardRelationRow = ({
             >
                 {dashboard.name || 'Untitled'}
             </Link>
+            {dashboard.pinned && (
+                <Tooltip title="Pinned dashboard">
+                    <span className="flex shrink-0 items-center">
+                        <IconPinFilled className="text-secondary text-base" />
+                    </span>
+                </Tooltip>
+            )}
+            {isMine && (
+                <Tooltip title="Your dashboard">
+                    <span className="flex shrink-0 items-center">
+                        <IconUser className="text-secondary text-base" />
+                    </span>
+                </Tooltip>
+            )}
             {isPrimary && (
                 <Tooltip title="Primary dashboards are shown on the project home page">
                     <span className="flex items-center">
@@ -91,6 +108,7 @@ interface DashboardRowProps {
     insightProps: InsightLogicProps
     canEditInsight: boolean
     scrollIndex: number
+    currentUserUuid: string | null
 }
 
 const DashboardRow = ({
@@ -101,6 +119,7 @@ const DashboardRow = ({
     insightProps,
     canEditInsight,
     scrollIndex,
+    currentUserUuid,
 }: {
     ariaAttributes: Record<string, unknown>
     index: number
@@ -115,6 +134,7 @@ const DashboardRow = ({
             isAlreadyOnDashboard={currentDashboards.some(
                 (currentDashboard) => currentDashboard.id === orderedDashboards[index].id
             )}
+            currentUserUuid={currentUserUuid}
             style={style}
         />
     )
@@ -137,7 +157,7 @@ export function AddToDashboardModal({
 }: SaveToDashboardModalProps): JSX.Element {
     const logic = addToDashboardModalLogic(insightProps)
 
-    const { searchQuery, currentDashboards, orderedDashboards, scrollIndex } = useValues(logic)
+    const { searchQuery, currentDashboards, orderedDashboards, scrollIndex, user } = useValues(logic)
     const { setSearchQuery, addNewDashboard } = useActions(logic)
     const listRef = useListRef(null)
 
@@ -153,6 +173,7 @@ export function AddToDashboardModal({
         insightProps,
         canEditInsight,
         scrollIndex,
+        currentUserUuid: user?.uuid ?? null,
     }
 
     return (

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
@@ -133,7 +133,7 @@ describe('addToDashboardModalLogic', () => {
             })
     })
 
-    it('orders dashboards: on insight first, then pinned, then mine, then the rest', async () => {
+    it('orders dashboards: on insight first, then mine, then others pinned, then the rest', async () => {
         const insightOnlyOnDash2: QueryBasedInsightModel = {
             ...MOCK_INSIGHT,
             dashboards: [2],
@@ -179,8 +179,8 @@ describe('addToDashboardModalLogic', () => {
         await expectLogic(logic).toMatchValues({
             orderedDashboards: [
                 expect.objectContaining({ id: 2 }),
-                expect.objectContaining({ id: 1 }),
                 expect.objectContaining({ id: 3 }),
+                expect.objectContaining({ id: 1 }),
                 expect.objectContaining({ id: 4 }),
             ],
         })

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
@@ -11,6 +11,7 @@ import { queryFromFilters } from '~/queries/nodes/InsightViz/utils'
 import { initKeaTests } from '~/test/init'
 import {
     AccessControlLevel,
+    AppContext,
     DashboardBasicType,
     DashboardType,
     InsightShortId,
@@ -99,6 +100,8 @@ describe('addToDashboardModalLogic', () => {
 
     afterEach(() => {
         logic?.unmount()
+        // Tests may set `current_user: null`; clear so the next test gets a fresh `initKeaTests` bootstrap.
+        delete window.POSTHOG_APP_CONTEXT
     })
 
     it('addNewDashboard sets redirectAfterCreation to false on newDashboardLogic', async () => {
@@ -182,6 +185,111 @@ describe('addToDashboardModalLogic', () => {
                 expect.objectContaining({ id: 3 }),
                 expect.objectContaining({ id: 1 }),
                 expect.objectContaining({ id: 4 }),
+            ],
+        })
+    })
+
+    it('when user is not loaded, dashboards with no creator are not grouped as mine', async () => {
+        window.POSTHOG_APP_CONTEXT = { current_user: null } as unknown as AppContext
+        const insightOnlyOnDash2: QueryBasedInsightModel = {
+            ...MOCK_INSIGHT,
+            dashboards: [2],
+            dashboard_tiles: [{ dashboard_id: 2 }] as any,
+        }
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/': {
+                    results: [insightOnlyOnDash2],
+                },
+                '/api/environments/:team_id/dashboards/': {
+                    results: [
+                        mkDashboard(2, 'Current', false, MOCK_USER_UUID),
+                        mkDashboard(1, 'No creator', false, null),
+                        mkDashboard(3, 'Other', false, OTHER_USER_UUID),
+                    ],
+                },
+            },
+            patch: {
+                '/api/environments/:team_id/insights/:id': async (req) => {
+                    const payload = await req.json()
+                    return [200, { ...insightOnlyOnDash2, ...payload }]
+                },
+            },
+        })
+        initKeaTests()
+
+        const dashboards = dashboardsModel()
+        dashboards.mount()
+        await expectLogic(dashboards, () => {
+            dashboards.actions.loadDashboards()
+        }).toFinishAllListeners()
+
+        const insightProps = { dashboardItemId: Insight1 }
+        const insightLog = insightLogic(insightProps)
+        insightLog.mount()
+        insightLog.actions.loadInsightSuccess(insightOnlyOnDash2)
+
+        logic = addToDashboardModalLogic(insightProps)
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            orderedDashboards: [
+                expect.objectContaining({ id: 2 }),
+                expect.objectContaining({ id: 1 }),
+                expect.objectContaining({ id: 3 }),
+            ],
+        })
+    })
+
+    it('places mine pinned in the mine bucket before others pinned', async () => {
+        const insightOnlyOnDash2: QueryBasedInsightModel = {
+            ...MOCK_INSIGHT,
+            dashboards: [2],
+            dashboard_tiles: [{ dashboard_id: 2 }] as any,
+        }
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/': {
+                    results: [insightOnlyOnDash2],
+                },
+                '/api/environments/:team_id/dashboards/': {
+                    results: [
+                        mkDashboard(2, 'Current', false, MOCK_USER_UUID),
+                        mkDashboard(3, 'Unpinned mine', false, MOCK_USER_UUID),
+                        mkDashboard(4, 'Pinned mine', true, MOCK_USER_UUID),
+                        mkDashboard(5, 'Other pinned', true, OTHER_USER_UUID),
+                    ],
+                },
+            },
+            patch: {
+                '/api/environments/:team_id/insights/:id': async (req) => {
+                    const payload = await req.json()
+                    return [200, { ...insightOnlyOnDash2, ...payload }]
+                },
+            },
+        })
+        initKeaTests()
+
+        const dashboards = dashboardsModel()
+        dashboards.mount()
+        await expectLogic(dashboards, () => {
+            dashboards.actions.loadDashboards()
+        }).toFinishAllListeners()
+
+        const insightProps = { dashboardItemId: Insight1 }
+        const insightLog = insightLogic(insightProps)
+        insightLog.mount()
+        insightLog.actions.loadInsightSuccess(insightOnlyOnDash2)
+
+        logic = addToDashboardModalLogic(insightProps)
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            orderedDashboards: [
+                expect.objectContaining({ id: 2 }),
+                expect.objectContaining({ id: 4 }),
+                expect.objectContaining({ id: 3 }),
+                expect.objectContaining({ id: 5 }),
             ],
         })
     })

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.test.ts
@@ -1,12 +1,23 @@
+import { MOCK_USER_UUID } from 'lib/api.mock'
+
 import { expectLogic } from 'kea-test-utils'
 
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { queryFromFilters } from '~/queries/nodes/InsightViz/utils'
 import { initKeaTests } from '~/test/init'
-import { AccessControlLevel, DashboardType, InsightShortId, InsightType, QueryBasedInsightModel } from '~/types'
+import {
+    AccessControlLevel,
+    DashboardBasicType,
+    DashboardType,
+    InsightShortId,
+    InsightType,
+    QueryBasedInsightModel,
+    UserBasicType,
+} from '~/types'
 
 import { addToDashboardModalLogic } from './addToDashboardModalLogic'
 
@@ -40,6 +51,28 @@ const MOCK_INSIGHT: QueryBasedInsightModel = {
     color: null,
     user_access_level: AccessControlLevel.Editor,
 } as QueryBasedInsightModel
+
+const OTHER_USER_UUID = 'other-user-uuid'
+
+const mkDashboard = (
+    id: number,
+    name: string,
+    pinned: boolean,
+    createdByUuid: string | null = null
+): DashboardBasicType => ({
+    id,
+    name,
+    description: '',
+    pinned,
+    created_at: '2021-01-01T00:00:00.000Z',
+    created_by: createdByUuid ? ({ uuid: createdByUuid } as UserBasicType) : null,
+    last_accessed_at: null,
+    last_viewed_at: null,
+    is_shared: false,
+    deleted: false,
+    creation_mode: 'default',
+    user_access_level: AccessControlLevel.Editor,
+})
 
 describe('addToDashboardModalLogic', () => {
     let logic: ReturnType<typeof addToDashboardModalLogic.build>
@@ -98,5 +131,58 @@ describe('addToDashboardModalLogic', () => {
             .toMatchValues({
                 _dashboardToNavigateTo: 99,
             })
+    })
+
+    it('orders dashboards: on insight first, then pinned, then mine, then the rest', async () => {
+        const insightOnlyOnDash2: QueryBasedInsightModel = {
+            ...MOCK_INSIGHT,
+            dashboards: [2],
+            dashboard_tiles: [{ dashboard_id: 2 }] as any,
+        }
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/': {
+                    results: [insightOnlyOnDash2],
+                },
+                '/api/environments/:team_id/dashboards/': {
+                    results: [
+                        mkDashboard(1, 'Pinned other', true, OTHER_USER_UUID),
+                        mkDashboard(2, 'Current mine', false, MOCK_USER_UUID),
+                        mkDashboard(3, 'Mine unpinned', false, MOCK_USER_UUID),
+                        mkDashboard(4, 'Other unpinned', false, OTHER_USER_UUID),
+                    ],
+                },
+            },
+            patch: {
+                '/api/environments/:team_id/insights/:id': async (req) => {
+                    const payload = await req.json()
+                    return [200, { ...insightOnlyOnDash2, ...payload }]
+                },
+            },
+        })
+        initKeaTests()
+
+        const dashboards = dashboardsModel()
+        dashboards.mount()
+        await expectLogic(dashboards, () => {
+            dashboards.actions.loadDashboards()
+        }).toFinishAllListeners()
+
+        const insightProps = { dashboardItemId: Insight1 }
+        const insightLog = insightLogic(insightProps)
+        insightLog.mount()
+        insightLog.actions.loadInsightSuccess(insightOnlyOnDash2)
+
+        logic = addToDashboardModalLogic(insightProps)
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            orderedDashboards: [
+                expect.objectContaining({ id: 2 }),
+                expect.objectContaining({ id: 1 }),
+                expect.objectContaining({ id: 3 }),
+                expect.objectContaining({ id: 4 }),
+            ],
+        })
     })
 })

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -8,8 +8,9 @@ import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
-import { dashboardsModel } from '~/models/dashboardsModel'
+import { dashboardsModel, nameCompareFunction } from '~/models/dashboardsModel'
 import { DashboardBasicType, DashboardType, InsightLogicProps } from '~/types'
 
 import type { addToDashboardModalLogicType } from './addToDashboardModalLogicType'
@@ -22,7 +23,7 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
     key(keyForInsightLogicProps('new')),
     path((key) => ['lib', 'components', 'AddToDashboard', 'saveToDashboardModalLogic', key]),
     connect((props: InsightLogicProps) => ({
-        values: [insightLogic(props), ['insight']],
+        values: [insightLogic(props), ['insight'], userLogic, ['user']],
         actions: [
             insightLogic(props),
             ['updateInsight', 'updateInsightSuccess', 'updateInsightFailure'],
@@ -87,11 +88,19 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
                 filteredDashboards.filter((d) => !currentDashboards?.map((cd) => cd.id).includes(d.id)),
         ],
         orderedDashboards: [
-            (s) => [s.currentDashboards, s.availableDashboards],
-            (currentDashboards, availableDashboards): DashboardBasicType[] => [
-                ...currentDashboards,
-                ...availableDashboards,
-            ],
+            (s) => [s.currentDashboards, s.availableDashboards, userLogic.selectors.user],
+            (currentDashboards, availableDashboards, user): DashboardBasicType[] => {
+                const myUuid = user?.uuid
+                const currentSorted = [...currentDashboards].sort(nameCompareFunction)
+                const pinnedAvailable = availableDashboards.filter((d) => d.pinned).sort(nameCompareFunction)
+                const myUnpinnedAvailable = availableDashboards
+                    .filter((d) => !d.pinned && d.created_by?.uuid === myUuid)
+                    .sort(nameCompareFunction)
+                const restAvailable = availableDashboards
+                    .filter((d) => !d.pinned && d.created_by?.uuid !== myUuid)
+                    .sort(nameCompareFunction)
+                return [...currentSorted, ...pinnedAvailable, ...myUnpinnedAvailable, ...restAvailable]
+            },
         ],
     }),
     listeners(({ actions, values }) => ({

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -92,14 +92,15 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
             (currentDashboards, availableDashboards, user): DashboardBasicType[] => {
                 const myUuid = user?.uuid
                 const currentSorted = [...currentDashboards].sort(nameCompareFunction)
-                const pinnedAvailable = availableDashboards.filter((d) => d.pinned).sort(nameCompareFunction)
-                const myUnpinnedAvailable = availableDashboards
-                    .filter((d) => !d.pinned && d.created_by?.uuid === myUuid)
+                const isMine = (d: DashboardBasicType): boolean => Boolean(myUuid && d.created_by?.uuid === myUuid)
+                const mineAvailable = availableDashboards.filter(isMine).sort(nameCompareFunction)
+                const othersPinnedAvailable = availableDashboards
+                    .filter((d) => d.pinned && !isMine(d))
                     .sort(nameCompareFunction)
-                const restAvailable = availableDashboards
-                    .filter((d) => !d.pinned && d.created_by?.uuid !== myUuid)
+                const othersUnpinnedAvailable = availableDashboards
+                    .filter((d) => !d.pinned && !isMine(d))
                     .sort(nameCompareFunction)
-                return [...currentSorted, ...pinnedAvailable, ...myUnpinnedAvailable, ...restAvailable]
+                return [...currentSorted, ...mineAvailable, ...othersPinnedAvailable, ...othersUnpinnedAvailable]
             },
         ],
     }),

--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -90,9 +90,9 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
         orderedDashboards: [
             (s) => [s.currentDashboards, s.availableDashboards, userLogic.selectors.user],
             (currentDashboards, availableDashboards, user): DashboardBasicType[] => {
-                const myUuid = user?.uuid
+                const myUuid = user?.uuid ?? null
                 const currentSorted = [...currentDashboards].sort(nameCompareFunction)
-                const isMine = (d: DashboardBasicType): boolean => Boolean(myUuid && d.created_by?.uuid === myUuid)
+                const isMine = (d: DashboardBasicType): boolean => myUuid !== null && d.created_by?.uuid === myUuid
                 const mineAvailable = availableDashboards.filter(isMine).sort(nameCompareFunction)
                 const othersPinnedAvailable = availableDashboards
                     .filter((d) => d.pinned && !isMine(d))


### PR DESCRIPTION
## Problem

When we're adding an insight to a dashboard from the insights page, we should all the dashboards you can add it to, with the dashboards it already belongs to first, and then the rest alphabetically.

Most people dont need to add it to all the dashboards, but the ones they operate on the most often. 

## Changes

We show in this order now:

- dashboard its already on
- dashboards you created
- your pinned dashboards
- the rest


<img width="1792" height="1404" alt="CleanShot 2026-03-26 at 11 21 25@2x" src="https://github.com/user-attachments/assets/8725dd8d-11db-40a4-8a4b-fcf6693a2e8e" />


## How did you test this code?

Locally.
## Publish to changelog?

No.