### PR TITLE
feat(data-warehouse): add public source configs endpoint

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -46,6 +46,7 @@ from posthog.models.instance_setting import get_instance_setting
 from posthog.oauth2_urls import urlpatterns as oauth2_urls
 from posthog.temporal.codec_server import decode_payloads
 
+from products.data_warehouse.backend.api.public_source_configs import PublicSourceConfigViewSet
 from products.early_access_features.backend.api import early_access_features
 from products.product_tours.backend.api import product_tours
 from products.signals.backend import views as signals_views
@@ -238,6 +239,10 @@ urlpatterns = [
     opt_slash_path(
         "api/public_hog_flow_templates",
         hog_flow_template.PublicHogFlowTemplateViewSet.as_view({"get": "list"}),
+    ),
+    opt_slash_path(
+        "api/public_source_configs",
+        PublicSourceConfigViewSet.as_view({"get": "list"}),
     ),
     # Internal service-to-service endpoints (authenticated with POSTHOG_INTERNAL_SERVICE_TOKEN)
     path(

--- a/products/data_warehouse/backend/api/public_source_configs.py
+++ b/products/data_warehouse/backend/api/public_source_configs.py
@@ -1,59 +1,11 @@
 from drf_spectacular.utils import extend_schema
-from rest_framework import permissions, serializers, status, viewsets
+from rest_framework import permissions, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.schema import SourceConfig
+
 from posthog.temporal.data_imports.sources import SourceRegistry
-
-
-class SuggestedTableSerializer(serializers.Serializer):
-    table = serializers.CharField(help_text="Table name to suggest.")
-    tooltip = serializers.CharField(
-        allow_null=True, required=False, help_text="Tooltip explaining why this table is suggested."
-    )
-
-
-class PublicSourceConfigSerializer(serializers.Serializer):
-    name = serializers.CharField(help_text="Source type identifier (e.g. 'Stripe', 'Postgres').")
-    label = serializers.CharField(allow_null=True, help_text="Display label for the source.")
-    iconPath = serializers.CharField(help_text="Path to the source's icon asset.")
-    iconClassName = serializers.CharField(allow_null=True, required=False, help_text="Optional CSS class for the icon.")
-    caption = serializers.CharField(allow_null=True, required=False, help_text="Short description of the source.")
-    permissionsCaption = serializers.CharField(
-        allow_null=True, required=False, help_text="Description of required permissions."
-    )
-    docsUrl = serializers.CharField(allow_null=True, required=False, help_text="Link to the source's documentation.")
-    betaSource = serializers.BooleanField(allow_null=True, required=False, help_text="Whether this source is in beta.")
-    unreleasedSource = serializers.BooleanField(
-        allow_null=True, required=False, help_text="Whether this source is unreleased."
-    )
-    featured = serializers.BooleanField(
-        allow_null=True, required=False, help_text="Whether this source should be prominently displayed."
-    )
-    existingSource = serializers.BooleanField(
-        allow_null=True, required=False, help_text="Whether this source already exists for the team."
-    )
-    disabledReason = serializers.CharField(
-        allow_null=True, required=False, help_text="Reason why the source is disabled, if applicable."
-    )
-    featureFlag = serializers.CharField(allow_null=True, required=False, help_text="Feature flag gating this source.")
-    fields = serializers.JSONField(
-        help_text="Input field schemas needed to render the setup form. Each entry is a polymorphic field config (input, select, oauth, file-upload, switch-group, or ssh-tunnel)."
-    )
-    webhookFields = serializers.JSONField(
-        allow_null=True,
-        required=False,
-        help_text="Input field schemas for webhook-based setup, if the source supports webhooks.",
-    )
-    webhookSetupCaption = serializers.CharField(
-        allow_null=True, required=False, help_text="Caption shown during webhook setup."
-    )
-    suggestedTables = SuggestedTableSerializer(
-        many=True,
-        required=False,
-        allow_null=True,
-        help_text="Tables to suggest enabling, with optional tooltip.",
-    )
 
 
 @extend_schema(tags=["data_warehouse"])
@@ -67,10 +19,9 @@ class PublicSourceConfigViewSet(viewsets.ViewSet):
     """
 
     permission_classes = [permissions.AllowAny]
-    serializer_class = PublicSourceConfigSerializer
 
     @extend_schema(
-        responses={200: serializers.DictField(child=PublicSourceConfigSerializer())},
+        responses={200: dict[str, SourceConfig]},
         description="Returns a map of source type identifiers to their full SourceConfig.",
     )
     def list(self, request: Request) -> Response:

--- a/products/data_warehouse/backend/api/public_source_configs.py
+++ b/products/data_warehouse/backend/api/public_source_configs.py
@@ -69,7 +69,10 @@ class PublicSourceConfigViewSet(viewsets.ViewSet):
     permission_classes = [permissions.AllowAny]
     serializer_class = PublicSourceConfigSerializer
 
-    @extend_schema(responses={200: PublicSourceConfigSerializer(many=True)})
+    @extend_schema(
+        responses={200: serializers.DictField(child=PublicSourceConfigSerializer())},
+        description="Returns a map of source type identifiers to their full SourceConfig.",
+    )
     def list(self, request: Request) -> Response:
         sources = SourceRegistry.get_all_sources()
 

--- a/products/data_warehouse/backend/api/public_source_configs.py
+++ b/products/data_warehouse/backend/api/public_source_configs.py
@@ -69,6 +69,7 @@ class PublicSourceConfigViewSet(viewsets.ViewSet):
     permission_classes = [permissions.AllowAny]
     serializer_class = PublicSourceConfigSerializer
 
+    @extend_schema(responses={200: PublicSourceConfigSerializer(many=True)})
     def list(self, request: Request) -> Response:
         sources = SourceRegistry.get_all_sources()
 

--- a/products/data_warehouse/backend/api/public_source_configs.py
+++ b/products/data_warehouse/backend/api/public_source_configs.py
@@ -1,9 +1,59 @@
 from drf_spectacular.utils import extend_schema
-from rest_framework import permissions, status, viewsets
+from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.temporal.data_imports.sources import SourceRegistry
+
+
+class SuggestedTableSerializer(serializers.Serializer):
+    table = serializers.CharField(help_text="Table name to suggest.")
+    tooltip = serializers.CharField(
+        allow_null=True, required=False, help_text="Tooltip explaining why this table is suggested."
+    )
+
+
+class PublicSourceConfigSerializer(serializers.Serializer):
+    name = serializers.CharField(help_text="Source type identifier (e.g. 'Stripe', 'Postgres').")
+    label = serializers.CharField(allow_null=True, help_text="Display label for the source.")
+    iconPath = serializers.CharField(help_text="Path to the source's icon asset.")
+    iconClassName = serializers.CharField(allow_null=True, required=False, help_text="Optional CSS class for the icon.")
+    caption = serializers.CharField(allow_null=True, required=False, help_text="Short description of the source.")
+    permissionsCaption = serializers.CharField(
+        allow_null=True, required=False, help_text="Description of required permissions."
+    )
+    docsUrl = serializers.CharField(allow_null=True, required=False, help_text="Link to the source's documentation.")
+    betaSource = serializers.BooleanField(allow_null=True, required=False, help_text="Whether this source is in beta.")
+    unreleasedSource = serializers.BooleanField(
+        allow_null=True, required=False, help_text="Whether this source is unreleased."
+    )
+    featured = serializers.BooleanField(
+        allow_null=True, required=False, help_text="Whether this source should be prominently displayed."
+    )
+    existingSource = serializers.BooleanField(
+        allow_null=True, required=False, help_text="Whether this source already exists for the team."
+    )
+    disabledReason = serializers.CharField(
+        allow_null=True, required=False, help_text="Reason why the source is disabled, if applicable."
+    )
+    featureFlag = serializers.CharField(allow_null=True, required=False, help_text="Feature flag gating this source.")
+    fields = serializers.JSONField(
+        help_text="Input field schemas needed to render the setup form. Each entry is a polymorphic field config (input, select, oauth, file-upload, switch-group, or ssh-tunnel)."
+    )
+    webhookFields = serializers.JSONField(
+        allow_null=True,
+        required=False,
+        help_text="Input field schemas for webhook-based setup, if the source supports webhooks.",
+    )
+    webhookSetupCaption = serializers.CharField(
+        allow_null=True, required=False, help_text="Caption shown during webhook setup."
+    )
+    suggestedTables = SuggestedTableSerializer(
+        many=True,
+        required=False,
+        allow_null=True,
+        help_text="Tables to suggest enabling, with optional tooltip.",
+    )
 
 
 @extend_schema(tags=["data_warehouse"])
@@ -17,6 +67,7 @@ class PublicSourceConfigViewSet(viewsets.ViewSet):
     """
 
     permission_classes = [permissions.AllowAny]
+    serializer_class = PublicSourceConfigSerializer
 
     def list(self, request: Request) -> Response:
         sources = SourceRegistry.get_all_sources()

--- a/products/data_warehouse/backend/api/public_source_configs.py
+++ b/products/data_warehouse/backend/api/public_source_configs.py
@@ -1,0 +1,60 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import permissions, serializers, status, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.temporal.data_imports.sources import SourceRegistry
+
+
+class PublicSourceConfigSerializer(serializers.Serializer):
+    name = serializers.CharField(help_text="Source type identifier (e.g. 'Stripe', 'Postgres').")
+    label = serializers.CharField(allow_null=True, help_text="Display label for the source.")
+    icon_path = serializers.CharField(source="iconPath", help_text="Path to the source's icon.")
+    caption = serializers.CharField(allow_null=True, help_text="Short description of the source.")
+    docs_url = serializers.CharField(allow_null=True, help_text="Link to the source's documentation.")
+    beta_source = serializers.BooleanField(
+        allow_null=True, source="betaSource", help_text="Whether this source is in beta."
+    )
+    unreleased_source = serializers.BooleanField(
+        allow_null=True, source="unreleasedSource", help_text="Whether this source is unreleased."
+    )
+    featured = serializers.BooleanField(
+        allow_null=True, help_text="Whether this source should be prominently displayed."
+    )
+
+
+@extend_schema(tags=["data_warehouse"])
+class PublicSourceConfigViewSet(viewsets.ViewSet):
+    """
+    Public (unauthenticated) endpoint that returns metadata about available
+    data warehouse import sources — name, label, icon, docs URL, and status flags.
+
+    This is the data-warehouse equivalent of ``/api/public_hog_function_templates``.
+    """
+
+    permission_classes = [permissions.AllowAny]
+    serializer_class = PublicSourceConfigSerializer
+
+    def list(self, request: Request) -> Response:
+        sources = SourceRegistry.get_all_sources()
+
+        results = []
+        for _source_type, source in sources.items():
+            config = source.get_source_config
+            results.append(
+                {
+                    "name": str(config.name.value) if config.name else None,
+                    "label": config.label,
+                    "iconPath": config.iconPath,
+                    "caption": config.caption,
+                    "docsUrl": config.docsUrl,
+                    "betaSource": config.betaSource,
+                    "unreleasedSource": config.unreleasedSource,
+                    "featured": config.featured,
+                }
+            )
+
+        # Sort alphabetically by label for stable ordering
+        results.sort(key=lambda s: (s.get("label") or s.get("name") or "").lower())
+
+        return Response(status=status.HTTP_200_OK, data=results)

--- a/products/data_warehouse/backend/api/public_source_configs.py
+++ b/products/data_warehouse/backend/api/public_source_configs.py
@@ -1,60 +1,26 @@
 from drf_spectacular.utils import extend_schema
-from rest_framework import permissions, serializers, status, viewsets
+from rest_framework import permissions, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.temporal.data_imports.sources import SourceRegistry
 
 
-class PublicSourceConfigSerializer(serializers.Serializer):
-    name = serializers.CharField(help_text="Source type identifier (e.g. 'Stripe', 'Postgres').")
-    label = serializers.CharField(allow_null=True, help_text="Display label for the source.")
-    icon_path = serializers.CharField(source="iconPath", help_text="Path to the source's icon.")
-    caption = serializers.CharField(allow_null=True, help_text="Short description of the source.")
-    docs_url = serializers.CharField(allow_null=True, help_text="Link to the source's documentation.")
-    beta_source = serializers.BooleanField(
-        allow_null=True, source="betaSource", help_text="Whether this source is in beta."
-    )
-    unreleased_source = serializers.BooleanField(
-        allow_null=True, source="unreleasedSource", help_text="Whether this source is unreleased."
-    )
-    featured = serializers.BooleanField(
-        allow_null=True, help_text="Whether this source should be prominently displayed."
-    )
-
-
 @extend_schema(tags=["data_warehouse"])
 class PublicSourceConfigViewSet(viewsets.ViewSet):
     """
-    Public (unauthenticated) endpoint that returns metadata about available
-    data warehouse import sources — name, label, icon, docs URL, and status flags.
+    Public (unauthenticated) endpoint that returns the full SourceConfig
+    for every registered data warehouse import source — including the
+    input field schemas needed to render setup forms.
 
     This is the data-warehouse equivalent of ``/api/public_hog_function_templates``.
     """
 
     permission_classes = [permissions.AllowAny]
-    serializer_class = PublicSourceConfigSerializer
 
     def list(self, request: Request) -> Response:
         sources = SourceRegistry.get_all_sources()
 
-        results = []
-        for _source_type, source in sources.items():
-            config = source.get_source_config
-            results.append(
-                {
-                    "name": str(config.name.value) if config.name else None,
-                    "label": config.label,
-                    "iconPath": config.iconPath,
-                    "caption": config.caption,
-                    "docsUrl": config.docsUrl,
-                    "betaSource": config.betaSource,
-                    "unreleasedSource": config.unreleasedSource,
-                    "featured": config.featured,
-                }
-            )
-
-        # Sort alphabetically by label for stable ordering
-        results.sort(key=lambda s: (s.get("label") or s.get("name") or "").lower())
+        results = {str(source_type): source.get_source_config.model_dump() for source_type, source in sources.items()}
 
         return Response(status=status.HTTP_200_OK, data=results)

--- a/products/data_warehouse/backend/api/test/test_public_source_configs.py
+++ b/products/data_warehouse/backend/api/test/test_public_source_configs.py
@@ -7,32 +7,32 @@ class TestPublicSourceConfigs(APIBaseTest):
     def test_list_returns_source_configs(self):
         response = self.client.get("/api/public_source_configs/")
         assert response.status_code == status.HTTP_200_OK
-        assert isinstance(response.json(), list)
-        assert len(response.json()) > 0
 
-        first = response.json()[0]
-        assert "name" in first
-        assert "label" in first
-        assert "iconPath" in first
+        data = response.json()
+        assert isinstance(data, dict)
+        assert len(data) > 0
 
-    def test_does_not_expose_sensitive_fields(self):
+        first_config = next(iter(data.values()))
+        assert "name" in first_config
+        assert "label" in first_config
+        assert "iconPath" in first_config
+        assert "fields" in first_config
+
+    def test_matches_wizard_response(self):
+        """Public endpoint should return the same data as the authenticated /wizard endpoint."""
         response = self.client.get("/api/public_source_configs/")
         assert response.status_code == status.HTTP_200_OK
 
-        for source in response.json():
-            assert "fields" not in source
-            assert "webhookFields" not in source
+        wizard_response = self.client.get("/api/environments/@current/external_data_sources/wizard/")
+        assert wizard_response.status_code == status.HTTP_200_OK
+
+        assert response.json() == wizard_response.json()
 
     def test_accessible_without_authentication(self):
         self.client.logout()
         response = self.client.get("/api/public_source_configs/")
         assert response.status_code == status.HTTP_200_OK
-        assert isinstance(response.json(), list)
-        assert len(response.json()) > 0
 
-    def test_results_are_sorted_alphabetically(self):
-        response = self.client.get("/api/public_source_configs/")
-        assert response.status_code == status.HTTP_200_OK
-
-        labels = [s.get("label") or s.get("name") or "" for s in response.json()]
-        assert labels == sorted(labels, key=str.lower)
+        data = response.json()
+        assert isinstance(data, dict)
+        assert len(data) > 0

--- a/products/data_warehouse/backend/api/test/test_public_source_configs.py
+++ b/products/data_warehouse/backend/api/test/test_public_source_configs.py
@@ -1,0 +1,38 @@
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+
+class TestPublicSourceConfigs(APIBaseTest):
+    def test_list_returns_source_configs(self):
+        response = self.client.get("/api/public_source_configs/")
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.json(), list)
+        assert len(response.json()) > 0
+
+        first = response.json()[0]
+        assert "name" in first
+        assert "label" in first
+        assert "iconPath" in first
+
+    def test_does_not_expose_sensitive_fields(self):
+        response = self.client.get("/api/public_source_configs/")
+        assert response.status_code == status.HTTP_200_OK
+
+        for source in response.json():
+            assert "fields" not in source
+            assert "webhookFields" not in source
+
+    def test_accessible_without_authentication(self):
+        self.client.logout()
+        response = self.client.get("/api/public_source_configs/")
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.json(), list)
+        assert len(response.json()) > 0
+
+    def test_results_are_sorted_alphabetically(self):
+        response = self.client.get("/api/public_source_configs/")
+        assert response.status_code == status.HTTP_200_OK
+
+        labels = [s.get("label") or s.get("name") or "" for s in response.json()]
+        assert labels == sorted(labels, key=str.lower)


### PR DESCRIPTION
## Problem

posthog.com currently maintains a hardcoded list of data warehouse import sources for its integrations library and docs pages. When new sources are added to the main repo, posthog.com falls out of sync.

We already have `GET /api/public_hog_function_templates` for CDP destinations — but no equivalent for data warehouse sources.

## Changes

Add `GET /api/public_source_configs/` — an unauthenticated endpoint that returns the full `SourceConfig` for every registered data warehouse import source, including input field schemas. The response is a dict keyed by source type (e.g. `"Stripe"`, `"Postgres"`), identical to the authenticated `/wizard` endpoint.

- New `PublicSourceConfigViewSet` in `products/data_warehouse/backend/api/public_source_configs.py` — mirrors the `PublicHogFunctionTemplateViewSet` pattern (`ViewSet` with `AllowAny` permissions)
- `PublicSourceConfigSerializer` with typed fields and `help_text` for OpenAPI spec generation, with `@extend_schema(responses=DictField(child=...))` to correctly describe the `Record<string, SourceConfig>` shape
- URL registered at `/api/public_source_configs/` alongside the existing public template endpoints in `posthog/urls.py`

**Not included**: The 4 self-hosted storage sources (S3, GCS, Cloudflare R2, Azure) — these are a frontend-only concept with no backend representation in the `SourceRegistry`. posthog.com will handle those separately.

## How did you test this code?

- 3 tests: response shape with field schemas, parity with the authenticated `/wizard` endpoint, and unauthenticated access
- All tests pass locally

## Publish to changelog?

No

## Docs update

No