### PR TITLE
fix: Disable alerts with invalid calculation intervals

### DIFF
--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -12,7 +12,14 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from posthog.schema import AlertCondition, AlertState, DetectorConfig, InsightThreshold, TrendsAlertConfig
+from posthog.schema import (
+    AlertCalculationInterval,
+    AlertCondition,
+    AlertState,
+    DetectorConfig,
+    InsightThreshold,
+    TrendsAlertConfig,
+)
 
 from posthog.api.documentation import extend_schema_field
 from posthog.api.insight import InsightBasicSerializer
@@ -176,6 +183,7 @@ class AlertSerializer(serializers.ModelSerializer):
     calculation_interval = serializers.ChoiceField(
         choices=AlertConfiguration.CALCULATION_INTERVAL_CHOICES,
         required=False,
+        default=AlertCalculationInterval.DAILY,
         help_text="How often the alert is checked: hourly, daily, weekly, or monthly.",
     )
     snoozed_until = RelativeDateTimeField(
@@ -427,8 +435,13 @@ class AlertSerializer(serializers.ModelSerializer):
         elif self.instance and self.instance.threshold:
             threshold_config = self.instance.threshold.configuration
 
+        calculation_interval = attrs.get(
+            "calculation_interval",
+            self.instance.calculation_interval if self.instance else attrs["calculation_interval"],
+        )
+
         try:
-            validate_alert_config(query, condition, config, threshold_config)
+            validate_alert_config(query, condition, config, threshold_config, calculation_interval)
         except ValueError as e:
             raise ValidationError(str(e))
 

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -183,7 +183,6 @@ class AlertSerializer(serializers.ModelSerializer):
     calculation_interval = serializers.ChoiceField(
         choices=AlertConfiguration.CALCULATION_INTERVAL_CHOICES,
         required=False,
-        default=AlertCalculationInterval.DAILY,
         help_text="How often the alert is checked: hourly, daily, weekly, or monthly.",
     )
     snoozed_until = RelativeDateTimeField(
@@ -437,7 +436,7 @@ class AlertSerializer(serializers.ModelSerializer):
 
         calculation_interval = attrs.get(
             "calculation_interval",
-            self.instance.calculation_interval if self.instance else attrs["calculation_interval"],
+            self.instance.calculation_interval if self.instance else AlertCalculationInterval.DAILY,
         )
 
         try:

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -324,6 +324,10 @@ class AlertSerializer(serializers.ModelSerializer):
                     user=user, alert_configuration=instance, defaults={"created_by": self.context["request"].user}
                 )
 
+        # Ignore null calculation_interval — treat as "don't change"
+        if validated_data.get("calculation_interval") is None:
+            validated_data.pop("calculation_interval", None)
+
         calculation_interval_changed = (
             "calculation_interval" in validated_data
             and validated_data["calculation_interval"] != instance.calculation_interval

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -176,7 +176,6 @@ class AlertSerializer(serializers.ModelSerializer):
     calculation_interval = serializers.ChoiceField(
         choices=AlertConfiguration.CALCULATION_INTERVAL_CHOICES,
         required=False,
-        allow_null=True,
         help_text="How often the alert is checked: hourly, daily, weekly, or monthly.",
     )
     snoozed_until = RelativeDateTimeField(
@@ -323,10 +322,6 @@ class AlertSerializer(serializers.ModelSerializer):
                 AlertSubscription.objects.get_or_create(
                     user=user, alert_configuration=instance, defaults={"created_by": self.context["request"].user}
                 )
-
-        # Ignore null calculation_interval — treat as "don't change"
-        if validated_data.get("calculation_interval") is None:
-            validated_data.pop("calculation_interval", None)
 
         calculation_interval_changed = (
             "calculation_interval" in validated_data

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -474,6 +474,27 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         assert expected_error_fragment in str(response.content).lower()
 
+    def test_patch_null_calculation_interval_preserves_existing(self):
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "alert name",
+            "calculation_interval": "weekly",
+        }
+        alert = self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+        assert alert["calculation_interval"] == "weekly"
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/alerts/{alert['id']}",
+            {"calculation_interval": None},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["calculation_interval"] == "weekly"
+
 
 class TestAlertSimulate(APIBaseTest):
     def setUp(self):

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -490,6 +490,13 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
                 "weekly",
                 "renamed alert",
             ),
+            (
+                "updated_interval_applied",
+                {"calculation_interval": "hourly"},
+                status.HTTP_200_OK,
+                "hourly",
+                "alert name",
+            ),
         ]
     )
     def test_patch_calculation_interval(self, _name, patch_payload, expected_status, expected_interval, expected_name):

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -474,7 +474,25 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         assert expected_error_fragment in str(response.content).lower()
 
-    def test_patch_null_calculation_interval_rejected(self):
+    @parameterized.expand(
+        [
+            (
+                "null_interval_rejected",
+                {"calculation_interval": None},
+                status.HTTP_400_BAD_REQUEST,
+                "weekly",
+                None,
+            ),
+            (
+                "omitted_interval_preserves_existing",
+                {"name": "renamed alert"},
+                status.HTTP_200_OK,
+                "weekly",
+                "renamed alert",
+            ),
+        ]
+    )
+    def test_patch_calculation_interval(self, _name, patch_payload, expected_status, expected_interval, expected_name):
         creation_request = {
             "insight": self.insight["id"],
             "subscribed_users": [self.user.id],
@@ -489,10 +507,13 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
 
         response = self.client.patch(
             f"/api/projects/{self.team.id}/alerts/{alert['id']}",
-            {"calculation_interval": None},
+            patch_payload,
             content_type="application/json",
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert response.status_code == expected_status, response.content
+        if expected_status == status.HTTP_200_OK:
+            assert response.json()["calculation_interval"] == expected_interval
+            assert response.json()["name"] == expected_name
 
 
 class TestAlertSimulate(APIBaseTest):

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -474,7 +474,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         assert expected_error_fragment in str(response.content).lower()
 
-    def test_patch_null_calculation_interval_preserves_existing(self):
+    def test_patch_null_calculation_interval_rejected(self):
         creation_request = {
             "insight": self.insight["id"],
             "subscribed_users": [self.user.id],
@@ -492,8 +492,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
             {"calculation_interval": None},
             content_type="application/json",
         )
-        assert response.status_code == status.HTTP_200_OK, response.content
-        assert response.json()["calculation_interval"] == "weekly"
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
 
 
 class TestAlertSimulate(APIBaseTest):

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -303,7 +303,9 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
             if insight.query is None:
                 raise ValueError("Alert's insight has no valid query")
             threshold_config = alert.threshold.configuration if alert.threshold else None
-            validate_alert_config(insight.query, alert.condition, alert.config, threshold_config)
+            validate_alert_config(
+                insight.query, alert.condition, alert.config, threshold_config, alert.calculation_interval
+            )
     except ValueError as e:
         _disable_invalid_alert(alert, str(e))
         return

--- a/posthog/tasks/alerts/test/test_validate_alert_config.py
+++ b/posthog/tasks/alerts/test/test_validate_alert_config.py
@@ -235,6 +235,15 @@ class TestValidateAlertConfig:
                 "every_5_minutes",
                 "Invalid calculation interval: every_5_minutes",
             ),
+            (
+                "none_calculation_interval",
+                _base_query(),
+                _base_condition(),
+                _base_config(),
+                _base_threshold(),
+                None,
+                "Invalid calculation interval: None",
+            ),
         ]
     )
     def test_validate_alert_config(

--- a/posthog/tasks/alerts/test/test_validate_alert_config.py
+++ b/posthog/tasks/alerts/test/test_validate_alert_config.py
@@ -42,6 +42,7 @@ class TestValidateAlertConfig:
                 _base_config(),
                 _base_threshold(),
                 None,
+                None,
             ),
             (
                 "valid_relative_increase",
@@ -50,12 +51,14 @@ class TestValidateAlertConfig:
                 _base_config(),
                 _base_threshold(),
                 None,
+                None,
             ),
             (
                 "none_condition",
                 _base_query(),
                 None,
                 _base_config(),
+                None,
                 None,
                 "Alert has invalid condition: None",
             ),
@@ -65,6 +68,7 @@ class TestValidateAlertConfig:
                 {},
                 _base_config(),
                 None,
+                None,
                 "Alert has invalid condition",
             ),
             (
@@ -73,12 +77,14 @@ class TestValidateAlertConfig:
                 {"type": "bogus"},
                 _base_config(),
                 None,
+                None,
                 "Alert has invalid condition",
             ),
             (
                 "missing_config",
                 _base_query(),
                 _base_condition(),
+                None,
                 None,
                 None,
                 "Unsupported alert config type: None",
@@ -89,6 +95,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 {"series_index": 0},
                 None,
+                None,
                 "Unsupported alert config type",
             ),
             (
@@ -97,6 +104,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 {"type": "TrendsAlertConfig"},
                 None,
+                None,
                 "Alert has invalid TrendsAlertConfig",
             ),
             (
@@ -104,6 +112,7 @@ class TestValidateAlertConfig:
                 {"kind": "FunnelsQuery", "series": []},
                 _base_condition(),
                 _base_config(),
+                None,
                 None,
                 "query kind 'FunnelsQuery' is not supported",
             ),
@@ -114,12 +123,14 @@ class TestValidateAlertConfig:
                 _base_config(),
                 _base_threshold(),
                 None,
+                None,
             ),
             (
                 "relative_on_pie",
                 _base_query(display="ActionsPie"),
                 _base_condition("relative_increase"),
                 _base_config(),
+                None,
                 None,
                 "not compatible with non time series",
             ),
@@ -129,6 +140,7 @@ class TestValidateAlertConfig:
                 _base_condition("relative_decrease"),
                 _base_config(),
                 None,
+                None,
                 "not compatible with non time series",
             ),
             (
@@ -137,6 +149,7 @@ class TestValidateAlertConfig:
                 _base_condition("absolute_value"),
                 _base_config(),
                 _base_threshold("percentage"),
+                None,
                 "Absolute value alerts require an absolute threshold, but a percentage threshold was configured",
             ),
             (
@@ -145,6 +158,7 @@ class TestValidateAlertConfig:
                 _base_condition("absolute_value"),
                 {"type": "TrendsAlertConfig", "series_index": 0, "check_ongoing_interval": True},
                 _base_threshold("absolute", {"lower": 0}),
+                None,
                 "check_ongoing_interval is only supported .* when upper threshold is specified",
             ),
             (
@@ -153,6 +167,7 @@ class TestValidateAlertConfig:
                 _base_condition("relative_increase"),
                 {"type": "TrendsAlertConfig", "series_index": 0, "check_ongoing_interval": True},
                 _base_threshold("absolute", {"lower": 0}),
+                None,
                 "check_ongoing_interval is only supported .* when upper threshold is specified",
             ),
             (
@@ -160,6 +175,7 @@ class TestValidateAlertConfig:
                 _base_query(series_count=1),
                 _base_condition(),
                 _base_config(series_index=5),
+                None,
                 None,
                 r"series_index 5 is out of range \(query has 1 series\)",
             ),
@@ -180,6 +196,7 @@ class TestValidateAlertConfig:
                 _base_config(series_index=1),
                 _base_threshold(),
                 None,
+                None,
             ),
             (
                 "series_index_out_of_range_with_formulas",
@@ -197,7 +214,26 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 _base_config(series_index=2),
                 None,
+                None,
                 r"series_index 2 is out of range \(query has 2 series\)",
+            ),
+            (
+                "valid_calculation_interval",
+                _base_query(),
+                _base_condition(),
+                _base_config(),
+                _base_threshold(),
+                "daily",
+                None,
+            ),
+            (
+                "invalid_calculation_interval",
+                _base_query(),
+                _base_condition(),
+                _base_config(),
+                _base_threshold(),
+                "every_5_minutes",
+                "Invalid calculation interval: every_5_minutes",
             ),
         ]
     )
@@ -208,10 +244,11 @@ class TestValidateAlertConfig:
         condition: dict[str, Any] | None,
         config: dict[str, Any] | None,
         threshold_config: dict[str, Any] | None,
+        calculation_interval: str | None,
         expected_error_fragment: str | None,
     ) -> None:
         if expected_error_fragment is None:
-            validate_alert_config(query, condition, config, threshold_config)
+            validate_alert_config(query, condition, config, threshold_config, calculation_interval)
         else:
             with pytest.raises(ValueError, match=expected_error_fragment):
-                validate_alert_config(query, condition, config, threshold_config)
+                validate_alert_config(query, condition, config, threshold_config, calculation_interval)

--- a/posthog/tasks/alerts/test/test_validate_alert_config.py
+++ b/posthog/tasks/alerts/test/test_validate_alert_config.py
@@ -41,7 +41,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 _base_config(),
                 _base_threshold(),
-                None,
+                "daily",
                 None,
             ),
             (
@@ -50,7 +50,7 @@ class TestValidateAlertConfig:
                 _base_condition("relative_increase"),
                 _base_config(),
                 _base_threshold(),
-                None,
+                "daily",
                 None,
             ),
             (
@@ -59,7 +59,7 @@ class TestValidateAlertConfig:
                 None,
                 _base_config(),
                 None,
-                None,
+                "daily",
                 "Alert has invalid condition: None",
             ),
             (
@@ -68,7 +68,7 @@ class TestValidateAlertConfig:
                 {},
                 _base_config(),
                 None,
-                None,
+                "daily",
                 "Alert has invalid condition",
             ),
             (
@@ -77,7 +77,7 @@ class TestValidateAlertConfig:
                 {"type": "bogus"},
                 _base_config(),
                 None,
-                None,
+                "daily",
                 "Alert has invalid condition",
             ),
             (
@@ -86,7 +86,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 None,
                 None,
-                None,
+                "daily",
                 "Unsupported alert config type: None",
             ),
             (
@@ -95,7 +95,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 {"series_index": 0},
                 None,
-                None,
+                "daily",
                 "Unsupported alert config type",
             ),
             (
@@ -104,7 +104,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 {"type": "TrendsAlertConfig"},
                 None,
-                None,
+                "daily",
                 "Alert has invalid TrendsAlertConfig",
             ),
             (
@@ -113,7 +113,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 _base_config(),
                 None,
-                None,
+                "daily",
                 "query kind 'FunnelsQuery' is not supported",
             ),
             (
@@ -122,7 +122,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 _base_config(),
                 _base_threshold(),
-                None,
+                "daily",
                 None,
             ),
             (
@@ -131,7 +131,7 @@ class TestValidateAlertConfig:
                 _base_condition("relative_increase"),
                 _base_config(),
                 None,
-                None,
+                "daily",
                 "not compatible with non time series",
             ),
             (
@@ -140,7 +140,7 @@ class TestValidateAlertConfig:
                 _base_condition("relative_decrease"),
                 _base_config(),
                 None,
-                None,
+                "daily",
                 "not compatible with non time series",
             ),
             (
@@ -149,7 +149,7 @@ class TestValidateAlertConfig:
                 _base_condition("absolute_value"),
                 _base_config(),
                 _base_threshold("percentage"),
-                None,
+                "daily",
                 "Absolute value alerts require an absolute threshold, but a percentage threshold was configured",
             ),
             (
@@ -158,7 +158,7 @@ class TestValidateAlertConfig:
                 _base_condition("absolute_value"),
                 {"type": "TrendsAlertConfig", "series_index": 0, "check_ongoing_interval": True},
                 _base_threshold("absolute", {"lower": 0}),
-                None,
+                "daily",
                 "check_ongoing_interval is only supported .* when upper threshold is specified",
             ),
             (
@@ -167,7 +167,7 @@ class TestValidateAlertConfig:
                 _base_condition("relative_increase"),
                 {"type": "TrendsAlertConfig", "series_index": 0, "check_ongoing_interval": True},
                 _base_threshold("absolute", {"lower": 0}),
-                None,
+                "daily",
                 "check_ongoing_interval is only supported .* when upper threshold is specified",
             ),
             (
@@ -176,7 +176,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 _base_config(series_index=5),
                 None,
-                None,
+                "daily",
                 r"series_index 5 is out of range \(query has 1 series\)",
             ),
             (
@@ -195,7 +195,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 _base_config(series_index=1),
                 _base_threshold(),
-                None,
+                "daily",
                 None,
             ),
             (
@@ -214,7 +214,7 @@ class TestValidateAlertConfig:
                 _base_condition(),
                 _base_config(series_index=2),
                 None,
-                None,
+                "daily",
                 r"series_index 2 is out of range \(query has 2 series\)",
             ),
             (

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -62,11 +62,8 @@ def validate_alert_config(
     calculation_interval: str | None = None,
 ) -> None:
     """Validate alert configuration dicts. Raises ValueError on failure."""
-    if calculation_interval is not None:
-        try:
-            AlertCalculationInterval(calculation_interval)
-        except ValueError:
-            raise ValueError(f"Invalid calculation interval: {calculation_interval}")
+    if calculation_interval is None or calculation_interval not in AlertCalculationInterval.__members__.values():
+        raise ValueError(f"Invalid calculation interval: {calculation_interval}")
 
     try:
         parsed_condition = AlertCondition.model_validate(condition)

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -59,8 +59,15 @@ def validate_alert_config(
     condition: dict | None,
     config: dict | None,
     threshold_config: dict | None = None,
+    calculation_interval: str | None = None,
 ) -> None:
     """Validate alert configuration dicts. Raises ValueError on failure."""
+    if calculation_interval is not None:
+        try:
+            AlertCalculationInterval(calculation_interval)
+        except ValueError:
+            raise ValueError(f"Invalid calculation interval: {calculation_interval}")
+
     try:
         parsed_condition = AlertCondition.model_validate(condition)
     except Exception:

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -62,7 +62,11 @@ def validate_alert_config(
     calculation_interval: str | None = None,
 ) -> None:
     """Validate alert configuration dicts. Raises ValueError on failure."""
-    if calculation_interval is None or calculation_interval not in AlertCalculationInterval.__members__.values():
+    if not calculation_interval or not isinstance(calculation_interval, str):
+        raise ValueError(f"Invalid calculation interval: {calculation_interval}")
+    try:
+        AlertCalculationInterval(calculation_interval)
+    except ValueError:
         raise ValueError(f"Invalid calculation interval: {calculation_interval}")
 
     try:

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -586,7 +586,7 @@ export interface AlertApi {
 * `daily` - daily
 * `weekly` - weekly
 * `monthly` - monthly */
-    calculation_interval?: CalculationIntervalEnumApi | NullEnumApi | null
+    calculation_interval?: CalculationIntervalEnumApi
     /**
      * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
      * @nullable
@@ -648,7 +648,7 @@ export interface PatchedAlertApi {
 * `daily` - daily
 * `weekly` - weekly
 * `monthly` - monthly */
-    calculation_interval?: CalculationIntervalEnumApi | NullEnumApi | null
+    calculation_interval?: CalculationIntervalEnumApi
     /**
      * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
      * @nullable

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4738,7 +4738,7 @@ export namespace Schemas {
     * `daily` - daily
     * `weekly` - weekly
     * `monthly` - monthly */
-      calculation_interval?: CalculationIntervalEnum | NullEnum | null;
+      calculation_interval?: CalculationIntervalEnum;
       /**
        * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
        * @nullable
@@ -21217,7 +21217,7 @@ export namespace Schemas {
     * `daily` - daily
     * `weekly` - weekly
     * `monthly` - monthly */
-      calculation_interval?: CalculationIntervalEnum | NullEnum | null;
+      calculation_interval?: CalculationIntervalEnum;
       /**
        * Snooze the alert until this time. Pass a relative date string (e.g. '2h', '1d') or null to unsnooze.
        * @nullable

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -924,13 +924,9 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
         .describe('Detector configuration types')
         .nullish(),
     calculation_interval: zod
-        .union([
-            zod
-                .enum(['hourly', 'daily', 'weekly', 'monthly'])
-                .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'),
-            zod.literal(null),
-        ])
-        .nullish()
+        .enum(['hourly', 'daily', 'weekly', 'monthly'])
+        .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
+        .optional()
         .describe(
             'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
@@ -1880,13 +1876,9 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe('Detector configuration types')
         .nullish(),
     calculation_interval: zod
-        .union([
-            zod
-                .enum(['hourly', 'daily', 'weekly', 'monthly'])
-                .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'),
-            zod.literal(null),
-        ])
-        .nullish()
+        .enum(['hourly', 'daily', 'weekly', 'monthly'])
+        .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
+        .optional()
         .describe(
             'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -55,7 +55,6 @@ export const alertsCreateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
 export const alertsCreateBodyDetectorConfigOneOneoneTypeDefault = `lof`
 export const alertsCreateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
 export const alertsCreateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
-export const alertsCreateBodyCalculationIntervalDefault = `daily`
 
 export const AlertsCreateBody = /* @__PURE__ */ zod.object({
     insight: zod
@@ -927,7 +926,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
     calculation_interval: zod
         .enum(['hourly', 'daily', 'weekly', 'monthly'])
         .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
-        .default(alertsCreateBodyCalculationIntervalDefault)
+        .optional()
         .describe(
             'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
@@ -1003,7 +1002,6 @@ export const alertsPartialUpdateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
 export const alertsPartialUpdateBodyDetectorConfigOneOneoneTypeDefault = `lof`
 export const alertsPartialUpdateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
 export const alertsPartialUpdateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
-export const alertsPartialUpdateBodyCalculationIntervalDefault = `daily`
 
 export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
     insight: zod
@@ -1880,7 +1878,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
     calculation_interval: zod
         .enum(['hourly', 'daily', 'weekly', 'monthly'])
         .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
-        .default(alertsPartialUpdateBodyCalculationIntervalDefault)
+        .optional()
         .describe(
             'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -55,6 +55,7 @@ export const alertsCreateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
 export const alertsCreateBodyDetectorConfigOneOneoneTypeDefault = `lof`
 export const alertsCreateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
 export const alertsCreateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
+export const alertsCreateBodyCalculationIntervalDefault = `daily`
 
 export const AlertsCreateBody = /* @__PURE__ */ zod.object({
     insight: zod
@@ -926,7 +927,7 @@ export const AlertsCreateBody = /* @__PURE__ */ zod.object({
     calculation_interval: zod
         .enum(['hourly', 'daily', 'weekly', 'monthly'])
         .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
-        .optional()
+        .default(alertsCreateBodyCalculationIntervalDefault)
         .describe(
             'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),
@@ -1002,6 +1003,7 @@ export const alertsPartialUpdateBodyDetectorConfigOneOnezeroTypeDefault = `hbos`
 export const alertsPartialUpdateBodyDetectorConfigOneOneoneTypeDefault = `lof`
 export const alertsPartialUpdateBodyDetectorConfigOneOnetwoTypeDefault = `ocsvm`
 export const alertsPartialUpdateBodyDetectorConfigOneOnethreeTypeDefault = `pca`
+export const alertsPartialUpdateBodyCalculationIntervalDefault = `daily`
 
 export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
     insight: zod
@@ -1878,7 +1880,7 @@ export const AlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
     calculation_interval: zod
         .enum(['hourly', 'daily', 'weekly', 'monthly'])
         .describe('* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly')
-        .optional()
+        .default(alertsPartialUpdateBodyCalculationIntervalDefault)
         .describe(
             'How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly'
         ),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
@@ -2,25 +2,9 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "anyOf": [
-                {
-                    "anyOf": [
-                        {
-                            "description": "* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
-                            "enum": ["hourly", "daily", "weekly", "monthly"],
-                            "type": "string"
-                        },
-                        {
-                            "const": null,
-                            "type": "null"
-                        }
-                    ]
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly"
+            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "enum": ["hourly", "daily", "weekly", "monthly"],
+            "type": "string"
         },
         "condition": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
@@ -2,7 +2,6 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "default": "daily",
             "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["hourly", "daily", "weekly", "monthly"],
             "type": "string"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-create.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
+            "default": "daily",
             "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["hourly", "daily", "weekly", "monthly"],
             "type": "string"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
@@ -2,25 +2,9 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "anyOf": [
-                {
-                    "anyOf": [
-                        {
-                            "description": "* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
-                            "enum": ["hourly", "daily", "weekly", "monthly"],
-                            "type": "string"
-                        },
-                        {
-                            "const": null,
-                            "type": "null"
-                        }
-                    ]
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly"
+            "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
+            "enum": ["hourly", "daily", "weekly", "monthly"],
+            "type": "string"
         },
         "condition": {
             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
@@ -2,7 +2,6 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
-            "default": "daily",
             "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["hourly", "daily", "weekly", "monthly"],
             "type": "string"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alert-update.json
@@ -2,6 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "calculation_interval": {
+            "default": "daily",
             "description": "How often the alert is checked: hourly, daily, weekly, or monthly.\n\n* `hourly` - hourly\n* `daily` - daily\n* `weekly` - weekly\n* `monthly` - monthly",
             "enum": ["hourly", "daily", "weekly", "monthly"],
             "type": "string"


### PR DESCRIPTION
## Problem

Whilst looking into our alert slo metrics, I noticed that we recently received a fair amount of failures again. After some investigation, it turns out that MCP's patch certain alerts with the calculation interval set to `null`, this causes an alert in an invalid state and therefore causes a whole bunch of failure triggers as we can't schedule a new date for the alert.

Please refer to this notebook for all the details / statistics: https://us.posthog.com/project/2/notebooks/O5EP

## Changes

This PR addresses the issue 2 fold:

1. Updating the patch endpoint to no longer accept `calculation_interval` values of Null if the field is present (this is needed to update our MCP to be aware of this)
2. Flagging alerts with an invalid `calculation_interval` as invalid, which in turn will disable the alert and email the subscribed users informing them that their alert has an invalid `calculation_interval` (with a link to change it).

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

:white_check_mark:New test cases are passing

:white_check_mark: Alerts can still be created locally

![CleanShot 2026-03-27 at 13.27.02.png](https://app.graphite.com/user-attachments/assets/955843bc-5e4d-44ea-a09c-e5f21ea8011f.png)



:white_check_mark:Alerts can still be updated locally

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

![CleanShot 2026-03-27 at 13.27.18.png](https://app.graphite.com/user-attachments/assets/a777cf14-c833-494c-80f0-c8c26442707b.png)



👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

No

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->