### PR TITLE
fix(phai): sse keepalive heartbeat and network error

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -438,18 +438,23 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
             serializer = AssistantSSESerializer()
             stream_manager = AgentExecutor(conversation, timeout=timeout, max_length=max_length)
             last_yield_time = time.time()
+            last_chunk_time = last_yield_time
             aiter = stream_manager.astream(workflow_class, workflow_inputs).__aiter__()
 
             while True:
                 next_task = asyncio.ensure_future(aiter.__anext__())
-
-                while not next_task.done():
-                    elapsed = time.time() - last_yield_time
-                    wait_time = max(0.1, SSE_KEEPALIVE_INTERVAL - elapsed)
-                    done, _ = await asyncio.wait({next_task}, timeout=wait_time)
-                    if not done:
-                        yield SSE_KEEPALIVE_COMMENT
-                        last_yield_time = time.time()
+                try:
+                    while not next_task.done():
+                        elapsed = time.time() - last_yield_time
+                        wait_time = max(0.1, SSE_KEEPALIVE_INTERVAL - elapsed)
+                        done, _ = await asyncio.wait({next_task}, timeout=wait_time)
+                        if not done:
+                            yield SSE_KEEPALIVE_COMMENT
+                            last_yield_time = time.time()
+                except BaseException:
+                    if not next_task.done():
+                        next_task.cancel()
+                    raise
 
                 try:
                     chunk = next_task.result()
@@ -457,7 +462,8 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
                     break
 
                 now = time.time()
-                STREAM_ITERATION_LATENCY_HISTOGRAM.observe(now - last_yield_time)
+                STREAM_ITERATION_LATENCY_HISTOGRAM.observe(now - last_chunk_time)
+                last_chunk_time = now
                 last_yield_time = now
 
                 event = await serializer.dumps(chunk)

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+import asyncio
 from collections.abc import AsyncGenerator
 from typing import cast
 
@@ -431,13 +432,33 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
         async def async_stream(
             workflow_inputs: ChatAgentWorkflowInputs | ResearchAgentWorkflowInputs,
         ) -> AsyncGenerator[bytes, None]:
+            SSE_KEEPALIVE_COMMENT = b": keepalive\n\n"
+            SSE_KEEPALIVE_INTERVAL = 15  # seconds — well under typical LB idle timeouts (60s)
+
             serializer = AssistantSSESerializer()
             stream_manager = AgentExecutor(conversation, timeout=timeout, max_length=max_length)
-            last_iteration_time = time.time()
-            async for chunk in stream_manager.astream(workflow_class, workflow_inputs):
-                chunk_received_time = time.time()
-                STREAM_ITERATION_LATENCY_HISTOGRAM.observe(chunk_received_time - last_iteration_time)
-                last_iteration_time = chunk_received_time
+            last_yield_time = time.time()
+            aiter = stream_manager.astream(workflow_class, workflow_inputs).__aiter__()
+
+            while True:
+                next_task = asyncio.ensure_future(aiter.__anext__())
+
+                while not next_task.done():
+                    elapsed = time.time() - last_yield_time
+                    wait_time = max(0.1, SSE_KEEPALIVE_INTERVAL - elapsed)
+                    done, _ = await asyncio.wait({next_task}, timeout=wait_time)
+                    if not done:
+                        yield SSE_KEEPALIVE_COMMENT
+                        last_yield_time = time.time()
+
+                try:
+                    chunk = next_task.result()
+                except StopAsyncIteration:
+                    break
+
+                now = time.time()
+                STREAM_ITERATION_LATENCY_HISTOGRAM.observe(now - last_yield_time)
+                last_yield_time = now
 
                 event = await serializer.dumps(chunk)
                 yield event.encode("utf-8")

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -910,7 +910,11 @@ function PlanningAnswer({ toolCall, isLastPlanningMessage = true }: PlanningAnsw
                                     )}
                                 >
                                     {step.description}
-                                    {isInProgress && <span className="text-muted ml-1">(in progress)</span>}
+                                    {isInProgress && (
+                                        <ShimmeringContent>
+                                            <span className="text-muted ml-1">(in progress)</span>
+                                        </ShimmeringContent>
+                                    )}
                                 </span>
                             </div>
                         )

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -575,6 +575,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             limit: queue.max_queue_messages,
                         }
                     } catch (error: any) {
+                        posthog.captureException(error)
                         if (error instanceof ApiError && error.status === 404) {
                             return { messages: [], limit: 0 }
                         }
@@ -668,6 +669,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     }
                 }
             } catch (e) {
+                posthog.captureException(e)
+
                 // Cancel any next iteration
                 actions.setForAnotherAgenticIteration(false)
 
@@ -751,7 +754,6 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                                 'Something is wrong with our servers. Please try again later.'
                         }
                     } else {
-                        posthog.captureException(e)
                         console.error(e)
                     }
 
@@ -837,6 +839,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.setQueuedMessages(queue.messages)
                 actions.setQueueLimit(queue.max_queue_messages)
             } catch (error: any) {
+                posthog.captureException(error)
                 actions.setQueuedMessages(values.queuedMessages)
                 if (error instanceof ApiError && error.status === 409) {
                     lemonToast.error('You can only queue two messages at a time.')
@@ -856,6 +859,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.setQueuedMessages(queue.messages)
                 actions.setQueueLimit(queue.max_queue_messages)
             } catch (error: any) {
+                posthog.captureException(error)
                 lemonToast.error(error?.data?.detail || 'Failed to update the queued message.')
             }
         },
@@ -875,6 +879,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.setQueuedMessages(queue.messages)
                 actions.setQueueLimit(queue.max_queue_messages)
             } catch (error: any) {
+                posthog.captureException(error)
                 if (error instanceof ApiError && error.status === 404) {
                     return
                 }
@@ -898,6 +903,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.setQueuedMessages(queue.messages)
                 actions.setQueueLimit(queue.max_queue_messages)
             } catch (error: any) {
+                posthog.captureException(error)
                 if (error instanceof ApiError && error.status === 404) {
                     return
                 }
@@ -915,6 +921,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.setQueuedMessages(queue.messages)
                 actions.setQueueLimit(queue.max_queue_messages)
             } catch (error: any) {
+                posthog.captureException(error)
                 lemonToast.error(error?.data?.detail || 'Failed to clear queued messages.')
             }
         },
@@ -1046,13 +1053,11 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 actions.clearQueuedMessages()
                 actions.resetThread()
             } catch (e: any) {
+                posthog.captureException(e)
                 lemonToast.error(e?.data?.detail || 'Failed to cancel the generation.')
             }
 
-            try {
-                await actions.loadConversation(values.conversation.id)
-            } catch {}
-
+            actions.loadConversation(values.conversation.id)
             actions.setCancelLoading(false)
         },
 
@@ -1186,6 +1191,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     })
                 }
             } catch (error) {
+                posthog.captureException(error)
                 console.error('Failed to navigate to notebook:', error)
             }
         },

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -731,9 +731,26 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                             }
                         }
 
-                        // Prevents parallel generation attempts. Total wait time is: 21 seconds.
+                        // 409 means the conversation is already in progress.
+                        // Reconnect to the existing stream instead of resending the message.
                         if (e.status === 409 && generationAttempt <= 5) {
-                            await retry()
+                            // Mark that the next stream replay should clear the thread on the
+                            // first real event. We defer the clear (rather than doing it now)
+                            // so the user keeps seeing the existing thread + loading indicator
+                            // while we reconnect. The stream replays all events from the
+                            // beginning so we must rebuild from scratch to avoid duplicates.
+                            cache.clearThreadOnReplay = true
+                            await breakpoint(1000 * (generationAttempt + 1))
+                            actions.decrActiveStreamingThreads()
+                            actions.streamConversation(
+                                {
+                                    content: null,
+                                    conversation: streamData.conversation,
+                                    agent_mode: agentMode,
+                                    is_sandbox: isSandbox || undefined,
+                                },
+                                generationAttempt + 1
+                            )
                             return
                         }
 
@@ -1877,6 +1894,14 @@ export async function onEventImplementation(
         agentMode: AgentMode | null
     }
 ): Promise<void> {
+    // On 409 reconnect, the stream replays all events from the beginning.
+    // Clear the thread on the first real event so the replay rebuilds it
+    // from scratch — this avoids duplicates and ordering conflicts.
+    if (cache.clearThreadOnReplay) {
+        cache.clearThreadOnReplay = false
+        actions.setThread([])
+    }
+
     // A Conversation object is only received when the conversation is new
     if (event === AssistantEventType.Conversation) {
         const parsedResponse = parseResponse<Conversation>(data)

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -669,8 +669,6 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     }
                 }
             } catch (e) {
-                posthog.captureException(e)
-
                 // Cancel any next iteration
                 actions.setForAnotherAgenticIteration(false)
 
@@ -692,6 +690,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 }
 
                 if (!(e instanceof DOMException) || e.name !== 'AbortError') {
+                    posthog.captureException(e)
                     let releaseException = true
                     // Generic message by default
                     const relevantErrorMessage = { ...FAILURE_MESSAGE, id: uuid() }

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -694,10 +694,16 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     const relevantErrorMessage = { ...FAILURE_MESSAGE, id: uuid() }
                     const offlineMessage = 'You appear to be offline. Please check your internet connection.'
 
-                    // Network exception errors might be overwritten by the API wrapper, so we check for the generic Error type.
-                    if (e instanceof Error && e.message.toLowerCase().includes('failed to fetch')) {
-                        // Failed to fetch -> request failed to connect.
-                        // If the conversation is in progress, we retry up to 15 times.
+                    // Network errors surface differently across browsers and may be wrapped by handleFetch:
+                    //   Chrome/Edge: "Failed to fetch"
+                    //   Firefox:     "NetworkError when attempting to fetch resource."
+                    //   Safari:      "Load failed"
+                    //   handleFetch: ApiError with status === undefined (fetch itself threw)
+                    const isNetworkError =
+                        (e instanceof Error && /failed to fetch|network\s*error|load failed/i.test(e.message)) ||
+                        (e instanceof ApiError && !e.status)
+
+                    if (isNetworkError) {
                         if (values.conversation?.status === ConversationStatus.InProgress) {
                             if (generationAttempt > 15) {
                                 relevantErrorMessage.content = offlineMessage
@@ -706,16 +712,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                                 return
                             }
                         } else {
-                            // No started conversation, show the offline message.
                             relevantErrorMessage.content = offlineMessage
-                        }
-                    } else if (e instanceof Error && e.message.toLowerCase() === 'network error') {
-                        // Network error -> request failed in progress.
-                        if (generationAttempt > 15) {
-                            relevantErrorMessage.content = offlineMessage
-                        } else {
-                            await retry()
-                            return
                         }
                     } else if (e instanceof ApiError) {
                         if (e.status === 400) {


### PR DESCRIPTION
## Problem

Users see recurring "Oops something went wrong" in the AI chat due to transient network errors that should be retryable.

1. **No SSE keepalive**: Backend yields bytes only on real data. During long LLM/tool operations, the connection goes idle and gets killed by load balancers/proxies (typically 60s idle timeout).

2. **Incomplete retry logic**: Client only retries Chrome's "Failed to fetch". Firefox ("NetworkError when attempting to fetch resource.") and Safari ("Load failed") bypass all retry predicates.

3. **409 retry resends original message, resulting in no update**: When a connection drops mid-stream (e.g., Django restart, deployment), the retry logic resends the original user message. The backend rejects it with 409 Conflict because the conversation is already in progress. Every subsequent retry also resends the same content, so all 5 retries fail with 409 and the user sees an error.
4. **UI is unordered on replay because of transient trace_id values**: When we replay events, the components are rendered out of order because trace_ids are inconsistent between states.

## Changes

**Backend:**
- Added keepalive comments every 15s during idle periods. SSE spec comments are silently ignored by the frontend's eventsource-parser.

**Client:**
- Unify network error with a single regex so that all browsers retry with backoff
- Change 409 retry connect bug by sending null content instead of original message, triggering update
- Defer thread cleanup until update is ready
- Add UI animation so that user has a visual indicator of activity

## How did you test this code?

- Tested locally

## Publish to changelog?

no