### PR TITLE
fix: pass user context to QueryExecutorNode and ReadDataTool

### DIFF
--- a/ee/hogai/chat_agent/query_executor/nodes.py
+++ b/ee/hogai/chat_agent/query_executor/nodes.py
@@ -29,6 +29,7 @@ class QueryExecutorNode(AssistantNode):
         try:
             context = InsightContext(
                 team=self._team,
+                user=self._user,
                 query=content.query,
                 name=content.name,
                 description=content.description,

--- a/ee/hogai/tools/read_data/tool.py
+++ b/ee/hogai/tools/read_data/tool.py
@@ -357,6 +357,7 @@ class ReadDataTool(HogQLDatabaseMixin, MaxTool):
         # Create insight context
         context = InsightContext(
             team=self._team,
+            user=self._user,
             query=result.content.query,
             name=insight_name,
             description=result.content.description,


### PR DESCRIPTION
## Problem

PR #47130 introduced a HogQL permission layer that removes `system.*` tables when `user=None` is passed to`Database.create_for(`. Two other paths still create `InsightContext` without passing `user`:

- `QueryExecutorNode` (re-executes queries from visualization artifacts)
- `ReadDataTool` (reads/executes existing insights via the AI assistant)
Both have `self._user` available but never pass it through, so when the `hogql-access-control` flag is enabled, queries hitting `system.*` tables fail with "You don't have access to table `system.<name>`".

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

Pass `user=self._user` to `InsightContext` in both `QueryExecutorNode` and `ReadDataTool`

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->