### PR TITLE
fix: Use capture_ph_event for the events to show up, as posthoganalytics.capture is not allowed in the alert checks

### DIFF
--- a/posthog/slo/events.py
+++ b/posthog/slo/events.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import posthoganalytics
 from prometheus_client import Counter, Histogram
 
@@ -48,13 +50,15 @@ def emit_slo_started(
     distinct_id: str,
     properties: SloStartedProperties,
     extra_properties: dict | None = None,
+    capture: Callable | None = None,
 ) -> None:
     all_properties = properties.to_dict()
     all_properties["deploy_sha"] = get_git_commit_short()
     if extra_properties:
         all_properties.update(extra_properties)
 
-    posthoganalytics.capture(
+    _capture = capture or posthoganalytics.capture
+    _capture(
         distinct_id=distinct_id,
         event="slo_operation_started",
         properties=all_properties,
@@ -69,13 +73,15 @@ def emit_slo_completed(
     distinct_id: str,
     properties: SloCompletedProperties,
     extra_properties: dict | None = None,
+    capture: Callable | None = None,
 ) -> None:
     all_properties = properties.to_dict()
     all_properties["deploy_sha"] = get_git_commit_short()
     if extra_properties:
         all_properties.update(extra_properties)
 
-    posthoganalytics.capture(
+    _capture = capture or posthoganalytics.capture
+    _capture(
         distinct_id=distinct_id,
         event="slo_operation_completed",
         properties=all_properties,

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -198,39 +198,41 @@ def check_alert_task(alert_id: str, team_id: int = 0, calculation_interval: str 
     outcome = SloOutcome.FAILURE
     started_at = time.monotonic()
     error_extra: dict | None = None
-    try:
-        emit_slo_started(
-            distinct_id=alert_id,
-            properties=SloStartedProperties(
-                area=SloArea.ANALYTIC_PLATFORM,
-                operation=SloOperation.ALERT_CHECK,
-                team_id=team_id,
-                resource_id=alert_id,
-            ),
-            extra_properties={"calculation_interval": calculation_interval},
-        )
-        with ph_scoped_capture() as capture_ph_event:
+    with ph_scoped_capture() as capture_ph_event:
+        try:
+            emit_slo_started(
+                distinct_id=alert_id,
+                properties=SloStartedProperties(
+                    area=SloArea.ANALYTIC_PLATFORM,
+                    operation=SloOperation.ALERT_CHECK,
+                    team_id=team_id,
+                    resource_id=alert_id,
+                ),
+                extra_properties={"calculation_interval": calculation_interval},
+                capture=capture_ph_event,
+            )
             check_alert(alert_id, capture_ph_event)
-        outcome = SloOutcome.SUCCESS
-    except Exception as exc:
-        error_extra = {
-            "error_type": type(exc).__name__,
-            "error_message": str(exc),
-        }
-        raise
-    finally:
-        emit_slo_completed(
-            distinct_id=alert_id,
-            properties=SloCompletedProperties(
-                area=SloArea.ANALYTIC_PLATFORM,
-                operation=SloOperation.ALERT_CHECK,
-                team_id=team_id,
-                resource_id=alert_id,
-                outcome=outcome,
-                duration_ms=(time.monotonic() - started_at) * 1000,
-            ),
-            extra_properties={"calculation_interval": calculation_interval, **(error_extra or {})},
-        )
+            outcome = SloOutcome.SUCCESS
+        except Exception as exc:
+            error_extra = {
+                "error_type": type(exc).__name__,
+                "error_message": str(exc),
+            }
+            raise
+        finally:
+            emit_slo_completed(
+                distinct_id=alert_id,
+                properties=SloCompletedProperties(
+                    area=SloArea.ANALYTIC_PLATFORM,
+                    operation=SloOperation.ALERT_CHECK,
+                    team_id=team_id,
+                    resource_id=alert_id,
+                    outcome=outcome,
+                    duration_ms=(time.monotonic() - started_at) * 1000,
+                ),
+                extra_properties={"calculation_interval": calculation_interval, **(error_extra or {})},
+                capture=capture_ph_event,
+            )
 
 
 @retry(

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -1194,29 +1194,32 @@ class TestAlertCheckSloInstrumentation(APIBaseTest, ClickhouseDestroyTablesMixin
         else:
             check_alert_task(self.alert_id, self.team.id, calculation_interval)
 
-        mock_slo_started.assert_called_once_with(
-            distinct_id=self.alert_id,
-            properties=SloStartedProperties(
-                area=SloArea.ANALYTIC_PLATFORM,
-                operation=SloOperation.ALERT_CHECK,
-                team_id=self.team.id,
-                resource_id=self.alert_id,
-            ),
-            extra_properties={"calculation_interval": calculation_interval},
+        mock_slo_started.assert_called_once()
+        started_kwargs = mock_slo_started.call_args.kwargs
+        assert started_kwargs["distinct_id"] == self.alert_id
+        assert started_kwargs["properties"] == SloStartedProperties(
+            area=SloArea.ANALYTIC_PLATFORM,
+            operation=SloOperation.ALERT_CHECK,
+            team_id=self.team.id,
+            resource_id=self.alert_id,
         )
-        mock_slo_completed.assert_called_once_with(
-            distinct_id=self.alert_id,
-            properties=SloCompletedProperties(
-                area=SloArea.ANALYTIC_PLATFORM,
-                operation=SloOperation.ALERT_CHECK,
-                team_id=self.team.id,
-                resource_id=self.alert_id,
-                outcome=expected_outcome,
-                duration_ms=mock_slo_completed.call_args.kwargs["properties"].duration_ms,
-            ),
-            extra_properties={
-                "calculation_interval": calculation_interval,
-                **(expected_error_extra or {}),
-            },
+        assert started_kwargs["extra_properties"] == {"calculation_interval": calculation_interval}
+        assert started_kwargs["capture"] is not None  # ph_scoped_capture callable
+
+        mock_slo_completed.assert_called_once()
+        completed_kwargs = mock_slo_completed.call_args.kwargs
+        assert started_kwargs["capture"] is completed_kwargs["capture"]  # same scoped client for both
+        assert completed_kwargs["distinct_id"] == self.alert_id
+        assert completed_kwargs["properties"] == SloCompletedProperties(
+            area=SloArea.ANALYTIC_PLATFORM,
+            operation=SloOperation.ALERT_CHECK,
+            team_id=self.team.id,
+            resource_id=self.alert_id,
+            outcome=expected_outcome,
+            duration_ms=completed_kwargs["properties"].duration_ms,
         )
+        assert completed_kwargs["extra_properties"] == {
+            "calculation_interval": calculation_interval,
+            **(expected_error_extra or {}),
+        }
         assert mock_slo_completed.call_args.kwargs["properties"].duration_ms >= 0


### PR DESCRIPTION
## Problem

After merging: [https://github.com/PostHog/posthog/pull/52294/](https://github.com/PostHog/posthog/pull/52294/changes#diff-98b2ca5b379964b2e131317ecebd630c9890bd9d0f45e53b76ff007ded0c4e15) I kept waiting to see when the new events would be emitted, however after the code was confirmed to be deployed (through Argo), I never saw the events coming through. Turns out that in order to emit events in Celery, we need to use the `ph_scoped_capture` as the global `posthoganalytics` client might be disabled (due to the `OPT_OUT_CAPTURE` env var). 

Thus in order to fix this, I've made a temporary fix for the SLO metrics (until the alerts are migrated to Temporal, then we can use the interceptor) so that we can pass that capture function, as is the standard pattern in the alert logic. This should get the metrics to emit correctly.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Started using `ph_scoped_capture` in order to emit the events inside the alert flow.

## How did you test this code?

:white_check_mark: Update the test to confirm that the callable is passed

I'm not able to replicate this locally (at least not easily) as I would need to replicate the production config, however based on my research this should do the trick :smiley:. Given that this is a low impact change, I figured this is fine / acceptable.

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->