### PR TITLE
fix(personhog_client): person team mismatch metric overcounting

### DIFF
--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -234,9 +234,10 @@ def _fetch_persons_by_distinct_ids_via_personhog(
         GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=distinct_ids)
     )
 
-    valid_results = [r for r in resp.results if r.person and r.person.id and r.person.team_id == team_id]
+    present_results = [r for r in resp.results if r.person and r.person.id]
+    valid_results = [r for r in present_results if r.person.team_id == team_id]
 
-    mismatched = len(resp.results) - len(valid_results)
+    mismatched = len(present_results) - len(valid_results)
     if mismatched:
         PERSONHOG_TEAM_MISMATCH_TOTAL.labels(
             operation="get_persons_by_distinct_ids", client_name=get_client_name()
@@ -390,9 +391,10 @@ def get_persons_mapped_by_distinct_id(
             GetPersonsByDistinctIdsInTeamRequest(team_id=team_id, distinct_ids=distinct_ids)
         )
 
-        valid_results = [r for r in resp.results if r.person and r.person.id and r.person.team_id == team_id]
+        present_results = [r for r in resp.results if r.person and r.person.id]
+        valid_results = [r for r in present_results if r.person.team_id == team_id]
 
-        mismatched = len(resp.results) - len(valid_results)
+        mismatched = len(present_results) - len(valid_results)
         if mismatched:
             PERSONHOG_TEAM_MISMATCH_TOTAL.labels(
                 operation="get_persons_mapped_by_distinct_id", client_name=get_client_name()
@@ -423,9 +425,10 @@ def _fetch_persons_by_uuids_via_personhog(team_id: int, uuids: list[str]) -> lis
 
     resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
 
-    valid_persons = [p for p in resp.persons if p.id and p.team_id == team_id]
+    present_persons = [p for p in resp.persons if p.id]
+    valid_persons = [p for p in present_persons if p.team_id == team_id]
 
-    mismatched = len(resp.persons) - len(valid_persons)
+    mismatched = len(present_persons) - len(valid_persons)
     if mismatched:
         PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation="get_persons_by_uuids", client_name=get_client_name()).inc(
             mismatched

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -276,9 +276,10 @@ def _fetch_people_via_personhog(
     uuids = [str(pid) for pid in people_ids]
     resp = client.get_persons_by_uuids(GetPersonsByUuidsRequest(team_id=team_id, uuids=uuids))
 
-    valid_persons = [p for p in resp.persons if p.id and p.team_id == team_id]
+    present_persons = [p for p in resp.persons if p.id]
+    valid_persons = [p for p in present_persons if p.team_id == team_id]
 
-    mismatched = len(resp.persons) - len(valid_persons)
+    mismatched = len(present_persons) - len(valid_persons)
     if mismatched:
         PERSONHOG_TEAM_MISMATCH_TOTAL.labels(operation="get_people", client_name=get_client_name()).inc(mismatched)
         logger.warning("personhog_team_mismatch", operation="get_people", team_id=team_id, dropped=mismatched)


### PR DESCRIPTION
## Problem

The person team mismatch metric being emitted by personhog client lookups was overcounting. It inadvertently counted any distinct id that no longer has a matching person as a person team mismatch.

## Changes

- first filter returned persons lists by team mismatch, store the list then filter that list on whether the person record exists/has an id
- use the two arrays to calculate the true number of persons filtered due to a team mismatch

## How did you test this code?

- there are plenty of unit/integration tests making sure this didn't change any behaviour

