### PR TITLE
fix(ci): correct trigger path for Rust flags integration tests

### DIFF
--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -6,7 +6,7 @@ on:
         paths:
             - 'rust/feature-flags/**'
             - 'posthog/api/test/rust_integration/**'
-            - 'posthog/api/feature_flags/**'
+            - 'posthog/api/feature_flag.py'
             - 'posthog/api/cohort.py'
             - 'posthog/models/feature_flag/**'
             - 'posthog/models/cohort/**'
@@ -17,7 +17,7 @@ on:
         paths:
             - 'rust/feature-flags/**'
             - 'posthog/api/test/rust_integration/**'
-            - 'posthog/api/feature_flags/**'
+            - 'posthog/api/feature_flag.py'
             - 'posthog/api/cohort.py'
             - 'posthog/models/feature_flag/**'
             - 'posthog/models/cohort/**'


### PR DESCRIPTION
## Problem

The Rust flags integration workflow (`ci-rust-flags-integration.yml`) watches `posthog/api/feature_flags/**` — a plural, nonexistent directory — instead of `posthog/api/feature_flag.py`. Changes to the feature flag API file never trigger the Rust integration tests.

This has been broken since the workflow was introduced 3 days ago, during which 5 commits to `feature_flag.py` landed without triggering the integration tests.

## Changes

Replace `posthog/api/feature_flags/**` with `posthog/api/feature_flag.py` in both the `pull_request` and `push` path triggers.

## How did you test this code?

Verified `posthog/api/feature_flags/` does not exist and `posthog/api/feature_flag.py` does. The fix is a straightforward path correction in YAML trigger config.

## Publish to changelog?

no

## Docs update

no