### PR TITLE
feat: add analytics events to agentic provisioning flows

### DIFF
--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 import functools
 from urllib.parse import urlparse, urlunparse
 
@@ -157,14 +158,14 @@ def stripe_region_proxy(strategy: str):
                     response = _proxy_to_region(request, target)
                     posthoganalytics.capture(
                         "agentic_provisioning region_proxy",
-                        distinct_id="agentic_provisioning_system",
+                        distinct_id=f"agentic_provisioning_{uuid.uuid4().hex[:16]}",
                         properties={"outcome": "proxied", **proxy_props},
                     )
                     return response
                 except requests.exceptions.RequestException:
                     posthoganalytics.capture(
                         "agentic_provisioning region_proxy",
-                        distinct_id="agentic_provisioning_system",
+                        distinct_id=f"agentic_provisioning_{uuid.uuid4().hex[:16]}",
                         properties={"outcome": "proxy_failed", **proxy_props},
                     )
                     if strategy == "body_region":

--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 
 import requests
 import structlog
+import posthoganalytics
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -146,9 +147,31 @@ def stripe_region_proxy(strategy: str):
                     current_region=current,
                     target_domain=target,
                 )
+                posthoganalytics.capture(
+                    "agentic_provisioning region_proxy",
+                    distinct_id="agentic_provisioning_system",
+                    properties={
+                        "outcome": "proxied",
+                        "strategy": strategy,
+                        "from_region": current,
+                        "to_domain": target,
+                        "endpoint": request.path,
+                    },
+                )
                 try:
                     return _proxy_to_region(request, target)
                 except requests.exceptions.RequestException:
+                    posthoganalytics.capture(
+                        "agentic_provisioning region_proxy",
+                        distinct_id="agentic_provisioning_system",
+                        properties={
+                            "outcome": "proxy_failed",
+                            "strategy": strategy,
+                            "from_region": current,
+                            "to_domain": target,
+                            "endpoint": request.path,
+                        },
+                    )
                     if strategy == "body_region":
                         return Response(
                             {"error": {"code": "proxy_failed", "message": "Failed to route to correct region"}},

--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -147,30 +147,25 @@ def stripe_region_proxy(strategy: str):
                     current_region=current,
                     target_domain=target,
                 )
-                posthoganalytics.capture(
-                    "agentic_provisioning region_proxy",
-                    distinct_id="agentic_provisioning_system",
-                    properties={
-                        "outcome": "proxied",
-                        "strategy": strategy,
-                        "from_region": current,
-                        "to_domain": target,
-                        "endpoint": request.path,
-                    },
-                )
+                proxy_props = {
+                    "strategy": strategy,
+                    "from_region": current,
+                    "to_domain": target,
+                    "endpoint": request.path,
+                }
                 try:
-                    return _proxy_to_region(request, target)
+                    response = _proxy_to_region(request, target)
+                    posthoganalytics.capture(
+                        "agentic_provisioning region_proxy",
+                        distinct_id="agentic_provisioning_system",
+                        properties={"outcome": "proxied", **proxy_props},
+                    )
+                    return response
                 except requests.exceptions.RequestException:
                     posthoganalytics.capture(
                         "agentic_provisioning region_proxy",
                         distinct_id="agentic_provisioning_system",
-                        properties={
-                            "outcome": "proxy_failed",
-                            "strategy": strategy,
-                            "from_region": current,
-                            "to_domain": target,
-                            "endpoint": request.path,
-                        },
+                        properties={"outcome": "proxy_failed", **proxy_props},
                     )
                     if strategy == "body_region":
                         return Response(

--- a/ee/api/agentic_provisioning/signature.py
+++ b/ee/api/agentic_provisioning/signature.py
@@ -1,6 +1,7 @@
 import re
 import hmac
 import time
+import uuid
 import hashlib
 
 from django.conf import settings
@@ -140,7 +141,7 @@ def _log_and_capture_event(outcome: str, status_code: int, endpoint: str, **extr
 
     posthoganalytics.capture(
         "agentic_provisioning signature verification",
-        distinct_id="agentic_provisioning_system",
+        distinct_id=f"agentic_provisioning_{uuid.uuid4().hex[:16]}",
         properties={"outcome": outcome, "status_code": status_code, "endpoint": endpoint, **extra},
     )
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -254,6 +254,8 @@ def _handle_existing_user(
         timeout=PENDING_AUTH_TTL_SECONDS,
     )
 
+    _capture_provisioning_event("account_request", "existing_user", region=region)
+
     authorize_url = _build_authorize_url(confirmation_secret, scopes)
     return Response(
         {
@@ -288,9 +290,11 @@ def _handle_new_user(
     except IntegrityError:
         existing = User.objects.filter(email=email).first()
         if existing:
+            _capture_provisioning_event("account_request", "race_condition_existing_user", region=region)
             return _handle_existing_user(
                 request_id, existing, data.get("confirmation_secret", ""), scopes, stripe_account_id, region
             )
+        _capture_provisioning_event("account_request", "creation_failed", region=region)
         return Response(
             {
                 "id": request_id,
@@ -299,6 +303,8 @@ def _handle_new_user(
             },
             status=500,
         )
+
+    _capture_provisioning_event("account_request", "new_user", region=region)
 
     code = secrets.token_urlsafe(32)
     cache_key = f"{AUTH_CODE_CACHE_PREFIX}{code}"
@@ -336,14 +342,17 @@ def _build_authorize_url(confirmation_secret: str, scopes: list[str]) -> str:
 def agentic_authorize(request: Any) -> HttpResponseBase:
     state = request.GET.get("state", "")
     if not state or not _SAFE_STATE_RE.match(state):
+        _capture_provisioning_event("authorize", "missing_state")
         return HttpResponseRedirect(f"{settings.SITE_URL}?error=missing_state")
 
     pending_key = f"{PENDING_AUTH_CACHE_PREFIX}{state}"
     pending = cache.get(pending_key)
     if pending is None:
+        _capture_provisioning_event("authorize", "expired_state")
         return HttpResponseRedirect(f"{settings.SITE_URL}?error=expired_or_invalid_state")
 
     if request.user.email != pending["email"]:
+        _capture_provisioning_event("authorize", "email_mismatch")
         return HttpResponseRedirect(f"{settings.SITE_URL}?error=email_mismatch")
 
     scope = " ".join(pending.get("scopes", []))
@@ -379,10 +388,14 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
             timeout=AUTH_CODE_TTL_SECONDS,
         )
 
+        _capture_provisioning_event("authorize", "auto_redirect", team_id=team.id)
+
         callback_url = settings.STRIPE_ORCHESTRATOR_CALLBACK_URL
         sanitized_state = re.sub(r"[^A-Za-z0-9_\-]", "", state)
         params = urlencode({"code": code, "state": sanitized_state})
         return HttpResponseRedirect(f"{callback_url}?{params}")
+
+    _capture_provisioning_event("authorize", "selection_required")
 
     base = settings.SITE_URL.rstrip("/")
     sanitized_state = re.sub(r"[^A-Za-z0-9_\-]", "", state)
@@ -397,24 +410,29 @@ def agentic_authorize_confirm(request: Request) -> Response:
     team_id = request.data.get("team_id")
 
     if not state or team_id is None or not _SAFE_STATE_RE.match(state):
+        _capture_provisioning_event("authorize_confirm", "invalid_request")
         return Response({"error": "state and team_id are required"}, status=400)
 
     pending_key = f"{PENDING_AUTH_CACHE_PREFIX}{state}"
     pending = cache.get(pending_key)
     if pending is None:
+        _capture_provisioning_event("authorize_confirm", "expired_state")
         return Response({"error": "expired_or_invalid_state"}, status=400)
 
     user = cast(User, request.user)
 
     if user.email != pending["email"]:
+        _capture_provisioning_event("authorize_confirm", "email_mismatch")
         return Response({"error": "email_mismatch"}, status=403)
 
     try:
         team = Team.objects.get(id=team_id, is_demo=False)
     except Team.DoesNotExist:
+        _capture_provisioning_event("authorize_confirm", "team_not_found", team_id=team_id)
         return Response({"error": "team_not_found"}, status=404)
 
     if not user.organization_memberships.filter(organization_id=team.organization_id).exists():
+        _capture_provisioning_event("authorize_confirm", "team_not_accessible", team_id=team_id)
         return Response({"error": "team_not_accessible"}, status=403)
 
     cache.delete(pending_key)
@@ -437,6 +455,8 @@ def agentic_authorize_confirm(request: Request) -> Response:
     sanitized_state = re.sub(r"[^A-Za-z0-9_\-]", "", state)
     params = urlencode({"code": code, "state": sanitized_state})
     redirect_url = f"{callback_url}?{params}"
+
+    _capture_provisioning_event("authorize_confirm", "success", team_id=team_id)
 
     return Response({"redirect_url": redirect_url})
 
@@ -472,6 +492,7 @@ def _exchange_authorization_code(request: Request) -> Response:
     cache_key = f"{AUTH_CODE_CACHE_PREFIX}{code}"
     code_data = cache.get(cache_key)
     if code_data is None:
+        _capture_provisioning_event("token_exchange", "invalid_code", grant_type="authorization_code")
         return Response(
             {"error": "invalid_grant", "error_description": "Invalid or expired authorization code"}, status=400
         )
@@ -511,6 +532,8 @@ def _exchange_authorization_code(request: Request) -> Response:
 
     account_id = str(code_data.get("org_id", ""))
 
+    _capture_provisioning_event("token_exchange", "success", grant_type="authorization_code")
+
     return Response(
         {
             "token_type": "bearer",
@@ -532,6 +555,7 @@ def _exchange_refresh_token(request: Request) -> Response:
 
     old_refresh = find_oauth_refresh_token(refresh_token_value)
     if old_refresh is None:
+        _capture_provisioning_event("token_exchange", "invalid_refresh_token", grant_type="refresh_token")
         return Response({"error": "invalid_grant", "error_description": "Invalid or revoked refresh token"}, status=400)
 
     oauth_app = old_refresh.application
@@ -566,6 +590,8 @@ def _exchange_refresh_token(request: Request) -> Response:
         scoped_teams=scoped_teams,
     )
 
+    _capture_provisioning_event("token_exchange", "success", grant_type="refresh_token")
+
     return Response(
         {
             "token_type": "bearer",
@@ -597,17 +623,20 @@ def provisioning_resources_create(request: Request) -> Response:
 
     service_id = request.data.get("service_id", "")
     if service_id and service_id not in VALID_SERVICE_IDS:
+        _capture_provisioning_event("resource_created", "error", error_code="unknown_service")
         return _error_response("unknown_service", f"Unknown service_id: {service_id}")
 
     scoped_teams = access_token.scoped_teams or []
 
     if not scoped_teams:
+        _capture_provisioning_event("resource_created", "error", error_code="no_team")
         return _error_response("no_team", "No team associated with this token")
 
     team_id = scoped_teams[0]
     try:
         team = Team.objects.get(id=team_id)
     except Team.DoesNotExist:
+        _capture_provisioning_event("resource_created", "error", error_code="team_not_found", team_id=team_id)
         return _error_response("team_not_found", "Team not found", resource_id=str(team_id), status=404)
 
     resolved_service_id = service_id or ANALYTICS_SERVICE_ID
@@ -615,6 +644,8 @@ def provisioning_resources_create(request: Request) -> Response:
 
     region = get_instance_region() or "US"
     host = _region_to_host(region)
+
+    _capture_provisioning_event("resource_created", "success", service_id=resolved_service_id, team_id=team_id)
 
     return Response(
         {
@@ -683,9 +714,12 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
         team.reset_token_and_save(user=user, is_impersonated_session=False)
     except Exception:
         capture_exception(additional_properties={"team_id": team_id})
+        _capture_provisioning_event("credential_rotation", "failed", team_id=team_id)
         return _error_response(
             "credential_rotation_failed", "Failed to rotate credentials", resource_id=resource_id, status=500
         )
+
+    _capture_provisioning_event("credential_rotation", "success", team_id=team_id)
 
     service_id = cache.get(f"{RESOURCE_SERVICE_CACHE_PREFIX}{team_id}") or ANALYTICS_SERVICE_ID
     region = get_instance_region() or "US"
@@ -968,6 +1002,14 @@ def _deep_link_redirect_path(purpose: str, team_id: int | None) -> str:
 def _capture_deep_link_event(outcome: str, **extra: object) -> None:
     posthoganalytics.capture(
         "agentic_provisioning deep link login",
+        distinct_id="agentic_provisioning_system",
+        properties={"outcome": outcome, **extra},
+    )
+
+
+def _capture_provisioning_event(event_type: str, outcome: str, **extra: object) -> None:
+    posthoganalytics.capture(
+        f"agentic_provisioning {event_type}",
         distinct_id="agentic_provisioning_system",
         properties={"outcome": outcome, **extra},
     )

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -194,6 +194,7 @@ def account_requests(request: Request) -> Response:
     request_id = data.get("id", "")
     email = data.get("email")
     if not email:
+        _capture_provisioning_event("account_request", "error", error_code="missing_email")
         return Response(
             {"type": "error", "error": {"code": "invalid_request", "message": "email is required"}}, status=400
         )
@@ -209,6 +210,7 @@ def account_requests(request: Request) -> Response:
 
         expires_at = parse_datetime(expires_at_str)
         if expires_at and expires_at < timezone.now():
+            _capture_provisioning_event("account_request", "error", error_code="expired")
             return Response(
                 {"type": "error", "error": {"code": "expired", "message": "Account request has expired"}},
                 status=400,
@@ -217,6 +219,7 @@ def account_requests(request: Request) -> Response:
     stripe_info = orchestrator.get("stripe") or {}
     stripe_account_id = stripe_info.get("account", "") if orchestrator.get("type") == "stripe" else ""
     if not stripe_account_id:
+        _capture_provisioning_event("account_request", "error", error_code="missing_stripe_account")
         return Response(
             {
                 "type": "error",
@@ -360,12 +363,14 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
     user = request.user
     memberships = list(user.organization_memberships.select_related("organization").all())
     if not memberships:
+        _capture_provisioning_event("authorize", "no_organization")
         return HttpResponseRedirect(f"{settings.SITE_URL}?error=no_organization")
 
     org_ids = [m.organization_id for m in memberships]
     non_demo_teams = list(Team.objects.filter(organization_id__in=org_ids, is_demo=False))
 
     if not non_demo_teams:
+        _capture_provisioning_event("authorize", "no_team")
         return HttpResponseRedirect(f"{settings.SITE_URL}?error=no_team")
 
     if len(memberships) == 1 and len(non_demo_teams) == 1:
@@ -478,6 +483,7 @@ def oauth_token(request: Request) -> Response:
     elif grant_type == "refresh_token":
         return _exchange_refresh_token(request)
     else:
+        _capture_provisioning_event("token_exchange", "unsupported_grant_type", grant_type=grant_type)
         return Response(
             {"error": "unsupported_grant_type", "error_description": f"Unsupported grant_type: {grant_type}"},
             status=400,
@@ -487,6 +493,7 @@ def oauth_token(request: Request) -> Response:
 def _exchange_authorization_code(request: Request) -> Response:
     code = request.data.get("code", "")
     if not code:
+        _capture_provisioning_event("token_exchange", "missing_code", grant_type="authorization_code")
         return Response({"error": "invalid_request", "error_description": "code is required"}, status=400)
 
     cache_key = f"{AUTH_CODE_CACHE_PREFIX}{code}"
@@ -506,6 +513,7 @@ def _exchange_authorization_code(request: Request) -> Response:
     try:
         user = User.objects.get(id=user_id)
     except User.DoesNotExist:
+        _capture_provisioning_event("token_exchange", "user_not_found", grant_type="authorization_code")
         return Response({"error": "invalid_grant", "error_description": "User not found"}, status=400)
 
     oauth_app = _get_stripe_oauth_app()
@@ -551,6 +559,7 @@ def _exchange_authorization_code(request: Request) -> Response:
 def _exchange_refresh_token(request: Request) -> Response:
     refresh_token_value = request.data.get("refresh_token", "")
     if not refresh_token_value:
+        _capture_provisioning_event("token_exchange", "missing_refresh_token", grant_type="refresh_token")
         return Response({"error": "invalid_request", "error_description": "refresh_token is required"}, status=400)
 
     old_refresh = find_oauth_refresh_token(refresh_token_value)
@@ -823,6 +832,7 @@ def deep_links(request: Request) -> Response:
 
     purpose = request.data.get("purpose", "dashboard")
     if purpose not in SUPPORTED_DEEP_LINK_PURPOSES:
+        _capture_provisioning_event("deep_link_created", "unsupported_purpose", purpose=purpose)
         return Response(
             {
                 "error": {
@@ -856,6 +866,8 @@ def deep_links(request: Request) -> Response:
     url = f"{host}/agentic/login?token={token}"
     if team_id:
         url += f"&team_id={team_id}"
+
+    _capture_provisioning_event("deep_link_created", "success", purpose=purpose, team_id=team_id)
 
     return Response(
         {

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -999,17 +999,13 @@ def _deep_link_redirect_path(purpose: str, team_id: int | None) -> str:
     return "/"
 
 
-def _capture_deep_link_event(outcome: str, **extra: object) -> None:
-    posthoganalytics.capture(
-        "agentic_provisioning deep link login",
-        distinct_id="agentic_provisioning_system",
-        properties={"outcome": outcome, **extra},
-    )
-
-
 def _capture_provisioning_event(event_type: str, outcome: str, **extra: object) -> None:
     posthoganalytics.capture(
         f"agentic_provisioning {event_type}",
         distinct_id="agentic_provisioning_system",
         properties={"outcome": outcome, **extra},
     )
+
+
+def _capture_deep_link_event(outcome: str, **extra: object) -> None:
+    _capture_provisioning_event("deep link login", outcome, **extra)

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import time
+import uuid
 import secrets
 from datetime import timedelta
 from typing import Any, cast
@@ -1012,9 +1013,11 @@ def _deep_link_redirect_path(purpose: str, team_id: int | None) -> str:
 
 
 def _capture_provisioning_event(event_type: str, outcome: str, **extra: object) -> None:
+    team_id = extra.get("team_id")
+    distinct_id = f"agentic_provisioning_team_{team_id}" if team_id else f"agentic_provisioning_{uuid.uuid4().hex[:16]}"
     posthoganalytics.capture(
         f"agentic_provisioning {event_type}",
-        distinct_id="agentic_provisioning_system",
+        distinct_id=distinct_id,
         properties={"outcome": outcome, **extra},
     )
 


### PR DESCRIPTION
## Problem

The agentic provisioning system (Stripe Projects integration) only tracks two events: signature verification and deep link logins. Critical flows like account requests (signups), OAuth token exchange, resource provisioning, credential rotation, deep link creation, authorization consent, and region proxying have zero analytics, making it impossible to monitor signup rates, auth success/failure, or provisioning health.

## Changes

Adds a `_capture_provisioning_event` helper (following the existing `_capture_deep_link_event` pattern) and captures events across all previously-untracked flows. Refactors `_capture_deep_link_event` to delegate to the new helper.

Events use `team_id`-based `distinct_id` when available (e.g. `agentic_provisioning_team_123`) to enable per-project lifecycle tracing and avoid hot partitions. Falls back to a per-request UUID for events where `team_id` isn't known (signature verification, region proxy, early account request errors). Each event includes an `outcome` property for breakdown, plus relevant context properties (region, team_id, grant_type, error_code) without PII.

| Endpoint | Event | Outcomes |
|---|---|---|
| **POST /provisioning/account_requests** | `account_request` | `new_user`, `existing_user`, `race_condition_existing_user`, `creation_failed`, `error` (missing_email, expired, missing_stripe_account) |
| **GET /api/agentic/authorize** | `authorize` | `missing_state`, `expired_state`, `email_mismatch`, `no_organization`, `no_team`, `auto_redirect`, `selection_required` |
| **POST /api/agentic/authorize/confirm** | `authorize_confirm` | `success`, `invalid_request`, `expired_state`, `email_mismatch`, `team_not_found`, `team_not_accessible` |
| **POST /oauth/token** | `token_exchange` | `success`, `invalid_code`, `missing_code`, `user_not_found`, `unsupported_grant_type`, `invalid_refresh_token`, `missing_refresh_token` (all with `grant_type`) |
| **POST /provisioning/resources** | `resource_created` | `success`, `error` (unknown_service, no_team, team_not_found) |
| **POST /resources/:id/rotate_credentials** | `credential_rotation` | `success`, `failed` |
| **POST /provisioning/deep_links** | `deep_link_created` | `success`, `unsupported_purpose` |
| **Region proxy** (account_requests, oauth/token) | `region_proxy` | `proxied`, `proxy_failed` (with strategy, from_region, to_domain, endpoint) |

Read-only GET endpoints (health, services, resource detail) are covered by existing signature verification events.

## How did you test this code

- Verified existing tests still pass (no behavioral changes, only added analytics captures)
- Events follow the exact same pattern as the existing `_capture_deep_link_event` helper
- A monitoring dashboard has been created at https://us.posthog.com/project/2/dashboard/1401455 to track these events once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)