### PR TITLE
refactor(logs): extract LogsFilterBuilder from LogsQueryRunnerMixin for standalone reuse

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -28,7 +28,7 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.filters.mixins.utils import cached_property
 
 if TYPE_CHECKING:
-    from posthog.models import User
+    from posthog.models import Team, User
 
 
 def _generate_resource_attribute_filters(
@@ -122,34 +122,26 @@ def _generate_resource_attribute_filters(
     )
 
 
-class LogsQueryRunnerMixin(QueryRunner):
-    @cached_property
-    def settings(self):
-        return HogQLGlobalSettings(
-            max_bytes_to_read=None,
-            read_overflow_mode=None,
-        )
+def _get_property_type(value) -> str:
+    try:
+        float(value)
+        return "float"
+    except ValueError:
+        pass
+    # todo: datetime?
+    return "str"
 
-    def __init__(self, query, *args, **kwargs):
-        super().__init__(query, *args, **kwargs)
 
-        self.paginator = HogQLHasMorePaginator.from_limit_context(
-            limit_context=LimitContext.QUERY,
-            limit=self.query.limit if self.query.limit else None,
-            offset=self.query.offset,
-        )
+class LogsFilterBuilder:
+    """Builds HogQL WHERE clause AST from LogsQuery filter fields.
 
-        self.modifiers.convertToProjectTimezone = False
-        self.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
+    Standalone — no QueryRunner dependency.
+    """
 
-        def get_property_type(value):
-            try:
-                value = float(value)
-                return "float"
-            except ValueError:
-                pass
-            # todo: datetime?
-            return "str"
+    def __init__(self, query: LogsQuery, team: "Team", query_date_range: QueryDateRange):
+        self.query = query
+        self.team = team
+        self.query_date_range = query_date_range
 
         self.resource_attribute_filters: list[LogPropertyFilter] = []
         self.resource_attribute_negative_filters: list[LogPropertyFilter] = []
@@ -163,7 +155,7 @@ class LogsQueryRunnerMixin(QueryRunner):
                         f
                         for f in property_group.values
                         if f.type == LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE
-                        and not operator_is_negative(f.operator)
+                        and not operator_is_negative(f.operator)  # type: ignore[arg-type, union-attr]
                     ],
                 )
                 self.resource_attribute_negative_filters = cast(
@@ -171,11 +163,12 @@ class LogsQueryRunnerMixin(QueryRunner):
                     [
                         f
                         for f in property_group.values
-                        if f.type == LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE and operator_is_negative(f.operator)
+                        if f.type == LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE and operator_is_negative(f.operator)  # type: ignore[arg-type, union-attr]
                     ],
                 )
                 self.log_filters = cast(
-                    list[LogPropertyFilter], [f for f in property_group.values if f.type == LogPropertyFilterType.LOG]
+                    list[LogPropertyFilter],
+                    [f for f in property_group.values if f.type == LogPropertyFilterType.LOG],
                 )
 
             # dynamically detect type of the given property values
@@ -194,61 +187,19 @@ class LogsQueryRunnerMixin(QueryRunner):
                 if isinstance(property_filter, LogPropertyFilter) and property_filter.value:
                     property_type = "str"
                     if isinstance(property_filter.value, list):
-                        property_types = {get_property_type(v) for v in property_filter.value}
+                        property_types = {_get_property_type(v) for v in property_filter.value}
                         # only use the detected type if all given values have the same type
                         # e.g. if values are '1', '2', we can use float, if values are '1', 'a', stick to str
                         if len(property_types) == 1:
                             property_type = property_types.pop()
                     else:
-                        property_type = get_property_type(property_filter.value)
+                        property_type = _get_property_type(property_filter.value)
 
                     # defensive copy as we mutate the filter here and don't want to impact other copies
                     property_filter = property_filter.copy(deep=True)
                     property_filter.key = f"{property_filter.key}__{property_type}"
 
                     self.attribute_filters.insert(0, property_filter)
-
-    @cached_property
-    def query_date_range(self) -> QueryDateRange:
-        qdr = QueryDateRange(
-            date_range=self.query.dateRange,
-            team=self.team,
-            interval=IntervalType.MINUTE,
-            interval_count=2,
-            now=dt.datetime.now(),
-        )
-
-        _step = (qdr.date_to() - qdr.date_from()) / 50
-        interval_type = IntervalType.SECOND
-
-        def find_closest(target, arr):
-            if not arr:
-                raise ValueError("Input array cannot be empty")
-            closest_number = min(arr, key=lambda x: (abs(x - target), x))
-
-            return closest_number
-
-        # set the number of intervals to a "round" number of minutes
-        # it's hard to reason about the rate of logs on e.g. 13 minute intervals
-        # the min interval is 1 minute and max interval is 1 day
-        interval_count = find_closest(
-            _step.total_seconds(),
-            [1, 5, 10] + [x * 60 for x in [1, 2, 5, 10, 15, 30, 60, 120, 240, 360, 720, 1440]],
-        )
-
-        if _step >= dt.timedelta(minutes=1):
-            interval_type = IntervalType.MINUTE
-            interval_count //= 60
-
-        return QueryDateRange(
-            date_range=self.query.dateRange,
-            team=self.team,
-            interval=interval_type,
-            interval_count=int(interval_count),
-            now=dt.datetime.now(),
-            timezone_info=ZoneInfo("UTC"),
-            exact_timerange=True,
-        )
 
     def where(self) -> ast.Expr:
         exprs: list[ast.Expr] = []
@@ -398,6 +349,79 @@ class LogsQueryRunnerMixin(QueryRunner):
             return negative_resource_filter
 
         return ast.Constant(value=1)
+
+
+class LogsQueryRunnerMixin(QueryRunner):
+    @cached_property
+    def settings(self):
+        return HogQLGlobalSettings(
+            max_bytes_to_read=None,
+            read_overflow_mode=None,
+        )
+
+    def __init__(self, query, *args, **kwargs):
+        super().__init__(query, *args, **kwargs)
+
+        self.paginator = HogQLHasMorePaginator.from_limit_context(
+            limit_context=LimitContext.QUERY,
+            limit=self.query.limit if self.query.limit else None,
+            offset=self.query.offset,
+        )
+
+        self.modifiers.convertToProjectTimezone = False
+        self.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
+
+    @cached_property
+    def _filter_builder(self) -> LogsFilterBuilder:
+        return LogsFilterBuilder(self.query, self.team, self.query_date_range)
+
+    @cached_property
+    def query_date_range(self) -> QueryDateRange:
+        qdr = QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=IntervalType.MINUTE,
+            interval_count=2,
+            now=dt.datetime.now(),
+        )
+
+        _step = (qdr.date_to() - qdr.date_from()) / 50
+        interval_type = IntervalType.SECOND
+
+        def find_closest(target, arr):
+            if not arr:
+                raise ValueError("Input array cannot be empty")
+            closest_number = min(arr, key=lambda x: (abs(x - target), x))
+
+            return closest_number
+
+        # set the number of intervals to a "round" number of minutes
+        # it's hard to reason about the rate of logs on e.g. 13 minute intervals
+        # the min interval is 1 minute and max interval is 1 day
+        interval_count = find_closest(
+            _step.total_seconds(),
+            [1, 5, 10] + [x * 60 for x in [1, 2, 5, 10, 15, 30, 60, 120, 240, 360, 720, 1440]],
+        )
+
+        if _step >= dt.timedelta(minutes=1):
+            interval_type = IntervalType.MINUTE
+            interval_count //= 60
+
+        return QueryDateRange(
+            date_range=self.query.dateRange,
+            team=self.team,
+            interval=interval_type,
+            interval_count=int(interval_count),
+            now=dt.datetime.now(),
+            timezone_info=ZoneInfo("UTC"),
+            exact_timerange=True,
+        )
+
+    def where(self) -> ast.Expr:
+        return self._filter_builder.where()
+
+    def resource_filter(self, *, existing_filters):
+        return self._filter_builder.resource_filter(existing_filters=existing_filters)
 
 
 class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):


### PR DESCRIPTION
## Problem

The alerting check query needs a HogQL WHERE clause from log filters but the only way to do that was by re using the `LogsQueryRunnerMixin` which drags in the entire `QueryRunner`, this decouples `LogsFilterBuilder` from the LogsQueryRunner so it can be used standalone

## Changes

- extract filter-parsing logic and `where()`/`resource_filter()` from `LogsQueryRunnerMixin` into standalone `LogsFilterBuilder` class with no `QueryRunner` dependency
- mixin now delegates to `LogsFilterBuilder` via `cached_property _filter_builder`
- `_get_property_type()` promoted from nested function to module-level

no changes to `LogsQueryRunner`, `SparklineQueryRunner`, `LogValuesQueryRunner`, or `LogAttributesQueryRunner`

## How did you test this code?

existing tests pass

## Publish to changelog?

no