### PR TITLE
fix(data-warehouse): prevent browser crash on ExternalDataSchema admin page

### DIFF
--- a/posthog/admin/admins/external_data_schema_admin.py
+++ b/posthog/admin/admins/external_data_schema_admin.py
@@ -26,7 +26,7 @@ class ExternalDataSchemaAdmin(admin.ModelAdmin):
     search_fields = ("id", "name", "team__name", "team__organization__name")
     autocomplete_fields = ("team",)
     raw_id_fields = ("table", "source")
-    readonly_fields = ("table", "source")
+    readonly_fields = ("table", "source", "created_by")
     ordering = ("-created_at",)
 
     change_form_template = "admin/data_warehouse/externaldataschema/change_form.html"


### PR DESCRIPTION
## Problem

Loading an ExternalDataSchema in Django admin (e.g. `/admin/data_warehouse/externaldataschema/<id>/change/`) causes the browser to hang and crash. The `created_by` ForeignKey field (inherited from `CreatedMetaFields`) renders a `<select>` dropdown populated with every user in the database.

## Changes

Added `created_by` to `readonly_fields` on `ExternalDataSchemaAdmin` so Django renders it as plain text instead of a dropdown. All other admin classes were audited — they either already protect `created_by` via `readonly_fields`, use explicit `fieldsets` that omit it, or disable the change form entirely.

## How did you test this code?

Audited all 46 admin files in `posthog/admin/admins/` to confirm this is the only affected class. The fix is a standard Django admin pattern — `readonly_fields` prevents form widget generation for the field.