### PR TITLE
fix(data-warehouse): Keep the job inputs access token fresh

### DIFF
--- a/posthog/temporal/data_imports/sources/hubspot/auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/auth.py
@@ -42,6 +42,11 @@ def _update_source_job_inputs(source_id: str, access_token: str) -> None:
     try:
         source = ExternalDataSource.objects.get(id=source_id)
         job_inputs = source.job_inputs or {}
+
+        # Only persist for legacy sources that store credentials directly in job_inputs
+        if "hubspot_integration_id" in job_inputs:
+            return
+
         job_inputs["hubspot_secret_key"] = access_token
         source.job_inputs = job_inputs
         source.save(update_fields=["job_inputs"])

--- a/posthog/temporal/data_imports/sources/hubspot/auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/auth.py
@@ -1,9 +1,12 @@
 from django.conf import settings
 
 import requests
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 
-def hubspot_refresh_access_token(refresh_token: str) -> str:
+def hubspot_refresh_access_token(refresh_token: str, source_id: str | None = None) -> str:
     res = requests.post(
         "https://api.hubapi.com/oauth/v1/token",
         data={
@@ -18,7 +21,25 @@ def hubspot_refresh_access_token(refresh_token: str) -> str:
         err_message = res.json()["message"]
         raise Exception(err_message)
 
-    return res.json()["access_token"]
+    access_token = res.json()["access_token"]
+
+    if source_id:
+        _update_source_job_inputs(source_id, access_token)
+
+    return access_token
+
+
+def _update_source_job_inputs(source_id: str, access_token: str) -> None:
+    from products.data_warehouse.backend.models.external_data_source import ExternalDataSource
+
+    try:
+        source = ExternalDataSource.objects.get(id=source_id)
+        job_inputs = source.job_inputs or {}
+        job_inputs["hubspot_secret_key"] = access_token
+        source.job_inputs = job_inputs
+        source.save(update_fields=["job_inputs"])
+    except Exception:
+        logger.exception("Failed to update job_inputs after HubSpot token refresh", source_id=source_id)
 
 
 def get_hubspot_access_token_from_code(code: str, redirect_uri: str) -> tuple[str, str]:

--- a/posthog/temporal/data_imports/sources/hubspot/auth.py
+++ b/posthog/temporal/data_imports/sources/hubspot/auth.py
@@ -29,6 +29,13 @@ def hubspot_refresh_access_token(refresh_token: str, source_id: str | None = Non
     return access_token
 
 
+def hubspot_access_token_is_valid(access_token: str) -> bool:
+    res = requests.get(
+        "https://api.hubapi.com/oauth/v1/access-tokens/" + access_token,
+    )
+    return res.status_code == 200
+
+
 def _update_source_job_inputs(source_id: str, access_token: str) -> None:
     from products.data_warehouse.backend.models.external_data_source import ExternalDataSource
 

--- a/posthog/temporal/data_imports/sources/hubspot/helpers.py
+++ b/posthog/temporal/data_imports/sources/hubspot/helpers.py
@@ -129,19 +129,15 @@ def fetch_data(
     headers = _get_headers(api_key)
 
     # Make the API request
+    r = requests.get(url, headers=headers, params=params)
     try:
-        r = requests.get(url, headers=headers, params=params)
-        if r.status_code == 401:
-            # refresh token
-            api_key = hubspot_refresh_access_token(refresh_token, source_id=source_id)
-            headers = _get_headers(api_key)
-            r = requests.get(url, headers=headers, params=params)
+        r.raise_for_status()
     except requests.exceptions.HTTPError as e:
         if e.response.status_code == 401:
-            # refresh token
             api_key = hubspot_refresh_access_token(refresh_token, source_id=source_id)
             headers = _get_headers(api_key)
             r = requests.get(url, headers=headers, params=params)
+            r.raise_for_status()
         else:
             raise
     # Parse the API response and yield the properties of each result
@@ -180,14 +176,15 @@ def fetch_data(
         if _next:
             next_url = _next["link"]
             # Get the next page response
+            r = requests.get(next_url, headers=headers)
             try:
-                r = requests.get(next_url, headers=headers)
+                r.raise_for_status()
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 401:
-                    # refresh token
                     api_key = hubspot_refresh_access_token(refresh_token, source_id=source_id)
                     headers = _get_headers(api_key)
                     r = requests.get(next_url, headers=headers)
+                    r.raise_for_status()
                 else:
                     raise
             _data = r.json()

--- a/posthog/temporal/data_imports/sources/hubspot/helpers.py
+++ b/posthog/temporal/data_imports/sources/hubspot/helpers.py
@@ -92,7 +92,11 @@ def fetch_property_history(
 
 
 def fetch_data(
-    endpoint: str, api_key: str, refresh_token: str, params: Optional[dict[str, Any]] = None
+    endpoint: str,
+    api_key: str,
+    refresh_token: str,
+    params: Optional[dict[str, Any]] = None,
+    source_id: str | None = None,
 ) -> Iterator[list[dict[str, Any]]]:
     """
     Fetch data from HUBSPOT endpoint using a specified API key and yield the properties of each result.
@@ -129,13 +133,13 @@ def fetch_data(
         r = requests.get(url, headers=headers, params=params)
         if r.status_code == 401:
             # refresh token
-            api_key = hubspot_refresh_access_token(refresh_token)
+            api_key = hubspot_refresh_access_token(refresh_token, source_id=source_id)
             headers = _get_headers(api_key)
             r = requests.get(url, headers=headers, params=params)
     except requests.exceptions.HTTPError as e:
         if e.response.status_code == 401:
             # refresh token
-            api_key = hubspot_refresh_access_token(refresh_token)
+            api_key = hubspot_refresh_access_token(refresh_token, source_id=source_id)
             headers = _get_headers(api_key)
             r = requests.get(url, headers=headers, params=params)
         else:
@@ -181,7 +185,7 @@ def fetch_data(
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code == 401:
                     # refresh token
-                    api_key = hubspot_refresh_access_token(refresh_token)
+                    api_key = hubspot_refresh_access_token(refresh_token, source_id=source_id)
                     headers = _get_headers(api_key)
                     r = requests.get(next_url, headers=headers)
                 else:
@@ -191,7 +195,7 @@ def fetch_data(
             _data = None
 
 
-def _get_property_names(api_key: str, refresh_token: str, object_type: str) -> list[str]:
+def _get_property_names(api_key: str, refresh_token: str, object_type: str, source_id: str | None = None) -> list[str]:
     """
     Retrieve property names for a given entity from the HubSpot API.
 
@@ -207,7 +211,7 @@ def _get_property_names(api_key: str, refresh_token: str, object_type: str) -> l
     properties = []
     endpoint = f"/crm/v3/properties/{OBJECT_TYPE_PLURAL[object_type]}"
 
-    for page in fetch_data(endpoint, api_key, refresh_token):
+    for page in fetch_data(endpoint, api_key, refresh_token, source_id=source_id):
         properties.extend([prop["name"] for prop in page])
 
     return properties

--- a/posthog/temporal/data_imports/sources/hubspot/hubspot.py
+++ b/posthog/temporal/data_imports/sources/hubspot/hubspot.py
@@ -44,11 +44,12 @@ def _get_properties_str(
     object_type: str,
     logger: FilteringBoundLogger,
     include_custom_props: bool = True,
+    source_id: str | None = None,
 ) -> str:
     """Builds a string of properties to be requested from the HubSpot API."""
     props = list(props)
     if include_custom_props:
-        all_props = _get_property_names(api_key, refresh_token, object_type)
+        all_props = _get_property_names(api_key, refresh_token, object_type, source_id=source_id)
         custom_props = [prop for prop in all_props if not prop.startswith("hs_")]
         props = props + [c for c in custom_props if c not in props]
 
@@ -116,6 +117,7 @@ def get_rows(
     resumable_source_manager: ResumableSourceManager[HubspotResumeConfig],
     include_custom_props: bool = True,
     selected_properties: list[str] | None = None,
+    source_id: str | None = None,
 ) -> Iterator[Any]:
     config = HUBSPOT_ENDPOINTS[endpoint]
     object_type = OBJECT_TYPE_SINGULAR[endpoint]
@@ -128,7 +130,7 @@ def get_rows(
 
     if selected_properties:
         # Validate selected properties against what HubSpot actually has
-        available_props = set(_get_property_names(api_key, refresh_token, object_type))
+        available_props = set(_get_property_names(api_key, refresh_token, object_type, source_id=source_id))
         invalid_props = [p for p in selected_properties if p not in available_props]
         if invalid_props:
             logger.warning(
@@ -151,6 +153,7 @@ def get_rows(
             object_type=object_type,
             include_custom_props=False,
             logger=logger,
+            source_id=source_id,
         )
     else:
         props_str = _get_properties_str(
@@ -160,6 +163,7 @@ def get_rows(
             object_type=object_type,
             include_custom_props=include_custom_props,
             logger=logger,
+            source_id=source_id,
         )
         expected_properties = props_str.split(",") if props_str else []
 
@@ -191,7 +195,7 @@ def get_rows(
         response = requests.get(page_url, headers=headers, timeout=60)
 
         if response.status_code == 401:
-            api_key = hubspot_refresh_access_token(refresh_token)
+            api_key = hubspot_refresh_access_token(refresh_token, source_id=source_id)
             headers = _get_headers(api_key)
             raise HubspotRetryableError(f"Hubspot API 401 - refreshed token, retrying: url={page_url}")
 
@@ -247,6 +251,7 @@ def hubspot_source(
     resumable_source_manager: ResumableSourceManager[HubspotResumeConfig],
     include_custom_props: bool = True,
     selected_properties: list[str] | None = None,
+    source_id: str | None = None,
 ) -> SourceResponse:
     endpoint_config = HUBSPOT_ENDPOINTS[endpoint]
 
@@ -260,6 +265,7 @@ def hubspot_source(
             resumable_source_manager=resumable_source_manager,
             include_custom_props=include_custom_props,
             selected_properties=selected_properties,
+            source_id=source_id,
         ),
         primary_keys=["id"],
         partition_count=1,

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -17,7 +17,10 @@ from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import HubspotSourceConfig
-from posthog.temporal.data_imports.sources.hubspot.auth import hubspot_refresh_access_token
+from posthog.temporal.data_imports.sources.hubspot.auth import (
+    hubspot_access_token_is_valid,
+    hubspot_refresh_access_token,
+)
 from posthog.temporal.data_imports.sources.hubspot.hubspot import HubspotResumeConfig, hubspot_source
 from posthog.temporal.data_imports.sources.hubspot.settings import (
     DEFAULT_PROPS,
@@ -138,7 +141,7 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             else:
                 refresh_token = config_refresh_token
 
-            if not config_hubspot_access_code:
+            if not config_hubspot_access_code or not hubspot_access_token_is_valid(config_hubspot_access_code):
                 hubspot_access_code = hubspot_refresh_access_token(refresh_token, source_id=inputs.source_id)
             else:
                 hubspot_access_code = config_hubspot_access_code

--- a/posthog/temporal/data_imports/sources/hubspot/source.py
+++ b/posthog/temporal/data_imports/sources/hubspot/source.py
@@ -139,7 +139,7 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
                 refresh_token = config_refresh_token
 
             if not config_hubspot_access_code:
-                hubspot_access_code = hubspot_refresh_access_token(refresh_token)
+                hubspot_access_code = hubspot_refresh_access_token(refresh_token, source_id=inputs.source_id)
             else:
                 hubspot_access_code = config_hubspot_access_code
 
@@ -157,4 +157,5 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             logger=inputs.logger,
             resumable_source_manager=resumable_source_manager,
             selected_properties=selected_properties,
+            source_id=inputs.source_id,
         )


### PR DESCRIPTION
## Problem
- We're having to refresh hubspot access tokens constantly cos we're not saving them back in the db, meaning we have to refresh them yet again on the next sync

## Changes
Save the new access token back into the db


## Publish to changelog?
No