### PR TITLE
chore(endpoints): disallow short interval materialization sync

### DIFF
--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -106,6 +106,7 @@ from common.hogvm.python.utils import HogVMException
 
 MIN_CACHE_AGE_SECONDS = 300
 MAX_CACHE_AGE_SECONDS = 86400
+MIN_SYNC_FREQUENCY_INTERVAL = timedelta(minutes=30)
 ENDPOINT_BREAKDOWN_LIMIT = 10_000
 
 
@@ -429,6 +430,15 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     }
                 )
 
+    def _validate_sync_frequency(self, sync_frequency: DataWarehouseSyncInterval | None) -> None:
+        """Validate sync_frequency is not too frequent for endpoints."""
+        if sync_frequency is not None:
+            interval = sync_frequency_to_sync_frequency_interval(sync_frequency.value)
+            if interval is not None and interval < MIN_SYNC_FREQUENCY_INTERVAL:
+                raise ValidationError(
+                    {"sync_frequency": f"Sync frequency must be at least 30 minutes. Got: {sync_frequency.value}."}
+                )
+
     def _validate_hogql_query(self, query: HogQLQuery) -> None:
         """Validate that a HogQL query can be parsed and the variables are valid."""
         try:
@@ -583,6 +593,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             self._validate_hogql_query(query)
 
         self._validate_cache_age_seconds(data.cache_age_seconds)
+        self._validate_sync_frequency(data.sync_frequency)
 
     @extend_schema(
         request=EndpointRequest,
@@ -668,6 +679,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         strict: bool = True,
     ) -> None:
         self._validate_cache_age_seconds(data.cache_age_seconds)
+        self._validate_sync_frequency(data.sync_frequency)
 
         # Determine final states after this request (for validation)
         will_be_active = data.is_active if data.is_active is not None else (endpoint.is_active if endpoint else True)

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -168,6 +168,49 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         saved_query.refresh_from_db()
         self.assertEqual(saved_query.sync_frequency_interval, timedelta(hours=1))
 
+    @parameterized.expand(
+        [
+            ("5min", DataWarehouseSyncInterval.FIELD_5MIN),
+            ("15min", DataWarehouseSyncInterval.FIELD_15MIN),
+        ]
+    )
+    def test_sync_frequency_below_30min_rejected_on_create(self, _name, sync_frequency):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/endpoints/",
+            {
+                "name": f"test_freq_{_name}",
+                "query": self.sample_hogql_query,
+                "sync_frequency": sync_frequency,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("at least 30 minutes", str(response.json()))
+
+    @parameterized.expand(
+        [
+            ("5min", DataWarehouseSyncInterval.FIELD_5MIN),
+            ("15min", DataWarehouseSyncInterval.FIELD_15MIN),
+        ]
+    )
+    def test_sync_frequency_below_30min_rejected_on_update(self, _name, sync_frequency):
+        endpoint = create_endpoint_with_version(
+            name=f"test_freq_update_{_name}",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+        )
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+            {
+                "is_materialized": True,
+                "sync_frequency": sync_frequency,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("at least 30 minutes", str(response.json()))
+
     def test_disable_materialization_removes_saved_query(self):
         """Test that disabling materialization removes the SavedQuery."""
         # Create and materialize an endpoint


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
endpoints go around the saved query stuff to set the sync frequency

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
disallow less than 30 min syncs
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
- ran tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
no
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
