### PR TITLE
chore(phrocs): color value to shared palette constant

### DIFF
--- a/tools/phrocs/internal/palette/palette.go
+++ b/tools/phrocs/internal/palette/palette.go
@@ -11,6 +11,7 @@ var (
 	ColorRed      = lipgloss.Color("#F04438")
 	ColorWhite    = lipgloss.Color("#FFFFFF")
 	ColorBlack    = lipgloss.Color("#151515")
+	ColorMidGrey  = lipgloss.Color("#555860") // focused-border accent
 
 	// Subtle background tint for CPU usage bars (htop-style)
 	ColorBarLow  = lipgloss.Color("#1A3A1A") // green tint, low CPU

--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -27,6 +27,7 @@ var (
 	colorRed      = sharedpalette.ColorRed
 	colorWhite    = sharedpalette.ColorWhite
 	colorBlack    = sharedpalette.ColorBlack
+	colorMidGrey  = sharedpalette.ColorMidGrey
 )
 
 // Outer width of the process list column (including border)
@@ -75,7 +76,7 @@ var (
 
 	borderFocusedStyle = borderStyle.
 				BorderStyle(lipgloss.ThickBorder()).
-				BorderForeground(lipgloss.Color("#555860"))
+				BorderForeground(colorMidGrey)
 
 	// Sidebar
 	procInactiveStyle = lipgloss.NewStyle().


### PR DESCRIPTION
## Problem

A hardcoded color value (`#555860`) was used directly in the styles file for the focused border accent, making it difficult to maintain consistency across the codebase and reuse this color elsewhere.

## Changes

- Added `ColorMidGrey` constant to the shared palette (`tools/phrocs/internal/palette/palette.go`) with the value `#555860` and a descriptive comment indicating its use for focused-border accent
- Updated `borderFocusedStyle` in `tools/phrocs/internal/tui/styles.go` to use the new `colorMidGrey` constant instead of the hardcoded hex value
- Imported the new constant into the styles file alongside other shared palette colors

This improves code maintainability by centralizing color definitions and making the purpose of the color explicit.

## How did you test this code?

This is a straightforward refactoring that extracts a magic value to a named constant. No functional behavior changes. The code compiles and the color value remains identical.

## Publish to changelog?

No

https://claude.ai/code/session_01WhTTpTsVKhkTyqtq7vtkUD