### PR TITLE
chore: increase per-team query cache size limit from 800MiB to 1GB

### DIFF
--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -38,8 +38,8 @@ COUNT_TILES_WITH_NO_FILTERS_HASH_INTERVAL_SECONDS = get_from_env(
 CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
-# Per-team cache size limit (default 800MiB, can be overridden per-team via Team.extra_settings)
-TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 800 * 1024 * 1024, type_cast=int)
+# Per-team cache size limit (default 1GB, can be overridden per-team via Team.extra_settings)
+TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 1_000_000_000, type_cast=int)
 
 # Schedule to run asynchronous data deletion on. Follows crontab syntax.
 # Use empty string to prevent this

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -39,6 +39,7 @@ CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
 # Per-team cache size limit (default 1GB, can be overridden per-team via Team.extra_settings)
+# Per-team cache size limit (default 1 GB = 1,000,000,000 bytes; can be overridden per-team via Team.extra_settings)
 TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 1_000_000_000, type_cast=int)
 
 # Schedule to run asynchronous data deletion on. Follows crontab syntax.

--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -39,7 +39,6 @@ CACHED_RESULTS_TTL_DAYS = 7
 CACHED_RESULTS_TTL = CACHED_RESULTS_TTL_DAYS * 24 * 60 * 60
 
 # Per-team cache size limit (default 1GB, can be overridden per-team via Team.extra_settings)
-# Per-team cache size limit (default 1 GB = 1,000,000,000 bytes; can be overridden per-team via Team.extra_settings)
 TEAM_CACHE_SIZE_LIMIT_BYTES = get_from_env("TEAM_CACHE_SIZE_LIMIT_BYTES", 1_000_000_000, type_cast=int)
 
 # Schedule to run asynchronous data deletion on. Follows crontab syntax.


### PR DESCRIPTION
## Summary

- Increases the default per-team query cache size limit from 800 MiB to 1 GB (`TEAM_CACHE_SIZE_LIMIT_BYTES`)

there is plenty of space

<img width="1728" height="618" alt="Screenshot 2026-03-26 at 5 05 14 PM" src="https://github.com/user-attachments/assets/7b13adaa-5aa9-4ac0-b255-1ba1b13d6252" />

https://grafana.prod-us.posthog.dev/d/af9h9hoy427swd/query-cache