### PR TITLE
fix: use _offset instead of _timestamp in HogQL realtime cohort query

### DIFF
--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -1167,7 +1167,7 @@ class HogQLRealtimeCohortQuery(HogQLCohortQuery):
                     team_id = {team_id}
                     AND condition = {condition_hash}
                 GROUP BY person_id
-                HAVING argMax(matches, _timestamp) = 1
+                HAVING argMax(matches, _offset) = 1
             """
 
             return cast(


### PR DESCRIPTION
## Problem

The HogQL realtime cohort query was using `_timestamp` instead of `_offset` in the `argMax` function, which could lead to incorrect temporal ordering when determining the most recent match state for persons in cohorts.

## Changes

- Updated `argMax(matches, _timestamp)` to `argMax(matches, _offset)` in the realtime cohort query
- This ensures correct ordering based on the ClickHouse offset rather than timestamp

## How did you test this code?

- Running calculations locally