### PR TITLE
feat: remove ambiguous characters from PostHog API keys/tokens

### DIFF
--- a/posthog/models/test/test_utils.py
+++ b/posthog/models/test/test_utils.py
@@ -98,14 +98,15 @@ class TestTokenGeneration:
             ("personal_35B", generate_random_token_personal, "phx_", 35),
         ]
     )
-    def test_minimum_length_preserves_entropy(self, _name, generator, prefix, entropy_bytes):
-        max_base57_digits = math.ceil(entropy_bytes * 8 / math.log2(57))
+    def test_exact_length(self, _name, generator, prefix, entropy_bytes):
+        bits = entropy_bytes * 8
+        # With top bit forced on, value is in [2^(bits-1), 2^bits)
+        min_digits = math.floor(math.log(2 ** (bits - 1), 57)) + 1
+        max_digits = math.floor(math.log(2**bits - 1, 57)) + 1
         for _ in range(20):
             token = generator()
             body = token[len(prefix) :]
-            # randbits can produce values with leading zeros in base57, so the
-            # output may be up to 1 digit shorter than the theoretical max
-            assert len(body) >= max_base57_digits - 1, f"Token body too short: {len(body)} < {max_base57_digits - 1}"
+            assert min_digits <= len(body) <= max_digits, f"Expected {min_digits}-{max_digits} digits, got {len(body)}"
 
 
 def test_convert_funnel_query():

--- a/posthog/models/test/test_utils.py
+++ b/posthog/models/test/test_utils.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from parameterized import parameterized
 
 from posthog.models.utils import (
+    AMBIGUOUS_CHARS,
     BASE57,
     convert_legacy_metric,
     convert_legacy_metrics,
@@ -62,7 +63,6 @@ def test_mask_key_value():
     assert mask_key_value("") == "********"  # Empty string
 
 
-AMBIGUOUS_CHARS = set("01OIl")
 BASE57_SET = set(BASE57)
 
 

--- a/posthog/models/test/test_utils.py
+++ b/posthog/models/test/test_utils.py
@@ -19,6 +19,7 @@ from posthog.models.utils import (
     generate_random_token_personal,
     generate_random_token_project,
     generate_random_token_secret,
+    int_to_base,
     mask_key_value,
     uuid7,
     validate_rate_limit,
@@ -95,7 +96,11 @@ class TestTokenGeneration:
     @parameterized.expand(
         [
             ("bare_32B", generate_random_token, "", 32),
+            ("project_32B", generate_random_token_project, "phc_", 32),
             ("personal_35B", generate_random_token_personal, "phx_", 35),
+            ("secret_35B", generate_random_token_secret, "phs_", 35),
+            ("oauth_access_32B", lambda: generate_random_oauth_access_token(None), "pha_", 32),
+            ("oauth_refresh_32B", lambda: generate_random_oauth_refresh_token(None), "phr_", 32),
         ]
     )
     def test_exact_length(self, _name, generator, prefix, entropy_bytes):
@@ -107,6 +112,59 @@ class TestTokenGeneration:
             token = generator()
             body = token[len(prefix) :]
             assert min_digits <= len(body) <= max_digits, f"Expected {min_digits}-{max_digits} digits, got {len(body)}"
+
+
+class TestIntToBase:
+    def test_zero_returns_first_char_of_alphabet(self):
+        assert int_to_base(0, 57, alphabet=BASE57) == "2"
+
+    def test_zero_returns_zero_with_default_alphabet(self):
+        assert int_to_base(0, 10) == "0"
+
+    def test_small_values(self):
+        assert int_to_base(1, 57, alphabet=BASE57) == "3"
+        assert int_to_base(56, 57, alphabet=BASE57) == "Z"
+        assert int_to_base(57, 57, alphabet=BASE57) == "32"
+
+    def test_negative_number(self):
+        result = int_to_base(-100, 57, alphabet=BASE57)
+        assert result.startswith("-")
+        assert set(result[1:]) <= set(BASE57)
+
+    def test_negative_zero(self):
+        assert int_to_base(-0, 57, alphabet=BASE57) == "2"
+
+    def test_large_number(self):
+        result = int_to_base(2**256, 57, alphabet=BASE57)
+        assert set(result) <= set(BASE57)
+        assert len(result) > 0
+
+    def test_default_alphabet_base10(self):
+        assert int_to_base(42, 10) == "42"
+        assert int_to_base(255, 16) == "ff"
+
+    def test_default_alphabet_base62(self):
+        assert int_to_base(61, 62) == "Z"
+
+    def test_alphabet_length_mismatch_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="Alphabet length"):
+            int_to_base(42, 10, alphabet=BASE57)
+
+    def test_base_above_62_without_alphabet_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="Cannot convert integer to base above 62"):
+            int_to_base(42, 63)
+
+    def test_custom_alphabet_respected(self):
+        alpha = "ab"
+        assert int_to_base(0, 2, alphabet=alpha) == "a"
+        assert int_to_base(1, 2, alphabet=alpha) == "b"
+        assert int_to_base(2, 2, alphabet=alpha) == "ba"
+        assert int_to_base(3, 2, alphabet=alpha) == "bb"
+        assert int_to_base(4, 2, alphabet=alpha) == "baa"
 
 
 def test_convert_funnel_query():

--- a/posthog/models/test/test_utils.py
+++ b/posthog/models/test/test_utils.py
@@ -1,3 +1,4 @@
+import math
 from random import Random
 from uuid import UUID
 
@@ -5,9 +6,18 @@ from posthog.test.base import BaseTest
 
 from django.core.exceptions import ValidationError
 
+from parameterized import parameterized
+
 from posthog.models.utils import (
+    BASE57,
     convert_legacy_metric,
     convert_legacy_metrics,
+    generate_random_oauth_access_token,
+    generate_random_oauth_refresh_token,
+    generate_random_token,
+    generate_random_token_personal,
+    generate_random_token_project,
+    generate_random_token_secret,
     mask_key_value,
     uuid7,
     validate_rate_limit,
@@ -50,6 +60,52 @@ def test_mask_key_value():
     assert mask_key_value("phx_shortenedAB") == "********"  # String shorter than 16 chars
     assert mask_key_value("phx_00000000ABCD") == "phx_...ABCD"  # Exactly 8 chars
     assert mask_key_value("") == "********"  # Empty string
+
+
+AMBIGUOUS_CHARS = set("01OIl")
+BASE57_SET = set(BASE57)
+
+
+class TestTokenGeneration:
+    def test_base57_alphabet(self):
+        assert BASE57 == "23456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
+        assert len(BASE57) == 57
+        assert not AMBIGUOUS_CHARS & set(BASE57)
+
+    @parameterized.expand(
+        [
+            ("bare", generate_random_token, "", 32),
+            ("project", generate_random_token_project, "phc_", 32),
+            ("personal", generate_random_token_personal, "phx_", 35),
+            ("secret", generate_random_token_secret, "phs_", 35),
+            ("oauth_access", lambda: generate_random_oauth_access_token(None), "pha_", 32),
+            ("oauth_refresh", lambda: generate_random_oauth_refresh_token(None), "phr_", 32),
+        ]
+    )
+    def test_uses_base57_alphabet(self, _name, generator, prefix, _entropy_bytes):
+        for _ in range(20):
+            token = generator()
+            assert token.startswith(prefix), f"Expected prefix {prefix!r}, got {token[: len(prefix)]!r}"
+            body = token[len(prefix) :]
+            assert set(body) <= BASE57_SET, f"Token body contains non-base57 chars: {set(body) - BASE57_SET}"
+            assert set(body).isdisjoint(AMBIGUOUS_CHARS), (
+                f"Token body contains ambiguous chars: {set(body) & AMBIGUOUS_CHARS}"
+            )
+
+    @parameterized.expand(
+        [
+            ("bare_32B", generate_random_token, "", 32),
+            ("personal_35B", generate_random_token_personal, "phx_", 35),
+        ]
+    )
+    def test_minimum_length_preserves_entropy(self, _name, generator, prefix, entropy_bytes):
+        max_base57_digits = math.ceil(entropy_bytes * 8 / math.log2(57))
+        for _ in range(20):
+            token = generator()
+            body = token[len(prefix) :]
+            # randbits can produce values with leading zeros in base57, so the
+            # output may be up to 1 digit shorter than the theoretical max
+            assert len(body) >= max_base57_digits - 1, f"Token body too short: {len(body)} < {max_base57_digits - 1}"
 
 
 def test_convert_funnel_query():

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -269,7 +269,9 @@ def generate_random_token(nbytes: int = 32) -> str:
 
     Uses base57 encoding (base62 minus 0, 1, O, I, l) to avoid visually ambiguous characters.
     """
-    return int_to_base(secrets.randbits(nbytes * 8), 57, alphabet=BASE57)
+    bits = nbytes * 8
+    value = secrets.randbits(bits) | (1 << (bits - 1))  # Set top bit to guarantee consistent length
+    return int_to_base(value, 57, alphabet=BASE57)
 
 
 def generate_random_token_project() -> str:

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 BASE62 = string.digits + string.ascii_letters  # All lowercase ASCII letters + all uppercase ASCII letters + digits
+BASE57 = "".join(c for c in BASE62 if c not in "01OIl")  # Base62 minus visually ambiguous characters
 EncryptionModeType = Literal["sha256", "pbkdf2"]
 SHA256_HASH_PREFIX = "sha256$"
 
@@ -265,8 +266,10 @@ def generate_random_token(nbytes: int = 32) -> str:
 
     Random 32 bytes - default value here - is believed to be sufficiently secure for practically all purposes:
     https://docs.python.org/3/library/secrets.html#how-many-bytes-should-tokens-use
+
+    Uses base57 encoding (base62 minus 0, 1, O, I, l) to avoid visually ambiguous characters.
     """
-    return int_to_base(secrets.randbits(nbytes * 8), 62)
+    return int_to_base(secrets.randbits(nbytes * 8), 57, alphabet=BASE57)
 
 
 def generate_random_token_project() -> str:
@@ -322,12 +325,15 @@ def hash_key_value(
     return f"sha256${value}"  # Following format from Django's PBKDF2PasswordHasher
 
 
-def int_to_base(number: int, base: int) -> str:
-    if base > 62:
-        raise ValueError("Cannot convert integer to base above 62")
-    alphabet = BASE62[:base]
+def int_to_base(number: int, base: int, *, alphabet: Optional[str] = None) -> str:
+    if alphabet is None:
+        if base > 62:
+            raise ValueError("Cannot convert integer to base above 62")
+        alphabet = BASE62[:base]
+    elif len(alphabet) != base:
+        raise ValueError(f"Alphabet length {len(alphabet)} does not match base {base}")
     if number < 0:
-        return "-" + int_to_base(-number, base)
+        return "-" + int_to_base(-number, base, alphabet=alphabet)
     value = ""
     while number != 0:
         number, index = divmod(number, len(alphabet))

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -33,7 +33,8 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 BASE62 = string.digits + string.ascii_letters  # All lowercase ASCII letters + all uppercase ASCII letters + digits
-BASE57 = "".join(c for c in BASE62 if c not in "01OIl")  # Base62 minus visually ambiguous characters
+AMBIGUOUS_CHARS = frozenset("01OIl")
+BASE57 = "".join(c for c in BASE62 if c not in AMBIGUOUS_CHARS)  # Base62 minus visually ambiguous characters
 EncryptionModeType = Literal["sha256", "pbkdf2"]
 SHA256_HASH_PREFIX = "sha256$"
 
@@ -340,7 +341,7 @@ def int_to_base(number: int, base: int, *, alphabet: Optional[str] = None) -> st
     while number != 0:
         number, index = divmod(number, len(alphabet))
         value = alphabet[index] + value
-    return value or "0"
+    return value or alphabet[0]
 
 
 class Percentile(models.Aggregate):

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -271,7 +271,10 @@ def generate_random_token(nbytes: int = 32) -> str:
     Uses base57 encoding (base62 minus 0, 1, O, I, l) to avoid visually ambiguous characters.
     """
     bits = nbytes * 8
-    value = secrets.randbits(bits) | (1 << (bits - 1))  # Set top bit to guarantee consistent length
+    # Force the top bit on so the encoded token always has the same number of
+    # digits (costs 1 bit of entropy: 255 instead of 256, still far above any
+    # practical brute-force threshold).
+    value = secrets.randbits(bits) | (1 << (bits - 1))
     return int_to_base(value, 57, alphabet=BASE57)
 
 


### PR DESCRIPTION
We've encountered some instances where an `I` is mistaken for a `1`. By switching to base57, we remove the visually ambiguous characters `0`, `1`, `O`, `I`, and `l`.
