### PR TITLE
fix(sql): non-timeseries line and area charts

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -24,6 +24,7 @@ import { ChartDisplayType } from '~/types'
 import { AxisSeries, dataVisualizationLogic } from '../dataVisualizationLogic'
 import { HeatmapSeriesTab } from './Heatmap/HeatmapSeriesTab'
 import { AxisBreakdownSeries, seriesBreakdownLogic } from './seriesBreakdownLogic'
+import { getAvailableSeriesBreakdownColumns } from './seriesBreakdownUtils'
 import { YSeriesLogicProps, YSeriesSettingsTab, ySeriesLogic } from './ySeriesLogic'
 
 export const SeriesTab = (): JSX.Element => {
@@ -37,15 +38,22 @@ export const SeriesTab = (): JSX.Element => {
         showTableSettings,
         tabularColumns,
         selectedXAxis,
+        selectedYAxis,
         dataVisualizationProps,
     } = useValues(dataVisualizationLogic)
     const { updateXSeries, addYSeries } = useActions(dataVisualizationLogic)
     const breakdownLogic = seriesBreakdownLogic({ key: dataVisualizationProps.key })
-    const { showSeriesBreakdown } = useValues(breakdownLogic)
+    const { selectedSeriesBreakdownColumn, showSeriesBreakdown } = useValues(breakdownLogic)
     const { addSeriesBreakdown } = useActions(breakdownLogic)
 
+    const availableBreakdownColumns = getAvailableSeriesBreakdownColumns(columns, selectedXAxis, selectedYAxis)
     const hideAddYSeries = yData.length >= numericalColumns.length
-    const hideAddSeriesBreakdown = !(!showSeriesBreakdown && selectedXAxis && columns.length > yData.length)
+    const hideAddSeriesBreakdown =
+        showSeriesBreakdown || selectedXAxis === null || availableBreakdownColumns.length === 0
+    const showSeriesBreakdownSelector =
+        selectedXAxis !== null &&
+        showSeriesBreakdown &&
+        (selectedSeriesBreakdownColumn !== null || availableBreakdownColumns.length > 0)
 
     if (effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
         return <HeatmapSeriesTab />
@@ -100,7 +108,7 @@ export const SeriesTab = (): JSX.Element => {
                     Add series breakdown
                 </LemonButton>
             )}
-            {showSeriesBreakdown && <SeriesBreakdownSelector />}
+            {showSeriesBreakdownSelector && <SeriesBreakdownSelector />}
 
             <LemonLabel className="mt-4 mb-1">Y-axis</LemonLabel>
             {yData.map((series, index) => (
@@ -424,24 +432,29 @@ const Y_SERIES_SETTINGS_TABS = {
 }
 
 export const SeriesBreakdownSelector = (): JSX.Element => {
-    const { columns, responseLoading, selectedXAxis, dataVisualizationProps } = useValues(dataVisualizationLogic)
+    const { columns, responseLoading, selectedXAxis, selectedYAxis, dataVisualizationProps } =
+        useValues(dataVisualizationLogic)
     const breakdownLogic = seriesBreakdownLogic({ key: dataVisualizationProps.key })
     const { selectedSeriesBreakdownColumn, seriesBreakdownData } = useValues(breakdownLogic)
     const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(breakdownLogic)
 
-    const seriesBreakdownOptions = columns
-        .map(({ name, type }) => ({
-            value: name,
-            label: (
-                <div className="items-center flex-1">
-                    {name}
-                    <LemonTag className="ml-2" type="default">
-                        {type.name}
-                    </LemonTag>
-                </div>
-            ),
-        }))
-        .filter((column) => column.value !== selectedXAxis)
+    const availableBreakdownColumns = getAvailableSeriesBreakdownColumns(columns, selectedXAxis, selectedYAxis)
+
+    if (selectedXAxis === null || (selectedSeriesBreakdownColumn === null && availableBreakdownColumns.length === 0)) {
+        return <></>
+    }
+
+    const seriesBreakdownOptions = availableBreakdownColumns.map(({ name, type }) => ({
+        value: name,
+        label: (
+            <div className="items-center flex-1">
+                {name}
+                <LemonTag className="ml-2" type="default">
+                    {type.name}
+                </LemonTag>
+            </div>
+        ),
+    }))
 
     return (
         <>

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -13,7 +13,10 @@ interface TableDisplayProps extends Pick<LemonSelectProps<ChartDisplayType>, 'di
 
 export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element => {
     const { setVisualizationType } = useActions(dataVisualizationLogic)
-    const { autoVisualizationType, hasDateTimeColumns, visualizationType } = useValues(dataVisualizationLogic)
+    const { autoVisualizationType, columns, hasDateTimeColumns, numericalColumns, visualizationType } =
+        useValues(dataVisualizationLogic)
+
+    const canDisplayLineChart = columns.length > 1 && numericalColumns.length > 0
 
     const displayTypeLabels: Record<ChartDisplayType, string> = {
         [ChartDisplayType.Auto]: 'Auto',
@@ -77,7 +80,9 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
                     value: ChartDisplayType.ActionsLineGraph,
                     icon: <IconTrends />,
                     label: 'Line chart',
-                    disabledReason: !hasDateTimeColumns ? 'Requires a date or datetime column' : undefined,
+                    disabledReason: !canDisplayLineChart
+                        ? 'Requires at least two columns, including one numeric column'
+                        : undefined,
                 },
                 {
                     value: ChartDisplayType.ActionsBar,

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -13,10 +13,9 @@ interface TableDisplayProps extends Pick<LemonSelectProps<ChartDisplayType>, 'di
 
 export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element => {
     const { setVisualizationType } = useActions(dataVisualizationLogic)
-    const { autoVisualizationType, columns, hasDateTimeColumns, numericalColumns, visualizationType } =
-        useValues(dataVisualizationLogic)
+    const { autoVisualizationType, columns, numericalColumns, visualizationType } = useValues(dataVisualizationLogic)
 
-    const canDisplayLineChart = columns.length > 1 && numericalColumns.length > 0
+    const canDisplayContinuousChart = columns.length > 1 && numericalColumns.length > 0
 
     const displayTypeLabels: Record<ChartDisplayType, string> = {
         [ChartDisplayType.Auto]: 'Auto',
@@ -80,7 +79,7 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
                     value: ChartDisplayType.ActionsLineGraph,
                     icon: <IconTrends />,
                     label: 'Line chart',
-                    disabledReason: !canDisplayLineChart
+                    disabledReason: !canDisplayContinuousChart
                         ? 'Requires at least two columns, including one numeric column'
                         : undefined,
                 },
@@ -98,7 +97,9 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
                     value: ChartDisplayType.ActionsAreaGraph,
                     icon: <IconAreaChart />,
                     label: 'Area chart',
-                    disabledReason: !hasDateTimeColumns ? 'Requires a date or datetime column' : undefined,
+                    disabledReason: !canDisplayContinuousChart
+                        ? 'Requires at least two columns, including one numeric column'
+                        : undefined,
                 },
                 {
                     value: ChartDisplayType.TwoDimensionalHeatmap,

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownUtils.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownUtils.test.ts
@@ -1,0 +1,42 @@
+import { Column, SelectedYAxis } from '../dataVisualizationLogic'
+import { getAvailableSeriesBreakdownColumns } from './seriesBreakdownUtils'
+
+const createColumn = (name: string, isNumerical: boolean): Column => ({
+    name,
+    type: {
+        name: isNumerical ? 'INTEGER' : 'STRING',
+        isNumerical,
+    },
+    label: name,
+    dataIndex: 0,
+})
+
+const createYAxis = (name: string): SelectedYAxis => ({
+    name,
+    settings: {
+        formatting: {
+            prefix: '',
+            suffix: '',
+        },
+    },
+})
+
+describe('getAvailableSeriesBreakdownColumns', () => {
+    it('returns no breakdown columns when only the current x-axis and y-axis remain', () => {
+        const columns = [createColumn('screen_width', true), createColumn('screen_height', true)]
+
+        expect(getAvailableSeriesBreakdownColumns(columns, 'screen_width', [createYAxis('screen_height')])).toEqual([])
+    })
+
+    it('excludes the selected x-axis and y-axis columns from breakdown options', () => {
+        const columns = [
+            createColumn('screen_width', true),
+            createColumn('screen_height', true),
+            createColumn('browser', false),
+        ]
+
+        expect(getAvailableSeriesBreakdownColumns(columns, 'screen_width', [createYAxis('screen_height')])).toEqual([
+            createColumn('browser', false),
+        ])
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownUtils.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownUtils.ts
@@ -1,0 +1,11 @@
+import { Column, SelectedYAxis } from '../dataVisualizationLogic'
+
+export const getAvailableSeriesBreakdownColumns = (
+    columns: Column[],
+    selectedXAxis: string | null,
+    selectedYAxis: (SelectedYAxis | null)[] | null
+): Column[] => {
+    const selectedYAxisNames = new Set((selectedYAxis ?? []).flatMap((series) => (series?.name ? [series.name] : [])))
+
+    return columns.filter((column) => column.name !== selectedXAxis && !selectedYAxisNames.has(column.name))
+}

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -225,7 +225,16 @@ describe('dataVisualizationLogic', () => {
         })
     })
 
-    it('uses the first numeric column as x-axis when enabling a line chart on all-numeric data', async () => {
+    it.each([
+        {
+            displayType: ChartDisplayType.ActionsLineGraph,
+            name: 'line chart',
+        },
+        {
+            displayType: ChartDisplayType.ActionsAreaGraph,
+            name: 'area chart',
+        },
+    ])('uses the first numeric column as x-axis when enabling a $name on all-numeric data', async ({ displayType }) => {
         dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
             columns: ['screen_width', 'screen_height'],
             types: [
@@ -238,10 +247,10 @@ describe('dataVisualizationLogic', () => {
             ],
         })
 
-        logic.actions.setVisualizationType(ChartDisplayType.ActionsLineGraph)
+        logic.actions.setVisualizationType(displayType)
 
         await expectLogic(logic).toMatchValues({
-            effectiveVisualizationType: ChartDisplayType.ActionsLineGraph,
+            effectiveVisualizationType: displayType,
             selectedXAxis: 'screen_width',
             selectedYAxis: [
                 {

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -225,6 +225,38 @@ describe('dataVisualizationLogic', () => {
         })
     })
 
+    it('uses the first numeric column as x-axis when enabling a line chart on all-numeric data', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['screen_width', 'screen_height'],
+            types: [
+                ['screen_width', 'Int64'],
+                ['screen_height', 'Int64'],
+            ],
+            results: [
+                [1920, 1080],
+                [1440, 900],
+            ],
+        })
+
+        logic.actions.setVisualizationType(ChartDisplayType.ActionsLineGraph)
+
+        await expectLogic(logic).toMatchValues({
+            effectiveVisualizationType: ChartDisplayType.ActionsLineGraph,
+            selectedXAxis: 'screen_width',
+            selectedYAxis: [
+                {
+                    name: 'screen_height',
+                    settings: {
+                        formatting: {
+                            prefix: '',
+                            suffix: '',
+                        },
+                    },
+                },
+            ],
+        })
+    })
+
     it('fills x-axis labels with empty values when no x-axis is selected', async () => {
         dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
             columns: ['first_value', 'second_value', 'third_value'],

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -319,6 +319,29 @@ const applyAutoHeatmapSettings = (
     })
 }
 
+const shouldUseFirstNumericColumnAsLineChartXAxis = (
+    columns: Column[],
+    numericalColumns: Column[],
+    selectedXAxis: string | null,
+    selectedYAxis: (SelectedYAxis | null)[] | null
+): boolean => {
+    if (selectedXAxis !== null || columns.length < 2 || numericalColumns.length < 2) {
+        return false
+    }
+
+    if (!columns.every((column) => column.type.isNumerical)) {
+        return false
+    }
+
+    if (!selectedYAxis || selectedYAxis.length !== numericalColumns.length) {
+        return false
+    }
+
+    const selectedYAxisNames = new Set(selectedYAxis.map((series) => series?.name))
+
+    return numericalColumns.every((column) => selectedYAxisNames.has(column.name))
+}
+
 export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
     key((props) => props.key),
     path(['queries', 'nodes', 'DataVisualization', 'dataVisualizationLogic']),
@@ -1103,6 +1126,26 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 ...query,
                 display: visualizationType,
             }))
+
+            if (
+                visualizationType === ChartDisplayType.ActionsLineGraph &&
+                shouldUseFirstNumericColumnAsLineChartXAxis(
+                    values.columns,
+                    values.numericalColumns,
+                    values.selectedXAxis,
+                    values.selectedYAxis
+                )
+            ) {
+                const [xAxisColumn] = values.numericalColumns
+                const xAxisSeriesIndex =
+                    values.selectedYAxis?.findIndex((series) => series?.name === xAxisColumn.name) ?? -1
+
+                actions.updateXSeries(xAxisColumn.name)
+
+                if (xAxisSeriesIndex > -1) {
+                    actions.deleteYSeries(xAxisSeriesIndex)
+                }
+            }
 
             const isAutoHeatmap =
                 visualizationType === ChartDisplayType.Auto &&

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -319,7 +319,7 @@ const applyAutoHeatmapSettings = (
     })
 }
 
-const shouldUseFirstNumericColumnAsLineChartXAxis = (
+const shouldUseFirstNumericColumnAsContinuousChartXAxis = (
     columns: Column[],
     numericalColumns: Column[],
     selectedXAxis: string | null,
@@ -1128,8 +1128,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             }))
 
             if (
-                visualizationType === ChartDisplayType.ActionsLineGraph &&
-                shouldUseFirstNumericColumnAsLineChartXAxis(
+                [ChartDisplayType.ActionsLineGraph, ChartDisplayType.ActionsAreaGraph].includes(visualizationType) &&
+                shouldUseFirstNumericColumnAsContinuousChartXAxis(
                     values.columns,
                     values.numericalColumns,
                     values.selectedXAxis,


### PR DESCRIPTION
## Problem

You can only do line charts with datetime axes in the SQL editor.

![2026-03-26 22 43 42](https://github.com/user-attachments/assets/0b8eb551-8bbf-463c-a070-217496af45b6)

## Changes

Remove this restriction. Same for area charts.

I also fixed a bug with series breakdowns in the configuration panel where it would override the x-axis label to None when clicking "+ add series breakdown".

![2026-03-26 23 43 18](https://github.com/user-attachments/assets/b3915215-a6d7-4d6c-9748-460556e66f52)


## How did you test this code?

Clicked around in the interface. See screencast.

## Publish to changelog?

Probably not

## Docs update

🤷‍♂️ 