### PR TITLE
fix(workflows): fix ubuntu custom font

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -575,7 +575,7 @@ function NativeEmailTemplaterForm({
                                                       {
                                                           label: 'Ubuntu',
                                                           value: "'Ubuntu',sans-serif",
-                                                          url: 'https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap',
+                                                          url: 'https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700',
                                                           weights: [
                                                               { label: 'Light', value: 300 },
                                                               { label: 'Regular', value: 400 },

--- a/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/emailTemplaterLogic.tsx
@@ -20,18 +20,6 @@ import type { emailTemplaterLogicType } from './emailTemplaterLogicType'
 export type UnlayerMergeTags = NonNullable<EmailEditorProps['options']>['mergeTags']
 
 /**
- * Unlayer exports bare `&` in `<link>` href attributes (e.g. Google Fonts URLs).
- * This is invalid in XHTML (which Unlayer uses) and can cause email clients to ignore the `<link>` tag,
- * preventing web fonts from loading. This function encodes bare `&` as `&amp;`.
- */
-function fixUnlayerHtmlForEmailClients(html: string): string {
-    return html.replace(/(<link\b[^>]*\bhref\s*=\s*")([^"]*?)(")/gi, (_match, before, url, after) => {
-        const fixedUrl = url.replace(/&(?!amp;)/g, '&amp;')
-        return before + fixedUrl + after
-    })
-}
-
-/**
  * email: basic email editor with free-text fields, used for configuring email platform realtime destinations
  * native_email: advanced editor with email integration dropdown, and additional email metafields
  * native_email_template: editor for creating reusable templates, with only subject and preheader, and email content fields
@@ -324,13 +312,11 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
                         new Promise<any>((res) => editor.exportPlainText(res)),
                     ])
 
-                const sanitizedHtml = fixUnlayerHtmlForEmailClients(htmlData.html)
-
                 const finalValues: EmailTemplate = {
                     ...formValues,
                     html: ['native_email', 'native_email_template'].includes(props.type)
-                        ? sanitizedHtml
-                        : escapeHTMLStringCurlies(sanitizedHtml),
+                        ? htmlData.html
+                        : escapeHTMLStringCurlies(htmlData.html),
                     text: textData.text,
                     design: htmlData.design,
                 }
@@ -435,13 +421,11 @@ export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
                             new Promise<any>((res) => editor.exportPlainText(res)),
                         ])
 
-                    const sanitizedHtml = fixUnlayerHtmlForEmailClients(htmlData.html)
-
                     emailContent = {
                         ...currentValues,
                         html: ['native_email', 'native_email_template'].includes(props.type)
-                            ? sanitizedHtml
-                            : escapeHTMLStringCurlies(sanitizedHtml),
+                            ? htmlData.html
+                            : escapeHTMLStringCurlies(htmlData.html),
                         text: textData.text,
                         design: htmlData.design,
                     }


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/52445 fixed the issue on clients like macOS mail, but still not working for gmail web client.

I tested a different Google Fonts that Unlayer comes preloaded with, and it works: 
<img width="600" height="514" alt="image" src="https://github.com/user-attachments/assets/19946b65-c2c2-405b-961b-2a041965a84f" />

So I looked at the head tag and noticed the only difference is the google fonts api used:

```
<!--[if !mso]><!--><link href=3D"https://fonts.googleapis.com/css2?family=
=3DUbuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&amp;dis=
play=3Dswap" rel=3D"stylesheet" type=3D"text/css"><link href=3D"https://fon=
ts.googleapis.com/css?family=3DLobster+Two:400,700" rel=3D"stylesheet" type=
=3D"text/css"><!--<![endif]-->
```

## Changes

- Use the same google fonts API as the working font
- Remove the previous fix as its no longer relevant

## How did you test this code?

Ensured everything still working in maildev client and in macos mail client after downloading

## Publish to changelog?

No