### PR TITLE
fix(symbols): Update docs link in symbols

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1047,7 +1047,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'error-tracking-symbol-sets',
                 title: 'Symbol sets',
                 description: 'Upload source maps to get readable stack traces from minified code.',
-                docsUrl: 'https://posthog.com/docs/error-tracking/source-maps',
+                docsUrl: 'https://posthog.com/docs/error-tracking/upload-source-maps',
                 component: <SymbolSets />,
                 keywords: ['source map', 'sourcemap', 'debug', 'minified', 'stack trace'],
             },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

On the /project/[projectid]/settings/project-error-tracking route, the docs link under the Symbol sets section pointed to https://posthog.com/docs/error-tracking/source-maps which returns a 404. The original slug was valid but became stale when the docs were reorganized under upload-source-maps.

Closes #15989 

## Changes

Updated the docsUrl in the error-tracking-symbol-sets entry in settings-map.tsx from:
https://posthog.com/docs/error-tracking/source-maps
to:
https://posthog.com/docs/error-tracking/upload-source-maps

## How did you test this code?

Manually verified the updated link resolves correctly to the source maps documentation page without a 404.

Also audited all other docsUrl references across the codebase using:
grep -r "error-tracking/source-maps" . --exclude-dir=node_modules --exclude-dir=.cache --exclude-dir=public -l

There were some files that showed source-maps links that might not be updated that did not get updated with this ticket.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No — this is a one-line bug fix for a broken docs link, not a feature.

## Docs update

skip-inkeep-docs — no docs changes required, only an app-side link fix.

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
