### PR TITLE
Perform all development inside docker containers

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,119 @@
+#
+# Development container for sandboxed local dev.
+# Contains all toolchains (Python, Node, Rust) but no source code —
+# the repo is bind-mounted at runtime for hot-reload.
+#
+# Build:  docker compose -f docker-compose.dev-sandboxed.yml build
+# Run:    bin/start-sandboxed
+#
+
+FROM python:3.12.12-bookworm
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# ── System deps ──────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        gnupg \
+        jq \
+        libffi-dev \
+        libpq-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        lld \
+        pkg-config \
+        protobuf-compiler \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Node.js 24 + corepack/pnpm ──────────────────────────────────────
+ENV NODE_MAJOR=24
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable
+
+# ── uv (fast Python package manager) ────────────────────────────────
+# Pinned to match pyproject.toml required-version (~=0.10.2)
+COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /usr/local/bin/uv
+
+# ── Rust toolchain ───────────────────────────────────────────────────
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH="/usr/local/cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --profile minimal \
+    && rustup show
+
+# ── sccache for Rust build caching ──────────────────────────────────
+RUN cargo install sccache --locked
+
+# ── sqlx-cli for database migrations ────────────────────────────────
+RUN cargo install sqlx-cli --locked --no-default-features --features postgres
+
+ENV RUSTC_WRAPPER=sccache
+
+# ── phrocs (process manager) ────────────────────────────────────────
+ADD https://github.com/PostHog/posthog/releases/download/phrocs-latest/phrocs-linux-arm64 /usr/local/bin/phrocs
+RUN chmod +x /usr/local/bin/phrocs
+
+# ── Non-root user ───────────────────────────────────────────────────
+RUN groupadd -g 1000 posthog \
+    && useradd -m -u 1000 -g posthog posthog \
+    && chown -R posthog:posthog /usr/local/cargo /usr/local/rustup \
+    && mkdir -p /home/posthog/.cache/sccache \
+    && chown -R posthog:posthog /home/posthog/.cache
+
+WORKDIR /code
+
+# Entrypoint fixes volume ownership then drops to non-root for everything else
+COPY <<'EOF' /usr/local/bin/dev-entrypoint.sh
+#!/bin/bash
+set -e
+
+# Named volumes are created as root — fix ownership recursively on first run
+for dir in /code/.venv /code/node_modules /code/rust/target \
+           /usr/local/cargo/registry /usr/local/cargo/git \
+           /home/posthog/.cache/sccache; do
+    if [ -d "$dir" ] && [ "$(stat -c %u "$dir")" != "1000" ]; then
+        chown -R posthog:posthog "$dir"
+    fi
+done
+
+# Drop to non-root for the rest
+exec gosu posthog /usr/local/bin/dev-entrypoint-user.sh "$@"
+EOF
+
+COPY <<'EOF' /usr/local/bin/dev-entrypoint-user.sh
+#!/bin/bash
+set -e
+
+# Install Python deps if .venv is empty (named volume, exists but may be empty)
+if [ ! -f /code/.venv/pyvenv.cfg ]; then
+    echo "==> Installing Python deps..."
+    uv sync
+fi
+
+# Install Node deps if node_modules is empty (named volume)
+if [ ! -f /code/node_modules/.modules.yaml ]; then
+    echo "==> Installing Node deps..."
+    corepack enable
+    pnpm install --frozen-lockfile || pnpm install
+fi
+
+exec "$@"
+EOF
+
+RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/* \
+    && chmod +x /usr/local/bin/dev-entrypoint.sh /usr/local/bin/dev-entrypoint-user.sh
+
+# Entrypoint runs as root to fix volume ownership, then drops to posthog via gosu
+
+ENTRYPOINT ["dev-entrypoint.sh"]
+CMD ["phrocs", "--config", ".posthog/.generated/mprocs.yaml"]

--- a/bin/start-backend
+++ b/bin/start-backend
@@ -4,8 +4,8 @@ set -e
 export PROMETHEUS_MULTIPROC_DIR=$(mktemp -d)
 trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 
-export OBJECT_STORAGE_ENDPOINT=http://localhost:19000
-export SESSION_RECORDING_V2_S3_ENDPOINT=http://localhost:8333
+export OBJECT_STORAGE_ENDPOINT=${OBJECT_STORAGE_ENDPOINT:-http://localhost:19000}
+export SESSION_RECORDING_V2_S3_ENDPOINT=${SESSION_RECORDING_V2_S3_ENDPOINT:-http://localhost:8333}
 
 export CLICKHOUSE_API_USER="api"
 export CLICKHOUSE_API_PASSWORD="apipass"
@@ -16,9 +16,12 @@ export CLICKHOUSE_APP_PASSWORD="apppass"
 export PYDEVD_DISABLE_FILE_VALIDATION=1
 
 # Cross-platform Docker host access
+# Inside sandboxed container: bind to 0.0.0.0 so ports are reachable from the Docker network
 # On macOS/Windows: Docker runs in a VM, use 127.0.0.1 for the host bind
 # On Linux: Use bridge gateway IP for container access while maintaining security
-if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "msys" ]]; then
+if [[ -n "${POSTHOG_SANDBOXED:-}" ]]; then
+    HOST_BIND="0.0.0.0"
+elif [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "msys" ]]; then
     HOST_BIND="127.0.0.1"
     echo "🍎 macOS/Windows detected, using secure localhost binding"
 else

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -24,8 +24,8 @@ case "$RS_SVC" in
     SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
-    export KAFKA_HOSTS=localhost:9092
-    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export KAFKA_HOSTS=${KAFKA_HOSTS:-localhost:9092}
+    export DATABASE_URL=${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}
     export SKIP_WRITES=false
     export SKIP_READS=false
     export FILTER_MODE=opt-out
@@ -37,9 +37,9 @@ case "$RS_SVC" in
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
     export ADDRESS=0.0.0.0:3307 # avoid port conflict in local dev
-    export KAFKA_HOSTS=localhost:9092
-    export REDIS_URL=redis://localhost:6379
-    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export KAFKA_HOSTS=${KAFKA_HOSTS:-localhost:9092}
+    export REDIS_URL=${REDIS_URL:-redis://localhost:6379}
+    export DATABASE_URL=${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}
     export CAPTURE_MODE=events
     export LOG_LEVEL=debug
     export DEBUG=1
@@ -50,11 +50,11 @@ case "$RS_SVC" in
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
     export ADDRESS=0.0.0.0:3306 # avoid port conflict in local dev
-    export KAFKA_HOSTS=localhost:9092
+    export KAFKA_HOSTS=${KAFKA_HOSTS:-localhost:9092}
     export KAFKA_TOPIC=session_recording_snapshot_item_events
     export KAFKA_OVERFLOW_TOPIC=session_recording_snapshot_item_overflow
-    export REDIS_URL=redis://localhost:6379
-    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export REDIS_URL=${REDIS_URL:-redis://localhost:6379}
+    export DATABASE_URL=${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}
     export CAPTURE_MODE=recordings
     export LOG_LEVEL=debug
     export DEBUG=1
@@ -66,16 +66,16 @@ case "$RS_SVC" in
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
     export ADDRESS=0.0.0.0:3309 # avoid port conflict in local dev (3308 is used by llm-gateway)
-    export KAFKA_HOSTS=localhost:9092
-    export REDIS_URL=redis://localhost:6379
-    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export KAFKA_HOSTS=${KAFKA_HOSTS:-localhost:9092}
+    export REDIS_URL=${REDIS_URL:-redis://localhost:6379}
+    export DATABASE_URL=${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}
     export CAPTURE_MODE=events
     export LOG_LEVEL=debug
     export DEBUG=1
     # AI endpoint S3 blob storage (MinIO)
     export AI_S3_BUCKET=ai-blobs
     export AI_S3_PREFIX=llma/
-    export AI_S3_ENDPOINT=http://localhost:19000
+    export AI_S3_ENDPOINT=${AI_S3_ENDPOINT:-http://localhost:19000}
     export AI_S3_REGION=us-east-1
     export AI_S3_ACCESS_KEY_ID=object_storage_root_user
     export AI_S3_SECRET_ACCESS_KEY=object_storage_root_password
@@ -100,9 +100,9 @@ case "$RS_SVC" in
     export SUPPRESSION_RULE_CACHE_TTL_SECS=0
     export BIND_PORT=3302 # HACK! avoid local-dev clash with property-defs-rs port
     export ALLOW_INTERNAL_IPS="true"
-    export PERSONS_URL=postgres://posthog:posthog@localhost:5432/posthog_persons
-    export ISSUE_BUCKETS_REDIS_URL=redis://localhost:6379
-    export SIGNALS_API_BASE_URL=http://localhost:8000 # Used to emit signals, via the internal API
+    export PERSONS_URL=${PERSONS_URL:-postgres://posthog:posthog@localhost:5432/posthog_persons}
+    export ISSUE_BUCKETS_REDIS_URL=${ISSUE_BUCKETS_REDIS_URL:-redis://localhost:6379}
+    export SIGNALS_API_BASE_URL=${SIGNALS_API_BASE_URL:-http://localhost:8000}
     export INTERNAL_API_SECRET=posthog123
     ;;
 
@@ -120,7 +120,7 @@ case "$RS_SVC" in
     SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL
     export RUST_BACKTRACE=1
-    export KAFKA_HOSTS=localhost:9092
+    export KAFKA_HOSTS=${KAFKA_HOSTS:-localhost:9092}
     export KAFKA_TOPIC=clickhouse_app_metrics2
     export DATABASE_URL=${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/cyclotron}
     export DEBUG=1
@@ -133,10 +133,10 @@ case "$RS_SVC" in
 
     export RUST_LOG=debug,tower=warn,maxminddb=warn
     export RUST_BACKTRACE=1
-    export WRITE_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
-    export READ_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export WRITE_DATABASE_URL=${WRITE_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}
+    export READ_DATABASE_URL=${READ_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}
     export MAXMIND_DB_PATH=../share/GeoLite2-City.mmdb
-    export REDIS_URL=redis://localhost:6379/
+    export REDIS_URL=${REDIS_URL:-redis://localhost:6379/}
     export FLAGS_REDIS_URL=${FLAGS_REDIS_URL:-redis://localhost:6379/1}
     export ADDRESS=0.0.0.0:3001
     export DEBUG=1
@@ -147,8 +147,8 @@ case "$RS_SVC" in
     SQLX_QUERY_LEVEL=${SQLX_QUERY_LEVEL:-warn}
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL,rdkafka=warn
     export RUST_BACKTRACE=1
-    export KAFKA_HOSTS=localhost:9092
-    export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog
+    export KAFKA_HOSTS=${KAFKA_HOSTS:-localhost:9092}
+    export DATABASE_URL=${DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}
     export BIND_HOST=0.0.0.0
     export BIND_PORT=3301
     export ENCRYPTION_KEYS=00beef0000beef0000beef0000beef00
@@ -163,7 +163,7 @@ case "$RS_SVC" in
     export RUST_LOG=debug,sqlx::query=$SQLX_QUERY_LEVEL
     export RUST_BACKTRACE=1
     export GRPC_ADDRESS=127.0.0.1:50051
-    export PRIMARY_DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog_persons
+    export PRIMARY_DATABASE_URL=${PRIMARY_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog_persons}
     export METRICS_PORT=9100
     ;;
 

--- a/bin/start-sandboxed
+++ b/bin/start-sandboxed
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# Start PostHog dev environment in a sandboxed Docker container.
+# App processes run inside the container; infra runs in docker-compose.dev.yml.
+#
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COMPOSE_INFRA="docker-compose.dev.yml"
+COMPOSE_PROFILES="docker-compose.profiles.yml"
+COMPOSE_PROXY_OVERRIDE="docker-compose.dev-sandboxed-proxy.yml"
+COMPOSE_SANDBOX="docker-compose.dev-sandboxed.yml"
+GENERATED_CONFIG=".posthog/.generated/mprocs.yaml"
+SANDBOX_CONFIG=".posthog/.generated/mprocs-sandboxed.yaml"
+
+# ── Parse flags ──────────────────────────────────────────────────────
+DOCKER_PROFILES=()
+SKIP_INFRA=false
+BUILD_ONLY=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --skip-infra)   SKIP_INFRA=true ;;
+        --build)        BUILD_ONLY=true ;;
+        --profile=*)    DOCKER_PROFILES+=("--profile" "${arg#--profile=}") ;;
+        *)              echo "Unknown flag: $arg"; exit 1 ;;
+    esac
+done
+
+# Always include dev_tools profile
+DOCKER_PROFILES+=("--profile" "dev_tools")
+
+# ── Step 1: Start infra ─────────────────────────────────────────────
+if [ "$SKIP_INFRA" = false ]; then
+    echo "==> Starting infrastructure services..."
+    # Use proxy override to remove extra_hosts (service names resolve via Docker DNS
+    # to the dev container's network aliases instead of host-gateway)
+    docker compose \
+        -f "$COMPOSE_INFRA" \
+        -f "$COMPOSE_PROFILES" \
+        -f "$COMPOSE_PROXY_OVERRIDE" \
+        "${DOCKER_PROFILES[@]}" \
+        up --pull always -d
+    echo "==> Infrastructure started."
+fi
+
+if [ "$BUILD_ONLY" = true ]; then
+    echo "==> Building dev container image..."
+    docker compose -f "$COMPOSE_SANDBOX" build
+    echo "==> Build complete."
+    exit 0
+fi
+
+# ── Step 2: Generate mprocs config ───────────────────────────────────
+if command -v hogli &>/dev/null; then
+    hogli dev:generate 2>/dev/null || true
+fi
+
+if [ ! -f "$GENERATED_CONFIG" ]; then
+    echo "ERROR: No generated mprocs config found at $GENERATED_CONFIG"
+    echo "Run 'hogli dev:setup' first, or ensure bin/mprocs.yaml exists."
+    exit 1
+fi
+
+# ── Step 3: Patch config for sandboxed mode ──────────────────────────
+# Remove the docker-compose process (infra is managed separately)
+# and update Caddy proxy to route to the dev container.
+python3 -c "
+import yaml, sys
+
+with open('$GENERATED_CONFIG') as f:
+    config = yaml.safe_load(f)
+
+procs = config.get('procs', {})
+
+# Remove docker-compose process — infra runs on host
+procs.pop('docker-compose', None)
+
+# Rewrite bin/wait-for-docker calls to use network checks instead
+# (container doesn't have Docker socket access)
+for name, proc in procs.items():
+    if 'shell' in proc and isinstance(proc['shell'], str):
+        # Replace 'bin/wait-for-docker' with a simple TCP check
+        proc['shell'] = proc['shell'].replace(
+            'bin/wait-for-docker',
+            'bin/wait-for-infra'
+        )
+
+config['procs'] = procs
+
+with open('$SANDBOX_CONFIG', 'w') as f:
+    yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+" 2>/dev/null || {
+    # Fallback: simple sed-based patching if PyYAML not available on host
+    cp "$GENERATED_CONFIG" "$SANDBOX_CONFIG"
+    # Remove docker-compose block (from its key to the next top-level key)
+    python3 -c "
+import re, sys
+with open('$SANDBOX_CONFIG') as f:
+    content = f.read()
+# Remove docker-compose process entry
+content = re.sub(r'  docker-compose:\n(?:    .*\n)*', '', content)
+# Replace wait-for-docker with wait-for-infra
+content = content.replace('bin/wait-for-docker', 'bin/wait-for-infra')
+with open('$SANDBOX_CONFIG', 'w') as f:
+    f.write(content)
+"
+}
+
+echo "==> Generated sandboxed mprocs config at $SANDBOX_CONFIG"
+
+# ── Step 4: Caddy routing ────────────────────────────────────────────
+# The dev container joins posthog_default with DNS aliases 'web', 'capture',
+# 'plugins' — so Caddy's reverse_proxy directives resolve to the container
+# automatically. No Caddy config changes needed.
+
+# ── Step 5: Launch dev container ─────────────────────────────────────
+echo "==> Starting sandboxed dev container..."
+exec docker compose -f "$COMPOSE_SANDBOX" run --rm --service-ports dev \
+    phrocs --config "$SANDBOX_CONFIG"

--- a/bin/wait-for-infra
+++ b/bin/wait-for-infra
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#
+# Docker-socket-free alternative to bin/wait-for-docker.
+# Checks infrastructure readiness via TCP connections instead of
+# docker inspect. Used inside the sandboxed dev container where
+# the Docker socket is not mounted.
+#
+
+TIMEOUT="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
+
+# Core services and their health-check endpoints
+declare -A CHECKS=(
+    [db]="db:5432"
+    [redis7]="redis7:6379"
+    [kafka]="kafka:9092"
+    [clickhouse]="clickhouse:8123"
+)
+
+# Add any extra services passed as arguments
+for svc in "$@"; do
+    case "$svc" in
+        temporal)     CHECKS[temporal]="temporal:7233" ;;
+        objectstorage) CHECKS[objectstorage]="objectstorage:19000" ;;
+        seaweedfs)    CHECKS[seaweedfs]="seaweedfs:8333" ;;
+        *)            echo "WARN: Unknown service '$svc', skipping" ;;
+    esac
+done
+
+check_tcp() {
+    local host="${1%%:*}"
+    local port="${1##*:}"
+    # Use bash built-in TCP check, fall back to curl/nc
+    (echo > /dev/tcp/"$host"/"$port") 2>/dev/null && return 0
+    return 1
+}
+
+check_http() {
+    curl -sf --max-time 2 "$1" >/dev/null 2>&1
+}
+
+SECONDS=0
+last_log=-5
+
+while true; do
+    all_ready=true
+    pending=()
+
+    for svc in "${!CHECKS[@]}"; do
+        endpoint="${CHECKS[$svc]}"
+
+        if check_tcp "$endpoint"; then
+            continue
+        fi
+
+        all_ready=false
+        pending+=("$svc")
+    done
+
+    if [ "$all_ready" = true ]; then
+        echo "All services ready in ${SECONDS}s."
+        exit 0
+    fi
+
+    if [ "$SECONDS" -ge "$TIMEOUT" ]; then
+        echo "TIMEOUT: ${TIMEOUT}s waiting for: ${pending[*]}"
+        exit 1
+    fi
+
+    if [ $(( SECONDS - last_log )) -ge 5 ]; then
+        echo "Waiting for: ${pending[*]} (${SECONDS}s)"
+        last_log=$SECONDS
+    fi
+
+    sleep 1
+done

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -729,3 +729,11 @@ environment:
         description: Disable anonymous usage telemetry
     telemetry:status:
         description: Show current telemetry settings
+    start:sandboxed:
+        bin_script: start-sandboxed
+        description: 'TODO: add description for start-sandboxed'
+        hidden: true
+    wait:for:infra:
+        bin_script: wait-for-infra
+        description: 'TODO: add description for wait-for-infra'
+        hidden: true

--- a/docker-compose.dev-sandboxed-proxy.yml
+++ b/docker-compose.dev-sandboxed-proxy.yml
@@ -1,0 +1,81 @@
+#
+# Replacement proxy for sandboxed dev mode.
+# The dev container provides DNS aliases (web, capture, plugins) on posthog_default,
+# so the proxy resolves them via Docker DNS instead of host-gateway.
+#
+
+services:
+    proxy:
+        extends:
+            file: docker-compose.base.yml
+            service: proxy
+        ports:
+            - 127.0.0.1:8010:8000
+        # No extra_hosts — service names resolve via Docker DNS to the dev container
+        environment:
+            CADDYFILE: |
+                http://localhost:8000 {
+                    @replay-capture {
+                        path /s
+                        path /s/*
+                    }
+
+                    @capture-ai {
+                        path /i/v0/ai
+                        path /i/v0/ai/*
+                    }
+
+                    @capture {
+                        path /e
+                        path /e/*
+                        path /i/v0/*
+                        path /batch
+                        path /batch*
+                        path /capture
+                        path /capture*
+                    }
+
+                    @capture-logs {
+                        path /i/v1/logs
+                    }
+
+                    @flags {
+                        path /flags
+                        path /flags*
+                    }
+
+                    @webhooks {
+                        path /public/webhooks
+                        path /public/webhooks/*
+                        path /public/m
+                        path /public/m/*
+                    }
+
+                    handle @capture-ai {
+                        reverse_proxy capture-ai:3309
+                    }
+
+                    handle @capture {
+                        reverse_proxy capture:3307
+                    }
+
+                    handle @capture-logs {
+                        reverse_proxy capture-logs:4318
+                    }
+
+                    handle @replay-capture {
+                        reverse_proxy replay-capture:3306
+                    }
+
+                    handle @flags {
+                        reverse_proxy feature-flags:3001
+                    }
+
+                    handle @webhooks {
+                        reverse_proxy plugins:6738
+                    }
+
+                    handle {
+                        reverse_proxy web:8000
+                    }
+                }

--- a/docker-compose.dev-sandboxed.yml
+++ b/docker-compose.dev-sandboxed.yml
@@ -1,0 +1,148 @@
+#
+# Sandboxed development container.
+# Runs all app processes (Django, Vite, Node, Rust, Celery) inside a container
+# for filesystem and env var isolation. Infra runs separately via docker-compose.dev.yml.
+#
+# Usage:
+#   1. Start infra:   docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml --profile dev_tools up -d
+#   2. Start dev:     docker compose -f docker-compose.dev-sandboxed.yml run --rm --service-ports dev
+#   Or just:          bin/start-sandboxed
+#
+
+services:
+    dev:
+        build:
+            context: .
+            dockerfile: Dockerfile.dev
+        volumes:
+            # Bind-mount repo for hot-reload. Changes on host are reflected instantly.
+            - .:/code
+            # Named volumes for deps — isolated from host, survive container restarts.
+            - dev-node-modules:/code/node_modules
+            - dev-venv:/code/.venv
+            # Rust build caches — persist across container restarts for fast rebuilds.
+            - dev-cargo-registry:/usr/local/cargo/registry
+            - dev-cargo-git:/usr/local/cargo/git
+            - dev-rust-target:/code/rust/target
+            - dev-sccache:/home/posthog/.cache/sccache
+        ports:
+            - '127.0.0.1:8000:8000' # Django backend
+            - '127.0.0.1:8234:8234' # Vite HMR
+            - '127.0.0.1:3030:3030' # Dagster
+            - '127.0.0.1:3307:3307' # Capture
+            - '127.0.0.1:3001:3001' # Feature flags
+            - '127.0.0.1:6739:6739' # Node ingestion
+            - '127.0.0.1:5678:5678' # Python debugpy
+        networks:
+            posthog_default:
+                # Caddy proxy resolves 'web' to this container
+                aliases:
+                    - web
+                    - capture
+                    - plugins
+        environment:
+            # ── Core app settings ────────────────────────────
+            DEBUG: '1'
+            SKIP_SERVICE_VERSION_REQUIREMENTS: '1'
+
+            # ── Database connections (Docker DNS, not localhost) ──
+            DATABASE_URL: postgres://posthog:posthog@db:5432/posthog
+            PGHOST: db
+            PGUSER: posthog
+            PGPASSWORD: posthog
+            POSTHOG_POSTGRES_HOST: db
+            PLUGIN_STORAGE_DATABASE_URL: postgres://posthog:posthog@db:5432/posthog
+            DATABASE_READONLY_URL: postgres://posthog:posthog@db:5432/posthog
+            PERSONS_READONLY_DATABASE_URL: postgres://posthog:posthog@db:5432/posthog_persons
+            CYCLOTRON_DATABASE_URL: postgres://posthog:posthog@db:5432/cyclotron
+            CYCLOTRON_NODE_DATABASE_URL: postgres://posthog:posthog@db:5432/cyclotron_node
+            ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
+            REDIS_URL: redis://redis7:6379/
+            KAFKA_HOSTS: kafka:9092
+            CLICKHOUSE_HOST: clickhouse
+
+            # ── Object storage ───────────────────────────────
+            OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
+            SESSION_RECORDING_V2_S3_ENDPOINT: http://seaweedfs:8333
+
+            # ── Rust service overrides (replace localhost refs) ──
+            # These are picked up by bin/start-rust-service case blocks
+            # but the env vars here take precedence.
+            WRITE_DATABASE_URL: postgres://posthog:posthog@db:5432/posthog
+            READ_DATABASE_URL: postgres://posthog:posthog@db:5432/posthog
+
+            # ── Ducklake ─────────────────────────────────────
+            DUCKLAKE_RDS_HOST: db
+            DUCKLAKE_RDS_PORT: '5432'
+            DUCKLAKE_RDS_DATABASE: ducklake
+            DUCKLAKE_RDS_USERNAME: posthog
+            DUCKLAKE_RDS_PASSWORD: posthog
+            DUCKLAKE_BUCKET: ducklake-dev
+            DUCKLAKE_BUCKET_REGION: us-east-1
+            DUCKLAKE_S3_ACCESS_KEY: object_storage_root_user
+            DUCKLAKE_S3_SECRET_KEY: object_storage_root_password
+
+            # ── Behavioral cohorts DB ────────────────────────
+            BEHAVIORAL_COHORTS_DATABASE_URL: postgres://posthog:posthog@db:5432/posthog_behavioral_cohorts
+            POSTGRES_BEHAVIORAL_COHORTS_HOST: db
+
+            # ── Persons DB (for cymbal, personhog, migrations) ──
+            PERSONS_URL: postgres://posthog:posthog@db:5432/posthog_persons
+            PERSONS_DATABASE_URL: postgres://posthog:posthog@db:5432/posthog_persons
+            PERSONS_DB_WRITER_URL: postgres://posthog:posthog@db:5432/posthog_persons
+            PRIMARY_DATABASE_URL: postgres://posthog:posthog@db:5432/posthog_persons
+            ISSUE_BUCKETS_REDIS_URL: redis://redis7:6379
+            SIGNALS_API_BASE_URL: http://localhost:8000
+
+            # ── Redis service overrides (Node/Rust services use host vars) ──
+            FLAGS_REDIS_URL: redis://redis7:6379/1
+            CDP_REDIS_HOST: redis7
+            COOKIELESS_REDIS_HOST: redis7
+            SESSION_RECORDING_API_REDIS_HOST: redis7
+            SESSION_RECORDING_API_REDIS_PORT: '6379'
+            LOGS_REDIS_HOST: redis7
+            TRACES_REDIS_HOST: redis7
+
+            # ── AI S3 (MinIO) ────────────────────────────────
+            AI_S3_ENDPOINT: http://objectstorage:19000
+
+            # ── Billing / misc ───────────────────────────────
+            BILLING_SERVICE_URL: https://billing.dev.posthog.dev
+            API_QUERIES_PER_TEAM: '{"1": 100}'
+
+            # ── Email (maildev in infra compose) ─────────────
+            EMAIL_HOST: maildev
+            EMAIL_PORT: '1025'
+            EMAIL_ENABLED: 'true'
+
+            # ── Telemetry ────────────────────────────────────
+            OTEL_SDK_DISABLED: 'true'
+            OTEL_SERVICE_NAME: posthog-local-dev
+
+            # ── Cargo ────────────────────────────────────────
+            CARGO_BUILD_JOBS: '2'
+
+            # ── Python venv activation ────────────────────────
+            VIRTUAL_ENV: /code/.venv
+            PATH: /code/.venv/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+            # ── DuckLake ─────────────────────────────────────
+            DUCKLAKE_AUTOMIGRATE: 'true'
+
+            # ── Signal that we're inside the sandboxed container ──
+            POSTHOG_SANDBOXED: '1'
+
+        stdin_open: true
+        tty: true
+
+networks:
+    posthog_default:
+        external: true
+
+volumes:
+    dev-node-modules:
+    dev-venv:
+    dev-cargo-registry:
+    dev-cargo-git:
+    dev-rust-target:
+    dev-sccache:


### PR DESCRIPTION
This is a draft PR to showcase how we might sandbox local development processes in a docker container. Source code is mounted from the local host.

## Problem                                                                                                                                                                                                        

Local dev processes (Django, Vite, Node, Rust, Celery) run directly on the host with full access to the host filesystem and environment variables. There's no sandboxing — a misbehaving process or dependency can read `~/.ssh`, `~/.aws`, host env vars, etc.

## Changes                             

Adds an optional sandboxed dev mode that runs all app processes inside a Docker container while keeping infra services (Postgres, Redis, ClickHouse, Kafka) in the existing docker-compose setup.                 

**New files:**                                                                                                                                                                                                    
- `Dockerfile.dev` — Dev image with Python 3.12, Node 24, Rust toolchain, uv, sqlx-cli, sccache, and phrocs. No source code baked in — repo is bind-mounted for hot-reload.
- `docker-compose.dev-sandboxed.yml` — Compose config for the dev container. Joins `posthog_default` network with DNS aliases (`web`, `capture`, `plugins`) so Caddy routes traffic correctly. Explicit env var allowlist — no host env leakage.                                                                                                                                                                                  
- `docker-compose.dev-sandboxed-proxy.yml` — Proxy override that removes `extra_hosts` entries so Caddy resolves service names via Docker DNS to the dev container.                                               
- `bin/start-sandboxed` — Entry point: starts infra, generates a patched mprocs config (strips `docker-compose` process, swaps `wait-for-docker` → `wait-for-infra`), launches the dev container with phrocs.     
- `bin/wait-for-infra` — Docker-socket-free alternative to `bin/wait-for-docker`. Checks infra readiness via TCP instead of `docker inspect`.                                                                     

**Modified files (backward-compatible):**                                                                                                                                                                         
- `bin/start-backend` — `OBJECT_STORAGE_ENDPOINT` and `SESSION_RECORDING_V2_S3_ENDPOINT` now respect existing env vars via `${VAR:-default}`. Added `POSTHOG_SANDBOXED` check to bind to `0.0.0.0` inside          container.                                                                                                                                                                                                        
- `bin/start-rust-service` — All hardcoded `localhost` URLs converted to `${VAR:-localhost:...}` so compose env vars take precedence inside the container. No behavioral change when running on host (defaults are identical).                                                                                                                                                                                                      

**Security isolation:**                                                                                                                                                                                           
- No host env vars leak (explicit allowlist)
- Processes cannot access `~/.ssh`, `~/.aws`, `~/.config`, etc.                                                                                                                                                   
- No Docker socket mounted                                                                                                                                                                                        
- Non-root user inside container (entrypoint drops to `posthog` via gosu after fixing volume ownership)                                                                                                           
- Named volumes for `node_modules`/`.venv`/cargo caches prevent host writes outside repo                                                                                                                          

## How did you test this code?                                                                                                                                                                                    

Ran `bin/start-sandboxed` end-to-end:                                                                                                                                                                             
- All phrocs processes start successfully (backend, frontend, celery, ingestion, capture, feature-flags, migrations)
- Django responds on `localhost:8000`                                                                                                                                                                             
- Vite HMR works — editing frontend files triggers hot reload
- Backend auto-reloads on Python file changes                                                                                                                                                                     
- Rust services compile and connect to infra via Docker DNS                                                                                                                                                       
- `docker exec` confirms only allowlisted env vars are present                                                                                                                                                    
- Non-sandboxed `bin/start` still works with no behavioral change                                                                                                                                                 
