### PR TITLE
feat(replay): add "Open in new browser tab" to share menu

### DIFF
--- a/frontend/src/scenes/session-recordings/player/share/PlayerShareMenu.tsx
+++ b/frontend/src/scenes/session-recordings/player/share/PlayerShareMenu.tsx
@@ -45,7 +45,10 @@ export function PlayerShareMenu(): JSX.Element {
         if (!sessionRecordingId) {
             return
         }
-        const fullUrl = `${window.location.origin}${urls.replaySingle(sessionRecordingId)}`
+        const path = urls.replaySingle(sessionRecordingId)
+        const timestamp = getCurrentPlayerTime()
+        const separator = path.includes('?') ? '&' : '?'
+        const fullUrl = `${window.location.origin}${path}${timestamp ? `${separator}t=${timestamp}` : ''}`
         window.open(fullUrl, '_blank', 'noopener,noreferrer')
     }
 

--- a/frontend/src/scenes/session-recordings/player/share/PlayerShareMenu.tsx
+++ b/frontend/src/scenes/session-recordings/player/share/PlayerShareMenu.tsx
@@ -41,6 +41,14 @@ export function PlayerShareMenu(): JSX.Element {
         newInternalTab(urls.replaySingle(sessionRecordingId))
     }
 
+    const onOpenInBrowserTab = (): void => {
+        if (!sessionRecordingId) {
+            return
+        }
+        const fullUrl = `${window.location.origin}${urls.replaySingle(sessionRecordingId)}`
+        window.open(fullUrl, '_blank', 'noopener,noreferrer')
+    }
+
     return (
         <LemonMenu
             items={[
@@ -50,6 +58,13 @@ export function PlayerShareMenu(): JSX.Element {
                     onClick: onOpenInNewTab,
                     disabledReason: !sessionRecordingId ? 'Recording not loaded yet' : undefined,
                     'data-attr': 'open-in-new-tab',
+                },
+                {
+                    label: 'Open in new browser tab',
+                    icon: <IconExternal />,
+                    onClick: onOpenInBrowserTab,
+                    disabledReason: !sessionRecordingId ? 'Recording not loaded yet' : undefined,
+                    'data-attr': 'open-in-browser-tab',
                 },
                 {
                     label: 'Share private link',


### PR DESCRIPTION
## Problem

"Open in new tab" opens recordings in the app's internal tab, which resets play position to the beginning when reopened. No way to open a recording in a real browser tab that preserves position on reload.

## Changes

Add "Open in new browser tab" option to the session replay share menu, using `window.open` to open the recording URL in an actual browser tab.

## How did you test this code?

Manually tested in the session replay player.