### PR TITLE
fix: unset GIT_DIR for uv sync and improve sandbox error reporting

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -552,7 +552,16 @@ def init_cache_from_master() -> None:
 
         info("Waiting for master to boot...")
         if not wait_for_health(f"http://localhost:{init_port}/_health", f"{init_project}-app-1"):
-            fatal("Cache init timed out. Check docker logs for errors.")
+            error("Cache init timed out. Dumping container logs:")
+            logs = run(
+                ["docker", "logs", "--tail", "200", f"{init_project}-app-1"],
+                check=False, capture=True,
+            )
+            for line in (logs.stdout or "").strip().splitlines():
+                print(f"  {line}")
+            for line in (logs.stderr or "").strip().splitlines():
+                print(f"  {line}")
+            fatal("Cache init failed. See logs above.")
 
         # Snapshot postgres (stop first for consistency)
         info("Snapshotting databases...")

--- a/bin/sandbox-entrypoint.py
+++ b/bin/sandbox-entrypoint.py
@@ -279,7 +279,17 @@ def apply_overlays() -> None:
 
 def install_python_deps() -> None:
     info("Started: uv sync...")
-    run(["uv", "sync", "--no-editable"])
+    # Remove GIT_DIR so uv's git fetches (e.g. infi.clickhouse_orm) work.
+    # The dummy GIT_DIR we set for pnpm confuses git when run from /cache.
+    uv_env = {k: v for k, v in os.environ.items() if k != "GIT_DIR"}
+    result = subprocess.run(["uv", "sync", "--no-editable"], capture_output=True, text=True, env=uv_env)
+    if result.returncode != 0:
+        info("ERROR: uv sync failed:")
+        for line in (result.stdout or "").strip().splitlines():
+            info(f"  {line}")
+        for line in (result.stderr or "").strip().splitlines():
+            info(f"  {line}")
+        raise subprocess.CalledProcessError(result.returncode, result.args)
     info("Finished: uv sync.")
     # Make hogli available — normally done by flox on-activate.sh.
     hogli_link = Path("/cache/python/bin/hogli")


### PR DESCRIPTION
## Summary

- **Fix `uv sync` failure in sandbox**: The dummy `GIT_DIR` env var (set for pnpm) was inherited by uv's git fetches, causing git dependency installs (e.g. `infi.clickhouse_orm`) to fail with "not a git repository". Now unset for `uv sync`.
- **Capture `uv sync` errors visibly**: On failure, stdout/stderr are written to the progress file so they appear in the host-side health check polling instead of being lost in cargo download noise.
- **Dump container logs on cache-init timeout**: Before cleanup removes the container, the last 200 lines of logs are printed so the failure cause is always visible.

## Test plan

- [x] Verified sandbox creates successfully with these changes (`sandbox create fix/sql-insight-dashboard`)
- [ ] Verify cache-init timeout path shows logs (can simulate by shortening timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)