### PR TITLE
chore(insights): extract SessionAnalysisWarning, SuggestionBanner, EditorFilterItems

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
@@ -1,14 +1,15 @@
 import clsx from 'clsx'
-import { Fragment, useState } from 'react'
+import { useState } from 'react'
 
 import { IconCollapse, IconExpand } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonField } from 'lib/lemon-ui/LemonField'
 import { inStorybook, inStorybookTestRunner, slugify } from 'lib/utils'
 
 import { InsightQueryNode } from '~/queries/schema/schema-general'
 import type { InsightEditorFilterGroup, InsightLogicProps } from '~/types'
+
+import { EditorFilterItems } from './EditorFilterItems'
 
 export interface EditorFilterGroupProps {
     editorFilterGroup: InsightEditorFilterGroup
@@ -41,7 +42,7 @@ export function EditorFilterGroup({ insightProps, editorFilterGroup }: EditorFil
                     title={isRowExpanded ? 'Show less' : 'Show more'}
                     data-attr={'editor-filter-group-collapse-' + slugify(title)}
                 >
-                    <div className="flex items-center deprecated-space-x-2 font-semibold">
+                    <div className="flex items-center gap-2 font-semibold">
                         <span>{title}</span>
                     </div>
                 </LemonButton>
@@ -53,24 +54,7 @@ export function EditorFilterGroup({ insightProps, editorFilterGroup }: EditorFil
                         'border rounded p-2 mt-1': isExpandable && isRowExpanded,
                     })}
                 >
-                    {editorFilters.map(({ label: Label, tooltip, showOptional, key, component: Component }) => {
-                        if (Component && Component.name === 'component') {
-                            throw new Error(
-                                `Component for filter ${key} is an anonymous function, which is not a valid React component! Use a named function instead.`
-                            )
-                        }
-                        return (
-                            <Fragment key={key}>
-                                <LemonField.Pure
-                                    label={typeof Label === 'function' ? <Label insightProps={insightProps} /> : Label}
-                                    info={tooltip}
-                                    showOptional={showOptional}
-                                >
-                                    {Component ? <Component insightProps={insightProps} /> : null}
-                                </LemonField.Pure>
-                            </Fragment>
-                        )
-                    })}
+                    <EditorFilterItems editorFilters={editorFilters} insightProps={insightProps} />
                 </div>
             )}
         </div>

--- a/frontend/src/queries/nodes/InsightViz/EditorFilterItems.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterItems.tsx
@@ -1,0 +1,35 @@
+import { Fragment } from 'react'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import type { InsightEditorFilter, InsightLogicProps } from '~/types'
+
+export interface EditorFilterItemsProps {
+    editorFilters: InsightEditorFilter[]
+    insightProps: InsightLogicProps
+}
+
+export function EditorFilterItems({ editorFilters, insightProps }: EditorFilterItemsProps): JSX.Element {
+    return (
+        <>
+            {editorFilters.map(({ label: Label, tooltip, showOptional, key, component: Component }) => {
+                if (Component && Component.name === 'component') {
+                    throw new Error(
+                        `Component for filter ${key} is an anonymous function, which is not a valid React component! Use a named function instead.`
+                    )
+                }
+                return (
+                    <Fragment key={key}>
+                        <LemonField.Pure
+                            label={typeof Label === 'function' ? <Label insightProps={insightProps} /> : Label}
+                            info={tooltip}
+                            showOptional={showOptional}
+                        >
+                            {Component ? <Component insightProps={insightProps} /> : null}
+                        </LemonField.Pure>
+                    </Fragment>
+                )
+            })}
+        </>
+    )
+}

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -1,13 +1,11 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useEffect, useRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
 
-import { IconInfo, IconX } from '@posthog/icons'
-import { LemonBanner, LemonButton, Link, Tooltip } from '@posthog/lemon-ui'
+import { IconInfo } from '@posthog/icons'
+import { Link, Tooltip } from '@posthog/lemon-ui'
 
 import { NON_BREAKDOWN_DISPLAY_TYPES } from 'lib/constants'
-import { pluralize } from 'lib/utils'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { Attribution } from 'scenes/insights/EditorFilters/AttributionFilter'
 import { FunnelsAdvanced } from 'scenes/insights/EditorFilters/FunnelsAdvanced'
@@ -26,7 +24,6 @@ import { SamplingDeprecationNotice } from 'scenes/insights/EditorFilters/Samplin
 import { WebAnalyticsEditorFilters } from 'scenes/insights/EditorFilters/WebAnalyticsEditorFilters'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-import { compareInsightTopLevelSections } from 'scenes/insights/utils'
 import MaxTool from 'scenes/max/MaxTool'
 import { castAssistantQuery } from 'scenes/max/utils'
 import { QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
@@ -49,20 +46,16 @@ import {
     WebStatsTableQuery,
 } from '~/queries/schema/schema-general'
 import { isHogQLQuery, isInsightQueryNode, isWebAnalyticsInsightQuery } from '~/queries/utils'
-import {
-    AvailableFeature,
-    ChartDisplayType,
-    EditorFilterProps,
-    InsightEditorFilter,
-    InsightEditorFilterGroup,
-    PathType,
-} from '~/types'
+import { AvailableFeature, ChartDisplayType, EditorFilterProps, InsightEditorFilterGroup, PathType } from '~/types'
 
 import { Breakdown } from './Breakdown'
 import { CumulativeStickinessFilter } from './CumulativeStickinessFilter'
 import { EditorFilterGroup } from './EditorFilterGroup'
+import { filterFalsy } from './editorFilterUtils'
 import { GlobalAndOrFilters } from './GlobalAndOrFilters'
 import { LifecycleToggles } from './LifecycleToggles'
+import { SessionAnalysisWarning } from './SessionAnalysisWarning'
+import { SuggestionBanner } from './SuggestionBanner'
 import { TrendsFormula } from './TrendsFormula'
 import { TrendsSeries } from './TrendsSeries'
 import { TrendsSeriesLabel } from './TrendsSeriesLabel'
@@ -96,14 +89,6 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
     const { previousQuery, suggestedQuery } = useValues(insightLogic(insightProps))
     const { isStepsFunnel, isTrendsFunnel } = useValues(funnelDataLogic(insightProps))
     const { setQuery } = useActions(insightVizDataLogic(insightProps))
-
-    const maxSuggestionActionsBanner = useRef<HTMLDivElement>(null)
-
-    useEffect(() => {
-        if (previousQuery && maxSuggestionActionsBanner.current) {
-            maxSuggestionActionsBanner.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
-        }
-    }, [previousQuery])
 
     if (!querySource) {
         return null
@@ -430,13 +415,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
     return (
         <CSSTransition in={showing} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
             <div className="EditorFiltersWrapper">
-                {shouldShowSessionAnalysisWarning ? (
-                    <LemonBanner type="info" className="mb-4">
-                        When using sessions and session properties, events without session IDs will be excluded from the
-                        set of results.{' '}
-                        <Link to="https://posthog.com/docs/user-guides/sessions">Learn more about sessions.</Link>
-                    </LemonBanner>
-                ) : null}
+                {shouldShowSessionAnalysisWarning ? <SessionAnalysisWarning /> : null}
 
                 <div>
                     <MaxTool
@@ -500,55 +479,14 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                     </MaxTool>
 
                     {previousQuery && (
-                        <div className="w-full px-2" ref={maxSuggestionActionsBanner}>
-                            <div className="bg-surface-tertiary/80 w-full flex justify-between items-center p-1 pl-2 mx-auto rounded-bl rounded-br">
-                                <div className="text-sm text-muted flex items-center gap-2 no-wrap">
-                                    <span className="size-2 bg-accent-active rounded-full" />
-                                    {(() => {
-                                        const changedLabels = compareInsightTopLevelSections(
-                                            previousQuery,
-                                            suggestedQuery
-                                        )
-                                        const diffString = `🔍 ${pluralize(
-                                            changedLabels.length,
-                                            'section'
-                                        )} changed: \n${changedLabels.join('\n')}`
-
-                                        return (
-                                            <div className="flex items-center gap-1">
-                                                <span>{pluralize(changedLabels.length, 'change')}</span>
-                                                {diffString && (
-                                                    <Tooltip
-                                                        title={<div className="whitespace-pre-line">{diffString}</div>}
-                                                    >
-                                                        <IconInfo className="text-sm text-muted cursor-help" />
-                                                    </Tooltip>
-                                                )}
-                                            </div>
-                                        )
-                                    })()}
-                                </div>
-
-                                <LemonButton
-                                    status="danger"
-                                    onClick={() => {
-                                        onRejectSuggestedInsight()
-                                    }}
-                                    tooltipPlacement="top"
-                                    size="small"
-                                    icon={<IconX />}
-                                >
-                                    Reject changes
-                                </LemonButton>
-                            </div>
-                        </div>
+                        <SuggestionBanner
+                            previousQuery={previousQuery}
+                            suggestedQuery={suggestedQuery}
+                            onReject={onRejectSuggestedInsight}
+                        />
                     )}
                 </div>
             </div>
         </CSSTransition>
     )
-}
-
-function filterFalsy(a: (InsightEditorFilter | false | null | undefined)[]): InsightEditorFilter[] {
-    return a.filter((e): e is InsightEditorFilter => !!e)
 }

--- a/frontend/src/queries/nodes/InsightViz/SessionAnalysisWarning.tsx
+++ b/frontend/src/queries/nodes/InsightViz/SessionAnalysisWarning.tsx
@@ -1,0 +1,10 @@
+import { LemonBanner, Link } from '@posthog/lemon-ui'
+
+export function SessionAnalysisWarning(): JSX.Element {
+    return (
+        <LemonBanner type="info" className="mb-4">
+            When using sessions and session properties, events without session IDs will be excluded from the set of
+            results. <Link to="https://posthog.com/docs/user-guides/sessions">Learn more about sessions.</Link>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/queries/nodes/InsightViz/SuggestionBanner.tsx
+++ b/frontend/src/queries/nodes/InsightViz/SuggestionBanner.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react'
+
+import { IconInfo, IconX } from '@posthog/icons'
+import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+
+import { pluralize } from 'lib/utils'
+import { compareInsightTopLevelSections } from 'scenes/insights/utils'
+
+import { Node } from '~/queries/schema/schema-general'
+
+export interface SuggestionBannerProps {
+    previousQuery: Node
+    suggestedQuery: Node | null
+    onReject: () => void
+}
+
+export function SuggestionBanner({ previousQuery, suggestedQuery, onReject }: SuggestionBannerProps): JSX.Element {
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (ref.current) {
+            ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }
+    }, [previousQuery])
+
+    const changedLabels = compareInsightTopLevelSections(previousQuery, suggestedQuery)
+    const diffString = `🔍 ${pluralize(changedLabels.length, 'section')} changed: \n${changedLabels.join('\n')}`
+
+    return (
+        <div className="w-full px-2" ref={ref}>
+            <div className="bg-surface-tertiary/80 w-full flex justify-between items-center p-1 pl-2 mx-auto rounded-bl rounded-br">
+                <div className="text-sm text-muted flex items-center gap-2 no-wrap">
+                    <span className="size-2 bg-accent-active rounded-full" />
+                    <div className="flex items-center gap-1">
+                        <span>{pluralize(changedLabels.length, 'change')}</span>
+                        {changedLabels.length > 0 && (
+                            <Tooltip title={<div className="whitespace-pre-line">{diffString}</div>}>
+                                <IconInfo className="text-sm text-muted cursor-help" />
+                            </Tooltip>
+                        )}
+                    </div>
+                </div>
+
+                <LemonButton status="danger" onClick={onReject} tooltipPlacement="top" size="small" icon={<IconX />}>
+                    Reject changes
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/queries/nodes/InsightViz/editorFilterUtils.ts
+++ b/frontend/src/queries/nodes/InsightViz/editorFilterUtils.ts
@@ -1,0 +1,5 @@
+import { InsightEditorFilter } from '~/types'
+
+export function filterFalsy(a: (InsightEditorFilter | false | null | undefined)[]): InsightEditorFilter[] {
+    return a.filter((e): e is InsightEditorFilter => !!e)
+}


### PR DESCRIPTION
## Problem

Making EditorFilters a little nicer before I drop a big PR which is hard to follow

## Changes

- Extract `SessionAnalysisWarning` component from inline `LemonBanner` in `EditorFilters`
- Extract `SuggestionBanner` component from inline Max suggestion banner JSX
- Extract `EditorFilterItems` component from the filter map loop in `EditorFilterGroup`
- Move `filterFalsy` helper to `editorFilterUtils.ts`
- Fix `deprecated-space-x-2` → `gap-2` in `EditorFilterGroup`

## How did you test this code?

Some tests, manually

## Publish to changelog?
no