### PR TITLE
feat: Support single region event emittance in the slo dashboard

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -13,7 +13,7 @@ locals {
     alert_check = {
       name    = "Alert checks"
       slo     = 99.95 # error budget = 0.05%
-      regions = ["US", "EU"]
+      regions = ["US"] # EU not captured yet: ph_scoped_capture hardcodes US client
     }
   }
 
@@ -24,10 +24,11 @@ locals {
     for op_key, op in local.slo_operations : {
       for region in op.regions :
       "${op_key}_${lower(region)}" => {
-        name      = op.name
-        slo       = op.slo
-        operation = op_key
-        region    = region
+        name         = op.name
+        slo          = op.slo
+        operation    = op_key
+        region       = region
+        region_count = length(op.regions)
       }
     }
   ]...)
@@ -161,7 +162,7 @@ locals {
 resource "posthog_insight" "slo_burn_rate" {
   for_each = local.slo_operation_regions
 
-  name        = "SLO: Burn Rates - ${each.value.name} (${each.value.slo}%) — ${each.value.region}"
+  name        = "SLO: Burn Rates - ${each.value.name} (${each.value.slo}%)${each.value.region_count > 1 ? " — ${each.value.region}" : ""}"
   description = "[Investigate failures with AI](/ai?ask=Investigate+${each.value.operation}+failures+in+${each.value.region}+region.+Check+slo_operation_started+events+without+matching+slo_operation_completed+success+outcomes+in+the+last+24h)"
   query_json = jsonencode({
     kind = "DataVisualizationNode"
@@ -208,7 +209,7 @@ resource "posthog_insight" "slo_burn_rate" {
 resource "posthog_insight" "slo_duration" {
   for_each = local.slo_operation_regions
 
-  name        = "SLO: Duration - ${each.value.name} — ${each.value.region}"
+  name        = "SLO: Duration - ${each.value.name}${each.value.region_count > 1 ? " — ${each.value.region}" : ""}"
   query_json = jsonencode({
     kind = "DataVisualizationNode"
     source = {
@@ -330,6 +331,7 @@ resource "posthog_insight" "slo_success_rate" {
 # ---------------------------------------------------------------------------
 resource "posthog_insight" "slo_volume" {
   name        = "SLO: 28d Volume by Operation"
+  description = "* = all regions, but events are only emitted from the US project (ph_scoped_capture hardcodes the US client)"
   query_json = jsonencode({
     kind = "DataVisualizationNode"
     source = {
@@ -337,7 +339,11 @@ resource "posthog_insight" "slo_volume" {
       query = <<-SQL
         SELECT
             properties.operation AS operation,
-            properties.region AS region,
+            if(
+                count(DISTINCT properties.region) OVER (PARTITION BY properties.operation) = 1,
+                'all*',
+                properties.region
+            ) AS region,
             countIf(event = 'slo_operation_started') AS started,
             countIf(event = 'slo_operation_completed' AND properties.outcome = 'success') AS successes,
             countIf(event = 'slo_operation_completed' AND properties.outcome = 'failure') AS failures,
@@ -352,7 +358,7 @@ resource "posthog_insight" "slo_volume" {
         FROM events
         WHERE event IN ('slo_operation_started', 'slo_operation_completed')
           AND timestamp >= now() - INTERVAL 28 DAY
-        GROUP BY operation, region
+        GROUP BY operation, properties.region
         ORDER BY operation, region
       SQL
     }

--- a/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slo-monitoring/insights.tf
@@ -340,7 +340,7 @@ resource "posthog_insight" "slo_volume" {
         SELECT
             properties.operation AS operation,
             if(
-                count(DISTINCT properties.region) OVER (PARTITION BY properties.operation) = 1,
+                count(properties.region) OVER (PARTITION BY properties.operation) = 1,
                 'all*',
                 properties.region
             ) AS region,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

After releasing: https://github.com/PostHog/posthog/pull/52446/files, I realised that with those `ph_scoped_capture` events, we "hardcode" the event to the US, as can be seen in the dashboard: https://us.posthog.com/project/2/dashboard/1397132. 

In order to not avoid confusion, I would like to exclude regions if it's just a single region for which we're gathering data (as I think it's safe to assume that both EU and US code flows through there).   
  
This PR updates the logic and titles to reflect this.

> [!NOTE]
> This is an intermediate solution for the alerts, as we will move them to temporal in the near future which _should_ ensure that we emit events from both regions. However if we want to adopt this dashboard more widespread, there might be other slo events that will suffer from this behaviour, therefore I think a structural (small) fix is warranted. 

## Changes

- Don't show the EU tiles for the alert SLOs
- If there is only 1 region, don't show the region in the insight title (given that we have a multi region app, I think this is a safe assumption as we should always have > 1 region)
- Update the Volume table to show `all` when there is 1 region

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

:white_check_mark: TF plan is passing in the CI

✅ The updated query renders correctly [in our SQL editor](https://us.posthog.com/project/2/sql#q=SELECT%0A%20%20%20%20properties.operation%20AS%20operation%2C%0A%20%20%20%20if(%0A%20%20%20%20%20%20%20%20count(properties.region)%20OVER%20(PARTITION%20BY%20properties.operation)%20%3D%201%2C%0A%20%20%20%20%20%20%20%20'all*'%2C%0A%20%20%20%20%20%20%20%20properties.region%0A%20%20%20%20)%20AS%20region%2C%0A%20%20%20%20countIf(event%20%3D%20'slo_operation_started')%20AS%20started%2C%0A%20%20%20%20countIf(event%20%3D%20'slo_operation_completed'%20AND%20properties.outcome%20%3D%20'success')%20AS%20successes%2C%0A%20%20%20%20countIf(event%20%3D%20'slo_operation_completed'%20AND%20properties.outcome%20%3D%20'failure')%20AS%20failures%2C%0A%20%20%20%20countIf(event%20%3D%20'slo_operation_started')%0A%20%20%20%20%20%20-%20countIf(event%20%3D%20'slo_operation_completed')%20AS%20never_completed%2C%0A%20%20%20%20if(%0A%20%20%20%20%20%20%20%20countIf(event%20%3D%20'slo_operation_started')%20%3E%200%2C%0A%20%20%20%20%20%20%20%20round(countIf(event%20%3D%20'slo_operation_completed'%20AND%20properties.outcome%20%3D%20'success')%0A%20%20%20%20%20%20%20%20%20%20%2F%20countIf(event%20%3D%20'slo_operation_started')%20*%20100%2C%202)%2C%0A%20%20%20%20%20%20%20%20NULL%0A%20%20%20%20)%20AS%20success_rate%0AFROM%20events%0AWHERE%20event%20IN%20('slo_operation_started'%2C%20'slo_operation_completed')%0A%20%20AND%20timestamp%20%3E%3D%20now()%20-%20INTERVAL%2028%20DAY%0AGROUP%20BY%20operation%2C%20properties.region%0AORDER%20BY%20operation%2C%20region%0A)

<!-- Briefly describe the steps you took. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->