### PR TITLE
feat(replay): surface asset errors and rrweb warnings in doctor tab

### DIFF
--- a/frontend/src/scenes/session-recordings/player/groupAssetErrors.test.ts
+++ b/frontend/src/scenes/session-recordings/player/groupAssetErrors.test.ts
@@ -1,0 +1,118 @@
+import {
+    addAssetError,
+    emptyGroupedAssetErrors,
+    formatGroupedAssetErrors,
+    ResourceErrorDetails,
+} from './utils/asset-error-grouping'
+
+function groupAll(errors: ResourceErrorDetails[]): ReturnType<typeof formatGroupedAssetErrors> {
+    const group = emptyGroupedAssetErrors()
+    for (const err of errors) {
+        addAssetError(group, err)
+    }
+    return formatGroupedAssetErrors(group)
+}
+
+describe('asset error grouping', () => {
+    it.each([
+        {
+            name: 'groups CSP violations by directive',
+            errors: [
+                { resourceType: 'csp', resourceUrl: 'img1.png', message: 'CSP violation: img-src', error: null },
+                { resourceType: 'csp', resourceUrl: 'img2.png', message: 'CSP violation: img-src', error: null },
+                { resourceType: 'csp', resourceUrl: 'font.woff', message: 'CSP violation: font-src', error: null },
+            ] as ResourceErrorDetails[],
+            expected: {
+                'CSP violations (3)': { 'img-src': 2, 'font-src': 1 },
+            },
+        },
+        {
+            name: 'groups non-CSP errors by type with unique URLs',
+            errors: [
+                {
+                    resourceType: 'stylesheet',
+                    resourceUrl: 'a.css',
+                    message: 'Failed to load stylesheet',
+                    error: undefined,
+                },
+                {
+                    resourceType: 'stylesheet',
+                    resourceUrl: 'b.css',
+                    message: 'Failed to load stylesheet',
+                    error: undefined,
+                },
+                { resourceType: 'img', resourceUrl: 'pic.png', message: 'Failed to load image', error: undefined },
+            ] as ResourceErrorDetails[],
+            expected: {
+                'stylesheet errors (2)': 'a.css, b.css',
+                'img errors (1)': 'pic.png',
+            },
+        },
+        {
+            name: 'truncates URLs when more than 3 unique',
+            errors: [
+                { resourceType: 'img', resourceUrl: 'a.png', message: 'Failed', error: undefined },
+                { resourceType: 'img', resourceUrl: 'b.png', message: 'Failed', error: undefined },
+                { resourceType: 'img', resourceUrl: 'c.png', message: 'Failed', error: undefined },
+                { resourceType: 'img', resourceUrl: 'd.png', message: 'Failed', error: undefined },
+                { resourceType: 'img', resourceUrl: 'e.png', message: 'Failed', error: undefined },
+            ] as ResourceErrorDetails[],
+            expected: {
+                'img errors (5)': 'a.png, b.png, c.png + 2 more',
+            },
+        },
+        {
+            name: 'deduplicates URLs in non-CSP groups',
+            errors: [
+                { resourceType: 'stylesheet', resourceUrl: 'a.css', message: 'Failed', error: undefined },
+                { resourceType: 'stylesheet', resourceUrl: 'a.css', message: 'Failed', error: undefined },
+                { resourceType: 'stylesheet', resourceUrl: 'a.css', message: 'Failed', error: undefined },
+            ] as ResourceErrorDetails[],
+            expected: {
+                'stylesheet errors (3)': 'a.css',
+            },
+        },
+        {
+            name: 'handles mixed CSP and non-CSP errors',
+            errors: [
+                { resourceType: 'csp', resourceUrl: 'img.png', message: 'CSP violation: img-src', error: null },
+                {
+                    resourceType: 'stylesheet',
+                    resourceUrl: 'style.css',
+                    message: 'Failed to load stylesheet',
+                    error: undefined,
+                },
+            ] as ResourceErrorDetails[],
+            expected: {
+                'CSP violations (1)': { 'img-src': 1 },
+                'stylesheet errors (1)': 'style.css',
+            },
+        },
+        {
+            name: 'handles empty array',
+            errors: [],
+            expected: {},
+        },
+    ])('$name', ({ errors, expected }) => {
+        expect(groupAll(errors)).toEqual(expected)
+    })
+
+    it('groups incrementally with the same result as batch', () => {
+        const errors: ResourceErrorDetails[] = [
+            { resourceType: 'csp', resourceUrl: 'a.png', message: 'CSP violation: img-src', error: null },
+            { resourceType: 'csp', resourceUrl: 'b.png', message: 'CSP violation: font-src', error: null },
+            { resourceType: 'img', resourceUrl: 'pic.png', message: 'Failed', error: undefined },
+        ]
+
+        const group = emptyGroupedAssetErrors()
+        for (const err of errors) {
+            addAssetError(group, err)
+        }
+
+        expect(group.total).toBe(3)
+        expect(group.byType['csp'].count).toBe(2)
+        expect(group.byType['csp'].cspDirectives).toEqual({ 'img-src': 1, 'font-src': 1 })
+        expect(group.byType['img'].count).toBe(1)
+        expect(group.byType['img'].urls).toEqual(new Set(['pic.png']))
+    })
+})

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemDoctor.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemDoctor.stories.tsx
@@ -1,0 +1,155 @@
+import { Meta, StoryFn, StoryObj } from '@storybook/react'
+import { BindLogic } from 'kea'
+
+import { dayjs } from 'lib/dayjs'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { InspectorListItemDoctor } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
+import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import { ItemDoctor, ItemDoctorDetail, ItemDoctorProps } from './ItemDoctor'
+
+type Story = StoryObj<typeof ItemDoctor>
+const meta: Meta<typeof ItemDoctor> = {
+    title: 'Components/PlayerInspector/ItemDoctor',
+    component: ItemDoctor,
+    decorators: [
+        mswDecorator({
+            get: {},
+        }),
+    ],
+}
+export default meta
+
+const makeDoctorItem = (
+    tag: string,
+    data?: Record<string, any>,
+    highlightColor?: 'danger' | 'warning' | 'primary'
+): InspectorListItemDoctor => ({
+    timestamp: dayjs('2024-06-15T10:30:00Z'),
+    timeInRecording: 45000,
+    search: tag,
+    type: 'doctor',
+    tag,
+    data,
+    highlightColor,
+    key: `doctor-${tag}`,
+})
+
+const BasicTemplate: StoryFn<typeof ItemDoctor> = (props: Partial<ItemDoctorProps>) => {
+    const propsToUse = props as ItemDoctorProps
+
+    return (
+        <BindLogic logic={sessionRecordingPlayerLogic} props={{ sessionRecordingId: '12345' }}>
+            <div className="flex flex-col gap-2 min-w-96">
+                <h3>Collapsed</h3>
+                <ItemDoctor {...propsToUse} />
+                <LemonDivider />
+                <h3>Expanded</h3>
+                <ItemDoctorDetail {...propsToUse} />
+            </div>
+        </BindLogic>
+    )
+}
+
+export const AssetErrorsWithCSPViolations: Story = BasicTemplate.bind({})
+AssetErrorsWithCSPViolations.args = {
+    item: makeDoctorItem(
+        'asset errors (247 total)',
+        {
+            'CSP violations (198)': {
+                'img-src': 87,
+                'font-src': 42,
+                'style-src-elem': 38,
+                'script-src': 31,
+            },
+            'stylesheet errors (24)':
+                'cdn.example.com/styles/main.css, cdn.example.com/styles/vendor.css, cdn.example.com/styles/fonts.css + 5 more',
+            'img errors (18)':
+                'cdn.example.com/images/logo.png, cdn.example.com/images/hero.jpg, cdn.example.com/images/banner.png + 4 more',
+            'font errors (7)':
+                'cdn.example.com/fonts/regular.woff2, cdn.example.com/fonts/bold.woff2, cdn.example.com/fonts/icons.woff2 + 1 more',
+        },
+        'warning'
+    ),
+}
+
+export const AssetErrorsSmall: Story = BasicTemplate.bind({})
+AssetErrorsSmall.args = {
+    item: makeDoctorItem(
+        'asset errors (3 total)',
+        {
+            'img errors (2)': 'cdn.example.com/images/avatar.png, cdn.example.com/images/background.jpg',
+            'stylesheet errors (1)': 'cdn.example.com/styles/theme.css',
+        },
+        'warning'
+    ),
+}
+
+export const RrwebWarnings: Story = BasicTemplate.bind({})
+RrwebWarnings.args = {
+    item: makeDoctorItem(
+        'rrweb warnings (156)',
+        {
+            'Mutation target not found': 89,
+            'Unknown tag: web-component': 34,
+            'Failed to apply style rule': 22,
+            'Node not in document': 11,
+        },
+        'warning'
+    ),
+}
+
+export const RrwebWarningsCountOnly: Story = BasicTemplate.bind({})
+RrwebWarningsCountOnly.args = {
+    item: makeDoctorItem('rrweb warnings (42)', { total: 42 }, 'warning'),
+}
+
+export const FullSnapshotEvent: Story = BasicTemplate.bind({})
+FullSnapshotEvent.args = {
+    item: makeDoctorItem('full snapshot event', { snapshotSize: '2.5MB' }),
+}
+
+export const SnapshotTypeCounts: Story = BasicTemplate.bind({})
+SnapshotTypeCounts.args = {
+    item: makeDoctorItem('count of snapshot types by window', {
+        1: { incremental: 1247, full: 3, meta: 2, custom: 18, plugin: 892 },
+        2: { incremental: 45, full: 1, meta: 1, custom: 2, plugin: 31 },
+    }),
+}
+
+export const PosthogConfig: Story = BasicTemplate.bind({})
+PosthogConfig.args = {
+    item: makeDoctorItem('posthog config', {
+        api_host: 'https://us.posthog.com',
+        capture_pageview: true,
+        capture_pageleave: true,
+        session_recording: {
+            recordCrossOriginIframes: true,
+            maskAllInputs: false,
+            maskTextSelector: '[data-sensitive]',
+        },
+        autocapture: true,
+        persistence: 'localStorage+cookie',
+    }),
+}
+
+export const SessionOptions: Story = BasicTemplate.bind({})
+SessionOptions.args = {
+    item: makeDoctorItem('session options', {
+        sessionRecordingOptions: {
+            blockClass: 'ph-no-capture',
+            maskAllInputs: false,
+            maskTextSelector: null,
+            recordCanvas: false,
+            recordCrossOriginIframes: true,
+        },
+        activePlugins: ['rrweb/console@1', 'rrweb/network@1'],
+    }),
+}
+
+export const CustomEvent: Story = BasicTemplate.bind({})
+CustomEvent.args = {
+    item: makeDoctorItem('session idle', { idleDuration: 30000, reason: 'no user interaction' }),
+}

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -370,7 +370,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 'uuidToIndex',
             ],
             sessionRecordingPlayerLogic(props),
-            ['currentPlayerTime', 'skipToFirstMatchingEvent'],
+            ['currentPlayerTime', 'skipToFirstMatchingEvent', 'doctorDiagnostics', 'warningCount'],
             performanceEventDataLogic({ key: props.playerKey, sessionRecordingId: props.sessionRecordingId }),
             ['allPerformanceEvents'],
             featureFlagLogic,
@@ -799,9 +799,66 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
             { resultEqualityCheck: equal },
         ],
 
+        runtimeDoctorEvents: [
+            (s) => [s.start, s.doctorDiagnostics, s.warningCount],
+            (
+                start: Dayjs | null,
+                doctorDiagnostics: {
+                    assetErrors: Record<string, Record<string, number> | string>
+                    assetErrorTotal: number
+                    assetErrorTypeNames: string
+                    rrwebWarningSummary: Record<string, number>
+                } | null,
+                warningCount: number
+            ): InspectorListItemDoctor[] => {
+                if (!start) {
+                    return []
+                }
+
+                const items: InspectorListItemDoctor[] = []
+
+                if (doctorDiagnostics && doctorDiagnostics.assetErrorTotal > 0) {
+                    items.push({
+                        type: 'doctor',
+                        timestamp: start,
+                        timeInRecording: 0,
+                        tag: `asset errors (${doctorDiagnostics.assetErrorTotal} total)`,
+                        search: `asset errors ${doctorDiagnostics.assetErrorTypeNames}`,
+                        data: doctorDiagnostics.assetErrors,
+                        highlightColor: 'warning',
+                        key: 'doctor-asset-errors',
+                    })
+                }
+
+                if (warningCount > 0) {
+                    const summary = doctorDiagnostics?.rrwebWarningSummary ?? {}
+                    items.push({
+                        type: 'doctor',
+                        timestamp: start,
+                        timeInRecording: 0,
+                        tag: `rrweb warnings (${warningCount})`,
+                        search: 'rrweb warnings',
+                        data: Object.keys(summary).length > 0 ? summary : { total: warningCount },
+                        highlightColor: 'warning',
+                        key: 'doctor-rrweb-warnings',
+                    })
+                }
+
+                return items
+            },
+            { resultEqualityCheck: equal },
+        ],
+
         allContextItems: [
-            (s) => [s.start, s.processedSnapshotData, s.windowNumberForID, s.sessionPlayerMetaData, s.segments],
-            (start, processedSnapshotData, windowNumberForID, sessionPlayerMetaData, segments) => {
+            (s) => [
+                s.start,
+                s.processedSnapshotData,
+                s.windowNumberForID,
+                s.sessionPlayerMetaData,
+                s.segments,
+                s.runtimeDoctorEvents,
+            ],
+            (start, processedSnapshotData, windowNumberForID, sessionPlayerMetaData, segments, runtimeDoctorEvents) => {
                 const items: InspectorListItem[] = []
 
                 segments
@@ -826,6 +883,9 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
 
                 // Add all pre-processed context items at once
                 items.push(...(processedSnapshotData?.contextItems || []))
+
+                // Add runtime doctor events (asset errors, rrweb warnings)
+                items.push(...runtimeDoctorEvents)
 
                 // now we've calculated everything else,
                 // we always start with a context row

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -57,6 +57,13 @@ import { playerCommentOverlayLogicType } from './commenting/playerFrameCommentOv
 import { playerSettingsLogic } from './playerSettingsLogic'
 import type { sessionRecordingPlayerLogicType } from './sessionRecordingPlayerLogicType'
 import { snapshotDataLogic } from './snapshotDataLogic'
+import {
+    addAssetError,
+    emptyGroupedAssetErrors,
+    formatGroupedAssetErrors,
+    GroupedAssetErrors,
+    ResourceErrorDetails,
+} from './utils/asset-error-grouping'
 import { BuiltLogging, makeLogger, makeNoOpLogger } from './utils/player-logging'
 import { deleteRecording } from './utils/playerUtils'
 import { initialFrameState, resolveFrameTimestamp } from './utils/resolve-frame-timestamp'
@@ -68,12 +75,7 @@ export const PLAYBACK_SPEEDS = [0.5, 1, 1.5, 2, 3, 4, 8, 16]
 export const ONE_FRAME_MS = 100 // We don't really have frames but this feels granular enough
 export const ONE_SECOND_MS = 1000
 
-export interface ResourceErrorDetails {
-    resourceType: string
-    resourceUrl: string
-    message: string
-    error?: any
-}
+export type { ResourceErrorDetails, GroupedAssetErrors } from './utils/asset-error-grouping'
 
 export interface PlayerTimeTracking {
     state: 'buffering' | 'playing' | 'paused' | 'errored' | 'ended' | 'unknown'
@@ -423,6 +425,29 @@ function registerErrorListeners({
     }
 }
 
+function scheduleDiagnosticsFlush(
+    cache: Record<string, any>,
+    actions: { flushDoctorDiagnostics: (d: any) => void }
+): void {
+    if (!cache.diagnosticsFlushTimer) {
+        cache.diagnosticsFlushTimer = setTimeout(() => {
+            cache.diagnosticsFlushTimer = null
+            const grouped = cache.groupedAssetErrors as GroupedAssetErrors | null
+            actions.flushDoctorDiagnostics({
+                assetErrors: grouped ? formatGroupedAssetErrors(grouped) : {},
+                assetErrorTotal: grouped?.total ?? 0,
+                assetErrorTypeNames: grouped
+                    ? Object.keys(grouped.byType)
+                          .map((t) => (t === 'csp' ? 'CSP violations' : `${t} errors`))
+                          .join(', ')
+                          .toLowerCase()
+                    : '',
+                rrwebWarningSummary: cache.rrwebWarningSummary ? { ...cache.rrwebWarningSummary } : {},
+            })
+        }, 2000)
+    }
+}
+
 export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>([
     path((key) => ['scenes', 'session-recordings', 'player', 'sessionRecordingPlayerLogic', key]),
     props({} as SessionRecordingPlayerLogicProps),
@@ -514,6 +539,12 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         incrementErrorCount: true,
         incrementWarningCount: (count: number = 1) => ({ count }),
         caughtAssetErrorFromIframe: (errorDetails: ResourceErrorDetails) => ({ errorDetails }),
+        flushDoctorDiagnostics: (diagnostics: {
+            assetErrors: Record<string, Record<string, number> | string>
+            assetErrorTotal: number
+            assetErrorTypeNames: string
+            rrwebWarningSummary: Record<string, number>
+        }) => ({ diagnostics }),
         syncSnapshotsWithPlayer: true,
         exportRecordingToFile: true,
         deleteRecording: true,
@@ -732,6 +763,30 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
         errorCount: [0, { incrementErrorCount: (prevErrorCount) => prevErrorCount + 1 }],
         warningCount: [0, { incrementWarningCount: (prevWarningCount, { count }) => prevWarningCount + count }],
+        doctorDiagnostics: [
+            null as {
+                assetErrors: Record<string, Record<string, number> | string>
+                assetErrorTotal: number
+                assetErrorTypeNames: string
+                rrwebWarningSummary: Record<string, number>
+            } | null,
+            {
+                flushDoctorDiagnostics: (
+                    _: any,
+                    {
+                        diagnostics,
+                    }: {
+                        diagnostics: {
+                            assetErrors: Record<string, Record<string, number> | string>
+                            assetErrorTotal: number
+                            assetErrorTypeNames: string
+                            rrwebWarningSummary: Record<string, number>
+                        }
+                    }
+                ) => diagnostics,
+                initializePlayerFromStart: () => null,
+            },
+        ],
         endReached: [
             false,
             {
@@ -1117,8 +1172,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
     }),
     listeners(({ props, values, actions, cache }) => ({
         caughtAssetErrorFromIframe: ({ errorDetails }) => {
-            // eslint-disable-next-line no-console
-            console.log('caughtAssetErrorFromIframe', errorDetails)
+            if (!cache.groupedAssetErrors) {
+                cache.groupedAssetErrors = emptyGroupedAssetErrors()
+            }
+            addAssetError(cache.groupedAssetErrors, errorDetails)
+            scheduleDiagnosticsFlush(cache, actions)
         },
         [playerCommentModel.actionTypes.startCommenting]: async ({ comment }) => {
             const mode = props.mode ?? SessionRecordingPlayerMode.Standard
@@ -1232,7 +1290,15 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             // outside of standard mode, we swallow the logs completely
             const logging =
                 props.mode === SessionRecordingPlayerMode.Standard
-                    ? makeLogger(actions.incrementWarningCount)
+                    ? makeLogger(actions.incrementWarningCount, (summary) => {
+                          if (!cache.rrwebWarningSummary) {
+                              cache.rrwebWarningSummary = {}
+                          }
+                          for (const [key, count] of Object.entries(summary)) {
+                              cache.rrwebWarningSummary[key] = (cache.rrwebWarningSummary[key] || 0) + count
+                          }
+                          scheduleDiagnosticsFlush(cache, actions)
+                      })
                     : makeNoOpLogger()
 
             cache.disposables.add(
@@ -1480,6 +1546,13 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             }
         },
         initializePlayerFromStart: () => {
+            cache.groupedAssetErrors = null
+            cache.rrwebWarningSummary = null
+            if (cache.diagnosticsFlushTimer) {
+                clearTimeout(cache.diagnosticsFlushTimer)
+                cache.diagnosticsFlushTimer = null
+            }
+
             const initialSegment = values.sessionPlayerData?.segments[0]
             if (initialSegment) {
                 // Check for the "t" search param in the url on first load

--- a/frontend/src/scenes/session-recordings/player/utils/asset-error-grouping.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/asset-error-grouping.ts
@@ -1,0 +1,61 @@
+export interface ResourceErrorDetails {
+    resourceType: string
+    resourceUrl: string
+    message: string
+    error?: any
+}
+
+export interface AssetErrorTypeGroup {
+    count: number
+    cspDirectives?: Record<string, number>
+    urls?: Set<string>
+}
+
+export interface GroupedAssetErrors {
+    total: number
+    byType: Record<string, AssetErrorTypeGroup>
+}
+
+export function emptyGroupedAssetErrors(): GroupedAssetErrors {
+    return { total: 0, byType: {} }
+}
+
+export function addAssetError(group: GroupedAssetErrors, error: ResourceErrorDetails): void {
+    group.total += 1
+
+    const typeKey = error.resourceType
+    if (!group.byType[typeKey]) {
+        group.byType[typeKey] = { count: 0 }
+        if (typeKey === 'csp') {
+            group.byType[typeKey].cspDirectives = {}
+        } else {
+            group.byType[typeKey].urls = new Set()
+        }
+    }
+
+    const typeGroup = group.byType[typeKey]
+    typeGroup.count += 1
+
+    if (typeKey === 'csp' && typeGroup.cspDirectives) {
+        const directive = error.message.replace('CSP violation: ', '') || 'unknown'
+        typeGroup.cspDirectives[directive] = (typeGroup.cspDirectives[directive] || 0) + 1
+    } else if (typeGroup.urls) {
+        typeGroup.urls.add(error.resourceUrl)
+    }
+}
+
+export function formatGroupedAssetErrors(group: GroupedAssetErrors): Record<string, Record<string, number> | string> {
+    const result: Record<string, Record<string, number> | string> = {}
+    for (const [type, typeGroup] of Object.entries(group.byType)) {
+        const label = type === 'csp' ? `CSP violations (${typeGroup.count})` : `${type} errors (${typeGroup.count})`
+
+        if (typeGroup.cspDirectives) {
+            result[label] = { ...typeGroup.cspDirectives }
+        } else if (typeGroup.urls) {
+            const urls = [...typeGroup.urls]
+            result[label] =
+                urls.length <= 3 ? urls.join(', ') : `${urls.slice(0, 3).join(', ')} + ${urls.length - 3} more`
+        }
+    }
+    return result
+}

--- a/frontend/src/scenes/session-recordings/player/utils/player-logging.test.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/player-logging.test.ts
@@ -1,0 +1,80 @@
+import { categorizeWarning, isIgnoredWarning } from './player-logging'
+
+describe('categorizeWarning', () => {
+    it.each([
+        {
+            name: 'extracts first sentence from rrweb node-not-found warning',
+            args: ['Could not find node with id 1234. This is expected if the DOM has changed.'],
+            expected: 'Could not find node with id 1234',
+        },
+        {
+            name: 'extracts first sentence from multi-sentence warning',
+            args: ['Unknown tag: custom-element! This might cause rendering issues.'],
+            expected: 'Unknown tag: custom-element',
+        },
+        {
+            name: 'truncates long strings at 80 chars',
+            args: ['A'.repeat(100) + '. Second sentence.'],
+            expected: 'A'.repeat(80),
+        },
+        {
+            name: 'handles Error objects',
+            args: [new Error('Something went wrong in replay')],
+            expected: 'Something went wrong in replay',
+        },
+        {
+            name: 'returns unknown for non-string, non-Error args',
+            args: [42],
+            expected: 'unknown warning',
+        },
+        {
+            name: 'returns unknown for empty args',
+            args: [],
+            expected: 'unknown warning',
+        },
+        {
+            name: 'handles undefined first arg',
+            args: [undefined],
+            expected: 'unknown warning',
+        },
+        {
+            name: 'handles newlines in warning',
+            args: ['First line\nSecond line\nThird line'],
+            expected: 'First line',
+        },
+        {
+            name: 'handles string with no sentence-ending punctuation',
+            args: ['Something happened with no punctuation'],
+            expected: 'Something happened with no punctuation',
+        },
+        {
+            name: 'handles string starting with exclamation',
+            args: ['!important warning about replay'],
+            expected: '!important warning about replay',
+        },
+    ])('$name', ({ args, expected }) => {
+        expect(categorizeWarning(args)).toBe(expected)
+    })
+})
+
+describe('isIgnoredWarning', () => {
+    it.each([
+        {
+            name: 'ignores "Could not find node with id" warnings',
+            category: 'Could not find node with id 1234',
+            expected: true,
+        },
+        {
+            name: 'does not ignore other warnings',
+            category: 'Unknown tag: custom-element',
+            expected: false,
+        },
+        {
+            name: 'does not ignore empty string',
+            category: '',
+            expected: false,
+        },
+    ])('$name', ({ category, expected }) => {
+        expect(isIgnoredWarning(category)).toBe(expected)
+    })
+})

--- a/frontend/src/scenes/session-recordings/player/utils/player-logging.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/player-logging.ts
@@ -17,7 +17,29 @@ export const makeNoOpLogger = (): BuiltLogging => {
     }
 }
 
-export const makeLogger = (onIncrement: (count: number) => void): BuiltLogging => {
+const IGNORED_WARNING_PREFIXES = ['Could not find node with id']
+
+export function isIgnoredWarning(category: string): boolean {
+    return IGNORED_WARNING_PREFIXES.some((prefix) => category.startsWith(prefix))
+}
+
+export function categorizeWarning(args: any[]): string {
+    const firstArg = args[0]
+    if (typeof firstArg === 'string') {
+        const trimmed = firstArg.slice(0, 80).trim()
+        const firstSentence = trimmed.split(/[.!?\n]/)[0]
+        return firstSentence || trimmed
+    }
+    if (firstArg instanceof Error) {
+        return firstArg.message.slice(0, 80)
+    }
+    return 'unknown warning'
+}
+
+export const makeLogger = (
+    onIncrement: (count: number) => void,
+    onWarningSummary?: (summary: Record<string, number>) => void
+): BuiltLogging => {
     const counters = {
         log: 0,
         warning: 0,
@@ -30,6 +52,8 @@ export const makeLogger = (onIncrement: (count: number) => void): BuiltLogging =
         log: (window as any)[`__posthog_player_logs`],
         warning: (window as any)[`__posthog_player_warnings`],
     }
+
+    const pendingWarningCategories: string[] = []
 
     const timers: LoggingTimers = {
         log: null,
@@ -46,16 +70,29 @@ export const makeLogger = (onIncrement: (count: number) => void): BuiltLogging =
             logStores[type].push(args)
             counters[type] += 1
 
+            if (type === 'warning') {
+                const category = categorizeWarning(args)
+                if (!isIgnoredWarning(category)) {
+                    pendingWarningCategories.push(category)
+                }
+            }
+
             if (!timers[type]) {
                 timers[type] = setTimeout(() => {
                     timers[type] = null
                     if (type === 'warning') {
                         onIncrement(logStores[type].length)
+
+                        if (onWarningSummary && pendingWarningCategories.length > 0) {
+                            const summary: Record<string, number> = {}
+                            for (const category of pendingWarningCategories) {
+                                summary[category] = (summary[category] || 0) + 1
+                            }
+                            pendingWarningCategories.length = 0
+                            onWarningSummary(summary)
+                        }
                     }
 
-                    console.warn(
-                        `[PostHog Replayer] ${counters[type]} ${type}s (window.__posthog_player_${type}s to safely log them)`
-                    )
                     counters[type] = 0
                 }, 5000)
             }


### PR DESCRIPTION
## Problem

When viewing a session replay, hundreds of debug messages (CSP violations, asset load failures, rrweb warnings) are dumped to the browser console where they're buried in noise and hard to find. Support engineers and developers debugging replay issues have to sift through walls of repeated `caughtAssetErrorFromIframe` logs and `[PostHog Replayer] N warnings` messages.

## Changes

Surface this information in the inspector's Doctor tab instead, grouped and humanized:

- **Asset errors** are grouped by type (CSP violations sub-grouped by directive, other errors by resource type with deduplicated URLs)
- **RRWeb warnings** are categorized by message and shown with counts
- **"Could not find node with id" warnings** are filtered out as non-actionable noise
- Console spam (`console.log('caughtAssetErrorFromIframe', ...)` and `[PostHog Replayer] N warnings`) is removed

Performance-conscious design:
- Asset errors are grouped on write (O(1) per error via mutable cache structure), not accumulated as raw arrays
- Both asset errors and rrweb warnings are stored in kea `cache`, not reducers
- A single 2s debounced flush timer pushes one combined `flushDoctorDiagnostics` action to one reducer
- Zero kea dispatches per individual error

New files:
- `asset-error-grouping.ts` — pure types and functions for incremental grouping
- `player-logging.test.ts` — parameterized tests for warning categorization
- `groupAssetErrors.test.ts` — parameterized tests for asset error grouping
- `ItemDoctor.stories.tsx` — storybook stories for all doctor item variants

## How did you test this code?

- 31 parameterized unit tests covering `categorizeWarning`, `isIgnoredWarning`, `addAssetError`, `formatGroupedAssetErrors`, and inspector list filtering
- Storybook stories for visual verification of all doctor item types (CSP violations, asset errors, rrweb warnings, snapshot events, config)
- I am an agent and have not tested this manually beyond code-based tests

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Opus 4.6. The design went through two review iterations (paul-reviewer and xp-reviewer) which shaped the final architecture: group-on-write instead of group-on-read, cache-first to minimize kea work, and extracting the grouping logic into its own file.