### PR TITLE
fix(devex): reduce false positives in pr-approval deny-list

### DIFF
--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -11,86 +11,175 @@ from pathlib import Path
 
 # ── Pattern data ─────────────────────────────────────────────────
 
-DENY_PATH_PATTERNS: dict[str, list[str]] = {
-    "auth": [
-        "auth",
-        "login",
-        "signup",
-        "session",
-        "token",
-        "oauth",
-        "saml",
-        "sso",
-        "permission",
-        "oidc",
-        "credential",
-        "password",
-        "2fa",
-        "mfa",
-    ],
-    "crypto_secrets": [
-        "crypto",
-        "encrypt",
-        "decrypt",
-        "secret",
-        "key",
-        "cert",
-        "signing",
-        ".env",
-        "vault",
-    ],
-    "migrations": [
-        "migrations/",
-        "migrate",
-        "backfill",
-        "schema_change",
-    ],
-    "infra_cicd": [
-        "terraform",
-        "k8s",
-        "kubernetes",
-        "helm",
-        "dockerfile",
-        "docker-compose",
-        ".github/workflows",
-        "deploy",
-        "iam",
-        "cloudflare",
-        "cdn",
-        "waf",
-        "routing",
-    ],
-    "billing": [
-        "billing",
-        "payment",
-        "stripe",
-        "invoice",
-        "subscription",
-        "pricing",
-    ],
-    "public_api": [
-        "openapi",
-        "api_schema",
-        "swagger",
-        "public_api",
-    ],
-    "deps_toolchain": [
-        "package.json",
-        "requirements.txt",
-        "pyproject.toml",
-        "pnpm-lock",
-        "package-lock",
-        "yarn.lock",
-        "uv.lock",
-        "Cargo.toml",
-        "go.mod",
-        "Makefile",
-        "Dockerfile",
-        "tsconfig",
-        ".tool-versions",
-        ".nvmrc",
-    ],
+# Deny patterns use word-boundary matching (\b) to avoid false positives
+# from substring hits like "session" in "SessionAnalysis" or "key" in
+# "localStorage key". Patterns are compiled into regexes at import time.
+#
+# Two pattern lists per category:
+#   "paths"  — matched against file paths only
+#   "any"    — matched against both file paths and the PR title
+# If a category only has "any", all patterns apply everywhere.
+
+_DENY_PATTERN_DEFS: dict[str, dict[str, list[str]]] = {
+    "auth": {
+        "any": [
+            "auth",
+            "login",
+            "signup",
+            "oauth",
+            "saml",
+            "sso",
+            "oidc",
+            "credential",
+            "password",
+            "2fa",
+            "mfa",
+        ],
+        # "session" and "token" match too broadly in titles and non-auth
+        # file paths (e.g. SessionAnalysisWarning, tokenize, tokenizer).
+        # "permission" matches permission-checking helpers everywhere.
+        # Restrict these to path-only with tighter patterns.
+        "paths": [
+            "session_auth",
+            "session_token",
+            "auth/session",
+            "auth/token",
+            "permission",
+        ],
+    },
+    "crypto_secrets": {
+        "any": [
+            "crypto",
+            "encrypt",
+            "decrypt",
+            "vault",
+        ],
+        # "key", "secret", "cert", "signing" are too broad for titles.
+        # "key" alone matches "keyboard", "hotkey", "localStorage key".
+        # Use path-only with compound patterns.
+        "paths": [
+            "secret",
+            r"api[_-]?key",
+            r"secret[_-]?key",
+            r"private[_-]?key",
+            r"signing[_-]?key",
+            "certificate",
+            r"\.env",
+            r"\.pem",
+        ],
+    },
+    "migrations": {
+        "paths": [
+            "migrations/",
+            "migrate",
+            "backfill",
+            "schema_change",
+        ],
+    },
+    "infra_cicd": {
+        "any": [
+            "terraform",
+            "kubernetes",
+            "helm",
+        ],
+        "paths": [
+            r"k8s",
+            "dockerfile",
+            "docker-compose",
+            r"\.github/workflows",
+            "deploy",
+            "iam",
+            "cloudflare",
+            "cdn",
+            "waf",
+            "routing",
+        ],
+    },
+    "billing": {
+        "any": [
+            "billing",
+            "payment",
+            "stripe",
+            "invoice",
+            "subscription",
+            "pricing",
+        ],
+    },
+    "public_api": {
+        "any": [
+            "openapi",
+            "api_schema",
+            "swagger",
+            "public_api",
+        ],
+    },
+    "deps_toolchain": {
+        # All path-only — these are literal filenames, not title words.
+        "paths": [
+            r"package\.json",
+            r"requirements\.txt",
+            r"pyproject\.toml",
+            "pnpm-lock",
+            "package-lock",
+            r"yarn\.lock",
+            r"uv\.lock",
+            r"Cargo\.toml",
+            r"go\.mod",
+            "Makefile",
+            "Dockerfile",
+            "tsconfig",
+            r"\.tool-versions",
+            r"\.nvmrc",
+        ],
+    },
 }
+
+
+def _compile_pattern(p: str, *, for_paths: bool) -> re.Pattern[str]:
+    r"""Compile a single deny pattern into a case-insensitive regex.
+
+    Patterns containing path separators (/) or starting with a dot are
+    treated as literal path fragments — no boundaries added.
+
+    For other patterns, boundary matching depends on context:
+    - Title matching uses \b (standard word boundaries — underscore is
+      a word char, which is correct for natural-language titles).
+    - Path matching uses a looser boundary that also breaks on _ and -,
+      since file paths use those as separators. This ensures "secret"
+      matches "secret_key_store.py" but not "nosecrets.py".
+    """
+    if "/" in p or p.startswith(r"\."):
+        return re.compile(rf"(?i){p}")
+    if for_paths:
+        # Break on non-alphanumeric (including _ and -) or string edges
+        return re.compile(rf"(?i)(?<![a-zA-Z0-9]){p}(?![a-zA-Z0-9])")
+    return re.compile(rf"(?i)\b{p}\b")
+
+
+def _compile_patterns(
+    defs: dict[str, dict[str, list[str]]],
+) -> dict[str, dict[str, list[re.Pattern[str]]]]:
+    """Compile pattern definitions into regexes.
+
+    "paths" patterns use path-friendly boundaries (break on _ and -).
+    "any" patterns are compiled twice: once for paths, once for titles,
+    and stored as a list of (path_rx, title_rx) tuples.
+    """
+    compiled: dict[str, dict[str, list]] = {}
+    for category, groups in defs.items():
+        compiled[category] = {}
+        for scope, patterns in groups.items():
+            if scope == "paths":
+                compiled[category][scope] = [_compile_pattern(p, for_paths=True) for p in patterns]
+            else:
+                # "any" — store (path_regex, title_regex) pairs
+                compiled[category][scope] = [
+                    (_compile_pattern(p, for_paths=True), _compile_pattern(p, for_paths=False)) for p in patterns
+                ]
+    return compiled
+
+
+DENY_PATTERNS = _compile_patterns(_DENY_PATTERN_DEFS)
 
 ALLOW_ONLY_EXTENSIONS = {
     ".md",
@@ -210,12 +299,34 @@ def test_only(categories: dict[str, int]) -> bool:
 
 def detect_deny_categories(files: list[str], subject: str) -> list[str]:
     hits: set[str] = set()
-    searchable = [f.lower() for f in files] + [subject.lower()]
-    for category, patterns in DENY_PATH_PATTERNS.items():
-        for text in searchable:
-            if any(p in text for p in patterns):
-                hits.add(category)
+    paths_lower = [f.lower() for f in files]
+    subject_lower = subject.lower()
+
+    for category, scopes in DENY_PATTERNS.items():
+        found = False
+        # "paths" patterns — only match against file paths
+        for rx in scopes.get("paths", []):
+            if found:
                 break
+            for p in paths_lower:
+                if rx.search(p):
+                    hits.add(category)
+                    found = True
+                    break
+        if found:
+            continue
+        # "any" patterns — match against file paths (path_rx) and title (title_rx)
+        for path_rx, title_rx in scopes.get("any", []):
+            if found:
+                break
+            for p in paths_lower:
+                if path_rx.search(p):
+                    hits.add(category)
+                    found = True
+                    break
+            if not found and title_rx.search(subject_lower):
+                hits.add(category)
+                found = True
     return sorted(hits)
 
 

--- a/tools/pr-approval-agent/test_gates.py
+++ b/tools/pr-approval-agent/test_gates.py
@@ -1,0 +1,141 @@
+"""Tests for deny-list pattern matching in gates.py."""
+
+import pytest
+
+from gates import detect_deny_categories
+
+# ── False positives that should NOT trigger ──────────────────────
+
+
+@pytest.mark.parametrize(
+    "files, subject",
+    [
+        pytest.param(
+            [
+                "frontend/src/queries/nodes/InsightViz/EditorFilters/SessionAnalysisWarning.tsx",
+                "frontend/src/queries/nodes/InsightViz/EditorFilters/SuggestionBanner.tsx",
+                "frontend/src/queries/nodes/InsightViz/EditorFilters/EditorFilterItems.tsx",
+            ],
+            "chore(insights): extract SessionAnalysisWarning, SuggestionBanner, EditorFilterItems",
+            id="session-analysis-warning-component",
+        ),
+        pytest.param(
+            ["frontend/src/lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic.ts"],
+            "fix(taxonomic-filter): scope recents localStorage key by team id",
+            id="localstorage-key-in-title",
+        ),
+        pytest.param(
+            ["frontend/src/lib/utils/tokenizer.ts"],
+            "fix: improve tokenizer performance",
+            id="tokenizer-not-auth-token",
+        ),
+        pytest.param(
+            ["frontend/src/scenes/session-recordings/SessionRecordingPlayer.tsx"],
+            "feat(replay): add session recording playback controls",
+            id="session-recording-not-auth",
+        ),
+        pytest.param(
+            ["frontend/src/lib/components/KeyboardShortcut.tsx"],
+            "fix: keyboard shortcut not working",
+            id="keyboard-not-crypto-key",
+        ),
+        pytest.param(
+            ["frontend/src/lib/hooks/useRoutingLogic.ts"],
+            "fix: routing logic for dashboard",
+            id="routing-logic-not-infra",
+        ),
+    ],
+)
+def test_no_false_positive(files: list[str], subject: str) -> None:
+    assert detect_deny_categories(files, subject) == []
+
+
+# ── True positives that SHOULD trigger ───────────────────────────
+
+
+@pytest.mark.parametrize(
+    "files, subject, expected_category",
+    [
+        pytest.param(
+            ["posthog/api/authentication.py"],
+            "fix: auth flow redirect",
+            "auth",
+            id="auth-file-and-title",
+        ),
+        pytest.param(
+            ["posthog/api/login.py"],
+            "fix: login endpoint",
+            "auth",
+            id="login-endpoint",
+        ),
+        pytest.param(
+            ["posthog/models/oauth_config.py"],
+            "feat: add oauth config",
+            "auth",
+            id="oauth-config",
+        ),
+        pytest.param(
+            ["posthog/api/auth/session_token.py"],
+            "fix: session token refresh",
+            "auth",
+            id="auth-session-token-path",
+        ),
+        pytest.param(
+            ["posthog/crypto/encrypt.py"],
+            "feat: add encryption support",
+            "crypto_secrets",
+            id="encryption-file",
+        ),
+        pytest.param(
+            ["posthog/settings/.env.example"],
+            "chore: update env example",
+            "crypto_secrets",
+            id="dot-env-file",
+        ),
+        pytest.param(
+            ["posthog/api/api_key.py"],
+            "fix: api key rotation",
+            "crypto_secrets",
+            id="api-key-file",
+        ),
+        pytest.param(
+            ["posthog/models/secret_key_store.py"],
+            "feat: secret key management",
+            "crypto_secrets",
+            id="secret-key-file",
+        ),
+        pytest.param(
+            ["posthog/migrations/0400_add_column.py"],
+            "feat: add new column",
+            "migrations",
+            id="migration-file",
+        ),
+        pytest.param(
+            [".github/workflows/ci.yml"],
+            "chore(ci): update workflow",
+            "infra_cicd",
+            id="github-workflow",
+        ),
+        pytest.param(
+            ["posthog/billing/stripe_webhook.py"],
+            "fix: billing webhook",
+            "billing",
+            id="billing-file",
+        ),
+        pytest.param(
+            ["package.json"],
+            "chore: update dependencies",
+            "deps_toolchain",
+            id="package-json",
+        ),
+        pytest.param(
+            ["pyproject.toml"],
+            "chore: bump version",
+            "deps_toolchain",
+            id="pyproject-toml",
+        ),
+    ],
+)
+def test_true_positive(files: list[str], subject: str, expected_category: str) -> None:
+    result = detect_deny_categories(files, subject)
+    assert expected_category in result, f"Expected '{expected_category}' in {result}"


### PR DESCRIPTION
**Problem**
The deny-list in the PR approval agent uses bare substring matching, causing false positives that block legitimate PRs from auto-approval. Two recent examples:
- [#52521](https://github.com/PostHog/posthog/pull/52521#pullrequestreview-4019744001) — `"session"` pattern matched `SessionAnalysisWarning.tsx` (a session replay component, not auth)
- [#52526](https://github.com/PostHog/posthog/pull/52526#pullrequestreview-4019749614) — `"key"` pattern matched "localStorage key" in the PR title (not crypto)

**Changes**
- Split patterns into `paths` (file paths only) vs `any` (paths + title) scopes — file-oriented patterns like `migrations/`, `.env`, `routing` no longer match PR titles
- Replace substring `in` checks with word-boundary regexes, using a path-friendly boundary that also breaks on `_` and `-`
- Tighten overly broad patterns: removed standalone `key`, `session`, `token` in favor of compound patterns like `api_key`, `session_auth`, `auth/token`
- Added `test_gates.py` with parameterized false-positive and true-positive test cases