### PR TITLE
chore(devex): add adopting-generated-api-types agent skill

### DIFF
--- a/.agents/skills/adopting-generated-api-types/SKILL.md
+++ b/.agents/skills/adopting-generated-api-types/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: adopting-generated-api-types
+description: Use when migrating frontend code from manual API client calls (`api.get`, `api.create`, `api.surveys.get`, `api.dashboards.list`, `new ApiRequest()`) and handwritten TypeScript interfaces to generated API functions and types. Triggers on files importing from `lib/api`, files with `api.get<`, `api.create<`, `api.<entity>.<method>`, manual interface definitions that duplicate backend serializers, or any frontend file that constructs API URLs by hand. Covers the full replacement workflow — finding the generated equivalent, swapping imports, adapting call sites, and removing dead manual types.
+---
+
+# Adopting generated API types
+
+## Overview
+
+PostHog generates TypeScript API client functions and types from Django serializers via the OpenAPI pipeline:
+
+```text
+Django serializer → drf-spectacular → OpenAPI JSON → Orval → TypeScript (api.ts + api.schemas.ts)
+```
+
+Generated files live in:
+
+- **Core:** `frontend/src/generated/core/api.ts` and `api.schemas.ts`
+- **Products:** `products/<product>/frontend/generated/api.ts` and `api.schemas.ts`
+
+Generated types use the `Api` suffix (`DashboardApi`, `SurveyApi`). Handwritten types never do.
+
+This skill guides replacing manual API calls and handwritten types with generated equivalents.
+
+## The three manual patterns to migrate
+
+The legacy `frontend/src/lib/api.ts` (~6000 lines) has three layers, all migration targets:
+
+### 1. High-level object API (most common)
+
+Domain-specific convenience methods on the `api` object:
+
+```typescript
+api.surveys.get(id)
+api.surveys.create(data)
+api.dashboards.list()
+api.cohorts.update(id, data)
+api.actions.create(data)
+```
+
+These are the most widely used pattern — every entity has its own namespace with CRUD plus custom methods (e.g., `api.surveys.getResponsesCount()`, `api.dashboards.streamTiles()`).
+
+### 2. Raw HTTP methods with manual URLs
+
+```typescript
+api.get<SomeType>(`api/projects/${id}/surveys/`)
+api.create<SomeType>(`api/projects/${id}/surveys/`, data)
+api.update<SomeType>(url, data)
+api.put<SomeType>(url, data)
+api.delete(url)
+```
+
+### 3. ApiRequest builder (fluent URL construction)
+
+```typescript
+const url = new ApiRequest().surveys().assembleFullUrl()
+const response = await api.get(url)
+
+// or directly:
+await new ApiRequest().survey(surveyId).withAction('summarize_responses').create({ data })
+```
+
+All three patterns should be replaced with generated functions where available.
+
+## When to use
+
+- Touching a file that calls `api.<entity>.<method>()` (e.g., `api.surveys.get()`)
+- Touching a file that calls `api.get<T>(...)`, `api.create<T>(...)`, etc.
+- Touching a file that uses `new ApiRequest()` to build URLs
+- Touching a file that imports handwritten interfaces from `~/types` for API response shapes
+- Cleaning up frontend code after backend serializer improvements
+
+## Step-by-step workflow
+
+### 1. Identify what the manual call does
+
+Look at the existing call and extract:
+
+- **HTTP method** — GET, POST, PUT, PATCH, DELETE
+- **Entity and action** — what resource, what operation
+- **Type parameter** — the handwritten type used for the response
+
+### 2. Find the generated equivalent
+
+Generated function names follow the `{resource}{Action}` convention:
+
+```text
+surveysList          — GET    /api/projects/{id}/surveys/
+surveysCreate        — POST   /api/projects/{id}/surveys/
+surveysRetrieve      — GET    /api/projects/{id}/surveys/{id}/
+surveysPartialUpdate — PATCH  /api/projects/{id}/surveys/{id}/
+surveysDestroy       — DELETE /api/projects/{id}/surveys/{id}/
+```
+
+**Where to search:**
+
+- Core endpoints: `frontend/src/generated/core/api.ts`
+- Product endpoints: `products/<product>/frontend/generated/api.ts`
+
+**Search strategies:**
+
+1. Grep for the entity name in the generated `api.ts` files
+2. Search by the `get*Url` helper functions — every generated function has a URL builder above it
+3. Search `api.schemas.ts` for the type name with `Api` suffix
+
+If no generated function exists, the backend endpoint may lack `@extend_schema` or `@validated_request`. Fix the backend first using the `improving-drf-endpoints` skill, then run `hogli build:openapi`.
+
+**Custom actions** (like `api.surveys.summarize_responses()`) may not have generated equivalents if the backend `@action` lacks `@extend_schema`. Check generated files first; if missing, fix the backend.
+
+### 3. Check type compatibility
+
+Compare the handwritten type with the generated `Api` type. Key differences:
+
+- **`readonly` modifiers** — generated types mark read-only fields
+- **Optional vs required** — generated types reflect `required=` precisely
+- **Nullability** — `null` types are explicit
+- **Extra fields** — generated types may include fields the handwritten type omits
+
+See [type-compatibility.md](references/type-compatibility.md) for details.
+
+### 4. Replace the call
+
+See [migration-patterns.md](references/migration-patterns.md) for detailed before/after examples covering:
+
+- High-level object API (`api.surveys.get()` → `surveysRetrieve()`)
+- Raw HTTP methods (`api.get<T>(url)` → generated function)
+- ApiRequest builder → generated function
+- Paginated list calls
+- Create/update with request bodies
+- Delete calls
+- Kea logic loaders and listeners
+- Calls with abort signals
+
+### 5. Replace the type at usage sites
+
+Update downstream references from the handwritten type to the generated one:
+
+```typescript
+// Before
+function renderSurvey(survey: Survey): JSX.Element { ... }
+
+// After
+function renderSurvey(survey: SurveyApi): JSX.Element { ... }
+```
+
+### 6. Clean up dead types
+
+After migrating all usages of a handwritten type:
+
+1. Remove the type definition from `~/types` or the local file
+2. Remove unused imports
+3. Run `pnpm --filter=@posthog/frontend typescript:check` to verify no breakage
+
+## Decision guide
+
+| Scenario                                            | Action                                                                                                       |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Generated function exists                           | Replace manual call with generated function                                                                  |
+| Generated type exists but function doesn't          | Use the generated type as the generic parameter on the manual call, file a follow-up to add `@extend_schema` |
+| Neither exists                                      | Keep the manual pattern, fix the backend serializer/viewset first                                            |
+| Custom action without generated equivalent          | Keep the `api.<entity>.<method>()` call, fix the backend `@action` annotation first                          |
+| Generated type has different shape than handwritten | Adapt call sites to the generated shape — the serializer is the source of truth                              |
+| Code mutates the response object                    | Use a local mutable copy: `const mutable = { ...response }` or use `Writable<T>` utility                     |
+| Need both read and write types                      | Use `FooApi` for reads, `NonReadonly<FooApi>` (from generated `api.ts`) for writes                           |
+
+## Import conventions
+
+```typescript
+// Core generated functions — import from api.ts
+import { domainsList, domainsCreate, domainsRetrieve } from '~/generated/core/api'
+
+// Core generated types — import type from api.schemas.ts
+import type { OrganizationDomainApi } from '~/generated/core/api.schemas'
+
+// Product generated functions — NO tilde prefix, use 'products/' path
+import { surveysList, surveysRetrieve } from 'products/surveys/frontend/generated/api'
+import type { SurveyApi } from 'products/surveys/frontend/generated/api.schemas'
+
+// Within a product, relative imports also work
+import { logsAlertsCreate } from '../generated/api'
+import type { LogsAlertConfigurationApi } from '../generated/api.schemas'
+```
+
+**Path rules:**
+
+- Core: `~/generated/core/...` (tilde prefix)
+- Products from outside: `products/<product>/frontend/generated/...` (no tilde)
+- Products from inside: relative `../generated/...` or `./generated/...`
+
+Use `import type` for types to enable proper tree-shaking.
+
+## How generated functions work under the hood
+
+Generated functions wrap the same `api` module via `api-orval-mutator.ts`:
+
+```text
+surveysList(projectId, params)
+  → apiMutator(url, { method: 'GET' })
+    → api.get(url)
+```
+
+Switching to generated functions does not change HTTP behavior — same cookies, same CSRF, same error handling. The only difference is type safety and URL construction.
+
+## Verifying the migration
+
+1. **TypeScript check:** `pnpm --filter=@posthog/frontend typescript:check`
+2. **Grep for leftover manual types:** search for the old type name across the codebase
+3. **Run relevant tests:** `pnpm --filter=@posthog/frontend jest <test_file>`
+
+## Related
+
+- **Backend side:** use `improving-drf-endpoints` to fix serializers that produce poor types
+- **Type system docs:** `docs/published/handbook/engineering/type-system.md`
+- **API mutator:** `frontend/src/lib/api-orval-mutator.ts`
+- **Regenerate types:** `hogli build:openapi`

--- a/.agents/skills/adopting-generated-api-types/SKILL.md
+++ b/.agents/skills/adopting-generated-api-types/SKILL.md
@@ -160,8 +160,8 @@ After migrating all usages of a handwritten type:
 | Neither exists                                      | Keep the manual pattern, fix the backend serializer/viewset first                                            |
 | Custom action without generated equivalent          | Keep the `api.<entity>.<method>()` call, fix the backend `@action` annotation first                          |
 | Generated type has different shape than handwritten | Adapt call sites to the generated shape — the serializer is the source of truth                              |
-| Code mutates the response object                    | Use a local mutable copy: `const mutable = { ...response }` or use `Writable<T>` utility                     |
-| Need both read and write types                      | Use `FooApi` for reads, `NonReadonly<FooApi>` (from generated `api.ts`) for writes                           |
+| Code mutates the response object                    | Use a local mutable copy: `const mutable = { ...response }` and mutate that                                  |
+| Need both read and write types                      | Use `FooApi` for reads, derive write types via `Parameters<typeof fooCreate>[1]` or use `PatchedFooApi`      |
 
 ## Import conventions
 

--- a/.agents/skills/adopting-generated-api-types/references/migration-patterns.md
+++ b/.agents/skills/adopting-generated-api-types/references/migration-patterns.md
@@ -1,0 +1,303 @@
+# Migration patterns — before/after
+
+## High-level object API
+
+### 1. Entity get
+
+```typescript
+// Before
+import api from 'lib/api'
+import { Survey } from '~/types'
+
+const survey = await api.surveys.get(surveyId)
+
+// After
+import { surveysRetrieve } from 'products/surveys/frontend/generated/api'
+
+const survey = await surveysRetrieve(String(values.currentProjectId), surveyId)
+```
+
+Generated functions always take `projectId` as the first argument — the high-level API pulls it from context implicitly, but generated functions are explicit.
+
+### 2. Entity list
+
+```typescript
+// Before
+const surveys = await api.surveys.list({ limit: 100 })
+
+// After
+import { surveysList } from 'products/surveys/frontend/generated/api'
+
+const surveys = await surveysList(String(values.currentProjectId), { limit: 100 })
+```
+
+### 3. Entity create
+
+```typescript
+// Before
+const survey = await api.surveys.create(surveyPayload)
+
+// After
+import { surveysCreate } from 'products/surveys/frontend/generated/api'
+
+const survey = await surveysCreate(String(values.currentProjectId), surveyPayload)
+```
+
+### 4. Entity update
+
+```typescript
+// Before
+const updated = await api.surveys.update(surveyId, surveyPayload)
+
+// After
+import { surveysPartialUpdate } from 'products/surveys/frontend/generated/api'
+
+const updated = await surveysPartialUpdate(String(values.currentProjectId), surveyId, surveyPayload)
+```
+
+### 5. Entity delete
+
+```typescript
+// Before
+await api.surveys.delete(surveyId)
+
+// After
+import { surveysDestroy } from 'products/surveys/frontend/generated/api'
+
+await surveysDestroy(String(values.currentProjectId), surveyId)
+```
+
+## Raw HTTP methods
+
+### 6. GET with type parameter
+
+```typescript
+// Before
+import api from 'lib/api'
+import { OrganizationDomainType } from '~/types'
+
+const domain = await api.get<OrganizationDomainType>(`api/organizations/${orgId}/domains/${domainId}/`)
+
+// After
+import { domainsRetrieve } from '~/generated/core/api'
+
+const domain = await domainsRetrieve(orgId, domainId)
+```
+
+### 7. Paginated GET
+
+```typescript
+// Before
+import { PaginatedResponse, OrganizationInviteType } from '~/types'
+
+const invites = await api.get<PaginatedResponse<OrganizationInviteType>>(
+  `api/organizations/${orgId}/invites/?limit=100`
+)
+const items = invites.results
+
+// After
+import { invitesList } from '~/generated/core/api'
+
+const invites = await invitesList(orgId, { limit: 100 })
+const items = invites.results // typed as OrganizationInviteApi[]
+```
+
+Query parameters are passed as an argument object — no manual URL encoding.
+
+### 8. POST (create)
+
+```typescript
+// Before
+const domain = await api.create<OrganizationDomainType>(`api/organizations/${orgId}/domains/`, {
+  domain: 'example.com',
+})
+
+// After
+import { domainsCreate } from '~/generated/core/api'
+
+const domain = await domainsCreate(orgId, { domain: 'example.com' })
+```
+
+The request body type is `NonReadonly<OrganizationDomainApi>` — read-only fields like `id` are stripped automatically.
+
+### 9. PATCH (partial update)
+
+```typescript
+// Before
+const updated = await api.update<OrganizationDomainType>(`api/organizations/${orgId}/domains/${domainId}/`, {
+  jit_provisioning_enabled: true,
+})
+
+// After
+import { domainsPartialUpdate } from '~/generated/core/api'
+
+const updated = await domainsPartialUpdate(orgId, domainId, {
+  jit_provisioning_enabled: true,
+})
+```
+
+### 10. DELETE
+
+```typescript
+// Before
+await api.delete(`api/organizations/${orgId}/domains/${domainId}/`)
+
+// After
+import { domainsDestroy } from '~/generated/core/api'
+
+await domainsDestroy(orgId, domainId)
+```
+
+## ApiRequest builder
+
+### 11. Builder to generated function
+
+```typescript
+// Before
+import { ApiRequest } from 'lib/api'
+
+const url = new ApiRequest().projects().projectsDetail(projectId).surveys().assembleFullUrl()
+const surveys = await api.get<PaginatedResponse<Survey>>(url)
+
+// After
+import { surveysList } from 'products/surveys/frontend/generated/api'
+
+const surveys = await surveysList(projectId)
+```
+
+### 12. Builder with action
+
+```typescript
+// Before
+await new ApiRequest()
+  .survey(surveyId)
+  .withAction('summarize_responses')
+  .withQueryString({ question_index: 1 })
+  .create({ data: { force_refresh: true } })
+
+// After — if the @action has @extend_schema, a generated function exists:
+import { surveysSummarizeResponsesCreate } from 'products/surveys/frontend/generated/api'
+
+await surveysSummarizeResponsesCreate(projectId, surveyId, {
+  force_refresh: true,
+  question_index: 1,
+})
+
+// If no generated function exists, keep the builder and fix the backend first.
+```
+
+## Kea patterns
+
+### 13. Kea logic loader
+
+```typescript
+// Before
+loaders({
+  domains: [
+    [] as OrganizationDomainType[],
+    {
+      loadDomains: async () => {
+        const response = await api.get<PaginatedResponse<OrganizationDomainType>>(
+          `api/organizations/${values.currentOrganizationId}/domains/`
+        )
+        return response.results
+      },
+    },
+  ],
+})
+
+// After
+import { domainsList } from '~/generated/core/api'
+import type { OrganizationDomainApi } from '~/generated/core/api.schemas'
+
+loaders({
+  domains: [
+    [] as OrganizationDomainApi[],
+    {
+      loadDomains: async () => {
+        const response = await domainsList(values.currentOrganizationId)
+        return response.results
+      },
+    },
+  ],
+})
+```
+
+### 14. Kea listener with error handling
+
+```typescript
+// Before
+listeners({
+  saveDomain: async ({ domain }) => {
+    try {
+      const response = await api.update<OrganizationDomainType>(
+        `api/organizations/${orgId}/domains/${domain.id}/`,
+        domain
+      )
+      actions.saveDomainSuccess(response)
+    } catch (e) {
+      actions.saveDomainFailure(String(e))
+    }
+  },
+})
+
+// After
+import { domainsPartialUpdate } from '~/generated/core/api'
+
+listeners({
+  saveDomain: async ({ domain }) => {
+    try {
+      const response = await domainsPartialUpdate(orgId, domain.id, domain)
+      actions.saveDomainSuccess(response)
+    } catch (e) {
+      actions.saveDomainFailure(String(e))
+    }
+  },
+})
+```
+
+Error handling stays the same — `apiMutator` throws `ApiError` just like `api.update` does.
+
+## Edge cases
+
+### 15. Call with abort signal
+
+```typescript
+// Before
+const controller = new AbortController()
+const result = await api.get<MyType>(url, { signal: controller.signal })
+
+// After
+const controller = new AbortController()
+const result = await myEndpointRetrieve(id, undefined, { signal: controller.signal })
+```
+
+The last argument to generated functions is `options?: RequestInit` — pass `signal`, `headers`, etc. there.
+
+### 16. Mixed file — partial migration
+
+When a file has many manual calls and you're only touching some:
+
+```typescript
+// OK to migrate incrementally — mix generated and manual calls in the same file
+import api from 'lib/api' // keep for un-migrated calls
+import { domainsList, domainsCreate } from '~/generated/core/api' // migrated
+import type { OrganizationDomainApi } from '~/generated/core/api.schemas'
+
+// Migrated
+const domains = await domainsList(orgId)
+
+// Not yet migrated (no generated function for this custom action)
+const verification = await api.create(`api/organizations/${orgId}/domains/${id}/verify/`)
+```
+
+Don't force-migrate calls where no generated function exists — leave them and fix the backend endpoint first.
+
+### 17. Custom methods without generated equivalents
+
+High-level API methods like `api.surveys.getResponsesCount()` or `api.dashboards.streamTiles()` may not have generated equivalents if the backend `@action` lacks `@extend_schema`. Leave these in place and file a follow-up to annotate the backend endpoint.
+
+```typescript
+// Keep as-is until the backend @action is annotated
+const counts = await api.surveys.getResponsesCount(surveyIds)
+```

--- a/.agents/skills/adopting-generated-api-types/references/migration-patterns.md
+++ b/.agents/skills/adopting-generated-api-types/references/migration-patterns.md
@@ -162,7 +162,7 @@ const surveys = await api.get<PaginatedResponse<Survey>>(url)
 // After
 import { surveysList } from 'products/surveys/frontend/generated/api'
 
-const surveys = await surveysList(projectId)
+const surveys = await surveysList(String(projectId))
 ```
 
 ### 12. Builder with action
@@ -178,9 +178,8 @@ await new ApiRequest()
 // After — if the @action has @extend_schema, a generated function exists:
 import { surveysSummarizeResponsesCreate } from 'products/surveys/frontend/generated/api'
 
-await surveysSummarizeResponsesCreate(projectId, surveyId, {
+await surveysSummarizeResponsesCreate(String(projectId), String(surveyId), {
   force_refresh: true,
-  question_index: 1,
 })
 
 // If no generated function exists, keep the builder and fix the backend first.

--- a/.agents/skills/adopting-generated-api-types/references/type-compatibility.md
+++ b/.agents/skills/adopting-generated-api-types/references/type-compatibility.md
@@ -1,0 +1,147 @@
+# Type compatibility — generated vs handwritten
+
+## readonly fields
+
+Generated types mark fields that are `read_only=True` in the serializer as `readonly`:
+
+```typescript
+// Generated
+interface DashboardApi {
+  readonly id: number
+  readonly created_at: string
+  name: string // writable
+}
+
+// Handwritten (typical)
+interface DashboardType {
+  id: number
+  created_at: string
+  name: string
+}
+```
+
+This means code that mutates response objects directly will error:
+
+```typescript
+// Error: Cannot assign to 'id' because it is a read-only property
+dashboard.id = 123
+```
+
+**Fix options:**
+
+1. Stop mutating the response — spread into a new object: `const local = { ...dashboard, id: 123 }`
+2. Use the `NonReadonly<T>` utility from the generated `api.ts` for write-side types
+3. If the code is building a request body, use the `Patched*Api` or `NonReadonly<*Api>` type instead
+
+## Patched types for partial updates
+
+Generated types include `Patched*Api` variants where all fields are optional — matching PATCH semantics:
+
+```typescript
+interface PatchedDashboardApi {
+  readonly id?: number
+  name?: string
+  description?: string
+}
+```
+
+Use `PatchedFooApi` when building partial update payloads.
+
+## Pagination wrappers
+
+Generated pagination types follow this pattern:
+
+```typescript
+interface PaginatedDashboardListApi {
+  count: number
+  next?: string | null
+  previous?: string | null
+  results: DashboardApi[]
+}
+```
+
+This replaces the generic `PaginatedResponse<T>` from handwritten types. The shape is identical, so usage code doesn't need to change — only the type annotation.
+
+## Nullable vs optional
+
+Generated types distinguish between:
+
+- **`nullable`** — field can be `null` (`field: string | null`)
+- **`optional`** — field can be omitted (`field?: string`)
+- **Both** — `field?: string | null`
+
+Handwritten types often use `?` for both cases. When migrating, you may see TypeScript errors where code checks `if (field)` but the generated type says the field is always present (just possibly `null`). Adjust the check:
+
+```typescript
+// Before (handwritten type had field?: string)
+if (response.verified_at) { ... }
+
+// After (generated type has verified_at: string | null)
+if (response.verified_at) { ... }  // still works — null is falsy
+```
+
+## Enum types
+
+Generated enums use `as const` objects:
+
+```typescript
+export type SurveyTypeApi = (typeof SurveyTypeApi)[keyof typeof SurveyTypeApi]
+export const SurveyTypeApi = {
+  Popover: 'popover',
+  Widget: 'widget',
+  FullScreen: 'full_screen',
+} as const
+```
+
+Handwritten enums might use TypeScript `enum` or string unions. When migrating:
+
+```typescript
+// Before
+if (survey.type === 'popover') { ... }
+
+// After — both work, but the const object gives autocomplete
+if (survey.type === SurveyTypeApi.Popover) { ... }
+if (survey.type === 'popover') { ... }  // also fine
+```
+
+## Fields present in handwritten but not generated
+
+If a handwritten type has fields that don't appear in the generated type, the serializer doesn't expose them. Common causes:
+
+- Field was removed from the serializer
+- Field is computed client-side (never came from the API)
+- Field is from a different endpoint (e.g., a detail view vs. list view serializer)
+
+For client-side computed fields, extend the generated type:
+
+```typescript
+import type { DashboardApi } from '~/products/dashboards/frontend/generated/api.schemas'
+
+interface DashboardWithLocal extends DashboardApi {
+  _localDraft: boolean // client-only field
+}
+```
+
+## Fields present in generated but not handwritten
+
+The serializer may expose fields the handwritten type never included. This is fine — the generated type is the source of truth. Frontend code may start using the new fields.
+
+## Working with NonReadonly for request bodies
+
+The generated `api.ts` includes a `NonReadonly<T>` utility type that strips `readonly` and recursively makes nested objects writable:
+
+```typescript
+// Generated create function signature
+export const domainsCreate = async (
+    organizationId: string,
+    organizationDomainApi: NonReadonly<OrganizationDomainApi>,
+    options?: RequestInit
+): Promise<OrganizationDomainApi>
+```
+
+You don't need to import or think about `NonReadonly` — just pass a plain object and TypeScript will accept it because plain objects satisfy `NonReadonly<T>`:
+
+```typescript
+// This works — plain objects are writable
+await domainsCreate(orgId, { domain: 'example.com' })
+```

--- a/.agents/skills/adopting-generated-api-types/references/type-compatibility.md
+++ b/.agents/skills/adopting-generated-api-types/references/type-compatibility.md
@@ -30,8 +30,7 @@ dashboard.id = 123
 **Fix options:**
 
 1. Stop mutating the response — spread into a new object: `const local = { ...dashboard, id: 123 }`
-2. Use the `NonReadonly<T>` utility from the generated `api.ts` for write-side types
-3. If the code is building a request body, use the `Patched*Api` or `NonReadonly<*Api>` type instead
+2. If building a request body, use the `Patched*Api` type or derive the parameter type via `Parameters<typeof fooCreate>[1]`
 
 ## Patched types for partial updates
 
@@ -115,7 +114,7 @@ If a handwritten type has fields that don't appear in the generated type, the se
 For client-side computed fields, extend the generated type:
 
 ```typescript
-import type { DashboardApi } from '~/products/dashboards/frontend/generated/api.schemas'
+import type { DashboardApi } from 'products/dashboards/frontend/generated/api.schemas'
 
 interface DashboardWithLocal extends DashboardApi {
   _localDraft: boolean // client-only field
@@ -126,22 +125,18 @@ interface DashboardWithLocal extends DashboardApi {
 
 The serializer may expose fields the handwritten type never included. This is fine — the generated type is the source of truth. Frontend code may start using the new fields.
 
-## Working with NonReadonly for request bodies
+## Request body types
 
-The generated `api.ts` includes a `NonReadonly<T>` utility type that strips `readonly` and recursively makes nested objects writable:
-
-```typescript
-// Generated create function signature
-export const domainsCreate = async (
-    organizationId: string,
-    organizationDomainApi: NonReadonly<OrganizationDomainApi>,
-    options?: RequestInit
-): Promise<OrganizationDomainApi>
-```
-
-You don't need to import or think about `NonReadonly` — just pass a plain object and TypeScript will accept it because plain objects satisfy `NonReadonly<T>`:
+Generated create/update functions accept a `NonReadonly<T>` parameter internally — this is a non-exported utility type that strips `readonly`. You don't need to import or reference it directly. Just pass a plain object and TypeScript will accept it:
 
 ```typescript
 // This works — plain objects are writable
 await domainsCreate(orgId, { domain: 'example.com' })
+```
+
+If you need to explicitly type a request body variable, derive the type from the function signature:
+
+```typescript
+type CreateBody = Parameters<typeof domainsCreate>[1]
+const body: CreateBody = { domain: 'example.com' }
 ```


### PR DESCRIPTION
Agent skill that guides replacing manual frontend API calls (`api.get<T>()`, `api.surveys.get()`, `new ApiRequest()`) and handwritten TypeScript interfaces with generated Orval functions and types.

**What's in the skill**
- Step-by-step workflow for identifying manual calls, finding generated equivalents, checking type compatibility, and swapping
- 17 before/after migration patterns covering all three legacy API layers (high-level object API, raw HTTP methods, ApiRequest builder)
- Type compatibility guide for readonly fields, Patched types, nullable vs optional, enums, and NonReadonly utilities
- Decision guide for when to migrate vs when to fix the backend first
- Correct import path conventions (core with `~/`, products without)

**Validation**
Tested against error tracking product — confirmed the skill correctly identifies endpoints where generated types are incomplete (bare `JSONField`, missing `@extend_schema`) and routes to "fix backend first." Also confirmed a clean partial migration of `issueActionsLogic.tsx` (3 calls swapped, 7 left as-is) with zero new TypeScript errors.