### PR TITLE
refactor: Catch quota errors looking also at exception message

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -997,6 +997,26 @@ class BigQueryClient:
                 await asyncio.sleep(backoff)
                 attempt += 1
 
+            except Forbidden as err:
+                if err.reason != "quotaExceeded" and "reason: quotaExceeded" not in str(err):
+                    raise
+
+                backoff = min(max_retry, initial_retry * (backoff_factor**attempt))
+                self.logger.exception("LoadJob quota exceeded", attempt=attempt, backoff=backoff, error_code=err.code)
+                self.external_logger.error(  # noqa: TRY400
+                    "BigQuery load job quota exceeded. This error will be retried in %d seconds, this is attempt number %d."
+                    " It may take several minutes or longer until the quota is restored, as it is restored over the course"
+                    " of 24 hours. If this happens frequently, consider contacting Google Cloud support to increase your quota.",
+                    backoff,
+                    attempt,
+                    err,
+                    attempt=attempt,
+                    backoff=backoff,
+                    error_code=err.code,
+                )
+                await asyncio.sleep(backoff)
+                attempt += 1
+
             else:
                 return result
 
@@ -1005,19 +1025,9 @@ class BigQueryClient:
 
         This method blocks and should only be run on an executor.
         """
-        try:
-            load_job = self.sync_client.load_table_from_file(file, bq_table, job_config=job_config, rewind=True)
-            result = load_job.result()
-        except Forbidden as err:
-            if err.reason == "quotaExceeded":
-                self.external_logger.exception(
-                    "BigQuery quota long-term limit exceeded. We will attempt to retry the batch export with an exponential back-off, but it may take several minutes or longer until the quota is restored."
-                )
-                raise BigQueryQuotaExceededError(err.message) from err
-
-            raise
-        else:
-            return result
+        load_job = self.sync_client.load_table_from_file(file, bq_table, job_config=job_config, rewind=True)
+        result = load_job.result()
+        return result
 
 
 class MissingRequiredPermissionsError(Exception):


### PR DESCRIPTION
## Problem

Sometimes quota errors do not have a `reason` set or something so they are not being re-raised properly.


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Check the exception message for the "reason: quotaExceeded" string on forbidden errors.
* Move the retry to the outside loop for consistency with the rest of the retry logic.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
