### PR TITLE
feat(sql): transpose table viz

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -27,7 +27,6 @@ import { AxisBreakdownSeries, seriesBreakdownLogic } from './seriesBreakdownLogi
 import { YSeriesLogicProps, YSeriesSettingsTab, ySeriesLogic } from './ySeriesLogic'
 
 export const SeriesTab = (): JSX.Element => {
-    const { effectiveVisualizationType } = useValues(dataVisualizationLogic)
     const {
         columns,
         numericalColumns,
@@ -35,11 +34,13 @@ export const SeriesTab = (): JSX.Element => {
         yData,
         responseLoading,
         showTableSettings,
-        tabularColumns,
+        sourceTabularColumns,
+        isTransposed,
         selectedXAxis,
         dataVisualizationProps,
+        effectiveVisualizationType,
     } = useValues(dataVisualizationLogic)
-    const { updateXSeries, addYSeries } = useActions(dataVisualizationLogic)
+    const { updateXSeries, addYSeries, setTransposeResults } = useActions(dataVisualizationLogic)
     const breakdownLogic = seriesBreakdownLogic({ key: dataVisualizationProps.key })
     const { showSeriesBreakdown } = useValues(breakdownLogic)
     const { addSeriesBreakdown } = useActions(breakdownLogic)
@@ -53,11 +54,22 @@ export const SeriesTab = (): JSX.Element => {
 
     if (showTableSettings) {
         return (
-            <div className="flex flex-col w-full p-3">
-                <LemonLabel>Columns</LemonLabel>
-                {tabularColumns.map((series, index) => (
-                    <YSeries series={series} index={index} key={`${series.column.name}-${index}`} />
-                ))}
+            <div className="flex flex-col w-full p-3 gap-4">
+                {effectiveVisualizationType === ChartDisplayType.ActionsTable && (
+                    <LemonSwitch
+                        className="flex-1 w-full"
+                        label="Transpose results"
+                        checked={isTransposed}
+                        onChange={setTransposeResults}
+                        tooltip="Rotate the table so rows become columns and columns become rows."
+                    />
+                )}
+                <div>
+                    <LemonLabel>Columns</LemonLabel>
+                    {sourceTabularColumns.map((series, index) => (
+                        <YSeries series={series} index={index} key={`${series.column.name}-${index}`} />
+                    ))}
+                </div>
             </div>
         )
     }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -48,12 +48,23 @@ function formatColumnTitle(title: string): React.ReactNode {
     )
 }
 
+function getDisplayedColumnTitle(
+    columnName: string,
+    label: string | JSX.Element | undefined,
+    query: DataVisualizationNode,
+    context: QueryContext<DataVisualizationNode> | undefined
+): React.ReactNode {
+    const { title } = renderColumnMeta(columnName, query, context)
+    return label || title || columnName
+}
+
 export const Table = (props: TableProps): JSX.Element => {
     const { isDarkModeOn } = useValues(themeLogic)
 
     const {
         tabularData,
         tabularColumns,
+        sourceTabularColumns,
         conditionalFormattingRules,
         responseLoading,
         responseError,
@@ -65,12 +76,12 @@ export const Table = (props: TableProps): JSX.Element => {
     } = useValues(dataVisualizationLogic)
     const { toggleColumnPin } = useActions(dataVisualizationLogic)
 
+    const sourceTabularColumnsByName = new Map(sourceTabularColumns.map((column) => [column.column.name, column]))
+
     const tableColumns: LemonTableColumn<TableDataCell<any>[], any>[] = tabularColumns.map(
         ({ column, settings }, index) => {
             const { title, ...columnMeta } = renderColumnMeta(column.name, props.query, props.context)
-
             const columnTitle = settings?.display?.label || title || column.name
-
             const formattedTitle = typeof columnTitle === 'string' ? formatColumnTitle(columnTitle) : columnTitle
 
             return {
@@ -99,18 +110,57 @@ export const Table = (props: TableProps): JSX.Element => {
                     </div>
                 ),
                 render: (_, data, recordIndex: number, rowCount: number) => {
+                    const cell = data[index]
+
+                    if (cell.isTransposedHeader) {
+                        const sourceColumnTitle = cell.sourceColumnName
+                            ? getDisplayedColumnTitle(
+                                  cell.sourceColumnName,
+                                  sourceTabularColumnsByName.get(cell.sourceColumnName)?.settings?.display?.label,
+                                  props.query,
+                                  props.context
+                              )
+                            : cell.formattedValue
+                        const renderedSourceColumnTitle =
+                            typeof sourceColumnTitle === 'string'
+                                ? formatColumnTitle(sourceColumnTitle)
+                                : React.isValidElement(sourceColumnTitle) ||
+                                    sourceColumnTitle == null ||
+                                    typeof sourceColumnTitle === 'number'
+                                  ? sourceColumnTitle
+                                  : String(sourceColumnTitle)
+
+                        return <div className="truncate">{renderedSourceColumnTitle}</div>
+                    }
+
                     return (
                         <div className="truncate">
-                            {renderColumn(column.name, data[index].formattedValue, data, recordIndex, rowCount, {
-                                kind: NodeKind.DataTableNode,
-                                source: props.query.source,
-                            })}
+                            {renderColumn(
+                                cell.sourceColumnName ?? column.name,
+                                cell.formattedValue,
+                                data,
+                                recordIndex,
+                                rowCount,
+                                {
+                                    kind: NodeKind.DataTableNode,
+                                    source: props.query.source,
+                                }
+                            )}
                         </div>
                     )
                 },
                 style: (_, data) => {
+                    const cell = data[index]
+
+                    if (cell.isTransposedHeader) {
+                        return undefined
+                    }
+
+                    const sourceColumnName = cell.sourceColumnName ?? column.name
+                    const sourceColumnType =
+                        sourceTabularColumnsByName.get(sourceColumnName)?.column.type.name ?? cell.type
                     const cf = conditionalFormattingRules
-                        .filter((n) => n.columnName === column.name)
+                        .filter((n) => n.columnName === sourceColumnName)
                         .filter((n) => {
                             const isValidHog = !!n.bytecode && n.bytecode.length > 0 && n.bytecode[0] === '_H'
                             if (!isValidHog) {
@@ -124,8 +174,8 @@ export const Table = (props: TableProps): JSX.Element => {
                         .map((n) => {
                             const res = execHog(n.bytecode, {
                                 globals: {
-                                    value: data[index].value,
-                                    input: convertTableValue(n.input, column.type.name),
+                                    value: cell.value,
+                                    input: convertTableValue(n.input, sourceColumnType),
                                 },
                                 functions: {},
                                 maxAsyncSteps: 0,

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -343,4 +343,72 @@ describe('dataVisualizationLogic', () => {
             },
         })
     })
+
+    it('transposes table results without changing the query source', async () => {
+        dataNodeLogic({ key: testKey, query: defaultQuery.source, dataNodeCollectionId }).actions.setResponse({
+            columns: ['region', 'value'],
+            types: [
+                ['region', 'String'],
+                ['value', 'Int64'],
+            ],
+            results: [
+                ['US', 10],
+                ['EU', 20],
+            ],
+        })
+
+        logic.actions.setTransposeResults(true)
+
+        await expectLogic(logic).toMatchValues({
+            isTransposed: true,
+            isPinningEnabled: false,
+            tabularData: [
+                [
+                    {
+                        value: 'region',
+                        formattedValue: 'region',
+                        type: 'STRING',
+                        sourceColumnName: 'region',
+                        isTransposedHeader: true,
+                    },
+                    {
+                        value: 'US',
+                        formattedValue: 'US',
+                        type: 'STRING',
+                        sourceColumnName: 'region',
+                    },
+                    {
+                        value: 'EU',
+                        formattedValue: 'EU',
+                        type: 'STRING',
+                        sourceColumnName: 'region',
+                    },
+                ],
+                [
+                    {
+                        value: 'value',
+                        formattedValue: 'value',
+                        type: 'STRING',
+                        sourceColumnName: 'value',
+                        isTransposedHeader: true,
+                    },
+                    {
+                        value: 10,
+                        formattedValue: '10',
+                        type: 'INTEGER',
+                        sourceColumnName: 'value',
+                    },
+                    {
+                        value: 20,
+                        formattedValue: '20',
+                        type: 'INTEGER',
+                        sourceColumnName: 'value',
+                    },
+                ],
+            ],
+        })
+
+        expect(logic.values.query.source).toEqual(defaultQuery.source)
+        expect(logic.values.query.tableSettings?.transpose).toEqual(true)
+    })
 })

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.test.ts
@@ -366,7 +366,7 @@ describe('dataVisualizationLogic', () => {
                 [
                     {
                         value: 'region',
-                        formattedValue: 'region',
+                        formattedValue: null,
                         type: 'STRING',
                         sourceColumnName: 'region',
                         isTransposedHeader: true,
@@ -387,7 +387,7 @@ describe('dataVisualizationLogic', () => {
                 [
                     {
                         value: 'value',
-                        formattedValue: 'value',
+                        formattedValue: null,
                         type: 'STRING',
                         sourceColumnName: 'value',
                         isTransposedHeader: true,

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -63,6 +63,8 @@ export interface TableDataCell<T extends string | number | boolean | Date | null
     value: T
     formattedValue: string | object | null
     type: ColumnScalar
+    sourceColumnName?: string
+    isTransposedHeader?: boolean
 }
 
 export interface AxisSeriesSettings {
@@ -116,6 +118,9 @@ const DefaultAxisSettings = (): AxisSeriesSettings => ({
         suffix: '',
     },
 })
+
+const TRANSPOSED_FIELD_COLUMN_NAME = '__transpose_field__'
+const TRANSPOSED_ROW_COLUMN_PREFIX = '__transpose_row__'
 
 export const formatDataWithSettings = (
     data: number | string | null | object,
@@ -404,6 +409,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         }),
         setConditionalFormattingRulesPanelActiveKeys: (keys: string[]) => ({ keys }),
         toggleColumnPin: (columnName: string) => ({ columnName }),
+        setTransposeResults: (transpose: boolean) => ({ transpose }),
         _setQuery: (node: DataVisualizationNode) => ({ node }),
     })),
     reducers(({ props }) => ({
@@ -787,6 +793,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             () => [(_, props) => props.cachedResults ?? null],
             (cachedResults: AnyResponseType | null): boolean => !!cachedResults,
         ],
+        isTransposed: [(s) => [s.query], (query): boolean => query.tableSettings?.transpose ?? false],
         yData: [
             (s) => [s.selectedYAxis, s.response, s.columns, s.chartSettings],
             (ySeries, response, columns, chartSettings): AxisSeries<number | null>[] => {
@@ -896,10 +903,28 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 }
             },
         ],
-        tabularData: [
-            (s) => [s.tabularColumns, s.response, s.chartSettings],
-            (tabularColumns, response, chartSettings): TableDataCell<any>[][] => {
-                if (!response || tabularColumns === null) {
+        sourceTabularColumns: [
+            (s) => [s.tabularColumnSettings, s.response, s.columns],
+            (tabularColumnSettings, response, columns): AxisSeries<any>[] => {
+                if (!response) {
+                    return []
+                }
+
+                return columns.map((col) => {
+                    const series = (tabularColumnSettings || []).find((n) => n?.name === col.name)
+
+                    return {
+                        column: col,
+                        data: [],
+                        settings: series?.settings ?? DefaultAxisSettings(),
+                    }
+                })
+            },
+        ],
+        sourceTabularData: [
+            (s) => [s.sourceTabularColumns, s.response, s.chartSettings],
+            (sourceTabularColumns, response, chartSettings): TableDataCell<any>[][] => {
+                if (!response) {
                     return []
                 }
 
@@ -912,7 +937,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                           : []
 
                 return data.map((row): TableDataCell<any>[] => {
-                    return tabularColumns.map((column): TableDataCell<any> => {
+                    return sourceTabularColumns.map((column): TableDataCell<any> => {
                         if (!column) {
                             return {
                                 value: null,
@@ -982,21 +1007,82 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             },
         ],
         tabularColumns: [
-            (s) => [s.tabularColumnSettings, s.response, s.columns],
-            (tabularColumnSettings, response, columns): AxisSeries<any>[] => {
-                if (!response) {
+            (s) => [s.sourceTabularColumns, s.sourceTabularData, s.isTransposed],
+            (sourceTabularColumns, sourceTabularData, isTransposed): AxisSeries<any>[] => {
+                if (!isTransposed) {
+                    return sourceTabularColumns
+                }
+
+                if (sourceTabularColumns.length === 0) {
                     return []
                 }
 
-                return columns.map((col) => {
-                    const series = (tabularColumnSettings || []).find((n) => n?.name === col.name)
-
-                    return {
-                        column: col,
+                return [
+                    {
+                        column: {
+                            name: TRANSPOSED_FIELD_COLUMN_NAME,
+                            type: {
+                                name: 'STRING',
+                                isNumerical: false,
+                            },
+                            label: 'Field',
+                            dataIndex: -1,
+                        },
                         data: [],
-                        settings: series?.settings ?? DefaultAxisSettings(),
-                    }
-                })
+                        settings: {
+                            ...DefaultAxisSettings(),
+                            display: {
+                                label: 'Field',
+                            },
+                        },
+                    },
+                    ...sourceTabularData.map(
+                        (_, index): AxisSeries<any> => ({
+                            column: {
+                                name: `${TRANSPOSED_ROW_COLUMN_PREFIX}${index}`,
+                                type: {
+                                    name: 'STRING',
+                                    isNumerical: false,
+                                },
+                                label: `Row ${index + 1}`,
+                                dataIndex: -1,
+                            },
+                            data: [],
+                            settings: {
+                                ...DefaultAxisSettings(),
+                                display: {
+                                    label: `Row ${index + 1}`,
+                                },
+                            },
+                        })
+                    ),
+                ]
+            },
+        ],
+        tabularData: [
+            (s) => [s.sourceTabularColumns, s.sourceTabularData, s.isTransposed],
+            (sourceTabularColumns, sourceTabularData, isTransposed): TableDataCell<any>[][] => {
+                if (!isTransposed) {
+                    return sourceTabularData
+                }
+
+                if (sourceTabularData.length === 0) {
+                    return []
+                }
+
+                return sourceTabularColumns.map((column, columnIndex) => [
+                    {
+                        value: column.column.name,
+                        formattedValue: column.settings?.display?.label ?? column.column.name,
+                        type: 'STRING',
+                        sourceColumnName: column.column.name,
+                        isTransposedHeader: true,
+                    },
+                    ...sourceTabularData.map((row) => ({
+                        ...row[columnIndex],
+                        sourceColumnName: column.column.name,
+                    })),
+                ])
             },
         ],
         dataVisualizationProps: [() => [(_, props) => props], (props): DataVisualizationLogicProps => props],
@@ -1035,10 +1121,10 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 },
         ],
         isPinningEnabled: [
-            (s) => [s.activeSceneId],
-            (activeSceneId: Scene | null): boolean => {
+            (s) => [s.activeSceneId, s.isTransposed],
+            (activeSceneId: Scene | null, isTransposed: boolean): boolean => {
                 // disable column pinning in sql editor
-                return activeSceneId !== Scene.SQLEditor
+                return activeSceneId !== Scene.SQLEditor && !isTransposed
             },
         ],
     }),
@@ -1111,6 +1197,15 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             if (visualizationType === ChartDisplayType.TwoDimensionalHeatmap || isAutoHeatmap) {
                 applyAutoHeatmapSettings(actions, values.columns, values.chartSettings.heatmap ?? {})
             }
+        },
+        setTransposeResults: ({ transpose }) => {
+            actions.setQuery((query) => ({
+                ...query,
+                tableSettings: {
+                    ...query.tableSettings,
+                    transpose,
+                },
+            }))
         },
         toggleChartSettingsPanel: ({ open }) => {
             const shouldOpen = open ?? !values.isChartSettingsPanelOpen

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -1073,7 +1073,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 return sourceTabularColumns.map((column, columnIndex) => [
                     {
                         value: column.column.name,
-                        formattedValue: column.settings?.display?.label ?? column.column.name,
+                        formattedValue: null,
                         type: 'STRING',
                         sourceColumnName: column.column.name,
                         isTransposedHeader: true,
@@ -1123,7 +1123,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         isPinningEnabled: [
             (s) => [s.activeSceneId, s.isTransposed],
             (activeSceneId: Scene | null, isTransposed: boolean): boolean => {
-                // disable column pinning in sql editor
+                // disable column pinning in sql editor or when transposed
                 return activeSceneId !== Scene.SQLEditor && !isTransposed
             },
         ],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -33853,6 +33853,9 @@
                         "type": "string"
                     },
                     "type": "array"
+                },
+                "transpose": {
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1126,6 +1126,7 @@ export interface TableSettings {
     columns?: ChartAxis[]
     conditionalFormatting?: ConditionalFormattingRule[]
     pinnedColumns?: string[]
+    transpose?: boolean
 }
 
 export interface SharingConfigurationSettings {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7395,6 +7395,7 @@ class TableSettings(BaseModel):
     columns: list[ChartAxis] | None = None
     conditionalFormatting: list[ConditionalFormattingRule] | None = None
     pinnedColumns: list[str] | None = None
+    transpose: bool | None = None
 
 
 class TaskExecutionItem(BaseModel):

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11342,6 +11342,8 @@ export namespace Schemas {
       conditionalFormatting?: ConditionalFormattingRule[] | null;
       /** @nullable */
       pinnedColumns?: string[] | null;
+      /** @nullable */
+      transpose?: boolean | null;
     }
 
     export interface DataVisualizationNode {


### PR DESCRIPTION
## Changes

Into the SQL editor's table viz, add a "transpose" button that flips rows/columns client side:

![2026-03-27 10 55 14](https://github.com/user-attachments/assets/d358c374-2c72-4c3e-bea4-a67f48d7f80b)


## How did you test this code?

See screencast. Also tried adding this insight to a dashboard.

## Publish to changelog?

Why not
