### PR TITLE
fix(discussions): load org members when discussion panel mounts for @mentions

### DIFF
--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
@@ -41,7 +41,12 @@ export const commentsLogic = kea<commentsLogicType>([
     key((props) => `${props.scope}-${props.item_id || ''}`),
 
     connect(() => ({
-        actions: [sidePanelDiscussionLogic, ['incrementCommentCount', 'scrollToLastComment']],
+        actions: [
+            sidePanelDiscussionLogic,
+            ['incrementCommentCount', 'scrollToLastComment'],
+            membersLogic,
+            ['ensureAllMembersLoaded'],
+        ],
         values: [
             userLogic,
             ['user'],
@@ -369,4 +374,8 @@ export const commentsLogic = kea<commentsLogicType>([
             }
         },
     })),
+
+    afterMount(({ actions }) => {
+        actions.ensureAllMembersLoaded()
+    }),
 ])


### PR DESCRIPTION
## Problem

Typing `@` in a discussion comment shows no users on orgs with 200+
members because `membersLogic` never fetches members unless a component
explicitly calls `ensureAllMembersLoaded`. On small local orgs this
goes unnoticed as members load from another page visited earlier in the
session.

## Changes

- Call `ensureAllMembersLoaded` in `commentsLogic.afterMount` so members
  start loading as soon as the discussion panel opens, before the user
  types `@`

## How did you test this code?

No automated tests added. Fix was identified by code analysis — the
`Mentions` component read `meFirstMembers` from `membersLogic` without
ever triggering the load, causing an empty list on orgs where no other
component had loaded members in the session.

## Publish to changelog?

no