### PR TITLE
fix(logs): consolidate logs query tracking to backend report_user_action

### DIFF
--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -507,15 +507,6 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
             if (debounce) {
                 await breakpoint(debounce)
             }
-            // Track query execution (skip initial page load)
-            if (values.hasRunQuery) {
-                posthog.capture('logs query executed', {
-                    has_search_term: !!values.filters.searchTerm,
-                    has_filters: values.filters.filterGroup.values.length > 0,
-                    severity_count: values.filters.severityLevels?.length ?? 0,
-                    service_count: values.filters.serviceNames?.length ?? 0,
-                })
-            }
             actions.clearLogs()
             actions.fetchLogs()
             actions.fetchSparkline()


### PR DESCRIPTION
## Problem

We have duplicate `logs query executed` tracking, frontend `posthog.capture` and backend `report_user_action`

## Changes

- Removed frontend `posthog.capture('logs query executed')`

## How did you test this code?

Local manual tests

## Publish to changelog?

no