### PR TITLE
feat(alerts): default zscore and mad detectors to use differencing

### DIFF
--- a/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/DetectorSelector.tsx
@@ -121,8 +121,8 @@ const SINGLE_DETECTOR_OPTIONS = DETECTOR_OPTIONS.filter((o) => o.value !== 'ense
 
 function getDefaultSingleConfigs(window: number): Record<string, SingleDetectorConfig> {
     return {
-        zscore: { type: 'zscore', threshold: DEFAULT_THRESHOLD, window },
-        mad: { type: 'mad', threshold: DEFAULT_THRESHOLD, window },
+        zscore: { type: 'zscore', threshold: DEFAULT_THRESHOLD, window, preprocessing: { diffs_n: 1 } },
+        mad: { type: 'mad', threshold: DEFAULT_THRESHOLD, window, preprocessing: { diffs_n: 1 } },
         iqr: { type: 'iqr', multiplier: 1.5, window },
         threshold: { type: 'threshold' },
         ecod: { type: 'ecod', threshold: DEFAULT_THRESHOLD, window },
@@ -160,8 +160,8 @@ function getDefaultEnsemble(window: number): EnsembleDetectorConfig {
         type: 'ensemble',
         operator: EnsembleOperator.AND,
         detectors: [
-            { type: 'zscore', threshold: DEFAULT_THRESHOLD, window },
-            { type: 'mad', threshold: DEFAULT_THRESHOLD, window },
+            { type: 'zscore', threshold: DEFAULT_THRESHOLD, window, preprocessing: { diffs_n: 1 } },
+            { type: 'mad', threshold: DEFAULT_THRESHOLD, window, preprocessing: { diffs_n: 1 } },
         ],
     }
 }

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -343,8 +343,9 @@ export function EditAlertModal({
                                                 if (value === 'detector') {
                                                     setAlertFormValue('detector_config', {
                                                         type: 'zscore',
-                                                        threshold: 0.9,
+                                                        threshold: 0.95,
                                                         window: getDefaultWindow(alertForm.calculation_interval),
+                                                        preprocessing: { diffs_n: 1 },
                                                     })
                                                 } else {
                                                     setAlertFormValue('detector_config', null)

--- a/posthog/tasks/alerts/detectors/statistical/mad.py
+++ b/posthog/tasks/alerts/detectors/statistical/mad.py
@@ -102,4 +102,5 @@ class MADDetector(BaseDetector):
             "type": DetectorType.MAD.value,
             "threshold": cls.DEFAULT_THRESHOLD,
             "window": 30,
+            "preprocessing": {"diffs_n": 1},
         }

--- a/posthog/tasks/alerts/detectors/statistical/zscore.py
+++ b/posthog/tasks/alerts/detectors/statistical/zscore.py
@@ -126,4 +126,5 @@ class ZScoreDetector(BaseDetector):
             "type": DetectorType.ZSCORE.value,
             "threshold": cls.DEFAULT_THRESHOLD,
             "window": 30,
+            "preprocessing": {"diffs_n": 1},
         }


### PR DESCRIPTION
## Summary

- Adds `diffs_n: 1` (first-order differencing) as the default preprocessing for zscore and mad detectors
- Updates both frontend defaults (`DetectorSelector.tsx`) and backend defaults (`get_default_config`)
- Also updates the default ensemble config which uses zscore + mad

Without differencing, zscore/mad compare absolute values against a rolling mean/median. For cyclical data (e.g. hourly metrics with daily patterns), normal peaks and troughs get flagged as anomalies because they're far from the mixed average — leading to false positives.

Differencing makes these detectors operate on changes between consecutive points, so only sudden spikes/drops trigger. This is what users typically care about.

Only affects **newly created** alerts — existing alerts keep their saved config.

## Test plan

- [x] `pytest posthog/tasks/alerts/detectors/test/test_detectors.py` — 114 pass
- [ ] Create a new zscore alert and verify the default config includes `preprocessing: { diffs_n: 1 }`
- [ ] Simulate on an hourly insight to confirm fewer false positives on cyclical data